### PR TITLE
persist: Redact row data and MFP in filter pushdown audit log (#33496)

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -277,9 +277,6 @@ def get_variable_system_parameters(
             ["100ms", "1s", "10s"],
         ),
         VariableSystemParameter(
-            "persist_encoding_enable_dictionary", "true", ["true", "false"]
-        ),
-        VariableSystemParameter(
             "persist_stats_audit_percent",
             "100",
             [

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -22,6 +22,7 @@ use futures::{StreamExt, future::Either};
 use mz_expr::{ColumnSpecs, EvalError, Interpreter, MfpPlan, ResultSpec, UnmaterializableFunc};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
+use mz_ore::str::redact;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::{PersistConfig, RetryParameters};
 use mz_persist_client::fetch::{ExchangeableBatchPart, ShardSourcePart};
@@ -644,8 +645,8 @@ impl PendingWork {
                                         error!(
                                             ?stats,
                                             name,
-                                            ?mfp,
-                                            ?result,
+                                            mfp = ?redact(&mfp),
+                                            result = ?redact(&result),
                                             "persist filter pushdown correctness violation!"
                                         );
                                         if self.panic_on_audit_failure {


### PR DESCRIPTION
The `error!` log added for filter pushdown audit violations printed `result` (containing raw Row data) and `mfp` (containing query literals) unredacted. With `STATS_AUDIT_PANIC=false`, this log is the primary artifact of a violation and can reach Sentry/log aggregation, leaking customer data. Wrap both fields with `mz_ore::str::redact`.

Also remove a duplicate `persist_encoding_enable_dictionary` entry in `get_variable_system_parameters` left over from the same PR's rebase.