### PR TITLE
sql: Clarify fast path peek storage reads

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -219,12 +219,12 @@ impl FastPathPlan {
                     ctx.indent += 1;
                 }
                 if let Some(literal_constraint) = literal_constraint {
-                    writeln!(f, "{}→Index Lookup on {coll} (from storage)", ctx.indent)?;
+                    writeln!(f, "{}→ReadStorage Lookup on {coll}", ctx.indent)?;
                     ctx.indent += 1;
                     let value = mode.expr(literal_constraint, None);
                     writeln!(f, "{}Lookup value: {value}", ctx.indent)?;
                 } else {
-                    writeln!(f, "{}→Indexed {coll} (from storage)", ctx.indent)?;
+                    writeln!(f, "{}→ReadStorage {coll}", ctx.indent)?;
                 }
 
                 ctx.indent.reset();

--- a/test/sqllogictest/explain/default.slt
+++ b/test/sqllogictest/explain/default.slt
@@ -2128,3 +2128,76 @@ Explained Query:
 Target cluster: no_replicas
 
 EOF
+
+# fast path operator names
+statement ok
+CREATE TABLE fp_t_raw(x int, y text);
+
+statement ok
+CREATE MATERIALIZED VIEW fp_mv_filtered AS SELECT * FROM fp_t_raw WHERE x IS NOT NULL;
+
+query T multiline
+EXPLAIN
+SELECT * FROM fp_mv_filtered LIMIT 5
+----
+Explained Query (fast path):
+  Finish limit=5 output=[#0, #1]
+    →Map/Filter/Project
+      →ReadStorage materialize.public.fp_mv_filtered
+
+Target cluster: no_replicas
+
+EOF
+
+# this does not seem to be successfully hitting the `ReadStorage`/`Lookup` path, so we don't have 100% coverage :(
+query T multiline
+EXPLAIN
+SELECT * FROM fp_mv_filtered WHERE x=15 AND y='hello' LIMIT 5
+----
+Explained Query:
+  Finish limit=5 output=[#0, #1]
+    →Read materialize.public.fp_mv_filtered
+
+Source materialize.public.fp_mv_filtered
+  filter=((#0{x} = 15) AND (#1{y} = "hello"))
+
+Target cluster: no_replicas
+
+EOF
+
+statement ok
+CREATE INDEX fp_idx ON fp_mv_filtered(x, y);
+
+query T multiline
+EXPLAIN
+SELECT * FROM fp_mv_filtered LIMIT 5
+----
+Explained Query (fast path):
+  Finish limit=5 output=[#0, #1]
+    →Map/Filter/Project
+      →Indexed materialize.public.fp_mv_filtered (using materialize.public.fp_idx)
+
+Used Indexes:
+  - materialize.public.fp_idx (fast path limit)
+
+Target cluster: no_replicas
+
+EOF
+
+query T multiline
+EXPLAIN
+SELECT * FROM fp_mv_filtered WHERE x=15 AND y='hello' LIMIT 5
+----
+Explained Query (fast path):
+  Finish limit=5 output=[#0, #1]
+    →Map/Filter/Project
+      Project: #0, #1
+      →Index Lookup on materialize.public.fp_mv_filtered (using materialize.public.fp_idx)
+        Lookup values: (15, "hello")
+
+Used Indexes:
+  - materialize.public.fp_idx (lookup)
+
+Target cluster: no_replicas
+
+EOF


### PR DESCRIPTION
### Motivation

https://materializeinc.slack.com/archives/CU7ELJ6E9/p1776710161607899?thread_ts=1776707127.468209&cid=CU7ELJ6E9

### Description

Clarifies wording for `FastPathPlan::PeekPersist` as `ReadStorage` rather than `Indexed` (which is the correct wording for `FastPathPlan::PeekExisting`, which actually does read from an index).

### Verification

Rewrite SLTs as necessary.
