### PR TITLE
parallel-workload: reconnect on cancelled ROLLBACK

### DIFF
--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -91,6 +91,10 @@ class Worker:
                     try:
                         self.exe.rollback()
                     except QueryError as e:
+                        # ROLLBACK can itself be cancelled by
+                        # `pg_cancel_backend`, leaving psycopg in
+                        # `InFailedSqlTransaction`. Force a reconnect rather
+                        # than retry the rollback.
                         if (
                             "Please disconnect and re-connect" in e.msg
                             or "server closed the connection unexpectedly" in e.msg
@@ -98,6 +102,8 @@ class Worker:
                             or "Connection refused" in e.msg
                             or "the connection is lost" in e.msg
                             or "connection in transaction status INERROR" in e.msg
+                            or "canceling statement due to user request" in e.msg
+                            or "current transaction is aborted" in e.msg
                         ):
                             self.exe.reconnect_next = True
                             self.exe.rollback_next = False


### PR DESCRIPTION
The cancel scenario periodically fires `pg_cancel_backend` against a random worker. If that signal arrives during the worker's ROLLBACK, psycopg's `connection.rollback()` raises a "canceling statement due to user request" error. The rollback-error handler didn't recognize that string, silently cleared `rollback_next`, and moved on — but psycopg was still in `InFailedSqlTransaction`, so the next psycopg-path query (COPY TO, SET, PREPARE, ...) died client-side with "current transaction is aborted", which no action tolerates.

Found this while working on changes that seemed to tickle this race condition more than before.