### PR TITLE
compute: reset memory limiter `last_check` on config change

### DIFF
--- a/src/compute/src/memory_limiter.rs
+++ b/src/compute/src/memory_limiter.rs
@@ -260,6 +260,13 @@ impl LimiterTask {
         info!(?config, "applying memory limiter config");
         self.config = config;
         self.burst_budget_remaining = config.burst_budget;
+        // Reset `last_check` so the next `check` measures the excess interval
+        // against the new config, not against a stale checkpoint left over from
+        // a period when the limiter was disabled or running with a different
+        // interval. Without this, enabling the limiter at runtime can charge an
+        // arbitrarily large excess byte-second amount against the burst budget
+        // and immediately terminate the process.
+        self.last_check = Instant::now();
 
         self.metrics
             .memory_limit
@@ -314,6 +321,67 @@ pub struct ProcStatus {
     pub vm_rss: usize,
     /// Swap memory in bytes.
     pub vm_swap: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task_for_test() -> LimiterTask {
+        let registry = MetricsRegistry::new();
+        let metrics = LimiterMetrics::new(&registry);
+        LimiterTask {
+            config: LimiterConfig::disabled(),
+            burst_budget_remaining: 0,
+            last_check: Instant::now(),
+            metrics,
+        }
+    }
+
+    /// Regression test for an issue where enabling the limiter at runtime would
+    /// immediately terminate the process because `last_check` had not been
+    /// advanced since task startup. After `apply_config` the next `check` would
+    /// see a huge `elapsed`, multiply it with the over-limit memory amount, and
+    /// instantly exhaust the burst budget.
+    #[mz_ore::test]
+    fn apply_config_resets_last_check() {
+        let mut task = task_for_test();
+
+        // Simulate a long period during which the limiter was disabled and
+        // `last_check` was never refreshed.
+        let stale = Instant::now() - Duration::from_secs(3600);
+        task.last_check = stale;
+
+        let new_config = LimiterConfig {
+            interval: Duration::from_secs(1),
+            memory_limit: 1024,
+            burst_budget: 1024,
+        };
+        task.apply_config(new_config);
+
+        assert!(
+            task.last_check > stale,
+            "apply_config must refresh last_check to avoid charging stale elapsed time \
+             against the burst budget when the limiter is enabled at runtime"
+        );
+        assert!(
+            task.last_check.elapsed() < Duration::from_secs(60),
+            "last_check should be ~now after apply_config"
+        );
+    }
+
+    /// A no-op config change must not refresh `last_check`, otherwise repeated
+    /// no-op calls would silently delay the next limit check.
+    #[mz_ore::test]
+    fn apply_config_noop_keeps_last_check() {
+        let mut task = task_for_test();
+        let stale = Instant::now() - Duration::from_secs(60);
+        task.last_check = stale;
+
+        task.apply_config(LimiterConfig::disabled());
+
+        assert_eq!(task.last_check, stale);
+    }
 }
 
 impl ProcStatus {


### PR DESCRIPTION
### Motivation

Fixes a regression introduced in #32939.
Toggling `memory_limiter_interval` from `0s` to any non-zero value at runtime is currently unsafe: it can kill replicas at the next config update, even when memory usage is well below the limit.

Fixes: https://github.com/MaterializeInc/database-issues/issues/11343

### Description

While disabled, the limiter task sleeps with `interval = Duration::MAX` and never updates `last_check`.
On enable, the first `check` runs with `last_check` still set to task startup, so `elapsed` can be arbitrarily large.
The over-limit calculation `excess_bs = excess * elapsed` then exhausts the burst budget on the first sample and triggers `exit_thread_safe(167)`.

`apply_config` now resets `last_check` whenever the configuration changes, so the next check measures excess against the new interval rather than against a stale checkpoint.
No-op config changes still leave `last_check` untouched, to avoid silently delaying the next limit check.

Added unit tests in `src/compute/src/memory_limiter.rs` covering both behaviors.