### PR TITLE
console: enable npmMinimalAgeGate (3d) and bump Yarn to 4.14.1

### DIFF
--- a/console/.yarnrc.yml
+++ b/console/.yarnrc.yml
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Allow packages to run their postinstall scripts. Required for
-# @sentry/cli (binary download) and msw (service worker copy).
-# Historically implicit under Yarn 4.3; made explicit after the 4.14 bump.
-enableScripts: true
-
 nodeLinker: node-modules
 
 # Block installation of npm packages published less than 3 days ago.

--- a/console/.yarnrc.yml
+++ b/console/.yarnrc.yml
@@ -9,14 +9,9 @@
 
 nodeLinker: node-modules
 
-# Block installation of npm packages published less than 3 days ago.
-# Reduces exposure to zero-day supply chain attacks by letting the
-# community catch compromised releases before we pull them in.
+# Supply-chain cooldown: block npm packages published in the last 3 days.
 # Requires Yarn 4.10+.
 npmMinimalAgeGate: "3d"
 
-# Packages allowlisted from npmMinimalAgeGate (and other package gates).
-# Supports exact descriptors ("foo@1.2.3") and name globs ("@scope/*").
-# Add an entry here only with a clear reason — each bypass is a supply
-# chain risk.
+# Escape hatch for npmMinimalAgeGate. Use sparingly.
 npmPreapprovedPackages: []

--- a/console/.yarnrc.yml
+++ b/console/.yarnrc.yml
@@ -7,4 +7,21 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Allow packages to run their postinstall scripts. Required for
+# @sentry/cli (binary download) and msw (service worker copy).
+# Historically implicit under Yarn 4.3; made explicit after the 4.14 bump.
+enableScripts: true
+
 nodeLinker: node-modules
+
+# Block installation of npm packages published less than 3 days ago.
+# Reduces exposure to zero-day supply chain attacks by letting the
+# community catch compromised releases before we pull them in.
+# Requires Yarn 4.10+.
+npmMinimalAgeGate: "3d"
+
+# Packages allowlisted from npmMinimalAgeGate (and other package gates).
+# Supports exact descriptors ("foo@1.2.3") and name globs ("@scope/*").
+# Add an entry here only with a clear reason — each bypass is a supply
+# chain risk.
+npmPreapprovedPackages: []

--- a/console/package.json
+++ b/console/package.json
@@ -357,9 +357,9 @@
   ],
   "volta": {
     "node": "20.12.2",
-    "yarn": "4.3.1"
+    "yarn": "4.14.1"
   },
-  "packageManager": "yarn@4.3.1",
+  "packageManager": "yarn@4.14.1",
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
       "eslint --fix --max-warnings 0"

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@aashutoshrathi/word-wrap@npm:^1.2.3":
@@ -14606,11 +14606,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
   version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
+  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation

Harden the console's npm supply chain against zero-day compromised package releases. Several recent npm malware events (dependency takeovers, postinstall exploits) have been caught by the community within days of publication, but a CI/dev install that happens to run during that window can pull in the bad version before detection. Yarn 4.10+ ships `npmMinimalAgeGate`, which blocks installation of packages published more recently than a configurable cooldown. This adopts it.

### Description

- Set `npmMinimalAgeGate: "3d"` in `console/.yarnrc.yml`. Packages published within the last 3 days will be excluded from resolution.
- Seed `npmPreapprovedPackages: []` with a comment explaining its purpose — the documented escape hatch if we ever need to bypass the gate for a specific descriptor or scope.
- Bump `packageManager` / `volta.yarn` from `4.3.1` → `4.14.1` (current stable 4.x). The gate requires Yarn 4.10+.
- Leave `enableScripts` at its default (`false`). This is a second supply-chain win: no third-party package lifecycle scripts run on install. The four packages that declare scripts (`@sentry/cli`, `msw`, `esbuild`, `core-js`) are all functional without them — binary tools ship via platform-specific optional deps, msw is used only in node-mode in our tests, and core-js's postinstall is just a support message.

`yarn.lock` metadata bumps `version: 8` → `9` (Yarn 4.14 lockfile format). The only other line inside is a TypeScript compat-patch hash rotation — internal to Yarn's patching, harmless. No CI scripts or Dockerfiles need updating; every install site already runs `corepack enable` + `yarn install --immutable` and follows `packageManager` from `package.json`.

**Risks / watch-outs for reviewers:**

1. *Lockfile v8 → v9 is incompatible with older Yarn clients.* Any dev on Yarn <~4.9 will fail to read the lockfile until they `corepack enable` to pick up the new pin. CI is fine (already runs `corepack enable`). Worth a team heads-up.
2. *Silent-failure UX on the age gate.* If someone runs `yarn add foo@latest` on a package published within the last 3 days, Yarn reports "not found" rather than "blocked by age gate." Confusing but not damaging. Escape hatch is `npmPreapprovedPackages`.
3. *Dependabot alignment.* Bump bots may propose versions the gate refuses. Dependabot v2 has a matching `cooldown` field — we should keep these aligned at 3 days.
4. *Future deps that actually need postinstall.* If a new dependency is added later whose binary/assets truly require a lifecycle script, the install will skip it silently (YN0004 warning). Fix is per-package allowlist via `dependenciesMeta` in `package.json`, not a global `enableScripts: true`.

### Verification

Locally on this branch, with `enableScripts` at the default (off) and no `dependenciesMeta` allowlist:

- `yarn install` (fresh, empty `node_modules/`) — completes. YN0004 warns that build scripts are disabled for `@sentry/cli`, `msw`, `esbuild`, `core-js`, but nothing downstream actually needs them (see below).
- `yarn install --immutable` (CI-style) — clean.
- `yarn typecheck` — passes.
- `yarn lint` — passes.
- `yarn test --run` — 6 tests fail, **same 6 fail on main baseline** with Yarn 4.3.1. Failures are a pre-existing `Set.prototype.difference is not a function` issue (requires Node 22+, `volta.node` is pinned to 20.12.2). Not caused by this PR.
- `yarn build:local` — succeeds (esbuild works without postinstall; platform binary from `@esbuild/darwin-arm64`).
- `yarn build` (with `SENTRY_RELEASE=test-build`) — succeeds. `sentry-cli` binary is present and callable via `@sentry/cli-darwin` optional dep; `@sentry/vite-plugin` can invoke it.
- `node .../node_modules/@sentry/cli/bin/sentry-cli --version` → `sentry-cli 2.58.5`. Works without the postinstall having run.
- `grep` across the repo confirms msw's service worker (`setupWorker` / `msw/browser` / `mockServiceWorker`) is not referenced anywhere in `console/src`. msw is used exclusively in node mode for unit tests.

Still to confirm:
- [x] CI green on this PR.
- [ ] Manual: `yarn add <package>@<fresh-version>` rejects as expected.