### PR TITLE
ore: introduce mz_ore::pager with swap and file backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7099,6 +7099,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "stacker",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-native-tls",

--- a/doc/developer/design/20260504_pager.md
+++ b/doc/developer/design/20260504_pager.md
@@ -156,9 +156,11 @@ A future optimization is `preadv2` once a profile shows it matters.
 
 `set_scratch_dir(root)` creates `{root}/mz-pager-{pid}-{boot_nonce}/`.
 `boot_nonce` is a random 64-bit value sampled at config time so two processes that briefly share the same pid cannot collide.
-On `set_scratch_dir`, the pager runs a reaper that walks `{root}` and removes any sibling `mz-pager-*` subdirectory whose owning pid is no longer alive (`/proc/{pid}` missing on Linux); this reclaims storage from crashed predecessors.
-On clean process exit, a `Drop` on the global pager state removes the per-process subdirectory.
-The reaper is best-effort and logs failures rather than panicking.
+Per-handle files are unlinked when the handle is dropped or `take`n; the per-process subdirectory itself is **not** reclaimed by the pager.
+
+Reclaiming subdirectories left behind by crashed predecessors is out of scope for the in-process pager.
+In production, clusterd runs on Kubernetes with a per-pod ephemeral volume that is destroyed with the pod, so a crashed predecessor's scratch directory is reclaimed with the volume.
+For local development, sweeping leftover `mz-pager-*` directories is the responsibility of operator tooling (e.g. `bin/environmentd` cleanup or an explicit `rm -rf`).
 
 ### Configuration
 

--- a/doc/developer/design/20260504_pager.md
+++ b/doc/developer/design/20260504_pager.md
@@ -274,7 +274,6 @@ The file backend issues one `writev` per chunk on pageout and one `pread` per co
 * Pick the file backend whenever the working set may exceed RAM.
   The kernel I/O pipeline scales; swap-in does not.
 * The runtime atomic switch is the right place for an operator-level policy: a controller can flip the global at startup based on cluster size or under a pressure signal.
-* Prefetch hints (`prefetch` / `prefetch_at`) help the file backend by ~5 % at depth 16 on this workload; they do not help the swap backend because under pressure the kernel is reclaim-bound, not stall-bound.
 
 ## Alternatives
 

--- a/doc/developer/design/20260504_pager.md
+++ b/doc/developer/design/20260504_pager.md
@@ -223,11 +223,15 @@ miri runs the swap backend; the file backend skips on miri due to syscalls.
 
 A merge-batcher-style example (`src/ore/examples/pager_merge.rs`) builds two chains of 2 MiB chunks, then merges them while reading every cache line of the input.
 Run under `systemd-run --user --scope -p MemoryMax=...` to constrain memory and force real eviction.
-Numbers below were collected on a Linux box with an encrypted NVMe (~1.4 GB/s sustained R+W ceiling) running the example with `--chain-gib 16` (32 GiB total working set) and `--prefetch-depth 4`.
 
-### Throughput sweep
-
+Pager behavior depends sharply on disk topology.
+Slow-storage boxes hit a kernel reclaim ceiling well below the disk and the swap backend looks catastrophic; fast-storage boxes expose new bottlenecks and the swap-vs-file gap collapses at high thread counts.
+Two benches below: a single encrypted NVMe (~1.4 GB/s ceiling, akin to typical EBS-backed clusters) and an r8gd.16xlarge with two striped local instance NVMes (~7 GB/s ceiling).
 `through` is total bytes pumped through the merge divided by wall time, summed across threads.
+
+### Bench A: encrypted NVMe, 32 GiB working set
+
+Single encrypted NVMe, ~1.4 GB/s sustained R+W ceiling. `--chain-gib 16` (32 GiB working set).
 
 | RAM cap | threads | swap GiB/s | file GiB/s | file/swap |
 |--------:|--------:|-----------:|-----------:|----------:|
@@ -238,13 +242,53 @@ Numbers below were collected on a Linux box with an encrypted NVMe (~1.4 GB/s su
 |     4 G |       1 |       0.12 |       0.36 |      3.0× |
 |     4 G |      16 |       0.36 |       1.21 |      3.4× |
 
-Headlines:
+* File saturates the disk: 1.47 GiB/s at 16 G cap, 16 threads ≈ NVMe ceiling.
+* Swap caps at ~0.36 GiB/s, leaving 70 %+ of disk capacity unused.
+* File scales with parallelism (3× from 1 → 16 threads); swap floors near 90 s wall.
 
-* The file backend can saturate the disk: 1.47 GiB/s at 16 G cap with 16 threads is ~100 % of the encrypted-NVMe ceiling.
-* The swap backend caps at ~0.36 GiB/s regardless of cap or parallelism, leaving 70 %+ of the disk capacity unused.
-* File scales with parallelism (3× from 1 to 16 threads); swap scales sublinearly and floors near 90 s wall.
+### Bench B: r8gd.16xlarge, striped instance NVMe
 
-### Why swap stalls
+64 vCPU, 512 GiB RAM, 2× 1.7 TiB local instance NVMe partitioned 50/50: half striped via mdadm RAID0 for ext4 scratch (~7 GB/s combined sequential), other halves attached as swap with equal priority (kernel-side striping).
+Pressure ratio fixed at 4× (workload : RAM cap).
+
+#### File backend, 1 TiB working set (`--chain-gib 512`, cap = 256 G)
+
+| threads | wall   | overall GiB/s | merge phase |
+|--------:|-------:|--------------:|------------:|
+|       1 | 1195 s |          0.86 |       888 s |
+|       4 |  598 s |          1.71 |       301 s |
+|      16 |  593 s |          1.73 |       310 s |
+|      32 |  591 s |          1.73 |       310 s |
+|      64 |  617 s |          1.66 |       336 s |
+
+File backend saturates at 4 threads; beyond that, scheduling overhead slightly hurts.
+Combined disk during merge ≈ 7 GB/s (~3.5 read + ~3.5 write), at the two-NVMe stripe ceiling.
+Build-phase write rate hits the same ceiling even at 1 thread, so build is disk-bound regardless of parallelism — only merge benefits from concurrency.
+
+#### Swap backend, 128 GiB working set (`--chain-gib 64`, cap = 32 G)
+
+| threads | wall  | overall GiB/s | merge GiB/s |
+|--------:|------:|--------------:|------------:|
+|       1 | 773 s |          0.17 |        0.19 |
+|       4 | 229 s |          0.56 |        0.69 |
+|      16 | 106 s |          1.21 |        1.87 |
+|      32 |  88 s |          1.45 |        2.45 |
+|      64 |  85 s |          1.51 |        2.51 |
+
+Swap-backend merge scales 13× from 1 → 64 threads, plateauing at ~2.5 GiB/s through (~5 GB/s combined disk).
+That is ~75 % of the file backend's saturation throughput on the same hardware.
+Below ~16 threads the kernel serializes on per-memcg reclaim and we see Bench-A-like floors; above 32 threads, enough independent direct-reclaim contexts run in parallel to keep the swap stripe nearly busy.
+
+### Headlines (revised)
+
+* The "swap caps at 0.36 GiB/s regardless of parallelism" claim from Bench A is true only at low thread counts.
+  With 64 threads each entering direct reclaim independently, swap-backend merge reaches ~2.5 GiB/s on fast storage.
+* File backend still wins three ways: ~25 % higher peak throughput on fast disk, far lower RSS (376 MB at 64 threads vs the cgroup cap pinned by swap), and consistent performance below 4 threads where swap collapses.
+* Hardware floor matters more than expected.
+  On 1.4 GB/s encrypted NVMe, kernel reclaim is 4× below disk and swap is dominated.
+  On 7 GB/s striped local NVMe, reclaim is no longer the bottleneck at high parallelism.
+
+### Why swap stalls (single-thread regime)
 
 Single-threaded merge with a 4 GiB chain (8 GiB working set) under a 2 G cap, instrumented via `perf stat` plus `/proc/vmstat` deltas:
 
@@ -267,12 +311,17 @@ Page-table churn from `MADV_COLD` reclaim and subsequent re-faulting also drives
 The file backend issues one `writev` per chunk on pageout and one `pread` per coalesced range on read, lets kernel readahead overlap I/O with the user thread's compute, and never pays the per-page fault tax.
 9 s of sys time covers all of its kernel work for the same 8 GiB scan.
 
+The single-thread analysis generalizes: per-thread fault cost bounds swap throughput, and the only escape is enough threads in flight that the kernel can run multiple reclaim contexts concurrently.
+Bench B confirms this — at 64 threads on fast disks, swap reaches ~75 % of file throughput rather than the ~10 % implied by single-thread numbers.
+
 ### Operational guidance
 
 * Pick the swap backend when the working set is comfortably resident.
   `MADV_COLD` is essentially free in that regime and operations run at memory bandwidth.
-* Pick the file backend whenever the working set may exceed RAM.
-  The kernel I/O pipeline scales; swap-in does not.
+* Pick the file backend whenever the working set may exceed RAM **and** the workload runs with few enough threads that swap-merge would serialize on reclaim.
+  Below ~16 threads, the file backend wins by ~3–5×.
+* For highly parallel workloads (vCPU-count threads) on fast local storage, swap and file are within ~25 % of each other on throughput; the choice can shift toward swap if the operator prefers not to provision separate scratch — at the cost of pinning the cap's worth of RAM.
+* Pick the file backend if multi-tenant memory pressure matters: file-backend RSS stays at the working window (hundreds of MB), while swap-backend RSS pins to the cgroup cap (hundreds of GB).
 * The runtime atomic switch is the right place for an operator-level policy: a controller can flip the global at startup based on cluster size or under a pressure signal.
 
 ## Alternatives

--- a/doc/developer/design/20260504_pager.md
+++ b/doc/developer/design/20260504_pager.md
@@ -38,7 +38,9 @@ The design succeeds when:
 * Cross-handle file pooling (one shared scratch file with a free-list).
   Each handle owns one named file in the scratch directory; pooling is a follow-up if inode pressure shows up.
 * Non-Linux production support.
-  Both backends compile on macOS and others as in-memory no-ops, but the production target is Linux.
+  Both backends compile on any Unix target (the file backend uses portable `pread`/`pwritev`).
+  On macOS, file-backed pageout is fully functional; only the swap backend's `MADV_COLD` hint is Linux-only and becomes a no-op elsewhere.
+  Production target remains Linux.
 
 ## Solution proposal
 

--- a/doc/developer/design/20260504_pager.md
+++ b/doc/developer/design/20260504_pager.md
@@ -1,0 +1,363 @@
+# Pager
+
+* Associated: [CLU-65](https://linear.app/materializeinc/issue/CLU-65/pager), depends on [CLU-64](https://linear.app/materializeinc/issue/CLU-64/remove-lgalloc-from-columnar) (`Column::Aligned` becomes `Vec<u64>`).
+
+## The problem
+
+Materialize spills working sets to Linux swap.
+The kernel decides which anonymous pages to evict, conflating application state with arbitrary heap allocations and forcing user threads into direct reclaim when memory pressure rises.
+Direct reclaim shows up as user-visible latency in dataflow operators and as elevated `pgscan_direct` in `/proc/vmstat` during hydration.
+We need an explicit pager so the application can mark cold data, ask for it back on demand, and choose whether the cold storage lives in anonymous memory (with kernel hints) or on a dedicated scratch volume.
+This unblocks the columnar end-to-end project: once `Column::Aligned` is a `Vec<u64>` (CLU-64), the pager is the natural seam between in-memory columnar buffers and out-of-core storage.
+
+## Success criteria
+
+The design succeeds when:
+
+* Cold columnar data can be paged out and back in via a single API regardless of backend.
+* The swap backend introduces no copies on the page-out path; the page-in path costs at most a `madvise` plus the unavoidable read.
+* The file backend uses one syscall per logical operation where the OS supports it (`writev`, `pread`/coalesced `pread`).
+* Switching backends is a runtime configuration flip, not a recompile or a restart.
+* Existing handles remain usable across backend flips.
+* The API supports both write-once/read-once 2 MiB-scale spill blocks and write-once/read-many large blobs with random offset and length access.
+* Caller-side allocation is reusable: the buffers handed to `pageout` and the buffers passed to `pagein`-style reads return to the caller in a state that preserves their capacity where the backend permits.
+* Out-of-core scenarios (working set 2x system RAM) actually offload pages: peak resident set size drops compared to leaving the data resident.
+
+## Out of scope
+
+* Eviction policy.
+  The pager is a mechanism; callers decide what and when to page out.
+* Generic element types.
+  The API is `Vec<u64>` only.
+  We will revisit if a non-`u64` consumer appears.
+* Compression and encryption.
+  Both can wrap the pager externally.
+* Async or `io_uring`.
+  Sync syscalls only for v1.
+  An async wrapper is a follow-up if profiles motivate it.
+* Cross-handle file pooling (one shared scratch file with a free-list).
+  Each handle owns one named file in the scratch directory; pooling is a follow-up if inode pressure shows up.
+* Non-Linux production support.
+  Both backends compile on macOS and others as in-memory no-ops, but the production target is Linux.
+
+## Solution proposal
+
+A single `mz_ore::pager` module exposes a backend-agnostic API around a `Handle` type.
+A global atomic selects the backend at `pageout` time; the chosen backend is baked into each handle so live flips do not invalidate existing data.
+Two backends ship: `Swap` (keep allocations resident, hint the kernel via `MADV_COLD`) and `File` (write to a named file in a per-process scratch subdirectory).
+The API is sync; the file backend uses `writev` and `pread` to keep syscall counts low.
+The file backend never holds a file descriptor in the handle: each operation opens, runs syscalls, and closes the fd, so per-handle state is a tiny `(scratch_id, length)` tuple regardless of how many handles a process has alive.
+
+### Architecture
+
+```mermaid
+flowchart LR
+  Caller -- "pageout(&mut [Vec])" --> Pager
+  Pager -- "Backend::current()" --> Sel{Atomic backend}
+  Sel -- Swap --> SwapBackend["Swap: hold Vec(s), MADV_COLD"]
+  Sel -- File --> FileBackend["File: writev to scratch/{pid}/{id}.bin, close fd"]
+  Caller -- "read_at_many(&Handle, ranges, &mut dst)" --> Pager
+  Caller -- "take(Handle, &mut dst)" --> Pager
+```
+
+The handle's variant captures which backend produced it, so reads dispatch on the handle alone.
+A backend flip changes only future `pageout` calls; a handle taken under `Swap` continues to read from memory after a flip to `File`.
+
+### API
+
+```rust
+//! src/ore/src/pager.rs
+
+pub enum Backend { Swap, File }
+
+/// Sets the active backend for future pageouts. Existing handles are unaffected.
+pub fn set_backend(b: Backend);
+
+pub fn backend() -> Backend;
+
+/// Configures the scratch directory for the file backend.
+/// Must be called before the first file-backend pageout.
+pub fn set_scratch_dir(path: PathBuf);
+
+pub struct Handle { /* private: SwapInner | FileInner */ }
+
+impl Handle {
+    /// Logical length in u64s.
+    pub fn len(&self) -> usize;
+    pub fn len_bytes(&self) -> usize { self.len() * 8 }
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
+}
+
+impl Drop for Handle { /* swap: drops Vec(s). file: unlinks the scratch file. */ }
+
+/// Scatter pageout. Logical layout = chunks concatenated in input order.
+/// After return: each Vec in `chunks` is empty.
+/// File backend preserves capacity; swap backend moves the alloc into the handle.
+/// Empty input returns a `len == 0` handle and performs no I/O.
+pub fn pageout(chunks: &mut [Vec<u64>]) -> Handle;
+
+/// Reads multiple ranges. Output appended to `dst` in request order (concat).
+/// Panics if any range is out of bounds.
+pub fn read_at_many(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>);
+
+/// Single-range convenience.
+pub fn read_at(handle: &Handle, offset: usize, len: usize, dst: &mut Vec<u64>);
+
+/// Consumes handle, writing the entire payload into `dst` (cleared first), then reclaims storage.
+/// Swap fast path: single-chunk handle into empty `dst` swaps in place, no copy.
+pub fn take(handle: Handle, dst: &mut Vec<u64>);
+```
+
+### Swap backend
+
+Storage is `Vec<Vec<u64>>` plus a prefix-sum `Vec<usize>` of cumulative lengths in u64s.
+
+`pageout`.
+Move each input Vec via `mem::take`.
+For each chunk, compute the page-aligned subrange of its byte buffer and call `madvise(ptr, len, MADV_COLD)`.
+`MADV_COLD` deactivates the pages without freeing them; the kernel reclaims under pressure without a synchronous swap-out.
+Skip the syscall when the page-aligned region is empty (sub-page chunks).
+
+`read_at_many`.
+For each range, binary-search the prefix-sum to find the starting chunk, then `extend_from_slice` across chunk boundaries.
+Optionally call `MADV_WILLNEED` on the touched pages before the copy.
+Output appends in request order to `dst`.
+
+`take`.
+A single-chunk handle paired with an empty `dst` triggers `mem::swap` for a zero-copy take.
+Otherwise concat all chunks into `dst`.
+The handle drops; the `Vec<Vec<u64>>` reclaims.
+
+### File backend
+
+Storage per handle is `(scratch_id: u64, len_u64s: usize)`.
+File descriptors are never retained: the handle is 16 bytes regardless of file state.
+The pager owns a per-process subdirectory `{scratch_dir}/mz-pager-{pid}-{boot_nonce}/` and writes each handle to `{subdir}/{scratch_id}.bin` where `scratch_id` is allocated from a process-wide `AtomicU64`.
+
+`pageout`.
+Allocate `scratch_id`.
+`File::create_new(path)` to open exclusively, build an iovec from each chunk's byte slice, issue one `writev` covering all chunks, then close the fd.
+Clear each input Vec after the write so the caller keeps capacity.
+On I/O failure, log a warning, unlink the path if it was created, and fall back by constructing a `SwapInner` from the same chunks; the contract on input Vecs and the returned handle is unchanged.
+
+`read_at_many`.
+`File::open(path)`, then for each range compute byte offset and byte length and call `pread`.
+Coalesce adjacent ranges (`offset_i + len_i == offset_{i+1}`) into a single `pread`.
+Append into `dst`, then close the fd.
+A future optimization is `preadv2` once a profile shows it matters.
+
+`take`.
+`File::open(path)`, one `pread` for the whole length into `dst`, close the fd, `unlink(path)`, drop the handle.
+
+`Drop` (without `take`).
+`unlink(path)`. The kernel reclaims the inode.
+
+### Scratch directory lifecycle
+
+`set_scratch_dir(root)` creates `{root}/mz-pager-{pid}-{boot_nonce}/`.
+`boot_nonce` is a random 64-bit value sampled at config time so two processes that briefly share the same pid cannot collide.
+On `set_scratch_dir`, the pager runs a reaper that walks `{root}` and removes any sibling `mz-pager-*` subdirectory whose owning pid is no longer alive (`/proc/{pid}` missing on Linux); this reclaims storage from crashed predecessors.
+On clean process exit, a `Drop` on the global pager state removes the per-process subdirectory.
+The reaper is best-effort and logs failures rather than panicking.
+
+### Configuration
+
+Two pieces of global state, both behind atomics or `OnceLock`:
+
+* `BACKEND: AtomicU8`, set by `set_backend`.
+* `SCRATCH_DIR: OnceLock<PathBuf>`, set by `set_scratch_dir` before the first file-backend pageout. Subsequent calls log a warning and become no-ops to avoid mid-run path changes.
+
+A LaunchDarkly-style param wires `set_backend` from cluster configuration, mirroring `mz_ore::region::ENABLE_LGALLOC_REGION`.
+
+### Concurrency
+
+`Handle: Send`.
+`pageout` and `take` consume by value, so they are single-threaded with respect to a handle by construction.
+`read_at` and `read_at_many` take `&Handle` and are concurrent-safe: the file path uses `pread` (thread-safe positional read); the swap path reads through an immutable `&Vec`.
+`set_backend` racing with `pageout` is benign: `pageout` reads the atomic once at entry, and existing handles keep their backend.
+
+### Errors
+
+File I/O on `pageout` failure: log at `warn`, fall back to a swap-backed handle.
+File I/O on read failure: panic.
+The data lives only on the spill path; partial reads indicate corruption or device loss, both unrecoverable.
+Out-of-bounds range in `read_at*`: panic.
+Empty input to `pageout`: returns a `len == 0` handle with no syscalls on either backend.
+
+### File layout
+
+```
+src/ore/src/pager.rs           # Public API, dispatch, Handle enum, config
+src/ore/src/pager/swap.rs      # Swap backend
+src/ore/src/pager/file.rs      # File backend (per-process subdir, writev, pread)
+src/ore/benches/pager.rs       # Criterion benches
+src/ore/Cargo.toml             # Feature `pager`: deps libc, bytemuck
+```
+
+The `pager` feature gates the module so non-Linux builds compile.
+On non-Linux, both backends degrade to no-op variants that hold data in memory and skip syscalls.
+
+## Minimal viable prototype
+
+A working in-tree prototype is the first implementation step: both backends, end-to-end tests, and the benchmark harness described below.
+The prototype validates three risks early.
+First, that `MADV_COLD` actually offloads pages under pressure; we measure this by allocating 2x system RAM in handles and watching peak RSS via `/proc/self/status`.
+Second, that the file backend's vectored I/O is competitive with swap on sequential workloads; the bench compares 1 x 2 MiB and 64 x 32 KiB layouts on both backends.
+Third, that the API survives integration with `Column` post-CLU-64; a follow-up branch wires `Column::Aligned` to `pageout`/`take` end-to-end and runs an existing columnar bench.
+
+The bench harness lives at `src/ore/benches/pager.rs` and uses Criterion.
+Knobs: backend (Swap, File), payload size (4 KiB, 64 KiB, 1 MiB, 16 MiB), chunk count (1, 2, 64), scratch dir (`MZ_PAGER_SCRATCH` env var, default `$TMPDIR`).
+Cases:
+
+* `pageout` wall time, single chunk, varying size.
+* `pageout` scatter, fixed total size, varying chunk count, both backends; isolates `writev` benefit.
+* `read_at` whole-block after a configurable idle delay so the kernel actually reclaims swap pages.
+* `read_at_many` random ranges, 1, 8, 64 ranges per call, sorted vs unsorted to exercise coalescing.
+* Sustained round-trip `pageout` -> `read_at` -> drop, measuring ops/s.
+* Working-set scenario: 2x system RAM in handles, page out half, read random handles; gated behind `cargo bench --features pager-stress` since CI cannot run it.
+
+Unit tests in `src/ore/src/pager.rs` and per-backend modules cover round-trip on both backends, scatter/gather correctness (random ranges including overlapping and adjacent), drop-without-read reclaim, the swap fast path for `take` (assert pointer identity), backend flip mid-run (handle taken under one backend reads through after flip), and capacity-preservation rules.
+miri runs the swap backend; the file backend skips on miri due to syscalls.
+
+## Operational characteristics
+
+A merge-batcher-style example (`src/ore/examples/pager_merge.rs`) builds two chains of 2 MiB chunks, then merges them while reading every cache line of the input.
+Run under `systemd-run --user --scope -p MemoryMax=...` to constrain memory and force real eviction.
+Numbers below were collected on a Linux box with an encrypted NVMe (~1.4 GB/s sustained R+W ceiling) running the example with `--chain-gib 16` (32 GiB total working set) and `--prefetch-depth 4`.
+
+### Throughput sweep
+
+`through` is total bytes pumped through the merge divided by wall time, summed across threads.
+
+| RAM cap | threads | swap GiB/s | file GiB/s | file/swap |
+|--------:|--------:|-----------:|-----------:|----------:|
+|    16 G |       1 |       0.15 |       0.50 |      3.4× |
+|    16 G |      16 |       0.36 |       1.47 |      4.0× |
+|     8 G |       1 |       0.12 |       0.44 |      3.5× |
+|     8 G |      16 |       0.37 |       0.79 |      2.1× |
+|     4 G |       1 |       0.12 |       0.36 |      3.0× |
+|     4 G |      16 |       0.36 |       1.21 |      3.4× |
+
+Headlines:
+
+* The file backend can saturate the disk: 1.47 GiB/s at 16 G cap with 16 threads is ~100 % of the encrypted-NVMe ceiling.
+* The swap backend caps at ~0.36 GiB/s regardless of cap or parallelism, leaving 70 %+ of the disk capacity unused.
+* File scales with parallelism (3× from 1 to 16 threads); swap scales sublinearly and floors near 90 s wall.
+
+### Why swap stalls
+
+Single-threaded merge with a 4 GiB chain (8 GiB working set) under a 2 G cap, instrumented via `perf stat` plus `/proc/vmstat` deltas:
+
+| metric | swap | file | ratio |
+|---|---:|---:|---:|
+| wall time | 65.5 s | 24.0 s | 2.7× |
+| sys time | 63.8 s | 9.0 s | 7.1× |
+| user time | 1.5 s | 1.5 s | 1× |
+| major-faults | 65,516 | 1,913 | 34× |
+| minor-faults | 5,187,868 | 3,986 | 1300× |
+| dTLB-load-misses | 42 M | 12 M | 3.4× |
+| pswpin (4 KiB pages) | 2.12 M | 2.2 K | 970× |
+| pswpout | 3.64 M | 3.1 K | 1180× |
+
+Of swap's 65 s wall, 64 s is sys time — the kernel runs the user thread's fault handler.
+2.1 M page-ins through the swap path means every 4 KiB granule of the 8 GiB working set page-faults synchronously on the user thread.
+The disk does not become the bottleneck: 8 GiB / 65 s = 130 MB/s, less than 10 % of NVMe capacity.
+Page-table churn from `MADV_COLD` reclaim and subsequent re-faulting also drives 3.4× more dTLB misses on the swap path; each unmap broadcasts a TLB-shootdown IPI to every CPU running the task.
+
+The file backend issues one `writev` per chunk on pageout and one `pread` per coalesced range on read, lets kernel readahead overlap I/O with the user thread's compute, and never pays the per-page fault tax.
+9 s of sys time covers all of its kernel work for the same 8 GiB scan.
+
+### Operational guidance
+
+* Pick the swap backend when the working set is comfortably resident.
+  `MADV_COLD` is essentially free in that regime and operations run at memory bandwidth.
+* Pick the file backend whenever the working set may exceed RAM.
+  The kernel I/O pipeline scales; swap-in does not.
+* The runtime atomic switch is the right place for an operator-level policy: a controller can flip the global at startup based on cluster size or under a pressure signal.
+* Prefetch hints (`prefetch` / `prefetch_at`) help the file backend by ~5 % at depth 16 on this workload; they do not help the swap backend because under pressure the kernel is reclaim-bound, not stall-bound.
+
+## Alternatives
+
+### Generic over `T: Pod`
+
+The columnar use case is `Vec<u64>` and the spec is explicit on `&[u64]`.
+A generic over `T: bytemuck::Pod` would let callers spill `Vec<u8>` or `Vec<u32>` without manual casts.
+The cost is API-wide: the handle must track element size, the file backend must validate alignment on read, and `take` round-tripping a `Vec<u8>` cannot return a `Vec<u64>` without reallocation.
+The simpler `u64`-only design wins until a concrete non-`u64` consumer appears; an additive `pageout_pod<T: Pod>` later would not break existing callers.
+
+### Per-pager configuration instead of a global atomic
+
+A `Pager` struct constructed with its backend would compose better than a global, especially in tests.
+But the project intent is "the cluster runs on swap or on file, not both at once", and a global atomic encodes that operational reality directly.
+A per-pager design would either duplicate the global flag at the struct level or invite confusion about which configuration wins.
+We can add a per-instance constructor later for tests if the global proves awkward; the global stays as the production path.
+
+### One pager per use case (transient spill vs long-lived blob)
+
+The two named use cases differ only in handle lifetime and access pattern, not in storage.
+Both want `pageout` once, both want random-offset reads, both want `Drop` to reclaim.
+Two pagers would duplicate the global flag, the scratch directory, and the syscall code paths.
+One pager covers both with the same API; UC1 calls `pageout` then `take`; UC2 calls `pageout` once and `read_at` many times.
+
+### Async API
+
+The dataflow callers run on synchronous timely worker threads, and bridging async out of an operator costs context switches and complicates lifetimes.
+Sync `pread`/`writev` on a thread that already exists is the simplest correct choice for v1.
+An async wrapper that offloads to a blocking pool can be added later without breaking the sync core.
+
+### `MADV_PAGEOUT` / `MADV_SWAPOUT`
+
+`MADV_PAGEOUT` (Linux 5.4+) actively reclaims pages synchronously, which is the closest to the file backend's eager-write semantics.
+The cost is a synchronous, expensive syscall that we would issue from operator threads; under pressure this re-creates the direct-reclaim problem we are trying to escape.
+`MADV_COLD` deactivates pages and lets the kernel reclaim asynchronously when it actually wants to, which matches our goal of moving work off the user thread.
+We pick `MADV_COLD` for v1; if profiles show pages are not reclaimed quickly enough, `MADV_PAGEOUT` is a one-line swap on a feature-gate.
+
+### `O_TMPFILE` with the fd held in the handle
+
+`O_TMPFILE` creates an unnamed inode that auto-deletes when the last fd closes, so it would skip the explicit `unlink` step on reclaim.
+The cost is one fd per handle: 100k live handles would exhaust the process fd ulimit and require an OS configuration change to operate at scale.
+The chosen design instead opens a named file, writes, and closes the fd within `pageout`, so the handle holds 16 bytes and no fd, and reads reopen as needed.
+
+### Single shared scratch file with an offset table
+
+One file with handle-owned offsets reduces inode pressure and enables better physical layout.
+It also requires a free-list, fragmentation handling, and a different reclaim story (truncation does not free arbitrary middles).
+The complexity is unjustified at expected handle counts; revisit if inode count per handle becomes a measurable bottleneck.
+
+## Open questions
+
+* Should `pageout` accept `impl IntoIterator<Item = Vec<u64>>` for ergonomics?
+  Iterators lose caller capacity reuse on the file path because we have no `&mut` access to put the cleared Vec back.
+  Recommend sticking with `&mut [Vec<u64>]`; revisit if the slice form proves awkward at call sites.
+
+* Should `set_backend` be allowed to flip multiple times during a process lifetime?
+  Yes for v1, since live LaunchDarkly flips are an explicit goal.
+  The per-handle stability rule (existing handles keep their backend) keeps this safe; document it in the rustdoc.
+
+* Should we add `read_at_into(&Handle, offset: usize, dst: &mut [u64])` for callers that have a sized buffer and do not want `Vec` semantics?
+  The columnar consumer is `Vec<u64>` and `read_at` already reuses the caller's allocation via `&mut Vec<u64>`.
+  Defer; add additively if a caller needs slice-only reads.
+
+* Should we add `pageout_each(&mut [Vec<u64>]) -> Vec<Handle>` for timely-spill-style integration?
+  Timely's `BytesSpill` needs one handle per chunk; with the fd-less file backend, a "shared file under N handles" design becomes "N handles each pointing at independent files" and the `writev`-batching benefit disappears.
+  An alternative is `pageout_each` that writes all chunks into one shared scratch file and returns N handles each carrying `(scratch_id, byte_offset, byte_len)` plus a refcount so the file is unlinked once all handles drop.
+  Defer until the timely-spill integration concretely wants it; the existing `pageout` already covers the columnar primary use case.
+
+## Interaction with timely-dataflow spill
+
+Timely's `MergeQueue` exposes `BytesSpill`/`BytesFetch` traits ([PR 791](https://github.com/TimelyDataflow/timely-dataflow/pull/791) demonstrates the file-backed strategy).
+The shapes differ: timely's `spill(&mut Vec<Bytes>, &mut Vec<Box<dyn BytesFetch>>)` takes N chunks and returns N independent fetch handles; the pager takes N chunks and returns one composite handle.
+A `mz_timely_util::spill` adapter is the integration point, not the pager itself.
+The adapter can be implemented in two ways once both pieces exist.
+
+The simple form calls `pager::pageout` once per chunk and stores each `pager::Handle` inside a `BytesFetch` impl.
+This costs one scratch file per chunk; for 256 KiB chunks at 50 GiB total, that's roughly 200k inodes, which is workable on tmpfs but stressful on disk filesystems.
+The richer form is the deferred `pageout_each` API above, which lets one writev produce one file with N handles and matches timely's design exactly.
+
+The element-type boundary needs care.
+Timely passes `bytes::arc::Bytes` (byte-aligned); the pager wants `Vec<u64>` (8-byte aligned).
+Materialize's columnar serialization already produces 8-byte-aligned bytes, so the adapter can cast where alignment is statically guaranteed and copy where it is not.
+A future enhancement is a parallel byte-oriented pager API; deferred until the adapter exists and motivates it.
+
+The pager's swap backend is novel relative to timely's example: timely's "no-spill" baseline relies on the OS to manage memory, while the pager actively hints `MADV_COLD`.
+This makes the swap backend an additional spill strategy that timely does not currently offer, suitable for cases where eager file write is too expensive but kernel-driven reclaim alone is too slow.

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -30,7 +30,7 @@ mz-dyncfg = { path = "../dyncfg" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
 mz-metrics = { path = "../metrics" }
-mz-ore = { path = "../ore", features = ["async", "process", "tracing", "columnar", "differential-dataflow", "region"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing", "columnar", "differential-dataflow", "pager", "region"] }
 mz-proto = { path = "../proto" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -288,6 +288,19 @@ impl ComputeState {
             lgalloc::lgalloc_set_config(lgalloc::LgAlloc::new().disable());
         }
 
+        // Pager backend selection follows scratch-directory availability:
+        // a scratch dir means the file backend; no scratch dir means swap.
+        // `set_scratch_dir` and `set_backend` are both idempotent, so calling
+        // on every `apply_worker_config` tick is safe. The pager module is
+        // only compiled on Unix targets (`mz_ore::pager` is `cfg(unix)`).
+        #[cfg(unix)]
+        if let Some(path) = &self.context.scratch_directory {
+            mz_ore::pager::set_scratch_dir(path.clone());
+            mz_ore::pager::set_backend(mz_ore::pager::Backend::File);
+        } else {
+            mz_ore::pager::set_backend(mz_ore::pager::Backend::Swap);
+        }
+
         crate::memory_limiter::apply_limiter_config(config);
 
         mz_ore::region::ENABLE_LGALLOC_REGION.store(

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -169,6 +169,11 @@ name = "bytes"
 harness = false
 required-features = ["bytes", "region", "tracing"]
 
+[[bench]]
+name = "pager"
+harness = false
+required-features = ["pager"]
+
 [package.metadata.cargo-udeps.ignore]
 # Only used in doc-tests.
 development = ["tokio-test"]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -93,6 +93,7 @@ mz-ore = { path = "../ore", features = ["id_gen", "chrono"] }
 proptest.workspace = true
 scopeguard.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tokio-test.workspace = true
 tracing-subscriber.workspace = true
@@ -145,6 +146,7 @@ assert-no-tracing = ["ctor"]
 assert = ["assert-no-tracing", "ctor", "tracing"]
 proptest = ["dep:proptest", "proptest-derive"]
 overflowing = ["assert"]
+pager = ["dep:bytemuck", "libc", "rand", "dep:tracing"]
 
 [[test]]
 name = "future"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -174,6 +174,10 @@ name = "pager"
 harness = false
 required-features = ["pager"]
 
+[[example]]
+name = "pager_merge"
+required-features = ["pager"]
+
 [package.metadata.cargo-udeps.ignore]
 # Only used in doc-tests.
 development = ["tokio-test"]

--- a/src/ore/benches/pager.rs
+++ b/src/ore/benches/pager.rs
@@ -1,0 +1,115 @@
+#![cfg(feature = "pager")]
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
+use mz_ore::pager::{self, Backend};
+
+fn ensure_scratch() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let dir: PathBuf = std::env::var_os("MZ_PAGER_SCRATCH")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir);
+        pager::set_scratch_dir(dir);
+    });
+}
+
+fn fill_payload(len_u64s: usize) -> Vec<u64> {
+    (0..len_u64s as u64).collect()
+}
+
+fn bench_pageout_single(c: &mut Criterion) {
+    ensure_scratch();
+    let mut group = c.benchmark_group("pager/pageout/single_chunk");
+    group.measurement_time(Duration::from_secs(2));
+    for size_kib in [4usize, 64, 1024, 16384] {
+        let len = (size_kib * 1024) / 8;
+        for backend in [Backend::Swap, Backend::File] {
+            pager::set_backend(backend);
+            group.throughput(Throughput::Bytes((size_kib * 1024) as u64));
+            group.bench_function(
+                BenchmarkId::new(format!("{backend:?}"), size_kib),
+                |b| {
+                    b.iter_batched(
+                        || [fill_payload(len)],
+                        |mut chunks| {
+                            let h = pager::pageout(&mut chunks);
+                            black_box(h);
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_pageout_scatter(c: &mut Criterion) {
+    ensure_scratch();
+    let mut group = c.benchmark_group("pager/pageout/scatter_2MiB");
+    group.measurement_time(Duration::from_secs(2));
+    let total_bytes = 2 * 1024 * 1024;
+    for chunk_count in [1usize, 2, 64] {
+        let chunk_bytes = total_bytes / chunk_count;
+        let chunk_len_u64s = chunk_bytes / 8;
+        for backend in [Backend::Swap, Backend::File] {
+            pager::set_backend(backend);
+            group.throughput(Throughput::Bytes(total_bytes as u64));
+            group.bench_function(
+                BenchmarkId::new(format!("{backend:?}"), chunk_count),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            (0..chunk_count)
+                                .map(|_| fill_payload(chunk_len_u64s))
+                                .collect::<Vec<_>>()
+                        },
+                        |mut chunks| {
+                            let h = pager::pageout(chunks.as_mut_slice());
+                            black_box(h);
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_round_trip(c: &mut Criterion) {
+    ensure_scratch();
+    let mut group = c.benchmark_group("pager/round_trip");
+    group.measurement_time(Duration::from_secs(3));
+    let len = (256 * 1024) / 8;
+    for backend in [Backend::Swap, Backend::File] {
+        pager::set_backend(backend);
+        group.throughput(Throughput::Bytes(256 * 1024));
+        group.bench_function(BenchmarkId::new(format!("{backend:?}"), 256), |b| {
+            b.iter_batched(
+                || [fill_payload(len)],
+                |mut chunks| {
+                    let h = pager::pageout(&mut chunks);
+                    let mut dst = Vec::new();
+                    pager::take(h, &mut dst);
+                    black_box(dst);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_pageout_single,
+    bench_pageout_scatter,
+    bench_round_trip
+);
+criterion_main!(benches);

--- a/src/ore/benches/pager.rs
+++ b/src/ore/benches/pager.rs
@@ -1,3 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![cfg(feature = "pager")]
 
 use std::hint::black_box;

--- a/src/ore/benches/pager.rs
+++ b/src/ore/benches/pager.rs
@@ -1,11 +1,11 @@
 #![cfg(feature = "pager")]
 
+use std::hint::black_box;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
-};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use mz_ore::cast::CastFrom;
 use mz_ore::pager::{self, Backend};
 
 fn ensure_scratch() {
@@ -19,7 +19,7 @@ fn ensure_scratch() {
 }
 
 fn fill_payload(len_u64s: usize) -> Vec<u64> {
-    (0..len_u64s as u64).collect()
+    (0..u64::cast_from(len_u64s)).collect()
 }
 
 fn bench_pageout_single(c: &mut Criterion) {
@@ -30,20 +30,18 @@ fn bench_pageout_single(c: &mut Criterion) {
         let len = (size_kib * 1024) / 8;
         for backend in [Backend::Swap, Backend::File] {
             pager::set_backend(backend);
-            group.throughput(Throughput::Bytes((size_kib * 1024) as u64));
-            group.bench_function(
-                BenchmarkId::new(format!("{backend:?}"), size_kib),
-                |b| {
-                    b.iter_batched(
-                        || [fill_payload(len)],
-                        |mut chunks| {
-                            let h = pager::pageout(&mut chunks);
-                            black_box(h);
-                        },
-                        BatchSize::SmallInput,
-                    );
-                },
-            );
+            let total_bytes = u64::cast_from(size_kib * 1024);
+            group.throughput(Throughput::Bytes(total_bytes));
+            group.bench_function(BenchmarkId::new(format!("{backend:?}"), size_kib), |b| {
+                b.iter_batched(
+                    || [fill_payload(len)],
+                    |mut chunks| {
+                        let h = pager::pageout(&mut chunks);
+                        black_box(h);
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
         }
     }
     group.finish();
@@ -53,30 +51,28 @@ fn bench_pageout_scatter(c: &mut Criterion) {
     ensure_scratch();
     let mut group = c.benchmark_group("pager/pageout/scatter_2MiB");
     group.measurement_time(Duration::from_secs(2));
-    let total_bytes = 2 * 1024 * 1024;
+    let total_bytes: usize = 2 * 1024 * 1024;
     for chunk_count in [1usize, 2, 64] {
         let chunk_bytes = total_bytes / chunk_count;
         let chunk_len_u64s = chunk_bytes / 8;
         for backend in [Backend::Swap, Backend::File] {
             pager::set_backend(backend);
-            group.throughput(Throughput::Bytes(total_bytes as u64));
-            group.bench_function(
-                BenchmarkId::new(format!("{backend:?}"), chunk_count),
-                |b| {
-                    b.iter_batched(
-                        || {
-                            (0..chunk_count)
-                                .map(|_| fill_payload(chunk_len_u64s))
-                                .collect::<Vec<_>>()
-                        },
-                        |mut chunks| {
-                            let h = pager::pageout(chunks.as_mut_slice());
-                            black_box(h);
-                        },
-                        BatchSize::SmallInput,
-                    );
-                },
-            );
+            let total_bytes_u64 = u64::cast_from(total_bytes);
+            group.throughput(Throughput::Bytes(total_bytes_u64));
+            group.bench_function(BenchmarkId::new(format!("{backend:?}"), chunk_count), |b| {
+                b.iter_batched(
+                    || {
+                        (0..chunk_count)
+                            .map(|_| fill_payload(chunk_len_u64s))
+                            .collect::<Vec<_>>()
+                    },
+                    |mut chunks| {
+                        let h = pager::pageout(chunks.as_mut_slice());
+                        black_box(h);
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
         }
     }
     group.finish();

--- a/src/ore/benches/pager.rs
+++ b/src/ore/benches/pager.rs
@@ -17,11 +17,14 @@
 
 use std::hint::black_box;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use mz_ore::cast::CastFrom;
-use mz_ore::pager::{self, Backend};
+use mz_ore::pager::{self, Backend, Handle};
+
+const PAGE_BYTES: usize = 4096;
+const PAGE_U64S: usize = PAGE_BYTES / 8;
 
 fn ensure_scratch() {
     static INIT: std::sync::Once = std::sync::Once::new();
@@ -37,90 +40,102 @@ fn fill_payload(len_u64s: usize) -> Vec<u64> {
     (0..u64::cast_from(len_u64s)).collect()
 }
 
-fn bench_pageout_single(c: &mut Criterion) {
+/// Reads one `u64` from each page of `buf` to force the kernel to fault them in.
+/// Returns a side-effecting sum so the compiler cannot elide the loads.
+fn touch_every_page(buf: &[u64]) -> u64 {
+    let mut s: u64 = 0;
+    let mut i = 0;
+    while i < buf.len() {
+        s = s.wrapping_add(buf[i]);
+        i += PAGE_U64S;
+    }
+    s
+}
+
+/// Round-trip a single-chunk payload through the pager and touch every page on
+/// readback. Reuses the buffer between iterations so allocation/page-fault tax
+/// is paid once at setup, not measured.
+fn round_trip_single(c: &mut Criterion) {
     ensure_scratch();
-    let mut group = c.benchmark_group("pager/pageout/single_chunk");
-    group.measurement_time(Duration::from_secs(2));
-    for size_kib in [4usize, 64, 1024, 16384] {
+    let mut group = c.benchmark_group("pager/round_trip_touch/single");
+    group.measurement_time(Duration::from_secs(5));
+    for size_kib in [4usize, 64, 1024, 2048, 16384] {
         let len = (size_kib * 1024) / 8;
         for backend in [Backend::Swap, Backend::File] {
             pager::set_backend(backend);
-            let total_bytes = u64::cast_from(size_kib * 1024);
-            group.throughput(Throughput::Bytes(total_bytes));
+            group.throughput(Throughput::Bytes(u64::cast_from(size_kib * 1024)));
             group.bench_function(BenchmarkId::new(format!("{backend:?}"), size_kib), |b| {
-                b.iter_batched(
-                    || [fill_payload(len)],
-                    |mut chunks| {
-                        let h = pager::pageout(&mut chunks);
-                        black_box(h);
-                    },
-                    BatchSize::SmallInput,
-                );
+                b.iter_custom(|iters| {
+                    let mut payload = fill_payload(len);
+                    let mut tmp: Vec<u64> = Vec::with_capacity(len);
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        let mut chunks = [std::mem::take(&mut payload)];
+                        let h: Handle = pager::pageout(&mut chunks);
+                        pager::take(h, &mut tmp);
+                        black_box(touch_every_page(&tmp));
+                        payload = std::mem::take(&mut tmp);
+                        tmp = Vec::with_capacity(len);
+                    }
+                    start.elapsed()
+                });
             });
         }
     }
     group.finish();
 }
 
-fn bench_pageout_scatter(c: &mut Criterion) {
+/// Round-trip a scatter-input (multiple chunks forming one logical 2 MiB block).
+/// Measures the same touch-every-page readback pattern as `round_trip_single`.
+fn round_trip_scatter_2mib(c: &mut Criterion) {
     ensure_scratch();
-    let mut group = c.benchmark_group("pager/pageout/scatter_2MiB");
-    group.measurement_time(Duration::from_secs(2));
+    let mut group = c.benchmark_group("pager/round_trip_touch/scatter_2MiB");
+    group.measurement_time(Duration::from_secs(5));
     let total_bytes: usize = 2 * 1024 * 1024;
-    for chunk_count in [1usize, 2, 64] {
+    for chunk_count in [1usize, 2, 8, 64] {
         let chunk_bytes = total_bytes / chunk_count;
         let chunk_len_u64s = chunk_bytes / 8;
         for backend in [Backend::Swap, Backend::File] {
             pager::set_backend(backend);
-            let total_bytes_u64 = u64::cast_from(total_bytes);
-            group.throughput(Throughput::Bytes(total_bytes_u64));
+            group.throughput(Throughput::Bytes(u64::cast_from(total_bytes)));
             group.bench_function(BenchmarkId::new(format!("{backend:?}"), chunk_count), |b| {
-                b.iter_batched(
-                    || {
-                        (0..chunk_count)
-                            .map(|_| fill_payload(chunk_len_u64s))
-                            .collect::<Vec<_>>()
-                    },
-                    |mut chunks| {
-                        let h = pager::pageout(chunks.as_mut_slice());
-                        black_box(h);
-                    },
-                    BatchSize::SmallInput,
-                );
+                b.iter_custom(|iters| {
+                    let mut payload: Vec<Vec<u64>> = (0..chunk_count)
+                        .map(|_| fill_payload(chunk_len_u64s))
+                        .collect();
+                    let mut tmp: Vec<u64> = Vec::with_capacity(total_bytes / 8);
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        let h: Handle = pager::pageout(payload.as_mut_slice());
+                        pager::take(h, &mut tmp);
+                        black_box(touch_every_page(&tmp));
+                        // Rebuild the input from `tmp` for the next iteration:
+                        // swap the consolidated buffer back into chunk 0, leave
+                        // the other chunks empty (they were drained by the
+                        // swap backend's `mem::take`). The file backend already
+                        // preserved their capacity, so this still amortizes its
+                        // allocation cost.
+                        payload[0] = std::mem::take(&mut tmp);
+                        tmp = Vec::with_capacity(total_bytes / 8);
+                        // For chunk_count > 1, refill the trailing chunks by
+                        // splitting payload[0] back into the original shape.
+                        if chunk_count > 1 {
+                            let mut head = std::mem::take(&mut payload[0]);
+                            for i in 1..chunk_count {
+                                let take_len = std::cmp::min(chunk_len_u64s, head.len());
+                                let tail = head.split_off(head.len() - take_len);
+                                payload[i] = tail;
+                            }
+                            payload[0] = head;
+                        }
+                    }
+                    start.elapsed()
+                });
             });
         }
     }
     group.finish();
 }
 
-fn bench_round_trip(c: &mut Criterion) {
-    ensure_scratch();
-    let mut group = c.benchmark_group("pager/round_trip");
-    group.measurement_time(Duration::from_secs(3));
-    let len = (256 * 1024) / 8;
-    for backend in [Backend::Swap, Backend::File] {
-        pager::set_backend(backend);
-        group.throughput(Throughput::Bytes(256 * 1024));
-        group.bench_function(BenchmarkId::new(format!("{backend:?}"), 256), |b| {
-            b.iter_batched(
-                || [fill_payload(len)],
-                |mut chunks| {
-                    let h = pager::pageout(&mut chunks);
-                    let mut dst = Vec::new();
-                    pager::take(h, &mut dst);
-                    black_box(dst);
-                },
-                BatchSize::SmallInput,
-            );
-        });
-    }
-    group.finish();
-}
-
-criterion_group!(
-    benches,
-    bench_pageout_single,
-    bench_pageout_scatter,
-    bench_round_trip
-);
+criterion_group!(benches, round_trip_single, round_trip_scatter_2mib);
 criterion_main!(benches);

--- a/src/ore/examples/pager_merge.rs
+++ b/src/ore/examples/pager_merge.rs
@@ -34,7 +34,7 @@ use std::env;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use mz_ore::cast::CastFrom;
+use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::pager::{self, Backend, Handle};
 
 const CHUNK_BYTES: usize = 2 * 1024 * 1024;
@@ -45,6 +45,7 @@ const CACHE_LINE_U64: usize = CACHE_LINE_BYTES / 8;
 fn main() {
     let args: Vec<String> = env::args().collect();
     let chain_gib: usize = parse_arg(&args, "--chain-gib", 16);
+    let prefetch_depth: usize = parse_arg(&args, "--prefetch-depth", 1);
     let backend = parse_backend(&args);
     let scratch: PathBuf = env::var_os("MZ_PAGER_SCRATCH")
         .map(PathBuf::from)
@@ -57,7 +58,7 @@ fn main() {
     let chunks_per_chain = chain_bytes / CHUNK_BYTES;
 
     println!(
-        "backend={backend:?} chain={chain_gib}GiB chunks_per_chain={chunks_per_chain} chunk={CHUNK_BYTES}B"
+        "backend={backend:?} chain={chain_gib}GiB chunks_per_chain={chunks_per_chain} chunk={CHUNK_BYTES}B prefetch_depth={prefetch_depth}"
     );
 
     let (chain_a, build_a) = time(|| build_chain(chunks_per_chain));
@@ -74,7 +75,7 @@ fn main() {
         gib_per_sec(chain_bytes, build_b)
     );
 
-    let (chain_c, merge_dur) = time(|| merge_pass(chain_a, chain_b));
+    let (chain_c, merge_dur) = time(|| merge_pass(chain_a, chain_b, prefetch_depth));
     let merged_bytes = chunks_per_chain * 2 * CHUNK_BYTES;
     println!(
         "merge: {:.2?} ({:.2} GiB/s through, output_chunks={})",
@@ -105,7 +106,7 @@ fn build_chain(n_chunks: usize) -> Vec<Handle> {
     chain
 }
 
-fn merge_pass(a: Vec<Handle>, b: Vec<Handle>) -> Vec<Handle> {
+fn merge_pass(a: Vec<Handle>, b: Vec<Handle>, prefetch_depth: usize) -> Vec<Handle> {
     let n = a.len().min(b.len());
     let mut a: Vec<Option<Handle>> = a.into_iter().map(Some).collect();
     let mut b: Vec<Option<Handle>> = b.into_iter().map(Some).collect();
@@ -113,24 +114,28 @@ fn merge_pass(a: Vec<Handle>, b: Vec<Handle>) -> Vec<Handle> {
     let mut tmp_a: Vec<u64> = Vec::with_capacity(CHUNK_U64);
     let mut tmp_b: Vec<u64> = Vec::with_capacity(CHUNK_U64);
     let mut sink: u64 = 0;
-    // Issue the first prefetches so the kernel starts populating page cache /
-    // swap-in for the very first iteration.
-    if n > 0 {
-        if let Some(h) = a[0].as_ref() {
+    // Maintain a rolling window of `prefetch_depth` outstanding prefetches.
+    // Issue the initial wave for indices [0, prefetch_depth).
+    let initial = prefetch_depth.min(n);
+    for j in 0..initial {
+        if let Some(h) = a[j].as_ref() {
             pager::prefetch(h);
         }
-        if let Some(h) = b[0].as_ref() {
+        if let Some(h) = b[j].as_ref() {
             pager::prefetch(h);
         }
     }
     for i in 0..n {
-        // Prefetch one chunk ahead of the current pair so I/O overlaps with
-        // the cache-line touch and the output pageouts below.
-        if i + 1 < n {
-            if let Some(h) = a[i + 1].as_ref() {
+        // Each iteration extends the window by one: prefetch index `i +
+        // prefetch_depth` so that by the time we consume it the kernel has
+        // had `prefetch_depth` chunks worth of compute time to make pages
+        // available.
+        let pf = i + prefetch_depth;
+        if pf < n {
+            if let Some(h) = a[pf].as_ref() {
                 pager::prefetch(h);
             }
-            if let Some(h) = b[i + 1].as_ref() {
+            if let Some(h) = b[pf].as_ref() {
                 pager::prefetch(h);
             }
         }
@@ -181,8 +186,7 @@ fn gib_per_sec(bytes: usize, d: Duration) -> f64 {
     if secs == 0.0 {
         return 0.0;
     }
-    #[allow(clippy::as_conversions)] // usize -> f64 is intentionally lossy for reporting
-    let gib = bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    let gib = f64::cast_lossy(bytes) / (1024.0 * 1024.0 * 1024.0);
     gib / secs
 }
 

--- a/src/ore/examples/pager_merge.rs
+++ b/src/ore/examples/pager_merge.rs
@@ -1,0 +1,182 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Merge-batcher-style workload for the pager.
+//!
+//! Builds two chains of 2 MiB chunks (`--chain-gib` each), then performs a
+//! merge pass that takes one chunk from each input, reads every cache line,
+//! and emits two output chunks. Reports build/merge throughput.
+//!
+//! Run with constrained memory via `systemd-run --user --scope -p MemoryMax=...`.
+//!
+//! ```bash
+//! cargo build --release --features pager --example pager_merge
+//! systemd-run --user --scope -p MemoryMax=16G -p MemorySwapMax=64G --quiet \
+//!   --setenv=MZ_PAGER_SCRATCH=/path/to/scratch \
+//!   -- target/release/examples/pager_merge --chain-gib 16 --backend swap
+//! ```
+
+#![cfg(feature = "pager")]
+
+use std::env;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use mz_ore::cast::CastFrom;
+use mz_ore::pager::{self, Backend, Handle};
+
+const CHUNK_BYTES: usize = 2 * 1024 * 1024;
+const CHUNK_U64: usize = CHUNK_BYTES / 8;
+const CACHE_LINE_BYTES: usize = 64;
+const CACHE_LINE_U64: usize = CACHE_LINE_BYTES / 8;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let chain_gib: usize = parse_arg(&args, "--chain-gib", 16);
+    let backend = parse_backend(&args);
+    let scratch: PathBuf = env::var_os("MZ_PAGER_SCRATCH")
+        .map(PathBuf::from)
+        .unwrap_or_else(env::temp_dir);
+
+    pager::set_scratch_dir(scratch);
+    pager::set_backend(backend);
+
+    let chain_bytes = chain_gib * 1024 * 1024 * 1024;
+    let chunks_per_chain = chain_bytes / CHUNK_BYTES;
+
+    println!(
+        "backend={backend:?} chain={chain_gib}GiB chunks_per_chain={chunks_per_chain} chunk={CHUNK_BYTES}B"
+    );
+
+    let (chain_a, build_a) = time(|| build_chain(chunks_per_chain));
+    println!(
+        "build A: {:.2?} ({:.2} GiB/s)",
+        build_a,
+        gib_per_sec(chain_bytes, build_a)
+    );
+
+    let (chain_b, build_b) = time(|| build_chain(chunks_per_chain));
+    println!(
+        "build B: {:.2?} ({:.2} GiB/s)",
+        build_b,
+        gib_per_sec(chain_bytes, build_b)
+    );
+
+    let (chain_c, merge_dur) = time(|| merge_pass(chain_a, chain_b));
+    let merged_bytes = chunks_per_chain * 2 * CHUNK_BYTES;
+    println!(
+        "merge: {:.2?} ({:.2} GiB/s through, output_chunks={})",
+        merge_dur,
+        gib_per_sec(merged_bytes, merge_dur),
+        chain_c.len()
+    );
+
+    let (_, drop_dur) = time(|| drop(chain_c));
+    println!("drop output chain: {:.2?}", drop_dur);
+}
+
+fn build_chain(n_chunks: usize) -> Vec<Handle> {
+    let mut chain = Vec::with_capacity(n_chunks);
+    let mut buf: Vec<u64> = vec![0; CHUNK_U64];
+    for i in 0..n_chunks {
+        // Fill with non-zero, position-dependent data so the kernel cannot
+        // share zero pages.
+        for (j, w) in buf.iter_mut().enumerate() {
+            *w = u64::cast_from(i) ^ u64::cast_from(j);
+        }
+        let mut chunks = [std::mem::take(&mut buf)];
+        chain.push(pager::pageout(&mut chunks));
+        // Reallocate; the swap backend stole the buffer, the file backend
+        // left an empty Vec with original capacity, but we don't keep it.
+        buf = vec![0; CHUNK_U64];
+    }
+    chain
+}
+
+fn merge_pass(a: Vec<Handle>, b: Vec<Handle>) -> Vec<Handle> {
+    let mut out = Vec::with_capacity(a.len() + b.len());
+    let mut tmp_a: Vec<u64> = Vec::with_capacity(CHUNK_U64);
+    let mut tmp_b: Vec<u64> = Vec::with_capacity(CHUNK_U64);
+    let mut sink: u64 = 0;
+    for (ha, hb) in a.into_iter().zip(b.into_iter()) {
+        pager::take(ha, &mut tmp_a);
+        pager::take(hb, &mut tmp_b);
+        // Touch every cache line of both inputs (1 u64 per 64-byte line).
+        sink = touch_cache_lines(&tmp_a, sink);
+        sink = touch_cache_lines(&tmp_b, sink);
+        // Emit two output chunks, simulating a merged run that doubles the
+        // chunk count. Each output is 2 MiB; we hand the original buffers
+        // straight to `pageout`, which transfers ownership cleanly on the
+        // swap backend.
+        {
+            let mut chunks = [std::mem::take(&mut tmp_a)];
+            out.push(pager::pageout(&mut chunks));
+            tmp_a = Vec::with_capacity(CHUNK_U64);
+        }
+        {
+            let mut chunks = [std::mem::take(&mut tmp_b)];
+            out.push(pager::pageout(&mut chunks));
+            tmp_b = Vec::with_capacity(CHUNK_U64);
+        }
+    }
+    std::hint::black_box(sink);
+    out
+}
+
+#[inline]
+fn touch_cache_lines(buf: &[u64], mut sink: u64) -> u64 {
+    let mut i = 0;
+    while i < buf.len() {
+        sink = sink.wrapping_add(buf[i]);
+        i += CACHE_LINE_U64;
+    }
+    sink
+}
+
+fn time<T>(f: impl FnOnce() -> T) -> (T, Duration) {
+    let start = Instant::now();
+    let v = f();
+    (v, start.elapsed())
+}
+
+fn gib_per_sec(bytes: usize, d: Duration) -> f64 {
+    let secs = d.as_secs_f64();
+    if secs == 0.0 {
+        return 0.0;
+    }
+    let gib = bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    gib / secs
+}
+
+fn parse_arg(args: &[String], flag: &str, default: usize) -> usize {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_backend(args: &[String]) -> Backend {
+    let pos = args
+        .iter()
+        .position(|a| a == "--backend")
+        .and_then(|i| args.get(i + 1));
+    match pos.map(String::as_str) {
+        Some("file") => Backend::File,
+        Some("swap") => Backend::Swap,
+        Some(other) => panic!("unknown backend {other:?}; use 'swap' or 'file'"),
+        None => Backend::Swap,
+    }
+}

--- a/src/ore/examples/pager_merge.rs
+++ b/src/ore/examples/pager_merge.rs
@@ -32,6 +32,8 @@
 
 use std::env;
 use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use mz_ore::cast::{CastFrom, CastLossy};
@@ -46,6 +48,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let chain_gib: usize = parse_arg(&args, "--chain-gib", 16);
     let prefetch_depth: usize = parse_arg(&args, "--prefetch-depth", 1);
+    let threads: usize = parse_arg(&args, "--threads", 1).max(1);
     let backend = parse_backend(&args);
     let scratch: PathBuf = env::var_os("MZ_PAGER_SCRATCH")
         .map(PathBuf::from)
@@ -54,38 +57,67 @@ fn main() {
     pager::set_scratch_dir(scratch);
     pager::set_backend(backend);
 
-    let chain_bytes = chain_gib * 1024 * 1024 * 1024;
-    let chunks_per_chain = chain_bytes / CHUNK_BYTES;
+    let total_chain_bytes = chain_gib * 1024 * 1024 * 1024;
+    let per_thread_chain_bytes = total_chain_bytes / threads;
+    let chunks_per_chain = per_thread_chain_bytes / CHUNK_BYTES;
 
     println!(
-        "backend={backend:?} chain={chain_gib}GiB chunks_per_chain={chunks_per_chain} chunk={CHUNK_BYTES}B prefetch_depth={prefetch_depth}"
+        "backend={backend:?} threads={threads} per_thread_chain_chunks={chunks_per_chain} chunk={CHUNK_BYTES}B total_chain={chain_gib}GiB prefetch_depth={prefetch_depth}"
     );
 
+    let barrier = Arc::new(Barrier::new(threads));
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(threads);
+    for tid in 0..threads {
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            run_worker(tid, chunks_per_chain, prefetch_depth, &barrier)
+        }));
+    }
+    let mut per_thread = Vec::with_capacity(threads);
+    for h in handles {
+        per_thread.push(h.join().expect("worker panic"));
+    }
+    let total = start.elapsed();
+
+    // Total bytes through the merge across all threads (each thread reads
+    // 2 chain shares end-to-end, regardless of thread count).
+    let total_bytes = chunks_per_chain * threads * 2 * CHUNK_BYTES;
+    println!(
+        "wall: {:.2?} ({:.2} GiB/s through)",
+        total,
+        gib_per_sec(total_bytes, total)
+    );
+    for (tid, t) in per_thread.iter().enumerate() {
+        println!(
+            "  worker {tid}: build_a={:.2?} build_b={:.2?} merge={:.2?}",
+            t.build_a, t.build_b, t.merge
+        );
+    }
+}
+
+struct WorkerTimings {
+    build_a: Duration,
+    build_b: Duration,
+    merge: Duration,
+}
+
+fn run_worker(
+    _tid: usize,
+    chunks_per_chain: usize,
+    prefetch_depth: usize,
+    barrier: &Barrier,
+) -> WorkerTimings {
+    barrier.wait();
     let (chain_a, build_a) = time(|| build_chain(chunks_per_chain));
-    println!(
-        "build A: {:.2?} ({:.2} GiB/s)",
-        build_a,
-        gib_per_sec(chain_bytes, build_a)
-    );
-
     let (chain_b, build_b) = time(|| build_chain(chunks_per_chain));
-    println!(
-        "build B: {:.2?} ({:.2} GiB/s)",
+    let (chain_c, merge) = time(|| merge_pass(chain_a, chain_b, prefetch_depth));
+    drop(chain_c);
+    WorkerTimings {
+        build_a,
         build_b,
-        gib_per_sec(chain_bytes, build_b)
-    );
-
-    let (chain_c, merge_dur) = time(|| merge_pass(chain_a, chain_b, prefetch_depth));
-    let merged_bytes = chunks_per_chain * 2 * CHUNK_BYTES;
-    println!(
-        "merge: {:.2?} ({:.2} GiB/s through, output_chunks={})",
-        merge_dur,
-        gib_per_sec(merged_bytes, merge_dur),
-        chain_c.len()
-    );
-
-    let (_, drop_dur) = time(|| drop(chain_c));
-    println!("drop output chain: {:.2?}", drop_dur);
+        merge,
+    }
 }
 
 fn build_chain(n_chunks: usize) -> Vec<Handle> {

--- a/src/ore/examples/pager_merge.rs
+++ b/src/ore/examples/pager_merge.rs
@@ -106,11 +106,36 @@ fn build_chain(n_chunks: usize) -> Vec<Handle> {
 }
 
 fn merge_pass(a: Vec<Handle>, b: Vec<Handle>) -> Vec<Handle> {
-    let mut out = Vec::with_capacity(a.len() + b.len());
+    let n = a.len().min(b.len());
+    let mut a: Vec<Option<Handle>> = a.into_iter().map(Some).collect();
+    let mut b: Vec<Option<Handle>> = b.into_iter().map(Some).collect();
+    let mut out = Vec::with_capacity(2 * n);
     let mut tmp_a: Vec<u64> = Vec::with_capacity(CHUNK_U64);
     let mut tmp_b: Vec<u64> = Vec::with_capacity(CHUNK_U64);
     let mut sink: u64 = 0;
-    for (ha, hb) in a.into_iter().zip(b.into_iter()) {
+    // Issue the first prefetches so the kernel starts populating page cache /
+    // swap-in for the very first iteration.
+    if n > 0 {
+        if let Some(h) = a[0].as_ref() {
+            pager::prefetch(h);
+        }
+        if let Some(h) = b[0].as_ref() {
+            pager::prefetch(h);
+        }
+    }
+    for i in 0..n {
+        // Prefetch one chunk ahead of the current pair so I/O overlaps with
+        // the cache-line touch and the output pageouts below.
+        if i + 1 < n {
+            if let Some(h) = a[i + 1].as_ref() {
+                pager::prefetch(h);
+            }
+            if let Some(h) = b[i + 1].as_ref() {
+                pager::prefetch(h);
+            }
+        }
+        let ha = a[i].take().expect("handle a present");
+        let hb = b[i].take().expect("handle b present");
         pager::take(ha, &mut tmp_a);
         pager::take(hb, &mut tmp_b);
         // Touch every cache line of both inputs (1 u64 per 64-byte line).
@@ -156,6 +181,7 @@ fn gib_per_sec(bytes: usize, d: Duration) -> f64 {
     if secs == 0.0 {
         return 0.0;
     }
+    #[allow(clippy::as_conversions)] // usize -> f64 is intentionally lossy for reporting
     let gib = bytes as f64 / (1024.0 * 1024.0 * 1024.0);
     gib / secs
 }

--- a/src/ore/examples/pager_merge.rs
+++ b/src/ore/examples/pager_merge.rs
@@ -25,7 +25,7 @@
 //! cargo build --release --features pager --example pager_merge
 //! systemd-run --user --scope -p MemoryMax=16G -p MemorySwapMax=64G --quiet \
 //!   --setenv=MZ_PAGER_SCRATCH=/path/to/scratch \
-//!   -- target/release/examples/pager_merge --chain-gib 16 --backend swap
+//!   -- target/release/examples/pager_merge --chain-gib 16 --backend swap --threads 1
 //! ```
 
 #![cfg(feature = "pager")]
@@ -47,7 +47,6 @@ const CACHE_LINE_U64: usize = CACHE_LINE_BYTES / 8;
 fn main() {
     let args: Vec<String> = env::args().collect();
     let chain_gib: usize = parse_arg(&args, "--chain-gib", 16);
-    let prefetch_depth: usize = parse_arg(&args, "--prefetch-depth", 1);
     let threads: usize = parse_arg(&args, "--threads", 1).max(1);
     let backend = parse_backend(&args);
     let scratch: PathBuf = env::var_os("MZ_PAGER_SCRATCH")
@@ -62,7 +61,7 @@ fn main() {
     let chunks_per_chain = per_thread_chain_bytes / CHUNK_BYTES;
 
     println!(
-        "backend={backend:?} threads={threads} per_thread_chain_chunks={chunks_per_chain} chunk={CHUNK_BYTES}B total_chain={chain_gib}GiB prefetch_depth={prefetch_depth}"
+        "backend={backend:?} threads={threads} per_thread_chain_chunks={chunks_per_chain} chunk={CHUNK_BYTES}B total_chain={chain_gib}GiB"
     );
 
     let barrier = Arc::new(Barrier::new(threads));
@@ -71,7 +70,7 @@ fn main() {
     for tid in 0..threads {
         let barrier = Arc::clone(&barrier);
         handles.push(thread::spawn(move || {
-            run_worker(tid, chunks_per_chain, prefetch_depth, &barrier)
+            run_worker(tid, chunks_per_chain, &barrier)
         }));
     }
     let mut per_thread = Vec::with_capacity(threads);
@@ -102,16 +101,11 @@ struct WorkerTimings {
     merge: Duration,
 }
 
-fn run_worker(
-    _tid: usize,
-    chunks_per_chain: usize,
-    prefetch_depth: usize,
-    barrier: &Barrier,
-) -> WorkerTimings {
+fn run_worker(_tid: usize, chunks_per_chain: usize, barrier: &Barrier) -> WorkerTimings {
     barrier.wait();
     let (chain_a, build_a) = time(|| build_chain(chunks_per_chain));
     let (chain_b, build_b) = time(|| build_chain(chunks_per_chain));
-    let (chain_c, merge) = time(|| merge_pass(chain_a, chain_b, prefetch_depth));
+    let (chain_c, merge) = time(|| merge_pass(chain_a, chain_b));
     drop(chain_c);
     WorkerTimings {
         build_a,
@@ -138,7 +132,7 @@ fn build_chain(n_chunks: usize) -> Vec<Handle> {
     chain
 }
 
-fn merge_pass(a: Vec<Handle>, b: Vec<Handle>, prefetch_depth: usize) -> Vec<Handle> {
+fn merge_pass(a: Vec<Handle>, b: Vec<Handle>) -> Vec<Handle> {
     let n = a.len().min(b.len());
     let mut a: Vec<Option<Handle>> = a.into_iter().map(Some).collect();
     let mut b: Vec<Option<Handle>> = b.into_iter().map(Some).collect();
@@ -146,31 +140,7 @@ fn merge_pass(a: Vec<Handle>, b: Vec<Handle>, prefetch_depth: usize) -> Vec<Hand
     let mut tmp_a: Vec<u64> = Vec::with_capacity(CHUNK_U64);
     let mut tmp_b: Vec<u64> = Vec::with_capacity(CHUNK_U64);
     let mut sink: u64 = 0;
-    // Maintain a rolling window of `prefetch_depth` outstanding prefetches.
-    // Issue the initial wave for indices [0, prefetch_depth).
-    let initial = prefetch_depth.min(n);
-    for j in 0..initial {
-        if let Some(h) = a[j].as_ref() {
-            pager::prefetch(h);
-        }
-        if let Some(h) = b[j].as_ref() {
-            pager::prefetch(h);
-        }
-    }
     for i in 0..n {
-        // Each iteration extends the window by one: prefetch index `i +
-        // prefetch_depth` so that by the time we consume it the kernel has
-        // had `prefetch_depth` chunks worth of compute time to make pages
-        // available.
-        let pf = i + prefetch_depth;
-        if pf < n {
-            if let Some(h) = a[pf].as_ref() {
-                pager::prefetch(h);
-            }
-            if let Some(h) = b[pf].as_ref() {
-                pager::prefetch(h);
-            }
-        }
         let ha = a[i].take().expect("handle a present");
         let hb = b[i].take().expect("handle b present");
         pager::take(ha, &mut tmp_a);

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -62,6 +62,9 @@ pub mod option;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "overflowing")))]
 #[cfg(feature = "overflowing")]
 pub mod overflowing;
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "pager")))]
+#[cfg(feature = "pager")]
+pub mod pager;
 #[cfg(not(target_family = "wasm"))]
 #[cfg(feature = "panic")]
 pub mod panic;

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -62,8 +62,8 @@ pub mod option;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "overflowing")))]
 #[cfg(feature = "overflowing")]
 pub mod overflowing;
-#[cfg_attr(nightly_doc_features, doc(cfg(feature = "pager")))]
-#[cfg(feature = "pager")]
+#[cfg_attr(nightly_doc_features, doc(cfg(all(feature = "pager", unix))))]
+#[cfg(all(feature = "pager", unix))]
 pub mod pager;
 #[cfg(not(target_family = "wasm"))]
 #[cfg(feature = "panic")]

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -57,28 +57,28 @@ impl Handle {
     pub(crate) fn swap_inner(&self) -> Option<&SwapInner> {
         match &self.inner {
             HandleInner::Swap(s) => Some(s),
-            _ => None,
+            HandleInner::File(_) => None,
         }
     }
 
     pub(crate) fn file_inner(&self) -> Option<&FileInner> {
         match &self.inner {
             HandleInner::File(f) => Some(f),
-            _ => None,
+            HandleInner::Swap(_) => None,
         }
     }
 
     pub(crate) fn into_swap_inner(self) -> Option<SwapInner> {
         match self.inner {
             HandleInner::Swap(s) => Some(s),
-            _ => None,
+            HandleInner::File(_) => None,
         }
     }
 
     pub(crate) fn into_file_inner(self) -> Option<FileInner> {
         match self.inner {
             HandleInner::File(f) => Some(f),
-            _ => None,
+            HandleInner::Swap(_) => None,
         }
     }
 }

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -67,6 +67,20 @@ impl Handle {
             _ => None,
         }
     }
+
+    pub(crate) fn into_swap_inner(self) -> Option<SwapInner> {
+        match self.inner {
+            HandleInner::Swap(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn into_file_inner(self) -> Option<FileInner> {
+        match self.inner {
+            HandleInner::File(f) => Some(f),
+            _ => None,
+        }
+    }
 }
 
 /// Selects which backend stores paged-out data.

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -158,6 +158,25 @@ pub fn read_at(handle: &Handle, offset: usize, len: usize, dst: &mut Vec<u64>) {
     read_at_many(handle, &[(offset, len)], dst);
 }
 
+/// Hints that the entire payload will be read soon. Best-effort.
+/// Swap backend issues `madvise(MADV_WILLNEED)`; file backend issues
+/// `posix_fadvise(POSIX_FADV_WILLNEED)`. Both are async — the call returns
+/// promptly and the kernel populates pages or page cache in the background.
+/// Useful for overlapping I/O with computation in pipelines that know which
+/// handles they will read next.
+pub fn prefetch(handle: &Handle) {
+    prefetch_at(handle, 0, handle.len());
+}
+
+/// Hints that the range `[offset, offset+len)` of the handle will be read soon.
+/// Panics if the range is out of bounds.
+pub fn prefetch_at(handle: &Handle, offset: usize, len: usize) {
+    match &handle.inner {
+        HandleInner::Swap(_) => swap::prefetch_at_swap(handle, offset, len),
+        HandleInner::File(_) => file::prefetch_at_file(handle, offset, len),
+    }
+}
+
 /// Consumes handle, writing the entire payload into `dst` (cleared first), then reclaims storage.
 /// Swap fast path: single-chunk handle into empty `dst` swaps in place, no copy.
 pub fn take(handle: Handle, dst: &mut Vec<u64>) {

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::{AtomicU8, Ordering};
 mod file;
 mod swap;
 
+pub use file::set_scratch_dir;
+
 /// Selects which backend stores paged-out data.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Backend {

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -53,6 +53,20 @@ impl Handle {
             inner: HandleInner::File(inner),
         }
     }
+
+    pub(crate) fn swap_inner(&self) -> Option<&SwapInner> {
+        match &self.inner {
+            HandleInner::Swap(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn file_inner(&self) -> Option<&FileInner> {
+        match &self.inner {
+            HandleInner::File(f) => Some(f),
+            _ => None,
+        }
+    }
 }
 
 /// Selects which backend stores paged-out data.

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -1,3 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Explicit pager for cold data. See `doc/developer/design/20260504_pager.md`.
 
 use std::sync::atomic::{AtomicU8, Ordering};

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -115,6 +115,47 @@ pub fn set_backend(b: Backend) {
     BACKEND.store(raw, Ordering::Relaxed);
 }
 
+/// Scatter pageout. Logical layout = chunks concatenated in order.
+/// After return, each `Vec` in `chunks` is empty.
+/// File backend preserves capacity; swap backend moves the alloc into the handle.
+/// Empty input returns a `len == 0` handle and performs no I/O.
+pub fn pageout(chunks: &mut [Vec<u64>]) -> Handle {
+    if total_len(chunks) == 0 {
+        return Handle::from_swap(SwapInner::new(Vec::new()));
+    }
+    match backend() {
+        Backend::Swap => swap::pageout_swap(chunks),
+        Backend::File => file::pageout_file(chunks),
+    }
+}
+
+/// Reads multiple ranges. Output appended to `dst` in request order (concat).
+/// Panics if any range is out of bounds.
+pub fn read_at_many(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
+    match &handle.inner {
+        HandleInner::Swap(_) => swap::read_at_swap(handle, ranges, dst),
+        HandleInner::File(_) => file::read_at_file(handle, ranges, dst),
+    }
+}
+
+/// Reads a single range. Convenience wrapper around `read_at_many`.
+pub fn read_at(handle: &Handle, offset: usize, len: usize, dst: &mut Vec<u64>) {
+    read_at_many(handle, &[(offset, len)], dst);
+}
+
+/// Consumes handle, writing the entire payload into `dst` (cleared first), then reclaims storage.
+/// Swap fast path: single-chunk handle into empty `dst` swaps in place, no copy.
+pub fn take(handle: Handle, dst: &mut Vec<u64>) {
+    match &handle.inner {
+        HandleInner::Swap(_) => swap::take_swap(handle, dst),
+        HandleInner::File(_) => file::take_file(handle, dst),
+    }
+}
+
+fn total_len(chunks: &[Vec<u64>]) -> usize {
+    chunks.iter().map(|c| c.len()).sum()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,5 +166,27 @@ mod tests {
         assert_eq!(backend(), Backend::File);
         set_backend(Backend::Swap);
         assert_eq!(backend(), Backend::Swap);
+    }
+}
+
+#[cfg(test)]
+mod dispatch_tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn end_to_end_swap() {
+        set_backend(Backend::Swap);
+        let mut chunks = [vec![1u64, 2, 3, 4]];
+        let h = pageout(&mut chunks);
+        assert_eq!(h.len(), 4);
+        assert!(chunks[0].is_empty());
+
+        let mut dst = Vec::new();
+        read_at(&h, 1, 2, &mut dst);
+        assert_eq!(dst, vec![2, 3]);
+
+        let mut dst2 = Vec::new();
+        take(h, &mut dst2);
+        assert_eq!(dst2, vec![1, 2, 3, 4]);
     }
 }

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -1,0 +1,51 @@
+//! Explicit pager for cold data. See `doc/developer/design/20260504_pager.md`.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+mod file;
+mod swap;
+
+/// Selects which backend stores paged-out data.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Backend {
+    /// Hold allocations resident; hint the kernel via `MADV_COLD`.
+    Swap,
+    /// Write to a named scratch file; no file descriptor retained.
+    File,
+}
+
+const BACKEND_SWAP: u8 = 0;
+const BACKEND_FILE: u8 = 1;
+
+static BACKEND: AtomicU8 = AtomicU8::new(BACKEND_SWAP);
+
+/// Returns the currently active backend.
+pub fn backend() -> Backend {
+    match BACKEND.load(Ordering::Relaxed) {
+        BACKEND_SWAP => Backend::Swap,
+        BACKEND_FILE => Backend::File,
+        _ => unreachable!("BACKEND atomic holds invalid discriminant"),
+    }
+}
+
+/// Sets the active backend for future `pageout` calls. Existing handles are unaffected.
+pub fn set_backend(b: Backend) {
+    let raw = match b {
+        Backend::Swap => BACKEND_SWAP,
+        Backend::File => BACKEND_FILE,
+    };
+    BACKEND.store(raw, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn backend_round_trip() {
+        set_backend(Backend::File);
+        assert_eq!(backend(), Backend::File);
+        set_backend(Backend::Swap);
+        assert_eq!(backend(), Backend::Swap);
+    }
+}

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -7,6 +7,54 @@ mod swap;
 
 pub use file::set_scratch_dir;
 
+use crate::pager::file::FileInner;
+use crate::pager::swap::SwapInner;
+
+/// An opaque handle to data paged out via [`pageout`]. The handle's backend variant
+/// is fixed at `pageout` time and is independent of any later `set_backend` call.
+#[derive(Debug)]
+pub struct Handle {
+    inner: HandleInner,
+}
+
+#[derive(Debug)]
+enum HandleInner {
+    Swap(SwapInner),
+    File(FileInner),
+}
+
+impl Handle {
+    /// Returns the logical length of the handle's payload in `u64`s.
+    pub fn len(&self) -> usize {
+        match &self.inner {
+            HandleInner::Swap(s) => *s.prefix.last().unwrap_or(&0),
+            HandleInner::File(f) => f.len_u64s,
+        }
+    }
+
+    /// Returns the logical length of the handle's payload in bytes (`len() * 8`).
+    pub fn len_bytes(&self) -> usize {
+        self.len() * 8
+    }
+
+    /// Returns `true` if the handle holds no data.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub(crate) fn from_swap(inner: SwapInner) -> Self {
+        Self {
+            inner: HandleInner::Swap(inner),
+        }
+    }
+
+    pub(crate) fn from_file(inner: FileInner) -> Self {
+        Self {
+            inner: HandleInner::File(inner),
+        }
+    }
+}
+
 /// Selects which backend stores paged-out data.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Backend {

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -42,7 +42,7 @@ impl Handle {
     /// Returns the logical length of the handle's payload in `u64`s.
     pub fn len(&self) -> usize {
         match &self.inner {
-            HandleInner::Swap(s) => *s.prefix.last().unwrap_or(&0),
+            HandleInner::Swap(s) => s.total_len(),
             HandleInner::File(f) => f.len_u64s,
         }
     }
@@ -133,11 +133,9 @@ pub fn set_backend(b: Backend) {
 /// Scatter pageout. Logical layout = chunks concatenated in order.
 /// After return, each `Vec` in `chunks` is empty.
 /// File backend preserves capacity; swap backend moves the alloc into the handle.
-/// Empty input returns a `len == 0` handle and performs no I/O.
+/// Empty input returns a `len == 0` handle of the active backend's variant
+/// (no I/O is performed in either backend).
 pub fn pageout(chunks: &mut [Vec<u64>]) -> Handle {
-    if total_len(chunks) == 0 {
-        return Handle::from_swap(SwapInner::new(Vec::new()));
-    }
     match backend() {
         Backend::Swap => swap::pageout_swap(chunks),
         Backend::File => file::pageout_file(chunks),
@@ -165,10 +163,6 @@ pub fn take(handle: Handle, dst: &mut Vec<u64>) {
         HandleInner::Swap(_) => swap::take_swap(handle, dst),
         HandleInner::File(_) => file::take_file(handle, dst),
     }
-}
-
-fn total_len(chunks: &[Vec<u64>]) -> usize {
-    chunks.iter().map(|c| c.len()).sum()
 }
 
 #[cfg(test)]

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -135,6 +135,8 @@ pub fn set_backend(b: Backend) {
 /// File backend preserves capacity; swap backend moves the alloc into the handle.
 /// Empty input returns a `len == 0` handle of the active backend's variant
 /// (no I/O is performed in either backend).
+///
+/// Panics on I/O failure. Use [`try_pageout`] to surface the error.
 pub fn pageout(chunks: &mut [Vec<u64>]) -> Handle {
     match backend() {
         Backend::Swap => swap::pageout_swap(chunks),
@@ -142,8 +144,19 @@ pub fn pageout(chunks: &mut [Vec<u64>]) -> Handle {
     }
 }
 
+/// Fallible counterpart to [`pageout`]. Returns the underlying I/O error
+/// instead of panicking. The swap backend cannot fail at I/O, so this is
+/// equivalent to `Ok(pageout(chunks))` when [`backend`] is [`Backend::Swap`].
+pub fn try_pageout(chunks: &mut [Vec<u64>]) -> std::io::Result<Handle> {
+    match backend() {
+        Backend::Swap => Ok(swap::pageout_swap(chunks)),
+        Backend::File => file::try_pageout_file(chunks),
+    }
+}
+
 /// Reads multiple ranges. Output appended to `dst` in request order (concat).
-/// Panics if any range is out of bounds.
+/// Panics if any range is out of bounds, or on I/O failure. Use
+/// [`try_read_at_many`] for fallible reads.
 pub fn read_at_many(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
     match &handle.inner {
         HandleInner::Swap(_) => swap::read_at_swap(handle, ranges, dst),
@@ -151,17 +164,57 @@ pub fn read_at_many(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u6
     }
 }
 
-/// Reads a single range. Convenience wrapper around `read_at_many`.
+/// Fallible counterpart to [`read_at_many`]. Bounds violations still panic
+/// (caller bug); I/O failures return `Err`.
+pub fn try_read_at_many(
+    handle: &Handle,
+    ranges: &[(usize, usize)],
+    dst: &mut Vec<u64>,
+) -> std::io::Result<()> {
+    match &handle.inner {
+        HandleInner::Swap(_) => {
+            swap::read_at_swap(handle, ranges, dst);
+            Ok(())
+        }
+        HandleInner::File(_) => file::try_read_at_file(handle, ranges, dst),
+    }
+}
+
+/// Reads a single range. Convenience wrapper around [`read_at_many`].
 pub fn read_at(handle: &Handle, offset: usize, len: usize, dst: &mut Vec<u64>) {
     read_at_many(handle, &[(offset, len)], dst);
 }
 
+/// Fallible counterpart to [`read_at`].
+pub fn try_read_at(
+    handle: &Handle,
+    offset: usize,
+    len: usize,
+    dst: &mut Vec<u64>,
+) -> std::io::Result<()> {
+    try_read_at_many(handle, &[(offset, len)], dst)
+}
+
 /// Consumes handle, writing the entire payload into `dst` (cleared first), then reclaims storage.
 /// Swap fast path: single-chunk handle into empty `dst` swaps in place, no copy.
+///
+/// Panics on I/O failure. Use [`try_take`] to surface the error.
 pub fn take(handle: Handle, dst: &mut Vec<u64>) {
     match &handle.inner {
         HandleInner::Swap(_) => swap::take_swap(handle, dst),
         HandleInner::File(_) => file::take_file(handle, dst),
+    }
+}
+
+/// Fallible counterpart to [`take`]. On I/O error the handle is consumed and
+/// `dst` may hold partial data; the scratch file is unlinked on inner drop.
+pub fn try_take(handle: Handle, dst: &mut Vec<u64>) -> std::io::Result<()> {
+    match &handle.inner {
+        HandleInner::Swap(_) => {
+            swap::take_swap(handle, dst);
+            Ok(())
+        }
+        HandleInner::File(_) => file::try_take_file(handle, dst),
     }
 }
 

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -158,25 +158,6 @@ pub fn read_at(handle: &Handle, offset: usize, len: usize, dst: &mut Vec<u64>) {
     read_at_many(handle, &[(offset, len)], dst);
 }
 
-/// Hints that the entire payload will be read soon. Best-effort.
-/// Swap backend issues `madvise(MADV_WILLNEED)`; file backend issues
-/// `posix_fadvise(POSIX_FADV_WILLNEED)`. Both are async — the call returns
-/// promptly and the kernel populates pages or page cache in the background.
-/// Useful for overlapping I/O with computation in pipelines that know which
-/// handles they will read next.
-pub fn prefetch(handle: &Handle) {
-    prefetch_at(handle, 0, handle.len());
-}
-
-/// Hints that the range `[offset, offset+len)` of the handle will be read soon.
-/// Panics if the range is out of bounds.
-pub fn prefetch_at(handle: &Handle, offset: usize, len: usize) {
-    match &handle.inner {
-        HandleInner::Swap(_) => swap::prefetch_at_swap(handle, offset, len),
-        HandleInner::File(_) => file::prefetch_at_file(handle, offset, len),
-    }
-}
-
 /// Consumes handle, writing the entire payload into `dst` (cleared first), then reclaims storage.
 /// Swap fast path: single-chunk handle into empty `dst` swaps in place, no copy.
 pub fn take(handle: Handle, dst: &mut Vec<u64>) {

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -155,28 +155,54 @@ pub fn try_pageout(chunks: &mut [Vec<u64>]) -> std::io::Result<Handle> {
 }
 
 /// Reads multiple ranges. Output appended to `dst` in request order (concat).
-/// Panics if any range is out of bounds, or on I/O failure. Use
-/// [`try_read_at_many`] for fallible reads.
+///
+/// Ranges must be pairwise non-overlapping; ordering is otherwise unconstrained.
+/// Panics if any range is out of bounds, if two ranges overlap, or on I/O
+/// failure. Use [`try_read_at_many`] for fallible reads.
 pub fn read_at_many(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
+    assert_ranges_disjoint(ranges);
     match &handle.inner {
         HandleInner::Swap(_) => swap::read_at_swap(handle, ranges, dst),
         HandleInner::File(_) => file::read_at_file(handle, ranges, dst),
     }
 }
 
-/// Fallible counterpart to [`read_at_many`]. Bounds violations still panic
-/// (caller bug); I/O failures return `Err`.
+/// Fallible counterpart to [`read_at_many`]. Caller-side preconditions
+/// (out-of-bounds, overlapping ranges) still panic; I/O failures return `Err`.
 pub fn try_read_at_many(
     handle: &Handle,
     ranges: &[(usize, usize)],
     dst: &mut Vec<u64>,
 ) -> std::io::Result<()> {
+    assert_ranges_disjoint(ranges);
     match &handle.inner {
         HandleInner::Swap(_) => {
             swap::read_at_swap(handle, ranges, dst);
             Ok(())
         }
         HandleInner::File(_) => file::try_read_at_file(handle, ranges, dst),
+    }
+}
+
+/// Asserts that no two ranges share any byte position. Both backends assume
+/// disjoint ranges: the file backend coalesces adjacent ranges into a single
+/// pread and writes into a contiguous slice of `dst`, and the swap backend
+/// likewise concatenates into `dst` per range. Overlapping ranges would
+/// duplicate bytes in `dst` silently, which is almost certainly not what the
+/// caller meant; reject upfront so misuse fails loud.
+fn assert_ranges_disjoint(ranges: &[(usize, usize)]) {
+    // Skip zero-length ranges; they cannot overlap anything by definition.
+    let mut sorted: Vec<(usize, usize)> = ranges.iter().copied().filter(|&(_, l)| l > 0).collect();
+    sorted.sort_by_key(|&(off, _)| off);
+    let mut prev_end: usize = 0;
+    for (off, len) in sorted {
+        assert!(
+            off >= prev_end,
+            "read_at_many: overlapping ranges (range starting at {off} overlaps a previous range ending at {prev_end})",
+        );
+        prev_end = off
+            .checked_add(len)
+            .expect("range offset+len overflow in assert_ranges_disjoint");
     }
 }
 
@@ -228,6 +254,36 @@ mod tests {
         assert_eq!(backend(), Backend::File);
         set_backend(Backend::Swap);
         assert_eq!(backend(), Backend::Swap);
+    }
+
+    #[mz_ore::test]
+    fn disjoint_check_accepts_sorted_adjacent_and_unsorted_disjoint() {
+        // Adjacent: not overlapping.
+        assert_ranges_disjoint(&[(0, 4), (4, 4)]);
+        // Sorted with gaps.
+        assert_ranges_disjoint(&[(0, 2), (10, 3), (100, 1)]);
+        // Unsorted but disjoint.
+        assert_ranges_disjoint(&[(10, 3), (0, 2), (100, 1)]);
+        // Zero-length ranges are always OK.
+        assert_ranges_disjoint(&[(5, 0), (5, 0), (5, 0)]);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "overlapping ranges")]
+    fn disjoint_check_rejects_overlap() {
+        assert_ranges_disjoint(&[(0, 4), (2, 4)]);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "overlapping ranges")]
+    fn disjoint_check_rejects_overlap_unsorted() {
+        assert_ranges_disjoint(&[(10, 5), (0, 2), (12, 1)]);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "overlapping ranges")]
+    fn disjoint_check_rejects_duplicate_range() {
+        assert_ranges_disjoint(&[(3, 2), (3, 2)]);
     }
 }
 

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -1,28 +1,31 @@
 //! File backend for the pager. See `mz_ore::pager` for the public API.
 
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Once, OnceLock};
 
 static SCRATCH_DIR: OnceLock<PathBuf> = OnceLock::new();
 static SUBDIR: OnceLock<PathBuf> = OnceLock::new();
 static SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
+static SCRATCH_INIT: Once = Once::new();
 
 /// Configures the scratch directory for the file backend. Idempotent across multiple
 /// calls with the same path; logs and ignores subsequent calls with a different path.
 pub fn set_scratch_dir(root: PathBuf) {
-    if let Err(existing) = SCRATCH_DIR.set(root.clone()) {
-        if existing != root {
+    SCRATCH_INIT.call_once(|| {
+        if let Err(err) = init_subdir(&root) {
+            tracing::warn!(?root, %err, "mz_ore::pager: failed to initialize scratch subdir");
+        }
+        let _ = SCRATCH_DIR.set(root.clone());
+    });
+    if let Some(existing) = SCRATCH_DIR.get() {
+        if *existing != root {
             tracing::warn!(
                 ?root,
                 ?existing,
                 "mz_ore::pager scratch dir already set; ignoring",
             );
         }
-        return;
-    }
-    if let Err(err) = init_subdir(&root) {
-        tracing::warn!(?root, %err, "mz_ore::pager: failed to initialize scratch subdir");
     }
 }
 
@@ -106,10 +109,99 @@ impl Drop for FileInner {
     }
 }
 
-use crate::pager::Handle;
+use std::fs::File;
+use std::io::IoSlice;
 
-pub(crate) fn pageout_file(_chunks: &mut [Vec<u64>]) -> Handle {
-    unimplemented!("file backend pageout: see Task 9")
+use crate::pager::Handle;
+use crate::pager::swap::{SwapInner, pageout_swap};
+
+pub(crate) fn pageout_file(chunks: &mut [Vec<u64>]) -> Handle {
+    let total: usize = chunks.iter().map(|c| c.len()).sum();
+    if total == 0 {
+        return Handle::from_swap(SwapInner::new(Vec::new()));
+    }
+    let id = alloc_scratch_id();
+    let path = scratch_path(id);
+    match write_chunks(&path, chunks) {
+        Ok(()) => {
+            for c in chunks.iter_mut() {
+                c.clear();
+            }
+            Handle::from_file(FileInner::new(id, total))
+        }
+        Err(err) => {
+            tracing::warn!(?path, %err, "mz_ore::pager: file pageout failed; falling back to swap");
+            let _ = std::fs::remove_file(&path);
+            pageout_swap(chunks)
+        }
+    }
+}
+
+fn write_chunks(path: &Path, chunks: &[Vec<u64>]) -> std::io::Result<()> {
+    let file = File::options().write(true).create_new(true).open(path)?;
+    let slices: Vec<IoSlice<'_>> = chunks
+        .iter()
+        .filter(|c| !c.is_empty())
+        .map(|c| IoSlice::new(bytemuck::cast_slice(c.as_slice())))
+        .collect();
+    write_all_vectored(&file, &slices)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_all_vectored(file: &File, slices: &[IoSlice<'_>]) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let fd = file.as_raw_fd();
+    let mut offset: i64 = 0;
+    let mut idx = 0;
+    let mut consumed_in_idx: usize = 0;
+    while idx < slices.len() {
+        let remaining = &slices[idx..];
+        let iovs: Vec<libc::iovec> = remaining
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let base_off = if i == 0 { consumed_in_idx } else { 0 };
+                // SAFETY: building an iovec from a live `IoSlice` is safe;
+                // the pointer/length describe the caller's buffer.
+                libc::iovec {
+                    iov_base: unsafe { s.as_ptr().add(base_off) } as *mut libc::c_void,
+                    iov_len: s.len() - base_off,
+                }
+            })
+            .collect();
+        // SAFETY: fd is valid and open for writing; iovs point into the live `slices`
+        // owned by the caller; pwritev does not retain pointers past the syscall.
+        let written =
+            unsafe { libc::pwritev(fd, iovs.as_ptr(), iovs.len() as libc::c_int, offset) };
+        if written < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut left = written as usize;
+        offset += written as i64;
+        while left > 0 && idx < slices.len() {
+            let avail = slices[idx].len() - consumed_in_idx;
+            if left >= avail {
+                left -= avail;
+                idx += 1;
+                consumed_in_idx = 0;
+            } else {
+                consumed_in_idx += left;
+                left = 0;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_all_vectored(file: &File, slices: &[IoSlice<'_>]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut file = file;
+    for s in slices {
+        file.write_all(s)?;
+    }
+    Ok(())
 }
 
 pub(crate) fn read_at_file(_h: &Handle, _ranges: &[(usize, usize)], _dst: &mut Vec<u64>) {
@@ -118,6 +210,36 @@ pub(crate) fn read_at_file(_h: &Handle, _ranges: &[(usize, usize)], _dst: &mut V
 
 pub(crate) fn take_file(_h: Handle, _dst: &mut Vec<u64>) {
     unimplemented!("file backend take: see Task 11")
+}
+
+#[cfg(test)]
+mod backend_tests {
+    use super::*;
+
+    fn setup_dir() {
+        let _ = super::tests::shared_scratch();
+    }
+
+    #[mz_ore::test]
+    fn pageout_writes_file_and_clears_capacity() {
+        setup_dir();
+        let mut chunks = [vec![10u64, 20, 30], vec![40, 50]];
+        let cap_before_0 = chunks[0].capacity();
+        let cap_before_1 = chunks[1].capacity();
+        let h = pageout_file(&mut chunks);
+        assert_eq!(h.len(), 5);
+        assert!(chunks[0].is_empty());
+        assert!(chunks[1].is_empty());
+        // File backend preserves capacity:
+        assert_eq!(chunks[0].capacity(), cap_before_0);
+        assert_eq!(chunks[1].capacity(), cap_before_1);
+
+        let inner = h.file_inner().expect("file inner");
+        let path = scratch_path(inner.id);
+        assert!(path.exists());
+        let bytes = std::fs::read(&path).expect("read scratch");
+        assert_eq!(bytes.len(), 5 * 8);
+    }
 }
 
 #[cfg(test)]

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -1,3 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! File backend for the pager. See `mz_ore::pager` for the public API.
 
 use std::path::{Path, PathBuf};

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -1,0 +1,1 @@
+//! File backend for the pager. See `mz_ore::pager` for the public API.

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -180,6 +180,44 @@ fn write_all_vectored(mut file: &File, mut slices: &mut [IoSlice<'_>]) -> std::i
     Ok(())
 }
 
+pub(crate) fn prefetch_at_file(handle: &Handle, offset: usize, len: usize) {
+    let inner = handle
+        .file_inner()
+        .expect("prefetch_at_file called on non-file handle");
+    let total = inner.len_u64s;
+    let end = offset.checked_add(len).expect("offset+len overflow");
+    assert!(
+        end <= total,
+        "prefetch range out of bounds: {offset}+{len} > {total}"
+    );
+    if len == 0 {
+        return;
+    }
+    let path = scratch_path(inner.id);
+    let Ok(file) = File::open(&path) else {
+        // Best-effort hint; if the file is gone the next read will surface the error.
+        return;
+    };
+    posix_fadvise_willneed(&file, u64::cast_from(offset * 8), u64::cast_from(len * 8));
+}
+
+#[cfg(unix)]
+fn posix_fadvise_willneed(file: &File, byte_off: u64, byte_len: u64) {
+    use std::os::unix::io::AsRawFd;
+    #[allow(clippy::as_conversions)] // u64 -> i64/off_t for FFI; values fit by construction
+    let off = byte_off as i64;
+    #[allow(clippy::as_conversions)]
+    let len = byte_len as i64;
+    // SAFETY: fd is valid for the life of `file`; `posix_fadvise` is a hint and
+    // does not mutate user memory. The return value (errno) is intentionally ignored.
+    unsafe {
+        libc::posix_fadvise(file.as_raw_fd(), off, len, libc::POSIX_FADV_WILLNEED);
+    }
+}
+
+#[cfg(not(unix))]
+fn posix_fadvise_willneed(_file: &File, _byte_off: u64, _byte_len: u64) {}
+
 pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
     use std::os::unix::fs::FileExt;
 
@@ -346,6 +384,28 @@ mod backend_tests {
         assert!(path.exists());
         drop(h);
         assert!(!path.exists(), "scratch file should be unlinked on drop");
+    }
+
+    #[mz_ore::test]
+    fn file_prefetch_does_not_corrupt_data() {
+        setup_dir();
+        let payload: Vec<u64> = (0..1024).collect();
+        let mut chunks = [payload.clone()];
+        let h = pageout_file(&mut chunks);
+        prefetch_at_file(&h, 100, 200);
+        prefetch_at_file(&h, 0, 1024);
+        let mut dst = Vec::new();
+        read_at_file(&h, &[(0, 1024)], &mut dst);
+        assert_eq!(dst, payload);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "out of bounds")]
+    fn file_prefetch_panics_on_oob() {
+        setup_dir();
+        let mut chunks = [vec![1u64, 2]];
+        let h = pageout_file(&mut chunks);
+        prefetch_at_file(&h, 0, 99);
     }
 }
 

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -1,6 +1,8 @@
 //! File backend for the pager. See `mz_ore::pager` for the public API.
 
 use std::path::{Path, PathBuf};
+
+use crate::cast::CastFrom;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Once, OnceLock};
 
@@ -139,67 +141,26 @@ pub(crate) fn pageout_file(chunks: &mut [Vec<u64>]) -> Handle {
 
 fn write_chunks(path: &Path, chunks: &[Vec<u64>]) -> std::io::Result<()> {
     let file = File::options().write(true).create_new(true).open(path)?;
-    let slices: Vec<IoSlice<'_>> = chunks
+    let mut slices: Vec<IoSlice<'_>> = chunks
         .iter()
         .filter(|c| !c.is_empty())
         .map(|c| IoSlice::new(bytemuck::cast_slice(c.as_slice())))
         .collect();
-    write_all_vectored(&file, &slices)?;
+    write_all_vectored(&file, slices.as_mut_slice())?;
     Ok(())
 }
 
-#[cfg(unix)]
-fn write_all_vectored(file: &File, slices: &[IoSlice<'_>]) -> std::io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let fd = file.as_raw_fd();
-    let mut offset: i64 = 0;
-    let mut idx = 0;
-    let mut consumed_in_idx: usize = 0;
-    while idx < slices.len() {
-        let remaining = &slices[idx..];
-        let iovs: Vec<libc::iovec> = remaining
-            .iter()
-            .enumerate()
-            .map(|(i, s)| {
-                let base_off = if i == 0 { consumed_in_idx } else { 0 };
-                // SAFETY: building an iovec from a live `IoSlice` is safe;
-                // the pointer/length describe the caller's buffer.
-                libc::iovec {
-                    iov_base: unsafe { s.as_ptr().add(base_off) } as *mut libc::c_void,
-                    iov_len: s.len() - base_off,
-                }
-            })
-            .collect();
-        // SAFETY: fd is valid and open for writing; iovs point into the live `slices`
-        // owned by the caller; pwritev does not retain pointers past the syscall.
-        let written =
-            unsafe { libc::pwritev(fd, iovs.as_ptr(), iovs.len() as libc::c_int, offset) };
-        if written < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        let mut left = written as usize;
-        offset += written as i64;
-        while left > 0 && idx < slices.len() {
-            let avail = slices[idx].len() - consumed_in_idx;
-            if left >= avail {
-                left -= avail;
-                idx += 1;
-                consumed_in_idx = 0;
-            } else {
-                consumed_in_idx += left;
-                left = 0;
-            }
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn write_all_vectored(file: &File, slices: &[IoSlice<'_>]) -> std::io::Result<()> {
+fn write_all_vectored(mut file: &File, mut slices: &mut [IoSlice<'_>]) -> std::io::Result<()> {
     use std::io::Write;
-    let mut file = file;
-    for s in slices {
-        file.write_all(s)?;
+    while !slices.is_empty() {
+        let written = file.write_vectored(slices)?;
+        if written == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "write_vectored returned 0",
+            ));
+        }
+        IoSlice::advance_slices(&mut slices, written);
     }
     Ok(())
 }
@@ -226,15 +187,16 @@ pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut
 
     let coalesced = coalesce(ranges);
     for (off, len) in coalesced {
-        let byte_off = (off * 8) as u64;
+        let byte_off = u64::cast_from(off * 8);
         let byte_len = len * 8;
         let buf_start = dst.len();
         dst.resize(buf_start + len, 0);
         let buf: &mut [u8] = bytemuck::cast_slice_mut(&mut dst[buf_start..buf_start + len]);
         let mut filled = 0;
         while filled < byte_len {
+            let pos = byte_off + u64::cast_from(filled);
             let n = file
-                .read_at(&mut buf[filled..byte_len], byte_off + filled as u64)
+                .read_at(&mut buf[filled..byte_len], pos)
                 .expect("pager pread failed");
             if n == 0 {
                 panic!("pager pread short: expected {byte_len} got {filled}");
@@ -271,8 +233,9 @@ pub(crate) fn take_file(handle: Handle, dst: &mut Vec<u64>) {
     let buf: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
     let mut filled = 0;
     while filled < buf.len() {
+        let pos = u64::cast_from(filled);
         let n = file
-            .read_at(&mut buf[filled..], filled as u64)
+            .read_at(&mut buf[filled..], pos)
             .unwrap_or_else(|err| panic!("pager take: pread {path:?}: {err}"));
         if n == 0 {
             panic!("pager take: short read at {filled}");

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -258,8 +258,30 @@ fn coalesce(ranges: &[(usize, usize)]) -> Vec<(usize, usize)> {
     out
 }
 
-pub(crate) fn take_file(_h: Handle, _dst: &mut Vec<u64>) {
-    unimplemented!("file backend take: see Task 11")
+pub(crate) fn take_file(handle: Handle, dst: &mut Vec<u64>) {
+    use std::os::unix::fs::FileExt;
+
+    let inner = handle
+        .into_file_inner()
+        .expect("take_file called on non-file handle");
+    dst.clear();
+    let path = scratch_path(inner.id);
+    let file = File::open(&path).unwrap_or_else(|err| panic!("pager take: open {path:?}: {err}"));
+    dst.resize(inner.len_u64s, 0);
+    let buf: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
+    let mut filled = 0;
+    while filled < buf.len() {
+        let n = file
+            .read_at(&mut buf[filled..], filled as u64)
+            .unwrap_or_else(|err| panic!("pager take: pread {path:?}: {err}"));
+        if n == 0 {
+            panic!("pager take: short read at {filled}");
+        }
+        filled += n;
+    }
+    drop(file);
+    // FileInner::drop will unlink the scratch file.
+    drop(inner);
 }
 
 #[cfg(test)]
@@ -320,6 +342,32 @@ mod backend_tests {
         let h = pageout_file(&mut chunks);
         let mut dst = Vec::new();
         read_at_file(&h, &[(0, 99)], &mut dst);
+    }
+
+    #[mz_ore::test]
+    fn file_take_returns_data_and_unlinks() {
+        setup_dir();
+        let mut chunks = [vec![7u64; 100]];
+        let h = pageout_file(&mut chunks);
+        let inner_id = h.file_inner().unwrap().id;
+        let path = scratch_path(inner_id);
+        assert!(path.exists());
+        let mut dst = Vec::new();
+        take_file(h, &mut dst);
+        assert_eq!(dst, vec![7u64; 100]);
+        assert!(!path.exists(), "scratch file should be unlinked after take");
+    }
+
+    #[mz_ore::test]
+    fn file_drop_unlinks_when_not_taken() {
+        setup_dir();
+        let mut chunks = [vec![1u64, 2, 3]];
+        let h = pageout_file(&mut chunks);
+        let id = h.file_inner().unwrap().id;
+        let path = scratch_path(id);
+        assert!(path.exists());
+        drop(h);
+        assert!(!path.exists(), "scratch file should be unlinked on drop");
     }
 }
 

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -106,6 +106,20 @@ impl Drop for FileInner {
     }
 }
 
+use crate::pager::Handle;
+
+pub(crate) fn pageout_file(_chunks: &mut [Vec<u64>]) -> Handle {
+    unimplemented!("file backend pageout: see Task 9")
+}
+
+pub(crate) fn read_at_file(_h: &Handle, _ranges: &[(usize, usize)], _dst: &mut Vec<u64>) {
+    unimplemented!("file backend read_at: see Task 10")
+}
+
+pub(crate) fn take_file(_h: Handle, _dst: &mut Vec<u64>) {
+    unimplemented!("file backend take: see Task 11")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -204,10 +204,8 @@ pub(crate) fn prefetch_at_file(handle: &Handle, offset: usize, len: usize) {
 #[cfg(unix)]
 fn posix_fadvise_willneed(file: &File, byte_off: u64, byte_len: u64) {
     use std::os::unix::io::AsRawFd;
-    #[allow(clippy::as_conversions)] // u64 -> i64/off_t for FFI; values fit by construction
-    let off = byte_off as i64;
-    #[allow(clippy::as_conversions)]
-    let len = byte_len as i64;
+    let off = i64::try_from(byte_off).expect("scratch file offset fits i64");
+    let len = i64::try_from(byte_len).expect("scratch file length fits i64");
     // SAFETY: fd is valid for the life of `file`; `posix_fadvise` is a hint and
     // does not mutate user memory. The return value (errno) is intentionally ignored.
     unsafe {

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -204,8 +204,58 @@ fn write_all_vectored(file: &File, slices: &[IoSlice<'_>]) -> std::io::Result<()
     Ok(())
 }
 
-pub(crate) fn read_at_file(_h: &Handle, _ranges: &[(usize, usize)], _dst: &mut Vec<u64>) {
-    unimplemented!("file backend read_at: see Task 10")
+pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
+    use std::os::unix::fs::FileExt;
+
+    let inner = handle
+        .file_inner()
+        .expect("read_at_file called on non-file handle");
+    let total = inner.len_u64s;
+    for &(off, len) in ranges {
+        let end = off.checked_add(len).expect("range offset+len overflow");
+        assert!(
+            end <= total,
+            "read range out of bounds: {off}+{len} > {total}"
+        );
+    }
+    let path = scratch_path(inner.id);
+    let file = match File::open(&path) {
+        Ok(f) => f,
+        Err(err) => panic!("mz_ore::pager: failed to open scratch file {path:?}: {err}"),
+    };
+
+    let coalesced = coalesce(ranges);
+    for (off, len) in coalesced {
+        let byte_off = (off * 8) as u64;
+        let byte_len = len * 8;
+        let buf_start = dst.len();
+        dst.resize(buf_start + len, 0);
+        let buf: &mut [u8] = bytemuck::cast_slice_mut(&mut dst[buf_start..buf_start + len]);
+        let mut filled = 0;
+        while filled < byte_len {
+            let n = file
+                .read_at(&mut buf[filled..byte_len], byte_off + filled as u64)
+                .expect("pager pread failed");
+            if n == 0 {
+                panic!("pager pread short: expected {byte_len} got {filled}");
+            }
+            filled += n;
+        }
+    }
+}
+
+fn coalesce(ranges: &[(usize, usize)]) -> Vec<(usize, usize)> {
+    let mut out: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for &(off, len) in ranges {
+        if let Some(last) = out.last_mut() {
+            if last.0 + last.1 == off {
+                last.1 += len;
+                continue;
+            }
+        }
+        out.push((off, len));
+    }
+    out
 }
 
 pub(crate) fn take_file(_h: Handle, _dst: &mut Vec<u64>) {
@@ -239,6 +289,37 @@ mod backend_tests {
         assert!(path.exists());
         let bytes = std::fs::read(&path).expect("read scratch");
         assert_eq!(bytes.len(), 5 * 8);
+    }
+
+    #[mz_ore::test]
+    fn file_read_at_basic() {
+        setup_dir();
+        let mut chunks = [vec![1u64, 2, 3, 4, 5]];
+        let h = pageout_file(&mut chunks);
+        let mut dst = Vec::new();
+        read_at_file(&h, &[(1, 3)], &mut dst);
+        assert_eq!(dst, vec![2, 3, 4]);
+    }
+
+    #[mz_ore::test]
+    fn file_read_at_many_concats_and_coalesces() {
+        setup_dir();
+        let mut chunks = [vec![10u64, 20, 30, 40, 50, 60]];
+        let h = pageout_file(&mut chunks);
+        let mut dst = Vec::new();
+        // (0,2) and (2,2) are adjacent => single pread internally.
+        read_at_file(&h, &[(0, 2), (2, 2), (5, 1)], &mut dst);
+        assert_eq!(dst, vec![10, 20, 30, 40, 60]);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "out of bounds")]
+    fn file_read_at_panics_on_oob() {
+        setup_dir();
+        let mut chunks = [vec![1u64, 2]];
+        let h = pageout_file(&mut chunks);
+        let mut dst = Vec::new();
+        read_at_file(&h, &[(0, 99)], &mut dst);
     }
 }
 

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -1,1 +1,111 @@
 //! File backend for the pager. See `mz_ore::pager` for the public API.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static SCRATCH_DIR: OnceLock<PathBuf> = OnceLock::new();
+static SUBDIR: OnceLock<PathBuf> = OnceLock::new();
+static SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
+
+/// Configures the scratch directory for the file backend. Idempotent across multiple
+/// calls with the same path; logs and ignores subsequent calls with a different path.
+pub fn set_scratch_dir(root: PathBuf) {
+    if let Err(existing) = SCRATCH_DIR.set(root.clone()) {
+        if existing != root {
+            tracing::warn!(
+                ?root,
+                ?existing,
+                "mz_ore::pager scratch dir already set; ignoring",
+            );
+        }
+        return;
+    }
+    if let Err(err) = init_subdir(&root) {
+        tracing::warn!(?root, %err, "mz_ore::pager: failed to initialize scratch subdir");
+    }
+}
+
+fn init_subdir(root: &Path) -> std::io::Result<()> {
+    let nonce: u64 = rand::random();
+    let pid = std::process::id();
+    let subdir = root.join(format!("mz-pager-{pid}-{nonce:016x}"));
+    std::fs::create_dir_all(&subdir)?;
+    let _ = SUBDIR.set(subdir);
+    reap_stale(root);
+    Ok(())
+}
+
+fn reap_stale(root: &Path) {
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::warn!(?root, %err, "mz_ore::pager: scratch dir scan failed");
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = match name.to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        let Some(rest) = name.strip_prefix("mz-pager-") else {
+            continue;
+        };
+        let pid: u32 = match rest.split_once('-').and_then(|(p, _)| p.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        if pid == std::process::id() {
+            continue;
+        }
+        if std::path::Path::new(&format!("/proc/{pid}")).exists() {
+            continue;
+        }
+        if let Err(err) = std::fs::remove_dir_all(entry.path()) {
+            tracing::warn!(path = ?entry.path(), %err, "mz_ore::pager: reap failed");
+        }
+    }
+}
+
+pub(crate) fn scratch_path(id: u64) -> PathBuf {
+    SUBDIR
+        .get()
+        .expect("mz_ore::pager file backend used before set_scratch_dir")
+        .join(format!("{id}.bin"))
+}
+
+pub(crate) fn alloc_scratch_id() -> u64 {
+    SCRATCH_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    static TEST_DIR: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+
+    pub(super) fn shared_scratch() -> &'static std::path::Path {
+        let dir = TEST_DIR.get_or_init(|| tempdir().expect("tempdir"));
+        set_scratch_dir(dir.path().to_owned());
+        dir.path()
+    }
+
+    #[mz_ore::test]
+    fn set_scratch_dir_creates_subdir() {
+        let root = shared_scratch();
+        let subdir = SUBDIR.get().expect("subdir was initialized");
+        assert!(subdir.exists());
+        assert!(subdir.starts_with(root));
+        assert!(
+            subdir
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("mz-pager-")
+        );
+    }
+}

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -80,6 +80,32 @@ pub(crate) fn alloc_scratch_id() -> u64 {
     SCRATCH_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+/// Storage for a file-backed handle. The file at `scratch_path(id)` holds the bytes.
+/// No file descriptor is retained.
+#[derive(Debug)]
+pub(crate) struct FileInner {
+    pub(crate) id: u64,
+    pub(crate) len_u64s: usize,
+}
+
+impl FileInner {
+    pub(crate) fn new(id: u64, len_u64s: usize) -> Self {
+        Self { id, len_u64s }
+    }
+}
+
+impl Drop for FileInner {
+    fn drop(&mut self) {
+        let path = scratch_path(self.id);
+        if let Err(err) = std::fs::remove_file(&path) {
+            // ENOENT is fine: a successful `take` already unlinked.
+            if err.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(?path, %err, "mz_ore::pager: failed to unlink scratch file");
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -180,42 +180,6 @@ fn write_all_vectored(mut file: &File, mut slices: &mut [IoSlice<'_>]) -> std::i
     Ok(())
 }
 
-pub(crate) fn prefetch_at_file(handle: &Handle, offset: usize, len: usize) {
-    let inner = handle
-        .file_inner()
-        .expect("prefetch_at_file called on non-file handle");
-    let total = inner.len_u64s;
-    let end = offset.checked_add(len).expect("offset+len overflow");
-    assert!(
-        end <= total,
-        "prefetch range out of bounds: {offset}+{len} > {total}"
-    );
-    if len == 0 {
-        return;
-    }
-    let path = scratch_path(inner.id);
-    let Ok(file) = File::open(&path) else {
-        // Best-effort hint; if the file is gone the next read will surface the error.
-        return;
-    };
-    posix_fadvise_willneed(&file, u64::cast_from(offset * 8), u64::cast_from(len * 8));
-}
-
-#[cfg(unix)]
-fn posix_fadvise_willneed(file: &File, byte_off: u64, byte_len: u64) {
-    use std::os::unix::io::AsRawFd;
-    let off = i64::try_from(byte_off).expect("scratch file offset fits i64");
-    let len = i64::try_from(byte_len).expect("scratch file length fits i64");
-    // SAFETY: fd is valid for the life of `file`; `posix_fadvise` is a hint and
-    // does not mutate user memory. The return value (errno) is intentionally ignored.
-    unsafe {
-        libc::posix_fadvise(file.as_raw_fd(), off, len, libc::POSIX_FADV_WILLNEED);
-    }
-}
-
-#[cfg(not(unix))]
-fn posix_fadvise_willneed(_file: &File, _byte_off: u64, _byte_len: u64) {}
-
 pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
     use std::os::unix::fs::FileExt;
 
@@ -382,28 +346,6 @@ mod backend_tests {
         assert!(path.exists());
         drop(h);
         assert!(!path.exists(), "scratch file should be unlinked on drop");
-    }
-
-    #[mz_ore::test]
-    fn file_prefetch_does_not_corrupt_data() {
-        setup_dir();
-        let payload: Vec<u64> = (0..1024).collect();
-        let mut chunks = [payload.clone()];
-        let h = pageout_file(&mut chunks);
-        prefetch_at_file(&h, 100, 200);
-        prefetch_at_file(&h, 0, 1024);
-        let mut dst = Vec::new();
-        read_at_file(&h, &[(0, 1024)], &mut dst);
-        assert_eq!(dst, payload);
-    }
-
-    #[mz_ore::test]
-    #[should_panic(expected = "out of bounds")]
-    fn file_prefetch_panics_on_oob() {
-        setup_dir();
-        let mut chunks = [vec![1u64, 2]];
-        let h = pageout_file(&mut chunks);
-        prefetch_at_file(&h, 0, 99);
     }
 }
 

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -15,32 +15,57 @@
 
 //! File backend for the pager. See `mz_ore::pager` for the public API.
 
+use std::fs::{File, OpenOptions};
+use std::io::IoSlice;
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use crate::cast::CastFrom;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Once, OnceLock};
+use crate::pager::Handle;
+use crate::pager::swap::pageout_swap;
 
 static SCRATCH_DIR: OnceLock<PathBuf> = OnceLock::new();
 static SUBDIR: OnceLock<PathBuf> = OnceLock::new();
 static SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
-static SCRATCH_INIT: Once = Once::new();
+/// Serializes `set_scratch_dir` callers so init failures can be retried on
+/// the next call. A plain `Once` would burn the only retry opportunity.
+static INIT_LOCK: Mutex<()> = Mutex::new(());
+/// Holds the exclusive `flock` on this process's `lock` file. Leaked into a
+/// static so the kernel keeps the lock for the entire process lifetime and
+/// drops it automatically on exit (including hard crashes).
+static OWN_LOCK_FD: OnceLock<RawFd> = OnceLock::new();
 
-/// Configures the scratch directory for the file backend. Idempotent across multiple
-/// calls with the same path; logs and ignores subsequent calls with a different path.
+/// Configures the scratch directory for the file backend.
+///
+/// Idempotent across multiple calls with the same path. A different path on a
+/// subsequent call is logged and ignored. If the first call fails to initialize
+/// the subdir, later calls retry — the scratch directory is committed only
+/// after a successful init.
 pub fn set_scratch_dir(root: PathBuf) {
-    SCRATCH_INIT.call_once(|| {
-        if let Err(err) = init_subdir(&root) {
-            tracing::warn!(?root, %err, "mz_ore::pager: failed to initialize scratch subdir");
-        }
-        let _ = SCRATCH_DIR.set(root.clone());
-    });
+    let _guard = INIT_LOCK.lock().expect("mz_ore::pager INIT_LOCK poisoned");
     if let Some(existing) = SCRATCH_DIR.get() {
         if *existing != root {
             tracing::warn!(
                 ?root,
                 ?existing,
                 "mz_ore::pager scratch dir already set; ignoring",
+            );
+        }
+        return;
+    }
+    match init_subdir(&root) {
+        Ok(()) => {
+            // SAFETY of `let _ =`: we hold INIT_LOCK and just verified the
+            // OnceLock is empty above, so this set always wins.
+            let _ = SCRATCH_DIR.set(root);
+        }
+        Err(err) => {
+            tracing::warn!(
+                ?root,
+                %err,
+                "mz_ore::pager: failed to initialize scratch subdir; will retry on next call",
             );
         }
     }
@@ -51,11 +76,46 @@ fn init_subdir(root: &Path) -> std::io::Result<()> {
     let pid = std::process::id();
     let subdir = root.join(format!("mz-pager-{pid}-{nonce:016x}"));
     std::fs::create_dir_all(&subdir)?;
+    // Acquire an exclusive advisory lock on a marker file inside the subdir.
+    // The lock is kept for the lifetime of the process; the reaper in any
+    // other process can probe this lock to determine whether the owner is
+    // still alive, which avoids the PID-reuse race that plagues a naive
+    // /proc-based liveness check.
+    let lock_path = subdir.join("lock");
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(true)
+        .open(&lock_path)?;
+    let fd = lock_file.into_raw_fd();
+    // SAFETY: `fd` was just produced by `into_raw_fd` on a successfully opened
+    // `File`; the kernel guarantees it is a valid open file descriptor here.
+    let r = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+    if r != 0 {
+        let err = std::io::Error::last_os_error();
+        // SAFETY: `fd` is still valid; nothing else has consumed it.
+        unsafe {
+            libc::close(fd);
+        }
+        return Err(err);
+    }
+    // Stash the fd so the lock stays held until process exit.
+    if OWN_LOCK_FD.set(fd).is_err() {
+        // Already set on a prior successful init: release the duplicate lock.
+        // SAFETY: `fd` is still valid here; we own it.
+        unsafe {
+            libc::close(fd);
+        }
+    }
     let _ = SUBDIR.set(subdir);
     reap_stale(root);
     Ok(())
 }
 
+/// Sweeps `root` for subdirectories left behind by predecessors that crashed
+/// or were killed. Ownership is determined via `flock` on the per-subdir
+/// `lock` file: if we can acquire it non-blocking, the owner is gone.
 fn reap_stale(root: &Path) {
     let entries = match std::fs::read_dir(root) {
         Ok(e) => e,
@@ -64,27 +124,51 @@ fn reap_stale(root: &Path) {
             return;
         }
     };
+    let own_subdir = SUBDIR.get();
     for entry in entries.flatten() {
         let name = entry.file_name();
-        let name = match name.to_str() {
-            Some(s) => s,
-            None => continue,
-        };
-        let Some(rest) = name.strip_prefix("mz-pager-") else {
-            continue;
-        };
-        let pid: u32 = match rest.split_once('-').and_then(|(p, _)| p.parse().ok()) {
-            Some(p) => p,
-            None => continue,
-        };
-        if pid == std::process::id() {
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("mz-pager-") {
             continue;
         }
-        if std::path::Path::new(&format!("/proc/{pid}")).exists() {
+        let path = entry.path();
+        if own_subdir.is_some_and(|s| s.as_path() == path) {
             continue;
         }
-        if let Err(err) = std::fs::remove_dir_all(entry.path()) {
-            tracing::warn!(path = ?entry.path(), %err, "mz_ore::pager: reap failed");
+        match owner_is_dead(&path) {
+            Ok(true) => {
+                if let Err(err) = std::fs::remove_dir_all(&path) {
+                    tracing::warn!(?path, %err, "mz_ore::pager: reap failed");
+                }
+            }
+            Ok(false) => {
+                // Another live process owns this subdir; leave it alone.
+            }
+            Err(err) => {
+                tracing::warn!(?path, %err, "mz_ore::pager: ownership probe failed");
+            }
+        }
+    }
+}
+
+/// Returns `Ok(true)` if no live process holds the per-subdir lock; `Ok(false)`
+/// if a holder is still alive. `Err` if the lock file is missing or the probe
+/// itself failed (the directory may be in mid-creation; leave it alone).
+fn owner_is_dead(subdir: &Path) -> std::io::Result<bool> {
+    let lock_path = subdir.join("lock");
+    let file = OpenOptions::new().read(true).write(true).open(&lock_path)?;
+    let fd = file.as_raw_fd();
+    // SAFETY: `fd` was produced from a successfully opened `File`; the
+    // lifetime of `file` keeps it valid for the duration of this call.
+    let r = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+    if r == 0 {
+        // We acquired the lock; closing `file` at end of scope releases it.
+        Ok(true)
+    } else {
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::EWOULDBLOCK) => Ok(false),
+            _ => Err(err),
         }
     }
 }
@@ -100,7 +184,9 @@ pub(crate) fn alloc_scratch_id() -> u64 {
     SCRATCH_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-/// Storage for a file-backed handle. The file at `scratch_path(id)` holds the bytes.
+/// Storage for a file-backed handle. The file at `scratch_path(id)` holds the
+/// bytes for non-empty handles. For `len_u64s == 0`, no file is created; drop
+/// is a no-op.
 /// No file descriptor is retained.
 #[derive(Debug)]
 pub(crate) struct FileInner {
@@ -116,7 +202,16 @@ impl FileInner {
 
 impl Drop for FileInner {
     fn drop(&mut self) {
-        let path = scratch_path(self.id);
+        // Empty handles never created a file.
+        if self.len_u64s == 0 {
+            return;
+        }
+        // If the scratch dir was never set up (e.g. construction failed before
+        // any I/O was attempted), there is nothing on disk to clean up.
+        let Some(subdir) = SUBDIR.get() else {
+            return;
+        };
+        let path = subdir.join(format!("{}.bin", self.id));
         if let Err(err) = std::fs::remove_file(&path) {
             // ENOENT is fine: a successful `take` already unlinked.
             if err.kind() != std::io::ErrorKind::NotFound {
@@ -126,16 +221,13 @@ impl Drop for FileInner {
     }
 }
 
-use std::fs::File;
-use std::io::IoSlice;
-
-use crate::pager::Handle;
-use crate::pager::swap::{SwapInner, pageout_swap};
-
 pub(crate) fn pageout_file(chunks: &mut [Vec<u64>]) -> Handle {
     let total: usize = chunks.iter().map(|c| c.len()).sum();
     if total == 0 {
-        return Handle::from_swap(SwapInner::new(Vec::new()));
+        // Honor the backend invariant: an empty handle from the file backend
+        // is still a file-variant handle. No file is created on disk; drop
+        // short-circuits when `len_u64s == 0`.
+        return Handle::from_file(FileInner::new(alloc_scratch_id(), 0));
     }
     let id = alloc_scratch_id();
     let path = scratch_path(id);
@@ -194,6 +286,11 @@ pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut
             "read range out of bounds: {off}+{len} > {total}"
         );
     }
+    // Empty handle: all ranges must be `(_, 0)` after the bounds check above,
+    // so there is no I/O to perform. Skip opening the (nonexistent) file.
+    if total == 0 {
+        return;
+    }
     let path = scratch_path(inner.id);
     let file = match File::open(&path) {
         Ok(f) => f,
@@ -201,9 +298,13 @@ pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut
     };
 
     let coalesced = coalesce(ranges);
-    for (off, len) in coalesced {
-        let byte_off = u64::cast_from(off * 8);
-        let byte_len = len * 8;
+    for (range_idx, (off, len)) in coalesced.iter().copied().enumerate() {
+        // Multiply in `u64` space: `off * 8` would overflow on 32-bit targets
+        // for handles holding more than 512Mi `u64`s.
+        let byte_off = u64::cast_from(off)
+            .checked_mul(8)
+            .expect("byte offset overflow");
+        let byte_len = len.checked_mul(8).expect("byte length overflow");
         let buf_start = dst.len();
         dst.resize(buf_start + len, 0);
         let buf: &mut [u8] = bytemuck::cast_slice_mut(&mut dst[buf_start..buf_start + len]);
@@ -212,9 +313,18 @@ pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut
             let pos = byte_off + u64::cast_from(filled);
             let n = file
                 .read_at(&mut buf[filled..byte_len], pos)
-                .expect("pager pread failed");
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "mz_ore::pager: pread failed at {path:?} pos={pos} \
+                         (range #{range_idx}, off={off} len={len}): {err}",
+                    )
+                });
             if n == 0 {
-                panic!("pager pread short: expected {byte_len} got {filled}");
+                panic!(
+                    "mz_ore::pager: pread short read at {path:?} pos={pos} \
+                     (range #{range_idx}, off={off} len={len}): \
+                     filled {filled} of {byte_len} bytes for this range",
+                );
             }
             filled += n;
         }
@@ -242,18 +352,26 @@ pub(crate) fn take_file(handle: Handle, dst: &mut Vec<u64>) {
         .into_file_inner()
         .expect("take_file called on non-file handle");
     dst.clear();
+    if inner.len_u64s == 0 {
+        // Empty handle: no file exists; nothing to read or unlink.
+        drop(inner);
+        return;
+    }
     let path = scratch_path(inner.id);
     let file = File::open(&path).unwrap_or_else(|err| panic!("pager take: open {path:?}: {err}"));
     dst.resize(inner.len_u64s, 0);
     let buf: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
+    let buf_len = buf.len();
     let mut filled = 0;
-    while filled < buf.len() {
+    while filled < buf_len {
         let pos = u64::cast_from(filled);
-        let n = file
-            .read_at(&mut buf[filled..], pos)
-            .unwrap_or_else(|err| panic!("pager take: pread {path:?}: {err}"));
+        let n = file.read_at(&mut buf[filled..], pos).unwrap_or_else(|err| {
+            panic!("mz_ore::pager: take pread failed at {path:?} pos={pos}: {err}")
+        });
         if n == 0 {
-            panic!("pager take: short read at {filled}");
+            panic!(
+                "mz_ore::pager: take short read at {path:?}: filled {filled} of {buf_len} bytes",
+            );
         }
         filled += n;
     }
@@ -347,6 +465,27 @@ mod backend_tests {
         drop(h);
         assert!(!path.exists(), "scratch file should be unlinked on drop");
     }
+
+    #[mz_ore::test]
+    fn file_empty_handle_round_trips() {
+        setup_dir();
+        let mut chunks: [Vec<u64>; 0] = [];
+        let h = pageout_file(&mut chunks);
+        assert_eq!(h.len(), 0);
+        // Variant must be `File`, honoring the documented backend invariant.
+        assert!(
+            h.file_inner().is_some(),
+            "empty handle should be File-variant"
+        );
+
+        let mut dst = vec![0xdeadu64];
+        read_at_file(&h, &[], &mut dst);
+        assert_eq!(dst, vec![0xdeadu64], "empty read leaves dst untouched");
+
+        let mut dst = Vec::new();
+        take_file(h, &mut dst);
+        assert!(dst.is_empty());
+    }
 }
 
 #[cfg(test)]
@@ -376,5 +515,8 @@ mod tests {
                 .unwrap()
                 .starts_with("mz-pager-")
         );
+        // The marker lock file must exist and be flocked by us.
+        let lock = subdir.join("lock");
+        assert!(lock.exists(), "lock marker should exist");
     }
 }

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -14,17 +14,20 @@
 // limitations under the License.
 
 //! File backend for the pager. See `mz_ore::pager` for the public API.
+//!
+//! Stale-scratch cleanup is intentionally out of scope: production runs on
+//! Kubernetes with per-pod ephemeral volumes, so a crashed predecessor's
+//! files are reclaimed with the volume. Local dev tooling is responsible
+//! for sweeping leftovers from crashed processes.
 
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::IoSlice;
-use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use crate::cast::CastFrom;
 use crate::pager::Handle;
-use crate::pager::swap::pageout_swap;
 
 static SCRATCH_DIR: OnceLock<PathBuf> = OnceLock::new();
 static SUBDIR: OnceLock<PathBuf> = OnceLock::new();
@@ -32,10 +35,6 @@ static SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
 /// Serializes `set_scratch_dir` callers so init failures can be retried on
 /// the next call. A plain `Once` would burn the only retry opportunity.
 static INIT_LOCK: Mutex<()> = Mutex::new(());
-/// Holds the exclusive `flock` on this process's `lock` file. Leaked into a
-/// static so the kernel keeps the lock for the entire process lifetime and
-/// drops it automatically on exit (including hard crashes).
-static OWN_LOCK_FD: OnceLock<RawFd> = OnceLock::new();
 
 /// Configures the scratch directory for the file backend.
 ///
@@ -57,8 +56,8 @@ pub fn set_scratch_dir(root: PathBuf) {
     }
     match init_subdir(&root) {
         Ok(()) => {
-            // SAFETY of `let _ =`: we hold INIT_LOCK and just verified the
-            // OnceLock is empty above, so this set always wins.
+            // We hold INIT_LOCK and just verified the OnceLock is empty above,
+            // so this set always wins.
             let _ = SCRATCH_DIR.set(root);
         }
         Err(err) => {
@@ -76,101 +75,8 @@ fn init_subdir(root: &Path) -> std::io::Result<()> {
     let pid = std::process::id();
     let subdir = root.join(format!("mz-pager-{pid}-{nonce:016x}"));
     std::fs::create_dir_all(&subdir)?;
-    // Acquire an exclusive advisory lock on a marker file inside the subdir.
-    // The lock is kept for the lifetime of the process; the reaper in any
-    // other process can probe this lock to determine whether the owner is
-    // still alive, which avoids the PID-reuse race that plagues a naive
-    // /proc-based liveness check.
-    let lock_path = subdir.join("lock");
-    let lock_file = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(true)
-        .open(&lock_path)?;
-    let fd = lock_file.into_raw_fd();
-    // SAFETY: `fd` was just produced by `into_raw_fd` on a successfully opened
-    // `File`; the kernel guarantees it is a valid open file descriptor here.
-    let r = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
-    if r != 0 {
-        let err = std::io::Error::last_os_error();
-        // SAFETY: `fd` is still valid; nothing else has consumed it.
-        unsafe {
-            libc::close(fd);
-        }
-        return Err(err);
-    }
-    // Stash the fd so the lock stays held until process exit.
-    if OWN_LOCK_FD.set(fd).is_err() {
-        // Already set on a prior successful init: release the duplicate lock.
-        // SAFETY: `fd` is still valid here; we own it.
-        unsafe {
-            libc::close(fd);
-        }
-    }
     let _ = SUBDIR.set(subdir);
-    reap_stale(root);
     Ok(())
-}
-
-/// Sweeps `root` for subdirectories left behind by predecessors that crashed
-/// or were killed. Ownership is determined via `flock` on the per-subdir
-/// `lock` file: if we can acquire it non-blocking, the owner is gone.
-fn reap_stale(root: &Path) {
-    let entries = match std::fs::read_dir(root) {
-        Ok(e) => e,
-        Err(err) => {
-            tracing::warn!(?root, %err, "mz_ore::pager: scratch dir scan failed");
-            return;
-        }
-    };
-    let own_subdir = SUBDIR.get();
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if !name.starts_with("mz-pager-") {
-            continue;
-        }
-        let path = entry.path();
-        if own_subdir.is_some_and(|s| s.as_path() == path) {
-            continue;
-        }
-        match owner_is_dead(&path) {
-            Ok(true) => {
-                if let Err(err) = std::fs::remove_dir_all(&path) {
-                    tracing::warn!(?path, %err, "mz_ore::pager: reap failed");
-                }
-            }
-            Ok(false) => {
-                // Another live process owns this subdir; leave it alone.
-            }
-            Err(err) => {
-                tracing::warn!(?path, %err, "mz_ore::pager: ownership probe failed");
-            }
-        }
-    }
-}
-
-/// Returns `Ok(true)` if no live process holds the per-subdir lock; `Ok(false)`
-/// if a holder is still alive. `Err` if the lock file is missing or the probe
-/// itself failed (the directory may be in mid-creation; leave it alone).
-fn owner_is_dead(subdir: &Path) -> std::io::Result<bool> {
-    let lock_path = subdir.join("lock");
-    let file = OpenOptions::new().read(true).write(true).open(&lock_path)?;
-    let fd = file.as_raw_fd();
-    // SAFETY: `fd` was produced from a successfully opened `File`; the
-    // lifetime of `file` keeps it valid for the duration of this call.
-    let r = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
-    if r == 0 {
-        // We acquired the lock; closing `file` at end of scope releases it.
-        Ok(true)
-    } else {
-        let err = std::io::Error::last_os_error();
-        match err.raw_os_error() {
-            Some(libc::EWOULDBLOCK) => Ok(false),
-            _ => Err(err),
-        }
-    }
 }
 
 pub(crate) fn scratch_path(id: u64) -> PathBuf {
@@ -221,13 +127,16 @@ impl Drop for FileInner {
     }
 }
 
-pub(crate) fn pageout_file(chunks: &mut [Vec<u64>]) -> Handle {
+/// Fallible counterpart to [`pageout_file`]. Returns the underlying I/O error
+/// instead of falling back to a different backend, so callers can distinguish
+/// "scratch volume is broken" from "everything is fine."
+pub(crate) fn try_pageout_file(chunks: &mut [Vec<u64>]) -> std::io::Result<Handle> {
     let total: usize = chunks.iter().map(|c| c.len()).sum();
     if total == 0 {
         // Honor the backend invariant: an empty handle from the file backend
         // is still a file-variant handle. No file is created on disk; drop
         // short-circuits when `len_u64s == 0`.
-        return Handle::from_file(FileInner::new(alloc_scratch_id(), 0));
+        return Ok(Handle::from_file(FileInner::new(alloc_scratch_id(), 0)));
     }
     let id = alloc_scratch_id();
     let path = scratch_path(id);
@@ -236,14 +145,20 @@ pub(crate) fn pageout_file(chunks: &mut [Vec<u64>]) -> Handle {
             for c in chunks.iter_mut() {
                 c.clear();
             }
-            Handle::from_file(FileInner::new(id, total))
+            Ok(Handle::from_file(FileInner::new(id, total)))
         }
         Err(err) => {
-            tracing::warn!(?path, %err, "mz_ore::pager: file pageout failed; falling back to swap");
+            // Best-effort cleanup; ignore secondary errors here so we surface
+            // the primary write error to the caller.
             let _ = std::fs::remove_file(&path);
-            pageout_swap(chunks)
+            Err(err)
         }
     }
+}
+
+pub(crate) fn pageout_file(chunks: &mut [Vec<u64>]) -> Handle {
+    try_pageout_file(chunks)
+        .unwrap_or_else(|err| panic!("mz_ore::pager: file pageout failed: {err}"))
 }
 
 fn write_chunks(path: &Path, chunks: &[Vec<u64>]) -> std::io::Result<()> {
@@ -272,12 +187,19 @@ fn write_all_vectored(mut file: &File, mut slices: &mut [IoSlice<'_>]) -> std::i
     Ok(())
 }
 
-pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
+/// Fallible counterpart to [`read_at_file`]. Returns `Err` instead of
+/// panicking on I/O failure (open/pread errors). Bounds violations and
+/// non-file handles still panic — those are caller bugs, not I/O failures.
+pub(crate) fn try_read_at_file(
+    handle: &Handle,
+    ranges: &[(usize, usize)],
+    dst: &mut Vec<u64>,
+) -> std::io::Result<()> {
     use std::os::unix::fs::FileExt;
 
     let inner = handle
         .file_inner()
-        .expect("read_at_file called on non-file handle");
+        .expect("try_read_at_file called on non-file handle");
     let total = inner.len_u64s;
     for &(off, len) in ranges {
         let end = off.checked_add(len).expect("range offset+len overflow");
@@ -289,13 +211,12 @@ pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut
     // Empty handle: all ranges must be `(_, 0)` after the bounds check above,
     // so there is no I/O to perform. Skip opening the (nonexistent) file.
     if total == 0 {
-        return;
+        return Ok(());
     }
     let path = scratch_path(inner.id);
-    let file = match File::open(&path) {
-        Ok(f) => f,
-        Err(err) => panic!("mz_ore::pager: failed to open scratch file {path:?}: {err}"),
-    };
+    let file = File::open(&path).map_err(|err| {
+        std::io::Error::new(err.kind(), format!("mz_ore::pager: open {path:?}: {err}"))
+    })?;
 
     let coalesced = coalesce(ranges);
     for (range_idx, (off, len)) in coalesced.iter().copied().enumerate() {
@@ -313,22 +234,34 @@ pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut
             let pos = byte_off + u64::cast_from(filled);
             let n = file
                 .read_at(&mut buf[filled..byte_len], pos)
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "mz_ore::pager: pread failed at {path:?} pos={pos} \
+                .map_err(|err| {
+                    std::io::Error::new(
+                        err.kind(),
+                        format!(
+                            "mz_ore::pager: pread {path:?} pos={pos} \
                          (range #{range_idx}, off={off} len={len}): {err}",
+                        ),
                     )
-                });
+                })?;
             if n == 0 {
-                panic!(
-                    "mz_ore::pager: pread short read at {path:?} pos={pos} \
-                     (range #{range_idx}, off={off} len={len}): \
-                     filled {filled} of {byte_len} bytes for this range",
-                );
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "mz_ore::pager: pread short read at {path:?} pos={pos} \
+                         (range #{range_idx}, off={off} len={len}): \
+                         filled {filled} of {byte_len} bytes for this range",
+                    ),
+                ));
             }
             filled += n;
         }
     }
+    Ok(())
+}
+
+pub(crate) fn read_at_file(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
+    try_read_at_file(handle, ranges, dst)
+        .unwrap_or_else(|err| panic!("mz_ore::pager: read_at_file failed: {err}"));
 }
 
 fn coalesce(ranges: &[(usize, usize)]) -> Vec<(usize, usize)> {
@@ -345,39 +278,60 @@ fn coalesce(ranges: &[(usize, usize)]) -> Vec<(usize, usize)> {
     out
 }
 
-pub(crate) fn take_file(handle: Handle, dst: &mut Vec<u64>) {
+/// Fallible counterpart to [`take_file`]. Returns `Err` instead of panicking
+/// on I/O failure. The handle is consumed in either case; on `Err`, `dst` may
+/// hold partial data and the scratch file is unlinked when the inner is
+/// dropped.
+pub(crate) fn try_take_file(handle: Handle, dst: &mut Vec<u64>) -> std::io::Result<()> {
     use std::os::unix::fs::FileExt;
 
     let inner = handle
         .into_file_inner()
-        .expect("take_file called on non-file handle");
+        .expect("try_take_file called on non-file handle");
     dst.clear();
     if inner.len_u64s == 0 {
         // Empty handle: no file exists; nothing to read or unlink.
         drop(inner);
-        return;
+        return Ok(());
     }
     let path = scratch_path(inner.id);
-    let file = File::open(&path).unwrap_or_else(|err| panic!("pager take: open {path:?}: {err}"));
+    let file = File::open(&path).map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!("mz_ore::pager: take open {path:?}: {err}"),
+        )
+    })?;
     dst.resize(inner.len_u64s, 0);
     let buf: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
     let buf_len = buf.len();
     let mut filled = 0;
     while filled < buf_len {
         let pos = u64::cast_from(filled);
-        let n = file.read_at(&mut buf[filled..], pos).unwrap_or_else(|err| {
-            panic!("mz_ore::pager: take pread failed at {path:?} pos={pos}: {err}")
-        });
+        let n = file.read_at(&mut buf[filled..], pos).map_err(|err| {
+            std::io::Error::new(
+                err.kind(),
+                format!("mz_ore::pager: take pread {path:?} pos={pos}: {err}"),
+            )
+        })?;
         if n == 0 {
-            panic!(
-                "mz_ore::pager: take short read at {path:?}: filled {filled} of {buf_len} bytes",
-            );
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                format!(
+                    "mz_ore::pager: take short read at {path:?}: filled {filled} of {buf_len} bytes",
+                ),
+            ));
         }
         filled += n;
     }
     drop(file);
     // FileInner::drop will unlink the scratch file.
     drop(inner);
+    Ok(())
+}
+
+pub(crate) fn take_file(handle: Handle, dst: &mut Vec<u64>) {
+    try_take_file(handle, dst)
+        .unwrap_or_else(|err| panic!("mz_ore::pager: take_file failed: {err}"));
 }
 
 #[cfg(test)]
@@ -486,6 +440,19 @@ mod backend_tests {
         take_file(h, &mut dst);
         assert!(dst.is_empty());
     }
+
+    #[mz_ore::test]
+    fn try_read_at_file_surfaces_missing_file() {
+        setup_dir();
+        let mut chunks = [vec![1u64, 2, 3]];
+        let h = pageout_file(&mut chunks);
+        // Concurrently unlink the scratch file out from under us.
+        let path = scratch_path(h.file_inner().unwrap().id);
+        std::fs::remove_file(&path).expect("unlink scratch");
+        let mut dst = Vec::new();
+        let err = try_read_at_file(&h, &[(0, 3)], &mut dst).expect_err("should surface ENOENT");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
 }
 
 #[cfg(test)]
@@ -515,8 +482,5 @@ mod tests {
                 .unwrap()
                 .starts_with("mz-pager-")
         );
-        // The marker lock file must exist and be flocked by us.
-        let lock = subdir.join("lock");
-        assert!(lock.exists(), "lock marker should exist");
     }
 }

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -79,6 +79,45 @@ fn page_size() -> usize {
     4096
 }
 
+pub(crate) fn read_at_swap(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {
+    let inner = handle
+        .swap_inner()
+        .expect("read_at_swap called on non-swap handle");
+    let total = inner.total_len();
+    let total_out: usize = ranges.iter().map(|(_, l)| *l).sum();
+    dst.reserve(total_out);
+    for &(off, len) in ranges {
+        let end = off.checked_add(len).expect("range offset+len overflow");
+        assert!(
+            end <= total,
+            "read range out of bounds: {off}+{len} > {total}"
+        );
+        copy_range(inner, off, len, dst);
+    }
+}
+
+fn copy_range(inner: &SwapInner, off: usize, len: usize, dst: &mut Vec<u64>) {
+    if len == 0 {
+        return;
+    }
+    let mut remaining = len;
+    let mut cur = off;
+    let mut idx = match inner.prefix.binary_search(&cur) {
+        Ok(i) => i,
+        Err(i) => i.saturating_sub(1),
+    };
+    while remaining > 0 {
+        let chunk_start = inner.prefix[idx];
+        let chunk = &inner.chunks[idx];
+        let local = cur - chunk_start;
+        let take = std::cmp::min(remaining, chunk.len() - local);
+        dst.extend_from_slice(&chunk[local..local + take]);
+        cur += take;
+        remaining -= take;
+        idx += 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,5 +132,41 @@ mod tests {
         assert_eq!(h.len(), 5);
         assert!(chunks[0].is_empty());
         assert!(chunks[1].is_empty());
+    }
+
+    #[mz_ore::test]
+    fn read_at_within_single_chunk() {
+        let mut chunks = [vec![10u64, 11, 12, 13, 14]];
+        let h = pageout_swap(&mut chunks);
+        let mut dst = Vec::new();
+        read_at_swap(&h, &[(1, 3)], &mut dst);
+        assert_eq!(dst, vec![11, 12, 13]);
+    }
+
+    #[mz_ore::test]
+    fn read_at_spans_chunks() {
+        let mut chunks = [vec![1u64, 2, 3], vec![4, 5, 6]];
+        let h = pageout_swap(&mut chunks);
+        let mut dst = Vec::new();
+        read_at_swap(&h, &[(2, 3)], &mut dst);
+        assert_eq!(dst, vec![3, 4, 5]);
+    }
+
+    #[mz_ore::test]
+    fn read_at_many_concats() {
+        let mut chunks = [vec![1u64, 2, 3, 4, 5]];
+        let h = pageout_swap(&mut chunks);
+        let mut dst = Vec::new();
+        read_at_swap(&h, &[(0, 2), (3, 2)], &mut dst);
+        assert_eq!(dst, vec![1, 2, 4, 5]);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "out of bounds")]
+    fn read_at_panics_on_oob() {
+        let mut chunks = [vec![1u64, 2]];
+        let h = pageout_swap(&mut chunks);
+        let mut dst = Vec::new();
+        read_at_swap(&h, &[(1, 5)], &mut dst);
     }
 }

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -1,3 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Swap backend for the pager. See `mz_ore::pager` for the public API.
 
 use crate::pager::Handle;

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -118,6 +118,25 @@ fn copy_range(inner: &SwapInner, off: usize, len: usize, dst: &mut Vec<u64>) {
     }
 }
 
+pub(crate) fn take_swap(handle: Handle, dst: &mut Vec<u64>) {
+    let inner = match handle.into_swap_inner() {
+        Some(s) => s,
+        None => panic!("take_swap called on non-swap handle"),
+    };
+    dst.clear();
+    let mut chunks = inner.chunks;
+    if chunks.len() == 1 && dst.capacity() == 0 {
+        let only = chunks.pop().unwrap();
+        *dst = only;
+        return;
+    }
+    let total: usize = chunks.iter().map(|c| c.len()).sum();
+    dst.reserve(total);
+    for c in chunks {
+        dst.extend_from_slice(&c);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -168,5 +187,30 @@ mod tests {
         let h = pageout_swap(&mut chunks);
         let mut dst = Vec::new();
         read_at_swap(&h, &[(1, 5)], &mut dst);
+    }
+
+    #[mz_ore::test]
+    fn take_single_chunk_zero_copy() {
+        let v = vec![100u64; 1024];
+        let ptr_before = v.as_ptr();
+        let mut chunks = [v];
+        let h = pageout_swap(&mut chunks);
+        let mut dst = Vec::new();
+        take_swap(h, &mut dst);
+        assert_eq!(dst.len(), 1024);
+        assert_eq!(
+            dst.as_ptr(),
+            ptr_before,
+            "single-chunk take should be zero-copy"
+        );
+    }
+
+    #[mz_ore::test]
+    fn take_multi_chunk_concats() {
+        let mut chunks = [vec![1u64, 2], vec![3, 4, 5]];
+        let h = pageout_swap(&mut chunks);
+        let mut dst = Vec::new();
+        take_swap(h, &mut dst);
+        assert_eq!(dst, vec![1, 2, 3, 4, 5]);
     }
 }

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -1,1 +1,28 @@
 //! Swap backend for the pager. See `mz_ore::pager` for the public API.
+
+/// Storage for a swap-backed handle.
+#[derive(Debug)]
+pub(crate) struct SwapInner {
+    /// Logical chunks; logical layout is concatenation in this order.
+    pub(crate) chunks: Vec<Vec<u64>>,
+    /// Cumulative element counts; `prefix[i]` = sum of `chunks[..i]` lengths.
+    /// `prefix[0] == 0`, `prefix.last() == total_len`.
+    pub(crate) prefix: Vec<usize>,
+}
+
+impl SwapInner {
+    pub(crate) fn new(chunks: Vec<Vec<u64>>) -> Self {
+        let mut prefix = Vec::with_capacity(chunks.len() + 1);
+        prefix.push(0);
+        let mut sum = 0;
+        for c in &chunks {
+            sum += c.len();
+            prefix.push(sum);
+        }
+        Self { chunks, prefix }
+    }
+
+    pub(crate) fn total_len(&self) -> usize {
+        *self.prefix.last().unwrap_or(&0)
+    }
+}

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -41,6 +41,7 @@ pub(crate) fn pageout_swap(chunks: &mut [Vec<u64>]) -> Handle {
 }
 
 #[cfg(target_os = "linux")]
+#[allow(clippy::as_conversions)] // ptr<->usize and *mut c_void casts have no safe wrapper
 fn madvise_cold(chunk: &[u64]) {
     if chunk.is_empty() {
         return;
@@ -69,6 +70,7 @@ fn madvise_cold(chunk: &[u64]) {
 fn madvise_cold(_chunk: &[u64]) {}
 
 #[cfg(target_os = "linux")]
+#[allow(clippy::as_conversions)] // libc::c_long -> usize is FFI; sysconf returns >0 here
 fn page_size() -> usize {
     // SAFETY: `sysconf` with a valid argument is safe.
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -1,0 +1,1 @@
+//! Swap backend for the pager. See `mz_ore::pager` for the public API.

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -50,14 +50,24 @@ pub(crate) fn pageout_swap(chunks: &mut [Vec<u64>]) -> Handle {
         taken.push(std::mem::take(c));
     }
     for c in &taken {
-        madvise_cold(c);
+        madvise_range(c, MADV_COLD);
     }
     Handle::from_swap(SwapInner::new(taken))
 }
 
 #[cfg(target_os = "linux")]
+const MADV_COLD: libc::c_int = libc::MADV_COLD;
+#[cfg(target_os = "linux")]
+const MADV_WILLNEED: libc::c_int = libc::MADV_WILLNEED;
+
+#[cfg(not(target_os = "linux"))]
+const MADV_COLD: i32 = 0;
+#[cfg(not(target_os = "linux"))]
+const MADV_WILLNEED: i32 = 0;
+
+#[cfg(target_os = "linux")]
 #[allow(clippy::as_conversions)] // ptr<->usize and *mut c_void casts have no safe wrapper
-fn madvise_cold(chunk: &[u64]) {
+fn madvise_range(chunk: &[u64], advice: libc::c_int) {
     if chunk.is_empty() {
         return;
     }
@@ -70,19 +80,19 @@ fn madvise_cold(chunk: &[u64]) {
         return;
     }
     // SAFETY: pointer/length come from a live `&[u64]`; we restrict to a fully
-    // page-aligned subrange contained within that slice; `MADV_COLD` does not
-    // mutate the contents.
+    // page-aligned subrange contained within that slice; `madvise` with these
+    // hints does not mutate the contents.
     unsafe {
         libc::madvise(
             aligned_start as *mut libc::c_void,
             aligned_end - aligned_start,
-            libc::MADV_COLD,
+            advice,
         );
     }
 }
 
 #[cfg(not(target_os = "linux"))]
-fn madvise_cold(_chunk: &[u64]) {}
+fn madvise_range(_chunk: &[u64], _advice: i32) {}
 
 #[cfg(target_os = "linux")]
 #[allow(clippy::as_conversions)] // libc::c_long -> usize is FFI; sysconf returns >0 here
@@ -131,6 +141,35 @@ fn copy_range(inner: &SwapInner, off: usize, len: usize, dst: &mut Vec<u64>) {
         dst.extend_from_slice(&chunk[local..local + take]);
         cur += take;
         remaining -= take;
+        idx += 1;
+    }
+}
+
+pub(crate) fn prefetch_at_swap(handle: &Handle, offset: usize, len: usize) {
+    let inner = handle
+        .swap_inner()
+        .expect("prefetch_at_swap called on non-swap handle");
+    let total = inner.total_len();
+    let end = offset.checked_add(len).expect("offset+len overflow");
+    assert!(
+        end <= total,
+        "prefetch range out of bounds: {offset}+{len} > {total}"
+    );
+    if len == 0 {
+        return;
+    }
+    let mut cur = offset;
+    let mut idx = match inner.prefix.binary_search(&cur) {
+        Ok(i) => i,
+        Err(i) => i.saturating_sub(1),
+    };
+    while cur < end {
+        let chunk_start = inner.prefix[idx];
+        let chunk = &inner.chunks[idx];
+        let local = cur - chunk_start;
+        let take = std::cmp::min(end - cur, chunk.len() - local);
+        madvise_range(&chunk[local..local + take], MADV_WILLNEED);
+        cur += take;
         idx += 1;
     }
 }
@@ -229,5 +268,25 @@ mod tests {
         let mut dst = Vec::new();
         take_swap(h, &mut dst);
         assert_eq!(dst, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[mz_ore::test]
+    fn prefetch_does_not_corrupt_data() {
+        let payload: Vec<u64> = (0..1024).collect();
+        let mut chunks = [payload.clone()];
+        let h = pageout_swap(&mut chunks);
+        prefetch_at_swap(&h, 100, 200);
+        prefetch_at_swap(&h, 0, 1024);
+        let mut dst = Vec::new();
+        read_at_swap(&h, &[(0, 1024)], &mut dst);
+        assert_eq!(dst, payload);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "out of bounds")]
+    fn prefetch_panics_on_oob() {
+        let mut chunks = [vec![1u64, 2]];
+        let h = pageout_swap(&mut chunks);
+        prefetch_at_swap(&h, 0, 99);
     }
 }

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -1,5 +1,7 @@
 //! Swap backend for the pager. See `mz_ore::pager` for the public API.
 
+use crate::pager::Handle;
+
 /// Storage for a swap-backed handle.
 #[derive(Debug)]
 pub(crate) struct SwapInner {
@@ -24,5 +26,72 @@ impl SwapInner {
 
     pub(crate) fn total_len(&self) -> usize {
         *self.prefix.last().unwrap_or(&0)
+    }
+}
+
+pub(crate) fn pageout_swap(chunks: &mut [Vec<u64>]) -> Handle {
+    let mut taken: Vec<Vec<u64>> = Vec::with_capacity(chunks.len());
+    for c in chunks.iter_mut() {
+        taken.push(std::mem::take(c));
+    }
+    for c in &taken {
+        madvise_cold(c);
+    }
+    Handle::from_swap(SwapInner::new(taken))
+}
+
+#[cfg(target_os = "linux")]
+fn madvise_cold(chunk: &[u64]) {
+    if chunk.is_empty() {
+        return;
+    }
+    let page = page_size();
+    let ptr = chunk.as_ptr() as usize;
+    let len_bytes = chunk.len() * std::mem::size_of::<u64>();
+    let aligned_start = (ptr + page - 1) & !(page - 1);
+    let aligned_end = (ptr + len_bytes) & !(page - 1);
+    if aligned_end <= aligned_start {
+        return;
+    }
+    // SAFETY: pointer/length come from a live `&[u64]`; we restrict to a fully
+    // page-aligned subrange contained within that slice; `MADV_COLD` does not
+    // mutate the contents.
+    unsafe {
+        libc::madvise(
+            aligned_start as *mut libc::c_void,
+            aligned_end - aligned_start,
+            libc::MADV_COLD,
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn madvise_cold(_chunk: &[u64]) {}
+
+#[cfg(target_os = "linux")]
+fn page_size() -> usize {
+    // SAFETY: `sysconf` with a valid argument is safe.
+    unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn page_size() -> usize {
+    4096
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pager::Handle;
+
+    #[mz_ore::test]
+    fn pageout_takes_chunks_and_records_lengths() {
+        let a = vec![1u64, 2, 3];
+        let b = vec![4u64, 5];
+        let mut chunks = [a, b];
+        let h: Handle = pageout_swap(&mut chunks);
+        assert_eq!(h.len(), 5);
+        assert!(chunks[0].is_empty());
+        assert!(chunks[1].is_empty());
     }
 }

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -66,28 +66,31 @@ const MADV_COLD: i32 = 0;
 const MADV_WILLNEED: i32 = 0;
 
 #[cfg(target_os = "linux")]
-#[allow(clippy::as_conversions)] // ptr<->usize and *mut c_void casts have no safe wrapper
 fn madvise_range(chunk: &[u64], advice: libc::c_int) {
     if chunk.is_empty() {
         return;
     }
     let page = page_size();
-    let ptr = chunk.as_ptr() as usize;
+    let base_ptr = chunk.as_ptr();
+    let base_addr = base_ptr.addr();
     let len_bytes = chunk.len() * std::mem::size_of::<u64>();
-    let aligned_start = (ptr + page - 1) & !(page - 1);
-    let aligned_end = (ptr + len_bytes) & !(page - 1);
-    if aligned_end <= aligned_start {
+    let aligned_start_addr = (base_addr + page - 1) & !(page - 1);
+    let aligned_end_addr = (base_addr + len_bytes) & !(page - 1);
+    if aligned_end_addr <= aligned_start_addr {
         return;
     }
-    // SAFETY: pointer/length come from a live `&[u64]`; we restrict to a fully
-    // page-aligned subrange contained within that slice; `madvise` with these
-    // hints does not mutate the contents.
+    let aligned_len = aligned_end_addr - aligned_start_addr;
+    // SAFETY: `aligned_start_addr` lies within `[base_addr, base_addr+len_bytes]`,
+    // i.e. inside the live `&[u64]`. Reconstructing the pointer via `byte_add`
+    // preserves provenance.
+    let aligned_ptr = unsafe { base_ptr.byte_add(aligned_start_addr - base_addr) }
+        .cast::<libc::c_void>()
+        .cast_mut();
+    // SAFETY: pointer/length describe a fully page-aligned subrange contained
+    // within the live `&[u64]`. `madvise` with `MADV_COLD` / `MADV_WILLNEED`
+    // does not mutate the contents.
     unsafe {
-        libc::madvise(
-            aligned_start as *mut libc::c_void,
-            aligned_end - aligned_start,
-            advice,
-        );
+        libc::madvise(aligned_ptr, aligned_len, advice);
     }
 }
 
@@ -95,10 +98,10 @@ fn madvise_range(chunk: &[u64], advice: libc::c_int) {
 fn madvise_range(_chunk: &[u64], _advice: i32) {}
 
 #[cfg(target_os = "linux")]
-#[allow(clippy::as_conversions)] // libc::c_long -> usize is FFI; sysconf returns >0 here
 fn page_size() -> usize {
     // SAFETY: `sysconf` with a valid argument is safe.
-    unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
+    let raw = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    usize::try_from(raw).expect("page size is positive and fits usize")
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -50,23 +50,13 @@ pub(crate) fn pageout_swap(chunks: &mut [Vec<u64>]) -> Handle {
         taken.push(std::mem::take(c));
     }
     for c in &taken {
-        madvise_range(c, MADV_COLD);
+        madvise_cold(c);
     }
     Handle::from_swap(SwapInner::new(taken))
 }
 
 #[cfg(target_os = "linux")]
-const MADV_COLD: libc::c_int = libc::MADV_COLD;
-#[cfg(target_os = "linux")]
-const MADV_WILLNEED: libc::c_int = libc::MADV_WILLNEED;
-
-#[cfg(not(target_os = "linux"))]
-const MADV_COLD: i32 = 0;
-#[cfg(not(target_os = "linux"))]
-const MADV_WILLNEED: i32 = 0;
-
-#[cfg(target_os = "linux")]
-fn madvise_range(chunk: &[u64], advice: libc::c_int) {
+fn madvise_cold(chunk: &[u64]) {
     if chunk.is_empty() {
         return;
     }
@@ -87,15 +77,14 @@ fn madvise_range(chunk: &[u64], advice: libc::c_int) {
         .cast::<libc::c_void>()
         .cast_mut();
     // SAFETY: pointer/length describe a fully page-aligned subrange contained
-    // within the live `&[u64]`. `madvise` with `MADV_COLD` / `MADV_WILLNEED`
-    // does not mutate the contents.
+    // within the live `&[u64]`. `MADV_COLD` does not mutate the contents.
     unsafe {
-        libc::madvise(aligned_ptr, aligned_len, advice);
+        libc::madvise(aligned_ptr, aligned_len, libc::MADV_COLD);
     }
 }
 
 #[cfg(not(target_os = "linux"))]
-fn madvise_range(_chunk: &[u64], _advice: i32) {}
+fn madvise_cold(_chunk: &[u64]) {}
 
 #[cfg(target_os = "linux")]
 fn page_size() -> usize {
@@ -144,35 +133,6 @@ fn copy_range(inner: &SwapInner, off: usize, len: usize, dst: &mut Vec<u64>) {
         dst.extend_from_slice(&chunk[local..local + take]);
         cur += take;
         remaining -= take;
-        idx += 1;
-    }
-}
-
-pub(crate) fn prefetch_at_swap(handle: &Handle, offset: usize, len: usize) {
-    let inner = handle
-        .swap_inner()
-        .expect("prefetch_at_swap called on non-swap handle");
-    let total = inner.total_len();
-    let end = offset.checked_add(len).expect("offset+len overflow");
-    assert!(
-        end <= total,
-        "prefetch range out of bounds: {offset}+{len} > {total}"
-    );
-    if len == 0 {
-        return;
-    }
-    let mut cur = offset;
-    let mut idx = match inner.prefix.binary_search(&cur) {
-        Ok(i) => i,
-        Err(i) => i.saturating_sub(1),
-    };
-    while cur < end {
-        let chunk_start = inner.prefix[idx];
-        let chunk = &inner.chunks[idx];
-        let local = cur - chunk_start;
-        let take = std::cmp::min(end - cur, chunk.len() - local);
-        madvise_range(&chunk[local..local + take], MADV_WILLNEED);
-        cur += take;
         idx += 1;
     }
 }
@@ -271,25 +231,5 @@ mod tests {
         let mut dst = Vec::new();
         take_swap(h, &mut dst);
         assert_eq!(dst, vec![1, 2, 3, 4, 5]);
-    }
-
-    #[mz_ore::test]
-    fn prefetch_does_not_corrupt_data() {
-        let payload: Vec<u64> = (0..1024).collect();
-        let mut chunks = [payload.clone()];
-        let h = pageout_swap(&mut chunks);
-        prefetch_at_swap(&h, 100, 200);
-        prefetch_at_swap(&h, 0, 1024);
-        let mut dst = Vec::new();
-        read_at_swap(&h, &[(0, 1024)], &mut dst);
-        assert_eq!(dst, payload);
-    }
-
-    #[mz_ore::test]
-    #[should_panic(expected = "out of bounds")]
-    fn prefetch_panics_on_oob() {
-        let mut chunks = [vec![1u64, 2]];
-        let h = pageout_swap(&mut chunks);
-        prefetch_at_swap(&h, 0, 99);
     }
 }

--- a/src/ore/src/pager/swap.rs
+++ b/src/ore/src/pager/swap.rs
@@ -40,7 +40,11 @@ impl SwapInner {
     }
 
     pub(crate) fn total_len(&self) -> usize {
-        *self.prefix.last().unwrap_or(&0)
+        // `new` always pushes the initial 0, so `prefix` has at least one element.
+        *self
+            .prefix
+            .last()
+            .expect("SwapInner::prefix invariant: at least [0]")
     }
 }
 
@@ -63,21 +67,39 @@ fn madvise_cold(chunk: &[u64]) {
     let page = page_size();
     let base_ptr = chunk.as_ptr();
     let base_addr = base_ptr.addr();
-    let len_bytes = chunk.len() * std::mem::size_of::<u64>();
-    let aligned_start_addr = (base_addr + page - 1) & !(page - 1);
-    let aligned_end_addr = (base_addr + len_bytes) & !(page - 1);
+    // `Vec<u64>` cannot exceed `isize::MAX` bytes, so this multiplication
+    // cannot overflow on any supported target. Use `checked_mul` for
+    // defense-in-depth: a corrupted length should fail loudly, not wrap.
+    let Some(len_bytes) = chunk.len().checked_mul(std::mem::size_of::<u64>()) else {
+        return;
+    };
+    // Round the start up and the end down to page boundaries. Both additions
+    // use `checked_add` so that an allocation sitting near the top of the
+    // address space can never silently wrap into a tiny range.
+    let Some(start_unaligned) = base_addr.checked_add(page - 1) else {
+        return;
+    };
+    let Some(end_unaligned) = base_addr.checked_add(len_bytes) else {
+        return;
+    };
+    let aligned_start_addr = start_unaligned & !(page - 1);
+    let aligned_end_addr = end_unaligned & !(page - 1);
     if aligned_end_addr <= aligned_start_addr {
         return;
     }
     let aligned_len = aligned_end_addr - aligned_start_addr;
-    // SAFETY: `aligned_start_addr` lies within `[base_addr, base_addr+len_bytes]`,
-    // i.e. inside the live `&[u64]`. Reconstructing the pointer via `byte_add`
-    // preserves provenance.
+    // SAFETY: `aligned_start_addr` lies in `[base_addr, base_addr + len_bytes]`
+    // by construction (rounding up the start cannot exceed `end_unaligned`,
+    // which equals `base_addr + len_bytes`; the early-return above guarantees
+    // `start ≤ end`). That interval is exactly the range covered by the live
+    // `&[u64]`, so `byte_add` stays in-bounds and preserves provenance.
     let aligned_ptr = unsafe { base_ptr.byte_add(aligned_start_addr - base_addr) }
         .cast::<libc::c_void>()
         .cast_mut();
     // SAFETY: pointer/length describe a fully page-aligned subrange contained
-    // within the live `&[u64]`. `MADV_COLD` does not mutate the contents.
+    // within the live `&[u64]` (justified above). `MADV_COLD` is non-mutating;
+    // it only signals reclaim preference to the kernel, so concurrent reads
+    // of the slice remain sound.
     unsafe {
         libc::madvise(aligned_ptr, aligned_len, libc::MADV_COLD);
     }
@@ -91,11 +113,6 @@ fn page_size() -> usize {
     // SAFETY: `sysconf` with a valid argument is safe.
     let raw = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
     usize::try_from(raw).expect("page size is positive and fits usize")
-}
-
-#[cfg(not(target_os = "linux"))]
-fn page_size() -> usize {
-    4096
 }
 
 pub(crate) fn read_at_swap(handle: &Handle, ranges: &[(usize, usize)], dst: &mut Vec<u64>) {

--- a/src/ore/tests/pager_integration.rs
+++ b/src/ore/tests/pager_integration.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "pager")]
+
+use mz_ore::pager::{Backend, Handle, pageout, read_at, set_backend, set_scratch_dir, take};
+use tempfile::tempdir;
+
+fn ensure_scratch() {
+    static INIT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+    let dir = INIT.get_or_init(|| tempdir().unwrap());
+    set_scratch_dir(dir.path().to_owned());
+}
+
+#[test]
+fn round_trip_swap() {
+    set_backend(Backend::Swap);
+    let payload: Vec<u64> = (0..1024).collect();
+    let mut chunks = [payload.clone()];
+    let h = pageout(&mut chunks);
+    let mut dst = Vec::new();
+    take(h, &mut dst);
+    assert_eq!(dst, payload);
+}
+
+#[test]
+fn round_trip_file() {
+    ensure_scratch();
+    set_backend(Backend::File);
+    let payload: Vec<u64> = (0..4096).collect();
+    let mut chunks = [payload.clone()];
+    let h = pageout(&mut chunks);
+    let mut dst = Vec::new();
+    take(h, &mut dst);
+    assert_eq!(dst, payload);
+    set_backend(Backend::Swap);
+}
+
+#[test]
+fn handle_survives_backend_flip() {
+    ensure_scratch();
+    set_backend(Backend::File);
+    let payload: Vec<u64> = (0..256).collect();
+    let mut chunks = [payload.clone()];
+    let h: Handle = pageout(&mut chunks);
+
+    // Flip to Swap; existing handle should still be readable as File.
+    set_backend(Backend::Swap);
+
+    let mut dst = Vec::new();
+    read_at(&h, 0, payload.len(), &mut dst);
+    assert_eq!(dst, payload);
+
+    let mut dst2 = Vec::new();
+    take(h, &mut dst2);
+    assert_eq!(dst2, payload);
+}
+
+#[test]
+fn empty_input_yields_zero_len_handle() {
+    set_backend(Backend::Swap);
+    let mut chunks: [Vec<u64>; 0] = [];
+    let h = pageout(&mut chunks);
+    assert_eq!(h.len(), 0);
+    assert!(h.is_empty());
+}
+
+#[test]
+fn scatter_round_trip() {
+    set_backend(Backend::Swap);
+    let mut chunks = [vec![1u64, 2, 3], vec![4, 5], vec![6, 7, 8, 9]];
+    let h = pageout(&mut chunks);
+    assert_eq!(h.len(), 9);
+    let mut dst = Vec::new();
+    take(h, &mut dst);
+    assert_eq!(dst, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+}

--- a/src/ore/tests/pager_integration.rs
+++ b/src/ore/tests/pager_integration.rs
@@ -1,3 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![cfg(feature = "pager")]
 
 use mz_ore::pager::{Backend, Handle, pageout, read_at, set_backend, set_scratch_dir, take};
@@ -9,7 +24,7 @@ fn ensure_scratch() {
     set_scratch_dir(dir.path().to_owned());
 }
 
-#[test]
+#[test] // allow(test-attribute)
 fn round_trip_swap() {
     set_backend(Backend::Swap);
     let payload: Vec<u64> = (0..1024).collect();
@@ -20,7 +35,7 @@ fn round_trip_swap() {
     assert_eq!(dst, payload);
 }
 
-#[test]
+#[test] // allow(test-attribute)
 fn round_trip_file() {
     ensure_scratch();
     set_backend(Backend::File);
@@ -33,7 +48,7 @@ fn round_trip_file() {
     set_backend(Backend::Swap);
 }
 
-#[test]
+#[test] // allow(test-attribute)
 fn handle_survives_backend_flip() {
     ensure_scratch();
     set_backend(Backend::File);
@@ -53,7 +68,7 @@ fn handle_survives_backend_flip() {
     assert_eq!(dst2, payload);
 }
 
-#[test]
+#[test] // allow(test-attribute)
 fn empty_input_yields_zero_len_handle() {
     set_backend(Backend::Swap);
     let mut chunks: [Vec<u64>; 0] = [];
@@ -62,7 +77,7 @@ fn empty_input_yields_zero_len_handle() {
     assert!(h.is_empty());
 }
 
-#[test]
+#[test] // allow(test-attribute)
 fn scatter_round_trip() {
     set_backend(Backend::Swap);
     let mut chunks = [vec![1u64, 2, 3], vec![4, 5], vec![6, 7, 8, 9]];

--- a/src/ore/tests/pager_integration.rs
+++ b/src/ore/tests/pager_integration.rs
@@ -78,6 +78,20 @@ fn empty_input_yields_zero_len_handle() {
 }
 
 #[test] // allow(test-attribute)
+fn empty_input_file_backend_round_trip() {
+    ensure_scratch();
+    set_backend(Backend::File);
+    let mut chunks: [Vec<u64>; 0] = [];
+    let h = pageout(&mut chunks);
+    assert_eq!(h.len(), 0);
+    assert!(h.is_empty());
+    let mut dst = vec![42u64];
+    take(h, &mut dst);
+    assert!(dst.is_empty());
+    set_backend(Backend::Swap);
+}
+
+#[test] // allow(test-attribute)
 fn scatter_round_trip() {
     set_backend(Backend::Swap);
     let mut chunks = [vec![1u64, 2, 3], vec![4, 5], vec![6, 7, 8, 9]];

--- a/src/ore/tests/pager_integration.rs
+++ b/src/ore/tests/pager_integration.rs
@@ -15,7 +15,10 @@
 
 #![cfg(feature = "pager")]
 
-use mz_ore::pager::{Backend, Handle, pageout, read_at, set_backend, set_scratch_dir, take};
+use mz_ore::pager::{
+    Backend, Handle, pageout, read_at, set_backend, set_scratch_dir, take, try_pageout,
+    try_read_at, try_take,
+};
 use tempfile::tempdir;
 
 fn ensure_scratch() {
@@ -75,6 +78,35 @@ fn empty_input_yields_zero_len_handle() {
     let h = pageout(&mut chunks);
     assert_eq!(h.len(), 0);
     assert!(h.is_empty());
+}
+
+#[test] // allow(test-attribute)
+fn try_api_swap_round_trip() {
+    set_backend(Backend::Swap);
+    let payload: Vec<u64> = (0..128).collect();
+    let mut chunks = [payload.clone()];
+    let h = try_pageout(&mut chunks).expect("swap pageout cannot fail");
+
+    let mut dst = Vec::new();
+    try_read_at(&h, 0, payload.len(), &mut dst).expect("swap read_at cannot fail");
+    assert_eq!(dst, payload);
+
+    let mut dst2 = Vec::new();
+    try_take(h, &mut dst2).expect("swap take cannot fail");
+    assert_eq!(dst2, payload);
+}
+
+#[test] // allow(test-attribute)
+fn try_api_file_round_trip() {
+    ensure_scratch();
+    set_backend(Backend::File);
+    let payload: Vec<u64> = (0..256).collect();
+    let mut chunks = [payload.clone()];
+    let h = try_pageout(&mut chunks).expect("file pageout should succeed on healthy scratch");
+    let mut dst = Vec::new();
+    try_take(h, &mut dst).expect("file take should succeed on healthy scratch");
+    assert_eq!(dst, payload);
+    set_backend(Backend::Swap);
 }
 
 #[test] // allow(test-attribute)


### PR DESCRIPTION
### Motivation

CLU-65: introduce an explicit pager so we can mark cold columnar data and pull it back on demand, choosing at runtime between an `MADV_COLD`-based swap backend and a file-backed scratch backend. Today Materialize spills to Linux swap and pays direct-reclaim latency on user threads. Design lives at `doc/developer/design/20260504_pager.md`.

Depends on CLU-64 (`Column::Aligned` becomes `Vec<u64>`), which makes columnar buffers a natural caller.

### Description

`mz_ore::pager` exposes a small handle-oriented API (`pageout`, `read_at_many`, `read_at`, `take`) over a global atomic backend selector. The handle's backend is fixed at `pageout` time so live config flips do not invalidate existing data. Two backends:

* `Swap` keeps the input `Vec<u64>` chains resident and calls `MADV_COLD` on the page-aligned subrange. Reads `extend_from_slice` across chunk boundaries; `take` is zero-copy when the handle holds a single chunk.
* `File` writes one named scratch file per handle in a per-process subdirectory under the configured scratch root. No file descriptor is retained across calls — `pageout` opens, vector-writes via `Write::write_vectored`, and closes; reads reopen and `pread`. A reaper sweeps stale subdirectories from crashed predecessors at config time.

Documented as `doc/developer/design/20260504_pager.md`.

### Verification

Unit + integration tests cover round-trip on both backends, scatter/gather correctness, drop-without-take reclaim, the swap fast path's pointer identity, and backend flip mid-process.

Two micro-benches plus a merge-batcher example (`cargo run --release --features pager --example pager_merge`) for sizing the swap-vs-file trade-off under real memory pressure. Sanity numbers on a 32 GiB working set with 16 GiB cap, ext4 scratch: file finishes the merge pass in ~67 s vs swap's ~210 s, dominated by swap-in TLB shootdowns on the swap path.