### PR TITLE
`repeat_row`: Wrangle negative accumulation error messages

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -32,8 +32,8 @@ use mz_controller_types::ClusterId;
 use mz_expr::explain::{HumanizedExplain, HumanizerMode, fmt_text_constant_rows};
 use mz_expr::row::RowCollection;
 use mz_expr::{
-    EvalError, Id, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing,
-    RowSetFinishingIncremental, permutation_for_arrangement,
+    EvalError, Id, MirRelationExpr, MirScalarExpr, MultiplicityErrorKind, OptimizedMirRelationExpr,
+    RowSetFinishing, RowSetFinishingIncremental, permutation_for_arrangement,
 };
 use mz_ore::cast::CastFrom;
 use mz_ore::str::{StrExt, separated};
@@ -676,9 +676,11 @@ impl crate::coord::Coordinator {
             let mut results = Vec::new();
             for (row, count) in rows {
                 if count.is_negative() {
-                    Err(EvalError::InvalidParameterValue(
-                        format!("Negative multiplicity in constant result: {}", count).into(),
-                    ))?
+                    Err(EvalError::MultiplicityError(mz_expr::MultiplicityError {
+                        kind: MultiplicityErrorKind::Negative,
+                        code_place: "constant result".into(),
+                        detail: format!("count={}", count).into(),
+                    }))?
                 };
                 if count.is_positive() {
                     let count = usize::cast_from(

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -16,6 +16,7 @@ use mz_compute_client::controller::instance_client::InstanceClient;
 use mz_compute_client::controller::instance_client::{AcquireReadHoldsError, InstanceShutDown};
 use mz_compute_client::protocol::command::PeekTarget;
 use mz_compute_types::ComputeInstanceId;
+use mz_expr::MultiplicityErrorKind;
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
 use mz_persist_client::PersistClient;
@@ -265,9 +266,12 @@ impl PeekClient {
                 let count = match u64::try_from(count.into_inner()) {
                     Ok(u) => usize::cast_from(u),
                     Err(_) => {
-                        return Err(AdapterError::Unstructured(anyhow::anyhow!(
-                            "Negative multiplicity in constant result: {}",
-                            count
+                        return Err(AdapterError::Eval(mz_expr::EvalError::MultiplicityError(
+                            mz_expr::MultiplicityError {
+                                kind: MultiplicityErrorKind::Negative,
+                                code_place: "constant result".into(),
+                                detail: format!("count={}", count).into(),
+                            },
                         )));
                     }
                 };

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -35,7 +35,7 @@ use mz_compute_types::dyncfgs::{
 use mz_compute_types::plan::render_plan::RenderPlan;
 use mz_dyncfg::ConfigSet;
 use mz_expr::row::RowCollection;
-use mz_expr::{RowComparator, SafeMfpPlan};
+use mz_expr::{MultiplicityErrorKind, RowComparator, SafeMfpPlan, log_multiplicity_error};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::{MetricsRegistry, UIntGauge};
@@ -1356,15 +1356,15 @@ impl PersistPeek {
                 }
 
                 let count: usize = d.try_into().map_err(|_| {
-                    error!(
-                        shard = %metadata.data_shard, diff = d, ?row,
-                        "persist peek encountered negative multiplicities",
-                    );
-                    format!(
-                        "Invalid data in source, \
-                         saw retractions ({}) for row that does not exist: {:?}",
-                        -d, row,
-                    )
+                    let err = mz_expr::MultiplicityError {
+                        kind: MultiplicityErrorKind::Negative,
+                        code_place: "persist peek".into(),
+                        detail:
+                            format!("shard={}, diff={}, row={:?}", metadata.data_shard, d, row,)
+                                .into(),
+                    };
+                    log_multiplicity_error(&err);
+                    err.to_string()
                 })?;
                 let Some(count) = NonZeroUsize::new(count) else {
                     continue;
@@ -1502,15 +1502,19 @@ impl IndexPeek {
             });
             if copies.is_negative() {
                 let error = cursor.key(&storage);
-                error!(
-                    target = %self.peek.target.id(), diff = %copies, %error,
-                    "index peek encountered negative multiplicities in error trace",
-                );
-                return PeekStatus::Ready(PeekResponse::Error(format!(
-                    "Invalid data in source errors, \
-                    saw retractions ({}) for row that does not exist: {}",
-                    -copies, error,
-                )));
+                let err = mz_expr::MultiplicityError {
+                    kind: MultiplicityErrorKind::Negative,
+                    code_place: "index peek error trace".into(),
+                    detail: format!(
+                        "target={}, diff={}, error={}",
+                        self.peek.target.id(),
+                        copies,
+                        error,
+                    )
+                    .into(),
+                };
+                log_multiplicity_error(&err);
+                return PeekStatus::Ready(PeekResponse::Error(err.to_string()));
             }
             if copies.is_positive() {
                 return PeekStatus::Ready(PeekResponse::Error(cursor.key(&storage).to_string()));

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -11,6 +11,7 @@ use std::ops::Range;
 
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Cursor, TraceReader};
+use mz_expr::{MultiplicityErrorKind, log_multiplicity_error};
 use mz_ore::result::ResultExt;
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena};
@@ -247,15 +248,14 @@ where
             });
             let copies: i64 = if copies.is_negative() {
                 let row = &*borrow;
-                tracing::error!(
-                    target = %self.target_id, diff = %copies, ?row,
-                    "index peek encountered negative multiplicities in ok trace",
-                );
-                return Err(format!(
-                    "Invalid data in source, \
-                             saw retractions ({}) for row that does not exist: {:?}",
-                    -copies, row,
-                ));
+                let err = mz_expr::MultiplicityError {
+                    kind: MultiplicityErrorKind::Negative,
+                    code_place: "index peek".into(),
+                    detail: format!("target={}, diff={}, row={:?}", self.target_id, copies, row,)
+                        .into(),
+                };
+                log_multiplicity_error(&err);
+                return Err(err.to_string());
             } else {
                 copies.into_inner()
             };

--- a/src/compute/src/render/errors.rs
+++ b/src/compute/src/render/errors.rs
@@ -27,6 +27,7 @@
 use columnar::Columnar;
 use columnation::{Columnation, Region};
 use mz_expr::EvalError;
+use mz_expr::{MULTIPLICITY_ERROR_TITLE, MultiplicityError};
 use mz_proto::{ProtoType, RustType};
 use mz_repr::Row;
 use mz_storage_types::errors::{DataflowError, ProtoDataflowError};
@@ -213,6 +214,7 @@ impl ErrorLogger {
     /// the breadcrumbs to their associated error in Sentry.
     ///
     // TODO(database-issues#5362): Rethink or justify our error logging strategy.
+    #[allow(dead_code)] // kept for future non-multiplicity uses
     pub fn log(&self, message: &'static str, details: &str) {
         tracing::warn!(
             dataflow = self.dataflow_name,
@@ -230,6 +232,30 @@ impl ErrorLogger {
             "[customer-data] {message} ({details})"
         );
         mz_ore::soft_panic_or_log!("{}", message);
+    }
+
+    /// Log a [`MultiplicityError`] using the standard "static title + [customer-data]
+    /// tagged details" contract, attaching the dataflow name of this [`ErrorLogger`]
+    /// as a structured field.
+    ///
+    /// Use this from call sites that have an [`ErrorLogger`] in scope (dataflow
+    /// rendering code in reduce/top-k); other call sites should use the free
+    /// [`mz_expr::log_multiplicity_error`] function instead.
+    ///
+    /// `kind` and `code_place` are emitted as structured tracing fields.
+    /// `detail` is emitted in the `[customer-data]`-tagged message body.
+    pub fn log_multiplicity_error(&self, err: &MultiplicityError) {
+        tracing::warn!(
+            dataflow = self.dataflow_name,
+            kind = ?err.kind,
+            code_place = %err.code_place,
+            "[customer-data] {}: {}",
+            MULTIPLICITY_ERROR_TITLE,
+            err.detail,
+        );
+        // Note: simply `tracing::error!(MULTIPLICITY_ERROR_TITLE);` wouldn't work well, because it
+        // would surprisingly print as `MULTIPLICITY_ERROR_TITLE="invalid record multiplicity"`.
+        tracing::error!("{}", MULTIPLICITY_ERROR_TITLE);
     }
 }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -32,7 +32,8 @@ use mz_compute_types::plan::reduce::{
     ReducePlan, ReductionType, SingleBasicPlan, reduction_type,
 };
 use mz_expr::{
-    AggregateExpr, AggregateFunc, EvalError, MapFilterProject, MirScalarExpr, SafeMfpPlan,
+    AggregateExpr, AggregateFunc, EvalError, MapFilterProject, MirScalarExpr,
+    MultiplicityErrorKind, SafeMfpPlan,
 };
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
 use mz_repr::fixed_length::ToDatumIter;
@@ -304,9 +305,13 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     if count.is_positive() {
                         continue;
                     }
-                    let message = "Non-positive multiplicity in DistinctBy";
-                    error_logger.log(message, &format!("row={key:?}, count={count}"));
-                    output.push((EvalError::Internal(message.into()).into(), Diff::ONE));
+                    let err = mz_expr::MultiplicityError {
+                        kind: MultiplicityErrorKind::NonPositive,
+                        code_place: "DistinctBy".into(),
+                        detail: format!("row={key:?}, count={count}").into(),
+                    };
+                    error_logger.log_multiplicity_error(&err);
+                    output.push((EvalError::MultiplicityError(err).into(), Diff::ONE));
                     return;
                 }
                 // If `mfp_after` can error, then evaluate it here.
@@ -473,15 +478,15 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             if validating {
                 let (oks, errs) = self
                     .build_reduce_inaccumulable_distinct::<
-                        RowValBuilder<Result<(), String>, _, _>,
-                        RowValSpine<Result<(), String>, _, _>,
+                        RowValBuilder<Result<(), DataflowErrorSer>, _, _>,
+                        RowValSpine<Result<(), DataflowErrorSer>, _, _>,
                     >(keyed, None)
                     .as_collection(|k, v| {
                         (
                             k.to_row(),
                             v.as_ref()
                                 .map(|&()| ())
-                                .map_err(|m| m.as_str().into()),
+                                .map_err(|m| m.clone()),
                         )
                     })
                     .map_fallible::<
@@ -494,9 +499,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         "Demux Errors",
                         move |(key_val, result)| match result {
                             Ok(()) => Ok(pairer.split(&key_val)),
-                            Err(m) => {
-                                Err(EvalError::Internal(m).into())
-                            }
+                            Err(m) => Err(m),
                         },
                     );
                 err_output = Some(errs);
@@ -626,12 +629,16 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                                         continue;
                                     }
                                     let value = value.to_row();
-                                    let message =
-                                        "Non-positive accumulation in ReduceInaccumulable";
-                                    error_logger
-                                        .log(message, &format!("value={value:?}, count={count}"));
-                                    let err = EvalError::Internal(message.into());
-                                    target.push((err.into(), Diff::ONE));
+                                    let err = mz_expr::MultiplicityError {
+                                        kind: MultiplicityErrorKind::NonPositive,
+                                        code_place: "ReduceInaccumulable".into(),
+                                        detail: format!("value={value:?}, count={count}").into(),
+                                    };
+                                    error_logger.log_multiplicity_error(&err);
+                                    target.push((
+                                        EvalError::MultiplicityError(err).into(),
+                                        Diff::ONE,
+                                    ));
                                     return;
                                 }
                             }
@@ -726,7 +733,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 KeyContainer: BatchContainer<Owned = Row>,
                 Time = T,
                 Diff = Diff,
-                ValOwn: Data + MaybeValidatingRow<(), String>,
+                ValOwn: Data + MaybeValidatingRow<(), DataflowErrorSer>,
             > + 'static,
         Bu: Builder<
                 Time = T,
@@ -757,9 +764,16 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                             continue;
                         }
 
-                        let message = "Non-positive accumulation in ReduceInaccumulable DISTINCT";
-                        error_logger.log(message, &format!("value={value:?}, count={count}"));
-                        t.push((err(message.to_string()), Diff::ONE));
+                        let m_err = mz_expr::MultiplicityError {
+                            kind: MultiplicityErrorKind::NonPositive,
+                            code_place: "ReduceInaccumulable DISTINCT".into(),
+                            detail: format!("value={value:?}, count={count}").into(),
+                        };
+                        error_logger.log_multiplicity_error(&m_err);
+                        t.push((
+                            err(DataflowErrorSer::from(EvalError::MultiplicityError(m_err))),
+                            Diff::ONE,
+                        ));
                         return;
                     }
                 }
@@ -894,12 +908,14 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                                             continue;
                                         }
                                         let val = val.to_row();
-                                        let message =
-                                            "Non-positive accumulation in ReduceMinsMaxes";
-                                        error_logger
-                                            .log(message, &format!("val={val:?}, count={count}"));
+                                        let err = mz_expr::MultiplicityError {
+                                            kind: MultiplicityErrorKind::NonPositive,
+                                            code_place: "ReduceMinsMaxes".into(),
+                                            detail: format!("val={val:?}, count={count}").into(),
+                                        };
+                                        error_logger.log_multiplicity_error(&err);
                                         target.push((
-                                            EvalError::Internal(message.into()).into(),
+                                            EvalError::MultiplicityError(err).into(),
                                             Diff::ONE,
                                         ));
                                         return;
@@ -1008,11 +1024,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         let mut hash_key_iter = hash_key.iter();
                         let _hash = hash_key_iter.next();
                         let key = SharedRow::pack(hash_key_iter);
-                        let message = format!(
-                            "Invalid data in source, saw non-positive accumulation \
-                                         for key {key:?} in hierarchical mins-maxes aggregate"
-                        );
-                        Err(EvalError::Internal(message.into()).into())
+                        Err(EvalError::MultiplicityError(mz_expr::MultiplicityError {
+                            kind: MultiplicityErrorKind::NonPositive,
+                            code_place: "hierarchical mins-maxes aggregate".into(),
+                            detail: format!("key={key:?}").into(),
+                        })
+                        .into())
                     }
                     Ok(values) => Ok((hash_key, values)),
                 },
@@ -1081,10 +1098,11 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         if count.is_positive() {
                             continue;
                         }
-                        error_logger.log(
-                            "Non-positive accumulation in MinsMaxesHierarchical",
-                            &format!("key={key:?}, value={value:?}, count={count}"),
-                        );
+                        error_logger.log_multiplicity_error(&mz_expr::MultiplicityError {
+                            kind: MultiplicityErrorKind::NonPositive,
+                            code_place: "MinsMaxesHierarchical".into(),
+                            detail: format!("key={key:?}, value={value:?}, count={count}").into(),
+                        });
                         // After complaining, output an error here so that we can eventually
                         // report it in an error stream.
                         target.push((
@@ -1160,12 +1178,13 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         // It should be now possible to ensure that we have a monotonic collection.
         let error_logger = self.error_logger();
         let (partial, validation_errs) = collection.ensure_monotonic(move |data, diff| {
-            error_logger.log(
-                "Non-monotonic input to ReduceMonotonic",
-                &format!("data={data:?}, diff={diff}"),
-            );
-            let m = "tried to build a monotonic reduction on non-monotonic input".into();
-            (EvalError::Internal(m).into(), Diff::ONE)
+            let err = mz_expr::MultiplicityError {
+                kind: MultiplicityErrorKind::NonMonotonicInput,
+                code_place: "ReduceMonotonic".into(),
+                detail: format!("data={data:?}, diff={diff}").into(),
+            };
+            error_logger.log_multiplicity_error(&err);
+            (EvalError::MultiplicityError(err).into(), Diff::ONE)
         });
         // We can place our rows directly into the diff field, and
         // only keep the relevant one corresponding to evaluating our
@@ -1407,33 +1426,39 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         // We first test here if inputs without net-positive records are present,
                         // producing an error to the logs and to the query output if that is the case.
                         if total == Diff::ZERO && !accum.is_zero() {
-                            error_logger.log(
-                                "Net-zero records with non-zero accumulation in ReduceAccumulable",
-                                &format!("aggr={aggr:?}, accum={accum:?}"),
-                            );
                             let key = key.to_row();
-                            let message = format!(
-                                "Invalid data in source, saw net-zero records for key {key} \
-                                 with non-zero accumulation in accumulable aggregate"
-                            );
-                            output.push((EvalError::Internal(message.into()).into(), Diff::ONE));
+                            let err = mz_expr::MultiplicityError {
+                                kind: MultiplicityErrorKind::InconsistentAccumulator,
+                                code_place: "ReduceAccumulable".into(),
+                                detail: format!(
+                                    "net-zero records with non-zero accumulation, \
+                                     key={key}, aggr={aggr:?}, accum={accum:?}"
+                                )
+                                .into(),
+                            };
+                            error_logger.log_multiplicity_error(&err);
+                            output.push((EvalError::MultiplicityError(err).into(), Diff::ONE));
                         }
                         match (&aggr.func, &accum) {
                             (AggregateFunc::SumUInt16, Accum::SimpleNumber { accum, .. })
                             | (AggregateFunc::SumUInt32, Accum::SimpleNumber { accum, .. })
                             | (AggregateFunc::SumUInt64, Accum::SimpleNumber { accum, .. }) => {
                                 if accum.is_negative() {
-                                    error_logger.log(
-                                    "Invalid negative unsigned aggregation in ReduceAccumulable",
-                                    &format!("aggr={aggr:?}, accum={accum:?}"),
-                                );
                                     let key = key.to_row();
-                                    let message = format!(
-                                        "Invalid data in source, saw negative accumulation with \
-                                         unsigned type for key {key}"
-                                    );
-                                    let err = EvalError::Internal(message.into());
-                                    output.push((err.into(), Diff::ONE));
+                                    let err = mz_expr::MultiplicityError {
+                                        kind: MultiplicityErrorKind::InconsistentAccumulator,
+                                        code_place: "ReduceAccumulable".into(),
+                                        detail: format!(
+                                            "negative accumulation with unsigned sum, \
+                                             key={key}, aggr={aggr:?}, accum={accum:?}"
+                                        )
+                                        .into(),
+                                    };
+                                    error_logger.log_multiplicity_error(&err);
+                                    output.push((
+                                        EvalError::MultiplicityError(err).into(),
+                                        Diff::ONE,
+                                    ));
                                 }
                             }
                             _ => (), // no more errors to check for at this point!
@@ -2215,9 +2240,16 @@ mod monoids {
                     }
                 }
                 (lhs, rhs) => {
-                    soft_panic_or_log!(
-                        "Mismatched monoid variants in reduction! lhs: {lhs:?} rhs: {rhs:?}"
+                    // `lhs`/`rhs` are `Row`s, which are customer data, so keep them
+                    // out of the panic/Sentry title and into a `[customer-data]`-tagged
+                    // breadcrumb. `mod monoids` has no access to an `ErrorLogger` here,
+                    // so we emit the warn line inline and keep the static title for
+                    // `soft_panic_or_log!`.
+                    tracing::warn!(
+                        "[customer-data] mismatched monoid variants in reduction \
+                         (lhs={lhs:?}, rhs={rhs:?})"
                     );
+                    soft_panic_or_log!("mismatched monoid variants in reduction");
                 }
             }
         }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -28,7 +28,7 @@ use mz_compute_types::plan::top_k::{
     BasicTopKPlan, MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan,
 };
 use mz_expr::func::CastUint64ToInt64;
-use mz_expr::{BinaryFunc, EvalError, MirScalarExpr, UnaryFunc, func};
+use mz_expr::{BinaryFunc, EvalError, MirScalarExpr, MultiplicityErrorKind, UnaryFunc, func};
 use mz_ore::cast::CastFrom;
 use mz_ore::soft_assert_or_log;
 use mz_repr::{Datum, DatumVec, Diff, ReprScalarType, Row, SharedRow};
@@ -148,12 +148,16 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
                     // It should be now possible to ensure that we have a monotonic collection.
                     let error_logger = self.error_logger();
                     let (collection, errs) = collection.ensure_monotonic(move |data, diff| {
-                        error_logger.log(
-                            "Non-monotonic input to MonotonicTopK",
-                            &format!("data={data:?}, diff={diff}"),
-                        );
-                        let m = "tried to build monotonic top-k on non-monotonic input".into();
-                        (DataflowErrorSer::from(EvalError::Internal(m)), Diff::ONE)
+                        let err = mz_expr::MultiplicityError {
+                            kind: MultiplicityErrorKind::NonMonotonicInput,
+                            code_place: "MonotonicTopK".into(),
+                            detail: format!("data={data:?}, diff={diff}").into(),
+                        };
+                        error_logger.log_multiplicity_error(&err);
+                        (
+                            DataflowErrorSer::from(EvalError::MultiplicityError(err)),
+                            Diff::ONE,
+                        )
                     });
                     err_collection = err_collection.concat(errs);
 
@@ -420,9 +424,13 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
                         let mut hk_iter = hk.iter();
                         let h = hk_iter.next().unwrap().unwrap_uint64();
                         let k = SharedRow::pack(hk_iter);
-                        let message = "Negative multiplicities in TopK";
-                        error_logger.log(message, &format!("k={k:?}, h={h}, v={v:?}"));
-                        Err(EvalError::Internal(message.into()).into())
+                        let err = mz_expr::MultiplicityError {
+                            kind: MultiplicityErrorKind::Negative,
+                            code_place: "TopK".into(),
+                            detail: format!("k={k:?}, h={h}, v={v:?}").into(),
+                        };
+                        error_logger.log_multiplicity_error(&err);
+                        Err(EvalError::MultiplicityError(err).into())
                     }
                     Ok(t) => Ok((hk, t)),
                 },
@@ -477,12 +485,13 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
         // It should be now possible to ensure that we have a monotonic collection and process it.
         let error_logger = self.error_logger();
         let (partial, errs) = collection.ensure_monotonic(move |data, diff| {
-            error_logger.log(
-                "Non-monotonic input to MonotonicTop1",
-                &format!("data={data:?}, diff={diff}"),
-            );
-            let m = "tried to build monotonic top-1 on non-monotonic input".into();
-            (EvalError::Internal(m).into(), Diff::ONE)
+            let err = mz_expr::MultiplicityError {
+                kind: MultiplicityErrorKind::NonMonotonicInput,
+                code_place: "MonotonicTop1".into(),
+                detail: format!("data={data:?}, diff={diff}").into(),
+            };
+            error_logger.log_multiplicity_error(&err);
+            (EvalError::MultiplicityError(err).into(), Diff::ONE)
         });
         let partial: KeyCollection<_, _, _> = partial
             .explode_one(move |(group_key, row)| {

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -48,7 +48,8 @@ pub use relation::{
 };
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{
-    EvalError, FilterCharacteristics, MirScalarExpr, ProtoDomainLimit, ProtoEvalError, like_pattern,
+    EvalError, FilterCharacteristics, MULTIPLICITY_ERROR_TITLE, MirScalarExpr, MultiplicityError,
+    MultiplicityErrorKind, ProtoDomainLimit, ProtoEvalError, like_pattern, log_multiplicity_error,
 };
 
 /// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3594,7 +3594,11 @@ impl TableFunc {
                 } else if count > 1 {
                     Err(EvalError::MultipleRowsFromSubquery)
                 } else if count < 0 {
-                    Err(EvalError::NegativeRowsFromSubquery)
+                    Err(EvalError::MultiplicityError(crate::MultiplicityError {
+                        kind: crate::MultiplicityErrorKind::Negative,
+                        code_place: "scalar subquery".into(),
+                        detail: format!("count={count}").into(),
+                    }))
                 } else {
                     // This shouldn't happen because this is not an SQL `count` but an MIR `count`,
                     // which produces no output on 0 input rows.

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -81,6 +81,18 @@ message ProtoEvalError {
     string a = 2;
     string b = 3;
   }
+  message ProtoMultiplicityError {
+    ProtoMultiplicityErrorKind kind = 1;
+    string code_place = 2;
+    string detail = 3;
+  }
+  enum ProtoMultiplicityErrorKind {
+    MULTIPLICITY_ERROR_KIND_UNSPECIFIED = 0;
+    MULTIPLICITY_ERROR_KIND_NEGATIVE = 1;
+    MULTIPLICITY_ERROR_KIND_NON_POSITIVE = 2;
+    MULTIPLICITY_ERROR_KIND_NON_MONOTONIC_INPUT = 3;
+    MULTIPLICITY_ERROR_KIND_INCONSISTENT_ACCUMULATOR = 4;
+  }
   oneof kind {
     int32 character_not_valid_for_encoding = 1;
     int32 character_too_large_for_encoding = 2;
@@ -164,6 +176,12 @@ message ProtoEvalError {
     google.protobuf.Empty key_cannot_be_null = 80;
     string invalid_catalog_json = 81;
     string redact_error = 82;
+    // Kept solely for read-compat with persisted errors written before
+    // MultiplicityError was introduced. The corresponding Rust variant has
+    // been folded into MultiplicityError; on deserialization we map this
+    // onto MultiplicityError { Negative, "scalar subquery", "" }. We never
+    // emit this variant.
     google.protobuf.Empty negative_rows_from_subquery = 83;
+    ProtoMultiplicityError multiplicity_error = 84;
   }
 }

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -2687,7 +2687,7 @@ pub enum EvalError {
     OutOfDomain(DomainLimit, DomainLimit, Box<str>),
     ComplexOutOfRange(Box<str>),
     MultipleRowsFromSubquery,
-    NegativeRowsFromSubquery,
+    MultiplicityError(MultiplicityError),
     Undefined(Box<str>),
     LikePatternTooLong,
     LikeEscapeTooLong,
@@ -2873,9 +2873,7 @@ impl fmt::Display for EvalError {
             EvalError::MultipleRowsFromSubquery => {
                 write!(f, "more than one record produced in subquery")
             }
-            EvalError::NegativeRowsFromSubquery => {
-                write!(f, "negative number of rows produced in subquery")
-            }
+            EvalError::MultiplicityError(err) => err.fmt(f),
             EvalError::Undefined(s) => {
                 write!(f, "{} is undefined", s)
             }
@@ -3039,6 +3037,115 @@ impl From<InvalidRangeError> for EvalError {
     }
 }
 
+/// An error indicating that a dataflow operator (or a peek result, or ...)
+/// observed a record multiplicity that is incompatible with the operator
+/// evaluating it. Typically caused by a Materialize source containing
+/// invalid data, or by incorrect usage of the `repeat_row` table function.
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect
+)]
+pub struct MultiplicityError {
+    pub kind: MultiplicityErrorKind,
+    /// Short identifier for where the error was detected, e.g. "DistinctBy",
+    /// "ReduceMinsMaxes", "index peek", "persist peek", "S3 oneshot sink",
+    /// "constant result", "scalar subquery".
+    pub code_place: Box<str>,
+    /// Optional per-site diagnostic (key, value, count, accumulator, …).
+    /// Rendered after `". Details: "` when non-empty.
+    pub detail: Box<str>,
+}
+
+/// Describes why a [`MultiplicityError`] was raised.
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect
+)]
+pub enum MultiplicityErrorKind {
+    /// Saw a record with multiplicity < 0 where only non-negative was allowed.
+    Negative,
+    /// Saw a record with multiplicity <= 0 where only positive was allowed.
+    NonPositive,
+    /// Input to a monotonic operator contained a retraction.
+    NonMonotonicInput,
+    /// The running accumulator is inconsistent with the record count
+    /// (net-zero rows with non-zero sum, or unsigned sum went negative).
+    InconsistentAccumulator,
+}
+
+impl fmt::Display for MultiplicityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let problem = match self.kind {
+            MultiplicityErrorKind::Negative => "negative record multiplicity",
+            MultiplicityErrorKind::NonPositive => "non-positive record multiplicity",
+            MultiplicityErrorKind::NonMonotonicInput => "non-monotonic input",
+            MultiplicityErrorKind::InconsistentAccumulator => "inconsistent aggregate state",
+        };
+        write!(
+            f,
+            "{problem} in {code_place}; this usually indicates that a \
+             Materialize source contains invalid data (for example, \
+             retractions for rows that were never inserted). This can be \
+             caused either by a bug or misconfiguration in the external \
+             system feeding the source, or by a bug in Materialize. It \
+             can also occur due to incorrect usage of the repeat_row \
+             table function.",
+            code_place = self.code_place,
+        )?;
+        if !self.detail.is_empty() {
+            write!(f, " Details: {}", self.detail)?;
+        }
+        Ok(())
+    }
+}
+
+/// Shared static title for every [`MultiplicityError`], so all occurrences
+/// merge into a single Sentry group regardless of kind or site.
+pub const MULTIPLICITY_ERROR_TITLE: &str = "invalid record multiplicity";
+
+/// Log a [`MultiplicityError`] using the standard "static title + [customer-data]
+/// tagged details" contract, without needing an `ErrorLogger` instance.
+///
+/// Use this from call sites that don't have an `ErrorLogger` in scope (peek
+/// paths, S3 oneshot sink, constant-result fast path in the coordinator).
+/// Compute dataflow rendering code that has an `ErrorLogger` in scope should
+/// prefer `ErrorLogger::log_multiplicity_error`, which additionally attaches
+/// the dataflow name as a structured field.
+///
+/// `kind` and `code_place` are emitted as structured tracing fields.
+/// `detail` is emitted in the `[customer-data]`-tagged message body.
+pub fn log_multiplicity_error(err: &MultiplicityError) {
+    tracing::warn!(
+        kind = ?err.kind,
+        code_place = %err.code_place,
+        "[customer-data] {}: {}",
+        MULTIPLICITY_ERROR_TITLE,
+        err.detail,
+    );
+    // Note: simply `tracing::error!(MULTIPLICITY_ERROR_TITLE);` wouldn't work well, because it
+    // would surprisingly print as `MULTIPLICITY_ERROR_TITLE="invalid record multiplicity"`.
+    tracing::error!("{}", MULTIPLICITY_ERROR_TITLE);
+}
+
 impl RustType<ProtoEvalError> for EvalError {
     fn into_proto(&self) -> ProtoEvalError {
         use proto_eval_error::Kind::*;
@@ -3156,7 +3263,14 @@ impl RustType<ProtoEvalError> for EvalError {
             }),
             EvalError::ComplexOutOfRange(v) => ComplexOutOfRange(v.into_proto()),
             EvalError::MultipleRowsFromSubquery => MultipleRowsFromSubquery(()),
-            EvalError::NegativeRowsFromSubquery => NegativeRowsFromSubquery(()),
+            EvalError::MultiplicityError(err) => {
+                let kind: ProtoMultiplicityErrorKind = err.kind.into();
+                MultiplicityError(ProtoMultiplicityError {
+                    kind: i32::from(kind),
+                    code_place: err.code_place.clone().into(),
+                    detail: err.detail.clone().into(),
+                })
+            }
             EvalError::Undefined(v) => Undefined(v.into_proto()),
             EvalError::LikePatternTooLong => LikePatternTooLong(()),
             EvalError::LikeEscapeTooLong => LikeEscapeTooLong(()),
@@ -3291,7 +3405,31 @@ impl RustType<ProtoEvalError> for EvalError {
                 )),
                 ComplexOutOfRange(v) => Ok(EvalError::ComplexOutOfRange(v.into())),
                 MultipleRowsFromSubquery(()) => Ok(EvalError::MultipleRowsFromSubquery),
-                NegativeRowsFromSubquery(()) => Ok(EvalError::NegativeRowsFromSubquery),
+                // Read-compat: `EvalError::NegativeRowsFromSubquery` was
+                // removed in favor of `MultiplicityError`. Persisted error
+                // collections written before that change may still contain
+                // this variant. Map it onto the equivalent `MultiplicityError`.
+                // We never write this variant from `into_proto`.
+                NegativeRowsFromSubquery(()) => {
+                    Ok(EvalError::MultiplicityError(super::MultiplicityError {
+                        kind: super::MultiplicityErrorKind::Negative,
+                        code_place: "scalar subquery".into(),
+                        detail: "".into(),
+                    }))
+                }
+                MultiplicityError(v) => {
+                    let kind = proto_eval_error::ProtoMultiplicityErrorKind::try_from(v.kind)
+                        .map_err(|_| {
+                            TryFromProtoError::UnknownEnumVariant(
+                                "ProtoMultiplicityErrorKind".into(),
+                            )
+                        })?;
+                    Ok(EvalError::MultiplicityError(super::MultiplicityError {
+                        kind: kind.try_into()?,
+                        code_place: v.code_place.into(),
+                        detail: v.detail.into(),
+                    }))
+                }
                 Undefined(v) => Ok(EvalError::Undefined(v.into())),
                 LikePatternTooLong(()) => Ok(EvalError::LikePatternTooLong),
                 LikeEscapeTooLong(()) => Ok(EvalError::LikeEscapeTooLong),
@@ -3335,6 +3473,43 @@ impl RustType<ProtoEvalError> for EvalError {
                 RedactError(s) => Ok(EvalError::RedactError(s.into())),
             },
             None => Err(TryFromProtoError::missing_field("ProtoEvalError::kind")),
+        }
+    }
+}
+
+impl From<MultiplicityErrorKind> for proto_eval_error::ProtoMultiplicityErrorKind {
+    fn from(kind: MultiplicityErrorKind) -> Self {
+        use proto_eval_error::ProtoMultiplicityErrorKind as P;
+        match kind {
+            MultiplicityErrorKind::Negative => P::MultiplicityErrorKindNegative,
+            MultiplicityErrorKind::NonPositive => P::MultiplicityErrorKindNonPositive,
+            MultiplicityErrorKind::NonMonotonicInput => P::MultiplicityErrorKindNonMonotonicInput,
+            MultiplicityErrorKind::InconsistentAccumulator => {
+                P::MultiplicityErrorKindInconsistentAccumulator
+            }
+        }
+    }
+}
+
+impl TryFrom<proto_eval_error::ProtoMultiplicityErrorKind> for MultiplicityErrorKind {
+    type Error = TryFromProtoError;
+
+    fn try_from(
+        kind: proto_eval_error::ProtoMultiplicityErrorKind,
+    ) -> Result<Self, TryFromProtoError> {
+        use proto_eval_error::ProtoMultiplicityErrorKind as P;
+        match kind {
+            P::MultiplicityErrorKindUnspecified => Err(TryFromProtoError::UnknownEnumVariant(
+                "ProtoMultiplicityErrorKind::Unspecified".into(),
+            )),
+            P::MultiplicityErrorKindNegative => Ok(MultiplicityErrorKind::Negative),
+            P::MultiplicityErrorKindNonPositive => Ok(MultiplicityErrorKind::NonPositive),
+            P::MultiplicityErrorKindNonMonotonicInput => {
+                Ok(MultiplicityErrorKind::NonMonotonicInput)
+            }
+            P::MultiplicityErrorKindInconsistentAccumulator => {
+                Ok(MultiplicityErrorKind::InconsistentAccumulator)
+            }
         }
     }
 }

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -18,6 +18,7 @@ use anyhow::anyhow;
 use aws_types::sdk_config::SdkConfig;
 use differential_dataflow::Hashable;
 use futures::StreamExt;
+use mz_expr::MultiplicityErrorKind;
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
@@ -380,16 +381,14 @@ where
                             let batch = row.hashed() % output_batch_count;
                             if !up_to.less_equal(ts) {
                                 if diff.is_negative() {
-                                    tracing::error!(
-                                        %sink_id, %diff, ?row,
-                                        "S3 oneshot sink encountered negative multiplicities",
-                                    );
-                                    anyhow::bail!(
-                                        "Invalid data in source, \
-                                         saw retractions ({}) for row that does not exist: {:?}",
-                                        -*diff,
-                                        row,
-                                    )
+                                    let err = mz_expr::MultiplicityError {
+                                        kind: MultiplicityErrorKind::Negative,
+                                        code_place: "S3 oneshot sink".into(),
+                                        detail: format!("sink={sink_id}, diff={diff}, row={row:?}")
+                                            .into(),
+                                    };
+                                    mz_expr::log_multiplicity_error(&err);
+                                    anyhow::bail!("{}", err);
                                 }
                                 row_count += u64::try_from(diff.into_inner()).unwrap();
                                 let uploader = match s3_uploaders.entry(batch) {

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -652,7 +652,6 @@ mod columnation {
                         | e @ EvalError::KeyCannotBeNull
                         | e @ EvalError::UnterminatedLikeEscapeSequence
                         | e @ EvalError::MultipleRowsFromSubquery
-                        | e @ EvalError::NegativeRowsFromSubquery
                         | e @ EvalError::LikePatternTooLong
                         | e @ EvalError::LikeEscapeTooLong
                         | e @ EvalError::MultidimensionalArrayRemovalNotSupported
@@ -873,6 +872,13 @@ mod columnation {
                         }
                         EvalError::RedactError(x) => {
                             EvalError::RedactError(self.string_region.copy(x))
+                        }
+                        EvalError::MultiplicityError(err) => {
+                            EvalError::MultiplicityError(mz_expr::MultiplicityError {
+                                kind: err.kind,
+                                code_place: self.string_region.copy(&err.code_place),
+                                detail: self.string_region.copy(&err.detail),
+                            })
                         }
                     };
                     let reference = self.eval_error_region.copy_iter(once(err));

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -207,7 +207,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     assert len(e.errors) > 0, "Exception contains no errors"
                     for error in e.errors:
                         # TODO(def-): Remove when database-issues#6825 is fixed
-                        if "Non-positive multiplicity in DistinctBy" in error.message:
+                        if (
+                            "non-positive record multiplicity in DistinctBy"
+                            in error.message
+                        ):
                             continue
                         if is_connection_error(error.message):
                             now = datetime.datetime.now(
@@ -226,7 +229,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 except CommandFailureCausedUIError as e:
                     msg = (e.stdout or "") + (e.stderr or "")
                     # TODO(def-): Remove when database-issues#6825 is fixed
-                    if "Non-positive multiplicity in DistinctBy" in msg:
+                    if "non-positive record multiplicity in DistinctBy" in msg:
                         continue
                     if is_connection_error(msg):
                         now = datetime.datetime.now(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -668,12 +668,12 @@ def workflow_test_github_4433(c: Composition) -> None:
 
             # Run a query that would generate a panic before the fix.
             ! SELECT * FROM sum_and_max;
-            contains:Non-positive accumulation in ReduceMinsMaxes
+            contains:non-positive record multiplicity in ReduceMinsMaxes
             """))
 
         # ensure that an error was put into the logs
         c1 = c.invoke("logs", "clusterd1", capture=True)
-        assert "Non-positive accumulation in ReduceMinsMaxes" in c1.stdout
+        assert "invalid record multiplicity" in c1.stdout
 
 
 def workflow_test_github_4966(c: Composition) -> None:
@@ -727,7 +727,7 @@ def workflow_test_github_4966(c: Composition) -> None:
             # The query below would not fail previously, but now should produce
             # a SQL-level error that is observable by users.
             ! SELECT SUM(data) FROM data;
-            contains:Invalid data in source, saw net-zero records for key
+            contains:inconsistent aggregate state in ReduceAccumulable
 
             # It should be possible to fix the data in the source and make the error
             # go away.
@@ -739,10 +739,7 @@ def workflow_test_github_4966(c: Composition) -> None:
 
         # ensure that an error was put into the logs
         c1 = c.invoke("logs", "clusterd1", capture=True)
-        assert (
-            "Net-zero records with non-zero accumulation in ReduceAccumulable"
-            in c1.stdout
-        )
+        assert "invalid record multiplicity" in c1.stdout
 
 
 def workflow_test_github_5087(c: Composition) -> None:
@@ -810,10 +807,9 @@ def workflow_test_github_5087(c: Composition) -> None:
 
             # Run a queries that would generate panics before the fix.
             ! SELECT SUM(data2) FROM data;
-            contains:Invalid data in source, saw negative accumulation with unsigned type for key
-
+            contains:inconsistent aggregate state in ReduceAccumulable
             ! SELECT SUM(data4) FROM data;
-            contains:Invalid data in source, saw negative accumulation with unsigned type for key
+            contains:inconsistent aggregate state in ReduceAccumulable
 
             ! SELECT * FROM constant_sums;
             contains:constant folding encountered reduce on collection with non-positive multiplicities
@@ -822,7 +818,7 @@ def workflow_test_github_5087(c: Composition) -> None:
             # is now rectified, i.e., instead of wrapping to a negative number, we produce
             # an error upon seeing invalid multiplicities.
             ! SELECT SUM(data8) FROM data;
-            contains:Invalid data in source, saw negative accumulation with unsigned type for key
+            contains:inconsistent aggregate state in ReduceAccumulable
 
             # Test repairs
             > INSERT INTO base VALUES (1, 1, 1, 1), (1, 1, 1, 1);
@@ -886,7 +882,7 @@ def workflow_test_github_5087(c: Composition) -> None:
 
         # ensure that an error was put into the logs
         c1 = c.invoke("logs", "clusterd1", capture=True)
-        assert "Invalid negative unsigned aggregation in ReduceAccumulable" in c1.stdout
+        assert "invalid record multiplicity" in c1.stdout
 
 
 def workflow_test_github_5086(c: Composition) -> None:
@@ -954,10 +950,9 @@ def workflow_test_github_5086(c: Composition) -> None:
 
             # The query below would return a null previously, but now fails cleanly.
             ! SELECT * FROM max_data;
-            contains:Invalid data in source, saw non-positive accumulation for key
-
+            contains:non-positive record multiplicity in hierarchical mins-maxes aggregate
             ! SELECT * FROM max_group_by_data;
-            contains:Invalid data in source, saw non-positive accumulation for key
+            contains:non-positive record multiplicity in hierarchical mins-maxes aggregate
 
             # Repairing the error must be possible.
             > INSERT INTO base VALUES (1, 2), (2, 1);
@@ -972,7 +967,9 @@ def workflow_test_github_5086(c: Composition) -> None:
 
         # ensure that an error was put into the logs
         c1 = c.invoke("logs", "clusterd1", capture=True)
-        assert "Non-positive accumulation in MinsMaxesHierarchical" in c1.stdout
+        assert "invalid record multiplicity" in c1.stdout
+        # The old ERROR-level Sentry titles no longer appear; keep the negative assertion
+        # for the former `ReduceMinsMaxes` title to guard against regressions.
         assert "Negative accumulation in ReduceMinsMaxes" not in c1.stdout
 
 

--- a/test/pg-cdc-old-syntax/publication-with-publish-option.td
+++ b/test/pg-cdc-old-syntax/publication-with-publish-option.td
@@ -70,8 +70,14 @@ DELETE FROM t1;
 > SELECT * FROM t1_insert;
 1
 
-! SELECT * FROM t1_update;
-contains:Invalid data in source, saw retractions (1) for row that does not exist
+![version<2602300] SELECT * FROM t1_update;
+contains:Invalid data in source, saw retractions
 
-! SELECT * FROM t1_delete;
-contains:Invalid data in source, saw retractions (1) for row that does not exist
+![version>=2602300] SELECT * FROM t1_update;
+contains:negative record multiplicity
+
+![version<2602300] SELECT * FROM t1_delete;
+contains:Invalid data in source, saw retractions
+
+![version>=2602300] SELECT * FROM t1_delete;
+contains:negative record multiplicity

--- a/test/pg-cdc/publication-with-publish-option.td
+++ b/test/pg-cdc/publication-with-publish-option.td
@@ -76,8 +76,14 @@ DELETE FROM t1;
 > SELECT * FROM t1_insert;
 1
 
-! SELECT * FROM t1_update;
-contains:Invalid data in source, saw retractions (1) for row that does not exist
+![version<2602300] SELECT * FROM t1_update;
+contains:Invalid data in source, saw retractions
 
-! SELECT * FROM t1_delete;
-contains:Invalid data in source, saw retractions (1) for row that does not exist
+![version>=2602300] SELECT * FROM t1_update;
+contains:negative record multiplicity
+
+![version<2602300] SELECT * FROM t1_delete;
+contains:Invalid data in source, saw retractions
+
+![version>=2602300] SELECT * FROM t1_delete;
+contains:negative record multiplicity

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -521,7 +521,7 @@ query I
 SELECT 5 FROM repeat_row_non_negative(null);
 ----
 
-statement error  Negative multiplicity in constant result: -1
+statement error  negative record multiplicity in constant result
 SELECT * FROM (values ('a')), repeat_row(-1)
 
 statement error constant folding encountered reduce on collection with non-positive multiplicities

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -23,7 +23,7 @@ ALTER SYSTEM SET enable_repeat_row  = true
 -1
 
 ! SELECT * FROM data
-contains:Invalid data in source, saw retractions (1) for row that does not exist: [Int64
+contains:negative record multiplicity in index peek
 
 > INSERT INTO base VALUES (1, 1, -1)
 
@@ -31,7 +31,7 @@ contains:Invalid data in source, saw retractions (1) for row that does not exist
 -2
 
 ! SELECT * FROM data
-contains:Invalid data in source, saw retractions (2) for row that does not exist: [Int64
+contains:negative record multiplicity in index peek
 
 # regression scenario per database-issues#5246, with non-monotonic rendering
 > CREATE VIEW topk AS
@@ -44,19 +44,19 @@ contains:Invalid data in source, saw retractions (2) for row that does not exist
 > CREATE DEFAULT INDEX ON topk;
 
 ! SELECT * from topk;
-contains:Negative multiplicities in TopK
+contains:negative record multiplicity in TopK
 
 # regression scenario per database-issues#5224
 ! SELECT DISTINCT data FROM data;
-contains:Non-positive multiplicity in DistinctBy
+contains:non-positive record multiplicity in DistinctBy
 
 # regression scenario per database-issues#5359
 ! SELECT list_agg(DISTINCT data)[1] FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable DISTINCT
+contains:non-positive record multiplicity in ReduceInaccumulable DISTINCT
 
 # regression scenario per database-issues#5360
 ! SELECT list_agg(data)[1] FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable
+contains:non-positive record multiplicity in ReduceInaccumulable
 
 # regression scenario per database-issues#5086, with non-monotonic rendering
 > CREATE VIEW max_data AS
@@ -65,7 +65,7 @@ contains:Non-positive accumulation in ReduceInaccumulable
 > CREATE DEFAULT INDEX ON max_data;
 
 ! SELECT * FROM max_data;
-contains:Invalid data in source, saw non-positive accumulation
+contains:non-positive record multiplicity in hierarchical mins-maxes aggregate
 
 # verify that some reduction in a collation plan catches a negative
 # multiplicity.
@@ -84,8 +84,7 @@ contains:Invalid data in source, saw non-positive accumulation
 > CREATE DEFAULT INDEX ON collation;
 
 ! SELECT * FROM collation;
-# Case-insensitive match for both 'Non' and 'non'
-contains:on-positive accumulation
+contains:non-positive record multiplicity
 
 # Window aggregations
 # These are currently commented out, because window functions currently don't check their inputs for negative


### PR DESCRIPTION
Resolves [SQL-165](https://linear.app/materializeinc/issue/SQL-165).

We have tons of places in the code where we emit errors for negative accumulations (or similar conditions), but they were quite inconsistent, and also need updating as part of productionizing `repeat_row`. (But we wanted to do this even before `repeat_row` came up: https://github.com/MaterializeInc/database-issues/issues/9526) This PR achieves several things:
- Adjusts the base message (see `Display for MultiplicityError`):
  - Don't start with "internal error:". (Even before `repeat_row`, this was not always the case: sometimes it was a bug/misconfiguration in an external system.)
  - Clarifies "Invalid data in source": either a bug or misconfiguration in the external system feeding the source, or a bug in Materialize.
  - Adds a mention of `repeat_row` being a possible cause.
- Centralizes these errors into a new structured error: `EvalError::MultiplicityError`, so that it will be easier to
  - have an overview of such errors, search for all places that emit them, etc.
  - emit them in a consistent way
  - adjust the wording of the error message for all sites
- Makes Sentry error titles the same (`invalid record multiplicity`), so that Sentry will group them into one issue.
- Fixes various inconsistencies:
  - Some sites didn't do the `warn!` + `error!` double logging dance (which now `log_multiplicity_error` does).
  - Not all sites were mentioning sources.
  - One site used `EvalError::InvalidParameterValue`, which didn't really make sense.

See commit msg for more details.

@MaterializeInc/sources-sinks, could you please check that what the new error message (see `Display for MultiplicityError`) says about sources is accurate?

```
"{problem} in {code_place}; this usually indicates that a \
Materialize source contains invalid data (for example, \
retractions for rows that were never inserted). This can be \
caused either by a bug or misconfiguration in the external \
system feeding the source, or by a bug in Materialize. It \
can also occur due to incorrect usage of the repeat_row \
table function.",
```

@materializekatrina, could you please check this from an alerting point of view? Log lines will now look like the following. Every occurrence will have the string `invalid record multiplicity`. Is this nicely alertable, or should I adjust something on this?
```
cluster-u1-replica-u1-gen-0: 2026-04-26T17:05:54.254080Z  WARN timely{name="compute" worker_id=0}: mz_expr::scalar: [customer-data] invalid record multiplicity: target=t38, diff=-2, row=[Int64(1), UInt32(1)] kind=Negative code_place=index peek
cluster-u1-replica-u1-gen-0: 2026-04-26T17:05:54.254118Z ERROR timely{name="compute" worker_id=0}: mz_expr::scalar: invalid record multiplicity
```

Nightly: https://buildkite.com/materialize/nightly/builds/16212