### PR TITLE
sql: Use fully-qualified name in SHOW CREATE TYPE & minor doc fixes

### DIFF
--- a/doc/user/content/headless/sql-command-privileges/show-create-type.md
+++ b/doc/user/content/headless/sql-command-privileges/show-create-type.md
@@ -1,4 +1,4 @@
 ---
 headless: true
 ---
-- `USAGE` privileges on the schema containing the table.
+- `USAGE` privileges on the schema containing the type.

--- a/doc/user/content/sql/show-create-type.md
+++ b/doc/user/content/sql/show-create-type.md
@@ -1,6 +1,6 @@
 ---
 title: "SHOW CREATE TYPE"
-description: "`SHOW CREATE TYPE` returns the DDL statement used to custom create the type."
+description: "`SHOW CREATE TYPE` returns the DDL statement used to create the custom type."
 menu:
   main:
     parent: commands
@@ -16,7 +16,7 @@ SHOW [REDACTED] CREATE TYPE <type_name>;
 
 {{< yaml-table data="show_create_redacted_option" >}}
 
-For available type names names, see [`SHOW TYPES`](/sql/show-types).
+For available type names, see [`SHOW TYPES`](/sql/show-types).
 
 ## Examples
 
@@ -26,9 +26,9 @@ SHOW CREATE TYPE point;
 ```
 
 ```nofmt
-    name          |    create_sql
-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- point            | CREATE TYPE materialize.public.point AS (x pg_catalog.int4, y pg_catalog.int4);
+    name                    |    create_sql
+----------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ materialize.public.point   | CREATE TYPE materialize.public.point AS (x pg_catalog.int4, y pg_catalog.int4);
 ```
 
 ## Privileges

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -268,15 +268,12 @@ pub fn plan_show_create_type(
 
     let type_item = scx.get_item(&id);
 
-    // check if a builtin type is being accessed
     if id.is_system() {
-        // builtin types do not have a create sql
         sql_bail!("cannot show create for system type {full_name}");
     }
 
-    let name = type_item.name().item.as_ref();
+    let name = full_name.to_string();
 
-    // if custom type we make the sql human readable
     let create_sql = humanize_sql_for_show_create(
         scx.catalog,
         type_item.id(),
@@ -286,7 +283,7 @@ pub fn plan_show_create_type(
 
     Ok(ShowCreatePlan {
         id: ObjectId::Item(id),
-        row: Row::pack_slice(&[Datum::String(name), Datum::String(&create_sql)]),
+        row: Row::pack_slice(&[Datum::String(&name), Datum::String(&create_sql)]),
     })
 }
 

--- a/test/sqllogictest/create_type_mods.slt
+++ b/test/sqllogictest/create_type_mods.slt
@@ -65,7 +65,7 @@ NULL
 query TT
 SHOW CREATE TYPE y1;
 ----
-y1
+materialize.public.y1
 CREATE TYPE materialize.public.y1 AS (id pg_catalog.int4, name pg_catalog.text, num pg_catalog.numeric(3, 1), "updatedAt" pg_catalog.timestamp(3));
 
 # For non existent types

--- a/test/sqllogictest/redacted.slt
+++ b/test/sqllogictest/redacted.slt
@@ -223,5 +223,5 @@ SHOW REDACTED CREATE VIEW mv1;
 query TT
 SHOW REDACTED CREATE TYPE ty;
 ----
-ty
+materialize.public.ty
 CREATE TYPE materialize.public.ty AS LIST (ELEMENT TYPE = pg_catalog.bool);


### PR DESCRIPTION
#33737 introduced `SHOW CREATE TYPE` but emitted the bare item name instead of `database.schema.item`, unlike every other `SHOW CREATE` variant. Also fix doc typos