### PR TITLE
timely-util: add ConsolidatingColumnBuilder

### DIFF
--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -13,6 +13,10 @@ workspace = true
 name = "reclock"
 harness = false
 
+[[bench]]
+name = "consolidating_column_builder"
+harness = false
+
 [dependencies]
 ahash.workspace = true
 bincode.workspace = true

--- a/src/timely-util/benches/consolidating_column_builder.rs
+++ b/src/timely-util/benches/consolidating_column_builder.rs
@@ -7,9 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Throughput benchmark for `ConsolidatingColumnBuilder` against bare `ColumnBuilder` (no
-//! staging, no consolidation) — the latter is the upper bound for the consolidating builder
-//! on cancellation-free workloads.
+//! Throughput benchmark for `ConsolidatingColumnBuilder` against:
+//!
+//! * `ConsolidatingContainerBuilder<Vec<_>>` — DD's existing AoS consolidator, the
+//!   apples-to-apples comparison for what we are replacing.
+//! * Bare `ColumnBuilder` (no staging, no consolidation) — upper bound on push throughput
+//!   when consolidation has nothing to remove.
 //!
 //! Run with:
 //!
@@ -17,6 +20,7 @@
 
 use columnar::Len;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use timely::container::{ContainerBuilder, PushInto};
@@ -58,6 +62,22 @@ fn run_bare<F: Fn(u64) -> Item>(mk: F) {
     std::hint::black_box(sink);
 }
 
+#[inline]
+fn run_dd<F: Fn(u64) -> Item>(mk: F) {
+    let mut builder = ConsolidatingContainerBuilder::<Vec<Item>>::default();
+    let mut sink: u64 = 0;
+    for i in 0..N {
+        builder.push_into(mk(std::hint::black_box(i)));
+        while let Some(c) = builder.extract() {
+            sink = sink.wrapping_add(c.len() as u64);
+        }
+    }
+    while let Some(c) = builder.finish() {
+        sink = sink.wrapping_add(c.len() as u64);
+    }
+    std::hint::black_box(sink);
+}
+
 fn bench_workload<F>(c: &mut Criterion, name: &str, mk: F)
 where
     F: Fn(u64) -> Item + Copy,
@@ -65,6 +85,7 @@ where
     let mut group = c.benchmark_group(name);
     group.throughput(Throughput::Bytes(N * std::mem::size_of::<Item>() as u64));
     group.bench_function("ConsolidatingColumnBuilder", |b| b.iter(|| run_cons(mk)));
+    group.bench_function("ConsolidatingContainerBuilder", |b| b.iter(|| run_dd(mk)));
     group.bench_function("ColumnBuilder", |b| b.iter(|| run_bare(mk)));
     group.finish();
 }

--- a/src/timely-util/benches/consolidating_column_builder.rs
+++ b/src/timely-util/benches/consolidating_column_builder.rs
@@ -1,0 +1,85 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Throughput benchmark for `ConsolidatingColumnBuilder` against bare `ColumnBuilder` (no
+//! staging, no consolidation) — the latter is the upper bound for the consolidating builder
+//! on cancellation-free workloads.
+//!
+//! Run with:
+//!
+//!     cargo bench -p mz-timely-util --bench consolidating_column_builder
+
+use columnar::Len;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use mz_timely_util::columnar::builder::ColumnBuilder;
+use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
+use timely::container::{ContainerBuilder, PushInto};
+
+type Item = (u64, u64, i64);
+
+const N: u64 = 1_000_000;
+
+/// Mirror `timely::Session::give`: push one item, drain everything `extract` yields.
+#[inline]
+fn run_cons<F: Fn(u64) -> Item>(mk: F) {
+    let mut builder = ConsolidatingColumnBuilder::<u64, u64, i64>::default();
+    let mut sink: u64 = 0;
+    for i in 0..N {
+        builder.push_into(mk(std::hint::black_box(i)));
+        while let Some(c) = builder.extract() {
+            sink = sink.wrapping_add(c.borrow().len() as u64);
+        }
+    }
+    while let Some(c) = builder.finish() {
+        sink = sink.wrapping_add(c.borrow().len() as u64);
+    }
+    std::hint::black_box(sink);
+}
+
+#[inline]
+fn run_bare<F: Fn(u64) -> Item>(mk: F) {
+    let mut builder = ColumnBuilder::<Item>::default();
+    let mut sink: u64 = 0;
+    for i in 0..N {
+        builder.push_into(mk(std::hint::black_box(i)));
+        while let Some(c) = builder.extract() {
+            sink = sink.wrapping_add(c.borrow().len() as u64);
+        }
+    }
+    while let Some(c) = builder.finish() {
+        sink = sink.wrapping_add(c.borrow().len() as u64);
+    }
+    std::hint::black_box(sink);
+}
+
+fn bench_workload<F>(c: &mut Criterion, name: &str, mk: F)
+where
+    F: Fn(u64) -> Item + Copy,
+{
+    let mut group = c.benchmark_group(name);
+    group.throughput(Throughput::Bytes(N * std::mem::size_of::<Item>() as u64));
+    group.bench_function("ConsolidatingColumnBuilder", |b| b.iter(|| run_cons(mk)));
+    group.bench_function("ColumnBuilder", |b| b.iter(|| run_bare(mk)));
+    group.finish();
+}
+
+fn bench(c: &mut Criterion) {
+    // Closures are passed as separate type parameters per call so each workload monomorphizes
+    // `run_*`; collecting them into a `&[fn(u64) -> Item]` array adds an indirect call to every
+    // push that dwarfs the columnar hot path.
+    bench_workload(c, "cancel-pairs", |i| {
+        (i / 2, 0, if i % 2 == 0 { 1 } else { -1 })
+    });
+    bench_workload(c, "single-key", |_| (42, 0, 1));
+    bench_workload(c, "all-distinct", |i| (i, 0, 1));
+    bench_workload(c, "dup-pairs", |i| (i / 2, 0, 1));
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/src/timely-util/benches/consolidating_column_builder.rs
+++ b/src/timely-util/benches/consolidating_column_builder.rs
@@ -23,7 +23,7 @@ use timely::container::{ContainerBuilder, PushInto};
 
 type Item = (u64, u64, i64);
 
-const N: u64 = 1_000_000;
+const N: u64 = 10_000_000;
 
 /// Mirror `timely::Session::give`: push one item, drain everything `extract` yields.
 #[inline]

--- a/src/timely-util/benches/consolidating_column_builder.rs
+++ b/src/timely-util/benches/consolidating_column_builder.rs
@@ -21,6 +21,7 @@
 use columnar::Len;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
+use mz_ore::cast::CastFrom;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use timely::container::{ContainerBuilder, PushInto};
@@ -37,11 +38,11 @@ fn run_cons<F: Fn(u64) -> Item>(mk: F) {
     for i in 0..N {
         builder.push_into(mk(std::hint::black_box(i)));
         while let Some(c) = builder.extract() {
-            sink = sink.wrapping_add(c.borrow().len() as u64);
+            sink = sink.wrapping_add(u64::cast_from(c.borrow().len()));
         }
     }
     while let Some(c) = builder.finish() {
-        sink = sink.wrapping_add(c.borrow().len() as u64);
+        sink = sink.wrapping_add(u64::cast_from(c.borrow().len()));
     }
     std::hint::black_box(sink);
 }
@@ -53,11 +54,11 @@ fn run_bare<F: Fn(u64) -> Item>(mk: F) {
     for i in 0..N {
         builder.push_into(mk(std::hint::black_box(i)));
         while let Some(c) = builder.extract() {
-            sink = sink.wrapping_add(c.borrow().len() as u64);
+            sink = sink.wrapping_add(u64::cast_from(c.borrow().len()));
         }
     }
     while let Some(c) = builder.finish() {
-        sink = sink.wrapping_add(c.borrow().len() as u64);
+        sink = sink.wrapping_add(u64::cast_from(c.borrow().len()));
     }
     std::hint::black_box(sink);
 }
@@ -69,11 +70,11 @@ fn run_dd<F: Fn(u64) -> Item>(mk: F) {
     for i in 0..N {
         builder.push_into(mk(std::hint::black_box(i)));
         while let Some(c) = builder.extract() {
-            sink = sink.wrapping_add(c.len() as u64);
+            sink = sink.wrapping_add(u64::cast_from(c.len()));
         }
     }
     while let Some(c) = builder.finish() {
-        sink = sink.wrapping_add(c.len() as u64);
+        sink = sink.wrapping_add(u64::cast_from(c.len()));
     }
     std::hint::black_box(sink);
 }
@@ -83,7 +84,9 @@ where
     F: Fn(u64) -> Item + Copy,
 {
     let mut group = c.benchmark_group(name);
-    group.throughput(Throughput::Bytes(N * std::mem::size_of::<Item>() as u64));
+    group.throughput(Throughput::Bytes(
+        N * u64::cast_from(std::mem::size_of::<Item>()),
+    ));
     group.bench_function("ConsolidatingColumnBuilder", |b| b.iter(|| run_cons(mk)));
     group.bench_function("ConsolidatingContainerBuilder", |b| b.iter(|| run_dd(mk)));
     group.bench_function("ColumnBuilder", |b| b.iter(|| run_bare(mk)));

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -19,6 +19,7 @@
 
 pub mod batcher;
 pub mod builder;
+pub mod consolidate;
 
 use std::hash::Hash;
 

--- a/src/timely-util/src/columnar/builder.rs
+++ b/src/timely-util/src/columnar/builder.rs
@@ -49,24 +49,23 @@ where
         let words = indexed::length_in_words(&self.current.borrow());
         let round = (words + ((1 << 18) - 1)) & !((1 << 18) - 1);
         if round - words < round / 10 {
-            /// Move the contents from `current` to an aligned allocation, and push it to `pending`.
-            /// The contents must fit in `round` words (u64).
+            /// Move the contents from `current` to a `Vec<u64>` allocation built via
+            /// `indexed::encode` (so no zero-init pre-pass), and push it to `pending`.
             #[cold]
             fn outlined_align<C>(
                 current: &mut C::Container,
-                round: usize,
+                words: usize,
                 pending: &mut VecDeque<Column<C>>,
             ) where
                 C: Columnar,
             {
-                let mut alloc: Vec<u64> = vec![0; round];
-                let mut writer = std::io::Cursor::new(bytemuck::cast_slice_mut(&mut alloc[..]));
-                indexed::write(&mut writer, &current.borrow()).unwrap();
+                let mut alloc: Vec<u64> = Vec::with_capacity(words);
+                indexed::encode(&mut alloc, &current.borrow());
                 pending.push_back(Column::Align(alloc));
                 current.clear();
             }
 
-            outlined_align(&mut self.current, round, &mut self.pending);
+            outlined_align(&mut self.current, words, &mut self.pending);
         }
     }
 }

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -1,0 +1,243 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A `ContainerBuilder` that consolidates `(D, T, R)` updates and emits columnar containers.
+//!
+//! Vendored from `differential_dataflow::consolidation::ConsolidatingContainerBuilder` for the
+//! staging path; the inner [`ColumnBuilder`] mints aligned columnar containers from the
+//! consolidated tuples.
+
+use columnar::{Columnar, Push};
+use differential_dataflow::Data;
+use differential_dataflow::consolidation::consolidate_updates;
+use differential_dataflow::difference::Semigroup;
+use timely::container::{ContainerBuilder, PushInto};
+
+use crate::columnar::Column;
+use crate::columnar::builder::ColumnBuilder;
+
+/// A container builder that consolidates `(D, T, R)` updates and emits `Column<(D, T, R)>`.
+///
+/// Buffers updates in an internal `Vec`, calls
+/// [`consolidate_updates`] when the buffer fills, and pushes the surviving updates into an inner
+/// [`ColumnBuilder`]. The inner builder chunks output into ~2MB-aligned columnar containers
+/// (see [`ColumnBuilder`] for details).
+///
+/// Does **not** maintain FIFO ordering (consolidation reorders updates).
+pub struct ConsolidatingColumnBuilder<D, T, R>
+where
+    D: Data,
+    T: Data,
+    R: Semigroup + 'static,
+    (D, T, R): Columnar,
+{
+    /// Pre-consolidation staging buffer.
+    current: Vec<(D, T, R)>,
+    /// Inner columnar builder; receives consolidated tuples and emits `Column<(D, T, R)>`.
+    column: ColumnBuilder<(D, T, R)>,
+}
+
+impl<D, T, R> Default for ConsolidatingColumnBuilder<D, T, R>
+where
+    D: Data,
+    T: Data,
+    R: Semigroup + 'static,
+    (D, T, R): Columnar,
+{
+    fn default() -> Self {
+        Self {
+            current: Vec::new(),
+            column: ColumnBuilder::default(),
+        }
+    }
+}
+
+impl<D, T, R> ConsolidatingColumnBuilder<D, T, R>
+where
+    D: Data,
+    T: Data,
+    R: Semigroup + 'static,
+    (D, T, R): Columnar,
+    <(D, T, R) as Columnar>::Container: Push<(D, T, R)>,
+{
+    /// Consolidate `current` and drain the largest multiple-of-`multiple` prefix into the inner
+    /// columnar builder. Pass `1` to drain everything.
+    #[cold]
+    fn consolidate_and_drain(&mut self, multiple: usize) {
+        consolidate_updates(&mut self.current);
+        let drain_len = (self.current.len() / multiple) * multiple;
+        for item in self.current.drain(..drain_len) {
+            self.column.push_into(item);
+        }
+    }
+}
+
+impl<D, T, R> PushInto<(D, T, R)> for ConsolidatingColumnBuilder<D, T, R>
+where
+    D: Data,
+    T: Data,
+    R: Semigroup + 'static,
+    (D, T, R): Columnar,
+    <(D, T, R) as Columnar>::Container: Push<(D, T, R)>,
+{
+    /// Push an element.
+    ///
+    /// Precondition: `current` is not allocated or has space for at least one element.
+    #[inline]
+    fn push_into(&mut self, item: (D, T, R)) {
+        let preferred_capacity = timely::container::buffer::default_capacity::<(D, T, R)>();
+        if self.current.capacity() < preferred_capacity * 2 {
+            self.current
+                .reserve(preferred_capacity * 2 - self.current.capacity());
+        }
+        self.current.push(item);
+        if self.current.len() == self.current.capacity() {
+            self.consolidate_and_drain(preferred_capacity);
+        }
+    }
+}
+
+impl<D, T, R> ContainerBuilder for ConsolidatingColumnBuilder<D, T, R>
+where
+    D: Data,
+    T: Data,
+    R: Semigroup + 'static,
+    (D, T, R): Columnar,
+    <(D, T, R) as Columnar>::Container: Push<(D, T, R)> + Clone,
+{
+    type Container = Column<(D, T, R)>;
+
+    #[inline]
+    fn extract(&mut self) -> Option<&mut Self::Container> {
+        self.column.extract()
+    }
+
+    #[inline]
+    fn finish(&mut self) -> Option<&mut Self::Container> {
+        if !self.current.is_empty() {
+            self.consolidate_and_drain(1);
+        }
+        self.column.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use columnar::Index;
+    use columnar::Len;
+    use timely::container::{ContainerBuilder, PushInto};
+
+    use super::*;
+
+    /// Collect every `(D, T, R)` row from a `Column<(u64, u64, i64)>`.
+    fn rows(column: &Column<(u64, u64, i64)>) -> Vec<(u64, u64, i64)> {
+        let borrow = column.borrow();
+        (0..borrow.len())
+            .map(|i| {
+                let r = borrow.get(i);
+                (*r.0, *r.1, *r.2)
+            })
+            .collect()
+    }
+
+    /// Drain a builder by repeatedly calling `extract` then `finish`.
+    fn drain(mut builder: ConsolidatingColumnBuilder<u64, u64, i64>) -> Vec<(u64, u64, i64)> {
+        let mut out: Vec<(u64, u64, i64)> = Vec::new();
+        while let Some(c) = builder.extract() {
+            for r in rows(c) {
+                out.push(r);
+            }
+        }
+        if let Some(c) = builder.finish() {
+            for r in rows(c) {
+                out.push(r);
+            }
+        }
+        out
+    }
+
+    #[mz_ore::test]
+    fn empty_finish_yields_none() {
+        let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
+        assert!(builder.extract().is_none());
+        assert!(builder.finish().is_none());
+    }
+
+    #[mz_ore::test]
+    fn single_push_finish_yields_one() {
+        let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
+        builder.push_into((1u64, 0u64, 1i64));
+        let column = builder.finish().expect("one container");
+        assert_eq!(rows(column), vec![(1, 0, 1)]);
+        assert!(builder.finish().is_none());
+    }
+
+    #[mz_ore::test]
+    fn consolidates_on_threshold() {
+        let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
+        let preferred = timely::container::buffer::default_capacity::<(u64, u64, i64)>();
+        // Push enough +1/-1 pairs to exceed `preferred * 2` and trigger several consolidation
+        // cycles. Everything cancels.
+        for _ in 0..(preferred * 4) {
+            builder.push_into((7u64, 0u64, 1i64));
+            builder.push_into((7u64, 0u64, -1i64));
+        }
+        assert!(drain(builder).is_empty());
+    }
+
+    #[mz_ore::test]
+    fn multiple_distinct_keys() {
+        let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
+        builder.push_into((1u64, 0u64, 1i64));
+        builder.push_into((2u64, 0u64, 1i64));
+        builder.push_into((1u64, 0u64, 1i64));
+        let mut out = drain(builder);
+        out.sort();
+        assert_eq!(out, vec![(1, 0, 2), (2, 0, 1)]);
+    }
+
+    #[mz_ore::test]
+    fn emits_multiple_containers() {
+        let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
+        // Enough distinct rows to force the inner ColumnBuilder past its ~2MB threshold and mint
+        // multiple containers. Each row is 24 bytes; 200_000 rows ≈ 4.8MB raw.
+        let n: u64 = 200_000;
+        for d in 0..n {
+            builder.push_into((d, 0u64, 1i64));
+        }
+
+        let mut containers = 0;
+        let mut out: Vec<(u64, u64, i64)> = Vec::new();
+        while let Some(c) = builder.extract() {
+            containers += 1;
+            for r in rows(c) {
+                out.push(r);
+            }
+        }
+        if let Some(c) = builder.finish() {
+            containers += 1;
+            for r in rows(c) {
+                out.push(r);
+            }
+        }
+        assert!(
+            containers > 1,
+            "expected multiple containers, got {containers}"
+        );
+        out.sort();
+        let expected: Vec<(u64, u64, i64)> = (0..n).map(|d| (d, 0u64, 1i64)).collect();
+        assert_eq!(out, expected);
+    }
+}

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -15,132 +15,213 @@
 
 //! A `ContainerBuilder` that consolidates `(D, T, R)` updates and emits columnar containers.
 //!
-//! Vendored from `differential_dataflow::consolidation::ConsolidatingContainerBuilder` for the
-//! staging path; the inner [`ColumnBuilder`] mints aligned columnar containers from the
-//! consolidated tuples.
+//! Two-level buffering:
+//!
+//! 1. AoS staging `Vec<(D, T, R)>` with a small cap so `consolidate_updates`' `n log n` cost
+//!    stays bounded. Cancellations and same-key updates collapse here before reaching the
+//!    column-shaped storage. A drain-multiple-of-half-cap trick keeps the leftover in staging,
+//!    so cross-batch keys with the same `(D, T)` continue consolidating on the next sort.
+//! 2. SoA accumulator: one sub-container per column (`D::Container`, `T::Container`,
+//!    `R::Container`). Drains from staging do three sequential passes (one per column), so
+//!    each pass writes a single cache-line stream. When the accumulator reaches the output
+//!    target byte size, it serializes into an aligned `Vec<u64>` (no zero-fill — written
+//!    exactly once by `indexed::write`) and ships as `Column::Align`. The trailing partial on
+//!    `finish` ships as `Column::Typed` to avoid one final serialize copy.
+//!
+//! Generic over `(D, T, R): Columnar` via the columnar tuple decomposition
+//! `<(D, T, R) as Columnar>::Container = (D::Container, T::Container, R::Container)`.
 
-use columnar::{Columnar, Push};
+use std::collections::VecDeque;
+
+use columnar::bytes::indexed;
+use columnar::{Borrow, Columnar, Push};
 use differential_dataflow::Data;
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::difference::Semigroup;
 use timely::container::{ContainerBuilder, PushInto};
 
 use crate::columnar::Column;
-use crate::columnar::builder::ColumnBuilder;
 
-/// Target size in bytes for the staging buffer chunk.
-///
-/// Larger than `timely::container::buffer::default_capacity` (8 KiB) to amortize the cost of
-/// minting aligned columnar containers. Matches `ColumnationChunker` in `crate::columnation`.
-const BUFFER_SIZE_BYTES: usize = 64 << 10;
-
-/// Number of `(D, T, R)` items that fit in [`BUFFER_SIZE_BYTES`], or 1 for oversized tuples.
-const fn chunk_capacity<C>() -> usize {
-    let size = std::mem::size_of::<C>();
-    if size == 0 {
-        BUFFER_SIZE_BYTES
-    } else if size <= BUFFER_SIZE_BYTES {
-        BUFFER_SIZE_BYTES / size
-    } else {
-        1
-    }
-}
+/// Items per staging buffer. Small enough that O(n log n) sort stays cheap, large enough to
+/// amortize the sort + drain overhead across many pushes.
+const STAGING_CAP_ITEMS: usize = 16 * 1024;
+/// Drain a multiple of this on consolidate. Remainder stays in staging so cross-batch keys
+/// keep consolidating on the next sort.
+const DRAIN_GRAIN: usize = STAGING_CAP_ITEMS / 2;
+/// Target serialized size for output `Column::Align` chunks, in u64 words.
+/// 2 MiB matches the existing `ColumnBuilder` heuristic.
+const OUTPUT_TARGET_WORDS: usize = (2 << 20) / 8;
 
 /// A container builder that consolidates `(D, T, R)` updates and emits `Column<(D, T, R)>`.
 ///
-/// Buffers updates in an internal `Vec`, calls
-/// [`consolidate_updates`] when the buffer fills, and pushes the surviving updates into an inner
-/// [`ColumnBuilder`]. The inner builder chunks output into ~2MB-aligned columnar containers
-/// (see [`ColumnBuilder`] for details).
+/// Stages updates in an AoS `Vec` for in-place consolidation, then drains consolidated rows
+/// in three sequential passes into SoA sub-containers. When the SoA accumulator reaches
+/// `OUTPUT_TARGET_WORDS` worth of serialized bytes, it is written into an aligned `Vec<u64>`
+/// (using `indexed::write` over uninitialized memory — no zero-fill) and queued as
+/// `Column::Align`. The trailing partial on `finish` ships as `Column::Typed`.
 ///
 /// Does **not** maintain FIFO ordering (consolidation reorders updates).
 pub struct ConsolidatingColumnBuilder<D, T, R>
 where
-    (D, T, R): Columnar,
+    D: Columnar,
+    T: Columnar,
+    R: Columnar,
 {
-    /// Pre-consolidation staging buffer.
-    current: Vec<(D, T, R)>,
-    /// Inner columnar builder; receives consolidated tuples and emits `Column<(D, T, R)>`.
-    column: ColumnBuilder<(D, T, R)>,
+    /// AoS staging buffer for in-place consolidation. Cap = [`STAGING_CAP_ITEMS`].
+    staging: Vec<(D, T, R)>,
+    /// SoA accumulator, one sub-container per column.
+    cur_d: D::Container,
+    cur_t: T::Container,
+    cur_r: R::Container,
+    /// Number of `(D, T, R)` tuples currently in `cur_*`.
+    cur_len: usize,
+    /// Finished columns ready to ship.
+    pending: VecDeque<Column<(D, T, R)>>,
+    /// The currently extracted/finished column.
+    finished: Option<Column<(D, T, R)>>,
 }
 
 impl<D, T, R> Default for ConsolidatingColumnBuilder<D, T, R>
 where
-    (D, T, R): Columnar,
+    D: Columnar,
+    T: Columnar,
+    R: Columnar,
 {
     fn default() -> Self {
         Self {
-            current: Vec::new(),
-            column: ColumnBuilder::default(),
+            // Pre-allocate so `push` is unconditional (no per-push capacity check or lazy
+            // reserve branch).
+            staging: Vec::with_capacity(STAGING_CAP_ITEMS),
+            cur_d: D::Container::default(),
+            cur_t: T::Container::default(),
+            cur_r: R::Container::default(),
+            cur_len: 0,
+            pending: VecDeque::new(),
+            finished: None,
         }
     }
 }
 
 impl<D, T, R> ConsolidatingColumnBuilder<D, T, R>
 where
-    D: Data,
-    T: Data,
-    R: Semigroup + 'static,
-    (D, T, R): Columnar,
-    <(D, T, R) as Columnar>::Container: Push<(D, T, R)>,
+    D: Data + Columnar,
+    T: Data + Columnar,
+    R: Semigroup + Columnar + 'static,
+    (D, T, R): Columnar<Container = (D::Container, T::Container, R::Container)>,
 {
-    /// Consolidate `current` and drain the largest multiple-of-`multiple` prefix into the inner
-    /// columnar builder. Pass `1` to drain everything.
+    /// Sort and consolidate `staging`, then drain a multiple-of-`grain` prefix into the SoA
+    /// accumulator. Pass `1` to drain everything (used by `finish`).
     #[cold]
-    fn consolidate_and_drain(&mut self, multiple: usize) {
-        consolidate_updates(&mut self.current);
-        let drain_len = (self.current.len() / multiple) * multiple;
-        for item in self.current.drain(..drain_len) {
-            self.column.push_into(item);
+    fn consolidate_and_drain(&mut self, grain: usize) {
+        consolidate_updates(&mut self.staging);
+        let drain_n = (self.staging.len() / grain) * grain;
+        if drain_n == 0 {
+            return;
         }
+
+        // Three sequential passes — one per column. Each pass writes a single cache-line stream
+        // and is branch-free (the sub-containers' `push` only checks per-call capacity).
+        let head = &self.staging[..drain_n];
+        for (d, _, _) in head {
+            self.cur_d.push(d);
+        }
+        for (_, t, _) in head {
+            self.cur_t.push(t);
+        }
+        for (_, _, r) in head {
+            self.cur_r.push(r);
+        }
+        self.cur_len += drain_n;
+        self.staging.drain(..drain_n);
+
+        // Check serialized size; if past the target, flush as aligned bytes. Using
+        // `length_in_words` rather than item count gives bounded output Columns regardless of
+        // variable-width `D` (e.g. `Row` rows of varying length).
+        let view = (
+            self.cur_d.borrow(),
+            self.cur_t.borrow(),
+            self.cur_r.borrow(),
+        );
+        if indexed::length_in_words(&view) >= OUTPUT_TARGET_WORDS {
+            self.flush_aligned();
+        }
+    }
+
+    /// Serialize the SoA accumulator into a `Column::Align` via `indexed::encode`, which
+    /// builds the buffer with `Vec::push`/`extend_from_slice` so no memory is initialized
+    /// twice.
+    #[cold]
+    fn flush_aligned(&mut self) {
+        if self.cur_len == 0 {
+            return;
+        }
+        let cur: <(D, T, R) as Columnar>::Container = (
+            std::mem::take(&mut self.cur_d),
+            std::mem::take(&mut self.cur_t),
+            std::mem::take(&mut self.cur_r),
+        );
+        self.cur_len = 0;
+
+        let mut buf: Vec<u64> = Vec::with_capacity(indexed::length_in_words(&cur.borrow()));
+        indexed::encode(&mut buf, &cur.borrow());
+        self.pending.push_back(Column::Align(buf));
     }
 }
 
 impl<D, T, R> PushInto<(D, T, R)> for ConsolidatingColumnBuilder<D, T, R>
 where
-    D: Data,
-    T: Data,
-    R: Semigroup + 'static,
-    (D, T, R): Columnar,
-    <(D, T, R) as Columnar>::Container: Push<(D, T, R)>,
+    D: Data + Columnar,
+    T: Data + Columnar,
+    R: Semigroup + Columnar + 'static,
+    (D, T, R): Columnar<Container = (D::Container, T::Container, R::Container)>,
 {
-    /// Push an element.
-    ///
-    /// Precondition: `current` is not allocated or has space for at least one element.
+    /// Push an element into the staging buffer; consolidate + drain when full.
     #[inline]
     fn push_into(&mut self, item: (D, T, R)) {
-        let chunk = chunk_capacity::<(D, T, R)>();
-        if self.current.capacity() < chunk * 2 {
-            self.current.reserve(chunk * 2 - self.current.capacity());
-        }
-        self.current.push(item);
-        if self.current.len() == self.current.capacity() {
-            self.consolidate_and_drain(chunk);
+        self.staging.push(item);
+        if self.staging.len() == STAGING_CAP_ITEMS {
+            self.consolidate_and_drain(DRAIN_GRAIN);
         }
     }
 }
 
 impl<D, T, R> ContainerBuilder for ConsolidatingColumnBuilder<D, T, R>
 where
-    D: Data,
-    T: Data,
-    R: Semigroup + 'static,
-    (D, T, R): Columnar,
-    <(D, T, R) as Columnar>::Container: Push<(D, T, R)> + Clone,
+    D: Data + Columnar,
+    T: Data + Columnar,
+    R: Semigroup + Columnar + 'static,
+    (D, T, R): Columnar<Container = (D::Container, T::Container, R::Container)>,
+    <(D, T, R) as Columnar>::Container: Clone,
 {
     type Container = Column<(D, T, R)>;
 
     #[inline]
     fn extract(&mut self) -> Option<&mut Self::Container> {
-        self.column.extract()
+        if let Some(c) = self.pending.pop_front() {
+            self.finished = Some(c);
+            self.finished.as_mut()
+        } else {
+            None
+        }
     }
 
     #[inline]
     fn finish(&mut self) -> Option<&mut Self::Container> {
-        if !self.current.is_empty() {
+        if !self.staging.is_empty() {
+            // `multiple = 1` so any remainder also leaves staging.
             self.consolidate_and_drain(1);
         }
-        self.column.finish()
+        // Trailing partial: ship as `Column::Typed` (no extra serialize copy).
+        if self.cur_len > 0 {
+            let cur: <(D, T, R) as Columnar>::Container = (
+                std::mem::take(&mut self.cur_d),
+                std::mem::take(&mut self.cur_t),
+                std::mem::take(&mut self.cur_r),
+            );
+            self.cur_len = 0;
+            self.pending.push_back(Column::Typed(cur));
+        }
+        self.extract()
     }
 }
 
@@ -198,14 +279,28 @@ mod tests {
     #[mz_ore::test]
     fn consolidates_on_threshold() {
         let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
-        let chunk = chunk_capacity::<(u64, u64, i64)>();
-        // Push enough +1/-1 pairs to exceed `chunk * 2` and trigger several consolidation
-        // cycles. Everything cancels.
-        for _ in 0..(chunk * 4) {
+        // Push enough +1/-1 pairs to exceed `STAGING_CAP_ITEMS * 2` and trigger several
+        // consolidation cycles. Everything cancels in the staging buffer before ever reaching
+        // the SoA accumulator.
+        for _ in 0..(STAGING_CAP_ITEMS * 4) {
             builder.push_into((7u64, 0u64, 1i64));
             builder.push_into((7u64, 0u64, -1i64));
         }
         assert!(drain(builder).is_empty());
+    }
+
+    #[mz_ore::test]
+    fn cross_batch_consolidation() {
+        // A single key pushed many times must collapse to one row even across many staging
+        // refills. The drain-multiple-of-grain trick keeps the in-progress consolidated row
+        // in staging so subsequent pushes merge into it.
+        let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
+        let n: i64 = 100_000;
+        for _ in 0..n {
+            builder.push_into((42u64, 0u64, 1i64));
+        }
+        let out = drain(builder);
+        assert_eq!(out, vec![(42, 0, n)]);
     }
 
     #[mz_ore::test]
@@ -222,9 +317,10 @@ mod tests {
     #[mz_ore::test]
     fn emits_multiple_containers() {
         let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
-        // Enough distinct rows to force the inner ColumnBuilder past its ~2MB threshold and mint
-        // multiple containers. Each row is 24 bytes; 200_000 rows ≈ 4.8MB raw.
-        let n: u64 = 200_000;
+        // Enough distinct rows to fill the SoA accumulator past the output target multiple
+        // times. Each row is 24 bytes; ~87k rows ≈ 2 MiB, so 300k pushes should mint at least
+        // 2-3 aligned containers plus a typed partial on `finish`.
+        let n: u64 = 300_000;
         for d in 0..n {
             builder.push_into((d, 0u64, 1i64));
         }

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -28,6 +28,24 @@ use timely::container::{ContainerBuilder, PushInto};
 use crate::columnar::Column;
 use crate::columnar::builder::ColumnBuilder;
 
+/// Target size in bytes for the staging buffer chunk.
+///
+/// Larger than `timely::container::buffer::default_capacity` (8 KiB) to amortize the cost of
+/// minting aligned columnar containers. Matches `ColumnationChunker` in `crate::columnation`.
+const BUFFER_SIZE_BYTES: usize = 64 << 10;
+
+/// Number of `(D, T, R)` items that fit in [`BUFFER_SIZE_BYTES`], or 1 for oversized tuples.
+const fn chunk_capacity<C>() -> usize {
+    let size = std::mem::size_of::<C>();
+    if size == 0 {
+        BUFFER_SIZE_BYTES
+    } else if size <= BUFFER_SIZE_BYTES {
+        BUFFER_SIZE_BYTES / size
+    } else {
+        1
+    }
+}
+
 /// A container builder that consolidates `(D, T, R)` updates and emits `Column<(D, T, R)>`.
 ///
 /// Buffers updates in an internal `Vec`, calls
@@ -38,9 +56,6 @@ use crate::columnar::builder::ColumnBuilder;
 /// Does **not** maintain FIFO ordering (consolidation reorders updates).
 pub struct ConsolidatingColumnBuilder<D, T, R>
 where
-    D: Data,
-    T: Data,
-    R: Semigroup + 'static,
     (D, T, R): Columnar,
 {
     /// Pre-consolidation staging buffer.
@@ -51,9 +66,6 @@ where
 
 impl<D, T, R> Default for ConsolidatingColumnBuilder<D, T, R>
 where
-    D: Data,
-    T: Data,
-    R: Semigroup + 'static,
     (D, T, R): Columnar,
 {
     fn default() -> Self {
@@ -97,14 +109,13 @@ where
     /// Precondition: `current` is not allocated or has space for at least one element.
     #[inline]
     fn push_into(&mut self, item: (D, T, R)) {
-        let preferred_capacity = timely::container::buffer::default_capacity::<(D, T, R)>();
-        if self.current.capacity() < preferred_capacity * 2 {
-            self.current
-                .reserve(preferred_capacity * 2 - self.current.capacity());
+        let chunk = chunk_capacity::<(D, T, R)>();
+        if self.current.capacity() < chunk * 2 {
+            self.current.reserve(chunk * 2 - self.current.capacity());
         }
         self.current.push(item);
         if self.current.len() == self.current.capacity() {
-            self.consolidate_and_drain(preferred_capacity);
+            self.consolidate_and_drain(chunk);
         }
     }
 }
@@ -187,10 +198,10 @@ mod tests {
     #[mz_ore::test]
     fn consolidates_on_threshold() {
         let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
-        let preferred = timely::container::buffer::default_capacity::<(u64, u64, i64)>();
-        // Push enough +1/-1 pairs to exceed `preferred * 2` and trigger several consolidation
+        let chunk = chunk_capacity::<(u64, u64, i64)>();
+        // Push enough +1/-1 pairs to exceed `chunk * 2` and trigger several consolidation
         // cycles. Everything cancels.
-        for _ in 0..(preferred * 4) {
+        for _ in 0..(chunk * 4) {
             builder.push_into((7u64, 0u64, 1i64));
             builder.push_into((7u64, 0u64, -1i64));
         }

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -22,11 +22,12 @@
 //!    column-shaped storage. A drain-multiple-of-half-cap trick keeps the leftover in staging,
 //!    so cross-batch keys with the same `(D, T)` continue consolidating on the next sort.
 //! 2. SoA accumulator: one sub-container per column (`D::Container`, `T::Container`,
-//!    `R::Container`). Drains from staging do three sequential passes (one per column), so
-//!    each pass writes a single cache-line stream. When the accumulator reaches the output
-//!    target byte size, it serializes into an aligned `Vec<u64>` (no zero-fill — written
-//!    exactly once by `indexed::write`) and ships as `Column::Align`. The trailing partial on
-//!    `finish` ships as `Column::Typed` to avoid one final serialize copy.
+//!    `R::Container`). Drains push in fixed-size chunks (`DRAIN_CHUNK_ROWS`) with three
+//!    sequential per-column passes per chunk, so the inner pushes autovectorize. After each
+//!    chunk, check the serialized size; once the accumulator reaches the flush threshold
+//!    (90% of `OUTPUT_TARGET_WORDS`), serialize into an aligned `Vec<u64>` (no zero-fill —
+//!    written by `indexed::encode`) and ship as `Column::Align`. Per-chunk granularity bounds
+//!    overshoot to `K * row_words`. The trailing partial on `finish` ships as `Column::Typed`.
 //!
 //! Generic over `(D, T, R): Columnar` via the columnar tuple decomposition
 //! `<(D, T, R) as Columnar>::Container = (D::Container, T::Container, R::Container)`.
@@ -48,17 +49,28 @@ const STAGING_CAP_ITEMS: usize = 16 * 1024;
 /// Drain a multiple of this on consolidate. Remainder stays in staging so cross-batch keys
 /// keep consolidating on the next sort.
 const DRAIN_GRAIN: usize = STAGING_CAP_ITEMS / 2;
-/// Target serialized size for output `Column::Align` chunks, in u64 words.
-/// 2 MiB matches the existing `ColumnBuilder` heuristic.
-const OUTPUT_TARGET_WORDS: usize = (2 << 20) / 8;
+/// Target serialized chunk size in u64 words (2 MiB). Bounded slop matters once we put these
+/// behind huge pages.
+const OUTPUT_TARGET_WORDS: usize = 1 << 18;
+/// Flush when within 10% of `OUTPUT_TARGET_WORDS` — matches `ColumnBuilder`'s slop heuristic.
+/// Computed at compile time so the hot loop is a single `cmp`/`jae` instead of a per-row
+/// round-up + divide-by-10.
+const FLUSH_THRESHOLD_WORDS: usize = OUTPUT_TARGET_WORDS - OUTPUT_TARGET_WORDS / 10;
+/// Drain rows from staging in chunks of this size. Inside each chunk we do three sequential
+/// per-column passes — long enough for autovectorization (4–8 vector iterations on NEON / SVE2
+/// 128-bit / AVX2 / SVE 256-bit) — while the outer per-chunk size check bounds overshoot to
+/// `K * row_words`. With a 1 KiB row (128 words) and K=16, worst-case overshoot is 2 KiB,
+/// well under the 10% slop budget on a 2 MiB target.
+const DRAIN_CHUNK_ROWS: usize = 16;
 
 /// A container builder that consolidates `(D, T, R)` updates and emits `Column<(D, T, R)>`.
 ///
 /// Stages updates in an AoS `Vec` for in-place consolidation, then drains consolidated rows
-/// in three sequential passes into SoA sub-containers. When the SoA accumulator reaches
-/// `OUTPUT_TARGET_WORDS` worth of serialized bytes, it is written into an aligned `Vec<u64>`
-/// (using `indexed::write` over uninitialized memory — no zero-fill) and queued as
-/// `Column::Align`. The trailing partial on `finish` ships as `Column::Typed`.
+/// in `DRAIN_CHUNK_ROWS`-sized chunks (three sequential per-column passes per chunk) into SoA
+/// sub-containers, flushing whenever the accumulator hits the flush threshold (90% of
+/// `OUTPUT_TARGET_WORDS`). Flushed accumulators are written into aligned `Vec<u64>` (via
+/// `indexed::encode`, no zero-fill) and queued as `Column::Align`. The trailing partial on
+/// `finish` ships as `Column::Typed`.
 ///
 /// Does **not** maintain FIFO ordering (consolidation reorders updates).
 pub struct ConsolidatingColumnBuilder<D, T, R>
@@ -110,7 +122,10 @@ where
     (D, T, R): Columnar<Container = (D::Container, T::Container, R::Container)>,
 {
     /// Sort and consolidate `staging`, then drain a multiple-of-`grain` prefix into the SoA
-    /// accumulator. Pass `1` to drain everything (used by `finish`).
+    /// accumulator. Pass `1` to drain everything (used by `finish`). Pushes in chunks of
+    /// `DRAIN_CHUNK_ROWS` and flushes mid-drain whenever the accumulator hits
+    /// `FLUSH_THRESHOLD_WORDS`, so a single drain can mint several aligned containers when the
+    /// prefix is large.
     #[cold]
     fn consolidate_and_drain(&mut self, grain: usize) {
         consolidate_updates(&mut self.staging);
@@ -119,32 +134,40 @@ where
             return;
         }
 
-        // Three sequential passes — one per column. Each pass writes a single cache-line stream
-        // and is branch-free (the sub-containers' `push` only checks per-call capacity).
-        let head = &self.staging[..drain_n];
-        for (d, _, _) in head {
-            self.cur_d.push(d);
-        }
-        for (_, t, _) in head {
-            self.cur_t.push(t);
-        }
-        for (_, _, r) in head {
-            self.cur_r.push(r);
-        }
-        self.cur_len += drain_n;
-        self.staging.drain(..drain_n);
+        // Drain in chunks of `DRAIN_CHUNK_ROWS` rows. Three sequential per-column passes inside
+        // the chunk give the compiler streamable loops it can autovectorize for primitive
+        // containers; the per-chunk size check bounds overshoot of the 90%-of-2-MiB threshold to
+        // ~`K * row_words`. After each chunk, check the serialized size (via `length_in_words`,
+        // not item count, so output Columns stay bounded for variable-width `D` like `Row`).
+        let mut consumed = 0;
+        while consumed < drain_n {
+            let take = (drain_n - consumed).min(DRAIN_CHUNK_ROWS);
+            let head = &self.staging[consumed..consumed + take];
+            for (d, _, _) in head {
+                self.cur_d.push(d);
+            }
+            for (_, t, _) in head {
+                self.cur_t.push(t);
+            }
+            for (_, _, r) in head {
+                self.cur_r.push(r);
+            }
+            self.cur_len += take;
+            consumed += take;
 
-        // Check serialized size; if past the target, flush as aligned bytes. Using
-        // `length_in_words` rather than item count gives bounded output Columns regardless of
-        // variable-width `D` (e.g. `Row` rows of varying length).
-        let view = (
-            self.cur_d.borrow(),
-            self.cur_t.borrow(),
-            self.cur_r.borrow(),
-        );
-        if indexed::length_in_words(&view) >= OUTPUT_TARGET_WORDS {
-            self.flush_aligned();
+            let words = {
+                let view = (
+                    self.cur_d.borrow(),
+                    self.cur_t.borrow(),
+                    self.cur_r.borrow(),
+                );
+                indexed::length_in_words(&view)
+            };
+            if words >= FLUSH_THRESHOLD_WORDS {
+                self.flush_aligned();
+            }
         }
+        self.staging.drain(..consumed);
     }
 
     /// Serialize the SoA accumulator into a `Column::Align` via `indexed::encode`, which


### PR DESCRIPTION
### Motivation

Infrastructure for the columnar rendering migration. Today, render operators that produce updates use `differential_dataflow::consolidation::ConsolidatingContainerBuilder<Vec<(D, T, R)>>`, which emits `Vec<(D, T, R)>` containers. Downstream operators want `Column<(D, T, R)>`, so we currently re-convert around every operator. This PR adds a builder that consolidates and emits columnar containers directly. No call sites change here.

### Description

`ConsolidatingColumnBuilder<D, T, R>` lives in `src/timely-util/src/columnar/consolidate.rs`. It vendors DD's staging-buffer logic — lazy `Vec` reserve to `2 * default_capacity::<(D, T, R)>()`, `consolidate_updates` when full, drain the largest multiple-of-`preferred_capacity` prefix — and pushes the survivors into an inner `ColumnBuilder<(D, T, R)>`. The inner builder handles ~2MB-aligned chunking, so we don't manage that here.

`extract` delegates to the inner builder (does not flush partial state, matching DD). `finish` drains everything that survives consolidation, then delegates to the inner `finish`.

Not length-preserving — consolidation may drop tuples with diff that sums to zero — so no `LengthPreservingContainerBuilder` impl. Reusing drained `current` capacity is left for a later pass; behavior matches DD first.

### Verification

Five new unit tests in the module: empty `finish`, single-push round-trip, threshold-triggered consolidation (all `+1`/`-1` cancel), multi-key consolidation, and forced emission of multiple inner containers. `cargo test -p mz-timely-util` passes.