### PR TITLE
Add bounded staleness isolation level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5574,6 +5574,7 @@ dependencies = [
  "governor",
  "hex",
  "http 1.4.0",
+ "humantime",
  "hyper-tls 0.5.0",
  "imbl",
  "ipnet",
@@ -6380,6 +6381,7 @@ name = "mz-dyncfg-launchdarkly"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "humantime",
  "hyper-tls 0.5.0",
  "launchdarkly-server-sdk",
  "mz-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6380,7 +6380,6 @@ name = "mz-dyncfg-launchdarkly"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "humantime",
  "hyper-tls 0.5.0",
  "launchdarkly-server-sdk",
  "mz-build-info",
@@ -7822,6 +7821,7 @@ dependencies = [
  "globset",
  "hex",
  "http 1.4.0",
+ "humantime",
  "iceberg",
  "imbl",
  "ipnet",

--- a/doc/developer/design/20260429_bounded_staleness_isolation.md
+++ b/doc/developer/design/20260429_bounded_staleness_isolation.md
@@ -1,0 +1,213 @@
+# Bounded staleness isolation
+
+* Associated: https://github.com/MaterializeInc/materialize/pull/36328
+
+## The problem
+
+Materialize today offers two practical isolation levels for SELECT traffic: serializable and strict serializable.
+
+* Strict serializable picks the freshest oracle-linearized timestamp across all queried objects.
+  This guarantees real-time recency but forces the query to wait until every input collection has caught up to that timestamp.
+  In practice this commonly costs ~1s of latency, governed by the timestamp tick rate, even when much fresher data already exists at a slightly lower timestamp.
+
+* Serializable picks the freshest timestamp available without waiting.
+  It avoids the wait but offers no upper bound on staleness.
+  When an input collection lags --- for example a slow source or a stalled materialized view --- the chosen timestamp can drift arbitrarily far behind the freshest known state of the system.
+
+Customers consistently want the third point on this curve: a bound on staleness rather than a guarantee of perfect freshness.
+A typical request is "give me data no older than five seconds, but do not block to get newer data."
+This is well known as bounded staleness in the literature and in production systems such as Spanner.
+
+## Success criteria
+
+A solution is successful when:
+
+1. A user can configure a session to read at a freshness ceiling of `D` (e.g. five seconds) and have queries served at any timestamp `T` satisfying `oracle.read_ts(now) - T <= D` without waiting on input frontiers.
+2. When the freshness ceiling cannot be met --- because some input collection lags by more than `D` --- the query returns a clear, actionable error that fires in the coordinator before any peek is dispatched, so the failure mode is independent of the cluster the query would have run on.
+3. The new isolation level is opt-in at two levels: the operator must enable a master feature flag, and individual sessions then opt in by `SET transaction_isolation`.
+4. The design preserves all existing strict-serializable correctness invariants documented in `guide-adapter.md`.
+
+## Out of scope
+
+* Bounded staleness for read-then-write transactions.
+  Writes still require a linearized oracle write timestamp, and mixing bounded staleness with writes raises questions about commit ordering that this design does not address.
+  An attempt to issue a write inside a bounded-staleness transaction errors.
+* A wait-with-timeout variant of the failure mode.
+  We expect to add a sibling behavior later, gated on a separate session variable, that waits up to a deadline before erroring.
+  This document specifies error-only behavior.
+* Bounded staleness on timelines other than `EpochMilliseconds`.
+  The freshness math is currently scoped to a single timeline.
+  Other timelines are out of scope until that property is re-derived for them.
+* Cross-session linearizability.
+  Two sessions running under bounded staleness may observe each other's writes at different timestamps within the bound.
+  This is the explicit trade-off and matches the existing serializable contract.
+* Interaction with `real_time_recency`.
+  The two settings are contradictory; combining them errors at session-variable validation time.
+
+## Solution proposal
+
+### High level
+
+Introduce an isolation level `bounded staleness <duration>` carrying an associated `Duration` payload.
+Under this isolation level, the timestamp selector picks the largest `T` in the closed interval `[oracle.read_ts(now) - D, largest_not_in_advance_of_upper]`.
+Each query makes one oracle round-trip to obtain the anchor (the same one strict serializable already pays); the oracle is the only anchor that stays correct across crashes, restarts, clock changes, and a future multi-`environmentd` deployment.
+
+If the interval is empty, the query errors with `BoundedStalenessExceeded` (`SQLSTATE 40001`).
+The whole feature is gated behind a master feature flag; until an operator enables it, `SET transaction_isolation = 'bounded staleness <D>'` errors at planning time.
+
+### Surface area
+
+In `src/sql/src/session/vars/value.rs`:
+
+```rust
+pub enum IsolationLevel {
+    ReadUncommitted,
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+    StrongSessionSerializable,
+    StrictSerializable,
+    BoundedStaleness(Duration),
+}
+```
+
+`Duration` is `Copy`, so the enum stays `Copy`.
+
+The parser accepts `bounded staleness <duration>` where `<duration>` is a humantime-style spec (`5s`, `500ms`, `1m30s`); zero and negative durations are rejected, large bounds are accepted (they degrade to serializable-like behavior when input frontiers stay within `D`).
+For Prometheus labels we expose a unit-cardinality variant identifier separate from the user-facing rendering, so the duration does not blow up label cardinality.
+
+`TRANSACTION_ISOLATION` itself does not change shape; it already stores an `IsolationLevel`.
+
+### Feature flag
+
+`enable_bounded_staleness_isolation` (feature-flag table in `src/sql/src/session/vars/definitions.rs`), default off.
+`plan_set_variable` in `src/sql/src/plan/statement/scl.rs` parses the value being assigned; if it parses to `BoundedStaleness(_)`, the planner calls `scx.require_feature_flag(&vars::ENABLE_BOUNDED_STALENESS_ISOLATION)`, which errors when the flag is off and otherwise lets the SET proceed.
+
+### Timestamp selection
+
+In `src/adapter/src/coord/timestamp_selection.rs`:
+
+* `needs_linearized_read_ts` returns `true` for `BoundedStaleness(_)`, so `oracle_read_ts` is fetched on the query path (one oracle round-trip per query, same as strict serializable).
+* `determine_timestamp_via_constraints`, when the isolation level is `BoundedStaleness(D)`:
+  1. Reads `anchor = oracle_read_ts` (always populated by construction; an `expect` documents the invariant).
+  2. Pushes a lower-bound constraint `Antichain::from_elem(anchor - D)` with reason `IsolationLevel(BoundedStaleness(D))`.
+  3. Pushes a *hard upper-bound constraint* `Antichain::from_elem(largest_not_in_advance_of_upper)` with the same reason.
+
+The hard upper bound is essential.
+Without it, a candidate forced above the inputs' upper by the lower bound would be sent to compute and block waiting for the upper to advance, making the failure mode cluster-shape-dependent.
+With it, the existing feasibility check in the constraint solver fires `BoundedStalenessExceeded` deterministically in the coordinator before any peek dispatch.
+
+The within-session monotonicity machinery (the prior read timestamp acting as a lower bound) is unchanged and continues to apply to bounded-staleness reads.
+
+### Feasibility check and error path
+
+After candidate selection, if no `T` exists in `[lower, upper]`, emit `AdapterError::BoundedStalenessExceeded { bound, gap_ms, slowest_input }`.
+The `Display` impl produces:
+
+```
+ERROR: cannot serve query under bounded staleness {D}; freshest available
+       timestamp is {gap_ms}ms older than the bound[; slowest input: {id}]
+```
+
+`SQLSTATE`: `T_R_SERIALIZATION_FAILURE` (`40001`).
+This matches what application retry loops already handle.
+
+`gap_ms` is computed from the constraint solver's `lower_bound().into_option().map_or(0, u64::from) - upper_bound().into_option().map_or(0, u64::from)`.
+`slowest_input` is currently `None` --- determining the specific lagging input requires more bookkeeping than the constraint API exposes today; left for follow-up.
+
+### Freshness math
+
+Let `R(t)` denote the oracle's `read_ts` value at instant `t`.
+The user-visible contract under `BoundedStaleness(D)` is `R(now) - T <= D`.
+
+The oracle is monotone (`R(t_2) >= R(t_1)` for `t_2 >= t_1`) and persisted, so it survives crashes, restarts, and arbitrary clock changes.
+We fetch `R(now)` once at query start and pick `T >= R(now) - D`, which gives `R(now) - T <= D` exactly.
+This is correct on a single `environmentd` and remains correct when the system grows to multiple `environmentd`s sharing one authoritative oracle: every node sees the same `R`.
+
+We considered a wall-clock anchor (`T >= NowFn() - D`, no oracle round-trip) during initial design.
+It is unsafe under crashes/restarts (a fresh `NowFn()` after a restart can regress past previously-served timestamps if the wall clock has been adjusted), and degrades in a multi-`environmentd` deployment by the inter-node clock skew.
+We rejected it; see [Alternatives](#alternatives).
+
+### Interactions
+
+* `AS OF`: when `AS OF` is explicit, the user has chosen `T`; bounded staleness adds no constraint.
+* `real_time_recency`: rejected at session-variable validation time when both are set.
+* Mixed read/write transactions: `INSERT`, `UPDATE`, `DELETE`, and `COPY FROM` all reject under bounded staleness with a clear error.
+* `StrongSessionSerializable`: orthogonal; no interaction.
+* Within-session monotonicity: maintained the same way as today.
+* Cross-session: no linearizability guarantee. Two sessions can observe data at timestamps separated by up to `2D`.
+* Multi-timeline queries: rejected at planning time when the query touches a non-`EpochMilliseconds` timeline.
+
+### File map
+
+* `src/sql/src/session/vars/value.rs` --- enum variant, parser, formatter, `as_str`, `as_variant_str`, `valid_values`.
+* `src/sql/src/session/vars/definitions.rs` --- `enable_bounded_staleness_isolation` feature flag.
+* `src/sql/src/plan/statement/scl.rs` --- gate the SET on the feature flag.
+* `src/adapter/src/coord/timestamp_selection.rs` --- `needs_linearized_read_ts`, the bounded-staleness lower- and upper-bound constraints, the `BoundedStalenessExceeded` emit path.
+* `src/adapter/src/coord/sequencer/inner.rs` plus `src/adapter/src/coord/sequencer/inner/copy_from.rs` --- write-path rejection.
+* `src/adapter/src/error.rs` --- `BoundedStalenessExceeded` variant.
+* `doc/developer/guide-adapter.md` --- invariant on bounded staleness's interaction with the timestamp oracle.
+
+### Testing
+
+* SLT (`test/sqllogictest/bounded_staleness.slt`): parsing, formatting, round-tripping, rejection of zero/negative/out-of-range/unparseable durations, mutual-exclusion with `real_time_recency`, write rejection. Enables the master feature flag at the top.
+* Testdrive (`test/testdrive/bounded-staleness.td`): happy-path SELECT under `bounded staleness 5s`; deterministic error-path scenario (build an MV on a dedicated cluster, drop replication factor to 0, sleep past the bound, verify the error fires). Enables the master feature flag at the top.
+* The error path now bails in the coordinator before peek dispatch (because of the hard upper-bound constraint), so the test does not need a separate serving cluster.
+
+## Minimal viable prototype
+
+A working prototype implements:
+
+1. The enum variant, parser, and formatter, with no behavioral effect yet.
+2. The constraint logic in `determine_timestamp_via_constraints`, gated behind the new isolation level only.
+3. The error path, exercised against a synthetic stalled MV.
+4. The master feature flag.
+
+We can validate end to end with a customer-representative dashboard query against a continuously updating source, comparing tail latencies under strict serializable, serializable, and `bounded staleness 5s`.
+
+## Alternatives
+
+### Wall-clock anchor
+
+An earlier draft of this design picked `T >= NowFn() - D` to skip the per-query oracle round-trip.
+
+This is unsafe.
+On restart, `NowFn()` may regress (NTP step backward, container migration, etc.); a query running before the regress can have served `T` past the post-regress floor, breaking monotonicity.
+In a future multi-`environmentd` deployment the picture is worse: the shared oracle reflects the max clock across all nodes, so a slow-clock node serves `T` outside the `D` contract by the inter-node skew.
+
+The oracle is monotone, persisted, and shared; anchoring against it sidesteps both problems.
+The cost --- one oracle round-trip per query --- is the same one strict serializable already pays, and is small relative to the latency budget that motivated bounded staleness in the first place.
+A future optimization could cache `read_ts` and refresh it asynchronously, which is sound under bounded staleness's relaxed contract; we leave that for later.
+
+### Two session variables instead of a parameterised isolation level
+
+Add a unit variant `BoundedStaleness` plus a separate `max_staleness_ms` session variable.
+Smaller parser change, but introduces an inconsistency window and splits one concept across two settings.
+Rejected for SQL ergonomics.
+
+### Standalone `max_staleness_ms` overlay on serializable
+
+Keep the existing isolation levels and add a separate session variable that overlays a staleness ceiling.
+This conflates a contract change with a knob.
+Rejected for clarity.
+
+### Wait-with-timeout instead of error
+
+Pick `T` at the staleness floor and block on input frontiers up to `D`, then either return or error.
+This silently degrades to strict-serializable-with-cap behavior and breaks the freshness contract during the wait.
+Error-on-infeasible is the primary semantic; wait-with-timeout is a future, opt-in extension behind a separate session variable.
+
+### Caching `read_ts` for all isolation levels (the rejected `peek_read_ts_fast` path)
+
+Use a cached oracle value for *every* isolation level, not just bounded staleness.
+This was attempted and rejected for strict serializable in `guide-adapter.md`; the strict-serializable contract requires the timestamp to be determined during the query's real-time interval.
+Bounded staleness's relaxed contract makes oracle-read caching legitimate for *its* path; we defer that work but flag it as the natural follow-up if the per-query oracle round-trip becomes a bottleneck.
+
+## Open questions
+
+* `slowest_input` in the `BoundedStalenessExceeded` error is currently `None`.
+  Plumbing the per-input upper antichain into the constraint solver would give us a more actionable message.
+* Should bounded staleness be permitted inside a multi-statement read transaction?
+  The within-session monotonicity argument suggests yes, but the design has not been stress-tested for that case.
+* When (if ever) does the per-query oracle round-trip become a bottleneck worth caching?
+  A `timestamp_difference_for_bounded_staleness_ms` metric is already wired in to help spot the regime where caching would pay off.

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -96,6 +96,28 @@ Before modifying timestamp selection or oracle interaction, verify:
    `read_ts` calls (including the fast path, if any) return `>= t`? This must
    hold across nodes, not just within the local process.
 
+### Bounded staleness must anchor against the oracle, not wall clock
+
+The `BoundedStaleness(D)` isolation level picks `T >= oracle.read_ts - D` as
+its freshness lower bound. The oracle is the only anchor that satisfies the
+user-visible contract `oracle_read_ts(now) - T <= D` across:
+
+- Crashes and restarts: a fresh `NowFn()` after a restart can regress (NTP
+  step backward, container migration), so a wall-clock anchor would let a
+  post-restart query pick `T` past a previously-served timestamp.
+- Clock changes during normal operation.
+- A future multi-`environmentd` deployment: the shared oracle reflects the
+  max clock across nodes, so a wall-clock anchor on a slow-clock node would
+  serve `T` outside the `D` contract by the inter-node skew.
+
+`needs_linearized_read_ts` returns `true` for `BoundedStaleness(_)`, so the
+oracle is consulted on every bounded-staleness query (one round-trip, the
+same one strict serializable already pays).
+
+The current implementation rejects bounded-staleness queries whose timeline
+is not `EpochMilliseconds`, in `determine_timestamp_for_inner`. The freshness
+math is currently scoped to that timeline.
+
 ## Rejected Optimizations
 
 This section records specific optimizations that have been attempted and found

--- a/doc/user/content/reference/isolation-level.md
+++ b/doc/user/content/reference/isolation-level.md
@@ -20,11 +20,21 @@ visible to a transaction during its execution.
 
 Materialize accepts the following isolation levels:
 
+{{< if-unreleased "v26.29" >}}
 | Isolation level | Behavior in Materialize |
 | --- | --- |
 | [**Strict Serializable**](#strict-serializable) | **Default.** Provides serializability and linearizability. |
 | [**Serializable**](#serializable) | Provides serializability but not linearizability. |
 | Read Uncommitted, Read Committed, Repeatable Read | Accepted for compatibility; treated as Serializable. |
+{{< /if-unreleased >}}
+{{< if-released "v26.29" >}}
+| Isolation level | Behavior in Materialize |
+| --- | --- |
+| [**Strict Serializable**](#strict-serializable) | **Default.** Provides serializability and linearizability. |
+| [**Serializable**](#serializable) | Provides serializability but not linearizability. |
+| [**Bounded Staleness `<duration>`**](#bounded-staleness) | **Public preview.** Serves reads at a timestamp at most `<duration>` stale; never blocks, errors if the bound cannot be met. |
+| Read Uncommitted, Read Committed, Repeatable Read | Accepted for compatibility; treated as Serializable. |
+{{< /if-released >}}
 
 ## Serializable
 
@@ -142,6 +152,99 @@ made available to us (e.g., querying PostgreSQL for the replication slot's LSN).
     Real-time recency queries return at least all data visible to Materialize
     when our client connection communicates with the external system.
 
+{{< if-released "v26.29" >}}
+## Bounded Staleness
+
+{{< public-preview />}}
+
+The Bounded Staleness isolation level lets you trade exact freshness for
+predictable latency. A query under bounded staleness is served at a timestamp
+that is at most `<duration>` stale—but never blocks waiting for input
+collections to catch up. If no timestamp within `<duration>` of "now" is
+available, the query errors immediately.
+
+This sits between [Serializable](#serializable) (no freshness ceiling) and
+[Strict Serializable](#strict-serializable) (always freshest, may wait for
+inputs to advance) on the freshness/latency spectrum. What distinguishes
+bounded staleness is that it never waits on input frontiers — it errors
+instead.
+
+### Syntax
+
+```mzsql
+SET TRANSACTION_ISOLATION TO 'bounded staleness <duration>';
+```
+
+`<duration>` is a duration string like `5s`, `500ms`, or `1m 30s` (compact
+forms like `1m30s` are also accepted). It must be greater than `0`.
+
+Bounded staleness is set through the `transaction_isolation` session variable,
+as shown above. Because it carries a duration, it cannot be set via the
+`BEGIN ... ISOLATION LEVEL` keyword form, which only accepts the standard
+isolation-level names.
+
+For example:
+
+```mzsql
+-- Read data no more than 5 seconds stale, never block.
+SET TRANSACTION_ISOLATION TO 'bounded staleness 5s';
+
+-- A tighter bound for dashboards.
+SET TRANSACTION_ISOLATION TO 'bounded staleness 250ms';
+```
+
+### Behavior
+
+When a query runs under bounded staleness, Materialize picks the freshest
+timestamp at which every queried collection has data, subject to the constraint
+that the timestamp is no more than `<duration>` stale relative to the current
+logical time. The query never blocks waiting for sources, materialized views,
+or indexes to advance. If even the freshest available timestamp is more than
+`<duration>` stale, the query errors with `SQLSTATE 40001`
+(`serialization_failure`):
+
+```
+ERROR: cannot serve query under bounded staleness 5s; freshest available
+       timestamp is 7000ms older than the bound
+```
+
+`40001` is a serialization failure; how to react is up to the application.
+Common responses include retrying, falling back to a different isolation level,
+or surfacing a "data unavailable" state.
+
+### Restrictions
+
+- **Read-only.** Writes (`INSERT`, `UPDATE`, `DELETE`, `COPY FROM`) are not
+  permitted under bounded staleness. The first write in a session running at
+  this isolation level errors.
+
+- **Mutually exclusive with `real_time_recency`.** Setting both errors at
+  session-variable validation time.
+
+- **Single timeline.** Bounded staleness only applies to queries on the
+  standard wall-clock timeline. Queries that touch other timelines error at
+  planning time.
+
+- **Bound must be greater than `0`.** A bound of zero is rejected; use
+  [Strict Serializable](#strict-serializable) if you need exact freshness.
+
+### When to use Bounded Staleness
+
+Pick bounded staleness when predictable latency matters more than perfect
+freshness, and "data is too stale" is a more useful signal than blocking.
+Common cases: dashboards, metric panels, alert evaluation.
+
+- Prefer [Strict Serializable](#strict-serializable) when you need
+  linearizable, end-to-end fresh reads, or when your application is willing to
+  wait for the freshest data.
+
+- Prefer [Serializable](#serializable) when you do not need a freshness bound
+  at all and want the simplest, lowest-latency reads.
+
+- Bounded staleness is read-only: if your session needs writes, use one of the
+  other isolation levels.
+{{< /if-released >}}
+
 ## Isolation levels and query latency
 
 Strict Serializable provides stronger consistency guarantees but may have slower
@@ -160,6 +263,12 @@ reads than Serializable.
   (but possibly slightly stale) snapshot, which avoids that latency at the cost
   of linearizability. However, if a consistent snapshot is not available, the
   query blocks until one becomes available.
+
+{{< if-released "v26.29" >}}
+- **Bounded Staleness** never waits for writes to propagate. It serves the
+  freshest consistent snapshot within the staleness bound, and errors
+  immediately when no such snapshot exists instead of blocking.
+{{< /if-released >}}
 
 ## Setting isolation level
 

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -26,6 +26,7 @@ fail.workspace = true
 futures.workspace = true
 governor.workspace = true
 hex.workspace = true
+humantime.workspace = true
 imbl.workspace = true
 http.workspace = true
 hyper-tls = "0.5.0"

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1931,6 +1931,20 @@ impl Coordinator {
                         session.add_notice(AdapterNotice::StrongSessionSerializable);
                     }
                 }
+
+                // Reject incompatible combinations of bounded staleness and
+                // `real_time_recency` after the variable has been applied. Either
+                // SET name can introduce the conflict, so check both.
+                if (name.as_str() == TRANSACTION_ISOLATION_VAR_NAME
+                    || name.as_str() == vars::REAL_TIME_RECENCY.name())
+                    && session
+                        .vars()
+                        .transaction_isolation()
+                        .is_bounded_staleness()
+                    && session.vars().real_time_recency()
+                {
+                    return Err(AdapterError::BoundedStalenessRealTimeRecencyConflict);
+                }
             }
             None => vars.reset(self.catalog().system_config(), &name, local)?,
         }
@@ -2538,6 +2552,15 @@ impl Coordinator {
             ctx.retire(Err(AdapterError::ReadOnlyTransaction));
             return;
         }
+        if ctx
+            .session()
+            .vars()
+            .transaction_isolation()
+            .is_bounded_staleness()
+        {
+            ctx.retire(Err(AdapterError::BoundedStalenessReadOnly));
+            return;
+        }
 
         // The structure of this code originates from a time where
         // `ReadThenWritePlan` was carrying an `MirRelationExpr` instead of an
@@ -2634,6 +2657,16 @@ impl Coordinator {
         mut ctx: ExecuteContext,
         plan: plan::ReadThenWritePlan,
     ) {
+        if ctx
+            .session()
+            .vars()
+            .transaction_isolation()
+            .is_bounded_staleness()
+        {
+            ctx.retire(Err(AdapterError::BoundedStalenessReadOnly));
+            return;
+        }
+
         let mut source_ids: BTreeSet<_> = plan
             .selection
             .depends_on()

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -50,6 +50,15 @@ impl Coordinator {
         plan: plan::CopyFromPlan,
         target_cluster: TargetCluster,
     ) {
+        if ctx
+            .session()
+            .vars()
+            .transaction_isolation()
+            .is_bounded_staleness()
+        {
+            return ctx.retire(Err(AdapterError::BoundedStalenessReadOnly));
+        }
+
         // STDIN is sequenced by handing control back to pgwire, which drives the
         // CopyData/CopyDone exchange. URL/S3 sources stage a one-shot ingestion
         // server-side and fall through to the rest of this function.

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -228,14 +228,18 @@ pub trait TimestampProvider {
     fn needs_linearized_read_ts(isolation_level: &IsolationLevel, when: &QueryWhen) -> bool {
         // When we're in the context of a timeline (assumption) and one of these
         // scenarios hold, we need to use a linearized read timestamp:
-        // - The isolation level is Strict Serializable and the `when` allows us to use the
-        //   the timestamp oracle (ex: queries with no AS OF).
-        // - The `when` requires us to use the timestamp oracle (ex: read-then-write queries).
+        // - The isolation level anchors against the oracle (Strict Serializable,
+        //   Strong Session Serializable, Bounded Staleness) and the `when` allows
+        //   us to use the timestamp oracle (ex: queries with no AS OF).
+        // - The `when` requires us to use the timestamp oracle (ex: read-then-write
+        //   queries).
         when.must_advance_to_timeline_ts()
             || (when.can_advance_to_timeline_ts()
                 && matches!(
                     isolation_level,
-                    IsolationLevel::StrictSerializable | IsolationLevel::StrongSessionSerializable
+                    IsolationLevel::StrictSerializable
+                        | IsolationLevel::StrongSessionSerializable
+                        | IsolationLevel::BoundedStaleness(_)
                 ))
     }
 
@@ -304,15 +308,27 @@ pub trait TimestampProvider {
             }
 
             // The specification of an `oracle_read_ts` may indicates that we must advance to it,
-            // except in one isolation mode, or if `when` does not indicate that we should.
+            // except in some isolation modes, or if `when` does not indicate that we should.
             // At the moment, only `QueryWhen::FreshestTableWrite` indicates that we should.
             // TODO: Should this just depend on the isolation level?
             if let Some(timestamp) = &oracle_read_ts {
-                if isolation_level != &IsolationLevel::StrongSessionSerializable
-                    || when.must_advance_to_timeline_ts()
-                {
-                    // When specification of an `oracle_read_ts` is required, we must advance to it.
-                    // If it's not present, lets bail out.
+                // Whether this isolation level treats `oracle_read_ts` as a hard
+                // lower bound. Strong session serializable (session-local oracle)
+                // and bounded staleness (`oracle - D` anchor) instead consult it
+                // below; pushing it here would shadow those semantics.
+                let hard_lower_bound = match isolation_level {
+                    IsolationLevel::StrongSessionSerializable
+                    | IsolationLevel::BoundedStaleness(_) => false,
+                    IsolationLevel::ReadUncommitted
+                    | IsolationLevel::ReadCommitted
+                    | IsolationLevel::RepeatableRead
+                    | IsolationLevel::Serializable
+                    | IsolationLevel::StrictSerializable => true,
+                };
+                // `must_advance_to_timeline_ts()` (only `FreshestTableWrite`)
+                // forces the bound regardless; bounded staleness rejects writes
+                // upstream, so that path is unreachable for it in practice.
+                if hard_lower_bound || when.must_advance_to_timeline_ts() {
                     constraints.lower.push((
                         Antichain::from_elem(*timestamp),
                         Reason::IsolationLevel(*isolation_level),
@@ -332,6 +348,27 @@ pub trait TimestampProvider {
                     Antichain::from_elem(real_time_recency_ts),
                     Reason::RealTimeRecency,
                 ));
+            }
+
+            // Bounded staleness anchors the freshness floor at `oracle.read_ts - D`
+            // and clamps the upper at `largest_not_in_advance_of_upper`. The upper
+            // clamp is what makes an infeasible bound fail fast in the coordinator
+            // instead of blocking on compute for the upper to advance — which would
+            // make the failure mode cluster-shape-dependent. `oracle_read_ts` is
+            // `None` under `AS OF`, where the user-chosen `T` is the only constraint.
+            if let IsolationLevel::BoundedStaleness(d) = isolation_level {
+                if let Some(anchor) = oracle_read_ts {
+                    let bound_ms = u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
+                    let lower = anchor.saturating_sub(bound_ms);
+                    constraints.lower.push((
+                        Antichain::from_elem(lower),
+                        Reason::IsolationLevel(*isolation_level),
+                    ));
+                    constraints.upper.push((
+                        Antichain::from_elem(largest_not_in_advance_of_upper),
+                        Reason::IsolationLevel(*isolation_level),
+                    ));
+                }
             }
 
             // If we are operating in Strong Session Serializable, we use an alternate timestamp lower bound.
@@ -382,7 +419,9 @@ pub trait TimestampProvider {
             // bound through the `oracle_read_ts`, and then requires the stalest valid timestamp.
 
             if when.can_advance_to_upper()
-                && (isolation_level == &IsolationLevel::Serializable || timeline.is_none())
+                && (isolation_level == &IsolationLevel::Serializable
+                    || matches!(isolation_level, IsolationLevel::BoundedStaleness(_))
+                    || timeline.is_none())
             {
                 Preference::FreshestAvailable
             } else {
@@ -412,6 +451,30 @@ pub trait TimestampProvider {
             if !constraints.lower_bound().less_equal(&candidate)
                 || constraints.upper_bound().less_than(&candidate)
             {
+                // Bounded staleness wants a specific error describing the staleness
+                // gap. Derive it directly from `anchor - D` and the inputs' upper,
+                // not from `constraints.{lower,upper}_bound()` — those join *all*
+                // reasons (`since`, `AS OF`, …), so a non-bs constraint could
+                // dominate and the reported gap would not describe the bs failure.
+                // A zero gap means the bs floor was satisfiable and something else
+                // caused the infeasibility; fall through to the generic error.
+                // `oracle_read_ts` is unset under `AS OF`, where bs added no
+                // constraint, so we cannot reach here for a bs-specific failure.
+                if let IsolationLevel::BoundedStaleness(d) = isolation_level {
+                    if let Some(anchor) = oracle_read_ts {
+                        let bound_ms = u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
+                        let bs_lower: u64 = anchor.saturating_sub(bound_ms).into();
+                        let upper: u64 = largest_not_in_advance_of_upper.into();
+                        let gap = bs_lower.saturating_sub(upper);
+                        if gap > 0 {
+                            return Err(AdapterError::BoundedStalenessExceeded {
+                                bound: *d,
+                                gap_ms: gap,
+                                slowest_input: None,
+                            });
+                        }
+                    }
+                }
                 return Err(AdapterError::ImpossibleTimestampConstraints {
                     constraints: constraints.display(timeline.as_ref()).to_string(),
                 });
@@ -498,6 +561,16 @@ pub trait TimestampProvider {
             return Err(AdapterError::CollectionUnreadable {
                 id: unreadable_collections.into_iter().join(", "),
             });
+        }
+
+        // Bounded staleness freshness math assumes the EpochMilliseconds timeline,
+        // where timestamps are wall-clock milliseconds. Timeline-less queries
+        // (`TimestampIndependent`, e.g. constant queries) are fine — the freshness
+        // contract is vacuous for them.
+        if isolation_level.is_bounded_staleness()
+            && matches!(&timeline, Some(t) if *t != Timeline::EpochMilliseconds)
+        {
+            return Err(AdapterError::BoundedStalenessTimelineUnsupported);
         }
 
         let raw_determination = Self::determine_timestamp_via_constraints(
@@ -651,6 +724,31 @@ impl Coordinator {
                         .with_label_values(&[compute_instance.to_string().as_str()])
                         .observe(f64::cast_lossy(u64::from(
                             strict.saturating_sub(*serializable),
+                        )));
+                }
+            }
+        }
+        if !det.respond_immediately()
+            && isolation_level.is_bounded_staleness()
+            && real_time_recency_ts.is_none()
+        {
+            // Note down the difference between BoundedStaleness and Serializable into a metric.
+            if let Some(bs_ts) = det.timestamp_context.timestamp() {
+                let (serializable_det, _tmp_read_holds) = self.determine_timestamp_for(
+                    session,
+                    id_bundle,
+                    when,
+                    timeline_context,
+                    oracle_read_ts,
+                    real_time_recency_ts,
+                    &IsolationLevel::Serializable,
+                )?;
+                if let Some(serializable) = serializable_det.timestamp_context.timestamp() {
+                    self.metrics
+                        .timestamp_difference_for_bounded_staleness_ms
+                        .with_label_values(&[compute_instance.to_string().as_str()])
+                        .observe(f64::cast_lossy(u64::from(
+                            serializable.saturating_sub(*bs_ts),
                         )));
                 }
             }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -270,6 +270,23 @@ pub enum AdapterError {
     },
     /// OIDC group-to-role sync failed and strict mode is enabled.
     OidcGroupSyncFailed(String),
+    /// Returned when bounded staleness was selected but the input frontiers lag
+    /// further than the bound permits, so no timestamp in the no-wait window is
+    /// at most `bound` stale.
+    BoundedStalenessExceeded {
+        bound: std::time::Duration,
+        gap_ms: u64,
+        slowest_input: Option<mz_repr::GlobalId>,
+    },
+    /// A write was attempted in a session whose isolation level is bounded
+    /// staleness. Bounded staleness is read-only.
+    BoundedStalenessReadOnly,
+    /// `real_time_recency = on` and bounded staleness were both requested in
+    /// the same session; they are mutually exclusive.
+    BoundedStalenessRealTimeRecencyConflict,
+    /// A bounded-staleness query touched a timeline whose timestamps are not
+    /// the `EpochMilliseconds` wall-clock timeline.
+    BoundedStalenessTimelineUnsupported,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -642,6 +659,25 @@ impl AdapterError {
             AdapterError::ImpossibleTimestampConstraints { constraints } => {
                 Some(format!("Constraints:\n{}", constraints))
             }
+            AdapterError::BoundedStalenessExceeded {
+                gap_ms,
+                slowest_input,
+                ..
+            } => {
+                let mut detail = format!(
+                    "Freshest available timestamp is {}ms older than the bound.",
+                    gap_ms,
+                );
+                if let Some(id) = slowest_input {
+                    detail.push_str(&format!(" Slowest input: {}.", id));
+                }
+                Some(detail)
+            }
+            AdapterError::BoundedStalenessTimelineUnsupported => Some(
+                "This query touches a timeline other than the EpochMilliseconds wall-clock \
+                 timeline."
+                    .into(),
+            ),
             _ => None,
         }
     }
@@ -885,6 +921,14 @@ impl AdapterError {
             // similar to AbsurdSubscribeBounds
             AdapterError::ImpossibleTimestampConstraints { .. } => SqlState::DATA_EXCEPTION,
             AdapterError::OidcGroupSyncFailed(_) => SqlState::INTERNAL_ERROR,
+            AdapterError::BoundedStalenessExceeded { .. } => SqlState::T_R_SERIALIZATION_FAILURE,
+            // Matches ReadOnlyTransaction/ReadOnly: a write was rejected
+            // because the session is effectively read-only.
+            AdapterError::BoundedStalenessReadOnly => SqlState::READ_ONLY_SQL_TRANSACTION,
+            AdapterError::BoundedStalenessRealTimeRecencyConflict => {
+                SqlState::FEATURE_NOT_SUPPORTED
+            }
+            AdapterError::BoundedStalenessTimelineUnsupported => SqlState::FEATURE_NOT_SUPPORTED,
         }
     }
 
@@ -1302,6 +1346,22 @@ impl fmt::Display for AdapterError {
             }
             AdapterError::OidcGroupSyncFailed(msg) => {
                 write!(f, "OIDC group-to-role sync failed: {msg}")
+            }
+            AdapterError::BoundedStalenessExceeded { bound, .. } => {
+                write!(
+                    f,
+                    "cannot serve query under bounded staleness {}",
+                    humantime::format_duration(*bound),
+                )
+            }
+            AdapterError::BoundedStalenessReadOnly => {
+                f.write_str("writes are not permitted under bounded staleness isolation")
+            }
+            AdapterError::BoundedStalenessRealTimeRecencyConflict => {
+                f.write_str("real_time_recency cannot be combined with bounded staleness isolation")
+            }
+            AdapterError::BoundedStalenessTimelineUnsupported => {
+                f.write_str("bounded staleness isolation requires the EpochMilliseconds timeline")
             }
         }
     }

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -1548,7 +1548,7 @@ impl PeekClient {
                         real_time_recency_ts,
                         &IsolationLevel::Serializable,
                         read_holds.clone(),
-                        upper,
+                        upper.clone(),
                     )?;
                 if let Some(serializable) = serializable_det.timestamp_context.timestamp() {
                     session
@@ -1558,6 +1558,36 @@ impl PeekClient {
                             .as_ref()])
                         .observe(f64::cast_lossy(u64::from(
                             strict.saturating_sub(*serializable),
+                        )));
+                }
+            }
+        }
+        if !det.respond_immediately()
+            && isolation_level.is_bounded_staleness()
+            && real_time_recency_ts.is_none()
+        {
+            // Note down the difference between BoundedStaleness and Serializable into a metric.
+            if let Some(bs_ts) = det.timestamp_context.timestamp() {
+                let (serializable_det, _tmp_read_holds) =
+                    <Coordinator as TimestampProvider>::determine_timestamp_for_inner(
+                        session,
+                        id_bundle,
+                        when,
+                        timeline_context,
+                        oracle_read_ts,
+                        real_time_recency_ts,
+                        &IsolationLevel::Serializable,
+                        read_holds.clone(),
+                        upper,
+                    )?;
+                if let Some(serializable) = serializable_det.timestamp_context.timestamp() {
+                    session
+                        .metrics()
+                        .timestamp_difference_for_bounded_staleness_ms(&[compute_instance
+                            .to_string()
+                            .as_ref()])
+                        .observe(f64::cast_lossy(u64::from(
+                            serializable.saturating_sub(*bs_ts),
                         )));
                 }
             }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -25,6 +25,7 @@ pub struct Metrics {
     pub queue_busy_seconds: Histogram,
     pub determine_timestamp: IntCounterVec,
     pub timestamp_difference_for_strict_serializable_ms: HistogramVec,
+    pub timestamp_difference_for_bounded_staleness_ms: HistogramVec,
     pub commands: IntCounterVec,
     pub storage_usage_collection_time_seconds: Histogram,
     pub arrangement_sizes_collection_time_seconds: Histogram,
@@ -93,6 +94,12 @@ impl Metrics {
             timestamp_difference_for_strict_serializable_ms: registry.register(metric!(
                 name: "mz_timestamp_difference_for_strict_serializable_ms",
                 help: "Difference in timestamp in milliseconds for running in strict serializable vs serializable isolation level.",
+                var_labels:["compute_instance"],
+                buckets: histogram_milliseconds_buckets(1., 8000.),
+            )),
+            timestamp_difference_for_bounded_staleness_ms: registry.register(metric!(
+                name: "mz_timestamp_difference_for_bounded_staleness_ms",
+                help: "How much older bounded-staleness timestamps are compared to serializable, in milliseconds. Measures the actual staleness incurred.",
                 var_labels:["compute_instance"],
                 buckets: histogram_milliseconds_buckets(1., 8000.),
             )),
@@ -268,6 +275,9 @@ impl Metrics {
             timestamp_difference_for_strict_serializable_ms: self
                 .timestamp_difference_for_strict_serializable_ms
                 .clone(),
+            timestamp_difference_for_bounded_staleness_ms: self
+                .timestamp_difference_for_bounded_staleness_ms
+                .clone(),
             optimization_notices: self.optimization_notices.clone(),
             statement_logging_records: self.statement_logging_records.clone(),
             statement_logging_unsampled_bytes: self.statement_logging_unsampled_bytes.clone(),
@@ -284,6 +294,7 @@ pub struct SessionMetrics {
     query_total: IntCounterVec,
     determine_timestamp: IntCounterVec,
     timestamp_difference_for_strict_serializable_ms: HistogramVec,
+    timestamp_difference_for_bounded_staleness_ms: HistogramVec,
     optimization_notices: IntCounterVec,
     statement_logging_records: IntCounterVec,
     statement_logging_unsampled_bytes: IntCounter,
@@ -312,6 +323,14 @@ impl SessionMetrics {
         label_values: &[&str],
     ) -> Histogram {
         self.timestamp_difference_for_strict_serializable_ms
+            .with_label_values(label_values)
+    }
+
+    pub(crate) fn timestamp_difference_for_bounded_staleness_ms(
+        &self,
+        label_values: &[&str],
+    ) -> Histogram {
+        self.timestamp_difference_for_bounded_staleness_ms
             .with_label_values(label_values)
     }
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -22,6 +22,7 @@ enum-kinds.workspace = true
 fail.workspace = true
 globset.workspace = true
 hex.workspace = true
+humantime.workspace = true
 http.workspace = true
 iceberg.workspace = true
 imbl.workspace = true

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -31,7 +31,9 @@ use crate::plan::{
     ShowVariablePlan, VariableValue, describe, query,
 };
 use crate::session::vars;
-use crate::session::vars::{IsolationLevel, SCHEMA_ALIAS, TRANSACTION_ISOLATION_VAR_NAME};
+use crate::session::vars::{
+    IsolationLevel, SCHEMA_ALIAS, TRANSACTION_ISOLATION_VAR_NAME, Value, VarInput,
+};
 
 pub fn describe_set_variable(
     _: &StatementContext,
@@ -53,10 +55,23 @@ pub fn plan_set_variable(
 
     if let VariableValue::Values(values) = &value {
         if let Some(value) = values.first() {
-            if name.as_str() == TRANSACTION_ISOLATION_VAR_NAME
-                && value == IsolationLevel::StrongSessionSerializable.as_variant_str()
-            {
-                scx.require_feature_flag(&vars::ENABLE_SESSION_TIMELINES)?;
+            if name.as_str() == TRANSACTION_ISOLATION_VAR_NAME {
+                // Parse the value to identify the isolation level kind. Parse
+                // failures are deliberately ignored here — the actual SET path
+                // surfaces them — but a successful parse lets us gate
+                // parameterised levels (like `bounded staleness 5s`) behind
+                // their feature flags.
+                if let Ok(level) = IsolationLevel::parse(VarInput::Flat(value)) {
+                    match level {
+                        IsolationLevel::StrongSessionSerializable => {
+                            scx.require_feature_flag(&vars::ENABLE_SESSION_TIMELINES)?;
+                        }
+                        IsolationLevel::BoundedStaleness(_) => {
+                            scx.require_feature_flag(&vars::ENABLE_BOUNDED_STALENESS_ISOLATION)?;
+                        }
+                        _ => {}
+                    }
+                }
             }
         }
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2246,6 +2246,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_bounded_staleness_isolation,
+        desc: "the `bounded staleness <duration>` transaction isolation level",
+        default: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -907,6 +907,11 @@ pub enum IsolationLevel {
      */
     StrongSessionSerializable,
     StrictSerializable,
+    /// Bounded staleness — pick `T` such that `T >= now_ms - D` and the
+    /// query does not wait on input frontiers. Errors if no such `T` exists
+    /// in the no-wait window. See
+    /// `doc/developer/design/20260429_bounded_staleness_isolation.md`.
+    BoundedStaleness(std::time::Duration),
 }
 
 impl IsolationLevel {
@@ -916,14 +921,17 @@ impl IsolationLevel {
     const SERIALIZABLE: &'static str = "serializable";
     const STRONG_SESSION_SERIALIZABLE: &'static str = "strong session serializable";
     const STRICT_SERIALIZABLE: &'static str = "strict serializable";
+    const BOUNDED_STALENESS: &'static str = "bounded staleness";
+    const BOUNDED_STALENESS_HINT: &'static str = "bounded staleness <duration>";
 
-    /// Unit-cardinality variant identifier, suitable for Prometheus labels,
-    /// equality checks against parsed input, and other contexts where one
-    /// bucket per kind of isolation is wanted.
-    ///
-    /// For the user-facing rendering (which round-trips through
-    /// [`Value::parse`]) use the [`fmt::Display`] impl — that is what
-    /// `SHOW transaction_isolation` returns.
+    /// Returns true if the isolation level is of bounded staleness.
+    pub fn is_bounded_staleness(&self) -> bool {
+        matches!(self, Self::BoundedStaleness(_))
+    }
+
+    /// Unit-cardinality variant identifier, suitable for Prometheus labels and
+    /// equality checks against parsed input. The duration on `BoundedStaleness`
+    /// is omitted; use [`fmt::Display`] for the user-facing rendering.
     pub fn as_variant_str(&self) -> &'static str {
         match self {
             Self::ReadUncommitted => Self::READ_UNCOMMITTED,
@@ -932,6 +940,7 @@ impl IsolationLevel {
             Self::Serializable => Self::SERIALIZABLE,
             Self::StrongSessionSerializable => Self::STRONG_SESSION_SERIALIZABLE,
             Self::StrictSerializable => Self::STRICT_SERIALIZABLE,
+            Self::BoundedStaleness(_) => Self::BOUNDED_STALENESS,
         }
     }
 
@@ -943,13 +952,22 @@ impl IsolationLevel {
             Self::SERIALIZABLE,
             // TODO(jkosh44) Add STRONG_SESSION_SERIALIZABLE when it becomes available to users.
             Self::STRICT_SERIALIZABLE,
+            Self::BOUNDED_STALENESS_HINT,
         ]
     }
 }
 
 impl fmt::Display for IsolationLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_variant_str())
+        match self {
+            Self::BoundedStaleness(d) => write!(
+                f,
+                "{} {}",
+                Self::BOUNDED_STALENESS,
+                humantime::format_duration(*d)
+            ),
+            other => f.write_str(other.as_variant_str()),
+        }
     }
 }
 
@@ -965,26 +983,46 @@ impl Value for IsolationLevel {
     where
         Self: Sized,
     {
-        let s = extract_single_value(input)?;
-        let s = UncasedStr::new(s);
+        let invalid = || VarParseError::ConstrainedParameter {
+            invalid_values: input.to_vec(),
+            valid_values: Some(IsolationLevel::valid_values()),
+        };
 
-        // We don't have any optimizations for levels below Serializable,
-        // so we upgrade them all to Serializable.
-        if s == Self::READ_UNCOMMITTED
-            || s == Self::READ_COMMITTED
-            || s == Self::REPEATABLE_READ
-            || s == Self::SERIALIZABLE
-        {
-            Ok(Self::Serializable)
-        } else if s == Self::STRONG_SESSION_SERIALIZABLE {
-            Ok(Self::StrongSessionSerializable)
-        } else if s == Self::STRICT_SERIALIZABLE {
-            Ok(Self::StrictSerializable)
-        } else {
-            Err(VarParseError::ConstrainedParameter {
-                invalid_values: input.to_vec(),
-                valid_values: Some(IsolationLevel::valid_values()),
-            })
+        let s = extract_single_value(input)?;
+        let lower = s.to_ascii_lowercase();
+        let lower = lower.trim();
+
+        match lower {
+            // Weak isolations all upgrade to Serializable.
+            Self::READ_UNCOMMITTED
+            | Self::READ_COMMITTED
+            | Self::REPEATABLE_READ
+            | Self::SERIALIZABLE => Ok(Self::Serializable),
+            Self::STRONG_SESSION_SERIALIZABLE => Ok(Self::StrongSessionSerializable),
+            Self::STRICT_SERIALIZABLE => Ok(Self::StrictSerializable),
+            other => {
+                let rest = other
+                    .strip_prefix(Self::BOUNDED_STALENESS)
+                    .ok_or_else(invalid)?;
+                // Require whitespace between the keyword and the duration, so
+                // e.g. `bounded staleness5s` is rejected.
+                if !rest.starts_with(char::is_whitespace) {
+                    return Err(invalid());
+                }
+                let rest = rest.trim();
+                if rest.is_empty() {
+                    return Err(invalid());
+                }
+                let d = humantime::parse_duration(rest).map_err(|_| invalid())?;
+                // Reject anything below 1ms: downstream we truncate to whole
+                // milliseconds, so e.g. `999us` would silently behave like
+                // `0ms` and degenerate to "no staleness allowed", which is
+                // exactly the case the zero-rejection meant to forbid.
+                if d < std::time::Duration::from_millis(1) {
+                    return Err(invalid());
+                }
+                Ok(Self::BoundedStaleness(d))
+            }
         }
     }
 
@@ -1299,5 +1337,89 @@ mod tests {
                 )
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod bounded_staleness_tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn parse_iso(s: &str) -> Result<IsolationLevel, VarParseError> {
+        IsolationLevel::parse(VarInput::Flat(s))
+    }
+
+    #[mz_ore::test]
+    fn parses_bounded_staleness() {
+        assert_eq!(
+            parse_iso("bounded staleness 5s").unwrap(),
+            IsolationLevel::BoundedStaleness(Duration::from_secs(5))
+        );
+        assert_eq!(
+            parse_iso("bounded staleness 500ms").unwrap(),
+            IsolationLevel::BoundedStaleness(Duration::from_millis(500))
+        );
+        // Upper-case input normalises.
+        assert_eq!(
+            parse_iso("BOUNDED STALENESS 5s").unwrap(),
+            IsolationLevel::BoundedStaleness(Duration::from_secs(5))
+        );
+        // Leading/trailing whitespace tolerated.
+        assert_eq!(
+            parse_iso("  bounded staleness 5s  ").unwrap(),
+            IsolationLevel::BoundedStaleness(Duration::from_secs(5))
+        );
+    }
+
+    #[mz_ore::test]
+    fn rejects_zero_duration() {
+        assert!(parse_iso("bounded staleness 0s").is_err());
+        assert!(parse_iso("bounded staleness 0ms").is_err());
+    }
+
+    #[mz_ore::test]
+    fn rejects_sub_millisecond_duration() {
+        // Truncated to 0ms downstream; treated as the same degenerate case as
+        // a literal zero.
+        assert!(parse_iso("bounded staleness 1us").is_err());
+        assert!(parse_iso("bounded staleness 999us").is_err());
+        assert!(parse_iso("bounded staleness 999ns").is_err());
+    }
+
+    #[mz_ore::test]
+    fn parses_multi_component_duration() {
+        // `1m30s` round-trips through humantime which formats as `1m 30s`,
+        // so the parser must accept the space-separated form.
+        let lvl = parse_iso("bounded staleness 1m30s").unwrap();
+        assert_eq!(
+            lvl,
+            IsolationLevel::BoundedStaleness(Duration::from_secs(90))
+        );
+        let formatted = lvl.format();
+        assert_eq!(parse_iso(&formatted).unwrap(), lvl);
+    }
+
+    #[mz_ore::test]
+    fn rejects_unparseable_duration() {
+        assert!(parse_iso("bounded staleness banana").is_err());
+        assert!(parse_iso("bounded staleness").is_err());
+        // Whitespace between the keyword and the duration is required.
+        assert!(parse_iso("bounded staleness5s").is_err());
+    }
+
+    #[mz_ore::test]
+    fn round_trips_format() {
+        let lvl = IsolationLevel::BoundedStaleness(Duration::from_secs(5));
+        assert_eq!(lvl.format(), "bounded staleness 5s");
+        let parsed = parse_iso(&lvl.format()).unwrap();
+        assert_eq!(parsed, lvl);
+    }
+
+    #[mz_ore::test]
+    fn accepts_long_durations() {
+        // No upper cap; a multi-hour bound is a perfectly valid (if loose)
+        // staleness contract.
+        assert!(parse_iso("bounded staleness 1h").is_ok());
+        assert!(parse_iso("bounded staleness 24h").is_ok());
     }
 }

--- a/test/sqllogictest/bounded_staleness.slt
+++ b/test/sqllogictest/bounded_staleness.slt
@@ -1,0 +1,241 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Bounded staleness isolation — SQL-surface coverage.
+
+mode cockroach
+
+reset-server
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_bounded_staleness_isolation = true;
+----
+COMPLETE 0
+
+# --- parse and SHOW round-trip -----------------------------------------------
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 5s'
+
+query T
+SHOW transaction_isolation
+----
+bounded staleness 5s
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 250ms'
+
+query T
+SHOW transaction_isolation
+----
+bounded staleness 250ms
+
+statement ok
+RESET transaction_isolation
+
+# --- rejected values ----------------------------------------------------------
+
+statement error invalid value for parameter "transaction_isolation"
+SET transaction_isolation TO 'bounded staleness 0s'
+
+statement error invalid value for parameter "transaction_isolation"
+SET transaction_isolation TO 'bounded staleness 0ms'
+
+statement error invalid value for parameter "transaction_isolation"
+SET transaction_isolation TO 'bounded staleness banana'
+
+statement error invalid value for parameter "transaction_isolation"
+SET transaction_isolation TO 'bounded staleness'
+
+# Long durations are accepted; there is no upper cap on the bound.
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 1h'
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 24h'
+
+statement ok
+RESET transaction_isolation
+
+# --- mutual exclusion with real_time_recency ----------------------------------
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 1s'
+
+statement error real_time_recency cannot be combined with bounded staleness isolation
+SET real_time_recency TO on
+
+# A failed conflicting SET must not have mutated the *other* variable.
+query T
+SHOW real_time_recency
+----
+off
+
+statement ok
+RESET transaction_isolation
+
+statement ok
+SET real_time_recency TO on
+
+statement error real_time_recency cannot be combined with bounded staleness isolation
+SET transaction_isolation TO 'bounded staleness 1s'
+
+# A failed conflicting SET must not have mutated `transaction_isolation`. The
+# mutual-exclusion check fires after `vars.set` has updated the staged value;
+# this guards against the staged value leaking into subsequent statements.
+query T
+SHOW transaction_isolation
+----
+strict serializable
+
+statement ok
+RESET real_time_recency
+
+# --- writes are rejected ------------------------------------------------------
+
+statement ok
+CREATE TABLE bs_writes (a int)
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 1s'
+
+statement error writes are not permitted under bounded staleness isolation
+INSERT INTO bs_writes VALUES (1)
+
+statement error writes are not permitted under bounded staleness isolation
+DELETE FROM bs_writes
+
+statement error writes are not permitted under bounded staleness isolation
+UPDATE bs_writes SET a = a + 1
+
+statement ok
+RESET transaction_isolation
+
+statement ok
+DROP TABLE bs_writes
+
+# --- sub-millisecond durations are rejected ----------------------------------
+
+statement error invalid value for parameter "transaction_isolation"
+SET transaction_isolation TO 'bounded staleness 1us'
+
+statement error invalid value for parameter "transaction_isolation"
+SET transaction_isolation TO 'bounded staleness 999us'
+
+statement error invalid value for parameter "transaction_isolation"
+SET transaction_isolation TO 'bounded staleness 1ns'
+
+# --- multi-component duration round-trip --------------------------------------
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 1m30s'
+
+# `humantime::format_duration` emits the canonical `1m 30s` form.
+query T
+SHOW transaction_isolation
+----
+bounded staleness 1m 30s
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 1m 30s'
+
+query T
+SHOW transaction_isolation
+----
+bounded staleness 1m 30s
+
+statement ok
+RESET transaction_isolation
+
+# --- AS OF queries do not panic under bounded staleness ----------------------
+#
+# `AS OF` skips the timestamp oracle round-trip (the user has chosen `T`); a
+# previous version of the constraint solver would reach an `expect` on the
+# unset oracle anchor and panic the server. The user-chosen timestamp is the
+# sole timestamp constraint; bounded staleness adds nothing further.
+#
+# We use `EXPLAIN TIMESTAMP` rather than the underlying `SELECT` itself: a
+# `SELECT ... AS OF 18446744073709551615` would block on the input upper
+# advancing past `u64::MAX`, which never happens (and under
+# `--auto-index-selects` the runner wraps the SELECT in an indexed view that
+# inherits the same AS OF). `EXPLAIN TIMESTAMP` invokes the same
+# `determine_timestamp_via_constraints` path without executing the peek, so
+# it catches the panic regression without hanging.
+
+statement ok
+CREATE TABLE bs_as_of (a int)
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 5s'
+
+statement ok
+EXPLAIN TIMESTAMP FOR SELECT * FROM bs_as_of AS OF 18446744073709551615
+
+# Smoke-test the non-AS-OF path through the same constraint solver — under
+# bounded staleness, this exercises the `oracle_read_ts = Some(_)` branch
+# that the AS OF case skips.
+
+statement ok
+EXPLAIN TIMESTAMP FOR SELECT * FROM bs_as_of
+
+# Constant queries are timestamp-independent (no timeline); the freshness
+# contract is vacuous and they must not be rejected.
+
+query T
+SELECT 1
+----
+1
+
+statement ok
+RESET transaction_isolation
+
+statement ok
+DROP TABLE bs_as_of
+
+# --- COPY FROM is rejected as a write -----------------------------------------
+
+statement ok
+CREATE TABLE bs_copy (a int)
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 1s'
+
+statement error writes are not permitted under bounded staleness isolation
+COPY bs_copy FROM stdin
+
+statement ok
+RESET transaction_isolation
+
+statement ok
+DROP TABLE bs_copy
+
+# --- feature-flag gating ------------------------------------------------------
+#
+# The flag defaults to `true` in public preview; explicitly turn it off here to
+# exercise the gating path.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_bounded_staleness_isolation = false;
+----
+COMPLETE 0
+
+statement error the `bounded staleness <duration>` transaction isolation level is not available
+SET transaction_isolation TO 'bounded staleness 5s'
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_bounded_staleness_isolation = true;
+----
+COMPLETE 0
+
+statement ok
+SET transaction_isolation TO 'bounded staleness 5s'
+
+statement ok
+RESET transaction_isolation

--- a/test/testdrive/bounded-staleness.td
+++ b/test/testdrive/bounded-staleness.td
@@ -1,0 +1,118 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Bounded staleness isolation — happy-path coverage.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_bounded_staleness_isolation = true
+
+> CREATE TABLE bs_t (a int);
+> INSERT INTO bs_t VALUES (1), (2), (3);
+
+# Read once under default (strict serializable) isolation so the read frontier
+# advances past the insert before we switch to bounded staleness. Under bounded
+# staleness, the SELECT does not block on input frontiers, so we must observe
+# the write here first.
+> SELECT count(*) FROM bs_t
+3
+
+> SET transaction_isolation = 'bounded staleness 5s'
+
+> SELECT count(*) FROM bs_t
+3
+
+> SELECT sum(a) FROM bs_t
+6
+
+# Round-trip via SHOW.
+> SHOW transaction_isolation
+"bounded staleness 5s"
+
+> RESET transaction_isolation
+
+> DROP TABLE bs_t
+
+# --- error path: bounded staleness exceeded -----------------------------------
+#
+# Build an MV on a dedicated cluster, then drop the cluster's replication factor
+# to 0 so the MV's upper frontier stops advancing. After waiting past the
+# staleness bound, a SELECT under bounded staleness must error.
+
+> CREATE CLUSTER bs_cluster SIZE 'scale=1,workers=1'
+
+> CREATE TABLE bs_t (a int)
+
+> INSERT INTO bs_t VALUES (1), (2), (3)
+
+> CREATE MATERIALIZED VIEW bs_mv IN CLUSTER bs_cluster AS
+  SELECT count(*) FROM bs_t
+
+> SELECT * FROM bs_mv
+3
+
+> ALTER CLUSTER bs_cluster SET (REPLICATION FACTOR 0)
+
+> SELECT mz_unsafe.mz_sleep(2)
+<null>
+
+> SET transaction_isolation = 'bounded staleness 500ms'
+
+! SELECT * FROM bs_mv
+contains: cannot serve query under bounded staleness
+
+> RESET transaction_isolation
+
+> DROP MATERIALIZED VIEW bs_mv
+
+> DROP TABLE bs_t
+
+> DROP CLUSTER bs_cluster
+
+# --- success path: upper lags but bound is generous ---------------------------
+#
+# Regression test for the constraint-shadowing bug where the existing
+# `oracle_read_ts -> hard lower bound` push (in `determine_timestamp_via_constraints`)
+# was not excluded for bounded staleness, shadowing the intended `anchor - D`
+# slack and forcing `T >= oracle.read_ts`. With the upper bound also clamped at
+# `largest_not_in_advance_of_upper`, queries used to fail deterministically as
+# soon as the upper lagged, even when the bound was orders of magnitude larger
+# than the lag — turning bounded staleness into something stricter than strict
+# serializable. With the carve-out in place, the chosen timestamp is allowed to
+# be as old as `oracle.read_ts - D`, so a generous bound serves a stale-but-
+# fresh-enough timestamp.
+
+> CREATE CLUSTER bs_cluster SIZE 'scale=1,workers=1'
+
+> CREATE TABLE bs_t (a int)
+
+> INSERT INTO bs_t VALUES (1), (2), (3)
+
+> CREATE MATERIALIZED VIEW bs_mv IN CLUSTER bs_cluster AS
+  SELECT count(*) FROM bs_t
+
+> SELECT * FROM bs_mv
+3
+
+> ALTER CLUSTER bs_cluster SET (REPLICATION FACTOR 0)
+
+> SELECT mz_unsafe.mz_sleep(1)
+<null>
+
+> SET transaction_isolation = 'bounded staleness 1h'
+
+> SELECT * FROM bs_mv
+3
+
+> RESET transaction_isolation
+
+> DROP MATERIALIZED VIEW bs_mv
+
+> DROP TABLE bs_t
+
+> DROP CLUSTER bs_cluster


### PR DESCRIPTION
Builds on #36906 (IsolationLevel string refactor) and #36907 (COPY FROM stdin sequencing), both merged.

Adds a new SQL isolation level `bounded staleness <duration>` that picks the freshest read timestamp `T` in `[oracle.read_ts(now) - D, largest_not_in_advance_of_upper]`, erroring (`SQLSTATE 40001`) when the window is empty. The error fires in the coordinator before any peek dispatch — the feasibility check is cluster-shape-independent.

Spec: `doc/developer/design/20260429_bounded_staleness_isolation.md`
User docs: `doc/user/content/reference/isolation-level.md`

Motivation: today strict serializable forces a wait up to one tick (~1s) for the freshest timestamp; serializable has no upper bound on staleness when an input lags. Bounded staleness gives users an explicit ceiling — "data no older than `D`" — without blocking on input frontiers, modeled on Spanner's bounded-staleness reads.

Anchor: bounded staleness always anchors against `oracle.read_ts` (one round-trip per query, the same one strict serializable already pays). The oracle is monotone, persisted, and shared, which makes it the only anchor that stays correct across crashes/restarts, clock changes, and a future multi-`environmentd` deployment. Caching the oracle read_ts under bounded staleness's relaxed contract is a possible future optimization.

Gating: feature flag `enable_bounded_staleness_isolation` (default on, public preview). Each rejection (writes, `real_time_recency = on`, non-`EpochMilliseconds` timelines) has a dedicated `AdapterError` variant.

Restrictions: writes (`INSERT`/`UPDATE`/`DELETE`/`COPY FROM`) and `real_time_recency = on` are rejected under bounded staleness; `D = 0` is rejected; `D` has no upper cap; timeline-less (constant) queries are allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

