### PR TITLE
Refactor subquery visitation

### DIFF
--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -31,7 +31,7 @@
 //!   * `children`: only visit direct children
 //!   * `post`: recursively visit children in post-order
 //!   * `pre`: recursively visit children in pre-order
-//!   * no suffix: recursively visit children in pre- and post-oder
+//!   * no suffix: recursively visit children in pre- and post-order
 //!     using a ~Visitor~` that encapsulates the shared context.
 
 use std::marker::PhantomData;
@@ -51,7 +51,7 @@ use crate::RECURSION_LIMIT;
 /// not possible to implement versions of `VisitChildren<A> for A` such
 /// that A considers as its children all A-nodes occurring at leaf
 /// positions of B-children and vice versa for `VisitChildren<B> for B`.
-/// Doing this will result in recusion limit violations as indicated
+/// Doing this will result in recursion limit violations as indicated
 /// in the accompanying `test_recursive_types_b` test.
 pub trait VisitChildren<T> {
     /// Apply an infallible immutable function `f` to each direct child.

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -3170,6 +3170,57 @@ impl HirScalarExpr {
         }
     }
 
+    /// Visit every subquery, without descending into subqueries.
+    pub fn visit_direct_subqueries<F>(&self, mut f: F)
+    where
+        F: FnMut(&HirRelationExpr),
+    {
+        // The infallible variants of the post-walk are deprecated in favor
+        // of the limit-aware `try_visit_post`, but we have no error channel
+        // here (the surrounding signature is infallible, mirroring the
+        // infallible `VisitChildren::{visit_children, visit_mut_children}`
+        // impls that this helper is designed to be called from).
+        #[allow(deprecated)]
+        self.visit_post_nolimit(&mut |e| {
+            VisitChildren::<HirRelationExpr>::visit_children(e, &mut f);
+        });
+    }
+
+    /// Mutable counterpart of [`HirScalarExpr::visit_direct_subqueries`].
+    pub fn visit_direct_subqueries_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut HirRelationExpr),
+    {
+        // See the comment on `visit_direct_subqueries` for why we use the
+        // deprecated `_nolimit` walk here.
+        #[allow(deprecated)]
+        self.visit_mut_post_nolimit(&mut |e| {
+            VisitChildren::<HirRelationExpr>::visit_mut_children(e, &mut f);
+        });
+    }
+
+    /// Fallible counterpart of [`HirScalarExpr::visit_direct_subqueries`].
+    pub fn try_visit_direct_subqueries<F, E>(&self, mut f: F) -> Result<(), E>
+    where
+        F: FnMut(&HirRelationExpr) -> Result<(), E>,
+        E: From<RecursionLimitError>,
+    {
+        self.try_visit_post(&mut |e| {
+            VisitChildren::<HirRelationExpr>::try_visit_children(e, &mut f)
+        })
+    }
+
+    /// Fallible mutable counterpart of [`HirScalarExpr::visit_direct_subqueries`].
+    pub fn try_visit_direct_subqueries_mut<F, E>(&mut self, mut f: F) -> Result<(), E>
+    where
+        F: FnMut(&mut HirRelationExpr) -> Result<(), E>,
+        E: From<RecursionLimitError>,
+    {
+        self.try_visit_mut_post(&mut |e| {
+            VisitChildren::<HirRelationExpr>::try_visit_mut_children(e, &mut f)
+        })
+    }
+
     /// Replaces any parameter references in the expression with the
     /// corresponding datum in `params`.
     pub fn bind_parameters(
@@ -3963,6 +4014,88 @@ impl VisitChildren<Self> for HirScalarExpr {
             }
             Exists(..) | Select(..) => (),
             Windowing(expr, _name) => expr.try_visit_mut_children(f)?,
+        }
+        Ok(())
+    }
+}
+
+impl VisitChildren<HirRelationExpr> for HirScalarExpr {
+    fn visit_children<F>(&self, mut f: F)
+    where
+        F: FnMut(&HirRelationExpr),
+    {
+        use HirScalarExpr::*;
+        match self {
+            Column(..)
+            | Parameter(..)
+            | Literal(..)
+            | CallUnmaterializable(..)
+            | CallUnary { .. }
+            | CallBinary { .. }
+            | CallVariadic { .. }
+            | If { .. }
+            | Windowing(..) => (),
+            Exists(expr, _name) | Select(expr, _name) => f(expr),
+        }
+    }
+
+    fn visit_mut_children<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut HirRelationExpr),
+    {
+        use HirScalarExpr::*;
+        match self {
+            Column(..)
+            | Parameter(..)
+            | Literal(..)
+            | CallUnmaterializable(..)
+            | CallUnary { .. }
+            | CallBinary { .. }
+            | CallVariadic { .. }
+            | If { .. }
+            | Windowing(..) => (),
+            Exists(expr, _name) | Select(expr, _name) => f(expr),
+        }
+    }
+
+    fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+    where
+        F: FnMut(&HirRelationExpr) -> Result<(), E>,
+        E: From<RecursionLimitError>,
+    {
+        use HirScalarExpr::*;
+        match self {
+            Column(..)
+            | Parameter(..)
+            | Literal(..)
+            | CallUnmaterializable(..)
+            | CallUnary { .. }
+            | CallBinary { .. }
+            | CallVariadic { .. }
+            | If { .. }
+            | Windowing(..) => (),
+            Exists(expr, _name) | Select(expr, _name) => f(expr)?,
+        }
+        Ok(())
+    }
+
+    fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+    where
+        F: FnMut(&mut HirRelationExpr) -> Result<(), E>,
+        E: From<RecursionLimitError>,
+    {
+        use HirScalarExpr::*;
+        match self {
+            Column(..)
+            | Parameter(..)
+            | Literal(..)
+            | CallUnmaterializable(..)
+            | CallUnary { .. }
+            | CallBinary { .. }
+            | CallVariadic { .. }
+            | If { .. }
+            | Windowing(..) => (),
+            Exists(expr, _name) | Select(expr, _name) => f(expr)?,
         }
         Ok(())
     }

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2487,13 +2487,7 @@ impl VisitChildren<Self> for HirRelationExpr {
         // Exists or Select variants within HirScalarExpr trees
         // attached at the current node, and we want to visit them as well
         VisitChildren::visit_children(self, |expr: &HirScalarExpr| {
-            #[allow(deprecated)]
-            Visit::visit_post_nolimit(expr, &mut |expr| match expr {
-                HirScalarExpr::Exists(expr, _name) | HirScalarExpr::Select(expr, _name) => {
-                    f(expr.as_ref())
-                }
-                _ => (),
-            });
+            expr.visit_direct_subqueries(&mut f);
         });
 
         use HirRelationExpr::*;
@@ -2576,13 +2570,7 @@ impl VisitChildren<Self> for HirRelationExpr {
         // Exists or Select variants within HirScalarExpr trees
         // attached at the current node, and we want to visit them as well
         VisitChildren::visit_mut_children(self, |expr: &mut HirScalarExpr| {
-            #[allow(deprecated)]
-            Visit::visit_mut_post_nolimit(expr, &mut |expr| match expr {
-                HirScalarExpr::Exists(expr, _name) | HirScalarExpr::Select(expr, _name) => {
-                    f(expr.as_mut())
-                }
-                _ => (),
-            });
+            expr.visit_direct_subqueries_mut(&mut f);
         });
 
         use HirRelationExpr::*;
@@ -2666,12 +2654,7 @@ impl VisitChildren<Self> for HirRelationExpr {
         // Exists or Select variants within HirScalarExpr trees
         // attached at the current node, and we want to visit them as well
         VisitChildren::try_visit_children(self, |expr: &HirScalarExpr| {
-            Visit::try_visit_post(expr, &mut |expr| match expr {
-                HirScalarExpr::Exists(expr, _name) | HirScalarExpr::Select(expr, _name) => {
-                    f(expr.as_ref())
-                }
-                _ => Ok(()),
-            })
+            expr.try_visit_direct_subqueries(&mut f)
         })?;
 
         use HirRelationExpr::*;
@@ -2756,12 +2739,7 @@ impl VisitChildren<Self> for HirRelationExpr {
         // Exists or Select variants within HirScalarExpr trees
         // attached at the current node, and we want to visit them as well
         VisitChildren::try_visit_mut_children(self, |expr: &mut HirScalarExpr| {
-            Visit::try_visit_mut_post(expr, &mut |expr| match expr {
-                HirScalarExpr::Exists(expr, _name) | HirScalarExpr::Select(expr, _name) => {
-                    f(expr.as_mut())
-                }
-                _ => Ok(()),
-            })
+            expr.try_visit_direct_subqueries_mut(&mut f)
         })?;
 
         use HirRelationExpr::*;

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -323,6 +323,8 @@ impl WindowExpr {
     }
 }
 
+/// Yields the scalars in `func`'s arguments, plus those in `partition_by`
+/// and `order_by`; does not descend into them.
 impl VisitChildren<HirScalarExpr> for WindowExpr {
     fn visit_children<F>(&self, mut f: F)
     where
@@ -455,6 +457,8 @@ impl WindowExprType {
     }
 }
 
+/// Dispatches to the inner `Value` / `Aggregate` variant's scalar children;
+/// `Scalar` window functions have no scalar children.
 impl VisitChildren<HirScalarExpr> for WindowExprType {
     fn visit_children<F>(&self, f: F)
     where
@@ -682,6 +686,8 @@ impl ValueWindowExpr {
     }
 }
 
+/// Yields `args` (the value-window function's argument expression);
+/// does not descend into it.
 impl VisitChildren<HirScalarExpr> for ValueWindowExpr {
     fn visit_children<F>(&self, mut f: F)
     where
@@ -868,6 +874,8 @@ impl AggregateWindowExpr {
     }
 }
 
+/// Yields the aggregate's argument expression (`aggregate_expr.expr`);
+/// does not descend into it.
 impl VisitChildren<HirScalarExpr> for AggregateWindowExpr {
     fn visit_children<F>(&self, mut f: F)
     where
@@ -1971,6 +1979,10 @@ impl HirRelationExpr {
         f(self, depth)
     }
 
+    /// WARNING: `VisitChildren<HirRelationExpr>::try_visit_children` is NOT a
+    /// drop-in replacement: in addition to the relation children visited here,
+    /// it also descends into every subquery (`Exists`/`Select`) reachable
+    /// through `self`'s scalar children — at any depth of scalar nesting.
     #[deprecated = "Use `VisitChildren<HirRelationExpr>::try_visit_children` instead."]
     pub fn visit1<'a, F, E>(&'a self, depth: usize, mut f: F) -> Result<(), E>
     where
@@ -2058,6 +2070,10 @@ impl HirRelationExpr {
         f(self, depth)
     }
 
+    /// WARNING: `VisitChildren<HirRelationExpr>::try_visit_mut_children` is NOT a
+    /// drop-in replacement: in addition to the relation children visited here,
+    /// it also descends into every subquery (`Exists`/`Select`) reachable
+    /// through `self`'s scalar children — at any depth of scalar nesting.
     #[deprecated = "Use `VisitChildren<HirRelationExpr>::try_visit_mut_children` instead."]
     pub fn visit1_mut<'a, F, E>(&'a mut self, depth: usize, mut f: F) -> Result<(), E>
     where
@@ -2478,6 +2494,11 @@ impl CollectionPlan for HirRelationExpr {
     }
 }
 
+/// In addition to direct relation children of `self`, this also yields every
+/// subquery (`Exists` / `Select`) reachable through `self`'s scalar children,
+/// at any depth of scalar nesting. This is the asymmetry warned about on the
+/// [`VisitChildren`] trait; the matching impl on `HirScalarExpr` deliberately
+/// does not do the symmetric thing, to avoid mutual recursion.
 impl VisitChildren<Self> for HirRelationExpr {
     fn visit_children<F>(&self, mut f: F)
     where
@@ -2816,6 +2837,9 @@ impl VisitChildren<Self> for HirRelationExpr {
     }
 }
 
+/// Yields the scalars directly attached to relation nodes (e.g. `Map.scalars`,
+/// `Filter.predicates`, `Join.on`, `Reduce` aggregate args, `TopK.{limit,
+/// offset}`, `CallTable.exprs`); does not descend into them.
 impl VisitChildren<HirScalarExpr> for HirRelationExpr {
     fn visit_children<F>(&self, mut f: F)
     where
@@ -3863,6 +3887,11 @@ impl HirScalarExpr {
     }
 }
 
+/// Yields the direct scalar children of `self`. Stops at `Exists` / `Select`:
+/// scalars inside subquery bodies are not surfaced. The asymmetry with
+/// `VisitChildren<Self> for HirRelationExpr` (which does see through scalars
+/// into subqueries) is what avoids the mutual recursion warned about on the
+/// [`VisitChildren`] trait.
 impl VisitChildren<Self> for HirScalarExpr {
     fn visit_children<F>(&self, mut f: F)
     where
@@ -3997,6 +4026,8 @@ impl VisitChildren<Self> for HirScalarExpr {
     }
 }
 
+/// Yields the immediate `HirRelationExpr` children of `self` (the bodies of
+/// `Exists` / `Select`); does not descend into them.
 impl VisitChildren<HirRelationExpr> for HirScalarExpr {
     fn visit_children<F>(&self, mut f: F)
     where

--- a/src/sql/src/plan/transform_hir.rs
+++ b/src/sql/src/plan/transform_hir.rs
@@ -94,22 +94,14 @@ pub fn split_subquery_predicates(expr: &mut HirRelationExpr) -> Result<(), Recur
     }
 
     fn walk_scalar(expr: &mut HirScalarExpr) -> Result<(), RecursionLimitError> {
-        expr.try_visit_mut_post(&mut |expr| {
-            match expr {
-                HirScalarExpr::Exists(input, _name) | HirScalarExpr::Select(input, _name) => {
-                    walk_relation(input)?
-                }
-                _ => (),
-            }
-            Ok(())
-        })
+        expr.try_visit_direct_subqueries_mut(&mut walk_relation)
     }
 
     fn contains_subquery(expr: &HirScalarExpr) -> Result<bool, RecursionLimitError> {
         let mut found = false;
-        expr.visit_pre(&mut |expr| match expr {
-            HirScalarExpr::Exists(..) | HirScalarExpr::Select(..) => found = true,
-            _ => (),
+        expr.try_visit_direct_subqueries(|_| {
+            found = true;
+            Ok(())
         })?;
         Ok(found)
     }


### PR DESCRIPTION
This adds `visit_direct_subqueries` helper functions on `HirScalarExpr`, to encapsulate the traversal and then manual match on the `Exists` and `Select` in 6 places.

Can be reviewed commit by commit.
1. adds `impl VisitChildren<HirRelationExpr> for HirScalarExpr`, which is the symmetric counterpart of the existing `impl VisitChildren<HirScalarExpr> for HirRelationExpr`.
2. adds `visit_direct_subqueries` and related helpers.
3. adds a bunch of comments to make exploration of HIR visitation code easier.