### PR TITLE
launchdarkly: Back to streaming data source

### DIFF
--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -204,7 +204,7 @@ fn ld_config(api_key: &str, metrics: &Metrics, now_fn: &NowFn) -> ld::Config {
     let mut event_processor = ld::EventProcessorBuilder::new();
     event_processor.transport(cse_transport);
 
-    let mut data_source = ld::PollingDataSourceBuilder::new();
+    let mut data_source = ld::StreamingDataSourceBuilder::new();
     data_source.transport(data_source_transport);
 
     ld::ConfigBuilder::new(api_key)

--- a/src/dyncfg-launchdarkly/src/lib.rs
+++ b/src/dyncfg-launchdarkly/src/lib.rs
@@ -55,7 +55,7 @@ where
             .build_https()
             .expect("failed to create HTTPS transport");
 
-        let mut data_source = ld::PollingDataSourceBuilder::new();
+        let mut data_source = ld::StreamingDataSourceBuilder::new();
         data_source.transport(transport.clone());
 
         let mut event_processor = ld::EventProcessorBuilder::new();


### PR DESCRIPTION
Fixes test failures in https://buildkite.com/materialize/nightly/builds/16164

Test run: https://buildkite.com/materialize/nightly/builds/16166