### PR TITLE
orchestratord: fix --enable-rbac flag silently inverting boolean values

### DIFF
--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -82,9 +82,8 @@ For a new setup you can run:
     parser_environment.add_argument("--authenticator-kind", required=False)
     parser_environment.add_argument(
         "--enable-rbac",
-        type=bool,
+        action=argparse.BooleanOptionalAction,
         default=False,
-        required=False,
     )
     parser_environment.set_defaults(func=environment)
 


### PR DESCRIPTION
`type=bool` in argparse calls `bool()` on the raw string, so `--enable-rbac False` evaluated to `True`. Use BooleanOptionalAction instead, giving correct `--enable-rbac` / `--no-enable-rbac` behavior. Seems like an argparse footgun to me... Follow-up to #32707. 