### PR TITLE
storage: gate upsert v2 batcher seal on eligibility preconditions

### DIFF
--- a/src/storage/src/upsert_continual_feedback_v2.rs
+++ b/src/storage/src/upsert_continual_feedback_v2.rs
@@ -397,9 +397,34 @@ where
             //     lookup on the persist trace.
             //   - Ineligible (persist_upper < ts < input_upper): persist
             //     hasn't caught up yet; pushed back into the batcher.
-            if stash_cap.is_some() {
-                let cap = stash_cap.as_mut().unwrap();
-
+            //
+            // We skip the seal entirely unless an eligible entry is at all
+            // possible. `seal` performs an O(N) merge of all chains
+            // regardless of how much it extracts, so calling it when nothing
+            // can be processed makes the operator quadratic in the number of
+            // wakeups (a real pathology during upstream snapshots and during
+            // rehydration when the source races ahead of persist).
+            //
+            // For an entry at `ts` to be eligible we need
+            // `ts == persist_upper && ts < input_upper`. The necessary
+            // preconditions, expressible without scanning the batcher:
+            //   1. `cap.time() <= persist_upper`. Since `cap.time()` is
+            //      maintained as a lower bound on `min(ts in batcher)`, if
+            //      `cap.time() > persist_upper` then every buffered ts is
+            //      strictly above persist_upper and none can equal it.
+            //   2. `persist_upper < input_upper`. Otherwise no `ts` that
+            //      satisfies `ts == persist_upper` can also satisfy
+            //      `ts < input_upper`.
+            //
+            // This naturally covers both the post-hydration source-snapshot
+            // case (cap == persist == input → condition 2 fails) and the
+            // rehydration-with-source-ahead case (cap > persist → condition
+            // 1 fails). It also no-ops correctly when persist has shut down
+            // (empty persist_upper makes condition 2 vacuously false).
+            if let Some(cap) = stash_cap.as_mut()
+                && !persist_upper.less_than(cap.time())
+                && PartialOrder::less_than(&persist_upper, &input_upper)
+            {
                 let sealed = batcher.seal::<CapturingBuilder<_, _>>(input_upper.clone());
                 // Frontier of data remaining in the batcher (ts >= input_upper).
                 let remaining_frontier = batcher.frontier().to_owned();


### PR DESCRIPTION
upsert_continual_feedback_v2 called MergeBatcher::seal on every wakeup whenever the source stash was non-empty. seal performs an O(N) merge of all chains regardless of how much it extracts, so during upstream snapshots — where input_upper sits at T0 while data piles up at ts=T0 — the operator burned O(N²) work merging-then-extracting-nothing, making snapshot CPU-bound.

Skip the seal unless an eligible entry is at all possible. For an entry at ts to be eligible we need ts == persist_upper && ts < input_upper, so the necessary preconditions are:
  1. cap.time() <= persist_upper (cap.time() lower-bounds min(ts)).
  2. persist_upper < input_upper.

The same expression covers both the post-hydration source-snapshot case (cap == persist == input → #2 fails) and the rehydration- with-source-ahead case (cap > persist → #1 fails).

Remove these sections if your commit already has a good description!

### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
