### PR TITLE
fix x-materialize-user header bypassing allowed_roles

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -282,9 +282,10 @@ impl HttpServer {
                     allowed_roles,
                 });
             if let listeners::AuthenticatorKind::None = authenticator_kind {
-                ws_router = ws_router.layer(middleware::from_fn(move |req, next| async move {
-                    x_materialize_user_header_auth(req, next, allowed_roles).await
-                }));
+                ws_router = ws_router.layer(middleware::from_fn_with_state(
+                    allowed_roles,
+                    x_materialize_user_header_auth,
+                ));
             }
             router = router.merge(ws_router);
         }
@@ -554,9 +555,10 @@ impl HttpServer {
                 router = router.merge(login_router).layer(session_layer);
             }
             listeners::AuthenticatorKind::None => {
-                base_router = base_router.layer(middleware::from_fn(move |req, next| async move {
-                    x_materialize_user_header_auth(req, next, allowed_roles).await
-                }));
+                base_router = base_router.layer(middleware::from_fn_with_state(
+                    allowed_roles,
+                    x_materialize_user_header_auth,
+                ));
             }
             _ => {}
         }
@@ -663,9 +665,9 @@ pub async fn handle_leader_skip_catchup(
 }
 
 async fn x_materialize_user_header_auth(
+    State(allowed_roles): State<AllowedRoles>,
     mut req: Request,
     next: Next,
-    allowed_roles: AllowedRoles,
 ) -> impl IntoResponse {
     // TODO migrate teleport to basic auth and remove this.
     if let Some(username) = req.headers().get("x-materialize-user").map(|h| h.to_str()) {

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -282,7 +282,9 @@ impl HttpServer {
                     allowed_roles,
                 });
             if let listeners::AuthenticatorKind::None = authenticator_kind {
-                ws_router = ws_router.layer(middleware::from_fn(x_materialize_user_header_auth));
+                ws_router = ws_router.layer(middleware::from_fn(move |req, next| async move {
+                    x_materialize_user_header_auth(req, next, allowed_roles).await
+                }));
             }
             router = router.merge(ws_router);
         }
@@ -552,8 +554,9 @@ impl HttpServer {
                 router = router.merge(login_router).layer(session_layer);
             }
             listeners::AuthenticatorKind::None => {
-                base_router =
-                    base_router.layer(middleware::from_fn(x_materialize_user_header_auth));
+                base_router = base_router.layer(middleware::from_fn(move |req, next| async move {
+                    x_materialize_user_header_auth(req, next, allowed_roles).await
+                }));
             }
             _ => {}
         }
@@ -659,7 +662,11 @@ pub async fn handle_leader_skip_catchup(
     }
 }
 
-async fn x_materialize_user_header_auth(mut req: Request, next: Next) -> impl IntoResponse {
+async fn x_materialize_user_header_auth(
+    mut req: Request,
+    next: Next,
+    allowed_roles: AllowedRoles,
+) -> impl IntoResponse {
     // TODO migrate teleport to basic auth and remove this.
     if let Some(username) = req.headers().get("x-materialize-user").map(|h| h.to_str()) {
         let username = match username {
@@ -670,6 +677,11 @@ async fn x_materialize_user_header_auth(mut req: Request, next: Next) -> impl In
                 )));
             }
         };
+        // Enforce the listener's `allowed_roles` policy here. Without this,
+        // a listener with `authenticator_kind=None` and `allowed_roles=Normal`
+        // would let any caller assert `x-materialize-user: mz_system` and
+        // bypass the role restriction.
+        check_role_allowed(&username, allowed_roles)?;
         req.extensions_mut().insert(AuthedUser {
             name: username,
             external_metadata_rx: None,

--- a/test/http-auth/listener_config_unauth_normal.json
+++ b/test/http-auth/listener_config_unauth_normal.json
@@ -1,0 +1,50 @@
+{
+  "sql": {
+    "external": {
+      "addr": "0.0.0.0:6875",
+      "authenticator_kind": "None",
+      "allowed_roles": "Normal",
+      "enable_tls": false
+    },
+    "internal": {
+      "addr": "0.0.0.0:6877",
+      "authenticator_kind": "None",
+      "allowed_roles": "Internal",
+      "enable_tls": false
+    }
+  },
+  "http": {
+    "external": {
+      "addr": "0.0.0.0:6876",
+      "authenticator_kind": "None",
+      "allowed_roles": "Normal",
+      "enable_tls": false,
+      "routes": {
+        "base": true,
+        "webhook": false,
+        "internal": false,
+        "metrics": false,
+        "profiling": false,
+        "mcp_agent": false,
+        "mcp_developer": false,
+        "console_config": false
+      }
+    },
+    "internal": {
+      "addr": "0.0.0.0:6878",
+      "authenticator_kind": "None",
+      "allowed_roles": "NormalAndInternal",
+      "enable_tls": false,
+      "routes": {
+        "base": true,
+        "webhook": false,
+        "internal": true,
+        "metrics": true,
+        "profiling": false,
+        "mcp_agent": false,
+        "mcp_developer": false,
+        "console_config": false
+      }
+    }
+  }
+}

--- a/test/http-auth/mzcompose.py
+++ b/test/http-auth/mzcompose.py
@@ -43,3 +43,58 @@ def workflow_default(c: Composition) -> None:
             assert (
                 "mz_session" not in s.cookies
             ), f"login rejection must not set a session cookie: {s.cookies}"
+
+    with c.override(
+        Materialized(
+            listeners_config_path=f"{MZ_ROOT}/test/http-auth/listener_config_unauth_normal.json"
+        )
+    ):
+        c.up("materialized")
+        ext = f"http://localhost:{c.port('materialized', 6876)}/api/sql"
+        internal = f"http://localhost:{c.port('materialized', 6878)}/api/sql"
+
+        def sql_post(url, query, user=None):
+            headers = {}
+            if user:
+                headers["x-materialize-user"] = user
+            return requests.post(url, headers=headers, json={"query": query})
+
+        def sql_user(url, query, user=None):
+            r = sql_post(url, query, user)
+            assert r.status_code == 200, f"expected 200, got {r.status_code}: {r.text}"
+            return r.json()["results"][0]["rows"][0][0]
+
+        with c.test_case("anonymous_external_request"):
+            assert sql_user(ext, "SELECT current_user;") == "anonymous_http_user"
+
+        with c.test_case("internal_mz_system_allowed"):
+            assert (
+                sql_user(internal, "SELECT current_user;", "mz_system") == "mz_system"
+            )
+
+        # Regression test for database-issues#11346. With
+        # `authenticator_kind=None` and `allowed_roles=Normal`, the
+        # `x-materialize-user` header previously injected an authenticated
+        # user without consulting `allowed_roles`, so external callers could
+        # assert `mz_system` or `mz_support` and bypass the policy.
+        with c.test_case("external_rejects_mz_system"):
+            r = sql_post(ext, "SELECT current_user;", "mz_system")
+            assert r.status_code in (
+                401,
+                403,
+            ), f"expected 401/403, got {r.status_code}: {r.text}"
+
+        with c.test_case("external_rejects_mz_support"):
+            r = sql_post(ext, "SELECT current_user;", "mz_support")
+            assert r.status_code in (
+                401,
+                403,
+            ), f"expected 401/403, got {r.status_code}: {r.text}"
+
+        with c.test_case("anonymous_cannot_alter_system"):
+            r = sql_post(ext, "ALTER SYSTEM SET max_tables = 100;")
+            assert r.status_code == 200
+            assert (
+                "permission denied"
+                in r.json()["results"][0]["error"]["message"].lower()
+            )


### PR DESCRIPTION
x_materialize_user_header_auth injected an AuthedUser whenever x-materialize-user was set to mz_system or mz_support, without checking the listener's allowed_roles. On an external HTTP listener with authenticator_kind=None and allowed_roles=Normal (the self-managed default), any client could assert x-materialize-user: mz_system and gain mz_system privileges. Run check_role_allowed inside the middleware so both the HTTP and WebSocket routers reject disallowed roles before the user is added to the request extensions.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/11346

### Verification
Additional nightly tests.