### PR TITLE
adapter: Fix statement_timeout=0 causing immediate timeout in frontend peek

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -15,6 +15,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::FutureExt;
 use futures::future::LocalBoxFuture;
@@ -1078,7 +1079,11 @@ pub(crate) async fn explain_pushdown_future_inner<
     mz_now: ResultSpec<'static>,
     imports: I,
 ) -> impl Future<Output = Result<ExecuteResponse, AdapterError>> + use<I> {
-    let explain_timeout = *session.vars().statement_timeout();
+    let mut explain_timeout = *session.vars().statement_timeout();
+    // Timeout of 0 is equivalent to "off", meaning we will wait "forever."
+    if explain_timeout == Duration::ZERO {
+        explain_timeout = Duration::MAX;
+    }
     let mut futures = FuturesOrdered::new();
     for (id, mfp) in imports {
         let catalog_entry = catalog.get_entry_by_global_id(&id);

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use itertools::Itertools;
 use mz_adapter_types::dyncfgs::ENABLE_FRONTEND_SUBSCRIBES;
@@ -1140,7 +1141,11 @@ impl PeekClient {
             }
         };
 
-        let optimization_timeout = *session.vars().statement_timeout();
+        let mut optimization_timeout = *session.vars().statement_timeout();
+        // Timeout of 0 is equivalent to "off", meaning we will wait "forever."
+        if optimization_timeout == Duration::ZERO {
+            optimization_timeout = Duration::MAX;
+        }
         let optimization_result =
             // Note: spawn_blocking tasks cannot be cancelled, so on timeout we stop waiting but the
             // optimization task continues running in the background until completion. See

--- a/test/sqllogictest/statement_timeout.slt
+++ b/test/sqllogictest/statement_timeout.slt
@@ -7,9 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Only works with the frontend peek sequencing.
+mode cockroach
+
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_frontend_peek_sequencing TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_explain_pushdown = true;
 ----
 COMPLETE 0
 
@@ -18,3 +24,19 @@ SET statement_timeout = '1s';
 
 query error canceling statement due to statement timeout
 SELECT mz_unsafe.mz_sleep(2);
+
+statement ok
+CREATE TABLE t (value int);
+
+statement ok
+SET statement_timeout = 0;
+
+query I
+SELECT count(*) FROM t;
+----
+0
+
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM t WHERE value > 10;
+----
+materialize.public.t  0  0  0  0


### PR DESCRIPTION
PR #34796 wrapped the optimizer call in `tokio::time::timeout(statement_timeout)`, but did not map `Duration::ZERO` to `Duration::MAX`. In PostgreSQL (and the rest of this codebase), `statement_timeout = 0` means "disabled / wait forever." With `Duration::ZERO`, `tokio::time::timeout` fires immediately, so every SELECT and EXPLAIN FILTER PUSHDOWN fails with a spurious StatementTimeout error when `statement_timeout = 0`.

Fix both occurrences (frontend_peek.rs and sequencer.rs) to match the existing pattern in coord/sequencer/inner.rs.