### PR TITLE
persist: replace FuturesUnordered with join_all in compare_and_append

### DIFF
--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -16,8 +16,7 @@ use std::sync::Arc;
 use differential_dataflow::difference::Monoid;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use futures::StreamExt;
-use futures::stream::FuturesUnordered;
+use futures::future::join_all;
 use mz_dyncfg::Config;
 use mz_ore::task::RuntimeExt;
 use mz_ore::{instrument, soft_panic_or_log};
@@ -805,20 +804,15 @@ where
                     let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id());
                     // We could have a large number of inline parts (imagine the
                     // sharded persist_sink), do this flushing concurrently.
-                    let flush_batches = batches
-                        .iter_mut()
-                        .map(|batch| async {
-                            batch
-                                .flush_to_blob(
-                                    &cfg,
-                                    &self.metrics.inline.backpressure,
-                                    &self.isolated_runtime,
-                                    &self.write_schemas,
-                                )
-                                .await
-                        })
-                        .collect::<FuturesUnordered<_>>();
-                    let () = flush_batches.collect::<()>().await;
+                    join_all(batches.iter_mut().map(|batch| {
+                        batch.flush_to_blob(
+                            &cfg,
+                            &self.metrics.inline.backpressure,
+                            &self.isolated_runtime,
+                            &self.write_schemas,
+                        )
+                    }))
+                    .await;
 
                     for batch in batches.iter() {
                         assert_eq!(batch.batch.inline_bytes(), 0);


### PR DESCRIPTION
Every retry of `compare_and_append_batch` that hits the inline-flush branch builds a fresh `FuturesUnordered` and drains it.
This function runs inside a timely async operator body on clusterd, so each FU re-construction and first-poll yield round-trips through the timely scheduler.

The pushed futures are short CPU plus blob writes with no early-return shortcut, and the caller does not care about completion order.
`join_all` polls every inner future on every outer poll, which avoids the per-poll linked-list traffic and first-poll-yield artefact of `FuturesUnordered`.

Profiling context: on production clusterd over a 1h window, `WriteHandle::compare_and_append_batch::closure#0` accounts for ~0.55% of cumulative time, with the inline-flush FU being the most visible path because inline batches are common under backpressure.