### PR TITLE
ore: fix OpenTelemetryRateLimitingFilter suppressing every event

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -865,12 +865,17 @@ impl<S> tracing_subscriber::layer::Filter<S> for OpenTelemetryRateLimitingFilter
 where
     S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
 {
+    // NB: `enabled` must stay non-mutating. tracing-subscriber calls both `enabled`
+    // and then `event_enabled` for every event; if `should_log` ran in both, the
+    // first call would insert the callsite into `last_logged` and the second would
+    // see it within the backoff window and suppress — dropping every OpenTelemetry
+    // event, including the first.
     fn enabled(
         &self,
-        metadata: &tracing::Metadata<'_>,
+        _metadata: &tracing::Metadata<'_>,
         _ctx: &tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        self.should_log(metadata)
+        true
     }
 
     fn event_enabled(


### PR DESCRIPTION
The filter's `should_log` ran in both `Filter::enabled` and `Filter::event_enabled`. tracing-subscriber calls both per event for a per-layer filter: the first call inserted the callsite into `last_logged`, the second saw it within the backoff window and returned false — so every OpenTelemetry internal log was dropped, including the first. Make `enabled` non-mutating and keep the rate-limit decision in `event_enabled`.

Introduced in #34850 (commit 6e16efb384 "rate limit opentelemetry internal logs").