### PR TITLE
persist: fix metric label logging using name instead of value

### DIFF
--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -380,7 +380,7 @@ pub(crate) fn info_log_non_zero_metrics(metric_families: &[MetricFamily]) {
                     }
                     labels.push_str(lb.name());
                     labels.push_str(":");
-                    labels.push_str(lb.name());
+                    labels.push_str(lb.value());
                 }
                 labels.push_str("}");
             }


### PR DESCRIPTION
The prometheus 0.14.0 bump (#32280) renamed `get_value()` to `name()` instead of `value()`, causing all metric labels to be logged as `name:name` instead of `name:value`.