### PR TITLE
sql-server: Fix composite key column ordering in constraint discovery

### DIFF
--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -499,27 +499,25 @@ pub async fn get_constraints_for_tables(
         .map(|idx| format!("@P{}", idx))
         .join(", ");
 
-    // Because we don't have an object idenfifier for the table(s), this query concatenates the
-    // schema and table name to create a single identifier for the query rather than compose a
-    // complex set of OR conditions for each schema + set of tables in the schema.
-    //
-    // This query may perform poorly due to the condition relying on a concatenated value. We may get
-    // better performance by adding a query constraint on the table names, but it isn't clear at
-    // this time if that is needed.
+    // KEY_COLUMN_USAGE (not CONSTRAINT_COLUMN_USAGE) because it exposes
+    // ORDINAL_POSITION, letting us preserve composite-key column order.
     let query = format!(
         "SELECT \
         tc.table_schema, \
         tc.table_name, \
-        ccu.column_name,  \
+        kcu.column_name, \
         tc.constraint_name, \
         tc.constraint_type \
     FROM information_schema.table_constraints tc \
-    JOIN information_schema.constraint_column_usage ccu \
-        ON ccu.constraint_schema = tc.constraint_schema \
-        AND ccu.constraint_name = tc.constraint_name \
+    JOIN information_schema.key_column_usage kcu \
+        ON kcu.constraint_schema = tc.constraint_schema \
+        AND kcu.constraint_name = tc.constraint_name \
+        AND kcu.table_schema = tc.table_schema \
+        AND kcu.table_name = tc.table_name \
     WHERE
         QUOTENAME(tc.table_schema) + '.' + QUOTENAME(tc.table_name) IN ({params})
-        AND tc.constraint_type in ('PRIMARY KEY', 'UNIQUE')"
+        AND tc.constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+    ORDER BY tc.table_schema, tc.table_name, tc.constraint_name, kcu.ordinal_position"
     );
 
     let query_params: Vec<_> = qualified_table_names

--- a/test/sql-server-cdc/26-constraint-column-order.td
+++ b/test/sql-server-cdc/26-constraint-column-order.td
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password};Database=test
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+> DROP CONNECTION IF EXISTS sql_server_test_26_connection CASCADE
+> CREATE CONNECTION sql_server_test_26_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+$ sql-server-execute name=sql-server
+CREATE TABLE t26_pk_order (a_col INT NOT NULL, val INT, z_col INT NOT NULL, PRIMARY KEY (z_col, a_col));
+INSERT INTO t26_pk_order VALUES (1, 10, 100);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't26_pk_order', @role_name = 'SA', @supports_net_changes = 0;
+
+> BEGIN;
+> CREATE SOURCE t26_source FROM SQL SERVER CONNECTION sql_server_test_26_connection;
+> CREATE TABLE t26_pk_order FROM SOURCE t26_source (REFERENCE t26_pk_order);
+> COMMIT;
+
+> SELECT create_sql LIKE '%PRIMARY KEY ("z_col", "a_col")%' FROM mz_tables WHERE name = 't26_pk_order';
+true
+
+> SELECT * FROM t26_pk_order;
+1 10 100


### PR DESCRIPTION
PR #33991 switched constraint discovery to INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE, which does not expose column ordinal position. For composite keys defined in non-alphabetical order (e.g. PRIMARY KEY (z_col, a_col)), SQL Server returns columns in arbitrary order, causing the persisted constraint SQL to record the wrong column order. This surfaces as non-deterministic constraint definitions across re-purification (ALTER SOURCE, refresh) and incorrect constraint text in mz_tables.create_sql.

Fix: use KEY_COLUMN_USAGE instead, which exposes ORDINAL_POSITION, and ORDER BY it to guarantee definition-order delivery.