### PR TITLE
[SSO] Wire JWT group-to-role sync into login and add edge case handling

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -928,6 +928,10 @@ impl Catalog {
         self.state.try_get_role_by_name(role_name)
     }
 
+    pub fn try_get_role_by_name_case_insensitive(&self, role_name: &str) -> Option<&Role> {
+        self.state.try_get_role_by_name_case_insensitive(role_name)
+    }
+
     pub fn try_get_role_auth_by_id(&self, id: &RoleId) -> Option<&RoleAuth> {
         self.state.try_get_role_auth_by_id(id)
     }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -932,6 +932,10 @@ impl Catalog {
         self.state.try_get_role_by_name_case_insensitive(role_name)
     }
 
+    pub fn roles_by_lowercase_name(&self) -> BTreeMap<String, &Role> {
+        self.state.roles_by_lowercase_name()
+    }
+
     pub fn try_get_role_auth_by_id(&self, id: &RoleId) -> Option<&RoleAuth> {
         self.state.try_get_role_auth_by_id(id)
     }

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -928,6 +928,17 @@ impl CatalogState {
             .map(|(_, id)| &self.roles_by_id[id])
     }
 
+    /// Returns a map from lowercased role name to `Role` for all roles.
+    ///
+    /// Use this when doing multiple case-insensitive lookups (e.g. iterating
+    /// JWT group claims) to avoid O(n) per lookup.
+    pub fn roles_by_lowercase_name(&self) -> BTreeMap<String, &Role> {
+        self.roles_by_name
+            .iter()
+            .map(|(name, id)| (name.to_lowercase(), &self.roles_by_id[id]))
+            .collect()
+    }
+
     pub(super) fn get_role_auth(&self, id: &RoleId) -> &RoleAuth {
         self.role_auth_by_id
             .get(id)

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -914,6 +914,20 @@ impl CatalogState {
             .map(|id| &self.roles_by_id[id])
     }
 
+    /// Case-insensitive role lookup for JWT group-to-role sync.
+    ///
+    /// Groups from JWTs are lowercased during extraction. SQL role names are
+    /// stored as-is (unquoted identifiers are lowercased by the parser, but
+    /// quoted identifiers preserve case). This method iterates all roles to
+    /// find a case-insensitive match.
+    pub fn try_get_role_by_name_case_insensitive(&self, role_name: &str) -> Option<&Role> {
+        let lower = role_name.to_lowercase();
+        self.roles_by_name
+            .iter()
+            .find(|(name, _)| name.to_lowercase() == lower)
+            .map(|(_, id)| &self.roles_by_id[id])
+    }
+
     pub(super) fn get_role_auth(&self, id: &RoleId) -> &RoleAuth {
         self.role_auth_by_id
             .get(id)

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -774,7 +774,10 @@ impl Coordinator {
         notice_tx: mpsc::UnboundedSender<AdapterNotice>,
     ) {
         // Early return if successful, otherwise cleanup any possible state.
-        match self.handle_startup_inner(&user, &conn_id, &client_ip).await {
+        match self
+            .handle_startup_inner(&user, &conn_id, &client_ip, &notice_tx)
+            .await
+        {
             Ok((role_id, superuser_attribute, session_defaults)) => {
                 let session_type = metrics::session_type_label_value(&user);
                 self.metrics
@@ -877,6 +880,7 @@ impl Coordinator {
         user: &User,
         _conn_id: &ConnectionId,
         client_ip: &Option<IpAddr>,
+        notice_tx: &mpsc::UnboundedSender<AdapterNotice>,
     ) -> Result<(RoleId, SuperuserAttribute, BTreeMap<String, OwnedVarInput>), AdapterError> {
         if self.catalog().try_get_role_by_name(&user.name).is_none() {
             // If the user has made it to this point, that means they have been fully authenticated.
@@ -913,8 +917,12 @@ impl Coordinator {
             .try_get_role_by_name(&user.name)
             .expect("created above");
         let role_id = role.id;
-
         let superuser_attribute = role.attributes.superuser;
+
+        // JWT group-to-role sync: reconcile role memberships with JWT group claims.
+        // Missing groups claim (None) → skip sync; empty (Some([])) → revoke all.
+        self.maybe_sync_jwt_groups(role_id, user.groups.as_deref(), notice_tx)
+            .await?;
 
         if role_id.is_user() && !ALLOW_USER_SESSIONS.get(self.catalog().system_config().dyncfgs()) {
             return Err(AdapterError::UserSessionsDisallowed);

--- a/src/adapter/src/coord/group_sync.rs
+++ b/src/adapter/src/coord/group_sync.rs
@@ -16,14 +16,19 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use mz_adapter_types::dyncfgs::{OIDC_GROUP_ROLE_SYNC_ENABLED, OIDC_GROUP_ROLE_SYNC_STRICT};
 use mz_repr::role_id::RoleId;
 use mz_sql::session::user::MZ_JWT_SYNC_ROLE_ID;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
 
-use crate::catalog::Op;
+use crate::AdapterError;
+use crate::catalog::{self, Op};
+use crate::coord::Coordinator;
+use crate::notice::AdapterNotice;
 
 /// Result of computing the group-to-role membership sync diff.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // used in tests; will be consumed by login path in a follow-up
 pub struct GroupSyncDiff {
     /// Roles to grant to the user (with sentinel grantor).
     pub grants: Vec<Op>,
@@ -38,9 +43,8 @@ pub struct GroupSyncDiff {
 /// - `member_id`: The user's role ID.
 /// - `current_membership`: The user's current `RoleMembership.map`
 ///   (role_id → grantor_id).
-/// - `target_role_ids`: Role IDs resolved from the JWT group names. Callers must
-///   lowercase JWT group names before catalog lookup since SQL role names are stored
-///   lowercase.
+/// - `target_role_ids`: Role IDs resolved from the JWT group names via
+///   case-insensitive catalog lookup.
 ///
 /// # Semantics
 /// - Only roles granted by the JWT sync sentinel (`MZ_JWT_SYNC_ROLE_ID`)
@@ -48,7 +52,6 @@ pub struct GroupSyncDiff {
 /// - Manually-granted roles (grantor != sentinel) are never revoked.
 /// - If a target role is already manually granted, it is skipped — the
 ///   manual grant takes precedence and we don't overwrite the grantor.
-#[allow(dead_code)] // used in tests; will be called from login path in a follow-up
 pub fn compute_group_sync_diff(
     member_id: RoleId,
     current_membership: &BTreeMap<RoleId, RoleId>,
@@ -91,9 +94,132 @@ pub fn compute_group_sync_diff(
     GroupSyncDiff { grants, revokes }
 }
 
+impl Coordinator {
+    /// Top-level entry point for JWT group-to-role sync during connection startup.
+    ///
+    /// Checks whether sync is enabled and whether the user has group claims,
+    /// then delegates to [`Self::sync_jwt_groups`]. Handles strict vs fail-open
+    /// error semantics and delivers notices to the client via `notice_tx`.
+    ///
+    /// - `groups == None` (claim absent) → skip sync entirely, preserving current state.
+    /// - `groups == Some([])` (empty claim) → revoke all sync-granted roles.
+    /// - Strict mode (`oidc_group_role_sync_strict`) → reject login on sync failure.
+    /// - Fail-open (default) → log warning, send notice, continue login.
+    pub(crate) async fn maybe_sync_jwt_groups(
+        &mut self,
+        member_id: RoleId,
+        groups: Option<&[String]>,
+        notice_tx: &mpsc::UnboundedSender<AdapterNotice>,
+    ) -> Result<(), AdapterError> {
+        let groups = match groups {
+            Some(g) => g,
+            None => return Ok(()),
+        };
+
+        let dyncfgs = self.catalog().system_config().dyncfgs();
+        let sync_enabled = OIDC_GROUP_ROLE_SYNC_ENABLED.get(dyncfgs);
+        let strict = OIDC_GROUP_ROLE_SYNC_STRICT.get(dyncfgs);
+
+        if !sync_enabled {
+            return Ok(());
+        }
+
+        let mut notices = Vec::new();
+        match self.sync_jwt_groups(member_id, groups, &mut notices).await {
+            Ok(()) => {}
+            Err(e) => {
+                if strict {
+                    return Err(AdapterError::OidcGroupSyncFailed(e.to_string()));
+                } else {
+                    warn!(
+                        error = %e,
+                        "OIDC group sync failed, proceeding with login (fail-open mode)"
+                    );
+                    notices.push(AdapterNotice::OidcGroupSyncError {
+                        message: e.to_string(),
+                    });
+                }
+            }
+        }
+        for notice in notices {
+            let _ = notice_tx.send(notice);
+        }
+        Ok(())
+    }
+
+    /// Syncs the user's role memberships based on JWT group claims.
+    ///
+    /// Resolves group names to catalog role IDs (case-insensitive),
+    /// computes the diff against current memberships, and executes
+    /// grant/revoke operations via `catalog_transact`.
+    ///
+    /// Groups that map to reserved role names (`mz_`/`pg_` prefixes) are
+    /// filtered out with a warning notice. Groups with no matching catalog
+    /// role produce an informational notice.
+    pub(crate) async fn sync_jwt_groups(
+        &mut self,
+        member_id: RoleId,
+        groups: &[String],
+        notices: &mut Vec<AdapterNotice>,
+    ) -> Result<(), AdapterError> {
+        // Resolve group names to role IDs (case-insensitive).
+        let mut target_role_ids = BTreeSet::new();
+        for group in groups {
+            // Filter out reserved role names (mz_/pg_ prefixes, PUBLIC).
+            if catalog::is_reserved_role_name(group) {
+                warn!(
+                    group = group.as_str(),
+                    "OIDC group maps to reserved role name, skipping"
+                );
+                notices.push(AdapterNotice::OidcGroupSyncReservedRole {
+                    group: group.clone(),
+                });
+                continue;
+            }
+
+            match self.catalog().try_get_role_by_name_case_insensitive(group) {
+                Some(role) => {
+                    target_role_ids.insert(role.id);
+                }
+                None => {
+                    info!(
+                        group = group.as_str(),
+                        "OIDC group has no matching Materialize role, skipping"
+                    );
+                    notices.push(AdapterNotice::OidcGroupSyncUnmatchedGroup {
+                        group: group.clone(),
+                    });
+                }
+            }
+        }
+
+        // Get the user's current memberships. Clone is needed to release the
+        // immutable catalog borrow before the mutable catalog_transact call below.
+        // This is cheap — role membership maps are typically small.
+        let current_membership = self.catalog().get_role(&member_id).membership.map.clone();
+
+        // Compute diff.
+        let diff = compute_group_sync_diff(member_id, &current_membership, &target_role_ids);
+
+        // Skip catalog_transact if no changes (common for reconnect with same groups).
+        if diff.grants.is_empty() && diff.revokes.is_empty() {
+            return Ok(());
+        }
+
+        // Execute ops: revoke first, then grant.
+        let mut ops = diff.revokes;
+        ops.extend(diff.grants);
+
+        self.catalog_transact(None, ops).await?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::catalog::is_reserved_role_name;
 
     fn user_id() -> RoleId {
         RoleId::User(100)
@@ -294,5 +420,74 @@ mod tests {
         assert_eq!(grant_role_ids(&diff), BTreeSet::from([role_d]));
         assert_eq!(diff.revokes.len(), 1);
         assert_eq!(revoke_role_ids(&diff), BTreeSet::from([role_c()]));
+    }
+
+    // --- Reserved role name filtering tests ---
+    // These verify the contract that `is_reserved_role_name` correctly
+    // identifies names that sync_jwt_groups should filter out.
+
+    #[mz_ore::test]
+    fn test_reserved_role_mz_prefix() {
+        assert!(is_reserved_role_name("mz_system"));
+        assert!(is_reserved_role_name("mz_introspection"));
+        assert!(is_reserved_role_name("mz_jwt_sync"));
+        assert!(is_reserved_role_name("mz_anything"));
+    }
+
+    #[mz_ore::test]
+    fn test_reserved_role_pg_prefix() {
+        assert!(is_reserved_role_name("pg_monitor"));
+        assert!(is_reserved_role_name("pg_read_all_data"));
+    }
+
+    #[mz_ore::test]
+    fn test_reserved_role_public() {
+        assert!(is_reserved_role_name("PUBLIC"));
+    }
+
+    #[mz_ore::test]
+    fn test_normal_role_names_not_reserved() {
+        assert!(!is_reserved_role_name("analytics"));
+        assert!(!is_reserved_role_name("platform_eng"));
+        assert!(!is_reserved_role_name("admin"));
+        assert!(!is_reserved_role_name("data_eng"));
+        // Prefix must be exact — "mzz_foo" or "pga_foo" are not reserved.
+        assert!(!is_reserved_role_name("mzz_custom"));
+        assert!(!is_reserved_role_name("pga_custom"));
+    }
+
+    // --- Diff tests for edge cases related to reserved role filtering ---
+    // When reserved roles are filtered out before reaching compute_group_sync_diff,
+    // the target set is effectively reduced. These tests verify the diff function
+    // handles the resulting scenarios correctly.
+
+    #[mz_ore::test]
+    fn test_all_reserved_filtered_results_in_empty_target() {
+        // If all groups are reserved and filtered, target is empty.
+        // Existing sync-granted roles should be revoked.
+        let current = BTreeMap::from([
+            (role_a(), MZ_JWT_SYNC_ROLE_ID),
+            (role_b(), MZ_JWT_SYNC_ROLE_ID),
+        ]);
+        let target = BTreeSet::new(); // empty after filtering
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 0);
+        assert_eq!(diff.revokes.len(), 2);
+        assert_eq!(revoke_role_ids(&diff), BTreeSet::from([role_a(), role_b()]));
+    }
+
+    #[mz_ore::test]
+    fn test_mixed_reserved_and_valid_after_filtering() {
+        // If some groups are reserved (filtered) and some are valid,
+        // only valid ones appear in target. This is the same as a
+        // partial target — only valid roles are granted.
+        let current = BTreeMap::new();
+        let target = BTreeSet::from([role_a()]); // role_b was reserved, filtered out
+        let diff = compute_group_sync_diff(user_id(), &current, &target);
+
+        assert_eq!(diff.grants.len(), 1);
+        assert_eq!(diff.revokes.len(), 0);
+        assert_eq!(grant_role_ids(&diff), BTreeSet::from([role_a()]));
     }
 }

--- a/src/adapter/src/coord/group_sync.rs
+++ b/src/adapter/src/coord/group_sync.rs
@@ -179,6 +179,17 @@ impl Coordinator {
 
             match self.catalog().try_get_role_by_name_case_insensitive(group) {
                 Some(role) => {
+                    // Skip if the group resolves to the user's own role. This
+                    // happens when an IdP echoes the username/email into the
+                    // groups claim. Granting a role to itself would trigger
+                    // the catalog's circular-membership guard.
+                    if role.id == member_id {
+                        info!(
+                            group = group.as_str(),
+                            "OIDC group maps to the user's own role, skipping"
+                        );
+                        continue;
+                    }
                     target_role_ids.insert(role.id);
                 }
                 None => {

--- a/src/adapter/src/coord/group_sync.rs
+++ b/src/adapter/src/coord/group_sync.rs
@@ -162,7 +162,6 @@ impl Coordinator {
         groups: &[String],
         notices: &mut Vec<AdapterNotice>,
     ) -> Result<(), AdapterError> {
-        // Build a lowercase name → role map once to avoid O(n) catalog scan per group.
         let role_map = self.catalog().roles_by_lowercase_name();
 
         // Resolve group names to role IDs (case-insensitive).

--- a/src/adapter/src/coord/group_sync.rs
+++ b/src/adapter/src/coord/group_sync.rs
@@ -162,6 +162,9 @@ impl Coordinator {
         groups: &[String],
         notices: &mut Vec<AdapterNotice>,
     ) -> Result<(), AdapterError> {
+        // Build a lowercase name → role map once to avoid O(n) catalog scan per group.
+        let role_map = self.catalog().roles_by_lowercase_name();
+
         // Resolve group names to role IDs (case-insensitive).
         let mut target_role_ids = BTreeSet::new();
         for group in groups {
@@ -177,7 +180,7 @@ impl Coordinator {
                 continue;
             }
 
-            match self.catalog().try_get_role_by_name_case_insensitive(group) {
+            match role_map.get(&group.to_lowercase()).copied() {
                 Some(role) => {
                     // Skip if the group resolves to the user's own role. This
                     // happens when an IdP echoes the username/email into the

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -265,6 +265,8 @@ pub enum AdapterError {
     ImpossibleTimestampConstraints {
         constraints: String,
     },
+    /// OIDC group-to-role sync failed and strict mode is enabled.
+    OidcGroupSyncFailed(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -725,6 +727,7 @@ impl AdapterError {
             }
             // similar to AbsurdSubscribeBounds
             AdapterError::ImpossibleTimestampConstraints { .. } => SqlState::DATA_EXCEPTION,
+            AdapterError::OidcGroupSyncFailed(_) => SqlState::INTERNAL_ERROR,
         }
     }
 
@@ -1139,6 +1142,9 @@ impl fmt::Display for AdapterError {
             }
             AdapterError::ImpossibleTimestampConstraints { .. } => {
                 write!(f, "could not find a valid timestamp for the query")
+            }
+            AdapterError::OidcGroupSyncFailed(msg) => {
+                write!(f, "OIDC group-to-role sync failed: {msg}")
             }
         }
     }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -136,6 +136,18 @@ pub enum AdapterNotice {
     PlanInsights(String),
     IntrospectionClusterUsage,
     AutoRouteIntrospectionQueriesUsage,
+    /// An OIDC group has no matching Materialize role.
+    OidcGroupSyncUnmatchedGroup {
+        group: String,
+    },
+    /// An OIDC group maps to a reserved role name (mz_/pg_ prefix).
+    OidcGroupSyncReservedRole {
+        group: String,
+    },
+    /// OIDC group sync encountered an error (fail-open mode).
+    OidcGroupSyncError {
+        message: String,
+    },
 }
 
 impl AdapterNotice {
@@ -203,6 +215,9 @@ impl AdapterNotice {
             AdapterNotice::PlanInsights(_) => Severity::Notice,
             AdapterNotice::IntrospectionClusterUsage => Severity::Warning,
             AdapterNotice::AutoRouteIntrospectionQueriesUsage => Severity::Warning,
+            AdapterNotice::OidcGroupSyncUnmatchedGroup { .. } => Severity::Notice,
+            AdapterNotice::OidcGroupSyncReservedRole { .. } => Severity::Warning,
+            AdapterNotice::OidcGroupSyncError { .. } => Severity::Warning,
         }
     }
 
@@ -312,6 +327,9 @@ impl AdapterNotice {
             AdapterNotice::PlanInsights(_) => SqlState::from_code("MZ001"),
             AdapterNotice::IntrospectionClusterUsage => SqlState::WARNING,
             AdapterNotice::AutoRouteIntrospectionQueriesUsage => SqlState::WARNING,
+            AdapterNotice::OidcGroupSyncUnmatchedGroup { .. } => SqlState::SUCCESSFUL_COMPLETION,
+            AdapterNotice::OidcGroupSyncReservedRole { .. } => SqlState::WARNING,
+            AdapterNotice::OidcGroupSyncError { .. } => SqlState::WARNING,
         }
     }
 }
@@ -500,6 +518,23 @@ impl fmt::Display for AdapterNotice {
                 f,
                 "The auto_route_introspection_queries variable has been renamed to auto_route_catalog_queries."
             ),
+            AdapterNotice::OidcGroupSyncUnmatchedGroup { group } => {
+                write!(
+                    f,
+                    "OIDC group \"{}\" has no matching Materialize role, skipping",
+                    group
+                )
+            }
+            AdapterNotice::OidcGroupSyncReservedRole { group } => {
+                write!(
+                    f,
+                    "OIDC group \"{}\" maps to a reserved role name, skipping",
+                    group
+                )
+            }
+            AdapterNotice::OidcGroupSyncError { message } => {
+                write!(f, "OIDC group-to-role sync failed: {}", message)
+            }
         }
     }
 }

--- a/src/authenticator/src/oidc.rs
+++ b/src/authenticator/src/oidc.rs
@@ -296,7 +296,6 @@ impl OidcClaims {
 pub struct ValidatedClaims {
     pub user: String,
     /// Groups extracted from the JWT group claim. None if claim absent.
-    #[zeroize(skip)]
     pub groups: Option<Vec<String>>,
     // Prevent construction outside of `GenericOidcAuthenticator::validate_token`.
     _private: (),

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -5428,3 +5428,154 @@ async fn test_auth_oidc_non_login_role() {
     )
     .await;
 }
+
+/// Fetches the role names a user is a member of, sorted alphabetically.
+async fn fetch_user_role_memberships(
+    client: &tokio_postgres::Client,
+    user_name: &str,
+) -> Vec<String> {
+    let rows = client
+        .query(
+            "SELECT r.name FROM mz_role_members rm
+             JOIN mz_roles r ON rm.role_id = r.id
+             JOIN mz_roles m ON rm.member = m.id
+             WHERE m.name = $1
+             ORDER BY r.name",
+            &[&user_name],
+        )
+        .await
+        .unwrap();
+    rows.iter().map(|r| r.get(0)).collect()
+}
+
+/// Sets up a test harness with OIDC auth, creates roles, and enables group sync.
+/// Returns the server, admin client, OIDC mock server, and a TLS factory closure.
+async fn setup_group_sync_test() -> (
+    test_util::TestServer,
+    tokio_postgres::Client,
+    OidcMockServer,
+) {
+    let ca = Ca::new_root("test ca").unwrap();
+    let (server_cert, server_key) = ca
+        .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+        .unwrap();
+
+    let encoding_key = String::from_utf8(ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
+
+    let oidc_server = OidcMockServer::start(
+        None,
+        encoding_key,
+        "test-key-1".to_string(),
+        SYSTEM_TIME.clone(),
+        i64::try_from(EXPIRES_IN_SECS).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let server = test_util::TestHarness::default()
+        .with_tls(server_cert, server_key)
+        .with_oidc_auth(
+            Some(oidc_server.issuer.clone()),
+            Some("sub".to_string()),
+            None,
+        )
+        .start()
+        .await;
+
+    let admin_client = server.connect().internal().await.unwrap();
+
+    admin_client
+        .batch_execute("CREATE ROLE analytics")
+        .await
+        .unwrap();
+    admin_client
+        .batch_execute("CREATE ROLE platform_eng")
+        .await
+        .unwrap();
+    admin_client
+        .batch_execute("CREATE ROLE data_eng")
+        .await
+        .unwrap();
+
+    admin_client
+        .batch_execute("ALTER SYSTEM SET oidc_group_role_sync_enabled = true")
+        .await
+        .unwrap();
+
+    (server, admin_client, oidc_server)
+}
+
+const GROUP_SYNC_USER: &str = "alice@example.com";
+
+fn make_insecure_tls() -> postgres_openssl::MakeTlsConnector {
+    make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
+        Ok(b.set_verify(SslVerifyMode::NONE))
+    }))
+}
+
+/// Helper: connect as the OIDC user with the given token.
+async fn oidc_connect(
+    server: &test_util::TestServer,
+    token: &str,
+) -> Result<tokio_postgres::Client, anyhow::Error> {
+    server
+        .connect()
+        .ssl_mode(SslMode::Require)
+        .user(GROUP_SYNC_USER)
+        .password(token)
+        .options("--oidc_auth_enabled=true")
+        .with_tls(make_insecure_tls())
+        .await
+        .map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Helper: generate a JWT with the given groups claim.
+fn jwt_with_groups(oidc_server: &OidcMockServer, groups: serde_json::Value) -> String {
+    oidc_server.generate_jwt(
+        GROUP_SYNC_USER,
+        GenerateJwtOptions {
+            extra_claims: Some(BTreeMap::from([("groups".to_string(), groups)])),
+            ..Default::default()
+        },
+    )
+}
+
+/// First login grants roles from JWT groups, with correct grantor and audit log entries.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method`
+async fn test_oidc_group_sync_first_login() {
+    let (server, admin_client, oidc_server) = setup_group_sync_test().await;
+
+    let token = jwt_with_groups(
+        &oidc_server,
+        serde_json::json!(["analytics", "platform_eng"]),
+    );
+    let _client = oidc_connect(&server, &token)
+        .await
+        .expect("login should succeed");
+
+    let role_names = fetch_user_role_memberships(&admin_client, GROUP_SYNC_USER).await;
+    assert_eq!(
+        role_names,
+        vec!["analytics", "platform_eng"],
+        "first login should grant analytics and platform_eng"
+    );
+
+    // Verify grantor is mz_jwt_sync.
+    let rows = admin_client
+        .query(
+            "SELECT g.name as grantor
+             FROM mz_role_members rm
+             JOIN mz_roles m ON rm.member = m.id
+             JOIN mz_roles g ON rm.grantor = g.id
+             WHERE m.name = $1
+             ORDER BY g.name",
+            &[&GROUP_SYNC_USER],
+        )
+        .await
+        .unwrap();
+    for row in &rows {
+        let grantor: String = row.get(0);
+        assert_eq!(grantor, "mz_jwt_sync", "grantor should be mz_jwt_sync");
+    }
+}

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -5604,3 +5604,197 @@ async fn test_oidc_group_sync_self_named_group() {
         vec!["analytics"],
     );
 }
+
+/// HTTP Bearer auth triggers group sync the same as pgwire.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method`
+async fn test_oidc_group_sync_http() {
+    let (server, admin_client, oidc_server) = setup_group_sync_test().await;
+
+    let token = jwt_with_groups(&oidc_server, serde_json::json!(["analytics"]));
+
+    let uri = Uri::builder()
+        .scheme("https")
+        .authority(format!(
+            "{}:{}",
+            Ipv4Addr::LOCALHOST,
+            server.http_local_addr().port()
+        ))
+        .path_and_query("/api/sql")
+        .build()
+        .unwrap();
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+
+    let resp = hyper_util::client::legacy::Client::builder(TokioExecutor::new())
+        .build(make_http_tls(|b| Ok(b.set_verify(SslVerifyMode::NONE))))
+        .request({
+            let mut req = Request::post(&uri);
+            for (k, v) in headers.iter() {
+                req.headers_mut().unwrap().insert(k, v.clone());
+            }
+            req.headers_mut()
+                .unwrap()
+                .insert("Content-Type", HeaderValue::from_static("application/json"));
+            req.body(json!({ "query": "SELECT current_user()" }).to_string())
+                .unwrap()
+        })
+        .await
+        .expect("HTTP request should succeed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert_eq!(
+        fetch_user_role_memberships(&admin_client, GROUP_SYNC_USER).await,
+        vec!["analytics"],
+        "HTTP login should sync groups"
+    );
+}
+
+/// WebSocket Bearer auth triggers group sync the same as pgwire.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method`
+async fn test_oidc_group_sync_ws() {
+    let (server, admin_client, oidc_server) = setup_group_sync_test().await;
+
+    let token = jwt_with_groups(&oidc_server, serde_json::json!(["analytics"]));
+
+    let uri = Uri::builder()
+        .scheme("wss")
+        .authority(format!(
+            "{}:{}",
+            Ipv4Addr::LOCALHOST,
+            server.http_local_addr().port()
+        ))
+        .path_and_query("/api/experimental/sql")
+        .build()
+        .unwrap();
+
+    let request = ClientRequestBuilder::new(uri.clone());
+    let stream = make_ws_tls(&uri, |b| Ok(b.set_verify(SslVerifyMode::NONE)));
+    let (mut ws, _resp) = tungstenite::client(request, stream).unwrap();
+
+    let auth = WebSocketAuth::Bearer {
+        token: token.clone(),
+        options: BTreeMap::default(),
+    };
+    ws.send(Message::Text(serde_json::to_string(&auth).unwrap().into()))
+        .unwrap();
+    ws.send(Message::Text(
+        r#"{"query": "SELECT current_user()"}"#.into(),
+    ))
+    .unwrap();
+
+    // Drain messages until we see CommandComplete, confirming the query ran.
+    loop {
+        let msg = ws.read().unwrap();
+        if let Message::Text(text) = msg {
+            let resp: WebSocketResponse = serde_json::from_str(&text).unwrap();
+            if matches!(resp, WebSocketResponse::CommandComplete(_)) {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(
+        fetch_user_role_memberships(&admin_client, GROUP_SYNC_USER).await,
+        vec!["analytics"],
+        "WebSocket login should sync groups"
+    );
+}
+
+/// Trigger a circular-membership catalog error to force sync_jwt_groups to fail.
+///
+/// Setup: grant alice's own role to r_cycle, so r_cycle is a member of alice.
+/// Then a JWT with group "r_cycle" makes sync try to grant r_cycle to alice,
+/// which would create a cycle (alice → r_cycle → alice).
+async fn setup_circular_group(
+    admin_client: &tokio_postgres::Client,
+    oidc_server: &OidcMockServer,
+    server: &test_util::TestServer,
+) {
+    // First login (no groups) to auto-provision alice's role.
+    let token = oidc_server.generate_jwt(GROUP_SYNC_USER, GenerateJwtOptions::default());
+    oidc_connect(server, &token)
+        .await
+        .expect("first login should succeed");
+
+    admin_client
+        .batch_execute("CREATE ROLE r_cycle")
+        .await
+        .unwrap();
+    // r_cycle becomes a member of alice; granting r_cycle back to alice is circular.
+    admin_client
+        .batch_execute(r#"GRANT "alice@example.com" TO r_cycle"#)
+        .await
+        .unwrap();
+}
+
+/// In strict mode, a sync error rejects the login entirely.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method`
+async fn test_oidc_group_sync_strict_rejects_on_error() {
+    let (server, admin_client, oidc_server) = setup_group_sync_test().await;
+    setup_circular_group(&admin_client, &oidc_server, &server).await;
+
+    admin_client
+        .batch_execute("ALTER SYSTEM SET oidc_group_role_sync_strict = true")
+        .await
+        .unwrap();
+
+    let token = jwt_with_groups(&oidc_server, serde_json::json!(["r_cycle"]));
+    let err = oidc_connect(&server, &token)
+        .await
+        .expect_err("strict mode should reject login on sync error");
+
+    // oidc_connect wraps tokio_postgres::Error in anyhow; downcast to get the DbError message.
+    let db_err = err
+        .downcast_ref::<tokio_postgres::Error>()
+        .and_then(|e| e.as_db_error())
+        .unwrap_or_else(|| panic!("expected a DbError, got: {err}"));
+
+    assert!(
+        db_err.message().contains("OIDC group-to-role sync failed"),
+        "unexpected error message: {}",
+        db_err.message()
+    );
+}
+
+/// In fail-open mode (default), a sync error lets login succeed and delivers a warning notice.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method`
+async fn test_oidc_group_sync_fail_open_sends_notice() {
+    let (server, admin_client, oidc_server) = setup_group_sync_test().await;
+    setup_circular_group(&admin_client, &oidc_server, &server).await;
+
+    let token = jwt_with_groups(&oidc_server, serde_json::json!(["r_cycle"]));
+
+    // Notice delivery happens in a background task (see test_util.rs ConnectBuilder), so we use a
+    // channel to await it rather than reading a Mutex immediately after connect.
+    let (notice_tx, mut notice_rx) = tokio::sync::mpsc::unbounded_channel();
+    let _client = server
+        .connect()
+        .ssl_mode(SslMode::Require)
+        .user(GROUP_SYNC_USER)
+        .password(&token)
+        .options("--oidc_auth_enabled=true")
+        .notice_callback(move |n| notice_tx.send(n).expect("notice channel open"))
+        .with_tls(make_insecure_tls())
+        .await
+        .expect("fail-open: login should succeed despite sync error");
+
+    let notice = tokio::time::timeout(Duration::from_secs(5), notice_rx.recv())
+        .await
+        .expect("timed out waiting for sync-error notice")
+        .expect("notice channel closed");
+
+    assert!(
+        notice.message().contains("OIDC group-to-role sync failed"),
+        "unexpected notice message: {}",
+        notice.message()
+    );
+}

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -5579,3 +5579,28 @@ async fn test_oidc_group_sync_first_login() {
         assert_eq!(grantor, "mz_jwt_sync", "grantor should be mz_jwt_sync");
     }
 }
+
+/// A JWT groups claim containing the user's own role name (common when an IdP
+/// echoes the username/email into groups) must not fail with CircularRoleMembership.
+/// The self-referential group should be silently skipped; other valid groups apply.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method`
+async fn test_oidc_group_sync_self_named_group() {
+    let (server, admin_client, oidc_server) = setup_group_sync_test().await;
+    admin_client
+        .batch_execute("ALTER SYSTEM SET oidc_group_role_sync_strict = true")
+        .await
+        .unwrap();
+    // "Alice@Example.com" normalizes to "alice@example.com" == GROUP_SYNC_USER,
+    // so it resolves to the user's own role. It should be skipped; "analytics"
+    // should still be granted.
+    let token = jwt_with_groups(
+        &oidc_server,
+        serde_json::json!(["Alice@Example.com", "analytics"]),
+    );
+    oidc_connect(&server, &token).await.unwrap();
+    assert_eq!(
+        fetch_user_role_memberships(&admin_client, GROUP_SYNC_USER).await,
+        vec!["analytics"],
+    );
+}

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -2048,9 +2048,9 @@ async fn test_auth_oidc_authentication_claim_switch() {
     let token = oidc_server.generate_jwt(
         sub_user,
         GenerateJwtOptions {
-            unknown_claims: Some(BTreeMap::from([(
+            extra_claims: Some(BTreeMap::from([(
                 "email".to_string(),
-                email_user.to_string(),
+                serde_json::Value::String(email_user.to_string()),
             )])),
             ..Default::default()
         },

--- a/src/oidc-mock/src/lib.rs
+++ b/src/oidc-mock/src/lib.rs
@@ -96,8 +96,11 @@ pub struct GenerateJwtOptions<'a> {
     /// Audience claim. If None, uses empty array.
     /// Use `AudClaim::Single` for a single string or `AudClaim::Multiple` for an array.
     pub aud: Option<AudClaim>,
-    /// Additional claims.
+    /// Additional claims as string values.
     pub unknown_claims: Option<BTreeMap<String, String>>,
+    /// Additional claims as arbitrary JSON values (e.g., arrays for group claims).
+    /// These take precedence over `unknown_claims` for the same key.
+    pub extra_claims: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 /// OIDC mock server for testing.
@@ -199,13 +202,18 @@ impl OidcMockServer {
         let now_secs = i64::try_from(now_ms / 1000).expect("timestamp must fit in i64");
         let sub_claim_map = BTreeMap::from([("sub".to_string(), sub.to_string())]);
 
-        let unknown_claims = opts
+        let mut unknown_claims: BTreeMap<String, serde_json::Value> = opts
             .unknown_claims
             .unwrap_or_default()
             .into_iter()
             .chain(sub_claim_map)
-            .map(|(k, v)| (k, serde_json::Value::String(v.to_string())))
+            .map(|(k, v)| (k, serde_json::Value::String(v)))
             .collect();
+
+        // Merge extra_claims (arbitrary JSON values), overriding string values.
+        if let Some(extra) = opts.extra_claims {
+            unknown_claims.extend(extra);
+        }
 
         let claims = MockClaims {
             iss: opts.issuer.unwrap_or(&self.issuer).to_string(),

--- a/src/oidc-mock/src/lib.rs
+++ b/src/oidc-mock/src/lib.rs
@@ -96,10 +96,7 @@ pub struct GenerateJwtOptions<'a> {
     /// Audience claim. If None, uses empty array.
     /// Use `AudClaim::Single` for a single string or `AudClaim::Multiple` for an array.
     pub aud: Option<AudClaim>,
-    /// Additional claims as string values.
-    pub unknown_claims: Option<BTreeMap<String, String>>,
     /// Additional claims as arbitrary JSON values (e.g., arrays for group claims).
-    /// These take precedence over `unknown_claims` for the same key.
     pub extra_claims: Option<BTreeMap<String, serde_json::Value>>,
 }
 
@@ -202,15 +199,11 @@ impl OidcMockServer {
         let now_secs = i64::try_from(now_ms / 1000).expect("timestamp must fit in i64");
         let sub_claim_map = BTreeMap::from([("sub".to_string(), sub.to_string())]);
 
-        let mut unknown_claims: BTreeMap<String, serde_json::Value> = opts
-            .unknown_claims
-            .unwrap_or_default()
+        let mut unknown_claims: BTreeMap<String, serde_json::Value> = sub_claim_map
             .into_iter()
-            .chain(sub_claim_map)
             .map(|(k, v)| (k, serde_json::Value::String(v)))
             .collect();
 
-        // Merge extra_claims (arbitrary JSON values), overriding string values.
         if let Some(extra) = opts.extra_claims {
             unknown_claims.extend(extra);
         }


### PR DESCRIPTION
Problem:
Users authenticating via OIDC had no automatic mechanism to sync their JWT group claims to Materialize role memberships. Operators had to manually assign roles to each user, which didn't scale as group membership changed in the identity provider.

Solution:
- Call sync_jwt_groups in handle_startup_inner after role auto-provisioning when the user has OIDC groups and oidc_group_role_sync_enabled is true. Resolves group names to role IDs (case-insensitive) via try_get_role_by_name_case_insensitive on CatalogState.

- Filter reserved role names (mz_/pg_ prefixes, PUBLIC) with warnings.
- Strict mode: reject login on sync failure when oidc_group_role_sync_strict=true.
- Fail-open mode (default): log warning and continue on sync failure.
- Send client NOTICEs for unmatched groups, reserved roles, and sync errors.
- Pass notice_tx to handle_startup_inner for pre-session notice delivery.
- Missing groups claim (None) skips sync; empty claim (Some([])) revokes all.

Test:
- Unit tests
- Small integration test

Fixes: SQL-181, SQL-182