### PR TITLE
Revert "Bump reqwest to 0.13 (#36215)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
  "pin-project",
  "quick-xml 0.31.0",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest",
  "rustc_version",
  "serde",
  "serde_json",
@@ -4340,7 +4340,7 @@ dependencies = [
  "parquet",
  "rand 0.8.5",
  "reqsign",
- "reqwest 0.12.28",
+ "reqwest",
  "roaring",
  "rust_decimal",
  "serde",
@@ -4370,7 +4370,7 @@ dependencies = [
  "http 1.4.0",
  "iceberg",
  "itertools 0.13.0",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4690,12 +4690,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -5088,7 +5086,7 @@ version = "1.4.3"
 source = "git+https://github.com/MaterializeInc/duckdb-rs.git?rev=752c7efe2582#752c7efe25820590f590fb0a112443b9ddd396e7"
 dependencies = [
  "flate2",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tar",
@@ -5515,7 +5513,7 @@ dependencies = [
  "mz-sql-parser",
  "open",
  "openssl-probe",
- "reqwest 0.13.2",
+ "reqwest",
  "rpassword",
  "security-framework",
  "semver",
@@ -5720,7 +5718,7 @@ dependencies = [
  "mz-frontegg-auth",
  "mz-ore",
  "mz-pgwire-common",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio-postgres",
@@ -5831,7 +5829,7 @@ dependencies = [
  "postgres",
  "prometheus",
  "proxy-header",
- "reqwest 0.13.2",
+ "reqwest",
  "semver",
  "tempfile",
  "tokio",
@@ -5995,7 +5993,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "prost-build",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -6012,7 +6010,7 @@ dependencies = [
  "chrono",
  "mz-frontegg-auth",
  "mz-frontegg-client",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -6283,7 +6281,7 @@ dependencies = [
  "mz-tls-util",
  "postgres-openssl",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_yaml",
  "tokio",
@@ -6472,7 +6470,7 @@ dependencies = [
  "rdkafka",
  "rdkafka-sys",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "rlimit",
  "semver",
  "sentry-tracing",
@@ -6636,7 +6634,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -6680,7 +6678,7 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "prometheus",
- "reqwest 0.13.2",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
@@ -6698,7 +6696,7 @@ dependencies = [
  "jsonwebtoken",
  "mz-frontegg-auth",
  "mz-ore",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6722,7 +6720,7 @@ dependencies = [
  "mz-frontegg-auth",
  "mz-ore",
  "openssl",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -6893,7 +6891,7 @@ dependencies = [
 name = "mz-metabase"
 version = "0.0.0"
 dependencies = [
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
 ]
 
@@ -6970,7 +6968,7 @@ dependencies = [
  "flate2",
  "hex",
  "hex-literal",
- "reqwest 0.13.2",
+ "reqwest",
  "sha2",
  "tar",
  "walkdir",
@@ -6986,7 +6984,7 @@ dependencies = [
  "jsonwebtoken",
  "mz-ore",
  "openssl",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -7026,7 +7024,7 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "mz-secrets",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -7112,7 +7110,7 @@ dependencies = [
  "mz-server-core",
  "prometheus",
  "rand 0.9.4",
- "reqwest 0.13.2",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -7251,7 +7249,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.9.4",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -7862,7 +7860,7 @@ dependencies = [
  "protobuf-native",
  "rdkafka",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "static_assertions",
@@ -8002,7 +8000,7 @@ dependencies = [
  "mz-tracing",
  "postgres-protocol",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "serde_json",
  "shell-words",
  "tempfile",
@@ -8241,7 +8239,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "prost",
- "reqwest 0.13.2",
+ "reqwest",
  "sentry",
  "serde",
  "smallvec",
@@ -8314,8 +8312,7 @@ dependencies = [
  "rand 0.9.4",
  "rdkafka",
  "regex",
- "reqwest 0.12.28",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8401,7 +8398,7 @@ dependencies = [
  "rand 0.9.4",
  "rdkafka",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -8910,7 +8907,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -9039,7 +9036,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
@@ -9054,7 +9051,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -10520,7 +10517,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest",
  "rust-ini",
  "serde",
  "serde_json",
@@ -10534,46 +10531,6 @@ name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-tls 0.6.0",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower 0.5.3",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.1",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -10611,30 +10568,30 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.5.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tower-service",
 ]
 
 [[package]]
 name = "reqwest-retry"
-version = "0.9.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+checksum = "105747e3a037fe5bf17458d794de91149e575b6183fc72c85623a44abb9683f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10642,7 +10599,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http 1.4.0",
  "hyper 1.9.0",
- "reqwest 0.13.2",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 2.0.18",
@@ -11055,7 +11012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664"
 dependencies = [
  "async-trait",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -11090,7 +11047,7 @@ checksum = "2f925d575b468e88b079faf590a8dd0c9c99e2ec29e9bab663ceb8b45056312f"
 dependencies = [
  "httpdate",
  "native-tls",
- "reqwest 0.12.28",
+ "reqwest",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -13179,44 +13136,24 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.68"
+name = "wasm-bindgen-backend"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
+ "log",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13224,10 +13161,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.118"
+name = "wasm-bindgen-futures"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
@@ -13237,19 +13209,6 @@ name = "wasm-streams"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -13274,9 +13233,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,15 +443,9 @@ rdkafka = { version = "0.29.0", features = ["cmake-build", "libz-static", "ssl-v
 rdkafka-sys = { version = "4.3.0", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = "1.12.3"
 regex-syntax = "0.8.10"
-# reqwest 0.13 changed defaults: `default-tls` now pulls in rustls
-# (banned) and `query`/`system-proxy` are opt-in. List features
-# explicitly to stay on native-tls.
-reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "charset", "cookies", "http2", "json", "native-tls", "native-tls-vendored", "query", "stream", "system-proxy"] }
-# Satisfies reqsign 0.16's `AwsCredentialLoad` trait, pulled in via our
-# iceberg fork and pinned to reqwest 0.12. Remove once iceberg bumps.
-reqwest_0_12 = { package = "reqwest", version = "0.12", default-features = false }
-reqwest-middleware = { version = "0.5.1", features = ["json"] }
-reqwest-retry = "0.9.1"
+reqwest = { version = "0.12.28", features = ["blocking", "charset", "cookies", "default-tls", "http2", "json", "native-tls-vendored", "stream"] }
+reqwest-middleware = { version = "0.4.2", features = ["json"] }
+reqwest-retry = "0.8.0"
 rlimit = "0.11.0"
 rocksdb = { version = "0.24.0", default-features = false, features = ["lz4", "snappy", "zstd"] }
 ropey = "1.6.1"

--- a/deny.toml
+++ b/deny.toml
@@ -128,8 +128,6 @@ skip = [
     { name = "fallible-iterator", version = "0.3.0" },
     # arrow
     { name = "hashbrown", version = "0.16.1" },
-    # reqwest_0_12 workspace alias; see Cargo.toml.
-    { name = "reqwest", version = "0.12" },
 ]
 
 [[bans.deny]]

--- a/src/persist/src/azure.rs
+++ b/src/persist/src/azure.rs
@@ -11,7 +11,7 @@
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
-use azure_core::{ExponentialRetryOptions, RetryOptions, StatusCode};
+use azure_core::{ExponentialRetryOptions, RetryOptions, StatusCode, TransportOptions};
 use azure_identity::create_default_credential;
 use azure_storage::{CloudLocation, EMULATOR_ACCOUNT, prelude::*};
 use azure_storage_blobs::blob::operations::GetBlobResponse;
@@ -70,11 +70,6 @@ impl AzureBlobConfig {
     ) -> Result<Self, Error> {
         let client = if account == EMULATOR_ACCOUNT {
             info!("Connecting to Azure emulator");
-            // Per-attempt/read/connect-timeout plumbing via `TransportOptions`
-            // was dropped: azure_core 0.21 pins reqwest 0.12 internally, so our
-            // 0.13 client no longer satisfies its `HttpClient` trait. Restored
-            // on the new SDK in the azure_sdk migration PR; `operation_timeout`
-            // still applies via the retry policy.
             ClientBuilder::with_location(
                 CloudLocation::Emulator {
                     address: url.domain().expect("domain for Azure emulator").to_string(),
@@ -82,6 +77,18 @@ impl AzureBlobConfig {
                 },
                 StorageCredentials::emulator(),
             )
+            .transport({
+                // Azure uses reqwest / hyper internally, but we specify a client explicitly to
+                // plumb through our timeouts.
+                TransportOptions::new(Arc::new(
+                    reqwest::ClientBuilder::new()
+                        .timeout(knobs.operation_attempt_timeout())
+                        .read_timeout(knobs.read_timeout())
+                        .connect_timeout(knobs.connect_timeout())
+                        .build()
+                        .expect("valid config for azure HTTP client"),
+                ))
+            })
             .retry(RetryOptions::exponential(
                 ExponentialRetryOptions::default().max_total_elapsed(knobs.operation_timeout()),
             ))

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -61,8 +61,6 @@ prost.workspace = true
 rdkafka.workspace = true
 regex.workspace = true
 reqwest.workspace = true
-# For impls of `iceberg::io::AwsCredentialLoad` (reqsign 0.16); see workspace Cargo.toml.
-reqwest_0_12 = { workspace = true }
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror.workspace = true

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -100,8 +100,7 @@ impl AwsSdkCredentialLoader {
 impl AwsCredentialLoad for AwsSdkCredentialLoader {
     async fn load_credential(
         &self,
-        // reqsign 0.16 trait signature; see `reqwest_0_12` in workspace Cargo.toml.
-        _client: reqwest_0_12::Client,
+        _client: reqwest::Client,
     ) -> anyhow::Result<Option<AwsCredential>> {
         let creds = self
             .provider

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -296,7 +296,7 @@ will_work
 
 > CREATE SOURCE webhook_text_headers_block_list IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT
-  INCLUDE HEADERS (NOT 'accept', NOT 'accept-encoding', NOT 'host')
+  INCLUDE HEADERS (NOT 'accept', NOT 'host')
 
 $ webhook-append name=webhook_text_headers_block_list
 foo
@@ -318,7 +318,7 @@ anotha_one "{x-random=>bar}"
   BODY FORMAT TEXT
   INCLUDE HEADER 'x-timestamp' as event_timestamp
   INCLUDE HEADER 'x-id' as event_id
-  INCLUDE HEADERS (NOT 'accept', NOT 'accept-encoding', NOT 'content-length', NOT 'host', NOT 'x-api-key')
+  INCLUDE HEADERS (NOT 'accept', NOT 'content-length', NOT 'host', NOT 'x-api-key')
   CHECK ( WITH (HEADERS) headers->'x-api-key' = 'abc123' )
 
 $ webhook-append name=webhook_text_filtering_headers x-timestamp=100 x-id=a x-api-key=abc123 content-type=text/example


### PR DESCRIPTION
This reverts commit 6d7c3bb255b947c86d6728ce5d659067c407a59a.

Causing a lot of flakiness in CI: https://buildkite.com/materialize/test/builds/121629 and https://buildkite.com/materialize/test/builds/121626

@jasonhernandez Alternatively you could also fix the test failures, or we could disable them.