### PR TITLE
catalog: canonicalize CIDRs in mz_egress_ips

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1774,7 +1774,7 @@ impl CatalogState {
         ip: &IpNet,
     ) -> Result<BuiltinTableUpdate<&'static BuiltinTable>, Error> {
         let id = &MZ_EGRESS_IPS;
-        let addr = ip.addr();
+        let addr = ip.network();
         let row = Row::pack_slice(&[
             Datum::String(&addr.to_string()),
             Datum::Int32(ip.prefix_len().into()),


### PR DESCRIPTION
Use `IpNet::network()` instead of `IpNet::addr()` so that host bits are zeroed before writing to the catalog. Without this, a non-canonical input like `10.0.5.7/24` would surface as-is rather than `10.0.5.0/24`.

Introduced in PR #29578.