### PR TITLE
sql_server: Fix opening progress connection to SQL Server

### DIFF
--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -83,6 +83,7 @@ pub(crate) fn render<'scope>(
                     stat.set_offset_known(0);
                     stat.set_offset_committed(0);
                 }
+                return Ok(());
             }
             let conn_config = connection
                 .resolve_config(


### PR DESCRIPTION
#32221 introduced a missing return in the progress operator's non-responsible-worker guard. As a result, every Timely worker — not just the one designated for progress — opens a long-lived connection to the upstream SQL Server, continuously polls get_max_lsn, and runs sp_cdc_cleanup_change_table on every committed upper advancement. With a workers=N cluster, this multiplies upstream connections and cleanup operations by N instead of 1.