### PR TITLE
ore: ref-count DeleteOnDropMetric so cloning is safe

### DIFF
--- a/src/ore/src/metrics/delete_on_drop.rs
+++ b/src/ore/src/metrics/delete_on_drop.rs
@@ -30,6 +30,7 @@
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use prometheus::core::{
     Atomic, GenericCounter, GenericCounterVec, GenericGauge, GenericGaugeVec, Metric, MetricVec,
@@ -171,10 +172,12 @@ impl PromLabelsExt for BTreeMap<&str, &str> {
     }
 }
 
-/// A [`Metric`] wrapper that deletes its labels from the vec when it is dropped.
+/// A [`Metric`] wrapper that deletes its labels from the vec when the last clone is dropped.
 ///
-/// It adds a method to create a concrete metric from the vector that gets removed from the vector
-/// when the concrete metric is dropped.
+/// Cloning is ref-counted: the labeled metric is unregistered from its parent vector exactly
+/// once, when the final clone drops. This means cloning is always safe — earlier versions of
+/// this type derived `Clone` directly, which made every clone's `Drop` unregister the metric
+/// and silently disabled the metric for surviving clones.
 ///
 /// NOTE: This type implements [`Borrow`], which imposes some constraints on implementers. To
 /// ensure these constraints, do *not* implement any of the `Eq`, `Ord`, or `Hash` traits on this.
@@ -186,6 +189,21 @@ where
     L: PromLabelsExt,
 {
     inner: V::M,
+    /// Shared cleanup handle. The label is removed from `vec` only when the last clone drops.
+    /// Held purely for its `Drop` side effect — never read directly.
+    #[allow(dead_code)]
+    cleanup: Arc<DeleteOnDropCleanup<V, L>>,
+}
+
+/// Owns the data needed to unregister a labeled metric from its parent vector. Held inside an
+/// [`Arc`] by [`DeleteOnDropMetric`] so that registration is reversed exactly once, when the
+/// last clone of the metric drops.
+#[derive(Debug)]
+struct DeleteOnDropCleanup<V, L>
+where
+    V: MetricVec_,
+    L: PromLabelsExt,
+{
     labels: L,
     vec: V,
 }
@@ -197,7 +215,10 @@ where
 {
     fn from_metric_vector(vec: V, labels: L) -> Self {
         let inner = labels.get_from_metric_vec(&vec);
-        Self { inner, labels, vec }
+        Self {
+            inner,
+            cleanup: Arc::new(DeleteOnDropCleanup { labels, vec }),
+        }
     }
 }
 
@@ -213,7 +234,7 @@ where
     }
 }
 
-impl<V, L> Drop for DeleteOnDropMetric<V, L>
+impl<V, L> Drop for DeleteOnDropCleanup<V, L>
 where
     V: MetricVec_,
     L: PromLabelsExt,
@@ -363,5 +384,36 @@ mod test {
         drop(metric_owned);
         let metrics = reg.gather();
         assert_eq!(metrics.len(), 0);
+    }
+
+    /// Cloning a `DeleteOnDropMetric` must not unregister the labeled metric until the last
+    /// clone is dropped. Regression test for CLU-63.
+    #[crate::test]
+    fn clones_share_registration() {
+        let reg = MetricsRegistry::new();
+        let vec: IntCounterVec = reg.register(metric!(
+            name: "test_metric",
+            help: "a test metric",
+            var_labels: ["dimension"]));
+
+        let metric_1 = vec.get_delete_on_drop_metric(&["one"][..]);
+        let metric_2 = metric_1.clone();
+        metric_1.inc();
+        metric_2.inc();
+
+        // Dropping one clone must not unregister the metric.
+        drop(metric_1);
+        let gathered = reg.gather();
+        assert_eq!(gathered.len(), 1);
+        assert_eq!(gathered[0].get_metric()[0].get_counter().get_value(), 2.0);
+
+        // Increment via the surviving clone is still observable.
+        metric_2.inc();
+        let gathered = reg.gather();
+        assert_eq!(gathered[0].get_metric()[0].get_counter().get_value(), 3.0);
+
+        // Dropping the last clone unregisters the metric.
+        drop(metric_2);
+        assert_eq!(reg.gather().len(), 0);
     }
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2767,6 +2767,58 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert metrics.get_wallclock_lag_count(mv_id) is None
 
 
+def workflow_test_response_count_survives_replica_replacement(
+    c: Composition,
+) -> None:
+    """Test that response_{send,recv}_count metrics survive replica drops."""
+
+    c.up("materialized")
+
+    def fetch_metrics() -> Metrics:
+        resp = c.exec(
+            "materialized", "curl", "localhost:6878/metrics", capture=True
+        ).stdout
+        return Metrics(resp).for_instance("u2")
+
+    c.sql("""
+        CREATE CLUSTER test MANAGED, SIZE 'scale=1,workers=1';
+        SET cluster = test;
+        CREATE TABLE t (a int);
+        INSERT INTO t SELECT generate_series(1, 10);
+        CREATE INDEX idx ON t (a);
+        SELECT * FROM t;
+        """)
+    time.sleep(2)
+
+    metrics = fetch_metrics()
+    send_before = metrics.get_value("mz_compute_controller_response_send_count")
+    recv_before = metrics.get_value("mz_compute_controller_response_recv_count")
+    assert send_before > 0, f"got {send_before}"
+    assert recv_before > 0, f"got {recv_before}"
+
+    c.sql("ALTER CLUSTER test SET (SIZE 'scale=1,workers=2')")
+    time.sleep(2)
+
+    metrics = fetch_metrics()
+    assert len(metrics.with_name("mz_compute_controller_response_send_count")) > 0
+    assert len(metrics.with_name("mz_compute_controller_response_recv_count")) > 0
+
+    c.sql("""
+        SET cluster = test;
+        INSERT INTO t SELECT generate_series(11, 20);
+        SELECT * FROM t;
+        """)
+    time.sleep(2)
+
+    metrics = fetch_metrics()
+    send_after = metrics.get_value("mz_compute_controller_response_send_count")
+    recv_after = metrics.get_value("mz_compute_controller_response_recv_count")
+    assert send_after > send_before, f"got {send_before} -> {send_after}"
+    assert recv_after > recv_before, f"got {recv_before} -> {recv_after}"
+
+    c.sql("DROP CLUSTER test CASCADE")
+
+
 def workflow_test_storage_controller_metrics(c: Composition) -> None:
     """Test metrics exposed by the storage controller."""
 


### PR DESCRIPTION
Fixes [CLU-63](https://linear.app/materializeinc/issue/CLU-63/replica-replacements-make-compute-metrics-disappear).

`DeleteOnDropMetric` derived `Clone`, but its `Drop` impl ran `remove_label_values` on the parent vec for every clone. Dropping any clone unregistered the metric from the Prometheus registry while other clones were still live and incrementing. The compute controller hit this on replica replacement: `mz_compute_controller_response_{send,recv}_count` permanently disappeared from `/metrics`, even though the in-memory counters kept going up.

### Description

Split the cleanup state out of `DeleteOnDropMetric` into a private `DeleteOnDropCleanup` struct held behind an `Arc`. The outer wrapper still derefs to the underlying Prometheus metric and still derives `Clone`, but cloning is now a refcount bump. `remove_label_values` runs exactly once, when the last clone drops.