### PR TITLE
dbt-materialize: Add PARTITION BY support for materialized views

### DIFF
--- a/doc/user/content/manage/dbt/get-started.md
+++ b/doc/user/content/manage/dbt/get-started.md
@@ -586,6 +586,52 @@ You can specify the retention period using common time units like:
 - `'1d'` for one day
 - `'1w'` for one week
 
+##### Using partition by
+
+{{< tip >}}
+For guidance and best practices on how to use `PARTITION BY` in Materialize,
+see [Partitioning and filter pushdown](/transform-data/patterns/partition-by/).
+{{</ tip >}}
+
+To control the internal storage order that Materialize uses for a
+materialized view, use the `partition_by` configuration. This declares the
+columns that Materialize should sort by when writing the underlying data into
+storage, so that rows with similar values are stored together. The main
+user-visible benefit is enabling [filter pushdown](/transform-data/patterns/partition-by/#filter-pushdown)
+for queries with selective filters on the partition columns.
+
+**Filename:** models/materialized_view_partitioned.sql
+```mzsql
+{{ config(
+    materialized='materialized_view',
+    partition_by=['col_a']
+) }}
+
+SELECT
+    col_a,
+    col_b,
+    col_c
+FROM {{ ref('view_a') }}
+```
+
+The model above will be compiled to the following SQL statement:
+
+```mzsql
+CREATE MATERIALIZED VIEW database.schema.materialized_view_partitioned
+WITH (PARTITION BY (col_a))
+AS
+SELECT
+    col_a,
+    col_b,
+    col_c
+FROM database.schema.view_a;
+```
+
+The listed columns must be a **prefix** of the relation's columns, and only
+columns with order-preserving types are supported. See the
+[`PARTITION BY` requirements](/transform-data/patterns/partition-by/#requirements)
+for the full list.
+
 ### Sinks
 
 In Materialize, a [sink](/sql/create-sink) describes an **external** system you

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+* Add support for the `partition_by` configuration in materialized views,
+  which declares the internal storage order Materialize uses to sort the
+  underlying data into parts, enabling [filter pushdown](https://materialize.com/docs/transform-data/patterns/partition-by/#filter-pushdown)
+  for queries with selective filters on the listed columns (e.g.
+  `partition_by: ['col_a']`). See [`PARTITION BY`](https://materialize.com/docs/transform-data/patterns/partition-by/)
+  for the requirements and supported column types.
+
+* Fix a bug in the `materialized_view` materialization where combining
+  `refresh_interval`, `retain_history`, and contract constraints would emit
+  multiple `WITH (...)` blocks, producing invalid SQL. The macro now collects
+  all options and emits a single `WITH (...)` block, matching Materialize's
+  `CREATE MATERIALIZED VIEW` grammar.
+
 ## 1.9.8 - 2026-05-12
 
 * Automatically retry the atomic swap transaction in `deploy_promote` when

--- a/misc/dbt-materialize/dbt/adapters/materialize/exceptions.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/exceptions.py
@@ -41,3 +41,17 @@ class RefreshIntervalConfigError(CompilationError):
         validator_msg = self.validator_error_message(self.exc)
         msg = f"Could not parse refresh interval config: {validator_msg}"
         return msg
+
+
+class PartitionByConfigError(CompilationError):
+    def __init__(self, raw_partition_by: Any):
+        self.raw_partition_by = raw_partition_by
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = (
+            f"Invalid partition_by config:\n"
+            f"  Got: {self.raw_partition_by!r}\n"
+            f"  Expected a list of column names (e.g. ['col_a', 'col_b'])"
+        )
+        return msg

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -107,6 +107,7 @@ class MaterializeRefreshIntervalConfig(dbtClassMixin):
 @dataclass
 class MaterializeConfig(AdapterConfig):
     cluster: Optional[str] = None
+    partition_by: Optional[List[str]] = None
     refresh_interval: Optional[MaterializeRefreshIntervalConfig] = None
     retain_history: Optional[str] = None
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -38,6 +38,7 @@ from dbt.adapters.capability import (
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.materialize.connections import MaterializeConnectionManager
 from dbt.adapters.materialize.exceptions import (
+    PartitionByConfigError,
     RefreshIntervalConfigError,
     RefreshIntervalConfigNotDictError,
 )
@@ -195,6 +196,20 @@ class MaterializeAdapter(PostgresAdapter, SQLAdapter):
         self, raw_refresh_interval: Any
     ) -> Optional[MaterializeRefreshIntervalConfig]:
         return MaterializeRefreshIntervalConfig.parse(raw_refresh_interval)
+
+    @available
+    def parse_partition_by(self, raw_partition_by: Any) -> Optional[List[str]]:
+        # Materialize requires PARTITION BY columns to be a prefix of the
+        # relation's columns and to have order-preserving types. We don't
+        # duplicate those checks here; they are enforced server-side and
+        # produce clear errors. We only validate the shape of the config.
+        if raw_partition_by is None:
+            return None
+        if not isinstance(raw_partition_by, list) or not all(
+            isinstance(c, str) for c in raw_partition_by
+        ):
+            raise PartitionByConfigError(raw_partition_by)
+        return raw_partition_by or None
 
     def list_relations_without_caching(
         self, schema_relation: MaterializeRelation

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -54,7 +54,10 @@
     {%- do with_options.append("retain history for '" ~ retain_history ~ "'") -%}
   {%- endif -%}
 
-  {# Contracts and constraints #}
+  {# Contracts and constraints — NOTE(morsapaes): only column-level constraints
+     are handled here. Model-level constraints (model['constraints']) are silently
+     ignored because dbt-core's model-level constraints are intended for
+     multi-column constraints, which Materialize does not support. #}
   {%- set contract_config = config.get('contract') -%}
   {%- if contract_config.enforced -%}
     {# render_raw_columns_constraints returns a list of strings like

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -45,6 +45,12 @@
     )
   {%- endif %}
 
+  {# Partition by #}
+  {%- set partition_by = config.get('partition_by') -%}
+  {%- if partition_by -%}
+    with (partition by ({{ partition_by | join(', ') }}))
+  {%- endif %}
+
   {# History retention #}
   {%- set retain_history = config.get('retain_history') -%}
   {%- if retain_history -%}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -56,8 +56,8 @@
 
   {# Contracts and constraints — NOTE(morsapaes): only column-level constraints
      are handled here. Model-level constraints (model['constraints']) are silently
-     ignored because dbt-core's model-level constraints are intended for
-     multi-column constraints, which Materialize does not support. #}
+     ignored; not_null is not supported at model-level in dbt-core, and
+     model-level constraints are intended for multi-column constraints. #}
   {%- set contract_config = config.get('contract') -%}
   {%- if contract_config.enforced -%}
     {# render_raw_columns_constraints returns a list of strings like

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -32,58 +32,51 @@
 {% macro materialize__create_materialized_view_as(relation, sql) -%}
   {%- set cluster = adapter.generate_final_cluster_name(config.get('cluster', target.cluster)) -%}
 
+  {# Collect all WITH-clause options into a single list, since Materialize
+     only allows one WITH (...) block per CREATE MATERIALIZED VIEW. #}
+  {%- set with_options = [] -%}
+
+  {# Scheduled refreshes #}
+  {%- set refresh_interval = config.get('refresh_interval') -%}
+  {%- if refresh_interval -%}
+    {%- do with_options.append(materialize__get_refresh_interval_sql(relation, refresh_interval) | trim) -%}
+  {%- endif -%}
+
+  {# Partition by #}
+  {%- set partition_by = config.get('partition_by') -%}
+  {%- if partition_by -%}
+    {%- do with_options.append('partition by (' ~ (partition_by | join(', ')) ~ ')') -%}
+  {%- endif -%}
+
+  {# History retention #}
+  {%- set retain_history = config.get('retain_history') -%}
+  {%- if retain_history -%}
+    {%- do with_options.append("retain history for '" ~ retain_history ~ "'") -%}
+  {%- endif -%}
+
+  {# Contracts and constraints #}
+  {%- set contract_config = config.get('contract') -%}
+  {%- if contract_config.enforced -%}
+    {# render_raw_columns_constraints returns a list of strings like
+       ["assert not null col_a", "assert not null col_b"] #}
+    {%- set rendered_constraints = adapter.render_raw_columns_constraints(model['columns']) -%}
+    {%- for constraint in rendered_constraints -%}
+      {%- do with_options.append(constraint) -%}
+    {%- endfor -%}
+  {%- endif -%}
+
   create materialized view {{ relation }}
   {% if cluster %}
     in cluster {{ cluster }}
   {% endif %}
 
-  {# Scheduled refreshes #}
-  {%- set refresh_interval = config.get('refresh_interval') -%}
-  {%- if refresh_interval -%}
-    with (
-      {{ materialize__get_refresh_interval_sql(relation, refresh_interval) }}
-    )
-  {%- endif %}
-
-  {# Partition by #}
-  {%- set partition_by = config.get('partition_by') -%}
-  {%- if partition_by -%}
-    with (partition by ({{ partition_by | join(', ') }}))
-  {%- endif %}
-
-  {# History retention #}
-  {%- set retain_history = config.get('retain_history') -%}
-  {%- if retain_history -%}
-    with (retain history for '{{ retain_history }}')
-  {%- endif %}
-
-  {# Contracts and constraints #}
-  {% set contract_config = config.get('contract') %}
-  {% if contract_config.enforced %}
+  {%- if contract_config.enforced -%}
     {{ get_assert_columns_equivalent(sql) }}
-
-    {% set ns = namespace(c_constraints=False, m_constraints=False) %}
-    {# Column-level constraints #}
-    {% set raw_columns = model['columns'] %}
-    {% for c_id, c_details in raw_columns.items() if c_details['constraints'] != [] %}
-      {% set ns.c_constraints = True %}
-    {%- endfor %}
-
-    {# Model-level constraints #}
-
-    -- NOTE(morsapaes): not_null constraints are not originally supported in
-    -- dbt-core at model-level, since model-level constraints are intended for
-    -- multi-columns constraints. Any model-level constraint is ignored in
-    -- dbt-materialize, albeit silently.
-    {% if model['constraints'] != [] %}
-      {% set ns.m_constraints = True %}
-    {%- endif %}
-
-    {% if ns.c_constraints %}
-      with
-        {{ get_table_columns_and_constraints() }}
-    {%- endif %}
   {%- endif %}
+
+  {% if with_options %}
+    with ({{ with_options | join(', ') }})
+  {% endif %}
 
   as (
     {{ sql }}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -43,7 +43,7 @@
   {%- endif -%}
 
   {# Partition by #}
-  {%- set partition_by = config.get('partition_by') -%}
+  {%- set partition_by = adapter.parse_partition_by(config.get('partition_by')) -%}
   {%- if partition_by -%}
     {%- do with_options.append('partition by (' ~ (partition_by | join(', ')) ~ ')') -%}
   {%- endif -%}

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -30,6 +30,15 @@ test_materialized_view_retain_history = """
     SELECT * FROM (VALUES ('chicken', 'pig', 'bird'), ('cow', 'horse', 'bird'), (NULL, NULL, NULL)) _ (a, b, c)
 """
 
+test_materialized_view_partition_by = """
+{{ config(
+    materialized='materialized_view',
+    partition_by=['a']
+) }}
+
+    SELECT * FROM (VALUES ('chicken', 'pig', 'bird'), ('cow', 'horse', 'bird'), (NULL, NULL, NULL)) _ (a, b, c)
+"""
+
 test_materialized_view_index = """
 {{ config(
     materialized='materialized_view',

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -39,6 +39,16 @@ test_materialized_view_partition_by = """
     SELECT * FROM (VALUES ('chicken', 'pig', 'bird'), ('cow', 'horse', 'bird'), (NULL, NULL, NULL)) _ (a, b, c)
 """
 
+test_materialized_view_multiple_with_options = """
+{{ config(
+    materialized='materialized_view',
+    partition_by=['a'],
+    retain_history='1hr'
+) }}
+
+    SELECT * FROM (VALUES ('chicken', 'pig', 'bird'), ('cow', 'horse', 'bird'), (NULL, NULL, NULL)) _ (a, b, c)
+"""
+
 test_materialized_view_index = """
 {{ config(
     materialized='materialized_view',

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -351,6 +351,27 @@ models:
         data_type: string
 """
 
+partition_by_with_constraints_schema_yml = """
+version: 2
+models:
+  - name: test_partition_by_with_constraints_ddl
+    config:
+      contract:
+        enforced: true
+      partition_by: ['a']
+    columns:
+      - name: a
+        data_type: string
+        constraints:
+          - type: not_null
+      - name: b
+        data_type: string
+        constraints:
+          - type: not_null
+      - name: c
+        data_type: string
+"""
+
 contract_invalid_cluster_schema_yml = """
 version: 2
 models:

--- a/misc/dbt-materialize/tests/adapter/test_constraints.py
+++ b/misc/dbt-materialize/tests/adapter/test_constraints.py
@@ -34,6 +34,7 @@ from fixtures import (
     contract_invalid_cluster_schema_yml,
     contract_pseudo_types_yml,
     nullability_assertions_schema_yml,
+    partition_by_with_constraints_schema_yml,
     test_materialized_view,
     test_pseudo_types,
     test_view,
@@ -134,6 +135,40 @@ class TestNullabilityAssertions:
         )
         assert (
             "ASSERT NOT NULL = a, ASSERT NOT NULL = b" in nullability_assertions_ddl[1]
+        )
+
+
+class TestPartitionByWithConstraints:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "partition_by_with_constraints_schema.yml": partition_by_with_constraints_schema_yml,
+            "test_partition_by_with_constraints_ddl.sql": test_materialized_view,
+        }
+
+    def test_ddl_enforcement(self, project):
+
+        partition_by_with_constraints_model = ".".join(
+            [
+                project.adapter.config.credentials.database,
+                project.adapter.config.credentials.schema,
+                "test_partition_by_with_constraints_ddl",
+            ]
+        )
+
+        run_dbt(["run"])
+
+        # Confirm that PARTITION BY and ASSERT NOT NULL both appear in a single
+        # WITH (...) clause and that the partition column matches.
+        partition_by_with_constraints_ddl = run_sql_with_adapter(
+            project.adapter,
+            f"SHOW CREATE MATERIALIZED VIEW {partition_by_with_constraints_model}",
+            fetch="one",
+        )
+        assert "PARTITION BY = (a)" in partition_by_with_constraints_ddl[1]
+        assert (
+            "ASSERT NOT NULL = a, ASSERT NOT NULL = b"
+            in partition_by_with_constraints_ddl[1]
         )
 
 

--- a/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
+++ b/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 import pytest
-from dbt.tests.util import check_relations_equal, run_dbt
+from dbt.tests.util import check_relations_equal, run_dbt, run_sql_with_adapter
 from fixtures import (
     actual_indexes,
     expected_indexes,
     test_materialized_view,
     test_materialized_view_index,
+    test_materialized_view_multiple_with_options,
     test_materialized_view_partition_by,
     test_materialized_view_retain_history,
     test_relation_name_length,
@@ -52,6 +53,7 @@ class TestCustomMaterializations:
             "test_materialized_view.sql": test_materialized_view,
             "test_materialized_view_retain_history.sql": test_materialized_view_retain_history,
             "test_materialized_view_partition_by.sql": test_materialized_view_partition_by,
+            "test_materialized_view_multiple_with_options.sql": test_materialized_view_multiple_with_options,
             "test_materialized_view_index.sql": test_materialized_view_index,
             "test_relation_name_loooooooooooooooooonger_than_postgres_63_limit.sql": test_relation_name_length,
             "test_source.sql": test_source,
@@ -72,12 +74,12 @@ class TestCustomMaterializations:
         # run models
         results = run_dbt(["run"])
         # run result length
-        assert len(results) == 14
+        assert len(results) == 15
         # re-run models to ensure there are no lingering errors in recreating
         # the materializations
         results = run_dbt(["run"])
         # re-run result length
-        assert len(results) == 14
+        assert len(results) == 15
         # relations_equal
         check_relations_equal(
             project.adapter,
@@ -85,6 +87,22 @@ class TestCustomMaterializations:
         )
 
         check_relations_equal(project.adapter, ["actual_indexes", "expected_indexes"])
+
+        # Verify that multiple WITH options are merged into a single WITH clause.
+        multiple_with_options_model = ".".join(
+            [
+                project.adapter.config.credentials.database,
+                project.adapter.config.credentials.schema,
+                "test_materialized_view_multiple_with_options",
+            ]
+        )
+        ddl = run_sql_with_adapter(
+            project.adapter,
+            f"SHOW CREATE MATERIALIZED VIEW {multiple_with_options_model}",
+            fetch="one",
+        )
+        assert "PARTITION BY" in ddl[1]
+        assert "RETAIN HISTORY" in ddl[1]
 
         # TODO(morsapaes): add test that ensures that the source/sink emit the
         # correct data once sinks land.

--- a/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
+++ b/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
@@ -20,6 +20,7 @@ from fixtures import (
     expected_indexes,
     test_materialized_view,
     test_materialized_view_index,
+    test_materialized_view_partition_by,
     test_materialized_view_retain_history,
     test_relation_name_length,
     test_sink,
@@ -50,6 +51,7 @@ class TestCustomMaterializations:
             "actual_indexes.sql": actual_indexes,
             "test_materialized_view.sql": test_materialized_view,
             "test_materialized_view_retain_history.sql": test_materialized_view_retain_history,
+            "test_materialized_view_partition_by.sql": test_materialized_view_partition_by,
             "test_materialized_view_index.sql": test_materialized_view_index,
             "test_relation_name_loooooooooooooooooonger_than_postgres_63_limit.sql": test_relation_name_length,
             "test_source.sql": test_source,
@@ -70,12 +72,12 @@ class TestCustomMaterializations:
         # run models
         results = run_dbt(["run"])
         # run result length
-        assert len(results) == 13
+        assert len(results) == 14
         # re-run models to ensure there are no lingering errors in recreating
         # the materializations
         results = run_dbt(["run"])
         # re-run result length
-        assert len(results) == 13
+        assert len(results) == 14
         # relations_equal
         check_relations_equal(
             project.adapter,

--- a/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
+++ b/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
@@ -88,6 +88,22 @@ class TestCustomMaterializations:
 
         check_relations_equal(project.adapter, ["actual_indexes", "expected_indexes"])
 
+        # Verify that the partition_by configuration is rendered correctly on
+        # its own.
+        partition_by_model = ".".join(
+            [
+                project.adapter.config.credentials.database,
+                project.adapter.config.credentials.schema,
+                "test_materialized_view_partition_by",
+            ]
+        )
+        partition_by_ddl = run_sql_with_adapter(
+            project.adapter,
+            f"SHOW CREATE MATERIALIZED VIEW {partition_by_model}",
+            fetch="one",
+        )
+        assert "PARTITION BY = (a)" in partition_by_ddl[1]
+
         # Verify that multiple WITH options are merged into a single WITH clause.
         multiple_with_options_model = ".".join(
             [


### PR DESCRIPTION
## Summary

- Add `partition_by` config option to `MaterializeConfig`, accepting a list of column names
- Generate `PARTITION BY (...)` in the materialized view `WITH` clause
- **Fix existing bug**: the macro previously emitted separate `WITH (...)` blocks for
  `refresh_interval`, `retain_history`, and contract constraints. Materialize only allows
  a single `WITH` clause per `CREATE MATERIALIZED VIEW`, so combining multiple options
  would produce invalid SQL. Refactored to collect all options and emit one unified
  `WITH (...)` block.
- For contract constraints, call `adapter.render_raw_columns_constraints()` directly
  instead of `get_table_columns_and_constraints()`, which wraps its output in parentheses
  that would need to be stripped before merging into the `WITH` clause

## Usage

```sql
{{ config(
    materialized='materialized_view',
    partition_by=['col1', 'col2']
) }}

SELECT col1, col2, col3 FROM ...
```

Partition columns must be a prefix of the relation's columns, matching Materialize's
`PARTITION BY` validation semantics.

## Test plan

- [ ] Added `test_materialized_view_partition_by` fixture and included it in `TestCustomMaterializations`
- [ ] Updated model count assertions (13 → 14) to account for the new model
- [ ] Existing constraint tests (`TestNullabilityAssertions`) validate the refactored
  constraint rendering path still produces correct `ASSERT NOT NULL` DDL

🤖 Generated with [Claude Code](https://claude.com/claude-code)