### PR TITLE
docs: collapse blank-line runs in gen-claude-skill output

### DIFF
--- a/bin/gen-claude-skill
+++ b/bin/gen-claude-skill
@@ -54,6 +54,17 @@ if [[ -f "$OUTPUT_DIR/index.md" ]]; then
     mv "$OUTPUT_DIR/index.md" "$OUTPUT_DIR/SKILL.md"
 fi
 
+# Collapse runs of consecutive blank lines down to a single blank line.
+# Hugo emits a blank line in place of each stripped shortcode/template
+# directive, which produces long runs around <table>/<tr>/<td> blocks
+# in pages like ingest-data/mysql/* and self-managed-deployments/*.
+find "$OUTPUT_DIR" -name '*.md' -type f -print0 | while IFS= read -r -d '' f; do
+    awk '
+        /^[[:space:]]*$/ { if (blank) next; blank = 1; print ""; next }
+        { blank = 0; print }
+    ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+done
+
 # Count generated files
 FILE_COUNT=$(find "$OUTPUT_DIR" -name "*.md" | wc -l | tr -d ' ')
 


### PR DESCRIPTION
## Summary

Hugo strips shortcode and template directives during skill generation but leaves the surrounding newlines, producing long runs of blank lines in the output. The effect is most visible around `<table>`/`<tr>`/`<td>` blocks in pages like `ingest-data/mysql/*` and the self-managed-deployment configuration tables, where ~30% of file lines were excess blanks.

## Motivation

In `MaterializeInc/agent-skills`, this skill is regenerated and committed by an automated workflow. The blank-line noise dominates the diff in regen PRs ([example](https://github.com/MaterializeInc/agent-skills/pull/9/files)) and makes them hard to review. Across the 518 generated files, the worst offenders were:

| % excess blanks | File |
|---:|---|
| 39% | `self-managed-deployments/operator-configuration/index.md` |
| 32% | `sql/create-source/mysql/index.md` |
| 30% | `ingest-data/mysql/{azure-db,google-cloud-sql,self-hosted}/index.md` |

## Change

Add a post-Hugo `awk` pass to `bin/gen-claude-skill` that collapses runs of 2+ blank lines (whitespace-only lines) down to a single blank line. ~13k lines removed across 518 files; semantic markdown content is unchanged.

Verified locally by running `bin/gen-claude-skill` and inspecting the affected pages — table content reads cleanly with single blank lines between rows.
