### PR TITLE
ci: Use linear as an additional source for ci-regexp/closed-issues

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -300,6 +300,7 @@ case "$cmd" in
                 --env METADATA_BACKEND_URL
                 # For ci-closed-issues-detect
                 --env GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN
+                --env LINEAR_READ_ONLY_TOKEN
                 # For auto_cut_release
                 --env GIT_AUTHOR_EMAIL
                 --env GIT_AUTHOR_NAME

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -51,6 +51,7 @@ from materialize.github import (
     for_github_re,
     get_known_issues_from_github,
 )
+from materialize.linear import get_known_issues_from_linear
 from materialize.observed_error import ObservedBaseError, WithIssue
 from materialize.test_analytics.config.test_analytics_db_config import (
     create_test_analytics_config_with_hostname,
@@ -307,17 +308,26 @@ class ObservedErrorWithIssue(ObservedError, WithIssue):
     issue_ignore_failure: bool
 
     def _get_issue_presentation(self) -> str:
-        issue_presentation = f"#{self.issue_number}"
+        issue_presentation = (
+            self.issue_number
+            if isinstance(self.issue_number, str)
+            else f"#{self.issue_number}"
+        )
         if self.issue_is_closed:
             issue_presentation = f"{issue_presentation}, closed"
 
         return issue_presentation
 
+    def _get_issue_id(self) -> str:
+        if isinstance(self.issue_number, str):
+            return self.issue_number
+        return f"database-issues/{self.issue_number}"
+
     def to_text(self) -> str:
         return f"{self.error_type} {self.issue_title} ({self._get_issue_presentation()}) in {self.location}: {self.error_message_as_text()}{self.error_details_as_text()}"
 
     def to_markdown(self) -> str:
-        ci_failures_url = f"https://ci.dev.materialize.com/#failures?issue={urllib.parse.quote(f'database-issues/{self.issue_number}', safe='')}"
+        ci_failures_url = f"https://ci.dev.materialize.com/#failures?issue={urllib.parse.quote(self._get_issue_id(), safe='')}"
         return f'<a href="{ci_failures_url}">{self.error_type}</a> <a href="{self.issue_url}">{self.issue_title} ({self._get_issue_presentation()})</a> in {self.location_as_markdown()}:\n{self.error_message_as_markdown()}{self.error_details_as_markdown()}{self.additional_collapsed_error_details_as_markdown()}'
 
 
@@ -550,8 +560,13 @@ def annotate_logged_errors(
         "GITHUB_TOKEN"
     )
     known_issues, issues_with_invalid_regex = get_known_issues_from_github(token)
+    linear_known_issues, linear_issues_with_invalid_regex = (
+        get_known_issues_from_linear()
+    )
+    known_issues.extend(linear_known_issues)
     unknown_errors: list[ObservedBaseError] = []
     unknown_errors.extend(issues_with_invalid_regex)
+    unknown_errors.extend(linear_issues_with_invalid_regex)
 
     job = os.getenv("BUILDKITE_JOB_ID")
 
@@ -559,7 +574,7 @@ def annotate_logged_errors(
     ignore_failure: bool = False
 
     # Keep track of known errors so we log each only once
-    already_reported_issue_numbers: set[int] = set()
+    already_reported_issue_numbers: set[int | str] = set()
 
     def handle_error(
         error_message: str,
@@ -1093,7 +1108,11 @@ def store_annotation_in_test_analytics(
             error_type=error.internal_error_type,
             message=error.to_text(),
             issue=(
-                f"database-issues/{error.issue_number}"
+                (
+                    error.issue_number
+                    if isinstance(error.issue_number, str)
+                    else f"database-issues/{error.issue_number}"
+                )
                 if isinstance(error, WithIssue)
                 else None
             ),

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -20,6 +20,7 @@ from typing import IO
 import requests
 
 from materialize import buildkite, spawn
+from materialize.linear import LINEAR_CLOSED_STATE_TYPES
 
 ISSUE_RE = re.compile(
     r"""
@@ -31,6 +32,8 @@ ISSUE_RE = re.compile(
     | ( terraform-aws-materialize\# | terraform-aws-materialize/issues/ ) (?P<terraformawsmaterialize>[0-9]+)
     | ( terraform-google-materialize\# | terraform-google-materialize/issues/ ) (?P<terraformgooglematerialize>[0-9]+)
     | ( materialize-terraform-self-managed\# | materialize-terraform-self-managed/issues/ ) (?P<materializeterraformselfmanaged>[0-9]+)
+    # Linear issue identifiers like linear#SEC-308 or full Linear URLs
+    | (linear\# | linear\.app/\S+/issue/) (?P<linear>[A-Z][A-Z0-9]+-[0-9]+)
     # only match from the beginning of the line or after a space character to avoid matching Buildkite URLs
     | (^|\s) \# (?P<ambiguous>[0-9]+)
     )
@@ -47,6 +50,7 @@ GROUP_REPO = {
     "terraformawsmaterialize": "MaterializeInc/terraform-aws-materialize",
     "terraformgooglematerialize": "MaterializeInc/terraform-google-materialize",
     "materializeterraformselfmanaged": "MaterializeInc/materialize-terraform-self-managed",
+    "linear": "linear",
     "ambiguous": None,
 }
 
@@ -117,7 +121,7 @@ FILENAME_REFERENCE_RE = re.compile(r".*\.(td|slt|test)\.gh(?P<ambiguous>[0-9]+)"
 @dataclass
 class IssueRef:
     repository: str | None
-    issue_id: int
+    issue_id: int | str
     filename: str
     line_number: int
     text: str | None
@@ -189,7 +193,7 @@ def detect_referenced_issues(filename: str) -> list[IssueRef]:
                 issue_refs.append(
                     IssueRef(
                         GROUP_REPO[group],
-                        int(issue_id),
+                        issue_id if group == "linear" else int(issue_id),
                         filename,
                         line_number,
                         text.strip(),
@@ -229,6 +233,51 @@ def is_issue_closed_on_github(repository: str | None, issue_id: int) -> bool:
     return issue_json["state"] == "closed"
 
 
+def is_issue_closed_on_linear(identifier: str) -> bool:
+    token = os.getenv("LINEAR_READ_ONLY_TOKEN")
+    if not token:
+        if not os.getenv("CI"):
+            print(
+                f"Can't check Linear issue {identifier}, set LINEAR_READ_ONLY_TOKEN environment variable"
+            )
+        return False
+
+    parts = identifier.split("-", 1)
+    if len(parts) != 2:
+        return False
+    team_key, number_str = parts
+    try:
+        number = int(number_str)
+    except ValueError:
+        return False
+
+    query = """
+    query($teamKey: String!, $number: Float!) {
+      issues(filter: { number: { eq: $number }, team: { key: { eq: $teamKey } } }) {
+        nodes {
+          state { type }
+        }
+      }
+    }
+    """
+
+    response = requests.post(
+        "https://api.linear.app/graphql",
+        headers={"Authorization": token, "Content-Type": "application/json"},
+        json={"query": query, "variables": {"teamKey": team_key, "number": number}},
+    )
+
+    if response.status_code != 200:
+        return False
+
+    result = response.json()
+    nodes = result.get("data", {}).get("issues", {}).get("nodes", [])
+    if not nodes:
+        return False
+
+    return nodes[0]["state"]["type"] in LINEAR_CLOSED_STATE_TYPES
+
+
 def filter_changed_lines(issue_refs: list[IssueRef]) -> list[IssueRef]:
     changed_lines = buildkite.find_modified_lines()
     return [
@@ -251,16 +300,34 @@ def filter_ambiguous_issues(
 
 
 def filter_closed_issues(issue_refs: list[IssueRef]) -> list[IssueRef]:
-    issues = {(issue_ref.repository, issue_ref.issue_id) for issue_ref in issue_refs}
-    closed_issues = {
-        (repository, issue)
-        for repository, issue in issues
-        if is_issue_closed_on_github(repository, issue)
+    github_issues = {
+        (ref.repository, ref.issue_id)
+        for ref in issue_refs
+        if ref.repository != "linear"
     }
+    closed_github = {
+        (repository, issue)
+        for repository, issue in github_issues
+        if isinstance(issue, int) and is_issue_closed_on_github(repository, issue)
+    }
+
+    linear_identifiers = {
+        ref.issue_id for ref in issue_refs if ref.repository == "linear"
+    }
+    closed_linear = {
+        identifier
+        for identifier in linear_identifiers
+        if is_issue_closed_on_linear(str(identifier))
+    }
+
     return [
-        issue_ref
-        for issue_ref in issue_refs
-        if (issue_ref.repository, issue_ref.issue_id) in closed_issues
+        ref
+        for ref in issue_refs
+        if (ref.repository == "linear" and ref.issue_id in closed_linear)
+        or (
+            ref.repository != "linear"
+            and (ref.repository, ref.issue_id) in closed_github
+        )
     ]
 
 
@@ -328,10 +395,16 @@ def main() -> int:
         )
 
     for issue_ref in issue_refs:
-        url = buildkite.inline_link(
-            f"https://github.com/{issue_ref.repository}/issues/{issue_ref.issue_id}",
-            f"{issue_ref.repository}#{issue_ref.issue_id}",
-        )
+        if issue_ref.repository == "linear":
+            url = buildkite.inline_link(
+                f"https://linear.app/materializeinc/issue/{issue_ref.issue_id}",
+                str(issue_ref.issue_id),
+            )
+        else:
+            url = buildkite.inline_link(
+                f"https://github.com/{issue_ref.repository}/issues/{issue_ref.issue_id}",
+                f"{issue_ref.repository}#{issue_ref.issue_id}",
+            )
         print(f"--- Issue is referenced in comment but already closed: {url}")
         if issue_ref.text is not None:
             print(f"{issue_ref.filename}:{issue_ref.line_number}:")

--- a/misc/python/materialize/github.py
+++ b/misc/python/materialize/github.py
@@ -41,7 +41,12 @@ class GitHubIssueWithInvalidRegexp(ObservedBaseError, WithIssue):
         return f"Invalid regex in ci-regexp: {self.regex_pattern}"
 
     def to_markdown(self) -> str:
-        return f'<a href="{self.issue_url}">{self.issue_title} (#{self.issue_number})</a>: Invalid regex in ci-regexp: {self.regex_pattern}, ignoring'
+        issue_ref = (
+            self.issue_number
+            if isinstance(self.issue_number, str)
+            else f"#{self.issue_number}"
+        )
+        return f'<a href="{self.issue_url}">{self.issue_title} ({issue_ref})</a>: Invalid regex in ci-regexp: {self.regex_pattern}, ignoring'
 
 
 def _search_issues_graphql(token: str, repo: str) -> list[dict[str, Any]]:

--- a/misc/python/materialize/linear.py
+++ b/misc/python/materialize/linear.py
@@ -1,0 +1,207 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Linear utilities."""
+
+import os
+import re
+from typing import Any
+
+import requests
+
+from materialize.github import (
+    CI_APPLY_TO,
+    CI_IGNORE_FAILURE,
+    CI_LOCATION,
+    CI_RE,
+    GitHubIssueWithInvalidRegexp,
+    KnownGitHubIssue,
+)
+
+LINEAR_CLOSED_STATE_TYPES = {"completed", "canceled"}
+
+
+def _search_issues_graphql(token: str) -> list[dict[str, Any]]:
+    query = """
+    query($term: String!, $cursor: String) {
+      searchIssues(
+        term: $term
+        first: 100
+        after: $cursor
+        includeArchived: false
+      ) {
+        nodes {
+          identifier
+          title
+          description
+          url
+          state {
+            type
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+    """
+
+    all_issues: list[dict[str, Any]] = []
+    cursor = None
+
+    while True:
+        variables: dict[str, Any] = {"term": "ci-regexp"}
+        if cursor:
+            variables["cursor"] = cursor
+
+        response = requests.post(
+            "https://api.linear.app/graphql",
+            headers={
+                "Authorization": token,
+                "Content-Type": "application/json",
+            },
+            json={"query": query, "variables": variables},
+        )
+
+        if response.status_code != 200:
+            raise ValueError(
+                f"Bad return code from Linear GraphQL: {response.status_code}, "
+                f"response={response.text[:500]}, "
+                f"has_token=True"
+            )
+
+        result = response.json()
+        if "errors" in result:
+            raise ValueError(f"Linear GraphQL errors: {result['errors']}")
+
+        search_data = result["data"]["searchIssues"]
+        for node in search_data["nodes"]:
+            if node is None:
+                continue
+            description = node.get("description") or ""
+            if "ci-regexp:" in description:
+                all_issues.append(node)
+
+        if not search_data["pageInfo"]["hasNextPage"]:
+            break
+        cursor = search_data["pageInfo"]["endCursor"]
+
+    return all_issues
+
+
+def get_known_issues_from_linear(
+    token: str | None = os.getenv("LINEAR_READ_ONLY_TOKEN"),
+) -> tuple[list[KnownGitHubIssue], list[GitHubIssueWithInvalidRegexp]]:
+    if not token:
+        return ([], [])
+
+    issues = _search_issues_graphql(token)
+
+    known_issues = []
+    issues_with_invalid_regex = []
+
+    for issue in issues:
+        body = issue.get("description") or ""
+
+        state_type = issue.get("state", {}).get("type", "")
+        state = "CLOSED" if state_type in LINEAR_CLOSED_STATE_TYPES else "OPEN"
+
+        info = {
+            "number": issue["identifier"],
+            "title": issue["title"],
+            "body": body,
+            "url": issue["url"],
+            "state": state,
+            "source": "linear",
+        }
+
+        matches = CI_RE.findall(body)
+        matches_apply_to = CI_APPLY_TO.findall(body)
+        matches_location = CI_LOCATION.findall(body)
+        matches_ignore_failure = CI_IGNORE_FAILURE.findall(body)
+
+        if len(matches) > 1:
+            issues_with_invalid_regex.append(
+                GitHubIssueWithInvalidRegexp(
+                    internal_error_type="LINEAR_INVALID_REGEXP",
+                    issue_url=issue["url"],
+                    issue_title=issue["title"],
+                    issue_number=issue["identifier"],
+                    regex_pattern=f"Multiple regexes, but only one supported: {[match.strip() for match in matches]}",
+                )
+            )
+            continue
+
+        if len(matches_ignore_failure) > 1:
+            issues_with_invalid_regex.append(
+                GitHubIssueWithInvalidRegexp(
+                    internal_error_type="LINEAR_INVALID_IGNORE_FAILURE",
+                    issue_url=issue["url"],
+                    issue_title=issue["title"],
+                    issue_number=issue["identifier"],
+                    regex_pattern=f"Multiple ci-ignore-failures, but only one supported: {[match.strip() for match in matches_ignore_failure]}",
+                )
+            )
+            continue
+
+        if len(matches) == 0:
+            continue
+
+        if len(matches_location) >= 2:
+            issues_with_invalid_regex.append(
+                GitHubIssueWithInvalidRegexp(
+                    internal_error_type="LINEAR_INVALID_LOCATION",
+                    issue_url=issue["url"],
+                    issue_title=issue["title"],
+                    issue_number=issue["identifier"],
+                    regex_pattern=f"Multiple ci-locations, but only one supported: {[match.strip() for match in matches_location]}",
+                )
+            )
+            continue
+
+        location: str | None = (
+            matches_location[0] if len(matches_location) == 1 else None
+        )
+
+        ignore_failure = len(matches_ignore_failure) == 1 and matches_ignore_failure[
+            0
+        ].strip() in ("true", "yes", "1")
+
+        try:
+            regex_pattern = re.compile(matches[0].strip().encode())
+        except:
+            issues_with_invalid_regex.append(
+                GitHubIssueWithInvalidRegexp(
+                    internal_error_type="LINEAR_INVALID_REGEXP",
+                    issue_url=issue["url"],
+                    issue_title=issue["title"],
+                    issue_number=issue["identifier"],
+                    regex_pattern=matches[0].strip(),
+                )
+            )
+            continue
+
+        if matches_apply_to:
+            for match_apply_to in matches_apply_to:
+                known_issues.append(
+                    KnownGitHubIssue(
+                        regex_pattern,
+                        match_apply_to.strip().lower(),
+                        info,
+                        ignore_failure,
+                        location,
+                    )
+                )
+        else:
+            known_issues.append(
+                KnownGitHubIssue(regex_pattern, None, info, ignore_failure, location)
+            )
+
+    return (known_issues, issues_with_invalid_regex)

--- a/misc/python/materialize/observed_error.py
+++ b/misc/python/materialize/observed_error.py
@@ -30,6 +30,6 @@ class ObservedBaseError:
 
 @dataclass(unsafe_hash=True)
 class WithIssue:
-    issue_number: int
+    issue_number: int | str
     issue_url: str
     issue_title: str

--- a/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
+++ b/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
@@ -17,7 +17,10 @@ class KnownIssuesStorage(BaseDataStorage):
         self,
         issue: KnownGitHubIssue,
     ) -> None:
-        issue_str = f"{issue.info['repository']['nameWithOwner'].split('/')[-1]}/{issue.info['number']}"
+        if issue.info.get("source") == "linear":
+            issue_str = str(issue.info["number"])
+        else:
+            issue_str = f"{issue.info['repository']['nameWithOwner'].split('/')[-1]}/{issue.info['number']}"
         sql_statements = [
             f"""
             UPDATE issue


### PR DESCRIPTION
Using the token from https://github.com/MaterializeInc/i2/pull/3211

Fixes: https://linear.app/materializeinc/issue/QAR-38/detect-closed-issues-in-ci-via-the-linear-api
Fixes: https://linear.app/materializeinc/issue/QAR-37/add-linear-support-to-ci-regexp