### PR TITLE
storage: replace ColumnationStack source edges with Vec

### DIFF
--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -38,7 +38,7 @@ use timely::progress::{Antichain, Timestamp};
 use tokio::time::{Instant, interval_at};
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
-use crate::source::types::{Probe, SignaledFuture, SourceRender, StackedCollection};
+use crate::source::types::{FuelSize, Probe, SignaledFuture, SourceRender, StackedCollection};
 use crate::source::{RawSourceCreationConfig, SourceMessage};
 
 mod auction;
@@ -389,13 +389,9 @@ fn render_simple_generator<'scope>(
                         // Since those are not required downstream we eagerly ignore them here.
                         if resume_offset <= offset {
                             for (&output, message) in outputs.iter().repeat_clone(message) {
-                                let size = match &message {
-                                    Ok(msg) => msg.byte_len(),
-                                    Err(_) => 0,
-                                };
-                                data_output
-                                    .give_fueled(&cap, ((output, message), offset, diff), size)
-                                    .await;
+                                let update = ((output, message), offset, diff);
+                                let size = update.fuel_size();
+                                data_output.give_fueled(&cap, update, size).await;
                             }
                         }
                     }

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -29,7 +29,7 @@ use mz_storage_types::sources::{MzOffset, SourceExportDetails, SourceTimestamp};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::containers::stack::AccountedBuilder;
+use mz_timely_util::containers::stack::FueledBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::core::Partition;
@@ -258,7 +258,7 @@ fn render_simple_generator<'scope>(
 ) {
     let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
-    let (data_output, stream) = builder.new_output::<AccountedBuilder<
+    let (data_output, stream) = builder.new_output::<FueledBuilder<
         CapacityContainerBuilder<
             Vec<(
                 (usize, Result<SourceMessage, DataflowError>),

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -29,7 +29,7 @@ use mz_storage_types::sources::{MzOffset, SourceExportDetails, SourceTimestamp};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::containers::stack::AccountedStackBuilder;
+use mz_timely_util::containers::stack::AccountedBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::core::Partition;
@@ -258,18 +258,26 @@ fn render_simple_generator<'scope>(
 ) {
     let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
-    let (data_output, stream) = builder.new_output::<AccountedStackBuilder<_>>();
+    let (data_output, stream) = builder.new_output::<AccountedBuilder<
+        CapacityContainerBuilder<
+            Vec<(
+                (usize, Result<SourceMessage, DataflowError>),
+                MzOffset,
+                Diff,
+            )>,
+        >,
+    >>();
     let export_ids: Vec<_> = config.source_exports.keys().copied().collect();
     let partition_count = u64::cast_from(export_ids.len());
     let data_streams: Vec<_> = stream.partition::<CapacityContainerBuilder<_>, _, _>(
         partition_count,
-        |((output, data), time, diff): &(
+        |((output, data), time, diff): (
             (usize, Result<SourceMessage, DataflowError>),
             MzOffset,
             Diff,
         )| {
-            let output = u64::cast_from(*output);
-            (output, (data.clone(), time.clone(), diff.clone()))
+            let output = u64::cast_from(output);
+            (output, (data, time, diff))
         },
     );
     let mut data_collections = BTreeMap::new();
@@ -381,8 +389,12 @@ fn render_simple_generator<'scope>(
                         // Since those are not required downstream we eagerly ignore them here.
                         if resume_offset <= offset {
                             for (&output, message) in outputs.iter().repeat_clone(message) {
+                                let size = match &message {
+                                    Ok(msg) => msg.byte_len(),
+                                    Err(_) => 0,
+                                };
                                 data_output
-                                    .give_fueled(&cap, ((output, message), offset, diff))
+                                    .give_fueled(&cap, ((output, message), offset, diff), size)
                                     .await;
                             }
                         }

--- a/src/storage/src/source/generator/key_value.rs
+++ b/src/storage/src/source/generator/key_value.rs
@@ -21,7 +21,7 @@ use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::load_generator::{KeyValueLoadGenerator, LoadGeneratorOutput};
 use mz_storage_types::sources::{MzOffset, SourceTimestamp};
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
-use mz_timely_util::containers::stack::AccountedStackBuilder;
+use mz_timely_util::containers::stack::AccountedBuilder;
 use rand_8::rngs::StdRng;
 use rand_8::{RngCore, SeedableRng};
 use timely::container::CapacityContainerBuilder;
@@ -55,18 +55,26 @@ pub fn render<'scope>(
 
     let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
-    let (data_output, stream) = builder.new_output::<AccountedStackBuilder<_>>();
+    let (data_output, stream) = builder.new_output::<AccountedBuilder<
+        CapacityContainerBuilder<
+            Vec<(
+                (usize, Result<SourceMessage, DataflowError>),
+                MzOffset,
+                Diff,
+            )>,
+        >,
+    >>();
     let export_ids: Vec<_> = config.source_exports.keys().copied().collect();
     let partition_count = u64::cast_from(export_ids.len());
     let data_streams: Vec<_> = stream.partition::<CapacityContainerBuilder<_>, _, _>(
         partition_count,
-        |((output, data), time, diff): &(
+        |((output, data), time, diff): (
             (usize, Result<SourceMessage, DataflowError>),
             MzOffset,
             Diff,
         )| {
-            let output = u64::cast_from(*output);
-            (output, (data.clone(), time.clone(), diff.clone()))
+            let output = u64::cast_from(output);
+            (output, (data, time, diff))
         },
     );
     let mut data_collections = BTreeMap::new();
@@ -195,7 +203,11 @@ pub fn render<'scope>(
                     for sp in local_partitions.iter_mut() {
                         let mut emitted_all_exports = 0;
                         for u in sp.produce_batch(&mut value_buffer, &output_indexes) {
-                            data_output.give_fueled(&cap, u).await;
+                            let size = match &u.0.1 {
+                                Ok(msg) => msg.byte_len(),
+                                Err(_) => 0,
+                            };
+                            data_output.give_fueled(&cap, u, size).await;
                             emitted_all_exports += 1;
                         }
                         // emitted_all_indexes is going to be some multiple of num_outputs;
@@ -242,7 +254,11 @@ pub fn render<'scope>(
                             up.produce_batch(&mut value_buffer, &output_indexes);
                         upper_offset = new_upper;
                         for u in iter {
-                            data_output.give_fueled(&cap, u).await;
+                            let size = match &u.0.1 {
+                                Ok(msg) => msg.byte_len(),
+                                Err(_) => 0,
+                            };
+                            data_output.give_fueled(&cap, u, size).await;
                         }
                     }
                     cap.downgrade(&MzOffset::from(upper_offset));

--- a/src/storage/src/source/generator/key_value.rs
+++ b/src/storage/src/source/generator/key_value.rs
@@ -21,7 +21,7 @@ use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::load_generator::{KeyValueLoadGenerator, LoadGeneratorOutput};
 use mz_storage_types::sources::{MzOffset, SourceTimestamp};
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
-use mz_timely_util::containers::stack::AccountedBuilder;
+use mz_timely_util::containers::stack::FueledBuilder;
 use rand_8::rngs::StdRng;
 use rand_8::{RngCore, SeedableRng};
 use timely::container::CapacityContainerBuilder;
@@ -55,7 +55,7 @@ pub fn render<'scope>(
 
     let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
-    let (data_output, stream) = builder.new_output::<AccountedBuilder<
+    let (data_output, stream) = builder.new_output::<FueledBuilder<
         CapacityContainerBuilder<
             Vec<(
                 (usize, Result<SourceMessage, DataflowError>),

--- a/src/storage/src/source/generator/key_value.rs
+++ b/src/storage/src/source/generator/key_value.rs
@@ -32,7 +32,7 @@ use timely::progress::{Antichain, Timestamp};
 use tracing::info;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
-use crate::source::types::{SignaledFuture, StackedCollection};
+use crate::source::types::{FuelSize, SignaledFuture, StackedCollection};
 use crate::source::{RawSourceCreationConfig, SourceMessage};
 
 pub fn render<'scope>(
@@ -203,10 +203,7 @@ pub fn render<'scope>(
                     for sp in local_partitions.iter_mut() {
                         let mut emitted_all_exports = 0;
                         for u in sp.produce_batch(&mut value_buffer, &output_indexes) {
-                            let size = match &u.0.1 {
-                                Ok(msg) => msg.byte_len(),
-                                Err(_) => 0,
-                            };
+                            let size = u.fuel_size();
                             data_output.give_fueled(&cap, u, size).await;
                             emitted_all_exports += 1;
                         }
@@ -254,10 +251,7 @@ pub fn render<'scope>(
                             up.produce_batch(&mut value_buffer, &output_indexes);
                         upper_offset = new_upper;
                         for u in iter {
-                            let size = match &u.0.1 {
-                                Ok(msg) => msg.byte_len(),
-                                Err(_) => 0,
-                            };
+                            let size = u.fuel_size();
                             data_output.give_fueled(&cap, u, size).await;
                         }
                     }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -66,7 +66,7 @@ use tracing::{error, info, trace};
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::metrics::source::kafka::KafkaSourceMetrics;
-use crate::source::types::{Probe, SignaledFuture, SourceRender, StackedCollection};
+use crate::source::types::{FuelSize, Probe, SignaledFuture, SourceRender, StackedCollection};
 use crate::source::{RawSourceCreationConfig, SourceMessage, probe};
 use crate::statistics::SourceStatistics;
 
@@ -719,7 +719,7 @@ fn render_reader<'scope>(
                             outputs.iter().map(|o| o.output_index).repeat_clone(error)
                         {
                             let update = ((output, error), time, Diff::ONE);
-                            let size = std::mem::size_of_val(&update);
+                            let size = update.fuel_size();
                             data_output
                                 .give_fueled(&data_cap, update, size)
                                 .await;
@@ -789,16 +789,10 @@ fn render_reader<'scope>(
                                             error: SourceErrorDetails::Other(e.to_string().into()),
                                         }))
                                     });
-                                    let size = match &msg {
-                                        Ok(msg) => msg.byte_len(),
-                                        Err(_) => 0,
-                                    };
+                                    let update = ((output_index, msg), time, diff);
+                                    let size = update.fuel_size();
                                     data_output
-                                        .give_fueled(
-                                            part_cap,
-                                            ((output_index, msg), time, diff),
-                                            size,
-                                        )
+                                        .give_fueled(part_cap, update, size)
                                         .await;
                                 }
                             }
@@ -843,16 +837,11 @@ fn render_reader<'scope>(
                                             error: SourceErrorDetails::Other(e.to_string().into()),
                                         }))
                                     });
-                                    let size = match &msg {
-                                        Ok(msg) => msg.byte_len(),
-                                        Err(_) => 0,
-                                    };
+                                    let update =
+                                        ((output.output_index, msg), time, diff);
+                                    let size = update.fuel_size();
                                     data_output
-                                        .give_fueled(
-                                            part_cap,
-                                            ((output.output_index, msg), time, diff),
-                                            size,
-                                        )
+                                        .give_fueled(part_cap, update, size)
                                         .await;
                                 }
                                 // The message was from an offset we've already seen.

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -42,7 +42,7 @@ use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
     Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::containers::stack::AccountedBuilder;
+use mz_timely_util::containers::stack::FueledBuilder;
 use mz_timely_util::order::Partitioned;
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
@@ -242,7 +242,7 @@ fn render_reader<'scope>(
     let name = format!("KafkaReader({})", config.id);
     let mut builder = AsyncOperatorBuilder::new(name, scope.clone());
 
-    let (data_output, stream) = builder.new_output::<AccountedBuilder<_>>();
+    let (data_output, stream) = builder.new_output::<FueledBuilder<_>>();
     let (health_output, health_stream) = builder.new_output::<CapacityContainerBuilder<Vec<_>>>();
 
     let mut metadata_input = builder.new_disconnected_input(metadata_stream.broadcast(), Pipeline);

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -42,7 +42,7 @@ use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
     Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::containers::stack::AccountedStackBuilder;
+use mz_timely_util::containers::stack::AccountedBuilder;
 use mz_timely_util::order::Partitioned;
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
@@ -205,8 +205,8 @@ impl SourceRender for KafkaSourceConnection {
         let data_streams: Vec<_> = data.inner.partition::<CapacityContainerBuilder<_>, _, _>(
             partition_count,
             |((output, data), time, diff)| {
-                let output = u64::cast_from(*output);
-                (output, (data.clone(), time.clone(), diff.clone()))
+                let output = u64::cast_from(output);
+                (output, (data, time, diff))
             },
         );
         let mut data_collections = BTreeMap::new();
@@ -242,7 +242,7 @@ fn render_reader<'scope>(
     let name = format!("KafkaReader({})", config.id);
     let mut builder = AsyncOperatorBuilder::new(name, scope.clone());
 
-    let (data_output, stream) = builder.new_output::<AccountedStackBuilder<_>>();
+    let (data_output, stream) = builder.new_output::<AccountedBuilder<_>>();
     let (health_output, health_stream) = builder.new_output::<CapacityContainerBuilder<Vec<_>>>();
 
     let mut metadata_input = builder.new_disconnected_input(metadata_stream.broadcast(), Pipeline);
@@ -718,8 +718,10 @@ fn render_reader<'scope>(
                         for (output, error) in
                             outputs.iter().map(|o| o.output_index).repeat_clone(error)
                         {
+                            let update = ((output, error), time, Diff::ONE);
+                            let size = std::mem::size_of_val(&update);
                             data_output
-                                .give_fueled(&data_cap, ((output, error), time, Diff::ONE))
+                                .give_fueled(&data_cap, update, size)
                                 .await;
                         }
 
@@ -787,8 +789,16 @@ fn render_reader<'scope>(
                                             error: SourceErrorDetails::Other(e.to_string().into()),
                                         }))
                                     });
+                                    let size = match &msg {
+                                        Ok(msg) => msg.byte_len(),
+                                        Err(_) => 0,
+                                    };
                                     data_output
-                                        .give_fueled(part_cap, ((output_index, msg), time, diff))
+                                        .give_fueled(
+                                            part_cap,
+                                            ((output_index, msg), time, diff),
+                                            size,
+                                        )
                                         .await;
                                 }
                             }
@@ -833,10 +843,15 @@ fn render_reader<'scope>(
                                             error: SourceErrorDetails::Other(e.to_string().into()),
                                         }))
                                     });
+                                    let size = match &msg {
+                                        Ok(msg) => msg.byte_len(),
+                                        Err(_) => 0,
+                                    };
                                     data_output
                                         .give_fueled(
                                             part_cap,
                                             ((output.output_index, msg), time, diff),
+                                            size,
                                         )
                                         .await;
                                 }

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -63,8 +63,7 @@ use mz_repr::Diff;
 use mz_repr::GlobalId;
 use mz_storage_types::errors::{DataflowError, SourceError};
 use mz_storage_types::sources::SourceExport;
-use mz_timely_util::columnation::ColumnationStack;
-use mz_timely_util::containers::stack::AccountedStackBuilder;
+use mz_timely_util::containers::stack::AccountedBuilder;
 use serde::{Deserialize, Serialize};
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::core::Partition;
@@ -188,13 +187,13 @@ impl SourceRender for MySqlSourceConnection {
             .inner
             .partition::<CapacityContainerBuilder<_>, _, _>(
                 partition_count,
-                |((output, data), time, diff): &(
+                |((output, data), time, diff): (
                     (usize, Result<SourceMessage, DataflowError>),
                     _,
                     Diff,
                 )| {
-                    let output = u64::cast_from(*output);
-                    (output, (data.clone(), time.clone(), diff.clone()))
+                    let output = u64::cast_from(output);
+                    (output, (data, time, diff))
                 },
             );
         let mut data_collections = BTreeMap::new();
@@ -381,10 +380,8 @@ pub(crate) struct RewindRequest {
     pub(crate) snapshot_upper: Antichain<GtidPartition>,
 }
 
-type StackedAsyncOutputHandle<T, D> = AsyncOutputHandle<
-    T,
-    AccountedStackBuilder<CapacityContainerBuilder<ColumnationStack<(D, T, Diff)>>>,
->;
+type StackedAsyncOutputHandle<T, D> =
+    AsyncOutputHandle<T, AccountedBuilder<CapacityContainerBuilder<Vec<(D, T, Diff)>>>>;
 
 async fn return_definite_error(
     err: DefiniteError,
@@ -407,7 +404,11 @@ async fn return_definite_error(
             GtidPartition::new_range(Uuid::minimum(), Uuid::maximum(), GtidState::MAX),
             Diff::ONE,
         );
-        data_handle.give_fueled(&data_cap_set[0], update).await;
+        // Definite errors are rare and small; account only for the tuple stack size.
+        let update_size = std::mem::size_of_val(&update);
+        data_handle
+            .give_fueled(&data_cap_set[0], update, update_size)
+            .await;
     }
     definite_error_handle.give(
         &definite_error_cap_set[0],

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -63,7 +63,7 @@ use mz_repr::Diff;
 use mz_repr::GlobalId;
 use mz_storage_types::errors::{DataflowError, SourceError};
 use mz_storage_types::sources::SourceExport;
-use mz_timely_util::containers::stack::AccountedBuilder;
+use mz_timely_util::containers::stack::FueledBuilder;
 use serde::{Deserialize, Serialize};
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::core::Partition;
@@ -381,7 +381,7 @@ pub(crate) struct RewindRequest {
 }
 
 type StackedAsyncOutputHandle<T, D> =
-    AsyncOutputHandle<T, AccountedBuilder<CapacityContainerBuilder<Vec<(D, T, Diff)>>>>;
+    AsyncOutputHandle<T, FueledBuilder<CapacityContainerBuilder<Vec<(D, T, Diff)>>>>;
 
 async fn return_definite_error(
     err: DefiniteError,

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -86,7 +86,7 @@ use mz_timely_util::order::Extrema;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::types::Probe;
-use crate::source::types::{SourceRender, StackedCollection};
+use crate::source::types::{FuelSize, SourceRender, StackedCollection};
 use crate::source::{RawSourceCreationConfig, SourceMessage};
 
 mod replication;
@@ -404,10 +404,9 @@ async fn return_definite_error(
             GtidPartition::new_range(Uuid::minimum(), Uuid::maximum(), GtidState::MAX),
             Diff::ONE,
         );
-        // Definite errors are rare and small; account only for the tuple stack size.
-        let update_size = std::mem::size_of_val(&update);
+        let size = update.fuel_size();
         data_handle
-            .give_fueled(&data_cap_set[0], update, update_size)
+            .give_fueled(&data_cap_set[0], update, size)
             .await;
     }
     definite_error_handle.give(

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -51,7 +51,7 @@ use mysql_async::prelude::Queryable;
 use mysql_async::{BinlogStream, BinlogStreamRequest, GnoInterval, Sid};
 use mz_ore::future::InTask;
 use mz_ssh_util::tunnel_manager::ManagedSshTunnelHandle;
-use mz_timely_util::containers::stack::AccountedBuilder;
+use mz_timely_util::containers::stack::FueledBuilder;
 use timely::PartialOrder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Exchange;
@@ -115,7 +115,7 @@ pub(crate) fn render<'scope>(
     let mut builder = AsyncOperatorBuilder::new(op_name, scope);
 
     let repl_reader_id = u64::cast_from(config.responsible_worker(REPL_READER));
-    let (mut data_output, data_stream) = builder.new_output::<AccountedBuilder<_>>();
+    let (mut data_output, data_stream) = builder.new_output::<FueledBuilder<_>>();
     // Captures DefiniteErrors that affect the entire source, including all outputs
     let (definite_error_handle, definite_errors) =
         builder.new_output::<CapacityContainerBuilder<Vec<_>>>();

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -51,7 +51,7 @@ use mysql_async::prelude::Queryable;
 use mysql_async::{BinlogStream, BinlogStreamRequest, GnoInterval, Sid};
 use mz_ore::future::InTask;
 use mz_ssh_util::tunnel_manager::ManagedSshTunnelHandle;
-use mz_timely_util::containers::stack::AccountedStackBuilder;
+use mz_timely_util::containers::stack::AccountedBuilder;
 use timely::PartialOrder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Exchange;
@@ -115,7 +115,7 @@ pub(crate) fn render<'scope>(
     let mut builder = AsyncOperatorBuilder::new(op_name, scope);
 
     let repl_reader_id = u64::cast_from(config.responsible_worker(REPL_READER));
-    let (mut data_output, data_stream) = builder.new_output::<AccountedStackBuilder<_>>();
+    let (mut data_output, data_stream) = builder.new_output::<AccountedBuilder<_>>();
     // Captures DefiniteErrors that affect the entire source, including all outputs
     let (definite_error_handle, definite_errors) =
         builder.new_output::<CapacityContainerBuilder<Vec<_>>>();

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -97,16 +97,13 @@ pub(super) async fn handle_query_event(
                            verification error for {table:?}[{}]: {err:?}",
                            err_output.output_index);
                     let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
-                    ctx.data_output
-                        .give_fueled(
-                            &gtid_cap,
-                            (
-                                (err_output.output_index, Err(err.into())),
-                                new_gtid.clone(),
-                                Diff::ONE,
-                            ),
-                        )
-                        .await;
+                    let update = (
+                        (err_output.output_index, Err(err.into())),
+                        new_gtid.clone(),
+                        Diff::ONE,
+                    );
+                    let size = std::mem::size_of_val(&update);
+                    ctx.data_output.give_fueled(&gtid_cap, update, size).await;
                     ctx.errored_outputs.insert(err_output.output_index);
                 }
             }
@@ -138,16 +135,13 @@ pub(super) async fn handle_query_event(
                 tracing::info!(%id, "timely-{worker_id} DDL change \
                            dropped output: {dropped_output:?}: {err:?}");
                 let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
-                ctx.data_output
-                    .give_fueled(
-                        &gtid_cap,
-                        (
-                            (dropped_output.output_index, Err(err.into())),
-                            new_gtid.clone(),
-                            Diff::ONE,
-                        ),
-                    )
-                    .await;
+                let update = (
+                    (dropped_output.output_index, Err(err.into())),
+                    new_gtid.clone(),
+                    Diff::ONE,
+                );
+                let size = std::mem::size_of_val(&update);
+                ctx.data_output.give_fueled(&gtid_cap, update, size).await;
                 ctx.errored_outputs.insert(dropped_output.output_index);
             }
         }
@@ -172,21 +166,18 @@ pub(super) async fn handle_query_event(
                 if let Some(info) = ctx.table_info.get(&table) {
                     let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
                     for output in info {
-                        ctx.data_output
-                            .give_fueled(
-                                &gtid_cap,
-                                (
-                                    (
-                                        output.output_index,
-                                        Err(DataflowError::from(DefiniteError::TableTruncated(
-                                            table.to_string(),
-                                        ))),
-                                    ),
-                                    new_gtid.clone(),
-                                    Diff::ONE,
-                                ),
-                            )
-                            .await;
+                        let update = (
+                            (
+                                output.output_index,
+                                Err(DataflowError::from(DefiniteError::TableTruncated(
+                                    table.to_string(),
+                                ))),
+                            ),
+                            new_gtid.clone(),
+                            Diff::ONE,
+                        );
+                        let size = std::mem::size_of_val(&update);
+                        ctx.data_output.give_fueled(&gtid_cap, update, size).await;
                         ctx.errored_outputs.insert(output.output_index);
                     }
                 }
@@ -329,8 +320,12 @@ pub(super) async fn handle_rows_event(
                 } else {
                     retractions += 1;
                 }
+                let size = match &data.1 {
+                    Ok(msg) => msg.byte_len(),
+                    Err(_) => 0,
+                };
                 ctx.data_output
-                    .give_fueled(&gtid_cap, (data, new_gtid.clone(), diff))
+                    .give_fueled(&gtid_cap, (data, new_gtid.clone(), diff), size)
                     .await;
             }
         }
@@ -345,7 +340,11 @@ pub(super) async fn handle_rows_event(
     if !event_buffer.is_empty() {
         for d in event_buffer.drain(..) {
             let (rewind_data_cap, _) = ctx.rewinds.get(&d.0.0).unwrap();
-            ctx.data_output.give_fueled(rewind_data_cap, d).await;
+            let size = match &d.0.1 {
+                Ok(msg) => msg.byte_len(),
+                Err(_) => 0,
+            };
+            ctx.data_output.give_fueled(rewind_data_cap, d, size).await;
         }
     }
 

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -17,7 +17,7 @@ use mz_storage_types::sources::mysql::GtidPartition;
 use timely::progress::Timestamp;
 use tracing::trace;
 
-use crate::source::types::SourceMessage;
+use crate::source::types::{FuelSize, SourceMessage};
 
 use super::super::schemas::verify_schemas;
 use super::super::{DefiniteError, MySqlTableName, TransientError};
@@ -102,7 +102,7 @@ pub(super) async fn handle_query_event(
                         new_gtid.clone(),
                         Diff::ONE,
                     );
-                    let size = std::mem::size_of_val(&update);
+                    let size = update.fuel_size();
                     ctx.data_output.give_fueled(&gtid_cap, update, size).await;
                     ctx.errored_outputs.insert(err_output.output_index);
                 }
@@ -176,7 +176,7 @@ pub(super) async fn handle_query_event(
                             new_gtid.clone(),
                             Diff::ONE,
                         );
-                        let size = std::mem::size_of_val(&update);
+                        let size = update.fuel_size();
                         ctx.data_output.give_fueled(&gtid_cap, update, size).await;
                         ctx.errored_outputs.insert(output.output_index);
                     }
@@ -320,13 +320,9 @@ pub(super) async fn handle_rows_event(
                 } else {
                     retractions += 1;
                 }
-                let size = match &data.1 {
-                    Ok(msg) => msg.byte_len(),
-                    Err(_) => 0,
-                };
-                ctx.data_output
-                    .give_fueled(&gtid_cap, (data, new_gtid.clone(), diff), size)
-                    .await;
+                let update = (data, new_gtid.clone(), diff);
+                let size = update.fuel_size();
+                ctx.data_output.give_fueled(&gtid_cap, update, size).await;
             }
         }
     }
@@ -340,10 +336,7 @@ pub(super) async fn handle_rows_event(
     if !event_buffer.is_empty() {
         for d in event_buffer.drain(..) {
             let (rewind_data_cap, _) = ctx.rewinds.get(&d.0.0).unwrap();
-            let size = match &d.0.1 {
-                Ok(msg) => msg.byte_len(),
-                Err(_) => 0,
-            };
+            let size = d.fuel_size();
             ctx.data_output.give_fueled(rewind_data_cap, d, size).await;
         }
     }

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -116,7 +116,7 @@ use tracing::{error, trace};
 
 use crate::metrics::source::mysql::MySqlSnapshotMetrics;
 use crate::source::RawSourceCreationConfig;
-use crate::source::types::{SignaledFuture, SourceMessage, StackedCollection};
+use crate::source::types::{FuelSize, SignaledFuture, SourceMessage, StackedCollection};
 use crate::statistics::SourceStatistics;
 
 use super::schemas::verify_schemas;
@@ -372,7 +372,7 @@ pub(crate) fn render<'scope>(
                         GtidPartition::minimum(),
                         Diff::ONE,
                     );
-                    let size = std::mem::size_of_val(&update);
+                    let size = update.fuel_size();
                     raw_handle.give_fueled(&data_cap_set[0], update, size).await;
                     tracing::warn!(%id, "timely-{worker_id} stopping snapshot of output {output:?} \
                                 due to schema mismatch");
@@ -432,15 +432,12 @@ pub(crate) fn render<'scope>(
                                 }
                                 Err(err) => Err(err)?,
                             };
-                            let size = match &event {
-                                Ok(msg) => msg.byte_len(),
-                                Err(_) => 0,
-                            };
                             let update = (
                                 (output.output_index, event),
                                 GtidPartition::minimum(),
                                 Diff::ONE,
                             );
+                            let size = update.fuel_size();
                             raw_handle.give_fueled(&data_cap_set[0], update, size).await;
                         }
                         // This overcounting maintains existing behavior but will be removed one readers no longer rely on the value.

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -106,7 +106,7 @@ use mz_storage_types::sources::MySqlSourceConnection;
 use mz_storage_types::sources::mysql::{GtidPartition, gtid_set_frontier};
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
-use mz_timely_util::containers::stack::AccountedBuilder;
+use mz_timely_util::containers::stack::FueledBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::core::Map;
 use timely::dataflow::operators::{CapabilitySet, Concat};
@@ -141,7 +141,7 @@ pub(crate) fn render<'scope>(
     let mut builder =
         AsyncOperatorBuilder::new(format!("MySqlSnapshotReader({})", config.id), scope.clone());
 
-    let (raw_handle, raw_data) = builder.new_output::<AccountedBuilder<_>>();
+    let (raw_handle, raw_data) = builder.new_output::<FueledBuilder<_>>();
     let (rewinds_handle, rewinds) = builder.new_output::<CapacityContainerBuilder<Vec<_>>>();
     // Captures DefiniteErrors that affect the entire source, including all outputs
     let (definite_error_handle, definite_errors) =

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -106,7 +106,7 @@ use mz_storage_types::sources::MySqlSourceConnection;
 use mz_storage_types::sources::mysql::{GtidPartition, gtid_set_frontier};
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
-use mz_timely_util::containers::stack::AccountedStackBuilder;
+use mz_timely_util::containers::stack::AccountedBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::core::Map;
 use timely::dataflow::operators::{CapabilitySet, Concat};
@@ -141,7 +141,7 @@ pub(crate) fn render<'scope>(
     let mut builder =
         AsyncOperatorBuilder::new(format!("MySqlSnapshotReader({})", config.id), scope.clone());
 
-    let (raw_handle, raw_data) = builder.new_output::<AccountedStackBuilder<_>>();
+    let (raw_handle, raw_data) = builder.new_output::<AccountedBuilder<_>>();
     let (rewinds_handle, rewinds) = builder.new_output::<CapacityContainerBuilder<Vec<_>>>();
     // Captures DefiniteErrors that affect the entire source, including all outputs
     let (definite_error_handle, definite_errors) =
@@ -367,16 +367,13 @@ pub(crate) fn render<'scope>(
                 let mut removed_outputs = BTreeSet::new();
                 for (output, err) in errored_outputs {
                     // Publish the error for this table and stop ingesting it
-                    raw_handle
-                        .give_fueled(
-                            &data_cap_set[0],
-                            (
-                                (output.output_index, Err(err.clone().into())),
-                                GtidPartition::minimum(),
-                                Diff::ONE,
-                            ),
-                        )
-                        .await;
+                    let update = (
+                        (output.output_index, Err(err.clone().into())),
+                        GtidPartition::minimum(),
+                        Diff::ONE,
+                    );
+                    let size = std::mem::size_of_val(&update);
+                    raw_handle.give_fueled(&data_cap_set[0], update, size).await;
                     tracing::warn!(%id, "timely-{worker_id} stopping snapshot of output {output:?} \
                                 due to schema mismatch");
                     removed_outputs.insert(output.output_index);
@@ -435,16 +432,16 @@ pub(crate) fn render<'scope>(
                                 }
                                 Err(err) => Err(err)?,
                             };
-                            raw_handle
-                                .give_fueled(
-                                    &data_cap_set[0],
-                                    (
-                                        (output.output_index, event),
-                                        GtidPartition::minimum(),
-                                        Diff::ONE,
-                                    ),
-                                )
-                                .await;
+                            let size = match &event {
+                                Ok(msg) => msg.byte_len(),
+                                Err(_) => 0,
+                            };
+                            let update = (
+                                (output.output_index, event),
+                                GtidPartition::minimum(),
+                                Diff::ONE,
+                            );
+                            raw_handle.give_fueled(&data_cap_set[0], update, size).await;
                         }
                         // This overcounting maintains existing behavior but will be removed one readers no longer rely on the value.
                         snapshot_staged_total += u64::cast_from(outputs.len());

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -205,13 +205,13 @@ impl SourceRender for PostgresSourceConnection {
             .inner
             .partition::<CapacityContainerBuilder<_>, _, _>(
                 partition_count,
-                |((output, data), time, diff): &(
+                |((output, data), time, diff): (
                     (usize, Result<SourceMessage, DataflowError>),
                     MzOffset,
                     Diff,
                 )| {
-                    let output = u64::cast_from(*output);
-                    (output, (data.clone(), time.clone(), diff.clone()))
+                    let output = u64::cast_from(output);
+                    (output, (data, time, diff))
                 },
             );
         let mut data_collections = BTreeMap::new();

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -118,7 +118,7 @@ use crate::source::RawSourceCreationConfig;
 use crate::source::postgres::verify_schema;
 use crate::source::postgres::{DefiniteError, ReplicationError, SourceOutputInfo, TransientError};
 use crate::source::probe;
-use crate::source::types::{Probe, SignaledFuture, SourceMessage, StackedCollection};
+use crate::source::types::{FuelSize, Probe, SignaledFuture, SourceMessage, StackedCollection};
 
 /// A logical replication message from the server.
 type LogicalReplMsg = ReplicationMessage<LogicalReplicationMessage>;
@@ -353,7 +353,7 @@ pub(crate) fn render<'scope>(
                                         MzOffset::from(u64::MAX),
                                         Diff::ONE,
                                     );
-                                    let size = std::mem::size_of_val(&update);
+                                    let size = update.fuel_size();
                                     data_output
                                         .give_fueled(&data_cap_set[0], update, size)
                                         .await;
@@ -401,7 +401,7 @@ pub(crate) fn render<'scope>(
                                 MzOffset::from(u64::MAX),
                                 Diff::ONE,
                             );
-                            let size = std::mem::size_of_val(&update);
+                            let size = update.fuel_size();
                             data_output
                                 .give_fueled(&data_cap_set[0], update, size)
                                 .await;
@@ -465,24 +465,20 @@ pub(crate) fn render<'scope>(
                             while let Some((oid, output_index, event, diff)) = tx.try_next().await?
                             {
                                 let event = event.map_err(Into::into);
-                                let size = match &event {
-                                    Ok(row) => row.byte_len(),
-                                    Err(_) => 0,
-                                };
                                 let data = (oid, output_index, event);
                                 if let Some(req) = rewinds.get(&output_index) {
                                     if commit_lsn <= req.snapshot_lsn {
+                                        let update = (data.clone(), MzOffset::from(0), -diff);
+                                        let size = update.fuel_size();
                                         data_output
-                                            .give_fueled(
-                                                &data_cap_set[0],
-                                                (data.clone(), MzOffset::from(0), -diff),
-                                                size,
-                                            )
+                                            .give_fueled(&data_cap_set[0], update, size)
                                             .await;
                                     }
                                 }
+                                let update = (data, commit_lsn, diff);
+                                let size = update.fuel_size();
                                 data_output
-                                    .give_fueled(&data_cap_set[0], (data, commit_lsn, diff), size)
+                                    .give_fueled(&data_cap_set[0], update, size)
                                     .await;
                             }
                         }
@@ -511,7 +507,7 @@ pub(crate) fn render<'scope>(
                                                 data_cap_set[0].time().clone(),
                                                 Diff::ONE,
                                             );
-                                            let size = std::mem::size_of_val(&update);
+                                            let size = update.fuel_size();
                                             data_output
                                                 .give_fueled(&data_cap_set[0], update, size)
                                                 .await;
@@ -539,7 +535,7 @@ pub(crate) fn render<'scope>(
                                         data_cap_set[0].time().clone(),
                                         Diff::ONE,
                                     );
-                                    let size = std::mem::size_of_val(&update);
+                                    let size = update.fuel_size();
                                     data_output
                                         .give_fueled(&data_cap_set[0], update, size)
                                         .await;

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -353,7 +353,10 @@ pub(crate) fn render<'scope>(
                                         MzOffset::from(u64::MAX),
                                         Diff::ONE,
                                     );
-                                    data_output.give_fueled(&data_cap_set[0], update).await;
+                                    let size = std::mem::size_of_val(&update);
+                                    data_output
+                                        .give_fueled(&data_cap_set[0], update, size)
+                                        .await;
                                 }
                             }
                             definite_error_handle.give(
@@ -398,7 +401,10 @@ pub(crate) fn render<'scope>(
                                 MzOffset::from(u64::MAX),
                                 Diff::ONE,
                             );
-                            data_output.give_fueled(&data_cap_set[0], update).await;
+                            let size = std::mem::size_of_val(&update);
+                            data_output
+                                .give_fueled(&data_cap_set[0], update, size)
+                                .await;
                         }
                     }
 
@@ -429,8 +435,6 @@ pub(crate) fn render<'scope>(
             // creating excessive progress tracking traffic when there are multiple small
             // transactions ready to go.
             let mut data_upper = resume_lsn;
-            // A stash of reusable vectors to convert from bytes::Bytes based data, which is not
-            // compatible with `columnation`, to Vec<u8> data that is.
             while let Some(event) = stream.as_mut().next().await {
                 use LogicalReplicationMessage::*;
                 use ReplicationMessage::*;
@@ -461,16 +465,25 @@ pub(crate) fn render<'scope>(
                             while let Some((oid, output_index, event, diff)) = tx.try_next().await?
                             {
                                 let event = event.map_err(Into::into);
-                                let mut data = (oid, output_index, event);
+                                let size = match &event {
+                                    Ok(row) => row.byte_len(),
+                                    Err(_) => 0,
+                                };
+                                let data = (oid, output_index, event);
                                 if let Some(req) = rewinds.get(&output_index) {
                                     if commit_lsn <= req.snapshot_lsn {
-                                        let update = (data, MzOffset::from(0), -diff);
-                                        data_output.give_fueled(&data_cap_set[0], &update).await;
-                                        data = update.0;
+                                        data_output
+                                            .give_fueled(
+                                                &data_cap_set[0],
+                                                (data.clone(), MzOffset::from(0), -diff),
+                                                size,
+                                            )
+                                            .await;
                                     }
                                 }
-                                let update = (data, commit_lsn, diff);
-                                data_output.give_fueled(&data_cap_set[0], &update).await;
+                                data_output
+                                    .give_fueled(&data_cap_set[0], (data, commit_lsn, diff), size)
+                                    .await;
                             }
                         }
                         _ => return Err(TransientError::BareTransactionEvent),
@@ -498,7 +511,10 @@ pub(crate) fn render<'scope>(
                                                 data_cap_set[0].time().clone(),
                                                 Diff::ONE,
                                             );
-                                            data_output.give_fueled(&data_cap_set[0], update).await;
+                                            let size = std::mem::size_of_val(&update);
+                                            data_output
+                                                .give_fueled(&data_cap_set[0], update, size)
+                                                .await;
                                         }
                                     }
                                     definite_error_handle.give(
@@ -523,7 +539,10 @@ pub(crate) fn render<'scope>(
                                         data_cap_set[0].time().clone(),
                                         Diff::ONE,
                                     );
-                                    data_output.give_fueled(&data_cap_set[0], update).await;
+                                    let size = std::mem::size_of_val(&update);
+                                    data_output
+                                        .give_fueled(&data_cap_set[0], update, size)
+                                        .await;
                                 }
                             }
                         }
@@ -559,7 +578,6 @@ pub(crate) fn render<'scope>(
         .cycle();
     let round_robin = Exchange::new(move |_| next_worker.next().unwrap());
     let replication_updates = data_stream
-        .map::<Vec<_>, _, _>(Clone::clone)
         .unary(round_robin, "PgCastReplicationRows", |_, _| {
             move |input, output| {
                 input.for_each_time(|time, data| {

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -203,7 +203,7 @@ use crate::source::postgres::replication::RewindRequest;
 use crate::source::postgres::{
     DefiniteError, ReplicationError, SourceOutputInfo, TransientError, verify_schema,
 };
-use crate::source::types::{SignaledFuture, SourceMessage, StackedCollection};
+use crate::source::types::{FuelSize, SignaledFuture, SourceMessage, StackedCollection};
 use crate::statistics::SourceStatistics;
 
 /// Information broadcasted from the snapshot leader to all workers.
@@ -545,7 +545,7 @@ pub(crate) fn render<'scope>(
                                             MzOffset::from(u64::MAX),
                                             Diff::ONE,
                                         );
-                                        let size = std::mem::size_of_val(&update);
+                                        let size = update.fuel_size();
                                         raw_handle
                                             .give_fueled(&data_cap_set[0], update, size)
                                             .await;
@@ -633,7 +633,7 @@ pub(crate) fn render<'scope>(
                             MzOffset::minimum(),
                             Diff::ONE,
                         );
-                        let size = std::mem::size_of_val(&update);
+                        let size = update.fuel_size();
                         raw_handle
                             .give_fueled(&data_cap_set[0], update, size)
                             .await;
@@ -693,12 +693,12 @@ pub(crate) fn render<'scope>(
 
                     let mut snapshot_staged = 0;
                     while let Some(bytes) = stream.try_next().await? {
-                        let size = bytes.len();
                         let update = (
                             (oid, output_index, Ok(bytes.to_vec())),
                             MzOffset::minimum(),
                             Diff::ONE,
                         );
+                        let size = update.fuel_size();
                         raw_handle
                             .give_fueled(&data_cap_set[0], update, size)
                             .await;

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -187,7 +187,6 @@ use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use timely::container::CapacityContainerBuilder;
-use timely::container::DrainContainer;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::core::Map;
 use timely::dataflow::operators::vec::Broadcast;
@@ -546,7 +545,10 @@ pub(crate) fn render<'scope>(
                                             MzOffset::from(u64::MAX),
                                             Diff::ONE,
                                         );
-                                        raw_handle.give_fueled(&data_cap_set[0], update).await;
+                                        let size = std::mem::size_of_val(&update);
+                                        raw_handle
+                                            .give_fueled(&data_cap_set[0], update, size)
+                                            .await;
                                     }
                                 }
 
@@ -626,15 +628,14 @@ pub(crate) fn render<'scope>(
             for (&oid, outputs) in tables_to_snapshot.iter() {
                 for (&output_index, info) in outputs.iter() {
                     if let Err(err) = verify_schema(oid, info, &upstream_info) {
+                        let update = (
+                            (oid, output_index, Err(err.into())),
+                            MzOffset::minimum(),
+                            Diff::ONE,
+                        );
+                        let size = std::mem::size_of_val(&update);
                         raw_handle
-                            .give_fueled(
-                                &data_cap_set[0],
-                                (
-                                    (oid, output_index, Err(err.into())),
-                                    MzOffset::minimum(),
-                                    Diff::ONE,
-                                ),
-                            )
+                            .give_fueled(&data_cap_set[0], update, size)
                             .await;
                         continue;
                     }
@@ -691,13 +692,16 @@ pub(crate) fn render<'scope>(
                     let mut stream = pin!(client.copy_out_simple(&query).await?);
 
                     let mut snapshot_staged = 0;
-                    let mut update =
-                        ((oid, output_index, Ok(vec![])), MzOffset::minimum(), Diff::ONE);
                     while let Some(bytes) = stream.try_next().await? {
-                        let data = update.0 .2.as_mut().unwrap();
-                        data.clear();
-                        data.extend_from_slice(&bytes);
-                        raw_handle.give_fueled(&data_cap_set[0], &update).await;
+                        let size = bytes.len();
+                        let update = (
+                            (oid, output_index, Ok(bytes.to_vec())),
+                            MzOffset::minimum(),
+                            Diff::ONE,
+                        );
+                        raw_handle
+                            .give_fueled(&data_cap_set[0], update, size)
+                            .await;
                         snapshot_staged += 1;
                         if snapshot_staged % 1000 == 0 {
                             let stat = &export_statistics[&(oid, output_index)];
@@ -766,11 +770,11 @@ pub(crate) fn render<'scope>(
                 input.for_each_time(|time, data| {
                     let mut session = output.session(&time);
                     for ((oid, output_index, event), time, diff) in
-                        data.flat_map(|data| data.drain())
+                        data.flat_map(|data| data.drain(..))
                     {
                         let output = &table_info
-                            .get(oid)
-                            .and_then(|outputs| outputs.get(output_index))
+                            .get(&oid)
+                            .and_then(|outputs| outputs.get(&output_index))
                             .expect("table_info contains all outputs");
 
                         let event = event
@@ -787,7 +791,7 @@ pub(crate) fn render<'scope>(
                                 })
                             });
 
-                        session.give(((*output_index, event), *time, *diff));
+                        session.give(((output_index, event), time, diff));
                     }
                 });
             }

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -694,7 +694,7 @@ pub(crate) fn render<'scope>(
                     let mut snapshot_staged = 0;
                     while let Some(bytes) = stream.try_next().await? {
                         let update = (
-                            (oid, output_index, Ok(bytes.to_vec())),
+                            (oid, output_index, Ok(bytes)),
                             MzOffset::minimum(),
                             Diff::ONE,
                         );

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -237,14 +237,14 @@ where
                 .map(move |(result, from_time, diff)| {
                     let result = match result {
                         Ok(msg) => Ok(SourceOutput {
-                            key: msg.key.clone(),
-                            value: msg.value.clone(),
-                            metadata: msg.metadata.clone(),
+                            key: msg.key,
+                            value: msg.value,
+                            metadata: msg.metadata,
                             from_time: from_time.clone(),
                         }),
-                        Err(err) => Err(err.clone()),
+                        Err(err) => Err(err),
                     };
-                    (result, from_time.clone(), *diff)
+                    (result, from_time, diff)
                 })
                 .capture_into(PusherCapture(reclock_pusher));
             reclocked_exports2.insert(id, reclocked);

--- a/src/storage/src/source/sql_server.rs
+++ b/src/storage/src/source/sql_server.rs
@@ -182,11 +182,11 @@ impl SourceRender for SqlServerSourceConnection {
             .inner
             .partition::<CapacityContainerBuilder<_>, _, _>(
                 partition_count,
-                move |((partition_idx, data), time, diff): &(
+                move |((partition_idx, data), time, diff): (
                     (u64, Result<SourceMessage, DataflowError>),
                     Lsn,
                     Diff,
-                )| { (*partition_idx, (data.clone(), time.clone(), diff.clone())) },
+                )| { (partition_idx, (data, time, diff)) },
             );
         let mut data_collections = BTreeMap::new();
         for (id, data_stream) in config.source_exports.keys().zip_eq(data_streams) {

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -46,7 +46,7 @@ use crate::source::RawSourceCreationConfig;
 use crate::source::sql_server::{
     DefiniteError, ReplicationError, SourceOutputInfo, TransientError,
 };
-use crate::source::types::{SignaledFuture, SourceMessage, StackedCollection};
+use crate::source::types::{FuelSize, SignaledFuture, SourceMessage, StackedCollection};
 
 /// Used as a partition ID to determine the worker that is responsible for
 /// reading data from SQL Server.
@@ -319,16 +319,11 @@ pub(crate) fn render<'scope>(
                                 &arena,
                                 None,
                             );
-                            let size = match &message {
-                                Ok(msg) => msg.byte_len(),
-                                Err(_) => 0,
-                            };
+                            let update =
+                                ((*partition_idx, message), Lsn::minimum(), Diff::ONE);
+                            let size = update.fuel_size();
                             data_output
-                                .give_fueled(
-                                    &data_cap_set[0],
-                                    ((*partition_idx, message), Lsn::minimum(), Diff::ONE),
-                                    size,
-                                )
+                                .give_fueled(&data_cap_set[0], update, size)
                                 .await;
                         }
                         snapshot_staged += 1;
@@ -593,7 +588,7 @@ pub(crate) fn render<'scope>(
                                     ddl_event.lsn,
                                     Diff::ONE,
                                 );
-                                let size = std::mem::size_of_val(&update);
+                                let size = update.fuel_size();
                                 data_output
                                     .give_fueled(&data_cap_set[0], update, size)
                                     .await;
@@ -696,29 +691,21 @@ async fn handle_data_event(
                 };
 
                 let update_old = decode(decoder, old_row, &mut mz_row, &arena, Some(new_row));
-                let update_old_size = match &update_old {
-                    Ok(msg) => msg.byte_len(),
-                    Err(_) => 0,
-                };
                 if rewind.is_some_and(|(_, snapshot_lsn)| commit_lsn <= *snapshot_lsn) {
+                    let update = (
+                        (*partition_idx, update_old.clone()),
+                        Lsn::minimum(),
+                        Diff::ONE,
+                    );
+                    let size = update.fuel_size();
                     data_output
-                        .give_fueled(
-                            &data_cap_set[0],
-                            (
-                                (*partition_idx, update_old.clone()),
-                                Lsn::minimum(),
-                                Diff::ONE,
-                            ),
-                            update_old_size,
-                        )
+                        .give_fueled(&data_cap_set[0], update, size)
                         .await;
                 }
+                let update = ((*partition_idx, update_old), commit_lsn, Diff::MINUS_ONE);
+                let size = update.fuel_size();
                 data_output
-                    .give_fueled(
-                        &data_cap_set[0],
-                        ((*partition_idx, update_old), commit_lsn, Diff::MINUS_ONE),
-                        update_old_size,
-                    )
+                    .give_fueled(&data_cap_set[0], update, size)
                     .await;
 
                 (
@@ -732,25 +719,17 @@ async fn handle_data_event(
                 )
             };
             assert_ne!(Diff::ZERO, diff);
-            let message_size = match &message {
-                Ok(msg) => msg.byte_len(),
-                Err(_) => 0,
-            };
             if rewind.is_some_and(|(_, snapshot_lsn)| commit_lsn <= *snapshot_lsn) {
+                let update = ((*partition_idx, message.clone()), Lsn::minimum(), -diff);
+                let size = update.fuel_size();
                 data_output
-                    .give_fueled(
-                        &data_cap_set[0],
-                        ((*partition_idx, message.clone()), Lsn::minimum(), -diff),
-                        message_size,
-                    )
+                    .give_fueled(&data_cap_set[0], update, size)
                     .await;
             }
+            let update = ((*partition_idx, message), commit_lsn, diff);
+            let size = update.fuel_size();
             data_output
-                .give_fueled(
-                    &data_cap_set[0],
-                    ((*partition_idx, message), commit_lsn, diff),
-                    message_size,
-                )
+                .give_fueled(&data_cap_set[0], update, size)
                 .await;
         }
     }
@@ -809,7 +788,7 @@ async fn return_definite_error(
             },
             Diff::ONE,
         );
-        let size = std::mem::size_of_val(&update);
+        let size = update.fuel_size();
         data_handle.give_fueled(&data_capset[0], update, size).await;
     }
     errs_handle.give(

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -34,8 +34,7 @@ use mz_storage_types::sources::sql_server::{MAX_LSN_WAIT, SNAPSHOT_PROGRESS_REPO
 use mz_timely_util::builder_async::{
     AsyncOutputHandle, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::columnation::ColumnationStack;
-use mz_timely_util::containers::stack::AccountedStackBuilder;
+use mz_timely_util::containers::stack::AccountedBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::operators::{CapabilitySet, Concat};
@@ -70,7 +69,7 @@ pub(crate) fn render<'scope>(
     let op_name = format!("SqlServerReplicationReader({})", config.id);
     let mut builder = AsyncOperatorBuilder::new(op_name, scope);
 
-    let (data_output, data_stream) = builder.new_output::<AccountedStackBuilder<_>>();
+    let (data_output, data_stream) = builder.new_output::<AccountedBuilder<_>>();
 
     // Captures DefiniteErrors that affect the entire source, including all outputs
     let (definite_error_handle, definite_errors) =
@@ -320,10 +319,15 @@ pub(crate) fn render<'scope>(
                                 &arena,
                                 None,
                             );
+                            let size = match &message {
+                                Ok(msg) => msg.byte_len(),
+                                Err(_) => 0,
+                            };
                             data_output
                                 .give_fueled(
                                     &data_cap_set[0],
                                     ((*partition_idx, message), Lsn::minimum(), Diff::ONE),
+                                    size,
                                 )
                                 .await;
                         }
@@ -584,11 +588,14 @@ pub(crate) fn render<'scope>(
                                 let msg = Err(
                                     error.clone().into(),
                                 );
+                                let update = (
+                                    (*partition_idx, msg),
+                                    ddl_event.lsn,
+                                    Diff::ONE,
+                                );
+                                let size = std::mem::size_of_val(&update);
                                 data_output
-                                    .give_fueled(
-                                        &data_cap_set[0],
-                                        ((*partition_idx, msg), ddl_event.lsn, Diff::ONE),
-                                    )
+                                    .give_fueled(&data_cap_set[0], update, size)
                                     .await;
                                 errored_partitions.insert(*partition_idx);
                             }
@@ -689,6 +696,10 @@ async fn handle_data_event(
                 };
 
                 let update_old = decode(decoder, old_row, &mut mz_row, &arena, Some(new_row));
+                let update_old_size = match &update_old {
+                    Ok(msg) => msg.byte_len(),
+                    Err(_) => 0,
+                };
                 if rewind.is_some_and(|(_, snapshot_lsn)| commit_lsn <= *snapshot_lsn) {
                     data_output
                         .give_fueled(
@@ -698,6 +709,7 @@ async fn handle_data_event(
                                 Lsn::minimum(),
                                 Diff::ONE,
                             ),
+                            update_old_size,
                         )
                         .await;
                 }
@@ -705,6 +717,7 @@ async fn handle_data_event(
                     .give_fueled(
                         &data_cap_set[0],
                         ((*partition_idx, update_old), commit_lsn, Diff::MINUS_ONE),
+                        update_old_size,
                     )
                     .await;
 
@@ -719,11 +732,16 @@ async fn handle_data_event(
                 )
             };
             assert_ne!(Diff::ZERO, diff);
+            let message_size = match &message {
+                Ok(msg) => msg.byte_len(),
+                Err(_) => 0,
+            };
             if rewind.is_some_and(|(_, snapshot_lsn)| commit_lsn <= *snapshot_lsn) {
                 data_output
                     .give_fueled(
                         &data_cap_set[0],
                         ((*partition_idx, message.clone()), Lsn::minimum(), -diff),
+                        message_size,
                     )
                     .await;
             }
@@ -731,6 +749,7 @@ async fn handle_data_event(
                 .give_fueled(
                     &data_cap_set[0],
                     ((*partition_idx, message), commit_lsn, diff),
+                    message_size,
                 )
                 .await;
         }
@@ -738,10 +757,8 @@ async fn handle_data_event(
     Ok(())
 }
 
-type StackedAsyncOutputHandle<T, D> = AsyncOutputHandle<
-    T,
-    AccountedStackBuilder<CapacityContainerBuilder<ColumnationStack<(D, T, Diff)>>>,
->;
+type StackedAsyncOutputHandle<T, D> =
+    AsyncOutputHandle<T, AccountedBuilder<CapacityContainerBuilder<Vec<(D, T, Diff)>>>>;
 
 /// Helper method to decode a row from a [`tiberius::Row`] (or 2 of them in the case of update)
 /// to a [`Row`]. This centralizes the decode and mapping to result.
@@ -792,7 +809,8 @@ async fn return_definite_error(
             },
             Diff::ONE,
         );
-        data_handle.give_fueled(&data_capset[0], update).await;
+        let size = std::mem::size_of_val(&update);
+        data_handle.give_fueled(&data_capset[0], update, size).await;
     }
     errs_handle.give(
         &errs_capset[0],

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -34,7 +34,7 @@ use mz_storage_types::sources::sql_server::{MAX_LSN_WAIT, SNAPSHOT_PROGRESS_REPO
 use mz_timely_util::builder_async::{
     AsyncOutputHandle, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::containers::stack::AccountedBuilder;
+use mz_timely_util::containers::stack::FueledBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::operators::{CapabilitySet, Concat};
@@ -69,7 +69,7 @@ pub(crate) fn render<'scope>(
     let op_name = format!("SqlServerReplicationReader({})", config.id);
     let mut builder = AsyncOperatorBuilder::new(op_name, scope);
 
-    let (data_output, data_stream) = builder.new_output::<AccountedBuilder<_>>();
+    let (data_output, data_stream) = builder.new_output::<FueledBuilder<_>>();
 
     // Captures DefiniteErrors that affect the entire source, including all outputs
     let (definite_error_handle, definite_errors) =
@@ -737,7 +737,7 @@ async fn handle_data_event(
 }
 
 type StackedAsyncOutputHandle<T, D> =
-    AsyncOutputHandle<T, AccountedBuilder<CapacityContainerBuilder<Vec<(D, T, Diff)>>>>;
+    AsyncOutputHandle<T, FueledBuilder<CapacityContainerBuilder<Vec<(D, T, Diff)>>>>;
 
 /// Helper method to decode a row from a [`tiberius::Row`] (or 2 of them in the case of update)
 /// to a [`Row`]. This centralizes the decode and mapping to result.

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -118,11 +118,10 @@ impl SourceMessage {
     }
 }
 
-/// Heap-size estimate used to drive `give_fueled` yielding in source operators.
+/// Heap-size estimate used by source operators to drive `give_fueled` yielding.
 ///
-/// Implementations should approximate the bytes the value would occupy when
-/// serialized. Stack-only values may report `size_of_val(self)`; values with
-/// heap-allocated payloads (rows, byte buffers) should include that payload.
+/// Stack-only values may report `size_of_val(self)`; values with heap-allocated
+/// payloads (rows, byte buffers) should include that payload.
 pub trait FuelSize {
     fn fuel_size(&self) -> usize;
 }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -24,7 +24,6 @@ use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_types::errors::{DataflowError, DecodeError};
 use mz_storage_types::sources::SourceTimestamp;
 use mz_timely_util::builder_async::PressOnDropButton;
-use mz_timely_util::columnation::ColumnationStack;
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::{Scope, StreamVec};
@@ -53,7 +52,7 @@ pub enum ProgressStatisticsUpdate {
     },
 }
 
-pub type StackedCollection<'scope, T, D> = Collection<'scope, T, ColumnationStack<(D, T, Diff)>>;
+pub type StackedCollection<'scope, T, D> = Collection<'scope, T, Vec<(D, T, Diff)>>;
 
 /// Describes a source that can render itself in a timely scope.
 pub trait SourceRender {
@@ -112,6 +111,13 @@ pub struct SourceMessage {
     pub metadata: Row,
 }
 
+impl SourceMessage {
+    /// Heap-size estimate used to drive fuel accounting in source operators.
+    pub fn byte_len(&self) -> usize {
+        self.key.byte_len() + self.value.byte_len() + self.metadata.byte_len()
+    }
+}
+
 /// The result of probing an upstream system for its write frontier.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Probe<T> {
@@ -119,62 +125,6 @@ pub struct Probe<T> {
     pub probe_ts: mz_repr::Timestamp,
     /// The frontier obtain from the upstream system.
     pub upstream_frontier: Antichain<T>,
-}
-
-mod columnation {
-    use columnation::{Columnation, Region};
-    use mz_repr::Row;
-
-    use super::SourceMessage;
-
-    impl Columnation for SourceMessage {
-        type InnerRegion = SourceMessageRegion;
-    }
-
-    #[derive(Default)]
-    pub struct SourceMessageRegion {
-        inner: <Row as Columnation>::InnerRegion,
-    }
-
-    impl Region for SourceMessageRegion {
-        type Item = SourceMessage;
-
-        unsafe fn copy(&mut self, item: &Self::Item) -> Self::Item {
-            SourceMessage {
-                key: unsafe { self.inner.copy(&item.key) },
-                value: unsafe { self.inner.copy(&item.value) },
-                metadata: unsafe { self.inner.copy(&item.metadata) },
-            }
-        }
-
-        fn clear(&mut self) {
-            self.inner.clear()
-        }
-
-        fn reserve_items<'a, I>(&mut self, items: I)
-        where
-            Self: 'a,
-            I: Iterator<Item = &'a Self::Item> + Clone,
-        {
-            self.inner.reserve_items(
-                items
-                    .map(|item| [&item.key, &item.value, &item.metadata])
-                    .flatten(),
-            )
-        }
-
-        fn reserve_regions<'a, I>(&mut self, regions: I)
-        where
-            Self: 'a,
-            I: Iterator<Item = &'a Self> + Clone,
-        {
-            self.inner.reserve_regions(regions.map(|r| &r.inner))
-        }
-
-        fn heap_size(&self, callback: impl FnMut(usize, usize)) {
-            self.inner.heap_size(callback)
-        }
-    }
 }
 
 /// A record produced by a source

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -145,11 +145,17 @@ impl FuelSize for Vec<u8> {
     }
 }
 
-impl<T: FuelSize, E> FuelSize for Result<T, E> {
+impl FuelSize for bytes::Bytes {
+    fn fuel_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: FuelSize, E: FuelSize> FuelSize for Result<T, E> {
     fn fuel_size(&self) -> usize {
         match self {
             Ok(t) => t.fuel_size(),
-            Err(e) => std::mem::size_of_val(e),
+            Err(e) => e.fuel_size(),
         }
     }
 }
@@ -191,6 +197,7 @@ impl_fuel_size_stack!(
     mz_repr::Timestamp,
     mz_storage_types::sources::MzOffset,
     mz_sql_server_util::cdc::Lsn,
+    DataflowError,
 );
 
 impl<P, T> FuelSize for mz_timely_util::order::Partitioned<P, T> {

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -118,6 +118,87 @@ impl SourceMessage {
     }
 }
 
+/// Heap-size estimate used to drive `give_fueled` yielding in source operators.
+///
+/// Implementations should approximate the bytes the value would occupy when
+/// serialized. Stack-only values may report `size_of_val(self)`; values with
+/// heap-allocated payloads (rows, byte buffers) should include that payload.
+pub trait FuelSize {
+    fn fuel_size(&self) -> usize;
+}
+
+impl FuelSize for SourceMessage {
+    fn fuel_size(&self) -> usize {
+        self.byte_len()
+    }
+}
+
+impl FuelSize for Row {
+    fn fuel_size(&self) -> usize {
+        self.byte_len()
+    }
+}
+
+impl FuelSize for Vec<u8> {
+    fn fuel_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: FuelSize, E> FuelSize for Result<T, E> {
+    fn fuel_size(&self) -> usize {
+        match self {
+            Ok(t) => t.fuel_size(),
+            Err(e) => std::mem::size_of_val(e),
+        }
+    }
+}
+
+/// Tuples sum the fuel size of their elements. Trivial coordinate fields
+/// (output indices, timestamps, diffs) implement `FuelSize` to return their
+/// stack size, so an `update.fuel_size()` call charges only the heap-allocated
+/// payload like rows or byte buffers.
+impl<A: FuelSize, B: FuelSize> FuelSize for (A, B) {
+    fn fuel_size(&self) -> usize {
+        self.0.fuel_size() + self.1.fuel_size()
+    }
+}
+
+impl<A: FuelSize, B: FuelSize, C: FuelSize> FuelSize for (A, B, C) {
+    fn fuel_size(&self) -> usize {
+        self.0.fuel_size() + self.1.fuel_size() + self.2.fuel_size()
+    }
+}
+
+/// Convenience macro for declaring `FuelSize` on a stack-only type.
+macro_rules! impl_fuel_size_stack {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl FuelSize for $t {
+                fn fuel_size(&self) -> usize {
+                    std::mem::size_of_val(self)
+                }
+            }
+        )*
+    };
+}
+
+impl_fuel_size_stack!(
+    usize,
+    u32,
+    u64,
+    Diff,
+    mz_repr::Timestamp,
+    mz_storage_types::sources::MzOffset,
+    mz_sql_server_util::cdc::Lsn,
+);
+
+impl<P, T> FuelSize for mz_timely_util::order::Partitioned<P, T> {
+    fn fuel_size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
+}
+
 /// The result of probing an upstream system for its write frontier.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Probe<T> {

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -39,7 +39,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::scheduling::{Activator, SyncActivator};
 use timely::{Bincode, Container, ContainerBuilder, PartialOrder};
 
-use crate::containers::stack::AccountedBuilder;
+use crate::containers::stack::FueledBuilder;
 
 /// Builds async operators with generic shape.
 pub struct OperatorBuilder<'scope, T: Timestamp> {
@@ -313,17 +313,21 @@ where
     }
 }
 
-impl<T, D> AsyncOutputHandle<T, AccountedBuilder<CapacityContainerBuilder<Vec<D>>>>
+impl<T, D> AsyncOutputHandle<T, FueledBuilder<CapacityContainerBuilder<Vec<D>>>>
 where
     D: Clone + 'static,
     T: Timestamp,
 {
     pub const MAX_OUTSTANDING_BYTES: usize = 128 * 1024 * 1024;
 
-    /// Provides one record at the time specified by the capability, accounting
-    /// `size_bytes` toward the fuel budget. Yields back to timely once at least
-    /// [`Self::MAX_OUTSTANDING_BYTES`] have been emitted since the last yield.
-    pub async fn give_fueled(&self, cap: &Capability<T>, data: D, size_bytes: usize) {
+    /// Provides one record at the time specified by the capability and
+    /// charges `size_bytes` against the builder's fuel counter. Once at least
+    /// [`Self::MAX_OUTSTANDING_BYTES`] have been emitted since the last yield
+    /// this method yields back to timely and resets the counter.
+    pub async fn give_fueled<D2>(&self, cap: &Capability<T>, data: D2, size_bytes: usize)
+    where
+        FueledBuilder<CapacityContainerBuilder<Vec<D>>>: PushInto<D2>,
+    {
         let should_yield = {
             let mut handle = self.inner.borrow_mut();
             handle.give(cap, data);

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll, Waker, ready};
 
-use columnation::Columnation;
 use futures_util::Stream;
 use futures_util::task::ArcWake;
 use timely::communication::{Pull, Push};
@@ -40,8 +39,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::scheduling::{Activator, SyncActivator};
 use timely::{Bincode, Container, ContainerBuilder, PartialOrder};
 
-use crate::columnation::ColumnationStack;
-use crate::containers::stack::AccountedStackBuilder;
+use crate::containers::stack::AccountedBuilder;
 
 /// Builds async operators with generic shape.
 pub struct OperatorBuilder<'scope, T: Timestamp> {
@@ -315,26 +313,25 @@ where
     }
 }
 
-impl<T, D>
-    AsyncOutputHandle<T, AccountedStackBuilder<CapacityContainerBuilder<ColumnationStack<D>>>>
+impl<T, D> AsyncOutputHandle<T, AccountedBuilder<CapacityContainerBuilder<Vec<D>>>>
 where
-    D: Clone + 'static + Columnation,
+    D: Clone + 'static,
     T: Timestamp,
 {
     pub const MAX_OUTSTANDING_BYTES: usize = 128 * 1024 * 1024;
 
-    /// Provides one record at the time specified by the capability. This method will automatically
-    /// yield back to timely after [Self::MAX_OUTSTANDING_BYTES] have been produced.
-    pub async fn give_fueled<D2>(&self, cap: &Capability<T>, data: D2)
-    where
-        ColumnationStack<D>: PushInto<D2>,
-    {
+    /// Provides one record at the time specified by the capability, accounting
+    /// `size_bytes` toward the fuel budget. Yields back to timely once at least
+    /// [`Self::MAX_OUTSTANDING_BYTES`] have been emitted since the last yield.
+    pub async fn give_fueled(&self, cap: &Capability<T>, data: D, size_bytes: usize) {
         let should_yield = {
             let mut handle = self.inner.borrow_mut();
             handle.give(cap, data);
-            let should_yield = handle.builder.bytes.get() > Self::MAX_OUTSTANDING_BYTES;
+            let bytes = &handle.builder.bytes;
+            bytes.set(bytes.get() + size_bytes);
+            let should_yield = bytes.get() > Self::MAX_OUTSTANDING_BYTES;
             if should_yield {
-                handle.builder.bytes.set(0);
+                bytes.set(0);
             }
             should_yield
         };

--- a/src/timely-util/src/containers/stack.rs
+++ b/src/timely-util/src/containers/stack.rs
@@ -13,28 +13,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Container builder wrapper that records bytes emitted for fuel-based yielding.
+//! Container builder wrapper that carries a byte counter for fuel-based yielding.
 
 use std::cell::Cell;
 
 use timely::container::{ContainerBuilder, PushInto};
 
-/// A [`ContainerBuilder`] wrapper that carries a byte counter.
-///
-/// The wrapper forwards all container-builder operations verbatim; bytes are
-/// accumulated externally through [`AsyncOutputHandle::give_fueled`][gf] so
-/// the caller can use whatever size estimate is cheapest for their data
-/// (e.g. `Row::byte_len`) without having to materialize the data into a
-/// columnated region.
+/// A [`ContainerBuilder`] wrapper carrying a byte counter that
+/// [`AsyncOutputHandle::give_fueled`][gf] increments when emitting items. The
+/// wrapper itself does no accounting; it exists so `give_fueled` can find a
+/// counter associated with the output handle. The caller supplies the size of
+/// each pushed item, which lets the source choose whatever estimate is
+/// cheapest for its data without needing the container to introspect items.
 ///
 /// [gf]: crate::builder_async::AsyncOutputHandle::give_fueled
 #[derive(Default)]
-pub struct AccountedBuilder<CB> {
+pub struct FueledBuilder<CB> {
     pub bytes: Cell<usize>,
     pub builder: CB,
 }
 
-impl<CB: ContainerBuilder> ContainerBuilder for AccountedBuilder<CB> {
+impl<CB: ContainerBuilder> ContainerBuilder for FueledBuilder<CB> {
     type Container = CB::Container;
 
     fn extract(&mut self) -> Option<&mut Self::Container> {
@@ -46,7 +45,7 @@ impl<CB: ContainerBuilder> ContainerBuilder for AccountedBuilder<CB> {
     }
 }
 
-impl<T, CB: PushInto<T>> PushInto<T> for AccountedBuilder<CB> {
+impl<T, CB: PushInto<T>> PushInto<T> for FueledBuilder<CB> {
     #[inline]
     fn push_into(&mut self, item: T) {
         self.builder.push_into(item);

--- a/src/timely-util/src/containers/stack.rs
+++ b/src/timely-util/src/containers/stack.rs
@@ -13,48 +13,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A chunked columnar container based on the columnation library. It stores the local
-//! portion in region-allocated data, too, which is different to the `ColumnationStack` type.
+//! Container builder wrapper that records bytes emitted for fuel-based yielding.
 
 use std::cell::Cell;
 
-use columnation::Columnation;
 use timely::container::{ContainerBuilder, PushInto};
 
-use crate::columnation::ColumnationStack;
-
-/// A Stacked container builder that keep track of container memory usage.
+/// A [`ContainerBuilder`] wrapper that carries a byte counter.
+///
+/// The wrapper forwards all container-builder operations verbatim; bytes are
+/// accumulated externally through [`AsyncOutputHandle::give_fueled`][gf] so
+/// the caller can use whatever size estimate is cheapest for their data
+/// (e.g. `Row::byte_len`) without having to materialize the data into a
+/// columnated region.
+///
+/// [gf]: crate::builder_async::AsyncOutputHandle::give_fueled
 #[derive(Default)]
-pub struct AccountedStackBuilder<CB> {
+pub struct AccountedBuilder<CB> {
     pub bytes: Cell<usize>,
     pub builder: CB,
 }
 
-impl<T, CB> ContainerBuilder for AccountedStackBuilder<CB>
-where
-    T: Clone + Columnation + 'static,
-    CB: ContainerBuilder<Container = ColumnationStack<T>>,
-{
-    type Container = ColumnationStack<T>;
+impl<CB: ContainerBuilder> ContainerBuilder for AccountedBuilder<CB> {
+    type Container = CB::Container;
 
     fn extract(&mut self) -> Option<&mut Self::Container> {
-        let container = self.builder.extract()?;
-        let mut new_bytes = 0;
-        container.heap_size(|_, cap| new_bytes += cap);
-        self.bytes.set(self.bytes.get() + new_bytes);
-        Some(container)
+        self.builder.extract()
     }
 
     fn finish(&mut self) -> Option<&mut Self::Container> {
-        let container = self.builder.finish()?;
-        let mut new_bytes = 0;
-        container.heap_size(|_, cap| new_bytes += cap);
-        self.bytes.set(self.bytes.get() + new_bytes);
-        Some(container)
+        self.builder.finish()
     }
 }
 
-impl<T, CB: PushInto<T>> PushInto<T> for AccountedStackBuilder<CB> {
+impl<T, CB: PushInto<T>> PushInto<T> for AccountedBuilder<CB> {
     #[inline]
     fn push_into(&mut self, item: T) {
         self.builder.push_into(item);


### PR DESCRIPTION
Source dataflows used `ColumnationStack<(D, T, Diff)>` on the output edge of every reader (kafka, generator, mysql, postgres, sql_server) only to drive a byte-based yield threshold in `AsyncOutputHandle::give_fueled`.
Downstream operators immediately unpacked every row via `iter`/`drain`, so the region copy into columnation was pure overhead — every emitted row paid one extra heap copy and then was read back out on the next operator hop.

This replaces `AccountedStackBuilder` with a container-agnostic `AccountedBuilder` that forwards to an inner `ContainerBuilder`, and changes `give_fueled` to take an explicit `size_bytes` argument supplied by the caller.
Data rows account for `SourceMessage::byte_len()`; definite errors (rare) account for `std::mem::size_of_val(&update)`.

Source outputs and the `StackedCollection` alias now use `Vec<(D, T, Diff)>`, and the `SourceMessage` `Columnation` implementation is removed.
The `Partition` route closures and downstream unary consumers update to match the new owned-item container semantics.

### Motivation

The `AccountedStackBuilder` + `ColumnationStack` combo existed purely to compute `heap_size` for yield accounting.
Since readers emit rows one at a time and the next operator always re-materializes them, the region-copy cost was pure overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)