### PR TITLE
Document SHOW CLUSTER REPLICAS output columns

### DIFF
--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -29,7 +29,7 @@ Column       | Description
 -------------|------------
 **cluster**  | The name of the cluster.
 **replica**  | The name of the replica.
-**size**     | The [size](/sql/create-cluster#size) of the replica.
+**size**     | The [size](/sql/create-cluster#available-sizes) of the replica.
 **ready**    | Whether all objects on the cluster have hydrated. `true` indicates that all indexes, materialized views, and other objects on this replica are caught up with the upstream data and ready to serve queries.
 **comment**  | The [comment](/sql/comment-on) associated with the cluster replica, if any.
 

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -30,7 +30,7 @@ Column       | Description
 **cluster**  | The name of the cluster.
 **replica**  | The name of the replica.
 **size**     | The [size](/sql/create-cluster#available-sizes) of the replica.
-**ready**    | Whether all objects on the cluster have hydrated. `true` indicates that all indexes, materialized views, and other objects on this replica are caught up with the upstream data and ready to serve queries.
+**ready**    | Whether all indexes, materialized views, sources, and sinks on the cluster have hydrated.
 **comment**  | The [comment](/sql/comment-on) associated with the cluster replica, if any.
 
 ## Examples

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -23,6 +23,16 @@ Syntax element                | Description
 **LIKE** \<pattern\>          | If specified, only show clusters that match the pattern.
 **WHERE** <condition(s)>      | If specified, only show clusters that match the condition(s).
 
+## Output
+
+Column       | Description
+-------------|------------
+**cluster**  | The name of the cluster.
+**replica**  | The name of the replica.
+**size**     | The [size](/sql/create-cluster#size) of the replica.
+**ready**    | Whether all objects on the cluster have [hydrated](/sql/create-index/#index-hydration). `true` indicates that all indexes, materialized views, and other objects on this replica are caught up with the upstream data and ready to serve queries.
+**comment**  | The [comment](/sql/comment-on) associated with the cluster replica, if any.
+
 ## Examples
 
 ```mzsql
@@ -30,8 +40,8 @@ SHOW CLUSTER REPLICAS;
 ```
 
 ```nofmt
-    cluster    | replica |  size  | ready |
----------------+---------|--------|-------|
+    cluster    | replica |  size  | ready | comment
+---------------+---------|--------|-------|--------
  auction_house | bigger  | 1600cc | t     |
  quickstart    | r1      | 25cc   | t     |
 ```
@@ -41,9 +51,9 @@ SHOW CLUSTER REPLICAS WHERE cluster = 'quickstart';
 ```
 
 ```nofmt
-    cluster    | replica |  size  | ready|
----------------+---------|--------|-------
- quickstart    | r1      | 25cc   | t    |
+    cluster    | replica |  size  | ready | comment
+---------------+---------|--------|-------|--------
+ quickstart    | r1      | 25cc   | t     |
 ```
 
 

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -30,7 +30,7 @@ Column       | Description
 **cluster**  | The name of the cluster.
 **replica**  | The name of the replica.
 **size**     | The [size](/sql/create-cluster#size) of the replica.
-**ready**    | Whether all objects on the cluster have [hydrated](/sql/create-index/#index-hydration). `true` indicates that all indexes, materialized views, and other objects on this replica are caught up with the upstream data and ready to serve queries.
+**ready**    | Whether all objects on the cluster have hydrated. `true` indicates that all indexes, materialized views, and other objects on this replica are caught up with the upstream data and ready to serve queries.
 **comment**  | The [comment](/sql/comment-on) associated with the cluster replica, if any.
 
 ## Examples


### PR DESCRIPTION
### Motivation

The `SHOW CLUSTER REPLICAS` documentation was missing a formal description of the output columns returned by the command. This makes it harder for users to understand what each column represents.

### Description

This change adds an "Output" section to the `SHOW CLUSTER REPLICAS` documentation that describes each column:
- **cluster**: The name of the cluster
- **replica**: The name of the replica
- **size**: The size of the replica
- **ready**: Whether all objects on the cluster have hydrated
- **comment**: The associated comment, if any

The example output tables have also been updated to include the `comment` column and fix formatting inconsistencies to match the documented output format.

### Verification

Documentation change only. The output format matches the actual command behavior.

https://claude.ai/code/session_01LfobjPj58rtwpvWVGtcqiV