### PR TITLE
Console maintained objects list

### DIFF
--- a/console/src/api/materialize/maintained-objects/constants.ts
+++ b/console/src/api/materialize/maintained-objects/constants.ts
@@ -1,0 +1,23 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * Object types we treat as "maintained" — sources, materialized views,
+ * indexes, sinks, and tables. Values match `mz_objects.type` (and the
+ * hyphenated form used by `mz_object_fully_qualified_names.object_type`).
+ */
+export const MAINTAINED_OBJECT_TYPES = [
+  "source",
+  "materialized-view",
+  "index",
+  "sink",
+  "table",
+] as const;
+
+export type MaintainedObjectType = (typeof MAINTAINED_OBJECT_TYPES)[number];

--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
@@ -1,0 +1,109 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  executeSqlHttp,
+  QUICKSTART_CLUSTER,
+} from "~/test/sql/materializeSqlClient";
+import { testdrive } from "~/test/sql/mzcompose";
+
+import { SEARCH_PATH } from "../executeSql";
+import { buildHydrationAggregateQuery } from "./hydrationAggregate";
+
+describe("buildHydrationAggregateQuery", () => {
+  it("aggregates hydrated and total replicas per object", async () => {
+    const testSchema = "test_hydration_aggregate";
+
+    // u1: single replica, hydrated → 1/1
+    // u2: 3 replicas, all hydrated → 3/3
+    // u3: 3 replicas, 1 hydrated → 1/3
+    // u4: 2 replicas, none hydrated → 0/2
+    await testdrive(`
+      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
+      > CREATE SCHEMA ${testSchema};
+      > CREATE TABLE ${testSchema}.mz_hydration_statuses (
+          object_id TEXT NOT NULL,
+          replica_id TEXT,
+          hydrated BOOLEAN
+        );
+      > INSERT INTO ${testSchema}.mz_hydration_statuses VALUES
+          ('u1', 'r1', true),
+          ('u2', 'r1', true),
+          ('u2', 'r2', true),
+          ('u2', 'r3', true),
+          ('u3', 'r1', true),
+          ('u3', 'r2', false),
+          ('u3', 'r3', false),
+          ('u4', 'r1', false),
+          ('u4', 'r2', false);
+    `);
+
+    const compiled = buildHydrationAggregateQuery().compile();
+    const result = await executeSqlHttp(compiled, {
+      sessionVariables: {
+        cluster: QUICKSTART_CLUSTER,
+        search_path: `${testSchema}, ${SEARCH_PATH}`,
+      },
+    });
+
+    const rows = result.rows.sort((a, b) =>
+      a.object_id.localeCompare(b.object_id),
+    );
+    expect(rows).toHaveLength(4);
+
+    expect(rows[0]).toMatchObject({ object_id: "u1" });
+    expect(Number(rows[0].hydratedReplicas)).toBe(1);
+    expect(Number(rows[0].totalReplicas)).toBe(1);
+
+    expect(rows[1]).toMatchObject({ object_id: "u2" });
+    expect(Number(rows[1].hydratedReplicas)).toBe(3);
+    expect(Number(rows[1].totalReplicas)).toBe(3);
+
+    expect(rows[2]).toMatchObject({ object_id: "u3" });
+    expect(Number(rows[2].hydratedReplicas)).toBe(1);
+    expect(Number(rows[2].totalReplicas)).toBe(3);
+
+    expect(rows[3]).toMatchObject({ object_id: "u4" });
+    expect(Number(rows[3].hydratedReplicas)).toBe(0);
+    expect(Number(rows[3].totalReplicas)).toBe(2);
+  });
+
+  it("treats null hydrated values as not-hydrated for the FILTER clause", async () => {
+    const testSchema = "test_hydration_aggregate";
+
+    // A replica that hasn't reported a status yet shows up as a null row;
+    // the FILTER (WHERE hydrated) should not count it as hydrated, but the
+    // total count still includes it.
+    await testdrive(`
+      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
+      > CREATE SCHEMA ${testSchema};
+      > CREATE TABLE ${testSchema}.mz_hydration_statuses (
+          object_id TEXT NOT NULL,
+          replica_id TEXT,
+          hydrated BOOLEAN
+        );
+      > INSERT INTO ${testSchema}.mz_hydration_statuses VALUES
+          ('u1', 'r1', true),
+          ('u1', 'r2', NULL);
+    `);
+
+    const compiled = buildHydrationAggregateQuery().compile();
+    const result = await executeSqlHttp(compiled, {
+      sessionVariables: {
+        cluster: QUICKSTART_CLUSTER,
+        search_path: `${testSchema}, ${SEARCH_PATH}`,
+      },
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ object_id: "u1" });
+    expect(Number(result.rows[0].hydratedReplicas)).toBe(1);
+    expect(Number(result.rows[0].totalReplicas)).toBe(2);
+  });
+});

--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
@@ -1,0 +1,35 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { sql } from "kysely";
+
+import { queryBuilder } from "~/api/materialize";
+
+export interface HydrationAggregateRow {
+  object_id: string;
+  hydratedReplicas: bigint;
+  totalReplicas: bigint;
+}
+
+/**
+ * One row per object: how many of its replicas report `hydrated = true`, out
+ * of the total replicas recorded in `mz_hydration_statuses`
+ */
+export function buildHydrationAggregateQuery() {
+  return queryBuilder
+    .selectFrom("mz_hydration_statuses")
+    .select((eb) => [
+      "object_id",
+      sql<bigint>`count(*) FILTER (WHERE ${eb.ref("hydrated")})`.as(
+        "hydratedReplicas",
+      ),
+      sql<bigint>`count(*)`.as("totalReplicas"),
+    ])
+    .groupBy("object_id");
+}

--- a/console/src/api/materialize/maintained-objects/lagAggregate.test.sql.ts
+++ b/console/src/api/materialize/maintained-objects/lagAggregate.test.sql.ts
@@ -1,0 +1,157 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  executeSqlHttp,
+  QUICKSTART_CLUSTER,
+} from "~/test/sql/materializeSqlClient";
+import { testdrive } from "~/test/sql/mzcompose";
+
+import { SEARCH_PATH } from "../executeSql";
+import { buildLagAggregateQuery } from "./lagAggregate";
+
+describe("buildLagAggregateQuery", () => {
+  it("returns max(lag) per object_id across multiple samples", async () => {
+    const testSchema = "test_lag_aggregate";
+
+    // u1 has three recent samples — max should win.
+    // u2 has a single recent sample.
+    // All samples are at `now()` so the temporal filter doesn't exclude any.
+    await testdrive(`
+      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
+      > CREATE SCHEMA ${testSchema};
+      > CREATE TABLE ${testSchema}.mz_wallclock_global_lag_recent_history (
+          object_id TEXT NOT NULL,
+          lag INTERVAL,
+          occurred_at TIMESTAMP
+        );
+      > INSERT INTO ${testSchema}.mz_wallclock_global_lag_recent_history VALUES
+          ('u1', INTERVAL '500 MILLISECONDS', now()),
+          ('u1', INTERVAL '2 SECONDS', now()),
+          ('u1', INTERVAL '1 SECOND', now()),
+          ('u2', INTERVAL '100 MILLISECONDS', now());
+    `);
+
+    const compiled = buildLagAggregateQuery({ lookbackMinutes: 60 }).compile();
+    const result = await executeSqlHttp(compiled, {
+      sessionVariables: {
+        cluster: QUICKSTART_CLUSTER,
+        search_path: `${testSchema}, ${SEARCH_PATH}`,
+      },
+    });
+
+    const rows = result.rows.sort((a, b) =>
+      a.object_id.localeCompare(b.object_id),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0].object_id).toBe("u1");
+    expect(rows[0].lag?.toPostgres()).toBe("2 seconds");
+    expect(rows[1].object_id).toBe("u2");
+    expect(rows[1].lag?.toPostgres()).toBe("0.1 seconds");
+  });
+
+  it("respects a 5-minute lookback at the temporal-filter boundary", async () => {
+    const testSchema = "test_lag_aggregate";
+
+    // u1: a 2-minute-old sample (inside the 5m window).
+    // u2: a 7-minute-old sample (outside the 5m window).
+    // u3: one 1-minute-old sample (in window) and one 7-minute-old sample
+    //     (out of window) — only the in-window sample should drive max(lag).
+    await testdrive(`
+      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
+      > CREATE SCHEMA ${testSchema};
+      > CREATE TABLE ${testSchema}.mz_wallclock_global_lag_recent_history (
+          object_id TEXT NOT NULL,
+          lag INTERVAL,
+          occurred_at TIMESTAMP
+        );
+      > INSERT INTO ${testSchema}.mz_wallclock_global_lag_recent_history VALUES
+          ('u1', INTERVAL '300 MILLISECONDS', now() - INTERVAL '2 MINUTES'),
+          ('u2', INTERVAL '9 SECONDS', now() - INTERVAL '7 MINUTES'),
+          ('u3', INTERVAL '500 MILLISECONDS', now() - INTERVAL '1 MINUTE'),
+          ('u3', INTERVAL '12 SECONDS', now() - INTERVAL '7 MINUTES');
+    `);
+
+    const compiled = buildLagAggregateQuery({ lookbackMinutes: 5 }).compile();
+    const result = await executeSqlHttp(compiled, {
+      sessionVariables: {
+        cluster: QUICKSTART_CLUSTER,
+        search_path: `${testSchema}, ${SEARCH_PATH}`,
+      },
+    });
+
+    const rows = result.rows.sort((a, b) =>
+      a.object_id.localeCompare(b.object_id),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0].object_id).toBe("u1");
+    expect(rows[0].lag?.toPostgres()).toBe("0.3 seconds");
+    // u3's 12-second sample is older than 5 minutes and must be filtered out;
+    // only the 0.5-second sample remains.
+    expect(rows[1].object_id).toBe("u3");
+    expect(rows[1].lag?.toPostgres()).toBe("0.5 seconds");
+  });
+
+  it("excludes samples older than the lookback window", async () => {
+    const testSchema = "test_lag_aggregate";
+
+    // u1: one recent sample (in window for 1m), one 10-minute-old sample
+    //     (in window for 60m, out of window for 1m)
+    // u2: only an old (10-minute-old) sample
+    await testdrive(`
+      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
+      > CREATE SCHEMA ${testSchema};
+      > CREATE TABLE ${testSchema}.mz_wallclock_global_lag_recent_history (
+          object_id TEXT NOT NULL,
+          lag INTERVAL,
+          occurred_at TIMESTAMP
+        );
+      > INSERT INTO ${testSchema}.mz_wallclock_global_lag_recent_history VALUES
+          ('u1', INTERVAL '200 MILLISECONDS', now()),
+          ('u1', INTERVAL '5 SECONDS', now() - INTERVAL '10 MINUTES'),
+          ('u2', INTERVAL '8 SECONDS', now() - INTERVAL '10 MINUTES');
+    `);
+
+    // Lookback 1 minute → only u1's recent sample passes the temporal filter.
+    {
+      const compiled = buildLagAggregateQuery({ lookbackMinutes: 1 }).compile();
+      const result = await executeSqlHttp(compiled, {
+        sessionVariables: {
+          cluster: QUICKSTART_CLUSTER,
+          search_path: `${testSchema}, ${SEARCH_PATH}`,
+        },
+      });
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].object_id).toBe("u1");
+      expect(result.rows[0].lag?.toPostgres()).toBe("0.2 seconds");
+    }
+
+    // Lookback 60 minutes → both objects in scope; max(lag) for u1 should
+    // include the 5-second 10-minute-old sample.
+    {
+      const compiled = buildLagAggregateQuery({
+        lookbackMinutes: 60,
+      }).compile();
+      const result = await executeSqlHttp(compiled, {
+        sessionVariables: {
+          cluster: QUICKSTART_CLUSTER,
+          search_path: `${testSchema}, ${SEARCH_PATH}`,
+        },
+      });
+      const rows = result.rows.sort((a, b) =>
+        a.object_id.localeCompare(b.object_id),
+      );
+      expect(rows).toHaveLength(2);
+      expect(rows[0].object_id).toBe("u1");
+      expect(rows[0].lag?.toPostgres()).toBe("5 seconds");
+      expect(rows[1].object_id).toBe("u2");
+      expect(rows[1].lag?.toPostgres()).toBe("8 seconds");
+    }
+  });
+});

--- a/console/src/api/materialize/maintained-objects/lagAggregate.ts
+++ b/console/src/api/materialize/maintained-objects/lagAggregate.ts
@@ -1,0 +1,41 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { sql } from "kysely";
+
+import { IPostgresInterval, queryBuilder } from "~/api/materialize";
+
+export interface LagAggregateParams {
+  /** Lookback window in minutes for the temporal filter on lag history. */
+  lookbackMinutes: number;
+}
+
+export interface LagAggregateRow {
+  object_id: string;
+  lag: IPostgresInterval | null;
+}
+
+/**
+ * One row per object: the maximum (pMAX) lag observed in
+ * `mz_wallclock_global_lag_recent_history` over the lookback window.
+ */
+export function buildLagAggregateQuery({
+  lookbackMinutes,
+}: LagAggregateParams) {
+  return queryBuilder
+    .selectFrom("mz_wallclock_global_lag_recent_history")
+    .select(["object_id", sql<IPostgresInterval | null>`max(lag)`.as("lag")])
+    .where(
+      (eb) =>
+        sql`${eb.ref("occurred_at")} + INTERVAL '${sql.raw(`${lookbackMinutes}`)} MINUTES'`,
+      ">=",
+      sql<Date>`mz_now()`,
+    )
+    .groupBy("object_id");
+}

--- a/console/src/components/Table/UniversalTable.tsx
+++ b/console/src/components/Table/UniversalTable.tsx
@@ -9,6 +9,11 @@
 
 import {
   Box,
+  Icon,
+  IconButton,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Skeleton,
   Table,
   Tbody,
@@ -17,11 +22,14 @@ import {
   Thead,
   Tooltip,
   Tr,
+  useTheme,
 } from "@chakra-ui/react";
 import { flexRender, Header, SortDirection } from "@tanstack/react-table";
 import React from "react";
 
-import { ChevronDownIcon, InfoIcon } from "~/icons";
+import { ChevronDownIcon, FilterIcon, InfoIcon } from "~/icons";
+import { MaterializeTheme } from "~/theme";
+import { viewportOverflowModifier } from "~/theme/components/Popover";
 
 import { UniversalTableProps } from "./tableTypes";
 
@@ -38,6 +46,58 @@ const SortIndicator = ({ direction }: { direction: SortDirection | false }) => {
   );
 };
 
+const ColumnFilterTrigger = <TData,>({
+  header,
+}: {
+  header: Header<TData, unknown>;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const renderFilter = header.column.columnDef.meta?.renderFilter;
+  if (!renderFilter) return null;
+  const isActive = header.column.getFilterValue() !== undefined;
+  return (
+    <Popover
+      gutter={2}
+      modifiers={viewportOverflowModifier}
+      variant="dropdown"
+      placement="bottom-end"
+    >
+      <PopoverTrigger>
+        <IconButton
+          aria-label={`Filter ${header.column.id}`}
+          icon={
+            <Icon
+              as={FilterIcon}
+              color={
+                isActive
+                  ? colors.accent.brightPurple
+                  : colors.foreground.secondary
+              }
+            />
+          }
+          size="xs"
+          variant="ghost"
+          minW="5"
+          height="5"
+          ml={1}
+          onClick={(e) => {
+            // Don't bubble into the header's sort-on-click handler.
+            e.stopPropagation();
+          }}
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        motionProps={{ animate: false }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Box width="280px">
+          {renderFilter(header.column, header.getContext().table)}
+        </Box>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
 const ColumnHeader = <TData,>({
   header,
 }: {
@@ -45,6 +105,7 @@ const ColumnHeader = <TData,>({
 }) => {
   const tooltip = header.column.columnDef.meta?.tooltip;
   const canSort = header.column.getCanSort();
+  const canFilter = !!header.column.columnDef.meta?.renderFilter;
 
   return (
     <Th
@@ -58,7 +119,12 @@ const ColumnHeader = <TData,>({
       }}
       onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
     >
-      <Box display="flex" alignItems="center">
+      <Box
+        display="flex"
+        alignItems="center"
+        flexWrap="nowrap"
+        whiteSpace="nowrap"
+      >
         {header.isPlaceholder
           ? null
           : flexRender(header.column.columnDef.header, header.getContext())}
@@ -68,6 +134,7 @@ const ColumnHeader = <TData,>({
             <InfoIcon ml={1} />
           </Tooltip>
         )}
+        {canFilter && <ColumnFilterTrigger header={header} />}
       </Box>
     </Th>
   );
@@ -99,6 +166,7 @@ export const UniversalTable = <TData,>({
   onRowClick,
   isLoading = false,
   skeletonRowCount = SKELETON_ROW_COUNT,
+  rowSx,
   "data-testid": testId,
 }: UniversalTableProps<TData>) => {
   const headerGroups = table.getHeaderGroups();
@@ -126,6 +194,7 @@ export const UniversalTable = <TData,>({
               onClick={onRowClick ? () => onRowClick(row.original) : undefined}
               sx={{
                 cursor: onRowClick ? "pointer" : undefined,
+                ...rowSx,
               }}
             >
               {row.getVisibleCells().map((cell) => (

--- a/console/src/components/Table/tableTypes.ts
+++ b/console/src/components/Table/tableTypes.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import { HTMLChakraProps } from "@chakra-ui/react";
-import { RowData, Table } from "@tanstack/react-table";
+import { Column, RowData, Table } from "@tanstack/react-table";
 import React from "react";
 
 /**
@@ -33,6 +33,8 @@ export interface UniversalTableProps<TData> {
   isLoading?: boolean;
   /** Number of skeleton rows to display when loading. */
   skeletonRowCount?: number;
+  /** Chakra `sx` merged onto every body `<Tr>`. */
+  rowSx?: HTMLChakraProps<"tr">["sx"];
   /** `data-testid` forwarded to the root `<Table>` element. */
   "data-testid"?: string;
 }
@@ -66,7 +68,6 @@ export interface TableSearchProps {
  * even though we don't reference them here.
  */
 declare module "@tanstack/react-table" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     /** Tooltip shown on the column header. */
     tooltip?: string;
@@ -74,5 +75,16 @@ declare module "@tanstack/react-table" {
     minWidth?: Record<string, string> | string;
     /** Chakra props spread onto the `<Td>` for every cell in this column. */
     cellProps?: HTMLChakraProps<"td">;
+    /**
+     * Renders a per-column filter UI inside a popover anchored on the column
+     * header. When defined, `UniversalTable` shows a small filter trigger next
+     * to the sort caret (with an active-state dot when the column has a
+     * filter value applied). Receives `table` so the panel can pull shared
+     * data (e.g. dropdown options) from `table.options.meta`.
+     */
+    renderFilter?: (
+      column: Column<TData, TValue>,
+      table: Table<TData>,
+    ) => React.ReactNode;
   }
 }

--- a/console/src/config/flexibleDeploymentFlags.ts
+++ b/console/src/config/flexibleDeploymentFlags.ts
@@ -12,7 +12,9 @@
  * is too big, we default all flags to true and specify the ones we want
  * to disable.
  */
-export const disabledFlexibleDeploymentFlags: Record<string, boolean> = {};
+export const disabledFlexibleDeploymentFlags: Record<string, boolean> = {
+  "maintained-objects-ui-50": false,
+};
 
 export const flexibleDeploymentFlags = new Proxy(
   {},

--- a/console/src/layouts/NavBar/NavMenu.tsx
+++ b/console/src/layouts/NavBar/NavMenu.tsx
@@ -117,6 +117,14 @@ const getNavItems = ({
               },
             ]
           : []),
+        ...(flags["maintained-objects-ui-50"]
+          ? [
+              {
+                label: "Objects",
+                href: `/regions/${regionSlug}/maintained-objects`,
+              },
+            ]
+          : []),
         {
           label: "Sources",
           href: `/regions/${regionSlug}/sources`,

--- a/console/src/platform/AuthenticatedRoutes.tsx
+++ b/console/src/platform/AuthenticatedRoutes.tsx
@@ -34,6 +34,7 @@ import BlockedState from "~/platform/environment-not-ready/BlockedState";
 import { EnvironmentNotReadyRoutes } from "~/platform/environment-not-ready/EnvironmentNotReadyRoutes";
 import { EnvironmentOverviewRoutes } from "~/platform/environment-overview/EnvironmentOverviewRoutes";
 import IntegrationsRoutes from "~/platform/integrations/IntegrationsRoutes";
+import { MaintainedObjectsRoutes } from "~/platform/maintained-objects/MaintainedObjectsRoutes";
 import { ObjectExplorerDetailRoutes } from "~/platform/object-explorer/ObjectExplorerDetailRoutes";
 import { ObjectExplorerRoutes } from "~/platform/object-explorer/ObjectExplorerRoutes";
 import QueryHistoryRoutes from "~/platform/query-history/QueryHistoryRoutes";
@@ -329,6 +330,16 @@ const EnvironmentRoutes = () => {
             element={
               <BaseLayout>
                 <EnvironmentOverviewRoutes />
+              </BaseLayout>
+            }
+          />
+        )}
+        {flags["maintained-objects-ui-50"] && (
+          <Route
+            path="maintained-objects/*"
+            element={
+              <BaseLayout>
+                <MaintainedObjectsRoutes />
               </BaseLayout>
             }
           />

--- a/console/src/platform/maintained-objects/FilterChips.tsx
+++ b/console/src/platform/maintained-objects/FilterChips.tsx
@@ -1,0 +1,121 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { HStack, Tag, TagCloseButton, TagLabel } from "@chakra-ui/react";
+import { Column, Table } from "@tanstack/react-table";
+import React from "react";
+
+import { MaintainedObjectType } from "~/api/materialize/maintained-objects/constants";
+import { fromSeconds } from "~/utils/format";
+
+import { HYDRATION_LABELS, HydrationBucket } from "./filters";
+import { MaintainedObjectListItem } from "./queries";
+
+interface Chip {
+  key: string;
+  label: string;
+  onRemove: () => void;
+}
+
+type AnyColumn = Column<MaintainedObjectListItem, unknown>;
+
+/** Per-value remover for a multi-select column: drops `value` from the
+ *  current filter array and clears the filter when the array empties. */
+const removeMultiValue =
+  <T,>(column: AnyColumn, value: T) =>
+  () => {
+    const current = (column.getFilterValue() as T[] | undefined) ?? [];
+    const next = current.filter((v) => v !== value);
+    column.setFilterValue(next.length ? next : undefined);
+  };
+
+const multiSelectChips = <T,>(
+  column: AnyColumn,
+  prefix: string,
+  itemLabel: (value: T) => string,
+): Chip[] => {
+  const values = (column.getFilterValue() as T[] | undefined) ?? [];
+  return values.map((value) => ({
+    key: `${column.id}:${String(value)}`,
+    label: `${prefix}: ${itemLabel(value)}`,
+    onRemove: removeMultiValue(column, value),
+  }));
+};
+
+interface ChipSource {
+  columnId: string;
+  build: (column: AnyColumn) => Chip[];
+}
+
+const CHIP_SOURCES: ChipSource[] = [
+  {
+    columnId: "clusterName",
+    build: (column) => multiSelectChips<string>(column, "Cluster", (c) => c),
+  },
+  {
+    columnId: "objectType",
+    build: (column) =>
+      multiSelectChips<MaintainedObjectType>(column, "Type", (t) => t),
+  },
+  {
+    columnId: "freshness",
+    build: (column) => {
+      const value = column.getFilterValue();
+      if (typeof value !== "number") return [];
+      const { amount, unit } = fromSeconds(value);
+      const unitLabel = amount === 1 ? unit.slice(0, -1) : unit;
+      return [
+        {
+          key: column.id,
+          label: `Freshness: ≥ ${amount} ${unitLabel}`,
+          onRemove: () => column.setFilterValue(undefined),
+        },
+      ];
+    },
+  },
+  {
+    columnId: "hydration",
+    build: (column) =>
+      multiSelectChips<HydrationBucket>(
+        column,
+        "Hydration",
+        (b) => HYDRATION_LABELS[b],
+      ),
+  },
+];
+
+export interface FilterChipsProps {
+  table: Table<MaintainedObjectListItem>;
+}
+
+export const FilterChips = ({ table }: FilterChipsProps) => {
+  const chips: Chip[] = [];
+  for (const source of CHIP_SOURCES) {
+    const column = table.getColumn(source.columnId);
+    if (!column) continue;
+    chips.push(...source.build(column));
+  }
+
+  if (chips.length === 0) return null;
+
+  return (
+    <HStack spacing="2" flexWrap="wrap">
+      {chips.map((chip) => (
+        <Tag key={chip.key} size="md" borderRadius="md" px="3" py="1">
+          <TagLabel>{chip.label}</TagLabel>
+          <TagCloseButton
+            aria-label={`Remove ${chip.label}`}
+            onClick={chip.onRemove}
+            ml="2"
+          />
+        </Tag>
+      ))}
+    </HStack>
+  );
+};

--- a/console/src/platform/maintained-objects/MaintainedObjects.test.tsx
+++ b/console/src/platform/maintained-objects/MaintainedObjects.test.tsx
@@ -1,0 +1,168 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { renderComponent } from "~/test/utils";
+
+import MaintainedObjects from "./MaintainedObjects";
+import {
+  MaintainedObjectListItem,
+  UseMaintainedObjectsListResult,
+} from "./queries";
+
+vi.mock("./queries", async () => {
+  const actual = await vi.importActual<typeof import("./queries")>("./queries");
+  return {
+    ...actual,
+    useMaintainedObjectsList: vi.fn(),
+  };
+});
+
+const { useMaintainedObjectsList } = await import("./queries");
+
+const buildObject = (
+  overrides: Partial<MaintainedObjectListItem>,
+): MaintainedObjectListItem => ({
+  id: "u1",
+  name: "object",
+  schemaName: "public",
+  databaseName: "materialize",
+  objectType: "materialized-view",
+  cluster: { id: "u1", name: "quickstart" },
+  hydratedReplicas: 1,
+  totalReplicas: 1,
+  lag: null,
+  ...overrides,
+});
+
+const ordersMv = buildObject({
+  id: "u101",
+  name: "orders_mv",
+  objectType: "materialized-view",
+  cluster: { id: "u101", name: "compute_cluster" },
+  hydratedReplicas: 2,
+  totalReplicas: 2,
+});
+
+const inventoryIdx = buildObject({
+  id: "u102",
+  name: "inventory_idx",
+  objectType: "index",
+  cluster: { id: "u101", name: "compute_cluster" },
+  hydratedReplicas: 1,
+  totalReplicas: 2,
+});
+
+const eventsSrc = buildObject({
+  id: "u103",
+  name: "events_src",
+  objectType: "source",
+  cluster: { id: "u200", name: "ingest_cluster" },
+  hydratedReplicas: 0,
+  totalReplicas: 1,
+});
+
+const buildResult = (
+  overrides?: Partial<UseMaintainedObjectsListResult>,
+): UseMaintainedObjectsListResult => ({
+  data: [ordersMv, inventoryIdx, eventsSrc],
+  isLoading: false,
+  lagReady: true,
+  hydrationReady: true,
+  isError: false,
+  ...overrides,
+});
+
+const renderMaintainedObjects = () =>
+  renderComponent(<MaintainedObjects />, {
+    initialRouterEntries: ["/maintained-objects"],
+  });
+
+describe("MaintainedObjects", () => {
+  beforeEach(() => {
+    vi.mocked(useMaintainedObjectsList).mockReturnValue(buildResult());
+  });
+
+  it("renders the list of maintained objects", async () => {
+    await renderMaintainedObjects();
+
+    expect(await screen.findByText("orders_mv")).toBeVisible();
+    expect(screen.getByText("inventory_idx")).toBeVisible();
+    expect(screen.getByText("events_src")).toBeVisible();
+
+    // Cluster links render with the cluster name.
+    expect(
+      screen.getAllByRole("link", { name: "compute_cluster" }),
+    ).toHaveLength(2);
+    expect(screen.getByRole("link", { name: "ingest_cluster" })).toBeVisible();
+  });
+
+  it("filters rows by object type", async () => {
+    const user = userEvent.setup();
+    await renderMaintainedObjects();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Filter objectType" }),
+    );
+    await user.click(await screen.findByLabelText("index"));
+
+    expect(screen.getByText("inventory_idx")).toBeVisible();
+    expect(screen.queryByText("orders_mv")).not.toBeInTheDocument();
+    expect(screen.queryByText("events_src")).not.toBeInTheDocument();
+
+    // Filter chip summarizes the active filter.
+    expect(screen.getByText("Type: index")).toBeVisible();
+  });
+
+  it("filters rows by search term", async () => {
+    const user = userEvent.setup();
+    await renderMaintainedObjects();
+
+    await user.type(
+      await screen.findByPlaceholderText("Search objects..."),
+      "orders",
+    );
+
+    // TableSearch debounces input, so wait for the filter to settle.
+    await waitFor(() => {
+      expect(screen.getByText("orders_mv")).toBeVisible();
+      expect(screen.queryByText("inventory_idx")).not.toBeInTheDocument();
+      expect(screen.queryByText("events_src")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows an empty state when filters match no rows", async () => {
+    const user = userEvent.setup();
+    await renderMaintainedObjects();
+
+    await user.type(
+      await screen.findByPlaceholderText("Search objects..."),
+      "no_such_object",
+    );
+
+    expect(
+      await screen.findByText("No objects match the selected filters"),
+    ).toBeVisible();
+  });
+
+  it("handles empty list", async () => {
+    vi.mocked(useMaintainedObjectsList).mockReturnValue(
+      buildResult({ data: [] }),
+    );
+    await renderMaintainedObjects();
+
+    expect(
+      await screen.findByText("No objects match the selected filters"),
+    ).toBeVisible();
+    expect(screen.queryByText("orders_mv")).not.toBeInTheDocument();
+  });
+});

--- a/console/src/platform/maintained-objects/MaintainedObjects.tsx
+++ b/console/src/platform/maintained-objects/MaintainedObjects.tsx
@@ -1,0 +1,525 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Button,
+  HStack,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Skeleton,
+  Spinner,
+  Tag,
+  TagCloseButton,
+  TagLabel,
+  Text,
+  Tooltip,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import {
+  ColumnFiltersState,
+  createColumnHelper,
+  OnChangeFn,
+  PaginationState,
+} from "@tanstack/react-table";
+import React from "react";
+import { Link as RouterLink, useLocation } from "react-router-dom";
+
+import { createNamespace } from "~/api/materialize";
+import { OUTDATED_THRESHOLD_SECONDS } from "~/api/materialize/cluster/materializationLag";
+import StatusPill from "~/components/StatusPill";
+import { sortingFunctions } from "~/components/Table/tableColumnBuilders";
+import { TablePagination } from "~/components/Table/TablePagination";
+import { TableSearch } from "~/components/Table/TableSearch";
+import { UniversalTable } from "~/components/Table/UniversalTable";
+import {
+  getInitialTableState,
+  useUniversalTable,
+} from "~/components/Table/useUniversalTable";
+import TextLink from "~/components/TextLink";
+import { useSyncObjectToSearchParams } from "~/hooks/useSyncObjectToSearchParams";
+import { useTimePeriodMinutes } from "~/hooks/useTimePeriodSelect";
+import { ChevronDownIcon, ClockIcon } from "~/icons";
+import {
+  MainContentContainer,
+  PageHeader,
+  PageHeading,
+} from "~/layouts/BaseLayout";
+import {
+  EmptyListHeader,
+  EmptyListHeaderContents,
+  EmptyListWrapper,
+} from "~/layouts/listPageComponents";
+import { absoluteClusterPath } from "~/platform/routeHelpers";
+import { useRegionSlug } from "~/store/environments";
+import { MaterializeTheme } from "~/theme";
+import { truncateMaxWidth } from "~/theme/components/Table";
+import { formatIntervalShort } from "~/utils/format";
+
+import { FilterChips } from "./FilterChips";
+import {
+  ClusterFilterPanel,
+  FreshnessFilterPanel,
+  HydrationFilterPanel,
+  ObjectTypeFilterPanel,
+} from "./filterPanels";
+import {
+  bucketForHydration,
+  clusterFilterFn,
+  FILTER_URL_SPECS,
+  freshnessFilterFn,
+  HYDRATION_LABELS,
+  hydrationFilterFn,
+  initialColumnFiltersFromUrl,
+  objectTypeFilterFn,
+  STATUS_COLOR_SCHEMES,
+} from "./filters";
+import { MaintainedObjectListItem, useMaintainedObjectsList } from "./queries";
+
+const PAGE_SIZE = 25;
+
+// `mz_wallclock_global_lag_recent_history` retains up to 24 hours.
+// "Live" is its own option (>1min / mz_now()-filtered), keyed at 1 minute.
+const LOOKBACK_OPTIONS: Record<string, string> = {
+  "1": "Live",
+  "5": "Past 5 minutes",
+  "15": "Past 15 minutes",
+  "30": "Past 30 minutes",
+  "60": "Past 1 hour",
+  "180": "Past 3 hours",
+  "360": "Past 6 hours",
+  "1440": "Past 24 hours",
+};
+
+/** Compact label for the Live tag, mirroring the selected lookback window. */
+const LOOKBACK_SHORT_LABELS: Record<string, string> = {
+  "5": "5m",
+  "15": "15m",
+  "30": "30m",
+  "60": "1h",
+  "180": "3h",
+  "360": "6h",
+  "1440": "24h",
+};
+
+const WindowControl = ({
+  timePeriodMinutes,
+  setTimePeriodMinutes,
+}: {
+  timePeriodMinutes: number;
+  setTimePeriodMinutes: (val: number) => void;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const key = String(timePeriodMinutes);
+  const currentLabel = LOOKBACK_OPTIONS[key] ?? "Custom window";
+  const shortLabel = LOOKBACK_SHORT_LABELS[key];
+  // Live is its own option separate from the historical windows below.
+  const isLive = key === "1";
+
+  return (
+    <HStack spacing="2">
+      <Menu>
+        <Tooltip
+          label="Lookback window applies to freshness only — it does not affect status."
+          lineHeight={1.2}
+          openDelay={300}
+        >
+          <MenuButton
+            as={Button}
+            variant="secondary"
+            size="sm"
+            leftIcon={<ClockIcon height="3" width="3" />}
+            rightIcon={<ChevronDownIcon height="3" width="3" />}
+          >
+            {isLive ? (
+              "Lookback Window"
+            ) : (
+              <>
+                <Text as="span" color={colors.foreground.secondary}>
+                  Window:{" "}
+                </Text>
+                {currentLabel}
+              </>
+            )}
+          </MenuButton>
+        </Tooltip>
+        <MenuList>
+          {Object.entries(LOOKBACK_OPTIONS).map(([value, label]) => (
+            <MenuItem
+              key={value}
+              onClick={() => setTimePeriodMinutes(parseInt(value, 10))}
+            >
+              {label}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
+      {isLive ? (
+        <Tag size="sm" colorScheme="green" borderRadius="full" px="2">
+          <Box
+            w="1.5"
+            h="1.5"
+            borderRadius="full"
+            bg={colors.accent.green}
+            mr="1.5"
+          />
+          <TagLabel>Live</TagLabel>
+        </Tag>
+      ) : (
+        <Tag size="md" borderRadius="md" px="3" py="1">
+          <TagLabel>Window: {shortLabel ?? currentLabel}</TagLabel>
+          <TagCloseButton
+            aria-label="Reset window to Live"
+            onClick={() => setTimePeriodMinutes(1)}
+            ml="2"
+          />
+        </Tag>
+      )}
+    </HStack>
+  );
+};
+
+const ObjectNameCell = ({ row }: { row: MaintainedObjectListItem }) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const namespace = createNamespace(row.databaseName, row.schemaName);
+  const fullyQualified = namespace ? `${namespace}.${row.name}` : row.name;
+  return (
+    <Tooltip label={fullyQualified} lineHeight={1.2} openDelay={200}>
+      <Box>
+        <Text
+          textStyle="text-small"
+          fontWeight="500"
+          noOfLines={1}
+          color={colors.foreground.secondary}
+        >
+          {namespace}
+        </Text>
+        <Text textStyle="text-ui-med" noOfLines={1}>
+          {row.name}
+        </Text>
+      </Box>
+    </Tooltip>
+  );
+};
+
+const OUTDATED_MS = OUTDATED_THRESHOLD_SECONDS * 1_000;
+const WARNING_MS = OUTDATED_MS / 2;
+const FRESH_MS = 1_000;
+
+interface MaintainedObjectsTableMeta {
+  lagReady: boolean;
+  hydrationReady: boolean;
+  regionSlug: string;
+  clusterNames: string[];
+}
+
+const ClusterCell = ({
+  row,
+  regionSlug,
+}: {
+  row: MaintainedObjectListItem;
+  regionSlug: string;
+}) => {
+  if (!row.cluster) return "-";
+  const path = absoluteClusterPath(regionSlug, row.cluster);
+  return (
+    <TextLink as={RouterLink} to={path} textStyle="text-ui-med" noOfLines={1}>
+      {row.cluster.name}
+    </TextLink>
+  );
+};
+
+const FreshnessCell = ({
+  row,
+  ready,
+}: {
+  row: MaintainedObjectListItem;
+  ready: boolean;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  if (!row.lag) {
+    return ready ? "-" : <Skeleton height="3" width="14" />;
+  }
+  const { value, ms } = row.lag;
+  const color =
+    ms >= OUTDATED_MS
+      ? colors.accent.red
+      : ms >= WARNING_MS
+        ? colors.accent.orange
+        : ms <= FRESH_MS
+          ? colors.accent.green
+          : colors.foreground.primary;
+  return (
+    <Text textStyle="text-ui-med" color={color}>
+      {formatIntervalShort(value as Parameters<typeof formatIntervalShort>[0])}
+    </Text>
+  );
+};
+
+const StatusCell = ({
+  row,
+  ready,
+}: {
+  row: MaintainedObjectListItem;
+  ready: boolean;
+}) => {
+  const { hydratedReplicas, totalReplicas } = row;
+  if (totalReplicas === 0) {
+    return ready ? "-" : <Skeleton height="5" width="20" borderRadius="full" />;
+  }
+  const bucket = bucketForHydration(hydratedReplicas, totalReplicas);
+  if (!bucket) return "-";
+  return (
+    <StatusPill
+      status={bucket}
+      label={HYDRATION_LABELS[bucket]}
+      colorScheme={STATUS_COLOR_SCHEMES[bucket]}
+    />
+  );
+};
+
+const columnHelper = createColumnHelper<MaintainedObjectListItem>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    id: "name",
+    header: "Object Name",
+    sortingFn: "alphanumeric",
+    cell: (info) => <ObjectNameCell row={info.row.original} />,
+    meta: {
+      minWidth: { md: "280px", sm: "auto" },
+      cellProps: { ...truncateMaxWidth, py: "2" },
+    },
+  }),
+  columnHelper.accessor("objectType", {
+    id: "objectType",
+    header: "Object Type",
+    sortingFn: "alphanumeric",
+    filterFn: objectTypeFilterFn,
+    cell: (info) => (
+      <Text textStyle="text-ui-reg">{info.getValue() ?? "-"}</Text>
+    ),
+    meta: {
+      renderFilter: (column) => <ObjectTypeFilterPanel column={column} />,
+    },
+  }),
+  columnHelper.accessor((row) => row.lag?.ms ?? null, {
+    id: "freshness",
+    header: "Freshness (pMAX)",
+    sortingFn: sortingFunctions.nullsLast,
+    filterFn: freshnessFilterFn,
+    cell: (info) => {
+      const meta = info.table.options.meta as MaintainedObjectsTableMeta;
+      return <FreshnessCell row={info.row.original} ready={meta.lagReady} />;
+    },
+    meta: {
+      tooltip: "Maximum freshness observed over the lookback window.",
+      renderFilter: (column) => <FreshnessFilterPanel column={column} />,
+    },
+  }),
+  columnHelper.accessor(
+    (row) =>
+      row.totalReplicas === 0 ? null : row.hydratedReplicas / row.totalReplicas,
+    {
+      id: "status",
+      header: "Status",
+      sortingFn: sortingFunctions.nullsLast,
+      filterFn: hydrationFilterFn,
+      cell: (info) => {
+        const meta = info.table.options.meta as MaintainedObjectsTableMeta;
+        return (
+          <StatusCell row={info.row.original} ready={meta.hydrationReady} />
+        );
+      },
+      meta: {
+        tooltip:
+          "Object status derived from replica hydration across all clusters.",
+        renderFilter: (column) => <HydrationFilterPanel column={column} />,
+      },
+    },
+  ),
+  columnHelper.accessor((row) => row.cluster?.name ?? null, {
+    id: "clusterName",
+    header: "Cluster",
+    sortingFn: sortingFunctions.nullsLast,
+    filterFn: clusterFilterFn,
+    cell: (info) => {
+      const meta = info.table.options.meta as MaintainedObjectsTableMeta;
+      return (
+        <ClusterCell row={info.row.original} regionSlug={meta.regionSlug} />
+      );
+    },
+    meta: {
+      renderFilter: (column, table) => {
+        const meta = table.options.meta as MaintainedObjectsTableMeta;
+        return (
+          <ClusterFilterPanel column={column} clusters={meta.clusterNames} />
+        );
+      },
+    },
+  }),
+];
+
+const MaintainedObjects = () => {
+  const location = useLocation();
+  const regionSlug = useRegionSlug();
+
+  const [timePeriodMinutes, setTimePeriodMinutes] = useTimePeriodMinutes({
+    localStorageKey: "maintained-objects-time-period",
+    defaultValue: "1",
+    timePeriodOptions: LOOKBACK_OPTIONS,
+  });
+
+  const {
+    data: objects,
+    isLoading,
+    lagReady,
+    hydrationReady,
+  } = useMaintainedObjectsList({
+    lookbackMinutes: timePeriodMinutes,
+  });
+
+  const [initialState] = React.useState(() =>
+    getInitialTableState(location.search),
+  );
+  const [columnFilters, setColumnFiltersState] =
+    React.useState<ColumnFiltersState>(() =>
+      initialColumnFiltersFromUrl(location.search),
+    );
+  const [pagination, setPagination] = React.useState<PaginationState>(() => ({
+    pageIndex: initialState.pageIndex ?? 0,
+    pageSize: PAGE_SIZE,
+  }));
+  const setColumnFilters: OnChangeFn<ColumnFiltersState> = (updater) => {
+    setColumnFiltersState(updater);
+    setPagination((p) => ({ ...p, pageIndex: 0 }));
+  };
+
+  const clusterNames = React.useMemo(() => {
+    if (!objects) return [];
+    const names = new Set<string>();
+    for (const obj of objects) {
+      if (obj.cluster) names.add(obj.cluster.name);
+    }
+    return [...names].sort();
+  }, [objects]);
+
+  const table = useUniversalTable({
+    data: objects ?? [],
+    columns,
+    state: { columnFilters, pagination },
+    onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
+    initialSorting: initialState.sorting ?? [{ id: "freshness", desc: false }],
+    initialState: {
+      globalFilter: initialState.globalFilter,
+    },
+    pageSize: PAGE_SIZE,
+    meta: {
+      lagReady,
+      hydrationReady,
+      regionSlug,
+      clusterNames,
+    } satisfies MaintainedObjectsTableMeta,
+  });
+
+  const tableState = table.getState();
+  const urlParamObject = React.useMemo(() => {
+    const obj: Record<string, unknown> = {};
+    for (const filter of tableState.columnFilters) {
+      const spec = FILTER_URL_SPECS.find((s) => s.columnId === filter.id);
+      const encoded = spec?.toUrl(filter.value);
+      if (encoded) obj[encoded.key] = encoded.value;
+    }
+    if (tableState.globalFilter) obj.q = tableState.globalFilter;
+    const sort = tableState.sorting[0];
+    if (sort) {
+      obj.sort = sort.id;
+      obj.dir = sort.desc ? "desc" : "asc";
+    }
+    if (tableState.pagination.pageIndex > 0) {
+      obj.page = tableState.pagination.pageIndex + 1;
+    }
+    return obj;
+  }, [
+    tableState.columnFilters,
+    tableState.globalFilter,
+    tableState.sorting,
+    tableState.pagination.pageIndex,
+  ]);
+  useSyncObjectToSearchParams(urlParamObject);
+
+  if (isLoading) {
+    return (
+      <MainContentContainer>
+        <PageHeader boxProps={{ mb: "4" }}>
+          <PageHeading>Objects</PageHeading>
+        </PageHeader>
+        <Spinner data-testid="loading-spinner" />
+      </MainContentContainer>
+    );
+  }
+
+  const filteredCount = table.getFilteredRowModel().rows.length;
+  const hasFilters = tableState.columnFilters.length > 0;
+  const showEmpty = objects && filteredCount === 0;
+
+  return (
+    <MainContentContainer>
+      <PageHeader variant="compact" sticky boxProps={{ pb: "4" }}>
+        <PageHeading>Objects</PageHeading>
+        <VStack alignItems="stretch" width="100%" spacing="3" mt="4">
+          <HStack width="100%" flexWrap="wrap" gap="3">
+            <TableSearch
+              initialValue={initialState.globalFilter ?? ""}
+              onValueChange={table.setGlobalFilter}
+              placeholder="Search objects..."
+            />
+            <WindowControl
+              timePeriodMinutes={timePeriodMinutes}
+              setTimePeriodMinutes={setTimePeriodMinutes}
+            />
+          </HStack>
+          {hasFilters && <FilterChips table={table} />}
+        </VStack>
+      </PageHeader>
+
+      <VStack alignItems="stretch" width="100%" spacing="4">
+        {showEmpty ? (
+          <EmptyListWrapper>
+            <EmptyListHeader>
+              <EmptyListHeaderContents
+                title="No objects match the selected filters"
+                helpText="Try adjusting your filters or time period."
+              />
+            </EmptyListHeader>
+          </EmptyListWrapper>
+        ) : (
+          <>
+            <Box overflowX="auto" width="100%">
+              <UniversalTable
+                table={table}
+                variant="linkable"
+                rowSx={{ cursor: "pointer" }}
+                data-testid="maintained-objects-table"
+              />
+            </Box>
+            <TablePagination table={table} itemLabel="objects" />
+          </>
+        )}
+      </VStack>
+    </MainContentContainer>
+  );
+};
+
+export { MaintainedObjects };
+export default MaintainedObjects;

--- a/console/src/platform/maintained-objects/MaintainedObjectsRoutes.tsx
+++ b/console/src/platform/maintained-objects/MaintainedObjectsRoutes.tsx
@@ -1,0 +1,23 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import React from "react";
+import { Route } from "react-router-dom";
+
+import { SentryRoutes } from "~/sentry";
+
+import { MaintainedObjects } from "./MaintainedObjects";
+
+export const MaintainedObjectsRoutes = () => {
+  return (
+    <SentryRoutes>
+      <Route path="*" element={<MaintainedObjects />} />
+    </SentryRoutes>
+  );
+};

--- a/console/src/platform/maintained-objects/filterPanels.tsx
+++ b/console/src/platform/maintained-objects/filterPanels.tsx
@@ -1,0 +1,264 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  HStack,
+  Input,
+  NumberInput,
+  NumberInputField,
+  Select,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import { Column } from "@tanstack/react-table";
+import React from "react";
+
+import {
+  MAINTAINED_OBJECT_TYPES,
+  MaintainedObjectType,
+} from "~/api/materialize/maintained-objects/constants";
+import { MaterializeTheme } from "~/theme";
+import { DurationUnit, fromSeconds, toSeconds } from "~/utils/format";
+
+import {
+  HYDRATION_BUCKETS,
+  HYDRATION_LABELS,
+  HydrationBucket,
+} from "./filters";
+import { MaintainedObjectListItem } from "./queries";
+
+type AnyColumn = Column<MaintainedObjectListItem, unknown>;
+
+interface FilterCheckboxRowProps {
+  isChecked: boolean;
+  onChange: () => void;
+  children: React.ReactNode;
+}
+
+const FilterCheckboxRow = ({
+  isChecked,
+  onChange,
+  children,
+}: FilterCheckboxRowProps) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  return (
+    <Checkbox
+      width="100%"
+      px="4"
+      py="1"
+      spacing="0"
+      display="flex"
+      flexDir="row-reverse"
+      justifyContent="space-between"
+      alignItems="center"
+      _hover={{ bg: colors.background.secondary }}
+      isChecked={isChecked}
+      onChange={onChange}
+    >
+      {children}
+    </Checkbox>
+  );
+};
+
+export interface MultiSelectFilterPanelProps<T extends string> {
+  column: AnyColumn;
+  items: readonly T[];
+  getLabel?: (item: T) => React.ReactNode;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+}
+
+/**
+ * Multi-select filter for a TanStack column whose filter value is a `T[]`.
+ * An empty selection clears the column filter.
+ */
+export const MultiSelectFilterPanel = <T extends string>({
+  column,
+  items,
+  getLabel,
+  searchable = false,
+  searchPlaceholder = "Search...",
+  emptyMessage = "No results",
+}: MultiSelectFilterPanelProps<T>) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const selected = (column.getFilterValue() as T[] | undefined) ?? [];
+  const [search, setSearch] = React.useState("");
+
+  const visibleItems = React.useMemo(() => {
+    if (!searchable || !search) return items;
+    const q = search.toLowerCase();
+    return items.filter((item) => item.toLowerCase().includes(q));
+  }, [items, search, searchable]);
+
+  const toggle = (item: T) => {
+    const next = selected.includes(item)
+      ? selected.filter((x) => x !== item)
+      : [...selected, item];
+    column.setFilterValue(next.length ? next : undefined);
+  };
+
+  return (
+    <VStack
+      alignItems="stretch"
+      px={searchable ? "4" : "0"}
+      py={searchable ? "3" : "2"}
+      spacing="2"
+    >
+      {searchable && (
+        <Input
+          size="sm"
+          placeholder={searchPlaceholder}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          autoFocus
+        />
+      )}
+      <Box maxHeight={searchable ? "220px" : undefined} overflowY="auto">
+        {visibleItems.length === 0 ? (
+          <Text
+            textStyle="text-ui-reg"
+            color={colors.foreground.secondary}
+            p="2"
+          >
+            {emptyMessage}
+          </Text>
+        ) : (
+          <VStack alignItems="stretch" gap={0}>
+            {visibleItems.map((item) => (
+              <FilterCheckboxRow
+                key={item}
+                isChecked={selected.includes(item)}
+                onChange={() => toggle(item)}
+              >
+                <Text textStyle="text-ui-reg" noOfLines={1}>
+                  {getLabel ? getLabel(item) : item}
+                </Text>
+              </FilterCheckboxRow>
+            ))}
+          </VStack>
+        )}
+      </Box>
+    </VStack>
+  );
+};
+
+export const ClusterFilterPanel = ({
+  column,
+  clusters,
+}: {
+  column: AnyColumn;
+  clusters: string[];
+}) => (
+  <MultiSelectFilterPanel
+    column={column}
+    items={clusters}
+    searchable
+    searchPlaceholder="Search clusters..."
+    emptyMessage="No clusters match"
+  />
+);
+
+export const ObjectTypeFilterPanel = ({ column }: { column: AnyColumn }) => (
+  <MultiSelectFilterPanel<MaintainedObjectType>
+    column={column}
+    items={MAINTAINED_OBJECT_TYPES}
+  />
+);
+
+export const HydrationFilterPanel = ({ column }: { column: AnyColumn }) => (
+  <MultiSelectFilterPanel<HydrationBucket>
+    column={column}
+    items={HYDRATION_BUCKETS}
+    getLabel={(b) => HYDRATION_LABELS[b]}
+  />
+);
+
+export const FreshnessFilterPanel = ({ column }: { column: AnyColumn }) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const filterValue = column.getFilterValue() as number | undefined;
+  const initial = filterValue ? fromSeconds(filterValue) : null;
+
+  const [amount, setAmount] = React.useState(
+    initial ? String(initial.amount) : "",
+  );
+  const [unit, setUnit] = React.useState<DurationUnit>(
+    initial?.unit ?? "seconds",
+  );
+
+  const apply = () => {
+    const n = parseFloat(amount);
+    column.setFilterValue(n > 0 ? toSeconds(n, unit) : undefined);
+  };
+
+  const clearFilter = () => {
+    setAmount("");
+    column.setFilterValue(undefined);
+  };
+
+  return (
+    <VStack alignItems="stretch" spacing={0}>
+      <HStack spacing={2} px={4} py={3}>
+        <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
+          pMAX ≥
+        </Text>
+        <NumberInput
+          size="sm"
+          value={amount}
+          min={1}
+          focusBorderColor={colors.accent.brightPurple}
+          onChange={(next) => setAmount(next)}
+          maxW="20"
+        >
+          <NumberInputField
+            placeholder="0"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") apply();
+            }}
+          />
+        </NumberInput>
+        <Select
+          size="sm"
+          value={unit}
+          focusBorderColor={colors.accent.brightPurple}
+          onChange={(e) => setUnit(e.target.value as DurationUnit)}
+          maxW="32"
+        >
+          <option value="seconds">seconds</option>
+          <option value="minutes">minutes</option>
+          <option value="hours">hours</option>
+        </Select>
+      </HStack>
+      <HStack
+        borderTopWidth="1px"
+        borderColor={colors.border.secondary}
+        justifyContent="space-between"
+        py={2}
+        px={4}
+      >
+        <Button
+          size="sm"
+          variant="secondary"
+          transition="none"
+          isDisabled={filterValue === undefined && amount === ""}
+          onClick={clearFilter}
+        >
+          Clear
+        </Button>
+        <Button size="sm" variant="primary" transition="none" onClick={apply}>
+          Apply
+        </Button>
+      </HStack>
+    </VStack>
+  );
+};

--- a/console/src/platform/maintained-objects/filters.ts
+++ b/console/src/platform/maintained-objects/filters.ts
@@ -1,0 +1,171 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { ColumnFiltersState, Row } from "@tanstack/react-table";
+
+import {
+  MAINTAINED_OBJECT_TYPES,
+  MaintainedObjectType,
+} from "~/api/materialize/maintained-objects/constants";
+
+import { MaintainedObjectListItem } from "./queries";
+
+/**
+ * Row-threshold options for the freshness filter, keyed by seconds. Selecting
+ * a value filters to objects whose pMAX lag meets the threshold.
+ */
+export const FRESHNESS_THRESHOLD_OPTIONS: Record<string, string> = {
+  "5": "pMAX ≥ 5 seconds",
+  "10": "pMAX ≥ 10 seconds",
+  "60": "pMAX ≥ 1 minute",
+  "300": "pMAX ≥ 5 minutes",
+  "900": "pMAX ≥ 15 minutes",
+  "1800": "pMAX ≥ 30 minutes",
+  "3600": "pMAX ≥ 1 hour",
+};
+
+export const HYDRATION_BUCKETS = [
+  "hydrated",
+  "hydrating",
+  "not_hydrated",
+] as const;
+export type HydrationBucket = (typeof HYDRATION_BUCKETS)[number];
+
+export const HYDRATION_LABELS: Record<HydrationBucket, string> = {
+  hydrated: "Running",
+  hydrating: "Hydrating",
+  not_hydrated: "Not Hydrated",
+};
+
+export const STATUS_COLOR_SCHEMES: Record<
+  HydrationBucket,
+  "green" | "yellow" | "red"
+> = {
+  hydrated: "green",
+  hydrating: "yellow",
+  not_hydrated: "red",
+};
+
+/** Bucketize per-object replica counts. Returns undefined when totals are
+ *  unknown (no rows in `mz_hydration_statuses` for the object yet). */
+export const bucketForHydration = (
+  hydratedReplicas: number,
+  totalReplicas: number,
+): HydrationBucket | undefined => {
+  if (totalReplicas === 0) return undefined;
+  if (hydratedReplicas === 0) return "not_hydrated";
+  if (hydratedReplicas === totalReplicas) return "hydrated";
+  return "hydrating";
+};
+
+/** Filter rows where `extract(row)` is one of the selected values. */
+export const arrayMatchFilter =
+  <T>(extract: (row: MaintainedObjectListItem) => T | null | undefined) =>
+  (row: Row<MaintainedObjectListItem>, _id: string, selected: T[]) => {
+    if (!selected?.length) return true;
+    const value = extract(row.original);
+    return value != null && selected.includes(value);
+  };
+
+export const clusterFilterFn = arrayMatchFilter((r) => r.cluster?.name);
+
+export const objectTypeFilterFn = arrayMatchFilter<MaintainedObjectType>(
+  (r) => r.objectType,
+);
+
+export const hydrationFilterFn = arrayMatchFilter<HydrationBucket>((r) =>
+  bucketForHydration(r.hydratedReplicas, r.totalReplicas),
+);
+
+export const freshnessFilterFn = (
+  row: Row<MaintainedObjectListItem>,
+  _id: string,
+  thresholdSeconds: number,
+) => {
+  if (thresholdSeconds === undefined) return true;
+  const lagMs = row.original.lag?.ms;
+  return lagMs !== undefined && lagMs >= thresholdSeconds * 1_000;
+};
+
+/**
+ * Maps a TanStack column filter to and from the URL search params. Array URL
+ * keys carry their `[]` suffix literally (see `useSyncObjectToSearchParams`).
+ */
+export interface FilterUrlSpec {
+  columnId: string;
+  /** Read this filter's value from URL params; undefined = not set. */
+  fromUrl(params: URLSearchParams): unknown;
+  /** Encode this filter's value for the URL object; undefined = skip. */
+  toUrl(value: unknown): { key: string; value: unknown } | undefined;
+}
+
+const nonEmpty = <T>(arr: T[]): T[] | undefined =>
+  arr.length > 0 ? arr : undefined;
+
+export const FILTER_URL_SPECS: readonly FilterUrlSpec[] = [
+  {
+    columnId: "clusterName",
+    fromUrl: (p) => nonEmpty(p.getAll("clusters[]")),
+    toUrl: (v) => {
+      const arr = v as string[];
+      return arr?.length ? { key: "clusters[]", value: arr } : undefined;
+    },
+  },
+  {
+    columnId: "objectType",
+    fromUrl: (p) =>
+      nonEmpty(
+        p
+          .getAll("objectType[]")
+          .filter((t): t is MaintainedObjectType =>
+            (MAINTAINED_OBJECT_TYPES as readonly string[]).includes(t),
+          ),
+      ),
+    toUrl: (v) => {
+      const arr = v as MaintainedObjectType[];
+      return arr?.length ? { key: "objectType[]", value: arr } : undefined;
+    },
+  },
+  {
+    columnId: "freshness",
+    fromUrl: (p) => {
+      const v = p.get("freshness");
+      if (!v) return undefined;
+      const n = parseInt(v, 10);
+      return Number.isFinite(n) && n > 0 ? n : undefined;
+    },
+    toUrl: (v) =>
+      typeof v === "number" ? { key: "freshness", value: v } : undefined,
+  },
+  {
+    columnId: "hydration",
+    fromUrl: (p) =>
+      nonEmpty(
+        p
+          .getAll("hydration[]")
+          .filter((h): h is HydrationBucket =>
+            (HYDRATION_BUCKETS as readonly string[]).includes(h),
+          ),
+      ),
+    toUrl: (v) => {
+      const arr = v as HydrationBucket[];
+      return arr?.length ? { key: "hydration[]", value: arr } : undefined;
+    },
+  },
+];
+
+export const initialColumnFiltersFromUrl = (
+  search: string,
+): ColumnFiltersState => {
+  const params = new URLSearchParams(search);
+  return FILTER_URL_SPECS.flatMap((spec) => {
+    const value = spec.fromUrl(params);
+    return value === undefined ? [] : [{ id: spec.columnId, value }];
+  });
+};

--- a/console/src/platform/maintained-objects/queries.ts
+++ b/console/src/platform/maintained-objects/queries.ts
@@ -1,0 +1,174 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import React from "react";
+
+import { isSystemId } from "~/api/materialize";
+import {
+  MAINTAINED_OBJECT_TYPES,
+  MaintainedObjectType,
+} from "~/api/materialize/maintained-objects/constants";
+import {
+  buildHydrationAggregateQuery,
+  HydrationAggregateRow,
+} from "~/api/materialize/maintained-objects/hydrationAggregate";
+import {
+  buildLagAggregateQuery,
+  LagAggregateRow,
+} from "~/api/materialize/maintained-objects/lagAggregate";
+import {
+  buildSubscribeQuery,
+  useSubscribe,
+} from "~/api/materialize/useSubscribe";
+import { useAllObjects } from "~/store/allObjects";
+import { sumPostgresIntervalMs } from "~/util";
+
+/** Cluster the object is maintained on. `null` for tables, which aren't
+ *  bound to a cluster. */
+export interface MaintainedObjectCluster {
+  id: string;
+  name: string;
+}
+
+/** pMAX lag snapshot. `null` until the SUBSCRIBE delivers a row. */
+export interface MaintainedObjectLag {
+  /** Raw Postgres interval, used for human-readable formatting. */
+  value: NonNullable<LagAggregateRow["lag"]>;
+  /** Same value flattened to milliseconds, used for filters and sorts. */
+  ms: number;
+}
+
+export interface MaintainedObjectListItem {
+  id: string;
+  name: string;
+  schemaName: string;
+  databaseName: string;
+  objectType: MaintainedObjectType;
+  cluster: MaintainedObjectCluster | null;
+  /** 0 until the hydration snapshot arrives. */
+  hydratedReplicas: number;
+  /** 0 until the hydration snapshot arrives. */
+  totalReplicas: number;
+  /** Null until the lag snapshot arrives. */
+  lag: MaintainedObjectLag | null;
+}
+
+const MAINTAINED_OBJECT_TYPE_SET: ReadonlySet<string> = new Set(
+  MAINTAINED_OBJECT_TYPES,
+);
+
+const bigintToNumber = (v: bigint | null | undefined): number =>
+  v ? Number(v) : 0;
+
+const useSubscribeToLagAggregate = ({
+  lookbackMinutes,
+}: {
+  lookbackMinutes: number;
+}) => {
+  const subscribe = React.useMemo(
+    () =>
+      buildSubscribeQuery(buildLagAggregateQuery({ lookbackMinutes }), {
+        upsertKey: "object_id",
+      }),
+    [lookbackMinutes],
+  );
+  return useSubscribe<LagAggregateRow, LagAggregateRow>({
+    subscribe,
+    upsertKey: (row) => row.data.object_id,
+    select: (row) => row.data,
+  });
+};
+
+const useSubscribeToHydrationAggregate = () => {
+  const subscribe = React.useMemo(
+    () =>
+      buildSubscribeQuery(buildHydrationAggregateQuery(), {
+        upsertKey: "object_id",
+      }),
+    [],
+  );
+  return useSubscribe<HydrationAggregateRow, HydrationAggregateRow>({
+    subscribe,
+    upsertKey: (row) => row.data.object_id,
+    select: (row) => row.data,
+  });
+};
+
+export interface UseMaintainedObjectsListResult {
+  data: MaintainedObjectListItem[];
+  /** True until the all-objects snapshot completes. */
+  isLoading: boolean;
+  /** Per-source snapshot flags; cells use these to show loading skeletons. */
+  lagReady: boolean;
+  hydrationReady: boolean;
+  isError: boolean;
+}
+
+/**
+ * Composes maintained objects from three live sources: `useAllObjects()` for
+ * object metadata, plus SUBSCRIBEs for pMAX lag and hydration aggregate. The
+ * table renders as soon as object metadata is ready; lag and hydration cells
+ * fill in as their snapshots arrive.
+ */
+export const useMaintainedObjectsList = ({
+  lookbackMinutes,
+}: {
+  lookbackMinutes: number;
+}): UseMaintainedObjectsListResult => {
+  const allObjects = useAllObjects();
+  const lag = useSubscribeToLagAggregate({ lookbackMinutes });
+  const hydration = useSubscribeToHydrationAggregate();
+
+  const data = React.useMemo<MaintainedObjectListItem[]>(() => {
+    const lagById = new Map(lag.data.map((r) => [r.object_id, r.lag]));
+    const hydrationById = new Map(hydration.data.map((r) => [r.object_id, r]));
+
+    const objectsById = new Map<string, MaintainedObjectListItem>();
+    for (const obj of allObjects.data) {
+      if (isSystemId(obj.id)) continue;
+      if (!MAINTAINED_OBJECT_TYPE_SET.has(obj.objectType)) continue;
+      // TODO(@leedqin): drop once `force_source_table_syntax` is on by
+      // default (#30483); until then mz_objects still returns subsources as
+      // sources, and we hide them and progress alongside their parent.
+      if (obj.sourceType === "subsource" || obj.sourceType === "progress") {
+        continue;
+      }
+      if (!obj.schemaName || !obj.databaseName) continue;
+      const lagInterval = lagById.get(obj.id);
+      const hydrationRow = hydrationById.get(obj.id);
+      objectsById.set(obj.id, {
+        id: obj.id,
+        name: obj.name,
+        schemaName: obj.schemaName,
+        databaseName: obj.databaseName,
+        objectType: obj.objectType as MaintainedObjectType,
+        cluster:
+          obj.clusterId && obj.clusterName
+            ? { id: obj.clusterId, name: obj.clusterName }
+            : null,
+        hydratedReplicas: bigintToNumber(hydrationRow?.hydratedReplicas),
+        totalReplicas: bigintToNumber(hydrationRow?.totalReplicas),
+        lag: lagInterval
+          ? { value: lagInterval, ms: sumPostgresIntervalMs(lagInterval) }
+          : null,
+      });
+    }
+    return [...objectsById.values()].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }, [allObjects.data, lag.data, hydration.data]);
+
+  return {
+    data,
+    isLoading: !allObjects.snapshotComplete,
+    lagReady: lag.snapshotComplete,
+    hydrationReady: hydration.snapshotComplete,
+    isError: allObjects.isError || lag.isError || hydration.isError,
+  };
+};

--- a/console/src/utils/format.test.ts
+++ b/console/src/utils/format.test.ts
@@ -9,7 +9,12 @@
 
 import parse from "postgres-interval";
 
-import { formatInterval, formatIntervalShort } from "./format";
+import {
+  formatInterval,
+  formatIntervalShort,
+  fromSeconds,
+  toSeconds,
+} from "./format";
 
 describe("formatIntervalShort", () => {
   it("only returns years if present", () => {
@@ -117,5 +122,29 @@ describe("formatInterval", () => {
   it("formats interval with only seconds and milliseconds", () => {
     const interval = parse("00:00:12.345");
     expect(formatInterval(interval)).toBe("12.345s");
+  });
+});
+
+describe("toSeconds", () => {
+  it("composes amount and unit into seconds", () => {
+    expect(toSeconds(2, "hours")).toBe(7200);
+    expect(toSeconds(5, "minutes")).toBe(300);
+    expect(toSeconds(23, "seconds")).toBe(23);
+  });
+
+  it("rounds fractional inputs", () => {
+    expect(toSeconds(1.5, "minutes")).toBe(90);
+  });
+});
+
+describe("fromSeconds", () => {
+  it("picks the largest unit that divides evenly", () => {
+    expect(fromSeconds(7200)).toEqual({ amount: 2, unit: "hours" });
+    expect(fromSeconds(300)).toEqual({ amount: 5, unit: "minutes" });
+    expect(fromSeconds(23)).toEqual({ amount: 23, unit: "seconds" });
+  });
+
+  it("falls back to seconds when no unit divides evenly", () => {
+    expect(fromSeconds(90)).toEqual({ amount: 90, unit: "seconds" });
   });
 });

--- a/console/src/utils/format.ts
+++ b/console/src/utils/format.ts
@@ -214,3 +214,32 @@ export function formatDurationForAxis(durationMs: number): string {
     return `${hours.toFixed(1)}h`;
   }
 }
+
+/** Units exposed in human-readable duration controls (filters, inputs). */
+export type DurationUnit = "seconds" | "minutes" | "hours";
+
+// Ordered largest → smallest so `fromSeconds` picks the friendliest unit that
+// still divides the input evenly (3600 → "1 hour", not "60 minutes").
+const SECONDS_PER_UNIT: Record<DurationUnit, number> = {
+  hours: 3600,
+  minutes: 60,
+  seconds: 1,
+};
+
+/** Compose `{ amount, unit }` into a single seconds value. */
+export const toSeconds = (amount: number, unit: DurationUnit): number =>
+  Math.round(amount * SECONDS_PER_UNIT[unit]);
+
+/** Decompose a seconds value into the largest unit that divides it evenly,
+ *  so 300 → 5 minutes, 3600 → 1 hour, 23 → 23 seconds. */
+export const fromSeconds = (
+  totalSeconds: number,
+): { amount: number; unit: DurationUnit } => {
+  for (const unit of Object.keys(SECONDS_PER_UNIT) as DurationUnit[]) {
+    const perUnit = SECONDS_PER_UNIT[unit];
+    if (totalSeconds % perUnit === 0) {
+      return { amount: totalSeconds / perUnit, unit };
+    }
+  }
+  return { amount: totalSeconds, unit: "seconds" };
+};


### PR DESCRIPTION


### Motivation
Maintained Objects List to show objects (sources, indexes, tables, mvs) in a table view to dive deeper into freshness (pMax), hydration status, clusters. 

First PR/ n for maintained objects feature. Fixes [CNS-50](https://linear.app/materializeinc/issue/CNS-50/objects-list-in-maintained-objects) 

### Description
- Maintained objects list wraps around TanStack table with column filters for pMax, hydration status, object type, clusters
- Added sql queries and tests for freshness lag and hydration status and did client side join with the data from allObjects subscribe
- Filter Chips component for the table to show which filters are active 
- Url params logic to save the filters in url params
- Expanded the tanstack table to have filters on the column headers

**Objects List**
<img width="1889" height="1158" alt="image" src="https://github.com/user-attachments/assets/0873fc59-bbf9-4558-aedc-f63306fd2935" />


**Filters for the objects list**
<img width="1977" height="715" alt="image" src="https://github.com/user-attachments/assets/0dcafa33-f1e4-432b-b935-6de71bfd4760" />

Objects filter:
<img width="447" height="307" alt="image" src="https://github.com/user-attachments/assets/1837c6e6-2c5e-441b-99ed-8cb78454ff6a" />

pMax Filter:
<img width="394" height="320" alt="image" src="https://github.com/user-attachments/assets/66b9792d-6028-4cdb-b75e-5ccdc67dde19" />

Cluster Filter
<img width="438" height="306" alt="image" src="https://github.com/user-attachments/assets/3086b0b6-4927-4c59-bfba-51a1f2af8ff9" />

### Tips for the reviewer
- Would recommend reviewing it by commit since the data/ query logic is in the first commit. And the rendering/ table filtering logic is in the second one