### PR TITLE
console: surface OIDC sign-in failures on the login page

### DIFF
--- a/console/src/api/apiClient.ts
+++ b/console/src/api/apiClient.ts
@@ -20,6 +20,7 @@ import {
 } from "~/config/AppConfig";
 import { ContextHolder } from "~/external-library-wrappers/frontegg";
 import { MzOidcUserManager } from "~/external-library-wrappers/oidc";
+import { readAuthErrorDetail } from "~/utils/oidcAuth";
 
 import { logoutAndRedirect } from "./materialize/auth";
 import {
@@ -177,9 +178,11 @@ export class SelfManagedApiClient
 
   #mzApiWithAuthRedirect = async (...req: Parameters<Fetch>) => {
     const response = await globalFetch(...req);
-    // If the user is not authenticated, we redirect to the login page.
     if (response.status === 401) {
-      await logoutAndRedirect({ apiClient: this });
+      // Surface only what the server shares — results in a redirect when
+      // there is a 401 error.
+      const error = await readAuthErrorDetail(response);
+      await logoutAndRedirect({ apiClient: this, error });
     }
     return response;
   };

--- a/console/src/api/materialize/auth.ts
+++ b/console/src/api/materialize/auth.ts
@@ -30,6 +30,9 @@ const getApiClient = () => {
 
 export const LOGIN_PATH = "/account/login";
 
+// Search-param on LOGIN_PATH carrying a sanitized auth-error message.
+export const LOGIN_ERROR_PARAM = "error";
+
 // Login API for to self-managed in password auth mode.
 // Throws if the API isn't supported for the deployment/auth mode.
 export async function loginOrThrow(request: { payload: LoginRequest }) {
@@ -83,9 +86,13 @@ export async function logout(logoutParams: {
 
 export async function logoutAndRedirect(logoutParams: {
   apiClient: SelfManagedApiClient;
+  error?: string;
 }) {
   logout(logoutParams);
-  window.location.href = LOGIN_PATH;
+  const url = logoutParams.error
+    ? `${LOGIN_PATH}?${new URLSearchParams({ [LOGIN_ERROR_PARAM]: logoutParams.error }).toString()}`
+    : LOGIN_PATH;
+  window.location.href = url;
 }
 
 export async function logoutAndRedirectOrThrow() {

--- a/console/src/components/OidcProviderWrapper.tsx
+++ b/console/src/components/OidcProviderWrapper.tsx
@@ -12,7 +12,6 @@ import React, { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { apiClient } from "~/api/apiClient";
-import Alert from "~/components/Alert";
 import LoadingScreen from "~/components/LoadingScreen";
 import { useAppConfig } from "~/config/useAppConfig";
 import { AuthProvider } from "~/external-library-wrappers/oidc";
@@ -58,16 +57,10 @@ export const OidcProviderWrapper = ({ children }: React.PropsWithChildren) => {
     return <LoadingScreen />;
   }
 
-  if (error) {
-    return (
-      <Alert
-        variant="error"
-        message={`Failed to initialize OIDC: ${error.message}`}
-      />
-    );
-  }
-
-  if (!oidcManager) {
+  // If OIDC isn't ready, render children without AuthProvider so password
+  // sign-in still works. Components that need OIDC must guard against
+  // `useAuth()` returning undefined.
+  if (error || !oidcManager) {
     return children;
   }
 

--- a/console/src/platform/UnauthenticatedRoutes.tsx
+++ b/console/src/platform/UnauthenticatedRoutes.tsx
@@ -22,6 +22,7 @@ import { AuthenticatedRoutes } from "~/platform/AuthenticatedRoutes";
 import { SentryRoutes } from "~/sentry";
 
 import { Login } from "./auth/Login";
+import { OidcCallback } from "./auth/OidcCallback";
 
 const OidcAuthGuard = ({ children }: React.PropsWithChildren) => {
   const auth = useAuth();
@@ -47,7 +48,7 @@ const SelfManagedRoutes = ({
       {(appConfig.authMode === "Password" ||
         appConfig.authMode === "Sasl" ||
         isOidc) && <Route path={LOGIN_PATH} element={<Login />} />}
-      {isOidc && <Route path="/auth/callback" element={<LoadingScreen />} />}
+      {isOidc && <Route path="/auth/callback" element={<OidcCallback />} />}
       <Route
         path="*"
         element={

--- a/console/src/platform/auth/Login.tsx
+++ b/console/src/platform/auth/Login.tsx
@@ -23,9 +23,9 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
-import { loginOrThrow } from "~/api/materialize/auth";
+import { LOGIN_ERROR_PARAM, loginOrThrow } from "~/api/materialize/auth";
 import Alert from "~/components/Alert";
 import { LabeledInput } from "~/components/formComponentsV2";
 import { MaterializeLogo } from "~/components/MaterializeLogo";
@@ -155,6 +155,8 @@ const SsoLoginLink = () => {
   const auth = useAuth();
   const [error, setError] = useState<string | null>(null);
 
+  if (!auth) return null;
+
   const handleSsoLogin = () => {
     setError(null);
     auth.signinRedirect().catch((err: unknown) => {
@@ -183,8 +185,11 @@ const SsoLoginLink = () => {
 
 export const Login = () => {
   const appConfig = useAppConfig();
+  const [searchParams] = useSearchParams();
   const isOidc =
     appConfig.mode === "self-managed" && appConfig.authMode === "Oidc";
+
+  const errorMessage = searchParams.get(LOGIN_ERROR_PARAM);
 
   return (
     <AuthLayout>
@@ -193,6 +198,14 @@ export const Login = () => {
           <HStack my={{ base: "8", lg: "0" }} paddingBottom="8">
             <MaterializeLogo height="12" />
           </HStack>
+          {errorMessage && (
+            <Alert
+              variant="error"
+              minWidth="100%"
+              message={errorMessage}
+              mb="4"
+            />
+          )}
           <PasswordLoginForm />
           {isOidc && <SsoLoginLink />}
         </VStack>

--- a/console/src/platform/auth/OidcCallback.tsx
+++ b/console/src/platform/auth/OidcCallback.tsx
@@ -1,0 +1,27 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import React from "react";
+import { Navigate } from "react-router-dom";
+
+import { LOGIN_ERROR_PARAM, LOGIN_PATH } from "~/api/materialize/auth";
+import LoadingScreen from "~/components/LoadingScreen";
+import { useAuth } from "~/external-library-wrappers/oidc";
+
+// Forwards IdP callback errors to the login page so all sign-in errors
+// render in one place.
+export const OidcCallback = () => {
+  const auth = useAuth();
+  if (auth.error) {
+    const message = auth.error.message?.trim() || "Sign-in failed";
+    const params = new URLSearchParams({ [LOGIN_ERROR_PARAM]: message });
+    return <Navigate to={`${LOGIN_PATH}?${params.toString()}`} replace />;
+  }
+  return <LoadingScreen />;
+};

--- a/console/src/utils/oidcAuth.ts
+++ b/console/src/utils/oidcAuth.ts
@@ -1,0 +1,23 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/** Reads the sanitized `OidcError::Display` body environmentd returns for OIDC
+ * 401s. Returns undefined for the generic `"unauthorized"` body so callers can
+ * distinguish a server-supplied detail from a routine 401. */
+export const readAuthErrorDetail = async (
+  response: Response,
+): Promise<string | undefined> => {
+  try {
+    const body = (await response.clone().text()).trim();
+    if (!body || body === "unauthorized") return undefined;
+    return body;
+  } catch {
+    return undefined;
+  }
+};

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -883,26 +883,33 @@ pub(crate) enum AuthError {
     FailedToUpdateSession,
     #[error("invalid credentials")]
     InvalidCredentials,
+    /// Payload is `OidcError`'s sanitized `Display` (no expected-values leaks).
+    #[error("{0}")]
+    OidcFailed(String),
 }
 
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         warn!("HTTP request failed authentication: {}", self);
         let mut headers = HeaderMap::new();
-        match self {
+        // We omit most detail from the error message we send to the client, to
+        // avoid giving attackers unnecessary information. `OidcFailed` is the
+        // exception — its payload is a sanitized `OidcError::Display` that the
+        // console embeds in the login-page error.
+        let body = match &self {
             AuthError::MissingHttpAuthentication {
                 include_www_authenticate_header,
-            } if include_www_authenticate_header => {
+            } if *include_www_authenticate_header => {
                 headers.insert(
                     http::header::WWW_AUTHENTICATE,
                     HeaderValue::from_static("Basic realm=Materialize"),
                 );
+                "unauthorized".to_string()
             }
-            _ => {}
+            AuthError::OidcFailed(message) => message.clone(),
+            _ => "unauthorized".to_string(),
         };
-        // We omit most detail from the error message we send to the client, to
-        // avoid giving attackers unnecessary information.
-        (StatusCode::UNAUTHORIZED, headers, "unauthorized").into_response()
+        (StatusCode::UNAUTHORIZED, headers, body).into_response()
     }
 }
 
@@ -1297,11 +1304,10 @@ async fn auth(
         }
         Authenticator::Oidc(oidc) => match creds {
             Some(Credentials::Token { token }) => {
-                // Validate JWT token
                 let (mut claims, authenticated) = oidc
                     .authenticate(&token, None)
                     .await
-                    .map_err(|_| AuthError::InvalidCredentials)?;
+                    .map_err(|e| AuthError::OidcFailed(e.to_string()))?;
                 let name = std::mem::take(&mut claims.user);
                 let groups = claims.groups.take();
                 (name, None, authenticated, groups)

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -1575,6 +1575,9 @@ async fn test_auth_oidc_audience_validation() {
         },
     );
 
+    let wrong_aud_headers = make_header(Authorization::bearer(&wrong_aud_token).unwrap());
+    let no_aud_headers = make_header(Authorization::bearer(&no_aud_token).unwrap());
+
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_oidc_auth(
@@ -1626,6 +1629,20 @@ async fn test_auth_oidc_audience_validation() {
                     );
                 })),
             },
+            // HTTP variant of the wrong-audience case: the response body
+            // should be the sanitized `OidcError::Display` so the console
+            // can render it on the login page.
+            TestCase::Http {
+                user_to_auth_as: oidc_user,
+                user_reported_by_system: oidc_user,
+                scheme: Scheme::HTTPS,
+                headers: &wrong_aud_headers,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Err(Box::new(|code, message| {
+                    assert_eq!(code, Some(StatusCode::UNAUTHORIZED));
+                    assert_eq!(message, "invalid audience");
+                })),
+            },
             // JWT with no audience should fail when audience is required.
             TestCase::Pgwire {
                 user_to_auth_as: oidc_user,
@@ -1637,6 +1654,18 @@ async fn test_auth_oidc_audience_validation() {
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "invalid audience");
                     assert_eq!(*err.code(), SqlState::INVALID_AUTHORIZATION_SPECIFICATION);
+                })),
+            },
+            // HTTP variant of the no-audience case.
+            TestCase::Http {
+                user_to_auth_as: oidc_user,
+                user_reported_by_system: oidc_user,
+                scheme: Scheme::HTTPS,
+                headers: &no_aud_headers,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Err(Box::new(|code, message| {
+                    assert_eq!(code, Some(StatusCode::UNAUTHORIZED));
+                    assert_eq!(message, "invalid audience");
                 })),
             },
         ],
@@ -2174,6 +2203,8 @@ async fn test_auth_oidc_no_matching_authentication_claim() {
         },
     );
 
+    let token_headers = make_header(Authorization::bearer(&token).unwrap());
+
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_oidc_auth(
@@ -2212,6 +2243,19 @@ async fn test_auth_oidc_no_matching_authentication_claim() {
                             .as_str()
                         )
                     );
+                })),
+            },
+            // HTTP variant: response body should be the sanitized
+            // `OidcError::Display` for the no-matching-claim error.
+            TestCase::Http {
+                user_to_auth_as: oidc_user,
+                user_reported_by_system: oidc_user,
+                scheme: Scheme::HTTPS,
+                headers: &token_headers,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Err(Box::new(|code, message| {
+                    assert_eq!(code, Some(StatusCode::UNAUTHORIZED));
+                    assert_eq!(message, "no matching authentication claim found in the JWT");
                 })),
             },
         ],
@@ -5323,26 +5367,42 @@ async fn test_auth_oidc_non_login_role() {
         .await
         .unwrap();
 
+    let jwt_headers = make_header(Authorization::bearer(&jwt_token).unwrap());
+
     // 1. Login should fail: role exists but has no LOGIN attribute.
     run_tests(
         "OIDC Non-Login Role - login rejected",
         &server,
-        &[TestCase::Pgwire {
-            user_to_auth_as: oidc_user,
-            user_reported_by_system: oidc_user,
-            password: Some(Cow::Borrowed(&jwt_token)),
-            ssl_mode: SslMode::Require,
-            options: Some("--oidc_auth_enabled=true"),
-            configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
-            assert: Assert::DbErr(Box::new(|err| {
-                assert_eq!(err.message(), "role is not allowed to login");
-                assert_eq!(*err.code(), SqlState::INVALID_AUTHORIZATION_SPECIFICATION);
-                assert_eq!(
-                    err.detail(),
-                    Some("The role does not have the LOGIN attribute.")
-                );
-            })),
-        }],
+        &[
+            TestCase::Pgwire {
+                user_to_auth_as: oidc_user,
+                user_reported_by_system: oidc_user,
+                password: Some(Cow::Borrowed(&jwt_token)),
+                ssl_mode: SslMode::Require,
+                options: Some("--oidc_auth_enabled=true"),
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::DbErr(Box::new(|err| {
+                    assert_eq!(err.message(), "role is not allowed to login");
+                    assert_eq!(*err.code(), SqlState::INVALID_AUTHORIZATION_SPECIFICATION);
+                    assert_eq!(
+                        err.detail(),
+                        Some("The role does not have the LOGIN attribute.")
+                    );
+                })),
+            },
+            // HTTP variant: same sanitized message in the response body.
+            TestCase::Http {
+                user_to_auth_as: oidc_user,
+                user_reported_by_system: oidc_user,
+                scheme: Scheme::HTTPS,
+                headers: &jwt_headers,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Err(Box::new(|code, message| {
+                    assert_eq!(code, Some(StatusCode::UNAUTHORIZED));
+                    assert_eq!(message, "role is not allowed to login");
+                })),
+            },
+        ],
     )
     .await;
 


### PR DESCRIPTION

### Motivation

Addressing SSO Feedback to show better error messages in the console if there are SSO failures and not have a confusing user experience. Fixes [CNS-53](https://linear.app/materializeinc/issue/CNS-53/improve-oidc-console-errors)

### Description

 - Added OIDC error messages to the console showing the errors when sign in failed/ surface environmentd warnings up in the console
### Verification
When the sign in failed and if the user is not part of the organization
<img width="1482" height="1158" alt="image" src="https://github.com/user-attachments/assets/5676da29-7300-478a-9256-56a80c9d022b" />

When OIDC might not be configured properly
<img width="1508" height="1278" alt="image" src="https://github.com/user-attachments/assets/4fad5dea-cac4-40e0-b324-9a39f844d36e" />


