### PR TITLE
copy-to-s3: reject parquet-incompatible types at planning time

### DIFF
--- a/src/arrow-util/src/builder.rs
+++ b/src/arrow-util/src/builder.rs
@@ -125,6 +125,50 @@ impl ArrowBuilder {
         Ok(())
     }
 
+    /// Helper to validate that a RelationDesc, after applying `overrides`, can
+    /// be encoded into Arrow AND converted from Arrow into parquet by
+    /// arrow-rs's `ArrowWriter`.
+    ///
+    /// Arrow encodability is a superset of parquet encodability — some Arrow
+    /// types are not (yet) implemented by arrow-rs's parquet writer. Callers
+    /// that write parquet must reject these up-front: copy-to-s3 writes an
+    /// `INCOMPLETE` sentinel during preflight and does not clean it up on a
+    /// failed upload, so a runtime failure inside the parquet writer leaves
+    /// the path in a state that blocks subsequent copies.
+    ///
+    /// Pass the same `overrides` you pass to [`desc_to_schema_with_overrides`]
+    /// — otherwise this check will reject types your sink is going to remap.
+    /// To add a new banned arrow datatype, extend `parquet_incompatible_type`.
+    pub fn validate_desc_for_parquet<F>(
+        desc: &RelationDesc,
+        overrides: F,
+    ) -> Result<(), anyhow::Error>
+    where
+        F: Fn(&SqlScalarType) -> Option<(DataType, String)>,
+    {
+        let mut errs = vec![];
+        for (col_name, col_type) in desc.iter() {
+            let dt =
+                match scalar_to_arrow_datatype_with_overrides(&col_type.scalar_type, &overrides) {
+                    Ok((dt, _)) => dt,
+                    Err(_) => {
+                        errs.push(format!("{}: {:?}", col_name, col_type.scalar_type));
+                        continue;
+                    }
+                };
+            if let Some(reason) = parquet_incompatible_type(&dt) {
+                errs.push(format!(
+                    "{}: {:?} ({})",
+                    col_name, col_type.scalar_type, reason
+                ));
+            }
+        }
+        if !errs.is_empty() {
+            anyhow::bail!("Cannot encode the following columns/types: {:?}", errs);
+        }
+        Ok(())
+    }
+
     /// Initializes a new ArrowBuilder with the schema of the provided RelationDesc.
     /// `item_capacity` is used to initialize the capacity of each column's builder which defines
     /// the number of values that can be appended to each column before reallocating.
@@ -234,6 +278,64 @@ fn scalar_to_arrow_datatype(
     scalar_type: &SqlScalarType,
 ) -> Result<(DataType, String), anyhow::Error> {
     scalar_to_arrow_datatype_impl(scalar_type, &|_| None)
+}
+
+/// Returns a description of why this Arrow [`DataType`] cannot be written to
+/// parquet by arrow-rs's `ArrowWriter`, or `None` if the type is supported.
+/// Recurses into composite types so a banned type is rejected even if it is
+/// nested inside a list/struct/map.
+///
+/// This is an allowlist mirroring what arrow-rs's parquet writer accepts in
+/// its `get_arrow_column_writer` and `write_leaf` paths. To support a new
+/// leaf type, add an arm to the allowlist match below — but only after
+/// verifying that arrow-rs's parquet writer can actually emit it.
+fn parquet_incompatible_type(dt: &DataType) -> Option<&'static str> {
+    use arrow::datatypes::IntervalUnit;
+    match dt {
+        DataType::List(f) | DataType::LargeList(f) | DataType::FixedSizeList(f, _) => {
+            parquet_incompatible_type(f.data_type())
+        }
+        DataType::Map(f, _) => parquet_incompatible_type(f.data_type()),
+        DataType::Struct(fields) => fields
+            .iter()
+            .find_map(|f| parquet_incompatible_type(f.data_type())),
+
+        // Allowlist of supported leaf types.
+        DataType::Null
+        | DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _)
+        | DataType::Duration(_)
+        | DataType::Interval(IntervalUnit::YearMonth | IntervalUnit::DayTime)
+        | DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::FixedSizeBinary(_)
+        | DataType::Decimal32(_, _)
+        | DataType::Decimal64(_, _)
+        | DataType::Decimal128(_, _)
+        | DataType::Decimal256(_, _) => None,
+
+        // Fail closed: anything not on the allowlist is rejected.
+        _ => Some("unsupported arrow datatype"),
+    }
 }
 
 /// Return the appropriate Arrow DataType for the given SqlScalarType, with optional

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use itertools::{Either, Itertools};
 use mz_adapter_types::compaction::{CompactionWindow, DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION};
 use mz_adapter_types::dyncfgs::ENABLE_MULTI_REPLICA_SOURCES;
+use mz_arrow_util::builder::ArrowBuilder;
 use mz_auth::password::Password;
 use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId};
 use mz_expr::{CollectionPlan, UnmaterializableFunc};
@@ -88,7 +89,7 @@ use mz_storage_types::connections::inline::{ConnectionAccess, ReferencedConnecti
 use mz_storage_types::connections::{Connection, KafkaTopicOptions};
 use mz_storage_types::sinks::{
     IcebergSinkConnection, KafkaIdStyle, KafkaSinkConnection, KafkaSinkFormat, KafkaSinkFormatType,
-    SinkEnvelope, StorageSinkConnection,
+    SinkEnvelope, StorageSinkConnection, iceberg_type_overrides,
 };
 use mz_storage_types::sources::encoding::{
     AvroEncoding, ColumnSpec, CsvEncoding, DataEncoding, ProtobufEncoding, RegexEncoding,
@@ -3780,6 +3781,7 @@ fn plan_sink(
             relation_key_indices,
             key_desc_and_indices,
             commit_interval,
+            &desc,
         )?,
     };
 
@@ -3950,8 +3952,15 @@ fn iceberg_sink_builder(
     relation_key_indices: Option<Vec<usize>>,
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     commit_interval: Option<Duration>,
+    desc: &RelationDesc,
 ) -> Result<StorageSinkConnection<ReferencedConnection>, PlanError> {
     scx.require_feature_flag(&vars::ENABLE_ICEBERG_SINK)?;
+
+    // Reject types that arrow-rs's parquet writer cannot handle, before
+    // sink creation. Pass the iceberg overrides so types iceberg remaps
+    // (e.g. interval -> string) don't trip the check.
+    ArrowBuilder::validate_desc_for_parquet(desc, iceberg_type_overrides)
+        .map_err(|e| sql_err!("{}", e))?;
     let catalog_connection_item = scx.get_item_by_resolved_name(&catalog_connection)?;
     let catalog_connection_id = catalog_connection_item.id();
     let aws_connection_item = scx.get_item_by_resolved_name(&aws_connection)?;

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -1872,8 +1872,10 @@ fn plan_copy_to_expr(
             ))
         }
         CopyFormat::Parquet => {
-            // Validate that the output desc can be formatted as parquet
-            ArrowBuilder::validate_desc(&desc).map_err(|e| sql_err!("{}", e))?;
+            // Validate that the output desc can be formatted as parquet.
+            // COPY TO does not apply any type overrides, so pass `|_| None`.
+            ArrowBuilder::validate_desc_for_parquet(&desc, |_| None)
+                .map_err(|e| sql_err!("{}", e))?;
             S3SinkFormat::Parquet
         }
         CopyFormat::Binary => bail_unsupported!("FORMAT BINARY"),

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -644,6 +644,45 @@ pub const ICEBERG_APPEND_DIFF_COLUMN: &str = "_mz_diff";
 /// Column name appended by MODE APPEND Iceberg sinks to record the logical timestamp.
 pub const ICEBERG_APPEND_TIMESTAMP_COLUMN: &str = "_mz_timestamp";
 
+/// The precision needed to store all UInt64 values in a Decimal128.
+/// UInt64 max value is 18,446,744,073,709,551,615 which has 20 digits.
+pub const ICEBERG_UINT64_DECIMAL_PRECISION: u8 = 20;
+
+/// Type overrides for Iceberg-compatible Arrow schemas.
+///
+/// Iceberg doesn't support unsigned integer types or interval natively, so we
+/// map them to compatible types:
+/// - `UInt8`, `UInt16` -> `Int32`
+/// - `UInt32` -> `Int64`
+/// - `UInt64` -> `Decimal128(20, 0)`
+/// - `MzTimestamp` (which uses UInt64) -> `Decimal128(20, 0)`
+/// - `Interval` -> string (`LargeUtf8`)
+///
+/// Pass this to `mz_arrow_util::builder::desc_to_schema_with_overrides`
+/// when producing the Arrow schema for an iceberg sink, and to
+/// `mz_arrow_util::builder::ArrowBuilder::validate_desc_for_parquet` to
+/// validate the desc before sink creation.
+pub fn iceberg_type_overrides(
+    scalar_type: &mz_repr::SqlScalarType,
+) -> Option<(arrow::datatypes::DataType, String)> {
+    use arrow::datatypes::DataType;
+    use mz_repr::SqlScalarType;
+    match scalar_type {
+        SqlScalarType::UInt16 => Some((DataType::Int32, "uint2".to_string())),
+        SqlScalarType::UInt32 => Some((DataType::Int64, "uint4".to_string())),
+        SqlScalarType::UInt64 => Some((
+            DataType::Decimal128(ICEBERG_UINT64_DECIMAL_PRECISION, 0),
+            "uint8".to_string(),
+        )),
+        SqlScalarType::MzTimestamp => Some((
+            DataType::Decimal128(ICEBERG_UINT64_DECIMAL_PRECISION, 0),
+            "mz_timestamp".to_string(),
+        )),
+        SqlScalarType::Interval => Some((DataType::LargeUtf8, "interval".to_string())),
+        _ => None,
+    }
+}
+
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct IcebergSinkConnection<C: ConnectionAccess = InlinedConnection> {
     pub catalog_connection_id: CatalogItemId,

--- a/src/storage/src/sink/iceberg.rs
+++ b/src/storage/src/sink/iceberg.rs
@@ -136,7 +136,9 @@ use mz_storage_types::StorageDiff;
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
-use mz_storage_types::sinks::{IcebergSinkConnection, SinkEnvelope, StorageSinkDesc};
+use mz_storage_types::sinks::{
+    IcebergSinkConnection, SinkEnvelope, StorageSinkDesc, iceberg_type_overrides,
+};
 use mz_storage_types::sources::SourceData;
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{Event, OperatorBuilder, PressOnDropButton};
@@ -469,10 +471,6 @@ impl EnvelopeHandler for AppendEnvelopeHandler {
             .context("Failed to create append record batch")
     }
 }
-
-/// The precision needed to store all UInt64 values in a Decimal128.
-/// UInt64 max value is 18,446,744,073,709,551,615 which has 20 digits.
-const ICEBERG_UINT64_DECIMAL_PRECISION: u8 = 20;
 
 /// Add Parquet field IDs to an Arrow schema. Iceberg requires field IDs in the
 /// Parquet metadata for schema evolution tracking. Field IDs are assigned
@@ -924,32 +922,6 @@ fn retrieve_upper_from_snapshots(
     }
 
     Ok(None)
-}
-
-/// Type overrides for Iceberg-compatible Arrow schemas.
-///
-/// Iceberg doesn't support unsigned integer types, so we map them to compatible types:
-/// - UInt8, UInt16 -> Int32
-/// - UInt32 -> Int64
-/// - UInt64 -> Decimal128(20, 0)
-/// - MzTimestamp (which uses UInt64) -> Decimal128(20, 0)
-fn iceberg_type_overrides(scalar_type: &mz_repr::SqlScalarType) -> Option<(DataType, String)> {
-    use mz_repr::SqlScalarType;
-    match scalar_type {
-        SqlScalarType::UInt16 => Some((DataType::Int32, "uint2".to_string())),
-        SqlScalarType::UInt32 => Some((DataType::Int64, "uint4".to_string())),
-        SqlScalarType::UInt64 => Some((
-            DataType::Decimal128(ICEBERG_UINT64_DECIMAL_PRECISION, 0),
-            "uint8".to_string(),
-        )),
-        SqlScalarType::MzTimestamp => Some((
-            DataType::Decimal128(ICEBERG_UINT64_DECIMAL_PRECISION, 0),
-            "mz_timestamp".to_string(),
-        )),
-        // Iceberg doesn't support interval types natively, so we store as string.
-        SqlScalarType::Interval => Some((DataType::LargeUtf8, "interval".to_string())),
-        _ => None,
-    }
 }
 
 /// Convert a Materialize RelationDesc into Arrow and Iceberg schemas.
@@ -1870,6 +1842,7 @@ mod tests {
     use super::*;
     use iceberg::spec::{PrimitiveType, Type};
     use mz_repr::SqlScalarType;
+    use mz_storage_types::sinks::ICEBERG_UINT64_DECIMAL_PRECISION;
 
     #[mz_ore::test]
     fn test_iceberg_type_overrides() {

--- a/test/testdrive/copy-s3-roundtrip-minio.td
+++ b/test/testdrive/copy-s3-roundtrip-minio.td
@@ -303,31 +303,30 @@ $ s3-verify-data bucket=copytos3 key=parquet_test/3 sort-rows=true
 # Ensure that at least one file is written even when the input is empty.
 $ s3-verify-keys bucket=copytos3 prefix-path=parquet_test/4 key-pattern=^parquet_test/4/mz.*\.parquet$
 
-# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/11329 is fixed
-# The `!` test below fails at runtime (in the parquet ArrowWriter) after preflight
-# has already written the INCOMPLETE sentinel to S3. The sentinel is not cleaned up
-# on failure, so the follow-up `>` COPY to the same path sees a non-empty bucket and
-# errors with "S3 bucket path is not empty".
-#
-# # Confirm that unsupported types error when writing to s3 parquet
-# ! COPY (SELECT '0 day'::interval)  TO 's3://copytos3/parquet_test/5'
-#   WITH (
-#     AWS CONNECTION = aws_conn,
-#     MAX FILE SIZE = "100MB",
-#     FORMAT = 'parquet'
-#   );
-# contains:Arrow interval type MonthDayNano to parquet that is not yet implemented
-#
-# # now should succeed since incomplete sentinel was never written
-# > COPY (SELECT 1::int)  TO 's3://copytos3/parquet_test/5'
-#   WITH (
-#     AWS CONNECTION = aws_conn,
-#     MAX FILE SIZE = "100MB",
-#     FORMAT = 'parquet'
-#   );
-#
-# $ s3-verify-data bucket=copytos3 key=parquet_test/5 sort-rows=true
-# 1
+# Confirm that types arrow-rs's parquet writer can't handle are rejected at
+# planning time, before preflight runs. This must not slip through to a
+# runtime failure: preflight writes an INCOMPLETE sentinel that is not
+# cleaned up on failure, which would leave the path in a state that blocks
+# subsequent copies (database-issues#11329).
+! COPY (SELECT '0 day'::interval)  TO 's3://copytos3/parquet_test/5'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+contains:interval: Interval (unsupported arrow datatype)
+
+# A subsequent COPY to the same path must succeed — the planning-time
+# rejection above runs before preflight writes the INCOMPLETE sentinel.
+> COPY (SELECT 1::int)  TO 's3://copytos3/parquet_test/5'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+
+$ s3-verify-data bucket=copytos3 key=parquet_test/5 sort-rows=true
+1
 
 # Tests for decimal / numeric type
 


### PR DESCRIPTION
Iceberg and copy-to-s3 have started to diverge in their handling of the less standard datatypes. Whether the arrow-util crate is _capable_ of describing a datatype is no longer a great standin for _if_ that type should be written in a certain config. Adds an explicit check during planning time that the canonical Arrow types picked by the copy-to-s3 and iceberg implementations are allowed. 

To start, bans `DataType::Interval(IntervalUnit::MonthDayNano)` in response to
https://github.com/MaterializeInc/database-issues/issues/11329.

TODO(@DAlperin): go check the parquet crate and compare them against arrow types to maintain a fuller list of incompatibilities.

Fixes https://github.com/MaterializeInc/database-issues/issues/11329