### PR TITLE
controller: Fix replica-name annotation inconsistency across restarts

### DIFF
--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -635,13 +635,12 @@ impl Coordinator {
                     let cluster = self.catalog().get_cluster(cluster_id);
                     let cluster_name = cluster.name.clone();
                     let cluster_role = cluster.role();
-                    let replica_name = format!("{}.{}", cluster_name, replica.name);
                     self.handle_create_cluster_replica(
                         cluster_id,
                         replica_id,
                         cluster_role,
                         cluster_name,
-                        replica_name,
+                        replica.name.clone(),
                         replica.config.clone(),
                     )
                     .await;

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -811,7 +811,10 @@ impl Controller {
                     ),
                 ]),
                 annotations: BTreeMap::from([
-                    ("replica-name".into(), replica_name),
+                    (
+                        "replica-name".into(),
+                        format!("{cluster_name}.{replica_name}"),
+                    ),
                     ("cluster-name".into(), cluster_name),
                 ]),
                 availability_zones: match location.availability_zones {


### PR DESCRIPTION
The bootstrap path in coord.rs passed the bare replica name while the runtime path in catalog_implications.rs passed the FQN. After an envd restart the annotation would flip from "cluster.replica" to "replica".

Move FQN construction into provision_replica so all callers get consistent "cluster.replica" annotations.

#33327 introduced this