### PR TITLE
adapter: don't apply Subscribe transaction ops for EXPLAIN SUBSCRIBE

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -189,7 +189,7 @@ impl Coordinator {
 
         // SUBSCRIBE AS OF, similar to peeks, doesn't need to worry about transaction
         // timestamp semantics.
-        if when == &QueryWhen::Immediately {
+        if explain_ctx.needs_cluster() && when == &QueryWhen::Immediately {
             // If this isn't a SUBSCRIBE AS OF, the SUBSCRIBE can be in a transaction if it's the
             // only operation.
             session.add_transaction_ops(TransactionOps::Subscribe)?;

--- a/test/sqllogictest/explain/subscribe.slt
+++ b/test/sqllogictest/explain/subscribe.slt
@@ -216,3 +216,15 @@ EXPLAIN LOCALLY OPTIMIZED PLAN FOR SUBSCRIBE t
 # Test error case: SUBSCRIBE on non-existent table
 statement error unknown catalog item 'nonexistent'
 EXPLAIN OPTIMIZED PLAN FOR SUBSCRIBE nonexistent
+
+statement ok
+BEGIN
+
+statement ok
+EXPLAIN OPTIMIZED PLAN FOR SUBSCRIBE t
+
+statement ok
+EXPLAIN OPTIMIZED PLAN FOR SUBSCRIBE t
+
+statement ok
+COMMIT


### PR DESCRIPTION
`subscribe_validate` is shared between real `SUBSCRIBE` and `EXPLAIN SUBSCRIBE` (introduced in #34912). `TransactionOps::Subscribe` is exclusive, so running `EXPLAIN SUBSCRIBE` inside an explicit transaction poisoned it and caused any following statement to fail with `SubscribeOnlyTransaction`.