### PR TITLE
orchestrator-kubernetes: suppress minDomains when topology spread is soft

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -784,9 +784,21 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     ..Default::default()
                 };
 
+                if config.soft && config.min_domains.is_some() {
+                    warn!(
+                        "topology spread is soft but min_domains is set; \
+                         Kubernetes rejects minDomains with ScheduleAnyway, \
+                         so min_domains will be ignored"
+                    );
+                }
+
                 let constraint = TopologySpreadConstraint {
                     label_selector: Some(ls),
-                    min_domains: config.min_domains,
+                    min_domains: if config.soft {
+                        None
+                    } else {
+                        config.min_domains
+                    },
                     max_skew: config.max_skew,
                     topology_key: "topology.kubernetes.io/zone".to_string(),
                     when_unsatisfiable: if config.soft {


### PR DESCRIPTION
Kubernetes rejects `minDomains` on a `TopologySpreadConstraint` when `whenUnsatisfiable=ScheduleAnyway` [1]. Since #32695 unconditionally forwarded `cluster_topology_spread_min_domains` into the constraint, setting both `cluster_topology_spread_soft=on` and `cluster_topology_spread_min_domains` caused all replica pod creation to fail with a kube-apiserver admission error.

[1]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition