### PR TITLE
persist: skip lgalloc memcpy in S3 get path

### DIFF
--- a/src/ore/src/lgbytes.rs
+++ b/src/ore/src/lgbytes.rs
@@ -92,8 +92,6 @@ impl<T: Copy> AsRef<[T]> for MetricsRegion<T> {
 /// Metrics for lgalloc'd bytes..
 #[derive(Debug, Clone)]
 pub struct LgBytesMetrics {
-    /// Metrics for the "persist_s3" usage of lgalloc bytes.
-    pub persist_s3: LgBytesOpMetrics,
     /// Metrics for the "persist_azure" usage of lgalloc bytes.
     pub persist_azure: LgBytesOpMetrics,
     /// Metrics for the "persist_arrow" usage of lgalloc bytes.
@@ -188,7 +186,6 @@ impl LgBytesMetrics {
             len_sizes: len_sizes.clone(),
         };
         LgBytesMetrics {
-            persist_s3: op("persist_s3"),
             persist_azure: op("persist_azure"),
             persist_arrow: op("persist_arrow"),
         }

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -36,8 +36,6 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_CC_SIZES)
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
-        .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
-        .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
         .add(&crate::postgres::USE_POSTGRES_TUNED_QUERIES)
 }
 
@@ -139,7 +137,6 @@ impl BlobConfig {
                     credentials,
                     knobs,
                     metrics,
-                    cfg,
                 )
                 .await?;
 

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -30,10 +30,8 @@ use aws_types::region::Region;
 use bytes::Bytes;
 use futures_util::stream::FuturesOrdered;
 use futures_util::{FutureExt, StreamExt};
-use mz_dyncfg::{Config, ConfigSet};
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
-use mz_ore::lgbytes::MetricsRegion;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::RuntimeExt;
 use tokio::runtime::Handle as AsyncHandle;
@@ -52,8 +50,6 @@ pub struct S3BlobConfig {
     client: S3Client,
     bucket: String,
     prefix: String,
-    cfg: Arc<ConfigSet>,
-    is_cc_active: bool,
 }
 
 // There is no simple way to hook into the S3 client to capture when its various timeouts
@@ -123,9 +119,7 @@ impl S3BlobConfig {
         credentials: Option<(String, String)>,
         knobs: Box<dyn BlobKnobs>,
         metrics: S3BlobMetrics,
-        cfg: Arc<ConfigSet>,
     ) -> Result<Self, Error> {
-        let is_cc_active = knobs.is_cc_active();
         let mut loader = mz_aws_util::defaults();
 
         if let Some(region) = region {
@@ -178,8 +172,6 @@ impl S3BlobConfig {
             client,
             bucket,
             prefix,
-            cfg,
-            is_cc_active,
         })
     }
 
@@ -273,11 +265,6 @@ impl S3BlobConfig {
             None,
             Box::new(TestBlobKnobs),
             metrics,
-            Arc::new(
-                ConfigSet::default()
-                    .add(&ENABLE_S3_LGALLOC_CC_SIZES)
-                    .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
-            ),
         )
         .await?;
         Ok(Some(config))
@@ -303,8 +290,6 @@ pub struct S3Blob {
     // Defaults to 1000 which is the current AWS max.
     max_keys: i32,
     multipart_config: MultipartConfig,
-    cfg: Arc<ConfigSet>,
-    is_cc_active: bool,
 }
 
 impl S3Blob {
@@ -317,8 +302,6 @@ impl S3Blob {
             prefix: config.prefix,
             max_keys: 1_000,
             multipart_config: MultipartConfig::default(),
-            cfg: config.cfg,
-            is_cc_active: config.is_cc_active,
         };
         // Connect before returning success. We don't particularly care about
         // what's stored in this blob (nothing writes to it, so presumably it's
@@ -331,18 +314,6 @@ impl S3Blob {
         format!("{}/{}", self.prefix, key)
     }
 }
-
-pub(crate) const ENABLE_S3_LGALLOC_CC_SIZES: Config<bool> = Config::new(
-    "persist_enable_s3_lgalloc_cc_sizes",
-    true,
-    "An incident flag to disable copying fetched s3 data into lgalloc on cc sized clusters.",
-);
-
-pub(crate) const ENABLE_S3_LGALLOC_NONCC_SIZES: Config<bool> = Config::new(
-    "persist_enable_s3_lgalloc_noncc_sizes",
-    false,
-    "A feature flag to enable copying fetched s3 data into lgalloc on non-cc sized clusters.",
-);
 
 #[async_trait]
 impl Blob for S3Blob {
@@ -474,65 +445,13 @@ impl Blob for S3Blob {
                 let body_start = Instant::now();
                 let mut body_parts: Vec<Bytes> = Vec::new();
 
-                // Get the data into lgalloc at the absolute earliest possible
-                // point without (yet) having to fork the s3 client library.
-                let enable_s3_lgalloc = if self.is_cc_active {
-                    ENABLE_S3_LGALLOC_CC_SIZES.get(&self.cfg)
-                } else {
-                    ENABLE_S3_LGALLOC_NONCC_SIZES.get(&self.cfg)
-                };
-
-                // Copy all of the bytes off the network and into a single allocation.
-                let mut buffer = match object.content_length() {
-                    Some(len @ 1..) => {
-                        let len: u64 = len.try_into().expect("positive integer");
-                        // N.B. `lgalloc` cannot reallocate so we need to make sure the initial
-                        // allocation is large enough to fit then entire blob.
-                        let buf: MetricsRegion<u8> = self
-                            .metrics
-                            .lgbytes
-                            .persist_s3
-                            .new_region(usize::cast_from(len));
-                        Some(buf)
-                    }
-                    // content-length of 0 isn't necessarily invalid.
-                    Some(len @ ..=-1) => {
-                        tracing::trace!(?len, "found invalid content-length, falling back");
-                        get_invalid_resp.inc();
-                        None
-                    }
-                    Some(0) | None => None,
-                };
-
-                while let Some(data) = object.body.next().await {
-                    let data = data.context("s3 get body err")?;
-                    match &mut buffer {
-                        // Write to our single allocation, if it's enabled.
-                        Some(buf) => buf.extend_from_slice(&data[..]),
-                        // Fallback to spilling into lgalloc is quick as possible.
-                        None if enable_s3_lgalloc => {
-                            body_parts.push(self.metrics.lgbytes.persist_s3.try_mmap_bytes(data));
-                        }
-                        // If all else false just heap allocate.
-                        None => {
-                            // In the CYA fallback case, make sure we skip the
-                            // memcpy to preserve the previous behavior as closely
-                            // as possible.
-                            //
-                            // TODO: Once we've validated the LgBytes path, change
-                            // this fallback path to be a heap allocated LgBytes.
-                            // Then we can remove the pub from MaybeLgBytes.
-                            body_parts.push(data);
-                        }
-                    }
+                if let Some(len @ ..=-1) = object.content_length() {
+                    tracing::trace!(?len, "found invalid content-length");
+                    get_invalid_resp.inc();
                 }
 
-                // Append our single segment, if it exists.
-                if let Some(body) = buffer {
-                    // If we're writing into a single buffer we shouldn't have
-                    // pushed anything else into our segments.
-                    assert!(body_parts.is_empty());
-                    body_parts.push(body.into());
+                while let Some(data) = object.body.next().await {
+                    body_parts.push(data.context("s3 get body err")?);
                 }
 
                 let body_elapsed = body_start.elapsed();
@@ -1166,12 +1085,6 @@ mod tests {
                     client: config.client.clone(),
                     bucket: config.bucket.clone(),
                     prefix: format!("{}/s3_blob_impl_test/{}", config.prefix, path),
-                    cfg: Arc::new(
-                        ConfigSet::default()
-                            .add(&ENABLE_S3_LGALLOC_CC_SIZES)
-                            .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
-                    ),
-                    is_cc_active: true,
                 };
                 let mut blob = S3Blob::open(config).await?;
                 blob.max_keys = 2;


### PR DESCRIPTION
The S3 get path copied each `Bytes` chunk returned by the SDK into a freshly-allocated `MetricsRegion<u8>`.
With lgalloc disabled in practice that region falls back to the heap, making the copy pure overhead.
Push SDK `Bytes` straight into `SegmentedBytes` instead.

Also removes the now-unused `persist_enable_s3_lgalloc_{cc,noncc}_sizes` dyncfgs, the `cfg`/`is_cc_active` fields on `S3BlobConfig`/`S3Blob`, and the dead `LgBytesMetrics::persist_s3` metric.

### Motivation

Reduces CPU and allocator pressure on every S3 read in persist.

### Tips for reviewer

The behavior change is in `Blob::get` in `src/persist/src/s3.rs`; everything else is dead-code removal that follows.

### Checklist

- [ ] This PR has adequate test coverage / QA is not needed.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.