### PR TITLE
peek stash: fix `LIMIT`+`OFFSET` short-circuit

### DIFF
--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -166,7 +166,7 @@ impl StashingPeek {
 
         let mut num_rows: u64 = 0;
 
-        loop {
+        'outer: loop {
             let row = rows_rx.recv().await;
             match row {
                 Some(Ok(rows)) => {
@@ -180,10 +180,12 @@ impl StashingPeek {
                             .await
                             .expect("invalid usage");
 
-                        // Stop if we have enough rows to satisfy the RowSetFinishing's offset + limit.
                         if let Some(max_rows) = max_rows {
                             if num_rows >= u64::cast_from(max_rows) {
-                                break;
+                                // Drop the receiver so the producer's next
+                                // try_reserve() fails, stopping row production.
+                                drop(rows_rx);
+                                break 'outer;
                             }
                         }
                     }


### PR DESCRIPTION
The `break` introduced in #33150 only exits the inner `for` loop, so the outer loop keeps calling `recv()` and processing all remaining rows. Use a labeled `break 'outer` and drop the receiver to also stop the producer.