### PR TITLE
sql_server: fix unbounded memory growth during snapshot

### DIFF
--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -250,7 +250,6 @@ pub(crate) fn render<'scope>(
                     SNAPSHOT_PROGRESS_REPORT_INTERVAL.handle(config.config.config_set());
                 let mut last_report = Instant::now();
                 let mut snapshot_lsns = BTreeMap::new();
-                let arena = RowArena::default();
 
                 for table in snapshot_tables {
                     // TODO(sql_server3): filter columns to only select columns required for Source.
@@ -307,6 +306,7 @@ pub(crate) fn render<'scope>(
                         for (partition_idx, _) in partition_indexes {
                             // Decode the SQL Server row into an MZ one.
                             let mut mz_row = Row::default();
+                            let arena = RowArena::default();
 
                             let decoder = decoder_map
                                 .get(partition_idx)


### PR DESCRIPTION
PR #33341 moved the RowArena allocation outside the snapshot loop, causing it to accumulate decoded data across all rows of all tables. Since RowArena is append-only and was never cleared, this leaked memory proportional to total snapshot size, risking OOM on large tables.