### PR TITLE
update-docs github workflow: Don't run on forks

### DIFF
--- a/.github/workflows/update-generated-docs.yml
+++ b/.github/workflows/update-generated-docs.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   update-docs:
+    if: github.repository == 'MaterializeInc/materialize'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
I get a daily email with failed run on my fork: https://github.com/def-/materialize/actions/runs/25308646858