### PR TITLE
persist: clear active_gc on no-op GC runs

### DIFF
--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -259,9 +259,11 @@ where
         if rollups_to_remove_from_state.is_empty() {
             // If there are no rollups to remove from state (either the work has already
             // been done, or the there aren't enough rollups <= seqno_since to have any
-            // to delete), we can safely exit.
+            // to delete), we can safely exit. We still call remove_rollups to clear
+            // active_gc if it was set, so the next GC isn't suppressed.
+            let (_removed, maintenance) = machine.remove_rollups(&[]).await;
             machine.applier.metrics.gc.noop.inc();
-            return (RoutineMaintenance::default(), gc_results);
+            return (maintenance, gc_results);
         }
 
         debug!(

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1423,13 +1423,21 @@ where
         &mut self,
         remove_rollups: &[(SeqNo, PartialRollupKey)],
     ) -> ControlFlow<NoOpStateTransition<Vec<SeqNo>>, Vec<SeqNo>> {
-        if remove_rollups.is_empty() || self.is_tombstone() {
+        if self.is_tombstone() {
             return Break(NoOpStateTransition(vec![]));
         }
 
-        //This state transition is called at the end of the GC process, so we
-        //need to unset the `active_gc` field.
-        self.active_gc = None;
+        // This state transition is called at the end of the GC process, so we
+        // need to unset the `active_gc` field.
+        let active_gc_was_set = self.active_gc.take().is_some();
+
+        if remove_rollups.is_empty() {
+            return if active_gc_was_set {
+                Continue(vec![])
+            } else {
+                Break(NoOpStateTransition(vec![]))
+            };
+        }
 
         let mut removed = vec![];
         for (seqno, key) in remove_rollups {


### PR DESCRIPTION
When GC finds no rollups to remove it returned early without clearing active_gc, suppressing further GC for the entire fallback threshold (15 min). Fix by calling remove_rollups(&[]) on the early-exit path and making remove_rollups commit a CaS when active_gc needs clearing.

Follow-up to #32301