### PR TITLE
expr: regexp_replace STRICT on NULL replacement with bad pattern

### DIFF
--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1272,8 +1272,8 @@ impl MirScalarExpr {
                             // The behavior of `regexp_replace` is that if the data is `NULL`, the
                             // function returns `NULL`, independently of whether the pattern or
                             // flags are correct. We need to check for this case and introduce an
-                            // if-then-else on the error path to only surface the error if the first
-                            // input is non-NULL.
+                            // if-then-else on the error path to only surface the error if both
+                            // the source and replacement inputs are non-NULL.
                             *e = match func::build_regex(pattern, &flags) {
                                 Ok(regex) => {
                                     let mut exprs = mem::take(exprs);
@@ -1286,13 +1286,17 @@ impl MirScalarExpr {
                                 }
                                 Err(err) => {
                                     let mut exprs = mem::take(exprs);
+                                    let replacement = exprs.swap_remove(2);
                                     let source = exprs.swap_remove(0);
                                     let scalar_type = e.typ(column_types).scalar_type;
                                     // We need to return `NULL` on `NULL` input, and error otherwise.
-                                    source.call_is_null().if_then_else(
-                                        MirScalarExpr::literal_null(scalar_type.clone()),
-                                        MirScalarExpr::literal(Err(err), scalar_type),
-                                    )
+                                    source
+                                        .call_is_null()
+                                        .or(replacement.call_is_null())
+                                        .if_then_else(
+                                            MirScalarExpr::literal_null(scalar_type.clone()),
+                                            MirScalarExpr::literal(Err(err), scalar_type),
+                                        )
                                 }
                             };
                         } else if *func == RegexpSplitToArray.into()

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -723,7 +723,7 @@ SELECT s, regexp_replace(s, 'b(..', replacement, 'ig') FROM e;
 ----
 Explained Query:
   Project (#0{s}, #3)
-    Map (case when (#0{s}) IS NULL then null else error("invalid regular expression: regex parse error:\n    b(..\n     ^\nerror: unclosed group") end)
+    Map (case when ((#0{s}) IS NULL OR (#2{replacement}) IS NULL) then null else error("invalid regular expression: regex parse error:\n    b(..\n     ^\nerror: unclosed group") end)
       ReadStorage materialize.public.e
 
 Source materialize.public.e
@@ -740,6 +740,40 @@ SELECT s, regexp_replace(s, regex, replacement, 'ig') FROM e;
 
 query error invalid regular expression flag: x
 SELECT regexp_replace(s, regex, replacement, 'igx') FROM e;
+
+# Regression test: `regexp_replace` is STRICT, so a NULL replacement column
+# must yield NULL even when the literal pattern fails to compile.
+
+statement ok
+CREATE TABLE e_null(s string, replacement string);
+
+statement ok
+INSERT INTO e_null VALUES ('abc', NULL), (NULL, 'X'), (NULL, NULL), ('abc', 'X');
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR
+SELECT regexp_replace(s, 'b(..', replacement, 'ig') FROM e_null;
+----
+Explained Query:
+  Project (#2)
+    Map (case when ((#0{s}) IS NULL OR (#1{replacement}) IS NULL) then null else error("invalid regular expression: regex parse error:\n    b(..\n     ^\nerror: unclosed group") end)
+      ReadStorage materialize.public.e_null
+
+Source materialize.public.e_null
+
+Target cluster: multiprocess
+
+EOF
+
+query T rowsort
+SELECT regexp_replace(s, 'b(..', replacement, 'ig') FROM e_null WHERE s IS NULL OR replacement IS NULL;
+----
+NULL
+NULL
+NULL
+
+query error invalid regular expression: regex parse error:
+SELECT regexp_replace(s, 'b(..', replacement, 'ig') FROM e_null;
 
 # regexp_matches
 


### PR DESCRIPTION
Regression from #32053. When `regexp_replace` is called with a literal pattern that fails to compile, the reduce-path guard checked only the source for NULL. PostgreSQL's `regexp_replace` is STRICT, so a NULL replacement column must also yield NULL rather than surface the regex error.

```sql
CREATE TABLE e (replacement text);
INSERT INTO e VALUES (NULL);
SELECT regexp_replace('abc', 'b(..', replacement, 'ig') FROM e;
-- before: ERROR: invalid regular expression
-- after:  NULL
```

The fix OR-s the source and replacement IS NULL checks before the if-then-else; pattern and flags are literals on this branch so source and replacement are the only runtime args to guard.

Fixes https://github.com/MaterializeInc/database-issues/issues/11350