### PR TITLE
timely-util: switch Column::Align to Vec<u64>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ bincode = "1.3.3"
 bitflags = "1.3.2"
 buildid = "1.0.4"
 bytefmt = "0.1.7"
-bytemuck = { version = "1.23.1", features = ["latest_stable_rust"] }
+bytemuck = { version = "1.23.1", features = ["extern_crate_alloc", "latest_stable_rust"] }
 byteorder = "1.5"
 bytes = "1.11.1"
 bytesize = "2.3.1"

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -149,13 +149,6 @@ pub const ENABLE_COLUMNATION_LGALLOC: Config<bool> = Config::new(
     "Enable allocating regions from lgalloc.",
 );
 
-/// Enable lgalloc for columnar.
-pub const ENABLE_COLUMNAR_LGALLOC: Config<bool> = Config::new(
-    "enable_columnar_lgalloc",
-    true,
-    "Enable allocating aligned regions in columnar from lgalloc.",
-);
-
 /// The interval at which the compute server performs maintenance tasks.
 pub const COMPUTE_SERVER_MAINTENANCE_INTERVAL: Config<Duration> = Config::new(
     "compute_server_maintenance_interval",
@@ -405,7 +398,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&MEMORY_LIMITER_BURST_FACTOR)
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_COLUMNATION_LGALLOC)
-        .add(&ENABLE_COLUMNAR_LGALLOC)
         .add(&COMPUTE_SERVER_MAINTENANCE_INTERVAL)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -295,9 +295,6 @@ impl ComputeState {
             std::sync::atomic::Ordering::Relaxed,
         );
 
-        let enable_columnar_lgalloc = ENABLE_COLUMNAR_LGALLOC.get(config);
-        mz_timely_util::containers::set_enable_columnar_lgalloc(enable_columnar_lgalloc);
-
         // Remember the maintenance interval locally to avoid reading it from the config set on
         // every server iteration.
         self.server_maintenance_interval = COMPUTE_SERVER_MAINTENANCE_INTERVAL.get(config);

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -29,7 +29,6 @@ use columnar::{Columnar, Ref};
 use columnar::{FromBytes, Index, Len};
 use differential_dataflow::Hashable;
 use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
-use mz_ore::region::Region;
 use timely::Accountable;
 use timely::bytes::arc::Bytes;
 use timely::container::{DrainContainer, PushInto};
@@ -60,7 +59,9 @@ pub enum Column<C: Columnar> {
     ///
     /// Reasons could include misalignment, cloning of data, or wanting
     /// to release the `Bytes` as a scarce resource.
-    Align(Region<u64>),
+    ///
+    /// `Vec<u64>` guarantees `u64` alignment for the contained bytes.
+    Align(Vec<u64>),
 }
 
 impl<C: Columnar> Column<C> {
@@ -96,16 +97,9 @@ where
             Column::Typed(t) => Column::Typed(t.clone()),
             Column::Bytes(b) => {
                 assert_eq!(b.len() % 8, 0);
-                let mut alloc: Region<u64> = crate::containers::alloc_aligned_zeroed(b.len() / 8);
-                let alloc_bytes = bytemuck::cast_slice_mut(&mut alloc);
-                alloc_bytes[..b.len()].copy_from_slice(b);
-                Self::Align(alloc)
+                Self::Align(bytemuck::allocation::pod_collect_to_vec(b))
             }
-            Column::Align(a) => {
-                let mut alloc = crate::containers::alloc_aligned_zeroed(a.len());
-                alloc[..a.len()].copy_from_slice(a);
-                Column::Align(alloc)
-            }
+            Column::Align(a) => Column::Align(a.clone()),
         }
     }
 }
@@ -155,11 +149,9 @@ impl<C: Columnar> ContainerBytes for Column<C> {
         if let Ok(_) = bytemuck::try_cast_slice::<_, u64>(&bytes) {
             Self::Bytes(bytes)
         } else {
-            // We failed to cast the slice, so we'll reallocate.
-            let mut alloc: Region<u64> = crate::containers::alloc_aligned_zeroed(bytes.len() / 8);
-            let alloc_bytes = bytemuck::cast_slice_mut(&mut alloc);
-            alloc_bytes[..bytes.len()].copy_from_slice(&bytes);
-            Self::Align(alloc)
+            // We failed to cast the slice, so we'll reallocate. `Vec<u64>`
+            // is u64-aligned by construction.
+            Self::Align(bytemuck::allocation::pod_collect_to_vec(&bytes[..]))
         }
     }
 
@@ -199,7 +191,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use mz_ore::region::Region;
     use timely::bytes::arc::BytesMut;
     use timely::container::PushInto;
     use timely::dataflow::channels::ContainerBytes;
@@ -239,8 +230,8 @@ mod tests {
         );
 
         let raw = raw_columnar_bytes();
-        let mut region: Region<u64> = crate::containers::alloc_aligned_zeroed(raw.len() / 8);
-        let region_bytes = bytemuck::cast_slice_mut(&mut region);
+        let mut region: Vec<u64> = vec![0; raw.len() / 8];
+        let region_bytes = bytemuck::cast_slice_mut(&mut region[..]);
         region_bytes[..raw.len()].copy_from_slice(&raw);
         let column_align: Column<i32> = Column::Align(region);
         let column_align2 = column_align.clone();

--- a/src/timely-util/src/columnar/builder.rs
+++ b/src/timely-util/src/columnar/builder.rs
@@ -59,7 +59,7 @@ where
             ) where
                 C: Columnar,
             {
-                let mut alloc = crate::containers::alloc_aligned_zeroed(round);
+                let mut alloc: Vec<u64> = vec![0; round];
                 let mut writer = std::io::Cursor::new(bytemuck::cast_slice_mut(&mut alloc[..]));
                 indexed::write(&mut writer, &current.borrow()).unwrap();
                 pending.push_back(Column::Align(alloc));

--- a/src/timely-util/src/containers.rs
+++ b/src/timely-util/src/containers.rs
@@ -16,37 +16,3 @@
 //! Reusable containers.
 
 pub mod stack;
-
-pub(crate) use alloc::alloc_aligned_zeroed;
-pub use alloc::{enable_columnar_lgalloc, set_enable_columnar_lgalloc};
-
-mod alloc {
-    use mz_ore::region::Region;
-
-    /// Allocate a region of memory with a capacity of at least `len` that is properly aligned
-    /// and zeroed. The memory in Regions is always aligned to its content type.
-    #[inline]
-    pub(crate) fn alloc_aligned_zeroed<T: bytemuck::AnyBitPattern>(len: usize) -> Region<T> {
-        if enable_columnar_lgalloc() {
-            Region::new_auto_zeroed(len)
-        } else {
-            Region::new_heap_zeroed(len)
-        }
-    }
-
-    thread_local! {
-        static ENABLE_COLUMNAR_LGALLOC: std::cell::Cell<bool> =
-            const { std::cell::Cell::new(false) };
-    }
-
-    /// Returns `true` if columnar allocations should come from lgalloc.
-    #[inline]
-    pub fn enable_columnar_lgalloc() -> bool {
-        ENABLE_COLUMNAR_LGALLOC.get()
-    }
-
-    /// Set whether columnar allocations should come from lgalloc. Applies to future allocations.
-    pub fn set_enable_columnar_lgalloc(enabled: bool) {
-        ENABLE_COLUMNAR_LGALLOC.set(enabled);
-    }
-}


### PR DESCRIPTION
### Motivation

CLU-64. `Vec<u64>` already provides `u64` alignment through the global allocator's contract, so the `Region<u64>` indirection and the `alloc_aligned_zeroed` plumbing aren't pulling their weight.

### Description

Switch `Column::Align` to hold a `Vec<u64>`. Drop the now-unused `alloc_aligned_zeroed` helper and the columnar-lgalloc toggle (and its dyncfg), which no longer affect anything once the variant uses `Vec`.