### PR TITLE
expr_cache: fix busy-loop when channel closes

### DIFF
--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -398,23 +398,21 @@ impl ExpressionCacheHandle {
             ExpressionCache::open(config).await;
         let (tx, mut rx) = mpsc::unbounded_channel();
         spawn(|| "expression-cache-task", async move {
-            loop {
-                while let Some(op) = rx.recv().await {
-                    match op {
-                        CacheOperation::Update {
-                            new_local_expressions,
-                            new_global_expressions,
-                            invalidate_ids,
-                            trigger: _trigger,
-                        } => {
-                            cache
-                                .update(
-                                    new_local_expressions,
-                                    new_global_expressions,
-                                    invalidate_ids,
-                                )
-                                .await
-                        }
+            while let Some(op) = rx.recv().await {
+                match op {
+                    CacheOperation::Update {
+                        new_local_expressions,
+                        new_global_expressions,
+                        invalidate_ids,
+                        trigger: _trigger,
+                    } => {
+                        cache
+                            .update(
+                                new_local_expressions,
+                                new_global_expressions,
+                                invalidate_ids,
+                            )
+                            .await
                     }
                 }
             }


### PR DESCRIPTION
The expression-cache-task wraps its receive loop in an outer `loop {}`. When all senders are dropped, `rx.recv()` returns `None` immediately, causing a tight CPU-burning spin. Remove the redundant outer loop so the task exits cleanly.

Introduced in #30122. Review with `-w`