### PR TITLE
arrow-util: check for overflow in interval micros-to-nanos conversion

### DIFF
--- a/src/arrow-util/src/builder.rs
+++ b/src/arrow-util/src/builder.rs
@@ -1027,7 +1027,12 @@ impl ArrowColumn {
                 struct_builder.append(true);
             }
             (ColBuilder::IntervalMonthDayNanoBuilder(builder), Datum::Interval(iv)) => {
-                let nanos = iv.micros * 1_000;
+                let nanos = iv.micros.checked_mul(1_000).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "interval microseconds {} overflow i64 nanoseconds",
+                        iv.micros
+                    )
+                })?;
                 builder.append_value(arrow::datatypes::IntervalMonthDayNano::new(
                     iv.months, iv.days, nanos,
                 ));


### PR DESCRIPTION
The `IntervalMonthDayNano` builder path introduced in #35753 computed `iv.micros * 1_000` without an overflow check. Intervals with `|micros| > i64::MAX / 1000` wrap in release and panic in debug. Switch to `checked_mul` and bail with an error instead.