### PR TITLE
[SSO] Thread JWT groups and add sync diff logic

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -472,6 +472,7 @@ Issue a SQL query to get started. Need help?
                 external_metadata_rx: None,
                 helm_chart_version: None,
                 authenticator_kind: AuthenticatorKind::None,
+                groups: None,
             },
             Authenticated,
         );

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -38,6 +38,7 @@ impl SystemParameterBackend {
                 external_metadata_rx: None,
                 helm_chart_version: None,
                 authenticator_kind: AuthenticatorKind::None,
+                groups: None,
             },
             Authenticated,
         );

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -226,6 +226,7 @@ pub mod catalog_implications;
 mod caught_up;
 mod command_handler;
 mod ddl;
+pub(crate) mod group_sync;
 mod indexes;
 mod introspection;
 mod message_handler;

--- a/src/adapter/src/coord/group_sync.rs
+++ b/src/adapter/src/coord/group_sync.rs
@@ -1,0 +1,298 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! JWT group-to-role membership sync logic.
+//!
+//! This module computes the diff between a user's current role memberships
+//! and their JWT group claims, producing `Op::GrantRole` and `Op::RevokeRole`
+//! operations. Only memberships granted by the `MZ_JWT_SYNC_ROLE_ID` sentinel
+//! are managed; manually-granted memberships are never touched.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use mz_repr::role_id::RoleId;
+use mz_sql::session::user::MZ_JWT_SYNC_ROLE_ID;
+
+use crate::catalog::Op;
+
+/// Result of computing the group-to-role membership sync diff.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // used in tests; will be consumed by login path in a follow-up
+pub struct GroupSyncDiff {
+    /// Roles to grant to the user (with sentinel grantor).
+    pub grants: Vec<Op>,
+    /// Roles to revoke from the user (with sentinel grantor).
+    pub revokes: Vec<Op>,
+}
+
+/// Computes the grant/revoke operations needed to sync a user's role
+/// memberships with their JWT group claims.
+///
+/// # Arguments
+/// - `member_id`: The user's role ID.
+/// - `current_membership`: The user's current `RoleMembership.map`
+///   (role_id → grantor_id).
+/// - `target_role_ids`: Role IDs resolved from the JWT group names. Callers must
+///   lowercase JWT group names before catalog lookup since SQL role names are stored
+///   lowercase.
+///
+/// # Semantics
+/// - Only roles granted by the JWT sync sentinel (`MZ_JWT_SYNC_ROLE_ID`)
+///   are managed by this function.
+/// - Manually-granted roles (grantor != sentinel) are never revoked.
+/// - If a target role is already manually granted, it is skipped — the
+///   manual grant takes precedence and we don't overwrite the grantor.
+#[allow(dead_code)] // used in tests; will be called from login path in a follow-up
+pub fn compute_group_sync_diff(
+    member_id: RoleId,
+    current_membership: &BTreeMap<RoleId, RoleId>,
+    target_role_ids: &BTreeSet<RoleId>,
+) -> GroupSyncDiff {
+    // Partition current memberships into sync-managed vs manually-granted.
+    let mut sync_granted: BTreeSet<RoleId> = BTreeSet::new();
+    let mut manual_granted: BTreeSet<RoleId> = BTreeSet::new();
+
+    for (role_id, grantor_id) in current_membership {
+        if *grantor_id == MZ_JWT_SYNC_ROLE_ID {
+            sync_granted.insert(*role_id);
+        } else {
+            manual_granted.insert(*role_id);
+        }
+    }
+
+    // Roles to grant: in target, not already sync-granted, not manually-granted.
+    let grants: Vec<Op> = target_role_ids
+        .iter()
+        .filter(|r| !sync_granted.contains(r) && !manual_granted.contains(r))
+        .map(|&role_id| Op::GrantRole {
+            role_id,
+            member_id,
+            grantor_id: MZ_JWT_SYNC_ROLE_ID,
+        })
+        .collect();
+
+    // Roles to revoke: sync-granted but no longer in target.
+    let revokes: Vec<Op> = sync_granted
+        .iter()
+        .filter(|r| !target_role_ids.contains(r))
+        .map(|&role_id| Op::RevokeRole {
+            role_id,
+            member_id,
+            grantor_id: MZ_JWT_SYNC_ROLE_ID,
+        })
+        .collect();
+
+    GroupSyncDiff { grants, revokes }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user_id() -> RoleId {
+        RoleId::User(100)
+    }
+    fn role_a() -> RoleId {
+        RoleId::User(1)
+    }
+    fn role_b() -> RoleId {
+        RoleId::User(2)
+    }
+    fn role_c() -> RoleId {
+        RoleId::User(3)
+    }
+    fn admin_id() -> RoleId {
+        RoleId::User(99)
+    }
+
+    /// Extract the role IDs from grant ops for easy assertion.
+    fn grant_role_ids(diff: &GroupSyncDiff) -> BTreeSet<RoleId> {
+        diff.grants
+            .iter()
+            .map(|op| match op {
+                Op::GrantRole { role_id, .. } => *role_id,
+                _ => panic!("expected GrantRole op"),
+            })
+            .collect()
+    }
+
+    /// Extract the role IDs from revoke ops for easy assertion.
+    fn revoke_role_ids(diff: &GroupSyncDiff) -> BTreeSet<RoleId> {
+        diff.revokes
+            .iter()
+            .map(|op| match op {
+                Op::RevokeRole { role_id, .. } => *role_id,
+                _ => panic!("expected RevokeRole op"),
+            })
+            .collect()
+    }
+
+    /// Verify all grant ops use the sentinel grantor and correct member.
+    fn assert_grants_well_formed(diff: &GroupSyncDiff, expected_member: RoleId) {
+        for op in &diff.grants {
+            match op {
+                Op::GrantRole {
+                    member_id,
+                    grantor_id,
+                    ..
+                } => {
+                    assert_eq!(*member_id, expected_member);
+                    assert_eq!(*grantor_id, MZ_JWT_SYNC_ROLE_ID);
+                }
+                _ => panic!("expected GrantRole op"),
+            }
+        }
+    }
+
+    /// Verify all revoke ops use the sentinel grantor and correct member.
+    fn assert_revokes_well_formed(diff: &GroupSyncDiff, expected_member: RoleId) {
+        for op in &diff.revokes {
+            match op {
+                Op::RevokeRole {
+                    member_id,
+                    grantor_id,
+                    ..
+                } => {
+                    assert_eq!(*member_id, expected_member);
+                    assert_eq!(*grantor_id, MZ_JWT_SYNC_ROLE_ID);
+                }
+                _ => panic!("expected RevokeRole op"),
+            }
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_first_login_grants_all() {
+        let current = BTreeMap::new();
+        let target = BTreeSet::from([role_a(), role_b()]);
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 2);
+        assert_eq!(diff.revokes.len(), 0);
+        assert_eq!(grant_role_ids(&diff), BTreeSet::from([role_a(), role_b()]));
+        assert_grants_well_formed(&diff, user_id());
+    }
+
+    #[mz_ore::test]
+    fn test_no_change_is_noop() {
+        let current = BTreeMap::from([
+            (role_a(), MZ_JWT_SYNC_ROLE_ID),
+            (role_b(), MZ_JWT_SYNC_ROLE_ID),
+        ]);
+        let target = BTreeSet::from([role_a(), role_b()]);
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 0);
+        assert_eq!(diff.revokes.len(), 0);
+    }
+
+    #[mz_ore::test]
+    fn test_revoke_removed_groups() {
+        let current = BTreeMap::from([
+            (role_a(), MZ_JWT_SYNC_ROLE_ID),
+            (role_b(), MZ_JWT_SYNC_ROLE_ID),
+            (role_c(), MZ_JWT_SYNC_ROLE_ID),
+        ]);
+        let target = BTreeSet::from([role_a()]);
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 0);
+        assert_eq!(diff.revokes.len(), 2);
+        assert_eq!(revoke_role_ids(&diff), BTreeSet::from([role_b(), role_c()]));
+        assert_revokes_well_formed(&diff, user_id());
+    }
+
+    #[mz_ore::test]
+    fn test_manual_grants_untouched() {
+        // Manual grant for A (by admin), sync grant for B.
+        // Target: A, C.
+        // Expected: grant C (A is manual, skip), revoke B (not in target).
+        let current = BTreeMap::from([(role_a(), admin_id()), (role_b(), MZ_JWT_SYNC_ROLE_ID)]);
+        let target = BTreeSet::from([role_a(), role_c()]);
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 1);
+        assert_eq!(diff.revokes.len(), 1);
+        assert_eq!(grant_role_ids(&diff), BTreeSet::from([role_c()]));
+        assert_eq!(revoke_role_ids(&diff), BTreeSet::from([role_b()]));
+    }
+
+    #[mz_ore::test]
+    fn test_empty_target_revokes_all_sync() {
+        // Sync-granted A, B. Manual C. Target: empty.
+        // Expected: revoke A and B, keep C.
+        let current = BTreeMap::from([
+            (role_a(), MZ_JWT_SYNC_ROLE_ID),
+            (role_b(), MZ_JWT_SYNC_ROLE_ID),
+            (role_c(), admin_id()),
+        ]);
+        let target = BTreeSet::new();
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 0);
+        assert_eq!(diff.revokes.len(), 2);
+        assert_eq!(revoke_role_ids(&diff), BTreeSet::from([role_a(), role_b()]));
+    }
+
+    #[mz_ore::test]
+    fn test_mixed_grant_and_revoke() {
+        // Sync-granted A. Target: B.
+        // Expected: grant B, revoke A.
+        let current = BTreeMap::from([(role_a(), MZ_JWT_SYNC_ROLE_ID)]);
+        let target = BTreeSet::from([role_b()]);
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 1);
+        assert_eq!(diff.revokes.len(), 1);
+        assert_eq!(grant_role_ids(&diff), BTreeSet::from([role_b()]));
+        assert_eq!(revoke_role_ids(&diff), BTreeSet::from([role_a()]));
+    }
+
+    #[mz_ore::test]
+    fn test_empty_current_empty_target() {
+        let current = BTreeMap::new();
+        let target = BTreeSet::new();
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 0);
+        assert_eq!(diff.revokes.len(), 0);
+    }
+
+    #[mz_ore::test]
+    fn test_all_manual_grants_no_revokes() {
+        // All current memberships are manual, none sync-granted.
+        // Target has a new role. Manual ones should not be revoked.
+        let current = BTreeMap::from([(role_a(), admin_id()), (role_b(), admin_id())]);
+        let target = BTreeSet::from([role_c()]);
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 1);
+        assert_eq!(diff.revokes.len(), 0);
+        assert_eq!(grant_role_ids(&diff), BTreeSet::from([role_c()]));
+    }
+
+    #[mz_ore::test]
+    fn test_target_overlaps_both_manual_and_sync() {
+        // A is manual, B is sync, C is sync. Target: A, B, D.
+        // Expected: grant D (A manual=skip, B sync=already there), revoke C.
+        let role_d = RoleId::User(4);
+        let current = BTreeMap::from([
+            (role_a(), admin_id()),
+            (role_b(), MZ_JWT_SYNC_ROLE_ID),
+            (role_c(), MZ_JWT_SYNC_ROLE_ID),
+        ]);
+        let target = BTreeSet::from([role_a(), role_b(), role_d]);
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 1);
+        assert_eq!(grant_role_ids(&diff), BTreeSet::from([role_d]));
+        assert_eq!(diff.revokes.len(), 1);
+        assert_eq!(revoke_role_ids(&diff), BTreeSet::from([role_c()]));
+    }
+}

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -226,6 +226,7 @@ mod tests {
                     external_metadata_rx: None,
                     helm_chart_version: None,
                     authenticator_kind: AuthenticatorKind::None,
+                    groups: None,
                 },
                 metrics.session_metrics(),
             );

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -209,6 +209,8 @@ pub struct SessionConfig {
     pub helm_chart_version: Option<String>,
     /// The authenticator that authenticated this user, if any.
     pub authenticator_kind: AuthenticatorKind,
+    /// Groups from JWT claims for OIDC group-to-role sync.
+    pub groups: Option<Vec<String>>,
 }
 
 impl Session {
@@ -296,6 +298,7 @@ impl Session {
                 external_metadata_rx: None,
                 helm_chart_version: None,
                 authenticator_kind: AuthenticatorKind::None,
+                groups: None,
             },
             metrics,
         );
@@ -313,6 +316,7 @@ impl Session {
             mut external_metadata_rx,
             helm_chart_version,
             authenticator_kind,
+            groups,
         }: SessionConfig,
         metrics: SessionMetrics,
     ) -> Session {
@@ -325,6 +329,7 @@ impl Session {
                 .as_mut()
                 .map(|rx| rx.borrow_and_update().clone()),
             authenticator_kind: Some(authenticator_kind),
+            groups,
         };
         let mut vars = SessionVars::new_unchecked(build_info, user, helm_chart_version);
         if let Some(default_cluster) = default_cluster {

--- a/src/authenticator/src/oidc.rs
+++ b/src/authenticator/src/oidc.rs
@@ -18,7 +18,9 @@ use std::time::Duration;
 
 use jsonwebtoken::jwk::JwkSet;
 use mz_adapter::{AdapterError, AuthenticationError, Client as AdapterClient};
-use mz_adapter_types::dyncfgs::{OIDC_AUDIENCE, OIDC_AUTHENTICATION_CLAIM, OIDC_ISSUER};
+use mz_adapter_types::dyncfgs::{
+    OIDC_AUDIENCE, OIDC_AUTHENTICATION_CLAIM, OIDC_GROUP_CLAIM, OIDC_ISSUER,
+};
 use mz_auth::Authenticated;
 use mz_ore::secure::{Zeroize, ZeroizeOnDrop};
 use mz_ore::soft_panic_or_log;
@@ -293,6 +295,9 @@ impl OidcClaims {
 #[derive(Zeroize, ZeroizeOnDrop)]
 pub struct ValidatedClaims {
     pub user: String,
+    /// Groups extracted from the JWT group claim. None if claim absent.
+    #[zeroize(skip)]
+    pub groups: Option<Vec<String>>,
     // Prevent construction outside of `GenericOidcAuthenticator::validate_token`.
     _private: (),
 }
@@ -568,8 +573,13 @@ impl GenericOidcAuthenticatorInner {
             }
         }
 
+        // Extract groups from the configured claim name for group-to-role sync.
+        let group_claim = OIDC_GROUP_CLAIM.get(system_vars.dyncfgs());
+        let groups = token_data.claims.groups(&group_claim);
+
         Ok(ValidatedClaims {
             user: user.to_string(),
+            groups,
             _private: (),
         })
     }
@@ -673,6 +683,7 @@ mod tests {
         use mz_ore::secure::Zeroize;
         let mut claims = ValidatedClaims {
             user: "alice@example.com".to_string(),
+            groups: Some(vec!["eng".to_string()]),
             _private: (),
         };
         claims.zeroize();

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -689,6 +689,7 @@ async fn x_materialize_user_header_auth(
             external_metadata_rx: None,
             authenticated: Authenticated,
             authenticator_kind: mz_auth::AuthenticatorKind::None,
+            groups: None,
         });
     }
     Ok(next.run(req).await)
@@ -708,6 +709,8 @@ pub struct AuthedUser {
     external_metadata_rx: Option<watch::Receiver<ExternalUserMetadata>>,
     authenticated: Authenticated,
     authenticator_kind: mz_auth::AuthenticatorKind,
+    /// Groups from JWT claims for OIDC group-to-role sync.
+    groups: Option<Vec<String>>,
 }
 
 pub struct AuthedClient {
@@ -739,6 +742,7 @@ impl AuthedClient {
                 external_metadata_rx: user.external_metadata_rx,
                 helm_chart_version,
                 authenticator_kind: user.authenticator_kind,
+                groups: user.groups,
             },
             user.authenticated,
         );
@@ -1226,6 +1230,7 @@ pub(crate) async fn ensure_session_unexpired(
         external_metadata_rx: None,
         authenticated: session_data.authenticated,
         authenticator_kind: session_data.authenticator_kind,
+        groups: None,
     })
 }
 
@@ -1235,14 +1240,14 @@ async fn auth(
     allowed_roles: AllowedRoles,
     include_www_authenticate_header: bool,
 ) -> Result<AuthedUser, AuthError> {
-    let (name, external_metadata_rx, authenticated) = match authenticator {
+    let (name, external_metadata_rx, authenticated, groups) = match authenticator {
         Authenticator::Frontegg(frontegg) => match creds {
             Some(Credentials::Password { username, password }) => {
                 let (auth_session, authenticated) =
                     frontegg.authenticate(&username, password.as_str()).await?;
                 let name = auth_session.user().into();
                 let external_metadata_rx = Some(auth_session.external_metadata_rx());
-                (name, external_metadata_rx, authenticated)
+                (name, external_metadata_rx, authenticated, None)
             }
             Some(Credentials::Token { token }) => {
                 let (claims, authenticated) = frontegg.validate_access_token(&token, None)?;
@@ -1250,7 +1255,7 @@ async fn auth(
                     user_id: claims.user_id,
                     admin: claims.is_admin,
                 });
-                (claims.user, Some(external_metadata_rx), authenticated)
+                (claims.user, Some(external_metadata_rx), authenticated, None)
             }
             None => {
                 return Err(AuthError::MissingHttpAuthentication {
@@ -1264,7 +1269,7 @@ async fn auth(
                     .authenticate(&username, &password)
                     .await
                     .map_err(|_| AuthError::InvalidCredentials)?;
-                (username, None, authenticated)
+                (username, None, authenticated, None)
             }
             _ => {
                 return Err(AuthError::MissingHttpAuthentication {
@@ -1288,7 +1293,8 @@ async fn auth(
                     .await
                     .map_err(|_| AuthError::InvalidCredentials)?;
                 let name = std::mem::take(&mut claims.user);
-                (name, None, authenticated)
+                let groups = claims.groups.take();
+                (name, None, authenticated, groups)
             }
             _ => {
                 return Err(AuthError::MissingHttpAuthentication {
@@ -1304,7 +1310,7 @@ async fn auth(
                 Some(Credentials::Password { username, .. }) => username,
                 _ => HTTP_DEFAULT_USER.name.to_owned(),
             };
-            (name, None, Authenticated)
+            (name, None, Authenticated, None)
         }
     };
 
@@ -1315,6 +1321,7 @@ async fn auth(
         external_metadata_rx,
         authenticated,
         authenticator_kind: authenticator.kind(),
+        groups,
     })
 }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -234,6 +234,7 @@ where
                             external_metadata_rx: Some(auth_session.external_metadata_rx()),
                             helm_chart_version,
                             authenticator_kind,
+                            groups: None,
                         },
                         authenticated,
                     );
@@ -263,6 +264,7 @@ where
             let auth_response = oidc.authenticate(&jwt, Some(&user)).await;
             match auth_response {
                 Ok((mut claims, authenticated)) => {
+                    let groups = claims.groups.take();
                     let session = adapter_client.new_session(
                         SessionConfig {
                             conn_id: conn.conn_id().clone(),
@@ -272,6 +274,7 @@ where
                             external_metadata_rx: None,
                             helm_chart_version,
                             authenticator_kind,
+                            groups,
                         },
                         authenticated,
                     );
@@ -482,6 +485,7 @@ where
                     external_metadata_rx: None,
                     helm_chart_version,
                     authenticator_kind,
+                    groups: None,
                 },
                 authenticated,
             );
@@ -500,6 +504,7 @@ where
                     external_metadata_rx: None,
                     helm_chart_version,
                     authenticator_kind,
+                    groups: None,
                 },
                 Authenticated,
             );
@@ -798,6 +803,7 @@ where
             external_metadata_rx: None,
             helm_chart_version,
             authenticator_kind,
+            groups: None,
         },
         authenticated,
     );

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -21,6 +21,7 @@ pub static SYSTEM_USER: LazyLock<User> = LazyLock::new(|| User {
     external_metadata: None,
     internal_metadata: None,
     authenticator_kind: None,
+    groups: None,
 });
 
 pub const SUPPORT_USER_NAME: &str = "mz_support";
@@ -29,6 +30,7 @@ pub static SUPPORT_USER: LazyLock<User> = LazyLock::new(|| User {
     external_metadata: None,
     internal_metadata: None,
     authenticator_kind: None,
+    groups: None,
 });
 
 pub const ANALYTICS_USER_NAME: &str = "mz_analytics";
@@ -37,6 +39,7 @@ pub static ANALYTICS_USER: LazyLock<User> = LazyLock::new(|| User {
     external_metadata: None,
     internal_metadata: None,
     authenticator_kind: None,
+    groups: None,
 });
 
 pub static INTERNAL_USER_NAMES: LazyLock<BTreeSet<String>> = LazyLock::new(|| {
@@ -63,6 +66,7 @@ pub static HTTP_DEFAULT_USER: LazyLock<User> = LazyLock::new(|| User {
     external_metadata: None,
     internal_metadata: None,
     authenticator_kind: None,
+    groups: None,
 });
 
 /// Identifies a user.
@@ -78,6 +82,9 @@ pub struct User {
     /// The authenticator that authenticated this user.
     /// If `None`, the user hasn't been authenticated.
     pub authenticator_kind: Option<AuthenticatorKind>,
+    /// Groups extracted from JWT claims during OIDC authentication.
+    /// None for non-OIDC connections or when the group claim is absent.
+    pub groups: Option<Vec<String>>,
 }
 
 impl From<&User> for mz_pgwire_common::UserMetadata {


### PR DESCRIPTION
Thread JWT group claims through the auth pipeline and add the core sync diff function:

- Add groups: Option<Vec<String>> to User, SessionConfig, ValidatedClaims, and AuthedUser so JWT group claims extracted during OIDC auth are available in handle_startup_inner. OIDC paths extract groups from ValidatedClaims; all non-OIDC paths pass groups: None.

- Add sync_jwt_groups_diff function that computes Op::GrantRole and Op::RevokeRole operations by diffing current role memberships against JWT group claims. Only manages memberships granted by MZ_JWT_SYNC_ROLE_ID — manually-granted roles are never touched.

No behavioral change yet as nothing calls the sync function.

SQL-179 and SQL-180