### PR TITLE
postgres-util: fix RLS policy validation false positives (#33784)

### DIFF
--- a/src/postgres-util/src/replication.rs
+++ b/src/postgres-util/src/replication.rs
@@ -107,8 +107,8 @@ pub async fn bypass_rls_attribute(client: &Client) -> Result<bool, PostgresError
 /// Returns an error if the tables identified by the oid's have RLS policies which
 /// affect the current user. Two checks are made:
 ///
-/// 1. Identify which tables, from the provided oid's, have RLS policies that affecct the user or
-///    public.
+/// 1. Identify which tables, from the provided oid's, have RLS SELECT or ALL policies that affect
+///    the user or public.
 /// 2. If there are policies that affect the user, check if the BYPASSRLS attribute is set. If set,
 ///    the role is unaffected by the policies.
 pub async fn validate_no_rls_policies(
@@ -121,13 +121,21 @@ pub async fn validate_no_rls_policies(
     let tables_with_rls_for_user = client
         .query(
             "SELECT
-                    format('%I.%I', pc.relnamespace::regnamespace, pc.relname) AS qualified_name
+                    format('%I.%I', n.nspname, pc.relname) AS qualified_name
                 FROM pg_policy pp
-                JOIN pg_class pc ON pc.oid = polrelid
+                JOIN pg_class pc ON pc.oid = pp.polrelid
+                JOIN pg_namespace n ON n.oid = pc.relnamespace
                 WHERE
-                    polrelid = ANY($1::oid[])
-                    AND
-                    (0 = ANY(polroles) OR CURRENT_USER::regrole::oid = ANY(polroles));",
+                    pp.polrelid = ANY($1::oid[])
+                    AND pp.polcmd IN ('r', '*')
+                    AND (
+                        0 = ANY(pp.polroles)
+                        OR EXISTS (
+                            SELECT 1
+                            FROM unnest(pp.polroles) AS r(role_oid)
+                            WHERE pg_has_role(CURRENT_USER, r.role_oid, 'USAGE')
+                        )
+                    );",
             &[&table_oids],
         )
         .await

--- a/test/pg-cdc/row-level-security.td
+++ b/test/pg-cdc/row-level-security.td
@@ -127,3 +127,38 @@ ALTER ROLE mz_user BYPASSRLS;
 > SELECT * FROM foo;
 1 apple true
 3 c true
+
+## Test that RLS policies applied via inherited roles are detected.
+## Previously, the check only matched policies where polroles contained the
+## exact oid of CURRENT_USER, missing policies attached to parent roles.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP POLICY restrict_mzuser ON foo;
+DROP ROLE IF EXISTS analyst;
+CREATE ROLE analyst;
+GRANT analyst TO mz_user;
+CREATE POLICY restrict_analyst ON foo FOR SELECT TO analyst USING (visible = TRUE);
+ALTER ROLE mz_user NOBYPASSRLS;
+
+> BEGIN
+> CREATE SOURCE mz_source_inherited
+  IN CLUSTER rls
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source');
+! CREATE TABLE foo_inherited FROM SOURCE mz_source_inherited (REFERENCE foo);
+contains:one or more tables requires BYPASSRLS
+> ROLLBACK;
+
+# BYPASSRLS on the user allows source creation even with inherited-role policies
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER ROLE mz_user BYPASSRLS;
+
+> BEGIN
+> CREATE SOURCE mz_source_inherited
+  IN CLUSTER rls
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source');
+> CREATE TABLE foo_inherited FROM SOURCE mz_source_inherited (REFERENCE foo);
+> COMMIT;
+
+> SELECT * FROM foo_inherited
+1 apple true
+3 c true


### PR DESCRIPTION
Fix three issues in `validate_no_rls_policies` introduced in #33784:

- Filter by `polcmd IN ('r', '*')` so INSERT/UPDATE/DELETE-only policies don't spuriously require BYPASSRLS. Only SELECT and ALL policies affect what the replication user can read.
- Use `pg_has_role(CURRENT_USER, role_oid, 'USAGE')` instead of a direct OID comparison so policies applied via inherited roles are matched. PostgreSQL applies RLS policies transitively through role inheritance (via `has_privs_of_role`), so a policy `TO analyst` silently filters reads for any member of `analyst` — the exact silent-data-loss scenario the original check was written to prevent.
- Join `pg_namespace` for the raw `nspname` instead of casting through `regnamespace` (already quoted) into `%I` (quotes again), which produced double-quoted schema names in error messages.

Regression test added: creates a parent role `analyst` with a SELECT policy, grants it to `mz_user`, and verifies purification catches the inherited-role policy. Verified the test fails without the fix (policy silently missed, CREATE TABLE succeeds) and passes with it.