### PR TITLE
adapter: Fix `OFFSET` planning in `INSERT INTO ... SELECT`

### DIFF
--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -38,7 +38,9 @@ use mz_repr::*;
 use serde::{Deserialize, Serialize};
 
 use crate::plan::error::PlanError;
-use crate::plan::query::{EXECUTE_CAST_CONTEXT, ExprContext, execute_expr_context};
+use crate::plan::query::{
+    EXECUTE_CAST_CONTEXT, ExprContext, execute_expr_context, offset_into_value,
+};
 use crate::plan::typeconv::{self, CastContext, plan_cast};
 use crate::plan::{Params, QueryContext, QueryLifetime, StatementContext};
 
@@ -2281,9 +2283,19 @@ impl HirRelationExpr {
         });
     }
 
-    /// Replaces any parameter references in the expression with the
-    /// corresponding datum from `params`.
-    pub fn bind_parameters(
+    /// Replaces parameter references in the expression with the corresponding datum from `params`.
+    /// Additionally, it simplifies OFFSET clauses to constants after parameter binding, and checks
+    /// them for non-negativity.
+    ///
+    /// TODO: This is currently quadratic with subquery nesting depth, because it calls
+    /// `bind_parameters` on each scalar expr at every nesting depth, but `bind_parameters` itself
+    /// also visits subqueries. I think we should
+    /// - make `bind_parameters_and_simplify_offset` call `bind_parameters` only on top-level scalar
+    ///   expressions,
+    /// - and make `bind_parameters` call back to us for subqueries.
+    /// (This would also fix another issue in `bind_parameters`, namely that it doesn't check OFFSET
+    /// clauses inside subqueries.)
+    pub fn bind_parameters_and_simplify_offset(
         &mut self,
         scx: &StatementContext,
         lifetime: QueryLifetime,
@@ -2292,7 +2304,20 @@ impl HirRelationExpr {
         #[allow(deprecated)]
         self.visit_scalar_expressions_mut(0, &mut |e: &mut HirScalarExpr, _: usize| {
             e.bind_parameters(scx, lifetime, params)
+        })?;
+
+        // OFFSET clauses in `expr` should become constants with the above binding of parameters.
+        // Let's check this and simplify them to literals.
+        self.try_visit_mut_pre(&mut |expr| {
+            if let HirRelationExpr::TopK { offset, .. } = expr {
+                let offset_value = offset_into_value(offset.take())?;
+                *offset = HirScalarExpr::literal(Datum::Int64(offset_value), SqlScalarType::Int64);
+            }
+            Ok::<(), PlanError>(())
         })
+        // (We don't need to simplify LIMIT clauses in `expr`, because we can handle non-constant
+        // expressions there. If they happen to be simplifiable to literals, then the optimizer will do
+        // so later.)
     }
 
     pub fn contains_parameters(&self) -> Result<bool, PlanError> {
@@ -3225,6 +3250,11 @@ impl HirScalarExpr {
 
     /// Replaces any parameter references in the expression with the
     /// corresponding datum in `params`.
+    ///
+    /// Warning: If calling this outside `HirRelationExpr::bind_parameters_and_simplify_offset`,
+    /// be sure that you only call it on expressions without subqueries, because this is currently
+    /// missing the OFFSET simplification inside subqueries that
+    /// `HirRelationExpr::bind_parameters_and_simplify_offset` performs.
     pub fn bind_parameters(
         &mut self,
         scx: &StatementContext,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1629,17 +1629,18 @@ fn plan_query_inner(qcx: &mut QueryContext, q: &Query<Aug>) -> Result<PlannedQue
 }
 
 /// Converts an OFFSET expression into a value.
-pub fn offset_into_value(offset: HirScalarExpr) -> Result<i64, PlanError> {
+pub(crate) fn offset_into_value(offset: HirScalarExpr) -> Result<i64, PlanError> {
     let offset = offset
         .try_into_literal_int64()
         .map_err(|err| PlanError::InvalidOffset(err.to_string_with_causes()))?;
     if offset < 0 {
-        return Err(PlanError::InvalidOffset(format!(
-            "must not be negative, got {}",
-            offset
-        )));
+        return Err(negative_offset_error(offset));
     }
     Ok(offset)
+}
+
+pub(crate) fn negative_offset_error(offset: i64) -> PlanError {
+    PlanError::InvalidOffset(format!("must not be negative, got {}", offset))
 }
 
 generate_extracted_config!(

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -51,7 +51,8 @@ use crate::catalog::CatalogItemType;
 use crate::names::{Aug, ResolvedItemName};
 use crate::normalize;
 use crate::plan::query::{
-    ExprContext, QueryLifetime, offset_into_value, plan_as_of_or_up_to, plan_expr,
+    ExprContext, QueryLifetime, negative_offset_error, offset_into_value, plan_as_of_or_up_to,
+    plan_expr,
 };
 use crate::plan::scope::Scope;
 use crate::plan::statement::show::ShowSelect;
@@ -258,9 +259,11 @@ fn plan_select_inner(
         let mut offset = finishing.offset.clone();
         offset.bind_parameters(scx, lifetime, params)?;
         let offset = offset_into_value(offset.take())?;
-        offset
-            .try_into()
-            .expect("checked in bind_parameters_and_simplify_offset/offset_into_value that it is not negative")
+        offset.try_into().map_err(|_| {
+            // We already checked in bind_parameters_and_simplify_offset / offset_into_value.
+            soft_panic_or_log!("unexpectedly negative OFFSET");
+            negative_offset_error(offset)
+        })?
     };
 
     // Unmaterializable functions are evaluated based on various information (e.g., the catalog)

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -18,7 +18,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use itertools::Itertools;
 use mz_arrow_util::builder::ArrowBuilder;
 use mz_expr::RowSetFinishing;
-use mz_expr::visit::Visit;
 use mz_ore::num::NonNeg;
 use mz_ore::soft_panic_or_log;
 use mz_ore::str::separated;
@@ -59,7 +58,7 @@ use crate::plan::statement::show::ShowSelect;
 use crate::plan::statement::{StatementContext, StatementDesc, ddl};
 use crate::plan::{
     self, CopyFromFilter, CopyToPlan, CreateSinkPlan, ExplainPushdownPlan, ExplainSinkSchemaPlan,
-    ExplainTimestampPlan, HirRelationExpr, HirScalarExpr, side_effecting_func, transform_ast,
+    ExplainTimestampPlan, HirRelationExpr, side_effecting_func, transform_ast,
 };
 use crate::plan::{
     CopyFormat, CopyFromPlan, ExplainPlanPlan, InsertPlan, MutationKind, Params, Plan, PlanError,
@@ -106,7 +105,7 @@ pub fn plan_insert(
 ) -> Result<Plan, PlanError> {
     let (id, mut expr, returning) =
         query::plan_insert_query(scx, table_name, columns, source, returning)?;
-    expr.bind_parameters(scx, QueryLifetime::OneShot, params)?;
+    expr.bind_parameters_and_simplify_offset(scx, QueryLifetime::OneShot, params)?;
     let returning = returning
         .expr
         .into_iter()
@@ -168,7 +167,7 @@ pub fn plan_read_then_write(
         assignments,
     }: query::ReadThenWritePlan,
 ) -> Result<Plan, PlanError> {
-    selection.bind_parameters(scx, QueryLifetime::OneShot, params)?;
+    selection.bind_parameters_and_simplify_offset(scx, QueryLifetime::OneShot, params)?;
     let mut assignments_outer = BTreeMap::new();
     for (idx, mut set) in assignments {
         set.bind_parameters(scx, QueryLifetime::OneShot, params)?;
@@ -227,20 +226,7 @@ fn plan_select_inner(
         finishing,
         scope: _,
     } = query::plan_root_query(scx, select.query.clone(), lifetime)?;
-    expr.bind_parameters(scx, lifetime, params)?;
-
-    // OFFSET clauses in `expr` should become constants with the above binding of parameters.
-    // Let's check this and simplify them to literals.
-    expr.try_visit_mut_pre(&mut |expr| {
-        if let HirRelationExpr::TopK { offset, .. } = expr {
-            let offset_value = offset_into_value(offset.take())?;
-            *offset = HirScalarExpr::literal(Datum::Int64(offset_value), SqlScalarType::Int64);
-        }
-        Ok::<(), PlanError>(())
-    })?;
-    // (We don't need to simplify LIMIT clauses in `expr`, because we can handle non-constant
-    // expressions there. If they happen to be simplifiable to literals, then the optimizer will do
-    // so later.)
+    expr.bind_parameters_and_simplify_offset(scx, lifetime, params)?;
 
     // We need to concretize the `limit` and `offset` of the RowSetFinishing, so that we go from
     // `RowSetFinishing<HirScalarExpr, HirScalarExpr>` to `RowSetFinishing`.
@@ -274,7 +260,7 @@ fn plan_select_inner(
         let offset = offset_into_value(offset.take())?;
         offset
             .try_into()
-            .expect("checked in offset_into_value that it is not negative")
+            .expect("checked in bind_parameters_and_simplify_offset/offset_into_value that it is not negative")
     };
 
     // Unmaterializable functions are evaluated based on various information (e.g., the catalog)
@@ -1653,7 +1639,7 @@ pub fn plan_subscribe(
                 finishing,
                 scope,
             } = query::plan_root_query(scx, query, QueryLifetime::Subscribe)?;
-            expr.bind_parameters(scx, QueryLifetime::Subscribe, params)?;
+            expr.bind_parameters_and_simplify_offset(scx, QueryLifetime::Subscribe, params)?;
             let query = query::PlannedRootQuery {
                 expr,
                 desc,

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -1602,6 +1602,25 @@ EXECUTE p6(2, 100, 200);
 11
 10
 
+# OFFSET in INSERT INTO ... SELECT
+statement ok
+PREPARE p7 AS INSERT INTO foo SELECT * FROM foo OFFSET $1;
+
+query error Invalid OFFSET clause: must not be negative, got \-1
+EXECUTE p7(-1);
+
+statement ok
+EXECUTE p7(1);
+
+query IT
+SELECT * FROM foo
+----
+0  zero
+1  one
+1  one
+2  two
+2  two
+
 # Prepared statement parameter in LIMIT
 statement ok
 PREPARE fizz_paginated AS


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/11347 by moving the `OFFSET` simplification and non-negativity check into `bind_parameters` (and renames `bind_parameters`), so that every caller will automatically get this functionality. Previously, this was missing from the call in planning `INSERT INTO ... SELECT`.

A second commit downgrades an `expect` to a soft-panic and a graceful query error, because now the code that ensures the invariant got a bit far from the `expect`.

(The added TODO comment on `bind_parameters_and_simplify_offset` is a pre-existing bug. A follow-up PR is fixing it: https://github.com/MaterializeInc/materialize/pull/36370)