### PR TITLE
launchdarkly test: Wait longer for result

### DIFF
--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -65,7 +65,7 @@ SERVICES = [
         },
         external_metadata_store=True,
     ),
-    Testdrive(no_reset=True, seed=1),
+    Testdrive(no_reset=True, seed=1, default_timeout="120s"),
 ]
 
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/16164

Test run: https://buildkite.com/materialize/nightly/builds/16165