### PR TITLE
sql-server-util: Transaction guard includes BEGIN TRANSACTION

### DIFF
--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -366,7 +366,14 @@ pub struct Transaction<'a> {
 
 impl<'a> Transaction<'a> {
     async fn new(client: &'a mut Client) -> Result<Self, SqlServerError> {
-        let results = client
+        // Construct the guard *before* awaiting BEGIN to avoid a potential race where
+        // transaction is started on remote, but the transaction is cancelled before returning.
+        let tx = Transaction {
+            client,
+            closed: false,
+        };
+        let results = tx
+            .client
             .simple_query("BEGIN TRANSACTION")
             .await
             .context("begin")?;
@@ -375,10 +382,7 @@ impl<'a> Transaction<'a> {
                 "expected empty result from BEGIN TRANSACTION. Got: {results:?}"
             )))
         } else {
-            Ok(Transaction {
-                client,
-                closed: false,
-            })
+            Ok(tx)
         }
     }
 


### PR DESCRIPTION
During creation of Transaction, possible race can occur where `BEGIN TRANSACTION` completes on upstream, transaction is cancelled, and a rollback doesn't occur on drop.

This should be extremely rare in practice. Noticed when reviewing @def- bugfixes.
