### PR TITLE
sql: fix seahash catalog return type (uint4 -> uint8)

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4759,9 +4759,9 @@ pub static MZ_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
         },
         "seahash" => Scalar {
             params!(String) => UnaryFunc::SeahashString(func::SeahashString)
-                => UInt32, oid::FUNC_SEAHASH_STRING_OID;
+                => UInt64, oid::FUNC_SEAHASH_STRING_OID;
             params!(Bytes) => UnaryFunc::SeahashBytes(func::SeahashBytes)
-                => UInt32, oid::FUNC_SEAHASH_BYTES_OID;
+                => UInt64, oid::FUNC_SEAHASH_BYTES_OID;
         },
         "starts_with" => Scalar {
             params!(String, String) => BinaryFunc::from(func::StartsWith) => Bool, 3696;

--- a/test/sqllogictest/hash.slt
+++ b/test/sqllogictest/hash.slt
@@ -54,6 +54,16 @@ SELECT kafka_murmur2('lkjh234lh9fiuh90y23oiuhsafujhadof229phr9h19h89h8')
 ----
 2088585677
 
+# Verify catalog return type is uint8, not uint4.
+query T
+SELECT t.name
+FROM mz_functions f
+JOIN mz_types t ON f.return_type_id = t.id
+WHERE f.name = 'seahash'
+LIMIT 1
+----
+uint8
+
 query T
 SELECT seahash('');
 ----


### PR DESCRIPTION
The seahash functions return u64 but were registered with UInt32 in func.rs, causing mz_functions.return_type_id to disagree with the actual runtime type. Introduced in PR #29099.