### PR TITLE
compute: fix divide-by-zero in `LimitProgress` with zero slack

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1776,8 +1776,14 @@ where
                             .iter()
                             .flat_map(|(_, time, _)| u64::from(time).checked_add(slack_ms))
                         {
-                            let rounded_time =
-                                (time / slack_ms).saturating_add(1).saturating_mul(slack_ms);
+                            // `slack_ms == 0` means no rounding; otherwise round up to the next
+                            // multiple of `slack_ms`. Avoids a divide-by-zero panic when the
+                            // operator is configured without slack.
+                            let rounded_time = if slack_ms == 0 {
+                                time
+                            } else {
+                                (time / slack_ms).saturating_add(1).saturating_mul(slack_ms)
+                            };
                             if !upper.less_than(&rounded_time.into()) {
                                 pending_times.insert(rounded_time.into());
                             }

--- a/test/testdrive/compute-logical-backpressure.td
+++ b/test/testdrive/compute-logical-backpressure.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for CLU-61: divide-by-zero panic in `LimitProgress`
+# when `compute_logical_backpressure_inflight_slack = '0s'`.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_compute_logical_backpressure = true;
+ALTER SYSTEM SET compute_logical_backpressure_inflight_slack = '0s';
+
+> CREATE SOURCE counter FROM LOAD GENERATOR COUNTER (TICK INTERVAL '100ms', UP TO 10);
+> CREATE TABLE counter_tbl FROM SOURCE counter;
+
+> SELECT count(*) FROM counter_tbl;
+10
+
+> CREATE MATERIALIZED VIEW mv AS SELECT * FROM counter_tbl;
+
+> SELECT count(*) > 0 FROM mv;
+true
+
+> DROP MATERIALIZED VIEW mv;
+> DROP TABLE counter_tbl;
+> DROP SOURCE counter;
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET enable_compute_logical_backpressure;
+ALTER SYSTEM RESET compute_logical_backpressure_inflight_slack;


### PR DESCRIPTION
### Motivation

Fixes https://linear.app/materializeinc/issue/CLU-61.

Setting `compute_logical_backpressure_inflight_slack` to `0s` caused
the timely worker to panic with `attempt to divide by zero` at
`src/compute/src/render.rs:1780`, where `LimitProgress` rounds
observed timestamps via `time / slack_ms`.

### Description

Short-circuit the rounding step when `slack_ms == 0` and use the
observed time directly. When slack is zero, no rounding is meaningful,
so the operator just tracks raw observed timestamps as pending
capabilities — preserving the limit-progress and `upper`-gating
behavior without dividing by zero.

### Verification

New testdrive `test/testdrive/compute-logical-backpressure.td` runs
the exact reproducer from CLU-61 (counter source + table + MV under
`enable_compute_logical_backpressure = true` and
`compute_logical_backpressure_inflight_slack = '0s'`) and passes.