### PR TITLE
Console [CNS-34]: Tanstack table in the console

### DIFF
--- a/console/doc/guide-tanstack-table.md
+++ b/console/doc/guide-tanstack-table.md
@@ -1,0 +1,482 @@
+# TanStack Table Guide
+
+How to build interactive data tables in the console with sorting, search, and pagination.
+
+## Overview
+
+The console uses [TanStack Table](https://tanstack.com/table/latest) (v8) — a headless library that provides table logic (sorting, filtering, pagination, global search) without controlling rendering. We pair it with Chakra UI components for the visuals.
+
+## Files
+
+Everything lives in [`src/components/Table/`](../src/components/Table/). Import directly from each module:
+
+| File | Purpose |
+| --- | --- |
+| `useUniversalTable.ts` | React hook wrapping TanStack's `useReactTable`; also exports `getInitialTableState` for URL-driven initial state |
+| `UniversalTable.tsx` | Renders the table with Chakra UI |
+| `TableSearch.tsx` | Debounced global search input |
+| `TablePagination.tsx` | Page count text and prev/next buttons; auto-hides on a single page |
+| `tableColumnBuilders.ts` | `sortingFunctions.nullsLast` and `globalTextFilter` |
+| `tableTypes.ts` | TypeScript interfaces and `ColumnMeta` augmentation |
+
+## Quick start
+
+The examples in this guide use a simple `User` type so the patterns are easy to follow. Substitute your own type when adapting them.
+
+```tsx
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: "admin" | "member";
+  createdAt: string; // ISO date
+}
+```
+
+### Basic table with sorting
+
+A minimal sortable table. Click any column header to sort.
+
+```tsx
+import { createColumnHelper } from "@tanstack/react-table";
+import { UniversalTable } from "~/components/Table/UniversalTable";
+import { useUniversalTable } from "~/components/Table/useUniversalTable";
+
+const columnHelper = createColumnHelper<User>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    header: "Name",
+    sortingFn: "alphanumeric",
+  }),
+  columnHelper.accessor("email", {
+    header: "Email",
+    sortingFn: "alphanumeric",
+  }),
+];
+
+export const UserList = ({ users }: { users: User[] }) => {
+  const table = useUniversalTable({ data: users, columns });
+  return <UniversalTable table={table} />;
+};
+```
+
+### Full-featured table with search, pagination, and clickable rows
+
+A typical list page: search across columns, paginate at 25 rows, and navigate on row click.
+
+```tsx
+import { VStack } from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
+import { TablePagination } from "~/components/Table/TablePagination";
+import { TableSearch } from "~/components/Table/TableSearch";
+import { UniversalTable } from "~/components/Table/UniversalTable";
+import { useUniversalTable } from "~/components/Table/useUniversalTable";
+
+export const UserList = ({ users }: { users: User[] }) => {
+  const navigate = useNavigate();
+  const table = useUniversalTable({
+    data: users,
+    columns,
+    initialSorting: [{ id: "name", desc: false }],
+    pageSize: 25,
+  });
+
+  return (
+    <VStack spacing={4} align="stretch">
+      <TableSearch
+        onValueChange={table.setGlobalFilter}
+        placeholder="Search users..."
+      />
+      <UniversalTable
+        table={table}
+        variant="linkable"
+        onRowClick={(user) => navigate(`/users/${user.id}`)}
+        isLoading={!users}
+      />
+      <TablePagination table={table} itemLabel="users" />
+    </VStack>
+  );
+};
+```
+
+## Important: keep `columns` static
+
+This is the most common bug when working with TanStack Table. **Don't put dynamic data in the `columns` `useMemo` dependency array.** Doing so causes the entire table to remount on every change, which breaks tooltips, popovers, and other interactive elements inside cells.
+
+
+// columns are static. Read dynamic data inside the cell renderer.
+const columns = React.useMemo(
+  () => [
+    columnHelper.accessor("name", {
+      cell: (info) => <UserNameCell user={info.row.original} />,
+    }),
+  ],
+  [],
+);
+
+const UserNameCell = ({ user }: { user: User }) => {
+  const userStatus = useUserStatus();
+  return (
+    <HStack>
+      <Text>{user.name}</Text>
+      {userStatus.data?.[user.id]?.isOnline && <OnlineIcon />}
+    </HStack>
+  );
+};
+```
+
+
+## Column patterns
+
+### Custom cell rendering
+
+Cells can render any React content. Use `info.getValue()` for the cell value or `info.row.original` for the full row.
+
+```tsx
+columnHelper.accessor("role", {
+  header: "Role",
+  cell: (info) => (
+    <Badge colorScheme={info.getValue() === "admin" ? "purple" : "gray"}>
+      {info.getValue()}
+    </Badge>
+  ),
+});
+```
+
+### Computed columns
+
+Columns that don't map directly to a field. Use an accessor function with a stable `id`:
+
+```tsx
+columnHelper.accessor((row) => row.email.split("@")[1], {
+  id: "domain",
+  header: "Domain",
+  sortingFn: "alphanumeric",
+});
+```
+
+### Action menu column
+
+A column for `OverflowMenu` actions. Disable sorting and pin a fixed width.
+
+```tsx
+import OverflowMenu, { OVERFLOW_BUTTON_WIDTH } from "~/components/OverflowMenu";
+
+columnHelper.display({
+  id: "actions",
+  header: "",
+  cell: (info) => (
+    <OverflowMenu
+      items={[
+        {
+          visible: info.row.original.role !== "admin",
+          render: () => <DeleteUserMenuItem user={info.row.original} />,
+        },
+      ]}
+    />
+  ),
+  enableSorting: false,
+  size: OVERFLOW_BUTTON_WIDTH,
+});
+```
+
+### Conditional columns
+
+Add or remove columns based on a flag. Wrap the array in `useMemo` — and only depend on the flag, not on changing data.
+
+```tsx
+const columns = React.useMemo(() => {
+  const cols = [
+    columnHelper.accessor("name", { header: "Name" }),
+    columnHelper.accessor("email", { header: "Email" }),
+  ];
+
+  if (showRole) {
+    cols.push(columnHelper.accessor("role", { header: "Role" }));
+  }
+
+  return cols;
+}, [showRole]);
+```
+
+### Date and timestamp columns
+
+Format inside the cell renderer; sort with `"datetime"` for `Date` objects or `"basic"` for ISO strings.
+
+```tsx
+import {
+  formatDate,
+  FRIENDLY_DATETIME_FORMAT_NO_SECONDS,
+} from "~/utils/dateFormat";
+
+columnHelper.accessor("createdAt", {
+  header: "Created",
+  sortingFn: "basic",
+  cell: (info) =>
+    formatDate(info.getValue(), FRIENDLY_DATETIME_FORMAT_NO_SECONDS),
+});
+```
+
+### Header tooltips and responsive widths
+
+The `meta` field carries metadata consumed by `UniversalTable`:
+
+```tsx
+columnHelper.accessor("role", {
+  header: "Role",
+  meta: {
+    tooltip: "Whether the user can manage other users",
+    minWidth: { md: "120px", sm: "auto" },
+  },
+});
+```
+
+This adds an info icon next to the header text and applies a responsive `min-width`.
+
+### Nullable columns
+
+Use `sortingFunctions.nullsLast` so empty values don't get jumbled with real ones:
+
+```tsx
+import { sortingFunctions } from "~/components/Table/tableColumnBuilders";
+
+columnHelper.accessor("lastLoginAt", {
+  header: "Last login",
+  sortingFn: sortingFunctions.nullsLast,
+  cell: (info) => info.getValue() ?? "Never",
+});
+```
+
+> **Note:** TanStack inverts the comparison for descending sort, so nulls move to the top in descending order. Either way, nulls stay grouped together.
+
+## Sorting functions
+
+Use TanStack's built-ins whenever possible:
+
+| `sortingFn` | When to use |
+| --- | --- |
+| `"alphanumeric"` | Strings that may contain numbers (handles "item2" vs "item10") |
+| `"text"` | Plain case-insensitive text — faster than `alphanumeric` |
+| `"basic"` | Numbers, booleans, dates — simple `<` / `>` comparison |
+| `"datetime"` | `Date` objects |
+| `sortingFunctions.nullsLast` | Any column where the value can be `null` / `undefined` |
+
+For one-off custom logic, pass an inline function:
+
+```tsx
+columnHelper.accessor("name", {
+  header: "Name",
+  sortingFn: (rowA, rowB, columnId) => {
+    const a = rowA.getValue<string>(columnId);
+    const b = rowB.getValue<string>(columnId);
+    return a.localeCompare(b, undefined, { numeric: true });
+  },
+});
+```
+
+## API reference
+
+### `useUniversalTable(options)`
+
+Wraps TanStack's `useReactTable` with the core, sorted, filtered, and paginated row models pre-wired. Pass any TanStack option directly. Convenience shorthands:
+
+| Option | Description |
+| --- | --- |
+| `data` | Array of rows. Required. |
+| `columns` | Array of column definitions. Required. |
+| `initialSorting` | Shorthand for `initialState.sorting`. |
+| `pageSize` | Shorthand for `initialState.pagination.pageSize`. Defaults to `25`. |
+
+Returns a TanStack `Table` instance. Use its native API — `table.getState()`, `table.setGlobalFilter("foo")`, `table.previousPage()`, etc. See the [TanStack docs](https://tanstack.com/table/v8/docs/api/core/table).
+
+### `<UniversalTable />`
+
+| Prop | Description |
+| --- | --- |
+| `table` | The instance returned by `useUniversalTable`. Required. |
+| `variant` | Chakra table variant. Defaults to `"linkable"`. See [Variants](#variants). |
+| `onRowClick` | Callback receiving the row's data when clicked. |
+| `isLoading` | When `true`, renders skeleton rows in place of data. |
+| `skeletonRowCount` | Number of skeleton rows. Defaults to `5`. |
+| `data-testid` | Forwarded to the root `<Table>` element. |
+
+```tsx
+<UniversalTable
+  table={table}
+  variant="linkable"
+  onRowClick={(user) => navigate(`/users/${user.id}`)}
+  isLoading={!users}
+/>
+```
+
+### `<TableSearch />`
+
+A debounced global search input. The component is **uncontrolled** — `initialValue` is read once on mount. To programmatically reset the input, pass a different `key` prop.
+
+| Prop | Description |
+| --- | --- |
+| `onValueChange` | Called with the new value after the debounce window. Required. |
+| `initialValue` | Initial input value. Defaults to `""`. |
+| `placeholder` | Defaults to `"Search"`. |
+| `debounceMs` | Debounce delay. Defaults to `250`. |
+
+```tsx
+<TableSearch
+  onValueChange={table.setGlobalFilter}
+  placeholder="Search users..."
+/>
+```
+
+The default `globalTextFilter` matches across every cell's stringified value. Override by passing `globalFilterFn` to `useUniversalTable`.
+
+### `<TablePagination />`
+
+Renders page count text and prev/next buttons. Auto-hides when `pageCount <= 1`.
+
+| Prop | Description |
+| --- | --- |
+| `table` | The table instance. Required. |
+| `itemLabel` | Label used in "Showing X-Y of Z {itemLabel}". Defaults to `"results"`. Accepts `ReactNode`. |
+
+```tsx
+<TablePagination table={table} itemLabel="users" />
+```
+
+Renders something like: `Showing 1-25 of 87 users    [<]  1 of 4  [>]`
+
+## Variants
+
+The `variant` prop maps to the Chakra theme in [`src/theme/components/Table.ts`](../src/theme/components/Table.ts):
+
+| Variant | Use case |
+| --- | --- |
+| `"linkable"` *(default)* | Rows are clickable and navigate somewhere |
+| `"standalone"` | Read-only data display, no row interaction |
+| `"borderless"` | Embedded inside a card or other container |
+| `"shell"` | Terminal-style listings |
+| `"rounded"` | Plain bordered table |
+
+## URL state sync
+
+Reflect sort, page, and search in the URL so users can bookmark or share table views. Two pieces:
+
+- **Read:** `getInitialTableState` parses the URL once and seeds `useUniversalTable`'s initial state.
+- **Write:** the project-wide [`useSyncObjectToSearchParams`](../src/hooks/useSyncObjectToSearchParams.ts) hook (same pattern as `useConnectorListSortOptions` and `QueryHistoryList`) writes state changes back.
+
+```tsx
+import React from "react";
+import { useSyncObjectToSearchParams } from "~/hooks/useSyncObjectToSearchParams";
+import { UniversalTable } from "~/components/Table/UniversalTable";
+import {
+  getInitialTableState,
+  useUniversalTable,
+} from "~/components/Table/useUniversalTable";
+
+export const UserList = ({ users }: { users: User[] }) => {
+  // Read URL once on mount — feeds initial state, no flicker.
+  const initial = React.useMemo(
+    () => getInitialTableState(window.location.search),
+    [],
+  );
+
+  const table = useUniversalTable({
+    data: users,
+    columns,
+    initialSorting: initial.sorting ?? [{ id: "name", desc: false }],
+    pageSize: 25,
+    initialState: {
+      pagination: { pageIndex: initial.pageIndex ?? 0, pageSize: 25 },
+      globalFilter: initial.globalFilter ?? "",
+    },
+  });
+
+  // Write current state back whenever it changes.
+  const { sorting, pagination, globalFilter } = table.getState();
+  useSyncObjectToSearchParams(
+    React.useMemo(
+      () => ({
+        sort: sorting[0]?.id,
+        dir: sorting[0]?.desc ? "desc" : "asc",
+        page: pagination.pageIndex + 1,
+        q: globalFilter,
+      }),
+      [sorting, pagination.pageIndex, globalFilter],
+    ),
+  );
+
+  return <UniversalTable table={table} />;
+};
+```
+
+URL format: `?sort=name&dir=asc&page=2&q=ada`
+
+## Migrating an existing table
+
+A typical Chakra-only list page has a manual `.map()` over rows. To migrate:
+
+1. Define a `columnHelper` typed to your row type
+2. Translate each `<Th>` / `<Td>` pair into a column definition with `header` and (if needed) `cell`
+3. Replace the `<Table>` JSX with `<UniversalTable>`
+4. Optionally add `<TableSearch>` and `<TablePagination>`
+
+**Before:**
+
+```tsx
+<Table variant="linkable">
+  <Thead>
+    <Tr>
+      <Th>Name</Th>
+      <Th>Email</Th>
+    </Tr>
+  </Thead>
+  <Tbody>
+    {users.map((u) => (
+      <Tr key={u.id} onClick={() => navigate(`/users/${u.id}`)}>
+        <Td>{u.name}</Td>
+        <Td>{u.email}</Td>
+      </Tr>
+    ))}
+  </Tbody>
+</Table>
+```
+
+**After:**
+
+```tsx
+const columnHelper = createColumnHelper<User>();
+const columns = [
+  columnHelper.accessor("name", { header: "Name", sortingFn: "alphanumeric" }),
+  columnHelper.accessor("email", { header: "Email", sortingFn: "alphanumeric" }),
+];
+
+const UserList = ({ users }: { users: User[] }) => {
+  const navigate = useNavigate();
+  const table = useUniversalTable({ data: users, columns });
+  return (
+    <UniversalTable
+      table={table}
+      onRowClick={(u) => navigate(`/users/${u.id}`)}
+    />
+  );
+};
+```
+
+You get sorting for free. Render `<TableSearch>` and `<TablePagination>` to add search and pagination.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Tooltips disappear / table flickers when data refreshes | Dynamic dependencies in your `columns` `useMemo`. See [Important: keep columns static](#important-keep-columns-static). |
+| Column header doesn't respond to clicks | Missing `sortingFn` on the column, or `enableSorting: false`. |
+| Search returns no matches | The default `globalTextFilter` checks all cells via `String()`. Custom values without a sensible string representation won't match — pass a custom `globalFilterFn` or normalize the value in the accessor. |
+| Pagination buttons don't appear | Your data fits in one page. `TablePagination` auto-hides. Use a smaller `pageSize` to test. |
+| TypeScript error about `SortingFn<unknown>` | Cast the column's `sortingFn` to `SortingFn<YourType>`, or rely on `sortingFunctions` (already typed for any data type). |
+| Action column shows a sort indicator | Set `enableSorting: false` on the column. |
+
+## Running the tests
+
+```bash
+yarn test src/components/Table/
+```

--- a/console/package.json
+++ b/console/package.json
@@ -56,6 +56,7 @@
     "@stripe/stripe-js": "^7.1.0",
     "@tanstack/react-query": "^5.95.0",
     "@tanstack/react-query-devtools": "^5.95.0",
+    "@tanstack/react-table": "^8.21.3",
     "@types/d3": "^7.4.3",
     "@types/d3-graphviz": "^2.6.10",
     "@types/debug": "^4.1.12",

--- a/console/src/components/Table/TablePagination.tsx
+++ b/console/src/components/Table/TablePagination.tsx
@@ -1,0 +1,64 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { HStack, IconButton, Text, useTheme } from "@chakra-ui/react";
+import React from "react";
+
+import { ChevronLeftIcon, ChevronRightIcon } from "~/icons";
+import { MaterializeTheme } from "~/theme";
+
+import { TablePaginationProps } from "./tableTypes";
+
+export const TablePagination = <TData,>({
+  table,
+  itemLabel = "results",
+}: TablePaginationProps<TData>) => {
+  const { colors } = useTheme<MaterializeTheme>();
+
+  const pageCount = table.getPageCount();
+  const totalRows = table.getFilteredRowModel().rows.length;
+  const { pageIndex, pageSize } = table.getState().pagination;
+
+  if (pageCount <= 1) return null;
+
+  const from = pageIndex * pageSize + 1;
+  const to = Math.min((pageIndex + 1) * pageSize, totalRows);
+
+  return (
+    <HStack spacing={2} justify="space-between" px={4} py={2}>
+      <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
+        Showing {from.toLocaleString("en-US")}-{to.toLocaleString("en-US")} of{" "}
+        {totalRows.toLocaleString("en-US")} {itemLabel}
+      </Text>
+      <HStack spacing={2}>
+        <IconButton
+          aria-label="Previous page"
+          icon={<ChevronLeftIcon height="4" width="4" />}
+          variant="secondary"
+          minW="8"
+          height="8"
+          isDisabled={!table.getCanPreviousPage()}
+          onClick={() => table.previousPage()}
+        />
+        <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
+          page {pageIndex + 1} of {pageCount}
+        </Text>
+        <IconButton
+          aria-label="Next page"
+          icon={<ChevronRightIcon height="4" width="4" />}
+          variant="secondary"
+          minW="8"
+          height="8"
+          isDisabled={!table.getCanNextPage()}
+          onClick={() => table.nextPage()}
+        />
+      </HStack>
+    </HStack>
+  );
+};

--- a/console/src/components/Table/TableSearch.tsx
+++ b/console/src/components/Table/TableSearch.tsx
@@ -1,0 +1,87 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { SearchIcon } from "@chakra-ui/icons";
+import {
+  Box,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  InputRightElement,
+  useTheme,
+} from "@chakra-ui/react";
+import debounce from "lodash.debounce";
+import React from "react";
+
+import { MaterializeTheme } from "~/theme";
+
+import { TableSearchProps } from "./tableTypes";
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+export const TableSearch = ({
+  initialValue = "",
+  onValueChange,
+  placeholder = "Search",
+  debounceMs = SEARCH_DEBOUNCE_MS,
+}: TableSearchProps) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const [value, setValue] = React.useState(initialValue);
+
+  const debouncedOnChange = React.useMemo(
+    () => debounce(onValueChange, debounceMs),
+    [onValueChange, debounceMs],
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    debouncedOnChange(e.target.value);
+  };
+
+  const handleClear = () => {
+    setValue("");
+    debouncedOnChange.cancel();
+    onValueChange("");
+  };
+
+  return (
+    <Box maxW="md">
+      <InputGroup>
+        <InputLeftElement pointerEvents="none" height="100%">
+          <SearchIcon color={colors.foreground.secondary} />
+        </InputLeftElement>
+        <Input
+          value={value}
+          onChange={handleChange}
+          placeholder={placeholder}
+          aria-label={placeholder}
+          pl={10}
+        />
+        {value && (
+          <InputRightElement height="100%">
+            <IconButton
+              aria-label="Clear search"
+              variant="ghost"
+              size="xs"
+              onClick={handleClear}
+              sx={{
+                fontSize: "sm",
+                color: "foreground.secondary",
+                _hover: { color: "foreground.primary" },
+              }}
+            >
+              &times;
+            </IconButton>
+          </InputRightElement>
+        )}
+      </InputGroup>
+    </Box>
+  );
+};

--- a/console/src/components/Table/UniversalTable.test.tsx
+++ b/console/src/components/Table/UniversalTable.test.tsx
@@ -1,0 +1,294 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { createColumnHelper } from "@tanstack/react-table";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { renderComponent } from "~/test/utils";
+
+import { sortingFunctions } from "./tableColumnBuilders";
+import { TablePagination } from "./TablePagination";
+import { TableSearch } from "./TableSearch";
+import { UniversalTable } from "./UniversalTable";
+import { useUniversalTable } from "./useUniversalTable";
+
+interface TestCluster {
+  id: string;
+  name: string;
+  replicas: number;
+  size: string | null;
+}
+
+const testData: TestCluster[] = [
+  { id: "1", name: "analytics", replicas: 2, size: "25cc" },
+  { id: "2", name: "default", replicas: 1, size: "100cc" },
+  { id: "3", name: "prod", replicas: 3, size: null },
+  { id: "4", name: "staging", replicas: 1, size: "50cc" },
+  { id: "5", name: "batch", replicas: 2, size: "200cc" },
+];
+
+const columnHelper = createColumnHelper<TestCluster>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    header: "Name",
+    sortingFn: "alphanumeric",
+  }),
+  columnHelper.accessor("replicas", {
+    header: "Replicas",
+    sortingFn: "basic",
+  }),
+  columnHelper.accessor("size", {
+    header: "Size",
+    sortingFn: sortingFunctions.nullsLast,
+    cell: (info) => info.getValue() ?? "-",
+    meta: {
+      tooltip: "Cluster size configuration",
+    },
+  }),
+];
+
+const BasicTable = ({ data = testData }: { data?: TestCluster[] }) => {
+  const table = useUniversalTable({ data, columns });
+  return <UniversalTable table={table} data-testid="test-table" />;
+};
+
+const SortableTable = ({
+  data = testData,
+  initialSorting,
+}: {
+  data?: TestCluster[];
+  initialSorting?: { id: string; desc: boolean }[];
+}) => {
+  const table = useUniversalTable({ data, columns, initialSorting });
+  return <UniversalTable table={table} data-testid="test-table" />;
+};
+
+const SearchableTable = ({ data = testData }: { data?: TestCluster[] }) => {
+  const table = useUniversalTable({ data, columns });
+  return (
+    <div>
+      <TableSearch
+        onValueChange={table.setGlobalFilter}
+        placeholder="Search clusters..."
+      />
+      <UniversalTable table={table} data-testid="test-table" />
+    </div>
+  );
+};
+
+const PaginatedTable = ({
+  data = testData,
+  pageSize = 2,
+}: {
+  data?: TestCluster[];
+  pageSize?: number;
+}) => {
+  const table = useUniversalTable({ data, columns, pageSize });
+  return (
+    <div>
+      <UniversalTable table={table} data-testid="test-table" />
+      <TablePagination table={table} itemLabel="clusters" />
+    </div>
+  );
+};
+
+const ClickableTable = ({
+  data = testData,
+  onClick,
+}: {
+  data?: TestCluster[];
+  onClick: (row: TestCluster) => void;
+}) => {
+  const table = useUniversalTable({ data, columns });
+  return (
+    <UniversalTable
+      table={table}
+      data-testid="test-table"
+      onRowClick={onClick}
+    />
+  );
+};
+
+const LoadingTable = () => {
+  const table = useUniversalTable({ data: [], columns });
+  return (
+    <UniversalTable
+      table={table}
+      data-testid="test-table"
+      isLoading
+      skeletonRowCount={3}
+    />
+  );
+};
+
+describe("UniversalTable", () => {
+  describe("Basic Rendering", () => {
+    it("renders column headers", async () => {
+      await renderComponent(<BasicTable />);
+
+      expect(screen.getByText("Name")).toBeInTheDocument();
+      expect(screen.getByText("Replicas")).toBeInTheDocument();
+      expect(screen.getByText("Size")).toBeInTheDocument();
+    });
+
+    it("renders data rows", async () => {
+      await renderComponent(<BasicTable />);
+
+      expect(screen.getByText("analytics")).toBeInTheDocument();
+      expect(screen.getByText("default")).toBeInTheDocument();
+      expect(screen.getByText("prod")).toBeInTheDocument();
+    });
+  });
+
+  describe("Sorting", () => {
+    it("sorts ascending on first header click", async () => {
+      const user = userEvent.setup();
+      await renderComponent(<SortableTable />);
+
+      await user.click(screen.getByText("Name"));
+
+      const rows = screen.getAllByRole("row");
+      expect(rows[1]).toHaveTextContent("analytics");
+      expect(rows[2]).toHaveTextContent("batch");
+      expect(rows[3]).toHaveTextContent("default");
+    });
+
+    it("sorts descending on second header click", async () => {
+      const user = userEvent.setup();
+      await renderComponent(<SortableTable />);
+
+      await user.click(screen.getByText("Name"));
+      await user.click(screen.getByText("Name"));
+
+      const rows = screen.getAllByRole("row");
+      expect(rows[1]).toHaveTextContent("staging");
+      expect(rows[2]).toHaveTextContent("prod");
+    });
+
+    it("applies initial sorting on mount", async () => {
+      await renderComponent(
+        <SortableTable initialSorting={[{ id: "replicas", desc: false }]} />,
+      );
+
+      const rows = screen.getAllByRole("row");
+      expect(rows[1]).toHaveTextContent("default");
+      expect(rows[rows.length - 1]).toHaveTextContent("prod");
+    });
+  });
+
+  describe("Global Filtering", () => {
+    it("filters rows by search text", async () => {
+      const user = userEvent.setup();
+      await renderComponent(<SearchableTable />);
+
+      await user.type(
+        screen.getByPlaceholderText("Search clusters..."),
+        "analytics",
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("analytics")).toBeInTheDocument();
+        expect(screen.queryByText("default")).not.toBeInTheDocument();
+        expect(screen.queryByText("prod")).not.toBeInTheDocument();
+      });
+    });
+
+    it("clears search via the clear button", async () => {
+      const user = userEvent.setup();
+      await renderComponent(<SearchableTable />);
+
+      await user.type(
+        screen.getByPlaceholderText("Search clusters..."),
+        "analytics",
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("default")).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText("Clear search"));
+
+      await waitFor(() => {
+        expect(screen.getByText("analytics")).toBeInTheDocument();
+        expect(screen.getByText("default")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Pagination", () => {
+    it("paginates results and renders count text", async () => {
+      await renderComponent(<PaginatedTable pageSize={2} />);
+
+      const rows = screen.getAllByRole("row");
+      expect(rows).toHaveLength(3); // 1 header + 2 data
+      expect(screen.getByText(/Showing 1-2 of 5 clusters/)).toBeInTheDocument();
+      expect(screen.getByText("page 1 of 3")).toBeInTheDocument();
+    });
+
+    it("navigates between pages with next/previous buttons", async () => {
+      const user = userEvent.setup();
+      await renderComponent(<PaginatedTable pageSize={2} />);
+
+      await user.click(screen.getByLabelText("Next page"));
+      expect(screen.getByText("page 2 of 3")).toBeInTheDocument();
+      expect(screen.getByText(/Showing 3-4 of 5/)).toBeInTheDocument();
+
+      await user.click(screen.getByLabelText("Previous page"));
+      expect(screen.getByText("page 1 of 3")).toBeInTheDocument();
+    });
+
+    it("disables previous button on first page", async () => {
+      await renderComponent(<PaginatedTable pageSize={2} />);
+
+      expect(screen.getByLabelText("Previous page")).toBeDisabled();
+    });
+
+    it("disables next button on last page", async () => {
+      const user = userEvent.setup();
+      await renderComponent(<PaginatedTable pageSize={2} />);
+
+      await user.click(screen.getByLabelText("Next page"));
+      await user.click(screen.getByLabelText("Next page"));
+
+      expect(screen.getByLabelText("Next page")).toBeDisabled();
+    });
+
+    it("hides pagination when data fits on one page", async () => {
+      await renderComponent(<PaginatedTable pageSize={10} />);
+
+      expect(screen.queryByLabelText("Next page")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Previous page")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Row Click", () => {
+    it("calls onRowClick with the row's data", async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+      await renderComponent(<ClickableTable onClick={onClick} />);
+
+      await user.click(screen.getByText("analytics"));
+
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "1", name: "analytics" }),
+      );
+    });
+  });
+
+  describe("Loading State", () => {
+    it("renders skeleton rows when isLoading is true", async () => {
+      await renderComponent(<LoadingTable />);
+
+      expect(screen.getAllByRole("row")).toHaveLength(4); // 1 header + 3 skeletons
+    });
+  });
+});

--- a/console/src/components/Table/UniversalTable.tsx
+++ b/console/src/components/Table/UniversalTable.tsx
@@ -1,0 +1,142 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Skeleton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tooltip,
+  Tr,
+} from "@chakra-ui/react";
+import { flexRender, Header, SortDirection } from "@tanstack/react-table";
+import React from "react";
+
+import { ChevronDownIcon, InfoIcon } from "~/icons";
+
+import { UniversalTableProps } from "./tableTypes";
+
+const SKELETON_ROW_COUNT = 5;
+
+const SortIndicator = ({ direction }: { direction: SortDirection | false }) => {
+  if (!direction) return null;
+  return (
+    <ChevronDownIcon
+      ml={1}
+      aria-hidden="true"
+      transform={direction === "asc" ? "rotate(180deg)" : undefined}
+    />
+  );
+};
+
+const ColumnHeader = <TData,>({
+  header,
+}: {
+  header: Header<TData, unknown>;
+}) => {
+  const tooltip = header.column.columnDef.meta?.tooltip;
+  const canSort = header.column.getCanSort();
+
+  return (
+    <Th
+      key={header.id}
+      sx={{
+        minW: header.column.columnDef.meta?.minWidth,
+        width:
+          header.column.getSize() !== 150 ? header.column.getSize() : undefined,
+        cursor: canSort ? "pointer" : "default",
+        userSelect: canSort ? "none" : undefined,
+      }}
+      onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+    >
+      <Box display="flex" alignItems="center">
+        {header.isPlaceholder
+          ? null
+          : flexRender(header.column.columnDef.header, header.getContext())}
+        {canSort && <SortIndicator direction={header.column.getIsSorted()} />}
+        {tooltip && (
+          <Tooltip label={tooltip} lineHeight={1.2}>
+            <InfoIcon ml={1} />
+          </Tooltip>
+        )}
+      </Box>
+    </Th>
+  );
+};
+
+const LoadingRows = ({
+  columnCount,
+  rowCount,
+}: {
+  columnCount: number;
+  rowCount: number;
+}) => (
+  <>
+    {Array.from({ length: rowCount }).map((_row, rowIndex) => (
+      <Tr key={`skeleton-${rowIndex}`}>
+        {Array.from({ length: columnCount }).map((_col, colIndex) => (
+          <Td key={`skeleton-${rowIndex}-${colIndex}`}>
+            <Skeleton height={4} />
+          </Td>
+        ))}
+      </Tr>
+    ))}
+  </>
+);
+
+export const UniversalTable = <TData,>({
+  table,
+  variant = "linkable",
+  onRowClick,
+  isLoading = false,
+  skeletonRowCount = SKELETON_ROW_COUNT,
+  "data-testid": testId,
+}: UniversalTableProps<TData>) => {
+  const headerGroups = table.getHeaderGroups();
+  const rows = table.getRowModel().rows;
+  const columnCount = table.getAllColumns().length;
+
+  return (
+    <Table variant={variant} data-testid={testId} borderRadius="xl">
+      <Thead>
+        {headerGroups.map((headerGroup) => (
+          <Tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <ColumnHeader key={header.id} header={header} />
+            ))}
+          </Tr>
+        ))}
+      </Thead>
+      <Tbody>
+        {isLoading ? (
+          <LoadingRows columnCount={columnCount} rowCount={skeletonRowCount} />
+        ) : (
+          rows.map((row) => (
+            <Tr
+              key={row.id}
+              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+              sx={{
+                cursor: onRowClick ? "pointer" : undefined,
+              }}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <Td key={cell.id} {...cell.column.columnDef.meta?.cellProps}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Td>
+              ))}
+            </Tr>
+          ))
+        )}
+      </Tbody>
+    </Table>
+  );
+};

--- a/console/src/components/Table/tableColumnBuilders.test.ts
+++ b/console/src/components/Table/tableColumnBuilders.test.ts
@@ -1,0 +1,57 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { Row } from "@tanstack/react-table";
+
+import { sortingFunctions } from "./tableColumnBuilders";
+
+// Helper to create a minimal Row-like object for testing sorting
+const mockRow = (values: Record<string, unknown>) =>
+  ({
+    getValue: (columnId: string) => values[columnId],
+  }) as unknown as Row<unknown>;
+
+describe("sortingFunctions.nullsLast", () => {
+  const sort = sortingFunctions.nullsLast;
+
+  it("sorts strings alphabetically", () => {
+    const a = mockRow({ col: "apple" });
+    const b = mockRow({ col: "banana" });
+    expect(sort(a, b, "col")).toBeLessThan(0);
+  });
+
+  it("sorts numeric-prefixed strings by number, not lexicographically", () => {
+    // e.g. cluster sizes "25cc" should sort before "100cc"
+    const a = mockRow({ col: "25cc" });
+    const b = mockRow({ col: "100cc" });
+    expect(sort(a, b, "col")).toBeLessThan(0);
+  });
+
+  it("sorts numbers correctly", () => {
+    const a = mockRow({ col: 10 });
+    const b = mockRow({ col: 5 });
+    expect(sort(a, b, "col")).toBeGreaterThan(0);
+  });
+
+  it("pushes nullish values to the end", () => {
+    expect(
+      sort(mockRow({ col: "apple" }), mockRow({ col: null }), "col"),
+    ).toBeLessThan(0);
+    expect(
+      sort(mockRow({ col: undefined }), mockRow({ col: "banana" }), "col"),
+    ).toBeGreaterThan(0);
+  });
+
+  it("treats nullish values as equal to each other", () => {
+    expect(sort(mockRow({ col: null }), mockRow({ col: null }), "col")).toBe(0);
+    expect(
+      sort(mockRow({ col: null }), mockRow({ col: undefined }), "col"),
+    ).toBe(0);
+  });
+});

--- a/console/src/components/Table/tableColumnBuilders.ts
+++ b/console/src/components/Table/tableColumnBuilders.ts
@@ -1,0 +1,34 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { Row } from "@tanstack/react-table";
+
+/**
+ * Sorting function that pushes `null` / `undefined` values to the end and
+ * compares the rest with numeric-aware locale collation (so "25cc" sorts
+ * before "100cc" instead of lexicographically).
+ */
+const nullsLast = <TData>(
+  rowA: Row<TData>,
+  rowB: Row<TData>,
+  columnId: string,
+): number => {
+  const a = rowA.getValue(columnId);
+  const b = rowB.getValue(columnId);
+
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+
+  return String(a).localeCompare(String(b), undefined, { numeric: true });
+};
+
+export const sortingFunctions = {
+  nullsLast,
+};

--- a/console/src/components/Table/tableTypes.ts
+++ b/console/src/components/Table/tableTypes.ts
@@ -1,0 +1,78 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { HTMLChakraProps } from "@chakra-ui/react";
+import { RowData, Table } from "@tanstack/react-table";
+import React from "react";
+
+/**
+ * Variants matching the Chakra UI table theme in
+ * `src/theme/components/Table.ts`.
+ */
+export type TableVariant =
+  | "linkable"
+  | "standalone"
+  | "rounded"
+  | "shell"
+  | "borderless";
+
+export interface UniversalTableProps<TData> {
+  /** TanStack table instance returned by `useUniversalTable`. */
+  table: Table<TData>;
+  /** Chakra table variant. Defaults to `"linkable"`. */
+  variant?: TableVariant;
+  /** Callback when a row is clicked. */
+  onRowClick?: (row: TData) => void;
+  /** Show a loading skeleton while data is being fetched. */
+  isLoading?: boolean;
+  /** Number of skeleton rows to display when loading. */
+  skeletonRowCount?: number;
+  /** `data-testid` forwarded to the root `<Table>` element. */
+  "data-testid"?: string;
+}
+
+export interface TablePaginationProps<TData> {
+  table: Table<TData>;
+  /** Pluralized item label, e.g. "clusters". Defaults to `"results"`. */
+  itemLabel?: React.ReactNode;
+}
+
+export interface TableSearchProps {
+  /**
+   * Initial search value. Read once on mount; the component is uncontrolled
+   * thereafter. Pass a `key` prop to force a reset.
+   */
+  initialValue?: string;
+  /** Called with the new search value after the debounce window. */
+  onValueChange: (value: string) => void;
+  /** Placeholder text. Defaults to `"Search"`. */
+  placeholder?: string;
+  /** Debounce delay in milliseconds. Defaults to `250`. */
+  debounceMs?: number;
+}
+
+/**
+ * Adds Chakra-specific fields to TanStack's `ColumnMeta` (tooltip, responsive
+ * width, per-cell Chakra props) that `UniversalTable` reads when rendering.
+ * See `console/doc/guide-tanstack-table.md`.
+ *
+ * `TData` / `TValue` must match TanStack's declaration for interface merging,
+ * even though we don't reference them here.
+ */
+declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    /** Tooltip shown on the column header. */
+    tooltip?: string;
+    /** Responsive min-width for the column (Chakra responsive object). */
+    minWidth?: Record<string, string> | string;
+    /** Chakra props spread onto the `<Td>` for every cell in this column. */
+    cellProps?: HTMLChakraProps<"td">;
+  }
+}

--- a/console/src/components/Table/useUniversalTable.ts
+++ b/console/src/components/Table/useUniversalTable.ts
@@ -1,0 +1,103 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  PaginationState,
+  SortingState,
+  TableOptions,
+  useReactTable,
+} from "@tanstack/react-table";
+import React from "react";
+
+const DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * Thin wrapper around TanStack's `useReactTable` with sensible defaults
+ * for sorting, filtering, and pagination row models. Pass any TanStack
+ * option directly; this hook does not introduce custom `enable*`
+ * wrapper props.
+ *
+ * @see https://tanstack.com/table/v8/docs/api/core/table
+ */
+export const useUniversalTable = <TData>(
+  options: Omit<TableOptions<TData>, "getCoreRowModel"> & {
+    /** Convenience shorthand for `initialState.sorting`. */
+    initialSorting?: SortingState;
+    /** Convenience shorthand for `initialState.pagination.pageSize`. Defaults to 25. */
+    pageSize?: number;
+  },
+) => {
+  const {
+    initialSorting,
+    pageSize = DEFAULT_PAGE_SIZE,
+    ...tableOptions
+  } = options;
+
+  const [sorting, setSorting] = React.useState<SortingState>(
+    initialSorting ?? [],
+  );
+  const [globalFilter, setGlobalFilter] = React.useState<string>(
+    (tableOptions.initialState?.globalFilter as string) ?? "",
+  );
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: tableOptions.initialState?.pagination?.pageIndex ?? 0,
+    pageSize,
+  });
+
+  return useReactTable({
+    ...tableOptions,
+    columns: tableOptions.columns as ColumnDef<TData, unknown>[],
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    globalFilterFn: tableOptions.globalFilterFn ?? "includesString",
+    state: {
+      sorting,
+      globalFilter,
+      pagination,
+      ...tableOptions.state,
+    },
+    onSortingChange: tableOptions.onSortingChange ?? setSorting,
+    onGlobalFilterChange: tableOptions.onGlobalFilterChange ?? setGlobalFilter,
+    onPaginationChange: tableOptions.onPaginationChange ?? setPagination,
+    // Background data refreshes (e.g., react-query polls) shouldn't snap
+    // the user back to page 1. Auto-reset only fires when the user
+    // explicitly changes filters/sorts via TanStack's defaults.
+    autoResetPageIndex: tableOptions.autoResetPageIndex ?? false,
+  });
+};
+
+/**
+ * Parses sort, page, and search from a URL search string into initial state
+ * for `useUniversalTable`. See `console/doc/guide-tanstack-table.md` for the
+ * full URL-sync pattern (read on mount, write on change).
+ *
+ * URL format: `?sort=<columnId>&dir=asc|desc&page=<1-based>&q=<search>`
+ */
+export const getInitialTableState = (search: string) => {
+  const params = new URLSearchParams(search);
+  const sort = params.get("sort");
+  const page = params.get("page");
+  const parsedPage = page ? parseInt(page, 10) : NaN;
+  return {
+    sorting: sort
+      ? ([{ id: sort, desc: params.get("dir") === "desc" }] as SortingState)
+      : undefined,
+    pageIndex: Number.isFinite(parsedPage)
+      ? Math.max(0, parsedPage - 1)
+      : undefined,
+    globalFilter: params.get("q") ?? undefined,
+  };
+};

--- a/console/src/platform/clusters/ClustersList.tsx
+++ b/console/src/platform/clusters/ClustersList.tsx
@@ -11,17 +11,13 @@ import {
   FormLabel,
   HStack,
   Switch,
-  Table,
-  Tbody,
-  Td,
   Text,
-  Th,
-  Thead,
   Tooltip,
-  Tr,
+  VStack,
 } from "@chakra-ui/react";
+import { createColumnHelper } from "@tanstack/react-table";
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 
 import { isSystemCluster } from "~/api/materialize";
 import { ClusterWithOwnership } from "~/api/materialize/cluster/clusterList";
@@ -33,8 +29,13 @@ import { CodeBlock } from "~/components/copyableComponents";
 import DeleteObjectMenuItem from "~/components/DeleteObjectMenuItem";
 import { LoadingContainer } from "~/components/LoadingContainer";
 import OverflowMenu, { OVERFLOW_BUTTON_WIDTH } from "~/components/OverflowMenu";
-import { ClustersIcon } from "~/icons";
-import { InfoIcon } from "~/icons";
+import { sortingFunctions } from "~/components/Table/tableColumnBuilders";
+import { TablePagination } from "~/components/Table/TablePagination";
+import { TableSearch } from "~/components/Table/TableSearch";
+import { UniversalTable } from "~/components/Table/UniversalTable";
+import { useUniversalTable } from "~/components/Table/useUniversalTable";
+import TextLink from "~/components/TextLink";
+import { ClustersIcon, InfoIcon } from "~/icons";
 import {
   MainContentContainer,
   PageHeader,
@@ -67,6 +68,162 @@ const createClusterSuggestion = {
   (SIZE = '25cc');`,
 };
 
+/**
+ * Shared data threaded into cell components via TanStack's table `meta`.
+ * Read from `info.table.options.meta` and cast to this shape inside cells.
+ */
+interface ClusterTableMeta {
+  refetchClusters: () => void;
+  offlineReplicaMap: LatestOfflineReplicaMap | undefined;
+}
+
+const ClusterNameCell = ({ cluster }: { cluster: ClusterWithOwnership }) => (
+  <HStack>
+    <TextLink
+      as={RouterLink}
+      to={relativeClusterPath(cluster)}
+      textStyle="text-ui-med"
+      noOfLines={1}
+    >
+      {cluster.name}
+    </TextLink>
+    {isSystemCluster(cluster.id) && (
+      <Tooltip
+        label="This is a built-in system cluster. You are not billed for this cluster."
+        lineHeight={1.2}
+      >
+        <InfoIcon />
+      </Tooltip>
+    )}
+  </HStack>
+);
+
+const LastStatusChangeCell = ({
+  cluster,
+  offlineReplicaMap,
+}: {
+  cluster: ClusterWithOwnership;
+  offlineReplicaMap: LatestOfflineReplicaMap | undefined;
+}) => {
+  const offlineStatus = offlineReplicaMap?.get(cluster.id);
+
+  const lastStatusChangeString = cluster.latestStatusUpdate
+    ? formatDate(
+        cluster.latestStatusUpdate,
+        FRIENDLY_DATETIME_FORMAT_NO_SECONDS,
+      )
+    : "-";
+
+  return (
+    <HStack>
+      <Text noOfLines={1} paddingRight="6" position="relative">
+        {lastStatusChangeString}
+        {offlineStatus?.shouldSurfaceOom && (
+          <Tooltip
+            px={3}
+            py={2}
+            minWidth="fit-content"
+            rounded="md"
+            label={`A replica ran out of memory on ${formatDate(
+              offlineStatus.lastOfflineAt,
+              FRIENDLY_DATETIME_FORMAT_NO_SECONDS,
+            )}`}
+          >
+            <WarningIcon position="absolute" right="0" />
+          </Tooltip>
+        )}
+      </Text>
+    </HStack>
+  );
+};
+
+const ClusterActionsCell = ({
+  cluster,
+  refetchClusters,
+}: {
+  cluster: ClusterWithOwnership;
+  refetchClusters: () => void;
+}) => (
+  <OverflowMenu
+    items={[
+      {
+        visible: !isSystemCluster(cluster.id) && cluster.isOwner,
+        render: () => (
+          <>
+            {cluster.managed && <AlterClusterMenuItem cluster={cluster} />}
+            <DeleteObjectMenuItem
+              key="delete-object"
+              selectedObject={cluster}
+              onSuccessAction={refetchClusters}
+              objectType="CLUSTER"
+            />
+          </>
+        ),
+      },
+    ]}
+  />
+);
+
+const columnHelper = createColumnHelper<ClusterWithOwnership>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    header: "Name",
+    sortingFn: "alphanumeric",
+    cell: (info) => <ClusterNameCell cluster={info.row.original} />,
+    meta: {
+      minWidth: { md: "280px", sm: "auto" },
+      cellProps: truncateMaxWidth,
+    },
+  }),
+  columnHelper.accessor((row) => row.replicas.length, {
+    id: "replicaCount",
+    header: "Replicas",
+    sortingFn: "basic",
+  }),
+  columnHelper.accessor(
+    (row) => {
+      const sizes = new Set(row.replicas.map((r) => r.size));
+      return sizes.size > 0 ? Array.from(sizes).join(", ") : null;
+    },
+    {
+      id: "sizes",
+      header: "Size",
+      sortingFn: sortingFunctions.nullsLast,
+      cell: (info) => info.getValue() ?? "-",
+    },
+  ),
+  columnHelper.accessor("latestStatusUpdate", {
+    id: "lastStatusChange",
+    header: "Last status change",
+    sortingFn: sortingFunctions.nullsLast,
+    cell: (info) => {
+      const meta = info.table.options.meta as ClusterTableMeta;
+      return (
+        <LastStatusChangeCell
+          cluster={info.row.original}
+          offlineReplicaMap={meta.offlineReplicaMap}
+        />
+      );
+    },
+  }),
+  columnHelper.display({
+    id: "actions",
+    header: "",
+    cell: (info) => {
+      const meta = info.table.options.meta as ClusterTableMeta;
+      return (
+        <ClusterActionsCell
+          cluster={info.row.original}
+          refetchClusters={meta.refetchClusters}
+        />
+      );
+    },
+    enableSorting: false,
+    size: OVERFLOW_BUTTON_WIDTH,
+  }),
+];
+
 const ClustersListContent = ({
   showSystemObjects,
 }: {
@@ -76,19 +233,16 @@ const ClustersListContent = ({
     includeSystemObjects: showSystemObjects,
   });
 
-  const deprioritizeSystemClusters = React.useMemo(() => {
-    const systemClusters = clusters.filter((cluster) =>
-      isSystemCluster(cluster.id),
-    );
+  const orderedClusters = React.useMemo(() => {
+    if (!clusters) return [];
+    const systemClusters = clusters.filter((c) => isSystemCluster(c.id));
     const nonSystemClusters = clusters
-      ?.filter((cluster) => !isSystemCluster(cluster.id))
+      .filter((c) => !isSystemCluster(c.id))
       .sort((a, b) => a.name.localeCompare(b.name));
-    return [...(nonSystemClusters ?? []), ...(systemClusters ?? [])];
+    return [...nonSystemClusters, ...systemClusters];
   }, [clusters]);
 
-  const isEmpty = clusters !== null && clusters.length === 0;
-
-  if (isEmpty) {
+  if (clusters !== null && clusters.length === 0) {
     return (
       <EmptyListWrapper>
         <EmptyListHeader>
@@ -116,11 +270,46 @@ const ClustersListContent = ({
     );
   }
 
+  return <ClusterTable clusters={orderedClusters} refetchClusters={refetch} />;
+};
+
+interface ClusterTableProps {
+  clusters: ClusterWithOwnership[];
+  refetchClusters: () => void;
+}
+
+const ClusterTable = ({ clusters, refetchClusters }: ClusterTableProps) => {
+  const { data: offlineReplicaMap, error: offlineReplicaError } =
+    useLatestOfflineReplica();
+
+  const meta: ClusterTableMeta = { refetchClusters, offlineReplicaMap };
+
+  const table = useUniversalTable({
+    data: clusters,
+    columns,
+    initialSorting: [{ id: "name", desc: false }],
+    pageSize: 20,
+    state: {
+      columnVisibility: {
+        lastStatusChange: !offlineReplicaError,
+      },
+    },
+    meta,
+  });
+
   return (
-    <ClusterTable
-      clusters={deprioritizeSystemClusters ?? []}
-      refetchClusters={refetch}
-    />
+    <VStack spacing={4} align="stretch">
+      <TableSearch
+        onValueChange={table.setGlobalFilter}
+        placeholder="Search clusters..."
+      />
+      <UniversalTable
+        table={table}
+        variant="linkable"
+        data-testid="cluster-table"
+      />
+      <TablePagination table={table} itemLabel="clusters" />
+    </VStack>
   );
 };
 
@@ -154,132 +343,6 @@ const ClustersListPage = () => {
         </React.Suspense>
       </AppErrorBoundary>
     </MainContentContainer>
-  );
-};
-
-const LastStatusChangeColumn = (props: {
-  latestOfflineReplicaMap: LatestOfflineReplicaMap;
-  cluster: ClusterWithOwnership;
-}) => {
-  const latestOfflineReplicaStatus = props.latestOfflineReplicaMap.get(
-    props.cluster.id,
-  );
-
-  const lastStatusChangeString = props.cluster.latestStatusUpdate
-    ? formatDate(
-        props.cluster.latestStatusUpdate,
-        FRIENDLY_DATETIME_FORMAT_NO_SECONDS,
-      )
-    : "-";
-
-  return (
-    <HStack>
-      <Text noOfLines={1} paddingRight="6" position="relative">
-        {lastStatusChangeString}
-        {latestOfflineReplicaStatus &&
-          latestOfflineReplicaStatus.shouldSurfaceOom && (
-            <Tooltip
-              px={3}
-              py={2}
-              minWidth="fit-content"
-              rounded="md"
-              label={`A replica ran out of memory on ${formatDate(
-                latestOfflineReplicaStatus.lastOfflineAt,
-                FRIENDLY_DATETIME_FORMAT_NO_SECONDS,
-              )}`}
-            >
-              <WarningIcon position="absolute" right="0" />
-            </Tooltip>
-          )}
-      </Text>
-    </HStack>
-  );
-};
-
-interface ClusterTableProps {
-  clusters: ClusterWithOwnership[];
-  refetchClusters: () => void;
-}
-
-const ClusterTable = (props: ClusterTableProps) => {
-  const navigate = useNavigate();
-  const latestOfflineReplicaResult = useLatestOfflineReplica();
-
-  return (
-    <Table variant="linkable" data-testid="cluster-table" borderRadius="xl">
-      <Thead>
-        <Tr>
-          <Th minW={{ md: "280px", sm: "auto" }}>Name</Th>
-          <Th>Replicas</Th>
-          <Th>Size</Th>
-          {!latestOfflineReplicaResult.error && (
-            <Th>
-              <Text noOfLines={1}>Last status change</Text>
-            </Th>
-          )}
-          <Th width={OVERFLOW_BUTTON_WIDTH}></Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        {props.clusters.map((c) => (
-          <Tr
-            key={c.id}
-            onClick={() => navigate(relativeClusterPath(c))}
-            cursor="pointer"
-          >
-            <Td {...truncateMaxWidth}>
-              <HStack>
-                <Text textStyle="text-ui-med" noOfLines={1}>
-                  {c.name}
-                </Text>
-                {c.id.startsWith("s") && (
-                  <Tooltip
-                    label="This is a built-in system cluster. You are not billed for this cluster."
-                    lineHeight={1.2}
-                  >
-                    <InfoIcon />
-                  </Tooltip>
-                )}
-              </HStack>
-            </Td>
-            <Td>{c.replicas.length}</Td>
-            <Td>
-              {Array.from(new Set(c.replicas.map((r) => r.size)).values()).join(
-                ", ",
-              )}
-            </Td>
-            {!latestOfflineReplicaResult.error && (
-              <Td>
-                <LastStatusChangeColumn
-                  latestOfflineReplicaMap={latestOfflineReplicaResult.data}
-                  cluster={c}
-                />
-              </Td>
-            )}
-            <Td>
-              <OverflowMenu
-                items={[
-                  {
-                    visible: !isSystemCluster(c.id) && c.isOwner,
-                    render: () => (
-                      <>
-                        {c.managed && <AlterClusterMenuItem cluster={c} />}
-                        <DeleteObjectMenuItem
-                          key="delete-object"
-                          selectedObject={c}
-                          onSuccessAction={props.refetchClusters}
-                          objectType="CLUSTER"
-                        />
-                      </>
-                    ),
-                  },
-                ]}
-              />
-            </Td>
-          </Tr>
-        ))}
-      </Tbody>
-    </Table>
   );
 };
 

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -4219,6 +4219,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-table@npm:^8.21.3":
+  version: 8.21.3
+  resolution: "@tanstack/react-table@npm:8.21.3"
+  dependencies:
+    "@tanstack/table-core": "npm:8.21.3"
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: 10c0/85d1d0fcb690ecc011f68a5a61c96f82142e31a0270dcf9cbc699a6f36715b1653fe6ff1518302a6d08b7093351fc4cabefd055a7db3cd8ac01e068956b0f944
+  languageName: node
+  linkType: hard
+
+"@tanstack/table-core@npm:8.21.3":
+  version: 8.21.3
+  resolution: "@tanstack/table-core@npm:8.21.3"
+  checksum: 10c0/40e3560e6d55e07cc047024aa7f83bd47a9323d21920d4adabba8071fd2d21230c48460b26cedf392588f8265b9edc133abb1b0d6d0adf4dae0970032900a8c9
+  languageName: node
+  linkType: hard
+
 "@testing-library/dom@npm:^10.4.0":
   version: 10.4.0
   resolution: "@testing-library/dom@npm:10.4.0"
@@ -10955,6 +10974,7 @@ __metadata:
     "@tanstack/eslint-plugin-query": "npm:^5.95.0"
     "@tanstack/react-query": "npm:^5.95.0"
     "@tanstack/react-query-devtools": "npm:^5.95.0"
+    "@tanstack/react-table": "npm:^8.21.3"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"


### PR DESCRIPTION


### Motivation

We need to add some sorting, filtering capabilities for our console tables. Tanstack tables let us do that without rethinking our current UI designs and it is very easy to integrate with existing table components. TanStack table is a headless UI library that provides powerful abstractions for sorting, filtering, and global search. This implementation wraps TanStack Table with Chakra UI components to maintain the visual elements while also TanStack's headless UI capabilities.

Linear Issue [CNS-34](https://linear.app/materializeinc/issue/CNS-34/migrate-current-tables-to-tanstack-tables-for-better-filtering-sorting)


### Core Components
| File | Purpose/Use |
| :--- | :--- |
| `UniversalTable.ts` | React hook wrapping **TanStack's** `useReactTable` with sensible defaults for sorting, filtering, pagination, and pinning |
| `UniversalTable.tsx` | Main rendering component that maps **TanStack** table state to **Chakra UI `<Table>`** components. Handles headers, rows, sorting indicators, loading skeletons, and sticky columns |
| `TablePagination.tsx` | Pagination controls showing "Showing X-Y of Z" and prev/next buttons. **Auto-hides** when data fits on one page |
| `TableSearch.tsx` | **Debounced search input** that integrates with **TanStack's global filter**. Includes search icon and clear button |
| `tableColumnBuilders.ts` | Utilities including `sortingFunctions.nullsLast` for nullable columns and `filterFunctions.globalTextFilter` for cross-column search |
| `tableTypes.ts` | **TypeScript interfaces** including `TableVariant`, `UniversalTableProps`, and module augmentation for `ColumnMeta` (adds `tooltip`, `isTruncated`, `minWidth`) |
| `guide-tanstack-table.md` | Developer guide with **usage examples, migration steps, and troubleshooting** |
'

- Added core table components and hooks wrapping TanStack Table with Chakra UI
- Migrated ClustersList as the first table using the new implementation
- Added documentation guide and tests 


Partial Fixes MaterializeInc/database-issues#11176, MaterializeInc/database-issues#10108 

This will make navigating tables/ pages with a lot of objects especially Clusters page that customers can benefit from sorting and searching for clusters. 

### How do you feel about this change? (Tips for the reviewer)
Pretty good! I have migrated Clusters List to the Tanstack table.I would recommend reading the testing guide first before reviewing the code.  Demo video: https://materializeinc.slack.com/files/U08QMH7H6TC/F0A2EV4REUC/cluster_table.mov

<img width="1199" height="529" alt="image" src="https://github.com/user-attachments/assets/95bbe83a-526a-450a-b2a4-aa21eff83fc3" />

Addressed feedback from this [console PR](https://github.com/MaterializeInc/console/pull/3872):
- Fixed bug for [comment ](https://github.com/MaterializeInc/console/pull/3872#discussion_r2682834939) where dynamic data in the columns caused objects to remount.
- Use Lodash debounce
- use UniversalDebounce is a more minimal hook especially removed the `enablePagination` prop and other `enable` configurations
- Deleted some brittle tests and assertions
- Removed pinning in the component
- Addressed nits:
     - [Using `currentPage` variable instead of `pageIndex+1](https://github.com/MaterializeInc/console/pull/3872#discussion_r2682670127)`
     - Relative units for styling instead of using "px"
   