### PR TITLE
adapter: wire up reset for 0dt panic-after-timeout durable mirror

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -2642,6 +2642,8 @@ impl Catalog {
                     tx.reset_0dt_deployment_max_wait()?;
                 } else if name == WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL.name() {
                     tx.reset_0dt_deployment_ddl_check_interval()?;
+                } else if name == ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT.name() {
+                    tx.reset_enable_0dt_deployment_panic_after_timeout()?;
                 }
 
                 CatalogState::add_to_audit_log(
@@ -2659,6 +2661,7 @@ impl Catalog {
                 tx.clear_system_configs();
                 tx.reset_0dt_deployment_max_wait()?;
                 tx.reset_0dt_deployment_ddl_check_interval()?;
+                tx.reset_enable_0dt_deployment_panic_after_timeout()?;
 
                 CatalogState::add_to_audit_log(
                     &state.system_configuration,


### PR DESCRIPTION
PR #29592 added a durable catalog mirror for
`enable_0dt_deployment_panic_after_timeout` but only wired the set path. Add the missing reset calls so `ALTER SYSTEM RESET` and `RESET ALL` clear the stale config entry, preventing an unintended panic on reboot.