### PR TITLE
coord: Skip bootstrap credit check for expired DisableClusterCreation licenses

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -118,7 +118,7 @@ use mz_controller::clusters::{
 use mz_controller::{ControllerConfig, Readiness};
 use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
 use mz_expr::{MapFilterProject, MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
-use mz_license_keys::ValidatedLicenseKey;
+use mz_license_keys::{ExpirationBehavior, ValidatedLicenseKey};
 use mz_orchestrator::OfflineReason;
 use mz_ore::cast::{CastFrom, CastInto, CastLossy};
 use mz_ore::channel::trigger::Trigger;
@@ -2058,17 +2058,28 @@ impl Coordinator {
             .update_orchestrator_scheduling_config(scheduling_config);
         self.controller.update_configuration(dyncfg_updates);
 
-        self.validate_resource_limit_numeric(
-            Numeric::zero(),
-            self.current_credit_consumption_rate(),
-            |system_vars| {
-                self.license_key
-                    .max_credit_consumption_rate()
-                    .map_or_else(|| system_vars.max_credit_consumption_rate(), Numeric::from)
-            },
-            "cluster replica",
-            MAX_CREDIT_CONSUMPTION_RATE.name(),
-        )?;
+        // Skip the credit consumption check at bootstrap when the license is expired
+        // with DisableClusterCreation behavior. That mode is a soft-fail: it warns and
+        // prevents *new* cluster creation, but must not block startup with existing replicas.
+        // The Disable case is already handled by a bail! in main.rs before we reach here.
+        let enforce_credit_limit_at_bootstrap = !(self.license_key.expired
+            && matches!(
+                self.license_key.expiration_behavior,
+                ExpirationBehavior::DisableClusterCreation,
+            ));
+        if enforce_credit_limit_at_bootstrap {
+            self.validate_resource_limit_numeric(
+                Numeric::zero(),
+                self.current_credit_consumption_rate(),
+                |system_vars| {
+                    self.license_key
+                        .max_credit_consumption_rate()
+                        .map_or_else(|| system_vars.max_credit_consumption_rate(), Numeric::from)
+                },
+                "cluster replica",
+                MAX_CREDIT_CONSUMPTION_RATE.name(),
+            )?;
+        }
 
         let mut policies_to_set: BTreeMap<CompactionWindow, CollectionIdBundle> =
             Default::default();

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2058,15 +2058,14 @@ impl Coordinator {
             .update_orchestrator_scheduling_config(scheduling_config);
         self.controller.update_configuration(dyncfg_updates);
 
-        // Skip the credit consumption check at bootstrap when the license is expired
-        // with DisableClusterCreation behavior. That mode is a soft-fail: it warns and
-        // prevents *new* cluster creation, but must not block startup with existing replicas.
+        // Skip the credit consumption check at bootstrap under DisableClusterCreation behavior:
+        // this codepath validates existing replicas at startup, not cluster creation, so it
+        // must not block startup. New cluster creation is still gated by the DDL-time check.
         // The Disable case is already handled by a bail! in main.rs before we reach here.
-        let enforce_credit_limit_at_bootstrap = !(self.license_key.expired
-            && matches!(
-                self.license_key.expiration_behavior,
-                ExpirationBehavior::DisableClusterCreation,
-            ));
+        let enforce_credit_limit_at_bootstrap = !matches!(
+            self.license_key.expiration_behavior,
+            ExpirationBehavior::DisableClusterCreation,
+        );
         if enforce_credit_limit_at_bootstrap {
             self.validate_resource_limit_numeric(
                 Numeric::zero(),


### PR DESCRIPTION
The bootstrap-time credit consumption validation introduced in #33654 returns ResourceExhaustion when an expired license with DisableClusterCreation behavior has any existing managed replicas, since max_credit_consumption_rate() returns 0.0 in that case. This crashes environmentd on restart, converting a soft-fail mode into a permanent lockout.

Skip the check when the license is expired with DisableClusterCreation so existing replicas survive restarts. New cluster creation is still blocked by the DDL-time validation.