### PR TITLE
mcp: restore indexed views as data products

### DIFF
--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -542,10 +542,12 @@ each materialized view with a refresh strategy other than `on-commit`.
 
 ## `mz_mcp_data_products`
 
-The `mz_mcp_data_products` view lists data products (materialized views)
-that are available through the Model Context Protocol (MCP) server and
-that the current user has SELECT access on. Indexes and comments are optional
-enrichment. This is a lightweight discovery view. Use
+The `mz_mcp_data_products` view lists data products (materialized views
+and indexed views) that are available through the Model Context Protocol
+(MCP) server and that the current user has SELECT access on. Non-indexed
+regular views are excluded to avoid triggering a full recompute when an
+agent queries the data product. Comments are optional enrichment. This
+is a lightweight discovery view. Use
 [`mz_mcp_data_product_details`](#mz_mcp_data_product_details) for full column
 schema information.
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -11676,9 +11676,10 @@ FROM
 
 /// Lightweight data product discovery for MCP (Model Context Protocol).
 ///
-/// Lists materialized views that the current user has SELECT privileges on.
-/// Indexes and comments are optional enrichment — any MV accessible via RBAC
-/// appears as a data product.
+/// Lists materialized views and indexed views that the current user has
+/// SELECT privileges on. Non-indexed regular views are excluded because
+/// querying them would trigger a full recompute. Comments are optional
+/// enrichment.
 /// Used by the `get_data_products` and `read_data_product` MCP tools.
 /// Does not include schema details: use `mz_mcp_data_product_details` for that.
 pub static MZ_MCP_DATA_PRODUCTS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {
@@ -11720,7 +11721,7 @@ LEFT JOIN mz_clusters c_obj ON c_obj.id = o.cluster_id
 LEFT JOIN mz_internal.mz_comments cts_idx ON cts_idx.id = i.id AND cts_idx.object_sub_id IS NULL
 LEFT JOIN mz_internal.mz_comments cts_obj ON cts_obj.id = o.id AND cts_obj.object_sub_id IS NULL
 WHERE op.privilege_type = 'SELECT'
-  AND o.type = 'materialized-view'
+  AND (o.type = 'materialized-view' OR (o.type = 'view' AND i.id IS NOT NULL))
   AND s.name NOT IN ('mz_catalog', 'mz_internal', 'pg_catalog', 'information_schema', 'mz_introspection')
 "#,
     access: vec![PUBLIC_SELECT],
@@ -11730,8 +11731,10 @@ WHERE op.privilege_type = 'SELECT'
 ///
 /// Extends `mz_mcp_data_products` with column types, index keys (when
 /// available), and column comments, formatted as a JSON Schema object.
-/// Used by the `get_data_product_details` MCP tool. Indexes and comments
-/// are optional enrichment.
+/// Used by the `get_data_product_details` MCP tool. Lists materialized
+/// views and indexed views; non-indexed regular views are excluded to
+/// avoid triggering full recompute on query. Comments are optional
+/// enrichment.
 pub static MZ_MCP_DATA_PRODUCT_DETAILS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {
     name: "mz_mcp_data_product_details",
     schema: MZ_INTERNAL_SCHEMA,
@@ -11835,7 +11838,7 @@ LEFT JOIN mz_internal.mz_comments cts_idx ON cts_idx.id = i.id AND cts_idx.objec
 LEFT JOIN mz_internal.mz_comments cts_obj ON cts_obj.id = o.id AND cts_obj.object_sub_id IS NULL
 LEFT JOIN mz_internal.mz_comments cts_col ON cts_col.id = o.id AND cts_col.object_sub_id = ccol.position
 WHERE op.privilege_type = 'SELECT'
-  AND o.type = 'materialized-view'
+  AND (o.type = 'materialized-view' OR (o.type = 'view' AND i.id IS NOT NULL))
   AND s.name NOT IN ('mz_catalog', 'mz_internal', 'pg_catalog', 'information_schema', 'mz_introspection')
 GROUP BY 1, 2, 3
 )

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5318,6 +5318,53 @@ fn test_mcp_agent_with_data_product() {
                 &HTTP_DEFAULT_USER.name
             ))
             .unwrap();
+
+        // Indexed regular view: cheap to query via the in-memory arrangement,
+        // should appear as a data product.
+        super_user
+            .batch_execute(
+                "CREATE VIEW test_indexed_view AS SELECT 2::int AS id, 'gadget'::text AS name",
+            )
+            .unwrap();
+        super_user
+            .batch_execute(
+                "CREATE INDEX test_indexed_view_idx IN CLUSTER quickstart ON test_indexed_view (id)",
+            )
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT SELECT ON test_indexed_view TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+
+        // Non-indexed regular view: would trigger full recompute on query,
+        // must NOT appear as a data product.
+        super_user
+            .batch_execute(
+                "CREATE VIEW test_unindexed_view AS SELECT 3::int AS id, 'sprocket'::text AS name",
+            )
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT SELECT ON test_unindexed_view TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+
+        // Materialized view without an explicit index: bounded query cost
+        // (Persist-backed), should appear as a data product.
+        super_user
+            .batch_execute(
+                "CREATE MATERIALIZED VIEW test_unindexed_mv IN CLUSTER quickstart AS SELECT 4::int AS id, 'bolt'::text AS name",
+            )
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT SELECT ON test_unindexed_mv TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
     }
 
     // get_data_products should now return our data product.
@@ -5336,9 +5383,32 @@ fn test_mcp_agent_with_data_product() {
     assert_eq!(status, StatusCode::OK);
     let result_text = body["result"]["content"][0]["text"].as_str().unwrap();
     let products: serde_json::Value = serde_json::from_str(result_text).unwrap();
+    let has_object = |needle: &str| {
+        products.as_array().unwrap().iter().any(|p| {
+            p.as_array()
+                .map(|arr| arr[0].as_str().unwrap_or("").contains(needle))
+                .unwrap_or(false)
+        })
+    };
+    // Indexed MV: appears.
     assert!(
-        products.as_array().unwrap().len() >= 1,
-        "expected at least one data product"
+        has_object("test_products"),
+        "indexed MV should appear as a data product"
+    );
+    // Indexed regular view: appears (in-memory arrangement is cheap to query).
+    assert!(
+        has_object("test_indexed_view"),
+        "indexed view should appear as a data product"
+    );
+    // Non-indexed MV: appears (Persist-backed, bounded query cost).
+    assert!(
+        has_object("test_unindexed_mv"),
+        "non-indexed materialized view should appear as a data product"
+    );
+    // Non-indexed regular view: excluded (would trigger full recompute).
+    assert!(
+        !has_object("test_unindexed_view"),
+        "non-indexed view must NOT appear as a data product"
     );
     // Find our product
     let product = products

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5320,7 +5320,8 @@ fn test_mcp_agent_with_data_product() {
             .unwrap();
 
         // Indexed regular view: cheap to query via the in-memory arrangement,
-        // should appear as a data product.
+        // should appear as a data product. Comment on the view (not the index)
+        // exercises the object-comment fallback path.
         super_user
             .batch_execute(
                 "CREATE VIEW test_indexed_view AS SELECT 2::int AS id, 'gadget'::text AS name",
@@ -5330,6 +5331,9 @@ fn test_mcp_agent_with_data_product() {
             .batch_execute(
                 "CREATE INDEX test_indexed_view_idx IN CLUSTER quickstart ON test_indexed_view (id)",
             )
+            .unwrap();
+        super_user
+            .batch_execute("COMMENT ON VIEW test_indexed_view IS 'View-level description'")
             .unwrap();
         super_user
             .batch_execute(&format!(
@@ -5353,10 +5357,16 @@ fn test_mcp_agent_with_data_product() {
             .unwrap();
 
         // Materialized view without an explicit index: bounded query cost
-        // (Persist-backed), should appear as a data product.
+        // (Persist-backed), should appear as a data product. Comment on the MV
+        // itself exercises the object-comment fallback path.
         super_user
             .batch_execute(
                 "CREATE MATERIALIZED VIEW test_unindexed_mv IN CLUSTER quickstart AS SELECT 4::int AS id, 'bolt'::text AS name",
+            )
+            .unwrap();
+        super_user
+            .batch_execute(
+                "COMMENT ON MATERIALIZED VIEW test_unindexed_mv IS 'MV-level description'",
             )
             .unwrap();
         super_user
@@ -5410,6 +5420,43 @@ fn test_mcp_agent_with_data_product() {
         !has_object("test_unindexed_view"),
         "non-indexed view must NOT appear as a data product"
     );
+
+    // Description fallback: index comment is preferred, object comment is used
+    // when no index comment exists.
+    let find_product = |needle: &str| -> &serde_json::Value {
+        products
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| {
+                p.as_array()
+                    .map(|arr| arr[0].as_str().unwrap_or("").contains(needle))
+                    .unwrap_or(false)
+            })
+            .unwrap_or_else(|| panic!("{needle} should exist as a data product"))
+    };
+    let description_of = |needle: &str| -> String {
+        find_product(needle).as_array().unwrap()[2]
+            .as_str()
+            .unwrap_or("")
+            .to_string()
+    };
+    assert_eq!(
+        description_of("test_products"),
+        "A test data product for integration testing",
+        "indexed MV with an index comment should use the index comment"
+    );
+    assert_eq!(
+        description_of("test_indexed_view"),
+        "View-level description",
+        "indexed view without an index comment should fall back to the view comment"
+    );
+    assert_eq!(
+        description_of("test_unindexed_mv"),
+        "MV-level description",
+        "non-indexed MV should use its own comment as description"
+    );
+
     // Find our product
     let product = products
         .as_array()
@@ -5444,6 +5491,31 @@ fn test_mcp_agent_with_data_product() {
     assert_eq!(status, StatusCode::OK);
     assert!(body["result"]["content"][0]["text"].as_str().is_some());
     assert!(body["error"].is_null());
+
+    // get_data_product_details should also resolve the indexed view, proving
+    // the filter change is applied consistently to mz_mcp_data_product_details.
+    let indexed_view_name = find_product("test_indexed_view").as_array().unwrap()[0]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (status, body) = mcp_post(
+        &agents_url,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "tools/call",
+            "params": {
+                "name": "get_data_product_details",
+                "arguments": {"name": indexed_view_name}
+            }
+        }),
+    );
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["error"].is_null(),
+        "indexed view should be resolvable via get_data_product_details, got: {body}"
+    );
+    assert!(body["result"]["content"][0]["text"].as_str().is_some());
 
     // read_data_product should return the row from the view.
     let (status, body) = mcp_post(


### PR DESCRIPTION
Follow-up to #36116. That PR narrowed the MCP data product filter to MVs, which dropped indexed views (they were surfaced in v26.20 and v26.21). Indexed views have an in-memory arrangement, so they're cheap to query and should stay as data products.

Non-indexed views are still excluded, since querying them would recompute the view from its sources/tables and hammer the cluster.
