### PR TITLE
expr: Fix mutation-before-validation in `as_mut_temporal_filter`

### DIFF
--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -625,8 +625,7 @@ impl MirScalarExpr {
             if !expr1.contains_temporal()
                 && **expr2 == MirScalarExpr::CallUnmaterializable(UnmaterializableFunc::MzNow)
             {
-                std::mem::swap(expr1, expr2);
-                *func = match func {
+                let new_func = match func {
                     BinaryFunc::Eq(_) => func::Eq.into(),
                     BinaryFunc::Lt(_) => func::Gt.into(),
                     BinaryFunc::Lte(_) => func::Gte.into(),
@@ -636,6 +635,8 @@ impl MirScalarExpr {
                         return Err(format!("Unsupported binary temporal operation: {:?}", x));
                     }
                 };
+                std::mem::swap(expr1, expr2);
+                *func = new_func;
             }
 
             // Error if MLT is referenced in an unsupported position.


### PR DESCRIPTION
`as_mut_temporal_filter` swapped operands via `std::mem::swap` before validating the operator, so an unsupported `BinaryFunc` would leave the expression with swapped operands but the original (un-flipped) operator, violating the documented "unchanged on Err" contract.

Move the swap after operator validation so the expression is only mutated when the full transformation succeeds.

Introduced in PR #33500.