### PR TITLE
build(deps): Bump pip from 26.0.1 to 26.1

### DIFF
--- a/ci/builder/requirements-core.txt
+++ b/ci/builder/requirements-core.txt
@@ -3,5 +3,5 @@
 # It is extremely unlikely that we'll ever need additional packages here. Do not
 # add to this list without consulting with @testing!
 
-pip==26.0.1
+pip==26.1
 setuptools==82.0.1


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/materialize/security/dependabot/379