### PR TITLE
sql: Fix `bind_parameters`' visitation

### DIFF
--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2286,15 +2286,6 @@ impl HirRelationExpr {
     /// Replaces parameter references in the expression with the corresponding datum from `params`.
     /// Additionally, it simplifies OFFSET clauses to constants after parameter binding, and checks
     /// them for non-negativity.
-    ///
-    /// TODO: This is currently quadratic with subquery nesting depth, because it calls
-    /// `bind_parameters` on each scalar expr at every nesting depth, but `bind_parameters` itself
-    /// also visits subqueries. I think we should
-    /// - make `bind_parameters_and_simplify_offset` call `bind_parameters` only on top-level scalar
-    ///   expressions,
-    /// - and make `bind_parameters` call back to us for subqueries.
-    /// (This would also fix another issue in `bind_parameters`, namely that it doesn't check OFFSET
-    /// clauses inside subqueries.)
     pub fn bind_parameters_and_simplify_offset(
         &mut self,
         scx: &StatementContext,
@@ -2303,7 +2294,7 @@ impl HirRelationExpr {
     ) -> Result<(), PlanError> {
         #[allow(deprecated)]
         self.visit_scalar_expressions_mut(0, &mut |e: &mut HirScalarExpr, _: usize| {
-            e.bind_parameters(scx, lifetime, params)
+            e.bind_parameters_and_simplify_offset(scx, lifetime, params)
         })?;
 
         // OFFSET clauses in `expr` should become constants with the above binding of parameters.
@@ -3248,21 +3239,18 @@ impl HirScalarExpr {
         })
     }
 
-    /// Replaces any parameter references in the expression with the
-    /// corresponding datum in `params`.
-    ///
-    /// Warning: If calling this outside `HirRelationExpr::bind_parameters_and_simplify_offset`,
-    /// be sure that you only call it on expressions without subqueries, because this is currently
-    /// missing the OFFSET simplification inside subqueries that
-    /// `HirRelationExpr::bind_parameters_and_simplify_offset` performs.
-    pub fn bind_parameters(
+    /// Replaces parameter references in the expression with the corresponding datum from `params`.
+    /// Additionally, it simplifies OFFSET clauses to constants after parameter binding, and checks
+    /// them for non-negativity.
+    pub fn bind_parameters_and_simplify_offset(
         &mut self,
         scx: &StatementContext,
         lifetime: QueryLifetime,
         params: &Params,
     ) -> Result<(), PlanError> {
-        #[allow(deprecated)]
-        self.visit_recursively_mut(0, &mut |_: usize, e: &mut HirScalarExpr| {
+        // First, rewrite each `Parameter` node to a literal. This walks only the scalar tree;
+        // it does not yet descend into subqueries.
+        self.try_visit_mut_post(&mut |e: &mut HirScalarExpr| {
             if let HirScalarExpr::Parameter(n, name) = e {
                 let datum = match params.datums.iter().nth(*n - 1) {
                     None => return Err(PlanError::UnknownParameter(*n)),
@@ -3290,10 +3278,15 @@ impl HirScalarExpr {
                 .expect("checked in plan_params");
             }
             Ok(())
+        })?;
+        // Then descend into any subqueries; the relation-side `bind_parameters_and_simplify_offset`
+        // handles corecursion back into scalars.
+        self.try_visit_direct_subqueries_mut(|r: &mut HirRelationExpr| {
+            r.bind_parameters_and_simplify_offset(scx, lifetime, params)
         })
     }
 
-    /// Like [`HirScalarExpr::bind_parameters`], except that parameters are
+    /// Like [`HirScalarExpr::bind_parameters_and_simplify_offset`], except that parameters are
     /// replaced with the corresponding expression fragment from `params` rather
     /// than a datum.
     ///

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2138,11 +2138,17 @@ impl HirRelationExpr {
     }
 
     #[deprecated = "Use a combination of `Visit` and `VisitChildren` methods."]
-    /// Visits all scalar expressions within the sub-tree of the given relation.
+    /// Visits all scalar expressions directly held by relation nodes within the sub-tree of `self`.
     ///
-    /// The `depth` argument should indicate the subquery nesting depth of the expression,
-    /// which will be incremented when entering the RHS of a join or a subquery and
-    /// presented to the supplied function `f`.
+    /// Note: this does NOT descend into subqueries that may appear inside the visited
+    /// `HirScalarExpr`s (i.e., `HirScalarExpr::Exists` / `HirScalarExpr::Select`). The closure
+    /// `f` is invoked once per top-level scalar expression attached to a relation node, and it
+    /// is the closure's responsibility to recurse into any subqueries if desired.
+    ///
+    /// The `depth` argument is just a seed: it is the value passed to `f` for scalar expressions
+    /// at the root of `self`, and it is incremented by 1 when descending into the RHS of a
+    /// `Join` node (the only place this function increments it). It does NOT control or limit
+    /// recursion; passing `0` is the usual choice.
     pub fn visit_scalar_expressions<F, E>(&self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&HirScalarExpr, usize) -> Result<(), E>,
@@ -2197,6 +2203,10 @@ impl HirRelationExpr {
 
     #[deprecated = "Use a combination of `Visit` and `VisitChildren` methods."]
     /// Like `visit_scalar_expressions`, but permits mutating the expressions.
+    ///
+    /// In particular, this also does NOT descend into subqueries inside the visited scalar
+    /// expressions, and `depth` is just a seed for the value passed to `f` (see
+    /// [`HirRelationExpr::visit_scalar_expressions`]).
     pub fn visit_scalar_expressions_mut<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut HirScalarExpr, usize) -> Result<(), E>,
@@ -2286,6 +2296,12 @@ impl HirRelationExpr {
     /// Replaces parameter references in the expression with the corresponding datum from `params`.
     /// Additionally, it simplifies OFFSET clauses to constants after parameter binding, and checks
     /// them for non-negativity.
+    ///
+    /// This walks the entire `HirRelationExpr` tree, including subqueries nested inside scalar
+    /// expressions: `visit_scalar_expressions_mut` covers the scalar expressions held directly
+    /// by relation nodes, and the corecursive call into
+    /// [`HirScalarExpr::bind_parameters_and_simplify_offset`] (made by the closure below) is
+    /// what descends into subqueries occurring inside those scalar expressions.
     pub fn bind_parameters_and_simplify_offset(
         &mut self,
         scx: &StatementContext,
@@ -3242,6 +3258,11 @@ impl HirScalarExpr {
     /// Replaces parameter references in the expression with the corresponding datum from `params`.
     /// Additionally, it simplifies OFFSET clauses to constants after parameter binding, and checks
     /// them for non-negativity.
+    ///
+    /// This handles subqueries nested inside `self` by calling back into
+    /// [`HirRelationExpr::bind_parameters_and_simplify_offset`] on each direct subquery; that
+    /// relation-level function in turn calls back here for the scalar expressions it holds, so
+    /// the two functions corecursively cover the entire HIR tree.
     pub fn bind_parameters_and_simplify_offset(
         &mut self,
         scx: &StatementContext,

--- a/src/sql/src/plan/side_effecting_func.rs
+++ b/src/sql/src/plan/side_effecting_func.rs
@@ -103,7 +103,7 @@ pub fn plan_select_if_side_effecting(
     let temp_storage = RowArena::new();
     let mut args = vec![];
     for mut arg in sef_call.args {
-        arg.bind_parameters(scx, QueryLifetime::OneShot, params)?;
+        arg.bind_parameters_and_simplify_offset(scx, QueryLifetime::OneShot, params)?;
         let arg = arg.lower_uncorrelated(scx.catalog.system_vars())?;
         args.push(arg);
     }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -111,7 +111,7 @@ pub fn plan_insert(
         .expr
         .into_iter()
         .map(|mut expr| {
-            expr.bind_parameters(scx, QueryLifetime::OneShot, params)?;
+            expr.bind_parameters_and_simplify_offset(scx, QueryLifetime::OneShot, params)?;
             expr.lower_uncorrelated(scx.catalog.system_vars())
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -171,7 +171,7 @@ pub fn plan_read_then_write(
     selection.bind_parameters_and_simplify_offset(scx, QueryLifetime::OneShot, params)?;
     let mut assignments_outer = BTreeMap::new();
     for (idx, mut set) in assignments {
-        set.bind_parameters(scx, QueryLifetime::OneShot, params)?;
+        set.bind_parameters_and_simplify_offset(scx, QueryLifetime::OneShot, params)?;
         let set = set.lower_uncorrelated(scx.catalog.system_vars())?;
         assignments_outer.insert(idx, set);
     }
@@ -237,7 +237,7 @@ fn plan_select_inner(
     let limit = match finishing.limit {
         None => None,
         Some(mut limit) => {
-            limit.bind_parameters(scx, lifetime, params)?;
+            limit.bind_parameters_and_simplify_offset(scx, lifetime, params)?;
             // TODO: Call `try_into_literal_int64` instead of `as_literal`.
             let Some(limit) = limit.as_literal() else {
                 sql_bail!(
@@ -257,7 +257,7 @@ fn plan_select_inner(
     };
     let offset = {
         let mut offset = finishing.offset.clone();
-        offset.bind_parameters(scx, lifetime, params)?;
+        offset.bind_parameters_and_simplify_offset(scx, lifetime, params)?;
         let offset = offset_into_value(offset.take())?;
         offset.try_into().map_err(|_| {
             // We already checked in bind_parameters_and_simplify_offset / offset_into_value.

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -1621,6 +1621,14 @@ SELECT * FROM foo
 2  two
 2  two
 
+# Prepared statement parameter in a subquery's OFFSET
+statement ok
+PREPARE p8 AS
+SELECT (SELECT (SELECT (SELECT (SELECT 1 OFFSET $1))))
+
+query error Invalid OFFSET clause: must not be negative, got \-1
+EXECUTE p8(-1);
+
 # Prepared statement parameter in LIMIT
 statement ok
 PREPARE fizz_paginated AS


### PR DESCRIPTION
This is on top of https://github.com/MaterializeInc/materialize/pull/36368 and https://github.com/MaterializeInc/materialize/pull/36369. Only the last commit is new. Edit: Added one more commit, so now the last 2 commits are new. The last commit just adds some more doc comments to HIR visitation.

This resolves the issue pointed out in https://github.com/MaterializeInc/materialize/pull/36368's TODO comment, which is that the HIR visitation in `bind_parameters` was messed up:
1. it was quadratic in subquery nesting depth to due to improper usage of HIR visitation functions;
2. calling the scalar expr `bind_parameters` naked (without an outer relation expr) was not doing the OFFSET simplification / checking inside subqueries.

(This is a bit hard to test: 1. can't really be tested with a real query at the moment, because it seems some other code has exponential slowdown with subquery nesting, which completely trumps the quadraticness issue, 2. all the current naked `bind_parameters` calls are in situations where subqueries are not allowed. But I added a simple test that at least exercises the changed code.)