### PR TITLE
Replace terraform disclaimer with usage note

### DIFF
--- a/doc/user/content/self-managed-deployments/_index.md
+++ b/doc/user/content/self-managed-deployments/_index.md
@@ -304,18 +304,11 @@ components work together:
 
 To help you get started, Materialize provides Terraform modules.
 
-{{< important >}}
-These modules are intended for evaluation/demonstration purposes and for serving
-as a template when building your own production deployment. The modules should
-not be directly relied upon for production deployments: **future releases of the
-modules will contain breaking changes.** Instead, to use as a starting point for
-your own production deployment, either:
+{{< note >}}
 
-- Fork the repo and pin to a specific version; or
+{{< self-managed/terraform-disclaimer >}}
 
-- Use the code as a reference when developing your own deployment.
-
-{{</ important >}}
+{{< /note >}}
 
 {{< tabs >}}
 {{< tab "Terraform Modules (New!)" >}}

--- a/doc/user/content/self-managed-deployments/installation/install-on-aws.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-aws.md
@@ -25,11 +25,11 @@ deploys a complete Materialize environment on AWS using the modular Terraform
 setup from this repository.
 
 
-{{< warning >}}
+{{< note >}}
 
 {{< self-managed/terraform-disclaimer >}}
 
-{{< /warning >}}
+{{< /note >}}
 
 
 ## What Gets Created
@@ -114,11 +114,11 @@ An active AWS account with appropriate permissions to create:
 
 ## Getting started: Simple example
 
-{{< warning >}}
+{{< note >}}
 
 {{< self-managed/terraform-disclaimer >}}
 
-{{< /warning >}}
+{{< /note >}}
 
 {{< tip >}}
 

--- a/doc/user/content/self-managed-deployments/installation/install-on-aws.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-aws.md
@@ -16,9 +16,8 @@ menu:
 Materialize provides a set of modular [Terraform
 modules](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main)
 that can be used to deploy all services required for Materialize to run on AWS.
-The module is intended to provide a simple set of examples on how to deploy
-Materialize. It can be used as is or modules can be taken from the example and
-integrated with existing DevOps tooling.
+These modules serve as composable building blocks that you can integrate into
+existing DevOps workflows, either as a full set or individually.
 
 {{% self-managed/materialize-components-sentence %}} The example on this page
 deploys a complete Materialize environment on AWS using the modular Terraform

--- a/doc/user/content/self-managed-deployments/installation/install-on-aws.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-aws.md
@@ -121,7 +121,9 @@ An active AWS account with appropriate permissions to create:
 
 {{< tip >}}
 
-The simple example used in this tutorial enables [Password
+* {{% self-managed/terraform-simple-example-tip %}}
+
+* The simple example used in this tutorial enables [Password
 authentication](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/main/aws/examples/simple/main.tf#L380)
 for the Materialize instance. To use a different authentication method, update
 [`authenticator_kind`](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/main/kubernetes/modules/materialize-instance/README.md#input_authenticator_kind).

--- a/doc/user/content/self-managed-deployments/installation/install-on-azure.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-azure.md
@@ -11,9 +11,8 @@ menu:
 Materialize provides a set of modular [Terraform
 modules](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main)
 that can be used to deploy all services required for Materialize to run on Azure.
-The module is intended to provide a simple set of examples on how to deploy
-Materialize. It can be used as is or modules can be taken from the example and
-integrated with existing DevOps tooling.
+These modules serve as composable building blocks that you can integrate into
+existing DevOps workflows, either as a full set or individually.
 
 {{% self-managed/materialize-components-sentence %}} The example on this page
 deploys a complete Materialize environment on Azure using the modular Terraform

--- a/doc/user/content/self-managed-deployments/installation/install-on-azure.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-azure.md
@@ -19,11 +19,11 @@ integrated with existing DevOps tooling.
 deploys a complete Materialize environment on Azure using the modular Terraform
 setup from this repository.
 
-{{< warning >}}
+{{< note >}}
 
 {{< self-managed/terraform-disclaimer >}}
 
-{{< /warning >}}
+{{< /note >}}
 
 ## What Gets Created
 
@@ -112,11 +112,11 @@ An active Azure subscription with appropriate permissions to create:
 
 ## Getting started: Simple example
 
-{{< warning >}}
+{{< note >}}
 
 {{< self-managed/terraform-disclaimer >}}
 
-{{< /warning >}}
+{{< /note >}}
 
 
 {{< tip >}}

--- a/doc/user/content/self-managed-deployments/installation/install-on-azure.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-azure.md
@@ -120,12 +120,16 @@ An active Azure subscription with appropriate permissions to create:
 
 {{< tip >}}
 
-The simple example used in this tutorial enables [Password
+* {{% self-managed/terraform-simple-example-tip %}}
+
+* The simple example used in this tutorial enables [Password
 authentication](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/main/azure/examples/simple/main.tf#L340)
 for the Materialize instance. To use a different authentication method, update
 [`authenticator_kind`](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/main/kubernetes/modules/materialize-instance/README.md#input_authenticator_kind).
 See [Authentication](/security/self-managed/authentication/) for the supported
-authentication mechanisms. {{< /tip >}}
+authentication mechanisms.
+
+{{< /tip >}}
 
 ### Step 1: Set Up the Environment
 

--- a/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
@@ -12,9 +12,8 @@ menu:
 Materialize provides a set of modular [Terraform
 modules](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main)
 that can be used to deploy all services required for Materialize to run on Google Cloud.
-The module is intended to provide a simple set of examples on how to deploy
-Materialize. It can be used as is or modules can be taken from the example and
-integrated with existing DevOps tooling.
+These modules serve as composable building blocks that you can integrate into
+existing DevOps workflows, either as a full set or individually.
 
 {{% self-managed/materialize-components-sentence %}} The example on this page
 deploys a complete Materialize environment on GCP using the modular Terraform

--- a/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
@@ -20,11 +20,11 @@ integrated with existing DevOps tooling.
 deploys a complete Materialize environment on GCP using the modular Terraform
 setup from this repository.
 
-{{< warning >}}
+{{< note >}}
 
 {{< self-managed/terraform-disclaimer >}}
 
-{{< /warning >}}
+{{< /note >}}
 
 ## What Gets Created
 
@@ -110,11 +110,11 @@ A Google account with permission to:
 
 ## Getting started: Simple example
 
-{{< warning >}}
+{{< note >}}
 
 {{< self-managed/terraform-disclaimer >}}
 
-{{< /warning >}}
+{{< /note >}}
 
 {{< tip >}}
 

--- a/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
@@ -117,12 +117,16 @@ A Google account with permission to:
 
 {{< tip >}}
 
-The simple example used in this tutorial enables [Password
+* {{% self-managed/terraform-simple-example-tip %}}
+
+* The simple example used in this tutorial enables [Password
 authentication](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/main/gcp/examples/simple/main.tf#L332)
 for the Materialize instance. To use a different authentication method, update
 [`authenticator_kind`](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/main/kubernetes/modules/materialize-instance/README.md#input_authenticator_kind).
 See [Authentication](/security/self-managed/authentication/) for the supported
-authentication mechanisms. s {{< /tip >}}
+authentication mechanisms.
+
+{{< /tip >}}
 
 ### Step 1: Set Up the Environment
 

--- a/doc/user/content/self-managed-deployments/installation/legacy/install-on-aws-legacy.md
+++ b/doc/user/content/self-managed-deployments/installation/legacy/install-on-aws-legacy.md
@@ -26,7 +26,7 @@ module](https://github.com/MaterializeInc/terraform-aws-materialize) to:
 
 {{< warning >}}
 
-{{< self-managed/terraform-disclaimer >}}
+{{< self-managed/legacy-terraform-disclaimer >}}
 
 {{< /warning >}}
 
@@ -66,7 +66,7 @@ documentation](https://helm.sh/docs/intro/install/).
 
 {{< warning >}}
 
-{{< self-managed/terraform-disclaimer >}}
+{{< self-managed/legacy-terraform-disclaimer >}}
 
 {{< self-managed/tutorial-disclaimer >}}
 

--- a/doc/user/content/self-managed-deployments/installation/legacy/install-on-azure-legacy.md
+++ b/doc/user/content/self-managed-deployments/installation/legacy/install-on-azure-legacy.md
@@ -24,7 +24,7 @@ modules](https://github.com/MaterializeInc/terraform-azurerm-materialize) to:
 
 {{< warning >}}
 
-{{< self-managed/terraform-disclaimer >}}
+{{< self-managed/legacy-terraform-disclaimer >}}
 
 {{< self-managed/tutorial-disclaimer >}}
 
@@ -109,7 +109,7 @@ If you want to use `jq` and do not have `jq` installed, install.
 
 {{< warning >}}
 
-{{< self-managed/terraform-disclaimer >}}
+{{< self-managed/legacy-terraform-disclaimer >}}
 
 {{< /warning >}}
 

--- a/doc/user/content/self-managed-deployments/installation/legacy/install-on-gcp-legacy.md
+++ b/doc/user/content/self-managed-deployments/installation/legacy/install-on-gcp-legacy.md
@@ -27,7 +27,7 @@ module](https://github.com/MaterializeInc/terraform-google-materialize) to:
 
 {{< warning >}}
 
-{{< self-managed/terraform-disclaimer >}}
+{{< self-managed/legacy-terraform-disclaimer >}}
 
 {{< self-managed/tutorial-disclaimer >}}
 
@@ -189,7 +189,7 @@ If you want to use `jq` and do not have `jq` installed, install.
 
 {{< warning >}}
 
-{{< self-managed/terraform-disclaimer >}}
+{{< self-managed/legacy-terraform-disclaimer >}}
 
 {{< /warning >}}
 

--- a/doc/user/layouts/shortcodes/self-managed/legacy-terraform-disclaimer.html
+++ b/doc/user/layouts/shortcodes/self-managed/legacy-terraform-disclaimer.html
@@ -1,0 +1,10 @@
+The Terraform modules used in this tutorial are intended for
+evaluation/demonstration purposes and for serving as a template when building
+your own production deployment. The modules should not be directly relied upon
+for production deployments: **future releases of the modules will contain
+breaking changes.** Instead, to use as a starting point for your own production
+deployment, either:
+
+- Fork the repo and pin to a specific version; or
+
+- Use the code as a reference when developing your own deployment.

--- a/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
+++ b/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
@@ -1,10 +1,5 @@
-The Terraform modules used in this tutorial are intended for
-evaluation/demonstration purposes and for serving as a template when building
-your own production deployment. The modules should not be directly relied upon
-for production deployments: **future releases of the modules will contain
-breaking changes.** Instead, to use as a starting point for your own production
-deployment, either:
+We recommend pinning your module sources to specific tags to avoid unexpected breaking
+changes in future versions.
 
-- Fork the repo and pin to a specific version; or
-
-- Use the code as a reference when developing your own deployment.
+We recommend updating your module source tags when updating Materialize versions,
+taking care to follow any instructions in the release notes

--- a/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
+++ b/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
@@ -2,4 +2,4 @@ We recommend pinning your module sources to specific tags to avoid unexpected br
 changes in future versions.
 
 We recommend updating your module source tags when updating Materialize versions,
-taking care to follow any instructions in the release notes
+taking care to follow any instructions in the release notes.

--- a/doc/user/layouts/shortcodes/self-managed/terraform-simple-example-tip.md
+++ b/doc/user/layouts/shortcodes/self-managed/terraform-simple-example-tip.md
@@ -1,0 +1,1 @@
+The `examples/simple` example, used in this tutorial, is provided for illustration and to help you get started. In practice, we recommend instantiating these modules within your own Terraform code rather than relying on the example configuration directly.


### PR DESCRIPTION
Replace Terraform disclaimer with usage note.

### Motivation

We want people to use these modules. Stop scaring them away from them.
Resolves https://linear.app/materializeinc/issue/CLO-66/updateremove-disclaimer-for-self-managed-terraform-modules

### Verification

Looked at the docs in hugo.