### PR TITLE
Revert moving off of LD SDK fork again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,12 +1876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cidr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579504560394e388085d0c080ea587dfa5c15f7e251b4d5247d1e1a61d1d6928"
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3266,15 +3260,14 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.17.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08d78ef3c0bd7cef8f9fdf7822eceb44fe2300689906b9984c577f549bc80dd"
+checksum = "c26451361cde19fe2322835b6e684f4825902edf3139ce9d6a70e6542566a0b2"
 dependencies = [
  "base64 0.22.1",
- "bytes",
  "futures",
- "http 1.4.0",
- "launchdarkly-sdk-transport",
+ "hyper 0.14.32",
+ "hyper-timeout 0.4.1",
  "log",
  "pin-project",
  "rand 0.8.5",
@@ -4153,26 +4146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-http-proxy"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http 1.4.0",
- "hyper 1.9.0",
- "hyper-tls 0.6.0",
- "hyper-util",
- "native-tls",
- "pin-project-lite",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-openssl"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4206,6 +4179,18 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -4816,7 +4801,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-openssl",
- "hyper-timeout",
+ "hyper-timeout 0.5.1",
  "hyper-util",
  "jiff",
  "jsonpath-rust",
@@ -4898,46 +4883,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "launchdarkly-sdk-transport"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe83622d04dfcaaeac0b5e3aaa1cc156eb1e70c8b68dfcaffaee4365faa00d3"
-dependencies = [
- "bytes",
- "futures",
- "http 1.4.0",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-http-proxy",
- "hyper-timeout",
- "hyper-tls 0.6.0",
- "hyper-util",
- "log",
- "native-tls",
- "no-proxy",
- "tower 0.4.13",
-]
-
-[[package]]
 name = "launchdarkly-server-sdk"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7d03f7f2557dfebc24147d90b2080313fd5a60a4de5219dce1b574956f1c4e"
+version = "2.6.2"
+source = "git+https://github.com/MaterializeInc/rust-server-sdk?rev=3e0a0b98b09a2970f292577a07e1c9382b65b5da#3e0a0b98b09a2970f292577a07e1c9382b65b5da"
 dependencies = [
- "bitflags 2.11.0",
- "bytes",
+ "aws-lc-rs",
  "chrono",
  "crossbeam-channel",
  "data-encoding",
  "eventsource-client",
  "futures",
- "http 1.4.0",
- "launchdarkly-sdk-transport",
+ "hyper 0.14.32",
  "launchdarkly-server-sdk-evaluation",
+ "lazy_static",
  "log",
  "lru",
  "moka",
- "openssl",
  "parking_lot",
  "rand 0.9.4",
  "serde",
@@ -4950,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "launchdarkly-server-sdk-evaluation"
-version = "2.1.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70166742950e523236f98dad92ad55f6b2f713d84124d6a360329bfd6c44fbd4"
+checksum = "63706c23ee67f699563e5c52c7542361eccc966cba0430b6a7862c0ecaee9432"
 dependencies = [
  "base16ct",
  "chrono",
@@ -5542,10 +5503,10 @@ dependencies = [
  "governor",
  "hex",
  "http 1.4.0",
+ "hyper-tls 0.5.0",
  "imbl",
  "ipnet",
  "itertools 0.14.0",
- "launchdarkly-sdk-transport",
  "launchdarkly-server-sdk",
  "maplit",
  "mz-adapter-types",
@@ -6339,7 +6300,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "humantime",
- "launchdarkly-sdk-transport",
+ "hyper-tls 0.5.0",
  "launchdarkly-server-sdk",
  "mz-build-info",
  "mz-dyncfg",
@@ -8555,9 +8516,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.15"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdede44f9a69cab2899a2049e2c3bd49bf911a157f6a3353d4a91c61abbce44"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -8591,15 +8552,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "no-proxy"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f79c902b31ceac6856e262af5dbaffef75390cf4647c9fef7b55da69a4b912e"
-dependencies = [
- "cidr",
 ]
 
 [[package]]
@@ -10975,11 +10927,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -12152,6 +12104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-io-utility"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12358,7 +12320,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-timeout",
+ "hyper-timeout 0.5.1",
  "hyper-util",
  "percent-encoding",
  "pin-project",
@@ -12423,7 +12385,6 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,8 +377,7 @@ junit-report = "0.8.3"
 k8s-controller = "0.10.0"
 k8s-openapi = { version = "0.27.0", features = ["schemars", "v1_32"] }
 kube = { version = "3.1.0", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
-launchdarkly-server-sdk = { version = "3.0.1", default-features = false, features = ["native-tls", "crypto-openssl"] }
-launchdarkly-sdk-transport = "0.1"
+launchdarkly-server-sdk = { version = "2.6.2", default-features = false }
 lgalloc = "0.6.0"
 libc = "0.2.184"
 lru = "0.16.3"
@@ -597,6 +596,9 @@ postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array"
 
 # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
+
+# Waiting for resolution of https://github.com/launchdarkly/rust-server-sdk/issues/116
+launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", rev = "3e0a0b98b09a2970f292577a07e1c9382b65b5da" }
 
 # Waiting on https://github.com/edenhill/librdkafka/pull/4051.
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }

--- a/deny.toml
+++ b/deny.toml
@@ -178,7 +178,6 @@ wrappers = [
     "globset",
     "launchdarkly-server-sdk",
     "launchdarkly-server-sdk-evaluation",
-    "launchdarkly-sdk-transport",
     "native-tls",
     "opendal",
     "os_info",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -28,10 +28,10 @@ governor.workspace = true
 hex.workspace = true
 imbl.workspace = true
 http.workspace = true
+hyper-tls = "0.5.0"
 ipnet.workspace = true
 itertools.workspace = true
 launchdarkly-server-sdk.workspace = true
-launchdarkly-sdk-transport.workspace = true
 maplit.workspace = true
 mz-adapter-types = { path = "../adapter-types" }
 mz-audit-log = { path = "../audit-log" }

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -10,16 +10,14 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::Bytes;
 use derivative::Derivative;
-use futures::TryStreamExt;
-use launchdarkly_sdk_transport::{ByteStream, HttpTransport, ResponseFuture};
+use hyper_tls::HttpsConnector;
 use launchdarkly_server_sdk as ld;
 use mz_build_info::BuildInfo;
 use mz_cloud_provider::CloudProvider;
-use mz_ore::metrics::UIntGauge;
 use mz_ore::now::NowFn;
 use mz_sql::catalog::EnvironmentId;
 use serde_json::Value as JsonValue;
@@ -66,7 +64,7 @@ impl SystemParameterFrontend {
     /// Create a new [SystemParameterFrontend] initialize.
     ///
     /// This will create and initialize an [ld::Client] instance. The
-    /// [ld::Client::wait_for_initialization] call will be attempted in a loop with an
+    /// [ld::Client::initialized_async] call will be attempted in a loop with an
     /// exponential backoff with power `2s` and max duration `60s`.
     pub async fn from(sync_config: &SystemParameterSyncConfig) -> Result<Self, anyhow::Error> {
         match &sync_config.backend_config {
@@ -148,68 +146,25 @@ impl SystemParameterFrontend {
     }
 }
 
-/// An [`HttpTransport`] wrapper that records timestamps on successful HTTP
-/// responses. Used to populate Prometheus metrics that track LaunchDarkly
-/// connectivity health.
-///
-/// Two instances are created — one for the event processor (CSE metric, tracks
-/// outbound event sends) and one for the streaming data source (SSE metric,
-/// tracks inbound SSE events).
-#[derive(Clone)]
-struct MetricsTransport<T> {
-    inner: T,
-    last_success_gauge: UIntGauge,
-    now_fn: NowFn,
-}
-
-impl<T: HttpTransport> HttpTransport for MetricsTransport<T> {
-    fn request(&self, request: http::Request<Option<Bytes>>) -> ResponseFuture {
-        let inner_fut = self.inner.request(request);
-        let gauge = self.last_success_gauge.clone();
-        let now_fn = self.now_fn.clone();
-        Box::pin(async move {
-            let resp = inner_fut.await?;
-            if resp.status().is_success() {
-                gauge.set(now_fn() / 1000);
-                let (parts, body) = resp.into_parts();
-                let wrapped: ByteStream = Box::pin(body.inspect_ok(move |_| {
-                    gauge.set(now_fn() / 1000);
-                }));
-                Ok(http::Response::from_parts(parts, wrapped))
-            } else {
-                Ok(resp)
-            }
-        })
-    }
-}
-
-fn ld_config(api_key: &str, metrics: &Metrics, now_fn: &NowFn) -> ld::Config {
-    let transport = launchdarkly_sdk_transport::HyperTransport::builder()
-        .connect_timeout(Duration::from_secs(10))
-        .read_timeout(Duration::from_secs(300))
-        .build_https()
-        .expect("failed to create HTTPS transport");
-
-    let cse_transport = MetricsTransport {
-        inner: transport.clone(),
-        last_success_gauge: metrics.last_cse_time_seconds.clone(),
-        now_fn: now_fn.clone(),
-    };
-    let data_source_transport = MetricsTransport {
-        inner: transport,
-        last_success_gauge: metrics.last_sse_time_seconds.clone(),
-        now_fn: now_fn.clone(),
-    };
-
-    let mut event_processor = ld::EventProcessorBuilder::new();
-    event_processor.transport(cse_transport);
-
-    let mut data_source = ld::PollingDataSourceBuilder::new();
-    data_source.transport(data_source_transport);
-
+fn ld_config(api_key: &str, metrics: &Metrics) -> ld::Config {
     ld::ConfigBuilder::new(api_key)
-        .event_processor(&event_processor)
-        .data_source(&data_source)
+        .event_processor(
+            ld::EventProcessorBuilder::new()
+                .https_connector(HttpsConnector::new())
+                .on_success({
+                    let last_cse_time_seconds = metrics.last_cse_time_seconds.clone();
+                    Arc::new(move |result| {
+                        if let Ok(ts) = u64::try_from(result.time_from_server / 1000) {
+                            last_cse_time_seconds.set(ts);
+                        } else {
+                            tracing::warn!(
+                                "Cannot convert time_from_server / 1000 from u128 to u64"
+                            );
+                        }
+                    })
+                }),
+        )
+        .data_source(ld::StreamingDataSourceBuilder::new().https_connector(HttpsConnector::new()))
         .build()
         .expect("valid config")
 }
@@ -219,9 +174,19 @@ async fn ld_client(
     metrics: &Metrics,
     now_fn: &NowFn,
 ) -> Result<ld::Client, anyhow::Error> {
-    let ld_client = ld::Client::build(ld_config(api_key, metrics, now_fn))?;
+    let ld_client = ld::Client::build(ld_config(api_key, metrics))?;
     tracing::info!("waiting for SystemParameterFrontend to initialize");
-    ld_client.start_with_default_executor();
+    // Start and initialize LD client for the frontend. The callback passed
+    // will export the last time when an SSE event from the LD server was
+    // received in a Prometheus metric.
+    ld_client.start_with_default_executor_and_callback({
+        let last_sse_time_seconds = metrics.last_sse_time_seconds.clone();
+        let now_fn = now_fn.clone();
+        Arc::new(move |_ev| {
+            let ts = now_fn() / 1000;
+            last_sse_time_seconds.set(ts);
+        })
+    });
 
     let max_backoff = Duration::from_secs(60);
     let mut backoff = Duration::from_secs(5);
@@ -307,154 +272,4 @@ fn ld_ctx(
     );
 
     ctx_builder.build().map_err(|e| anyhow::anyhow!(e))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures::StreamExt;
-    use launchdarkly_sdk_transport::{ByteStream, TransportError};
-    use mz_ore::metrics::MetricsRegistry;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    /// A fake transport that simulates a long-lived SSE streaming connection:
-    /// returns 200 OK immediately, then delivers multiple SSE events as body
-    /// chunks (exactly how LaunchDarkly's streaming data source works).
-    #[derive(Clone)]
-    struct FakeSseTransport;
-
-    impl HttpTransport for FakeSseTransport {
-        fn request(&self, _request: http::Request<Option<Bytes>>) -> ResponseFuture {
-            let body: ByteStream = Box::pin(futures::stream::iter(vec![
-                Ok(Bytes::from("event: put\ndata: {\"flags\":{}}\n\n")),
-                Ok(Bytes::from("event: patch\ndata: {\"key\":\"flag1\"}\n\n")),
-                Ok(Bytes::from("event: patch\ndata: {\"key\":\"flag2\"}\n\n")),
-            ]));
-            Box::pin(async move {
-                http::Response::builder()
-                    .status(200)
-                    .body(body)
-                    .map_err(|e| TransportError::new(std::io::Error::other(e)))
-            })
-        }
-    }
-
-    /// A fake transport that returns an error, simulating a failed connection.
-    #[derive(Clone)]
-    struct FailingTransport;
-
-    impl HttpTransport for FailingTransport {
-        fn request(&self, _request: http::Request<Option<Bytes>>) -> ResponseFuture {
-            Box::pin(async move {
-                Err(TransportError::new(std::io::Error::new(
-                    std::io::ErrorKind::ConnectionRefused,
-                    "connection refused",
-                )))
-            })
-        }
-    }
-
-    fn test_gauge(registry: &MetricsRegistry, name: &str) -> UIntGauge {
-        registry.register(mz_ore::metric!(
-            name: name,
-            help: "test gauge",
-        ))
-    }
-
-    /// Verifies that MetricsTransport updates the gauge on each body chunk,
-    /// not just on the initial HTTP 200 response head. This matters for
-    /// long-lived streaming connections where SSE events arrive as body chunks.
-    #[mz_ore::test(tokio::test)]
-    async fn test_metric_updated_on_body_chunks() -> Result<(), anyhow::Error> {
-        let time = Arc::new(AtomicU64::new(1_000_000));
-        let time_clone = Arc::clone(&time);
-        let now_fn = NowFn::from(move || time_clone.load(Ordering::SeqCst));
-
-        let registry = MetricsRegistry::new();
-        let gauge = test_gauge(&registry, "test_sse_gauge");
-
-        let transport = MetricsTransport {
-            inner: FakeSseTransport,
-            last_success_gauge: gauge.clone(),
-            now_fn,
-        };
-
-        assert_eq!(gauge.get(), 0);
-
-        let request = http::Request::builder()
-            .uri("https://stream.launchdarkly.com/all")
-            .body(None)?;
-        let response = transport.request(request).await?;
-
-        assert_eq!(gauge.get(), 1000);
-
-        time.store(2_800_000, Ordering::SeqCst);
-
-        let mut body = response.into_body();
-        let mut event_count = 0;
-        while let Some(Ok(_chunk)) = body.next().await {
-            event_count += 1;
-        }
-        assert_eq!(event_count, 3);
-
-        assert_eq!(gauge.get(), 2800);
-        Ok(())
-    }
-
-    #[mz_ore::test(tokio::test)]
-    async fn test_cse_metric_updates_correctly_per_request() -> Result<(), anyhow::Error> {
-        let time = Arc::new(AtomicU64::new(1_000_000));
-        let time_clone = Arc::clone(&time);
-        let now_fn = NowFn::from(move || time_clone.load(Ordering::SeqCst));
-
-        let registry = MetricsRegistry::new();
-        let gauge = test_gauge(&registry, "test_cse_gauge");
-
-        let transport = MetricsTransport {
-            inner: FakeSseTransport,
-            last_success_gauge: gauge.clone(),
-            now_fn,
-        };
-
-        let req = || -> Result<http::Request<Option<Bytes>>, http::Error> {
-            http::Request::builder()
-                .uri("https://events.launchdarkly.com/bulk")
-                .body(None)
-        };
-
-        let _ = transport.request(req()?).await?;
-        assert_eq!(gauge.get(), 1000);
-
-        time.store(2_000_000, Ordering::SeqCst);
-        let _ = transport.request(req()?).await?;
-        assert_eq!(gauge.get(), 2000);
-
-        time.store(3_000_000, Ordering::SeqCst);
-        let _ = transport.request(req()?).await?;
-        assert_eq!(gauge.get(), 3000);
-        Ok(())
-    }
-
-    #[mz_ore::test(tokio::test)]
-    async fn test_metric_not_updated_on_failed_request() -> Result<(), anyhow::Error> {
-        let now_fn = NowFn::from(|| 5_000_000u64);
-
-        let registry = MetricsRegistry::new();
-        let gauge = test_gauge(&registry, "test_fail_gauge");
-
-        let transport = MetricsTransport {
-            inner: FailingTransport,
-            last_success_gauge: gauge.clone(),
-            now_fn,
-        };
-
-        let request = http::Request::builder()
-            .uri("https://stream.launchdarkly.com/all")
-            .body(None)?;
-        let result = transport.request(request).await;
-        assert!(result.is_err());
-        assert_eq!(gauge.get(), 0, "gauge must not update on transport error");
-        Ok(())
-    }
 }

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -204,7 +204,7 @@ fn ld_config(api_key: &str, metrics: &Metrics, now_fn: &NowFn) -> ld::Config {
     let mut event_processor = ld::EventProcessorBuilder::new();
     event_processor.transport(cse_transport);
 
-    let mut data_source = ld::StreamingDataSourceBuilder::new();
+    let mut data_source = ld::PollingDataSourceBuilder::new();
     data_source.transport(data_source_transport);
 
     ld::ConfigBuilder::new(api_key)

--- a/src/dyncfg-launchdarkly/Cargo.toml
+++ b/src/dyncfg-launchdarkly/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 humantime.workspace = true
+hyper-tls = "0.5.0"
 launchdarkly-server-sdk.workspace = true
-launchdarkly-sdk-transport.workspace = true
 mz-build-info = { path = "../build-info" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-ore = { path = "../ore", default-features = false, features = ["async"] }

--- a/src/dyncfg-launchdarkly/src/lib.rs
+++ b/src/dyncfg-launchdarkly/src/lib.rs
@@ -55,7 +55,7 @@ where
             .build_https()
             .expect("failed to create HTTPS transport");
 
-        let mut data_source = ld::StreamingDataSourceBuilder::new();
+        let mut data_source = ld::PollingDataSourceBuilder::new();
         data_source.transport(transport.clone());
 
         let mut event_processor = ld::EventProcessorBuilder::new();

--- a/src/dyncfg-launchdarkly/src/lib.rs
+++ b/src/dyncfg-launchdarkly/src/lib.rs
@@ -11,6 +11,7 @@
 
 use std::time::Duration;
 
+use hyper_tls::HttpsConnector;
 use launchdarkly_server_sdk as ld;
 use mz_build_info::BuildInfo;
 use mz_dyncfg::{ConfigSet, ConfigUpdates, ConfigVal};
@@ -49,21 +50,13 @@ where
         let _ = dyn_into_flag(entry.val())?;
     }
     let ld_client = if let Some(key) = launchdarkly_sdk_key {
-        let transport = launchdarkly_sdk_transport::HyperTransport::builder()
-            .connect_timeout(Duration::from_secs(10))
-            .read_timeout(Duration::from_secs(300))
-            .build_https()
-            .expect("failed to create HTTPS transport");
-
-        let mut data_source = ld::PollingDataSourceBuilder::new();
-        data_source.transport(transport.clone());
-
-        let mut event_processor = ld::EventProcessorBuilder::new();
-        event_processor.transport(transport);
-
         let config = ld::ConfigBuilder::new(key)
-            .data_source(&data_source)
-            .event_processor(&event_processor)
+            .event_processor(
+                ld::EventProcessorBuilder::new().https_connector(HttpsConnector::new()),
+            )
+            .data_source(
+                ld::StreamingDataSourceBuilder::new().https_connector(HttpsConnector::new()),
+            )
             .build()
             .expect("valid config");
         let client = ld::Client::build(config)?;


### PR DESCRIPTION
See [incident-984](https://materializeinc.slack.com/archives/C0B0FUQ9NP7).

There is a critical bug causing connections to be permanently broken quite often, which is fixed in our fork, but is not fixed upstream even on the latest version: https://github.com/launchdarkly/rust-server-sdk/issues/116

LD test from Nightly: https://buildkite.com/materialize/nightly/builds/16253 (green)