### PR TITLE
catalog: Fix pg_index.indnatts and pg_class.relnatts for index rows

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -7111,14 +7111,24 @@ SELECT
         WHEN class_objects.type = 'view' THEN 'v'
         WHEN class_objects.type = 'materialized-view' THEN 'm'
     END relkind,
-    COALESCE(
-        (
-            SELECT count(*)::pg_catalog.int2
-            FROM mz_catalog.mz_columns
-            WHERE mz_columns.id = class_objects.id
-        ),
-        0::pg_catalog.int2
-    ) AS relnatts,
+    CASE
+        WHEN class_objects.type = 'index' THEN COALESCE(
+            (
+                SELECT count(*)::pg_catalog.int2
+                FROM mz_catalog.mz_index_columns
+                WHERE mz_index_columns.index_id = class_objects.id
+            ),
+            0::pg_catalog.int2
+        )
+        ELSE COALESCE(
+            (
+                SELECT count(*)::pg_catalog.int2
+                FROM mz_catalog.mz_columns
+                WHERE mz_columns.id = class_objects.id
+            ),
+            0::pg_catalog.int2
+        )
+    END AS relnatts,
     -- MZ doesn't support CHECK constraints so relchecks is filled with 0
     0::pg_catalog.int2 AS relchecks,
     -- MZ doesn't support creating rules so relhasrules is filled with false
@@ -7334,15 +7344,7 @@ pub static PG_INDEX: LazyLock<BuiltinView> = LazyLock::new(|| {
         sql: "SELECT
     mz_indexes.oid AS indexrelid,
     mz_relations.oid AS indrelid,
-    COALESCE(
-        (
-            SELECT count(*)::pg_catalog.int2
-            FROM mz_catalog.mz_columns
-            JOIN mz_catalog.mz_relations mri ON mz_columns.id = mri.id
-            WHERE mri.oid = mz_catalog.mz_relations.oid
-        ),
-        0::pg_catalog.int2
-    ) AS indnatts,
+    count(mz_index_columns.index_position)::pg_catalog.int2 AS indnatts,
     -- MZ doesn't support creating unique indexes so indisunique is filled with false
     false::pg_catalog.bool AS indisunique,
     false::pg_catalog.bool AS indisprimary,

--- a/test/sqllogictest/pg_catalog_class.slt
+++ b/test/sqllogictest/pg_catalog_class.slt
@@ -48,6 +48,13 @@ WHERE relname = (SELECT name FROM mz_indexes WHERE on_id = (SELECT id FROM mz_ob
 ----
 0 0 0 0 false p i 0 false false false false d false false
 
+# relnatts for an index row is the number of columns in the index
+query TI
+SELECT relname, relnatts FROM pg_catalog.pg_class
+WHERE relname = (SELECT name FROM mz_indexes WHERE on_id = (SELECT id FROM mz_objects WHERE name = 'a'))
+----
+a_primary_idx  1
+
 # Test that pg_class is restricted to the current database, but includes items
 # in ambient schemas (in this case, pg_class itself).
 

--- a/test/sqllogictest/pg_catalog_index.slt
+++ b/test/sqllogictest/pg_catalog_index.slt
@@ -15,10 +15,21 @@ CREATE TABLE a (b int, c int);
 statement ok
 CREATE INDEX a_index ON a (b);
 
-# Test that pg_class reports the correct number of columns of an index's relation
+# indnatts is the number of columns in the index, not the indexed table
 query I
 SELECT indnatts FROM pg_catalog.pg_index
-JOIN mz_catalog.mz_relations ON pg_catalog.pg_index.indrelid = mz_catalog.mz_relations.oid
-WHERE mz_catalog.mz_relations.name = 'a'
+JOIN mz_catalog.mz_indexes ON pg_catalog.pg_index.indexrelid = mz_catalog.mz_indexes.oid
+WHERE mz_catalog.mz_indexes.name = 'a_index'
+----
+1
+
+statement ok
+CREATE INDEX a_index2 ON a (b, c);
+
+# Multi-column index reports 2
+query I
+SELECT indnatts FROM pg_catalog.pg_index
+JOIN mz_catalog.mz_indexes ON pg_catalog.pg_index.indexrelid = mz_catalog.mz_indexes.oid
+WHERE mz_catalog.mz_indexes.name = 'a_index2'
 ----
 2


### PR DESCRIPTION
indnatts was counting columns of the indexed table instead of the index itself. relnatts was always 0 for index rows because mz_columns has no entries keyed by index IDs. Follow-up to https://github.com/MaterializeInc/materialize/pull/33204