### PR TITLE
webhook: remove dead ResourceExhausted backpressure path

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -318,7 +318,7 @@ Webhook sources apply the following limits to received requests:
 
 * The maximum size of the request body is **`2MB`**. Requests larger than this
   will fail with `413 Payload Too Large`.
-* The rate of concurrent requests/second across **all** webhook sources
+* The maximum number of concurrent requests across **all** webhook sources
   is **500**. Trying to connect when the server is at capacity will fail with
   `429 Too Many Requests`.
 * Requests that contain a header name specified more than once will be rejected

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -339,8 +339,7 @@ impl ShouldTerminateGracefully for FenceError {
 impl ShouldTerminateGracefully for StorageError {
     fn should_terminate_gracefully(&self) -> bool {
         match self {
-            StorageError::ResourceExhausted(_)
-            | StorageError::CollectionMetadataAlreadyExists(_)
+            StorageError::CollectionMetadataAlreadyExists(_)
             | StorageError::PersistShardAlreadyInUse(_)
             | StorageError::PersistSchemaEvolveRace { .. }
             | StorageError::PersistInvalidSchemaEvolve { .. }

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -311,6 +311,9 @@ impl BodyRow {
 /// errors also generally need to map to HTTP status codes that we can use to respond to a webhook
 /// request. As such, webhook errors don't cleanly map to any existing error type, hence the
 /// existence of this error type.
+///
+/// Note: 429 Too Many Requests is handled at the HTTP layer via Tower's
+/// `GlobalConcurrencyLimitLayer`, not through these error variants.
 #[derive(Error, Debug)]
 pub enum WebhookError {
     #[error("no object was found at the path {}", .0.quoted())]
@@ -387,9 +390,6 @@ impl IntoResponse for WebhookError {
             e @ WebhookError::Unavailable => {
                 (StatusCode::SERVICE_UNAVAILABLE, e.to_string()).into_response()
             }
-            e @ WebhookError::InternalStorageError(StorageError::ResourceExhausted(_)) => {
-                (StatusCode::TOO_MANY_REQUESTS, e.to_string()).into_response()
-            }
             e @ WebhookError::InternalStorageError(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
             }
@@ -452,14 +452,7 @@ mod tests {
 
     #[mz_ore::test]
     fn smoke_test_storage_error_response_status() {
-        // Resource exhausted should get mapped to a specific status code.
-        let resp = WebhookError::from(AppendWebhookError::StorageError(
-            StorageError::ResourceExhausted("test"),
-        ))
-        .into_response();
-        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-
-        // IdentifierMissing should also get mapped to a specific status code.
+        // IdentifierMissing should get mapped to a specific status code.
         let resp = WebhookError::from(AppendWebhookError::StorageError(
             StorageError::IdentifierMissing(GlobalId::User(42)),
         ))

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -121,8 +121,6 @@ pub enum StorageError {
     /// The controller API was used in some invalid way. This usually indicates
     /// a bug.
     InvalidUsage(String),
-    /// The specified resource was exhausted, and is not currently accepting more requests.
-    ResourceExhausted(&'static str),
     /// The specified component is shutting down.
     ShuttingDown(&'static str),
     /// Collection metadata already exists for ID.
@@ -176,7 +174,6 @@ impl Error for StorageError {
             Self::DataflowError(err) => Some(err),
             Self::InvalidAlter { .. } => None,
             Self::InvalidUsage(_) => None,
-            Self::ResourceExhausted(_) => None,
             Self::ShuttingDown(_) => None,
             Self::CollectionMetadataAlreadyExists(_) => None,
             Self::PersistShardAlreadyInUse(_) => None,
@@ -247,7 +244,6 @@ impl fmt::Display for StorageError {
             Self::DataflowError(_err) => write!(f, "dataflow failed to process request",),
             Self::InvalidAlter(err) => std::fmt::Display::fmt(err, f),
             Self::InvalidUsage(err) => write!(f, "invalid usage: {}", err),
-            Self::ResourceExhausted(rsc) => write!(f, "{rsc} is exhausted"),
             Self::ShuttingDown(cmp) => write!(f, "{cmp} is shutting down"),
             Self::CollectionMetadataAlreadyExists(key) => {
                 write!(f, "storage metadata for '{key}' already exists")


### PR DESCRIPTION
PR #29354 replaced bounded channels with unbounded ones in MonotonicAppender, making StorageError::ResourceExhausted unreachable. The webhook 429 response is still produced by the Tower GlobalConcurrencyLimitLayer at the HTTP layer, so remove the dead variant and its match arms. Fix the docs to say "concurrent requests" instead of "concurrent requests/second" (it's a semaphore, not a rate limiter).