### PR TITLE
Fix `string_to_array`'s handling of `null_string` when `delim` is empty

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -500,6 +500,9 @@
       If `null_string` is supplied and is not NULL, fields matching that string
       are replaced by NULL.
 
+      If `s` is NULL, the result is NULL. If `s` is the empty string, the
+      result is an empty array (regardless of `delimiter` or `null_string`).
+
       For example: `string_to_array('xx~~yy~~zz', '~~', 'yy')` → `{xx,NULL,zz}`
 
 - type: Scalar

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -1328,14 +1328,18 @@ fn string_to_array<'a>(
     if delimiter.is_empty() {
         let mut row = Row::default();
         let mut packer = row.packer();
-        packer.try_push_array(
-            &[ArrayDimension {
-                lower_bound: 1,
-                length: 1,
-            }],
-            vec![string].into_iter().map(Datum::String),
-        )?;
-
+        let dims = &[ArrayDimension {
+            lower_bound: 1,
+            length: 1,
+        }];
+        match null_string.flatten() {
+            Some(null_string) if null_string == string => {
+                packer.try_push_array(dims, std::iter::once(Datum::Null))?;
+            }
+            _ => {
+                packer.try_push_array(dims, vec![string].into_iter().map(Datum::String))?;
+            }
+        }
         Ok(temp_storage.push_unary_row(row))
     } else {
         string_to_array_impl(string, delimiter, null_string.flatten(), temp_storage)

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1897,4 +1897,75 @@ NULL
 query error
 select string_to_array('hello world', 0) from string_to_array_words;
 
+# string_to_array - consecutive delimiters produce empty fields.
+query T
+select string_to_array('a||b', '|') from string_to_array_words;
+----
+{a,"",b}
+
+# string_to_array - leading and trailing delimiters produce empty fields.
+query T
+select string_to_array('|a|b|', '|') from string_to_array_words;
+----
+{"",a,b,""}
+
+# string_to_array - null_string set to empty string replaces empty fields with NULL.
+query T
+select string_to_array('a||b', '|', '') from string_to_array_words;
+----
+{a,NULL,b}
+
+query T
+select string_to_array('|a|b|', '|', '') from string_to_array_words;
+----
+{NULL,a,b,NULL}
+
+# string_to_array - null_string matches a token in the middle.
+query T
+select string_to_array('a|b|c', '|', 'b') from string_to_array_words;
+----
+{a,NULL,c}
+
+# string_to_array - null_string matches the last token.
+query T
+select string_to_array('a|b|c', '|', 'c') from string_to_array_words;
+----
+{a,b,NULL}
+
+# string_to_array - NULL delimiter (split into chars) with null_string set.
+query T
+select string_to_array('hello', NULL, 'l') from string_to_array_words;
+----
+{h,e,NULL,NULL,o}
+
+# string_to_array - NULL delimiter (split into chars) with null_string set to NULL.
+query T
+select string_to_array('hello', NULL, NULL) from string_to_array_words;
+----
+{h,e,l,l,o}
+
+# string_to_array - multi-character delimiter.
+query T
+select string_to_array('a<>b<>c', '<>') from string_to_array_words;
+----
+{a,b,c}
+
+# string_to_array - multi-character delimiter with null_string matching middle token.
+query T
+select string_to_array('a<>b<>c', '<>', 'b') from string_to_array_words;
+----
+{a,NULL,c}
+
+# string_to_array - delimiter not present in input.
+query T
+select string_to_array('abc', '|') from string_to_array_words;
+----
+{abc}
+
+# string_to_array - delimiter not present in input, with null_string matching whole input.
+query T
+select string_to_array('abc', '|', 'abc') from string_to_array_words;
+----
+{NULL}
+
 # string_to_array - end.

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1841,9 +1841,19 @@ select string_to_array(word, ' ', 'hello') from string_to_array_words;
 {NULL,world}
 
 # string_to_array - empty string delimiter and null_string set to whole word.
-# expectation: null_string is ignored if no delimiter is passed.
+# expectation: null_string is still respected if delimiter is empty. (Same as Postgres.)
 query T
 select string_to_array(word, '', 'hello world') from string_to_array_words;
+----
+{NULL}
+
+query T
+select string_to_array(word, '', 'aaa') from string_to_array_words;
+----
+{"hello world"}
+
+query T
+select string_to_array(word, '', null) from string_to_array_words;
 ----
 {"hello world"}
 


### PR DESCRIPTION
As it says on the tin. Fixes https://github.com/MaterializeInc/database-issues/issues/11351

Additionally:
- The 2. commit adds a bunch more tests, suggested by my AI agent.
- The 3. commit adds some more edge cases to our docs.