### PR TITLE
Standardize name resolution in COPY FROM and AWS CONNECTION

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7102,6 +7102,7 @@ dependencies = [
  "http 1.4.0",
  "hyper-tls 0.6.0",
  "hyper-util",
+ "ipnet",
  "itertools 0.14.0",
  "lgalloc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5731,11 +5731,13 @@ dependencies = [
  "bytesize",
  "futures",
  "http 1.4.0",
+ "hyper 0.14.32",
  "hyper-tls 0.5.0",
  "mz-ore",
  "pin-project",
  "thiserror 2.0.18",
  "tokio",
+ "tower-service",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,8 +360,12 @@ http-body-util = "0.1.3"
 httparse = "1.8.0"
 humantime = "2.3.0"
 hyper = { version = "1.9.0", features = ["http1", "server"] }
+# hyper 0.14 is used by AWS SDK. Used to override the DNS resolver used by the SDK,
+# which can only be done by constructing the HTTP Client
+hyper-0-14 = { package = "hyper", version = "0.14", features = ["client", "tcp"] }
 hyper-openssl = "0.10.2"
 hyper-util = "0.1.20"
+tower-service = "0.3.3"
 iceberg = "0.7.0"
 iceberg-catalog-rest = "0.7.0"
 imbl = { version = "7.0.0", features = ["serde"] }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -471,6 +471,9 @@ impl Coordinator {
                     // Spawn a background task to perform the slow S3 preflight operations.
                     // This avoids blocking the coordinator's main task.
                     let connection_context = self.connection_context().clone();
+                    let enforce_external_addresses =
+                        mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+                            .get(self.controller.storage.config().config_set());
                     task::spawn(|| "copy_to_preflight", async move {
                         let result = mz_storage_types::sinks::s3_oneshot_sink::preflight(
                             connection_context,
@@ -478,6 +481,7 @@ impl Coordinator {
                             &s3_sink_connection.upload_info,
                             s3_sink_connection.connection_id,
                             sink_id,
+                            enforce_external_addresses,
                         )
                         .await
                         .map_err(AdapterError::from);

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -119,6 +119,20 @@ impl Coordinator {
                     .map_err(|err| AdapterError::Unstructured(anyhow::anyhow!("{err}")));
                 let url = return_if_err!(result, ctx);
 
+                // Only allow http(s) schemes. Technically we would fail later, as the current
+                // crate (reqwest) doesn't support other schemes.
+                // Prefer to fail early and explicitly in case the downstream ever changes.
+                // DNS resolution checks are performed at execution time to avoid stalls
+                // during sequencing.
+                match url.scheme() {
+                    "http" | "https" => {}
+                    other => {
+                        return ctx.retire(Err(AdapterError::Unstructured(anyhow::anyhow!(
+                            "only 'http://' and 'https://' urls are supported as COPY FROM \
+                             target, got '{other}://'"
+                        ))));
+                    }
+                }
                 mz_storage_types::oneshot_sources::ContentSource::Http { url }
             }
             CopyFromSource::AwsS3 {

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -122,8 +122,9 @@ impl Coordinator {
                 // Only allow http(s) schemes. Technically we would fail later, as the current
                 // crate (reqwest) doesn't support other schemes.
                 // Prefer to fail early and explicitly in case the downstream ever changes.
-                // DNS resolution checks are performed at execution time to avoid stalls
-                // during sequencing.
+                // DNS resolution for hostnames is performed at execution time to avoid stalls
+                // during sequencing; IP-literal hosts are validated here because reqwest's
+                // custom DNS resolver is only invoked for hostnames.
                 match url.scheme() {
                     "http" | "https" => {}
                     other => {
@@ -131,6 +132,15 @@ impl Coordinator {
                             "only 'http://' and 'https://' urls are supported as COPY FROM \
                              target, got '{other}://'"
                         ))));
+                    }
+                }
+                let enforce_external_addresses =
+                    mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+                        .get(self.controller.storage.config().config_set());
+                if enforce_external_addresses {
+                    if let Err(err) = mz_ore::netio::ensure_url_ip_global(&url) {
+                        return ctx
+                            .retire(Err(AdapterError::Unstructured(anyhow::anyhow!("{err}"))));
                     }
                 }
                 mz_storage_types::oneshot_sources::ContentSource::Http { url }

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -921,9 +921,11 @@ impl Coordinator {
         copy_to: PeekStageCopyTo,
     ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         let connection_context = self.connection_context().clone();
+        let enforce_external_addresses = mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+            .get(self.controller.storage.config().config_set());
         Ok(StageResult::Handle(mz_ore::task::spawn(
             || "peek copy to preflight",
-            async {
+            async move {
                 let sinks = &copy_to.global_lir_plan.df_desc().sink_exports;
                 if sinks.len() != 1 {
                     return Err(AdapterError::Internal(
@@ -941,6 +943,7 @@ impl Coordinator {
                             &conn.upload_info,
                             conn.connection_id,
                             *sink_id,
+                            enforce_external_addresses,
                         )
                         .await?;
                         Ok(Box::new(PeekStage::CopyToDataflow(copy_to)))

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -21,8 +21,10 @@ bytes.workspace = true
 bytesize.workspace = true
 futures.workspace = true
 http.workspace = true
+hyper-0-14.workspace = true
 hyper-tls = "0.5.0"
-mz-ore = { path = "../ore", features = ["async"], default-features = false }
+mz-ore = { path = "../ore", features = ["async", "network"], default-features = false }
+tower-service.workspace = true
 pin-project.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/src/aws-util/src/lib.rs
+++ b/src/aws-util/src/lib.rs
@@ -7,10 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use aws_config::{BehaviorVersion, ConfigLoader};
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
-use aws_smithy_runtime_api::client::http::HttpClient;
+use aws_smithy_runtime_api::client::http::{HttpClient, SharedHttpClient};
+use hyper_0_14::client::HttpConnector;
+use hyper_0_14::client::connect::dns::Name;
 use hyper_tls::HttpsConnector;
+use tower_service::Service;
 
 #[cfg(feature = "s3")]
 pub mod s3;
@@ -43,4 +51,55 @@ pub fn http_client() -> impl HttpClient {
     // The default AWS HTTP client uses rustls, while our company policy is to
     // use native TLS.
     HyperClientBuilder::new().build(HttpsConnector::new())
+}
+
+/// Returns an AWS SDK HTTP client whose DNS resolver delegates to
+/// [`mz_ore::netio::resolve_address`].
+///
+/// Only the IP resolution step is overridden — the SDK still uses the original
+/// hostname for SNI and TLS certificate validation, so HTTPS endpoints work
+/// unchanged.
+pub fn http_client_with_resolver(enforce_external_addresses: bool) -> SharedHttpClient {
+    let resolver = MzAwsResolver {
+        enforce_external_addresses,
+    };
+    let mut http = HttpConnector::new_with_resolver(resolver);
+    // The SDK speaks HTTPS to the public AWS API; the wrapper we build below
+    // handles TLS, but the underlying HTTP connector must allow non-`http://`
+    // schemes.
+    http.enforce_http(false);
+    let https = HttpsConnector::new_with_connector(http);
+    HyperClientBuilder::new().build(https)
+}
+
+/// A `tower_service::Service<Name>` resolver that delegates to
+/// [`mz_ore::netio::resolve_address`], used by [`http_client_with_resolver`].
+#[derive(Clone)]
+struct MzAwsResolver {
+    enforce_external_addresses: bool,
+}
+
+impl Service<Name> for MzAwsResolver {
+    type Response = std::vec::IntoIter<SocketAddr>;
+    type Error = mz_ore::netio::DnsResolutionError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, name: Name) -> Self::Future {
+        let enforce = self.enforce_external_addresses;
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let ips = mz_ore::netio::resolve_address(&host, enforce).await?;
+            // Hyper substitutes the URL's port (or the default for the scheme)
+            // when the SocketAddr's port is 0.
+            Ok(ips
+                .into_iter()
+                .map(|ip| SocketAddr::new(ip, 0))
+                .collect::<Vec<_>>()
+                .into_iter())
+        })
+    }
 }

--- a/src/aws-util/src/lib.rs
+++ b/src/aws-util/src/lib.rs
@@ -103,3 +103,57 @@ impl Service<Name> for MzAwsResolver {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::str::FromStr;
+
+    use mz_ore::netio::DnsResolutionError;
+
+    use super::*;
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolver_rejects_loopback_when_enforced() {
+        let mut resolver = MzAwsResolver {
+            enforce_external_addresses: true,
+        };
+        let name = Name::from_str("127.0.0.1").unwrap();
+        let err = resolver.call(name).await.expect_err("must reject loopback");
+        assert!(
+            matches!(err, DnsResolutionError::PrivateAddress),
+            "got {err:?}"
+        );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolver_allows_loopback_when_not_enforced() {
+        let mut resolver = MzAwsResolver {
+            enforce_external_addresses: false,
+        };
+        let name = Name::from_str("127.0.0.1").unwrap();
+        let addrs: Vec<SocketAddr> = resolver
+            .call(name)
+            .await
+            .expect("loopback should resolve when enforcement is off")
+            .collect();
+        assert!(addrs.iter().any(|a| a.ip() == IpAddr::from([127, 0, 0, 1])));
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolver_allows_public_when_enforced() {
+        let mut resolver = MzAwsResolver {
+            enforce_external_addresses: true,
+        };
+        let name = Name::from_str("8.8.8.8").unwrap();
+        let addrs: Vec<SocketAddr> = resolver
+            .call(name)
+            .await
+            .expect("public IP should resolve")
+            .collect();
+        assert!(addrs.iter().any(|a| a.ip() == IpAddr::from([8, 8, 8, 8])));
+    }
+}

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -116,6 +116,9 @@ impl<'scope> SinkRender<'scope> for CopyToS3OneshotSinkConnection {
         use timely::dataflow::operators::vec::Map;
         let error_stream = error_stream.map(|(err, time, diff)| (err.deserialize(), time, diff));
 
+        let enforce_external_addresses =
+            mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES.get(&compute_state.worker_config);
+
         let token = mz_storage_operators::s3_oneshot_sink::copy_to(
             input,
             error_stream,
@@ -128,6 +131,7 @@ impl<'scope> SinkRender<'scope> for CopyToS3OneshotSinkConnection {
             params,
             result_callback,
             self.output_batch_count,
+            enforce_external_addresses,
         );
 
         Some(token)

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -33,6 +33,7 @@ derivative.workspace = true
 either.workspace = true
 futures = { workspace = true, optional = true }
 hibitset = { workspace = true, optional = true }
+ipnet.workspace = true
 itertools.workspace = true
 lgalloc = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }

--- a/src/ore/src/netio.rs
+++ b/src/ore/src/netio.rs
@@ -23,7 +23,7 @@ mod socket;
 mod timeout;
 
 pub use crate::netio::async_ready::AsyncReady;
-pub use crate::netio::dns::{DnsResolutionError, resolve_address};
+pub use crate::netio::dns::{DnsResolutionError, ensure_url_ip_global, resolve_address};
 pub use crate::netio::framed::{FrameTooBig, MAX_FRAME_SIZE};
 pub use crate::netio::read_exact::{ReadExactOrEof, read_exact_or_eof};
 pub use crate::netio::socket::{Listener, SocketAddr, SocketAddrType, Stream, UnixSocketAddr};

--- a/src/ore/src/netio/dns.rs
+++ b/src/ore/src/netio/dns.rs
@@ -68,13 +68,40 @@ pub async fn resolve_address(
 }
 
 fn is_global(addr: IpAddr) -> bool {
-    // TODO: Switch to `addr.is_global()` once stable: https://github.com/rust-lang/rust/issues/27709
+    // TODO: Switch to `addr.is_global()` once stable:
+    // https://github.com/rust-lang/rust/issues/27709
     match addr {
-        IpAddr::V4(ip) => {
-            !(ip.is_unspecified() || ip.is_private() || ip.is_loopback() || ip.is_link_local())
+        IpAddr::V4(ip) => is_global_v4(ip),
+        IpAddr::V6(ip) => {
+            // Treat IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) as their
+            // underlying IPv4 address — connecting to `::ffff:127.0.0.1`
+            // reaches loopback on dual-stack sockets.
+            if let Some(v4) = ip.to_ipv4_mapped() {
+                return is_global_v4(v4);
+            }
+            let segments = ip.segments();
+            !(ip.is_loopback()
+                || ip.is_unspecified()
+                // link-local (fe80::/10)
+                || (segments[0] & 0xffc0) == 0xfe80
+                // unique local (fc00::/7)
+                || (segments[0] & 0xfe00) == 0xfc00)
         }
-        IpAddr::V6(ip) => !(ip.is_loopback() || ip.is_unspecified()),
     }
+}
+
+fn is_global_v4(ip: std::net::Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    !(ip.is_unspecified()
+        || ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        // shared address space / carrier-grade NAT (100.64.0.0/10)
+        || (octets[0] == 100 && (octets[1] & 0xc0) == 64)
+        // benchmarking (198.18.0.0/15)
+        || (octets[0] == 198 && (octets[1] & 0xfe) == 18))
 }
 
 #[cfg(test)]
@@ -126,6 +153,56 @@ mod tests {
             .await
             .expect("loopback should resolve when enforcement is off");
         assert!(ips.contains(&PRIVATE_V4.parse::<IpAddr>().unwrap()));
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_rejects_ipv4_mapped_loopback() {
+        let err = resolve_address("::ffff:127.0.0.1", true)
+            .await
+            .expect_err("IPv4-mapped loopback must be rejected");
+        assert!(
+            matches!(err, DnsResolutionError::PrivateAddress),
+            "got {err:?}"
+        );
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_rejects_ipv6_unique_local() {
+        let err = resolve_address("fc00::1", true)
+            .await
+            .expect_err("ULA must be rejected");
+        assert!(
+            matches!(err, DnsResolutionError::PrivateAddress),
+            "got {err:?}"
+        );
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_rejects_ipv6_link_local() {
+        let err = resolve_address("fe80::1", true)
+            .await
+            .expect_err("link-local must be rejected");
+        assert!(
+            matches!(err, DnsResolutionError::PrivateAddress),
+            "got {err:?}"
+        );
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_rejects_ipv4_cgnat() {
+        // 100.64.0.0/10 is the IETF shared-address-space range used for
+        // carrier-grade NAT — `Ipv4Addr::is_global` rejects it.
+        let err = resolve_address("100.64.0.1", true)
+            .await
+            .expect_err("CGNAT must be rejected");
+        assert!(
+            matches!(err, DnsResolutionError::PrivateAddress),
+            "got {err:?}"
+        );
     }
 
     #[crate::test(tokio::test)]

--- a/src/ore/src/netio/dns.rs
+++ b/src/ore/src/netio/dns.rs
@@ -67,6 +67,27 @@ pub async fn resolve_address(
     Ok(ips)
 }
 
+/// If `url`'s host is an IP literal, validates that it is a globally routable
+/// address, returning [`DnsResolutionError::PrivateAddress`] if not. Hostnames
+/// and URLs without a host are passed through; they are expected to be
+/// validated by a connector-level DNS resolver at connect time.
+///
+/// This closes the gap that reqwest/hyper custom DNS resolvers are only
+/// invoked for hostnames, so IP-literal URLs (e.g. `http://127.0.0.1`) would
+/// otherwise bypass global-address enforcement.
+pub fn ensure_url_ip_global(url: &url::Url) -> Result<(), DnsResolutionError> {
+    let ip = match url.host() {
+        Some(url::Host::Ipv4(ip)) => IpAddr::V4(ip),
+        Some(url::Host::Ipv6(ip)) => IpAddr::V6(ip),
+        Some(url::Host::Domain(_)) | None => return Ok(()),
+    };
+    if is_global(ip) {
+        Ok(())
+    } else {
+        Err(DnsResolutionError::PrivateAddress)
+    }
+}
+
 fn is_global(addr: IpAddr) -> bool {
     // TODO: Switch to `addr.is_global()` once stable:
     // https://github.com/rust-lang/rust/issues/27709

--- a/src/ore/src/netio/dns.rs
+++ b/src/ore/src/netio/dns.rs
@@ -76,3 +76,64 @@ fn is_global(addr: IpAddr) -> bool {
         IpAddr::V6(ip) => !(ip.is_loopback() || ip.is_unspecified()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Use IP literals so the tests don't depend on /etc/hosts or DNS.
+    const PRIVATE_V4: &str = "127.0.0.1";
+    const PUBLIC_V4: &str = "8.8.8.8";
+    const LOOPBACK_V6: &str = "::1";
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_rejects_loopback_v4_when_enforced() {
+        let err = resolve_address(PRIVATE_V4, true)
+            .await
+            .expect_err("loopback should be rejected");
+        assert!(
+            matches!(err, DnsResolutionError::PrivateAddress),
+            "got {err:?}"
+        );
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_rejects_loopback_v6_when_enforced() {
+        let err = resolve_address(LOOPBACK_V6, true)
+            .await
+            .expect_err("::1 should be rejected");
+        assert!(
+            matches!(err, DnsResolutionError::PrivateAddress),
+            "got {err:?}"
+        );
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_allows_public_v4_when_enforced() {
+        let ips = resolve_address(PUBLIC_V4, true)
+            .await
+            .expect("public IP should resolve");
+        assert!(ips.contains(&PUBLIC_V4.parse::<IpAddr>().unwrap()));
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_allows_loopback_when_not_enforced() {
+        let ips = resolve_address(PRIVATE_V4, false)
+            .await
+            .expect("loopback should resolve when enforcement is off");
+        assert!(ips.contains(&PRIVATE_V4.parse::<IpAddr>().unwrap()));
+    }
+
+    #[crate::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn resolve_address_strips_port() {
+        let ips = resolve_address(&format!("{PUBLIC_V4}:443"), true)
+            .await
+            .expect("host:port form should parse");
+        assert!(ips.contains(&PUBLIC_V4.parse::<IpAddr>().unwrap()));
+    }
+}

--- a/src/ore/src/netio/dns.rs
+++ b/src/ore/src/netio/dns.rs
@@ -15,8 +15,10 @@
 
 use std::collections::BTreeSet;
 use std::io;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::LazyLock;
 
+use ipnet::{Ipv4Net, Ipv6Net};
 use tokio::net::lookup_host;
 
 /// An error returned by `resolve_address`.
@@ -88,41 +90,66 @@ pub fn ensure_url_ip_global(url: &url::Url) -> Result<(), DnsResolutionError> {
     }
 }
 
+/// IPv4 CIDR blocks that are not globally routable. Anything outside this set
+/// is treated as a public address.
+// TODO: Switch to `Ipv4Addr::is_global()` once stable:
+// https://github.com/rust-lang/rust/issues/27709
+static V4_NON_GLOBAL: LazyLock<Vec<Ipv4Net>> = LazyLock::new(|| {
+    [
+        "0.0.0.0/8",       // unspecified / "this network"
+        "10.0.0.0/8",      // private (RFC 1918)
+        "100.64.0.0/10",   // shared address space / CGNAT (RFC 6598)
+        "127.0.0.0/8",     // loopback
+        "169.254.0.0/16",  // link-local
+        "172.16.0.0/12",   // private (RFC 1918)
+        "192.0.0.0/24",    // IETF protocol assignments
+        "192.0.2.0/24",    // documentation (TEST-NET-1)
+        "192.168.0.0/16",  // private (RFC 1918)
+        "198.18.0.0/15",   // benchmarking
+        "198.51.100.0/24", // documentation (TEST-NET-2)
+        "203.0.113.0/24",  // documentation (TEST-NET-3)
+        "224.0.0.0/4",     // multicast
+        "240.0.0.0/4",     // reserved (includes broadcast 255.255.255.255)
+    ]
+    .iter()
+    .map(|s| s.parse().expect("valid CIDR"))
+    .collect()
+});
+
+/// IPv6 CIDR blocks that are not globally routable.
+// TODO: Switch to `Ipv6Addr::is_global()` once stable:
+// https://github.com/rust-lang/rust/issues/27709
+static V6_NON_GLOBAL: LazyLock<Vec<Ipv6Net>> = LazyLock::new(|| {
+    [
+        "::/128",    // unspecified
+        "::1/128",   // loopback
+        "fc00::/7",  // unique local
+        "fe80::/10", // link-local
+    ]
+    .iter()
+    .map(|s| s.parse().expect("valid CIDR"))
+    .collect()
+});
+
 fn is_global(addr: IpAddr) -> bool {
-    // TODO: Switch to `addr.is_global()` once stable:
-    // https://github.com/rust-lang/rust/issues/27709
     match addr {
         IpAddr::V4(ip) => is_global_v4(ip),
-        IpAddr::V6(ip) => {
-            // Treat IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) as their
-            // underlying IPv4 address — connecting to `::ffff:127.0.0.1`
-            // reaches loopback on dual-stack sockets.
-            if let Some(v4) = ip.to_ipv4_mapped() {
-                return is_global_v4(v4);
-            }
-            let segments = ip.segments();
-            !(ip.is_loopback()
-                || ip.is_unspecified()
-                // link-local (fe80::/10)
-                || (segments[0] & 0xffc0) == 0xfe80
-                // unique local (fc00::/7)
-                || (segments[0] & 0xfe00) == 0xfc00)
-        }
+        IpAddr::V6(ip) => is_global_v6(ip),
     }
 }
 
-fn is_global_v4(ip: std::net::Ipv4Addr) -> bool {
-    let octets = ip.octets();
-    !(ip.is_unspecified()
-        || ip.is_private()
-        || ip.is_loopback()
-        || ip.is_link_local()
-        || ip.is_broadcast()
-        || ip.is_documentation()
-        // shared address space / carrier-grade NAT (100.64.0.0/10)
-        || (octets[0] == 100 && (octets[1] & 0xc0) == 64)
-        // benchmarking (198.18.0.0/15)
-        || (octets[0] == 198 && (octets[1] & 0xfe) == 18))
+fn is_global_v4(ip: Ipv4Addr) -> bool {
+    !V4_NON_GLOBAL.iter().any(|net| net.contains(&ip))
+}
+
+fn is_global_v6(ip: Ipv6Addr) -> bool {
+    // Treat IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) as their underlying
+    // IPv4 address — connecting to `::ffff:127.0.0.1` reaches loopback on
+    // dual-stack sockets.
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_global_v4(v4);
+    }
+    !V6_NON_GLOBAL.iter().any(|net| net.contains(&ip))
 }
 
 #[cfg(test)]

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -615,6 +615,8 @@ async fn purify_create_sink(
                     &storage_configuration.connection_context,
                     aws_conn_id.clone(),
                     InTask::No,
+                    mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+                        .get(storage_configuration.config_set()),
                 )
                 .await
                 .map_err(|e| IcebergSinkPurificationError::AwsSdkContextError(Arc::new(e)))?;

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -188,6 +188,7 @@ where
                 connection_context,
                 uri,
                 use_checksum,
+                enforce_external_addresses,
             );
             SourceKind::AwsS3(source)
         }

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -102,7 +102,9 @@ use tracing::info;
 
 use crate::oneshot_source::aws_source::{AwsS3Source, S3Checksum, S3Object};
 use crate::oneshot_source::csv::{CsvDecoder, CsvRecord, CsvWorkRequest};
-use crate::oneshot_source::http_source::{HttpChecksum, HttpObject, HttpOneshotSource};
+use crate::oneshot_source::http_source::{
+    HttpChecksum, HttpObject, HttpOneshotSource, build_http_client,
+};
 use crate::oneshot_source::parquet::{ParquetFormat, ParquetRowGroup, ParquetWorkRequest};
 
 pub mod csv;
@@ -137,6 +139,7 @@ pub fn render<'scope, F>(
     collection_id: GlobalId,
     collection_meta: CollectionMetadata,
     request: OneshotIngestionRequest,
+    enforce_external_addresses: bool,
     worker_callback: F,
 ) -> Vec<PressOnDropButton>
 where
@@ -151,7 +154,16 @@ where
 
     let source = match source {
         ContentSource::Http { url } => {
-            let source = HttpOneshotSource::new(reqwest::Client::default(), url);
+            let client = match build_http_client(enforce_external_addresses) {
+                Ok(client) => client,
+                Err(err) => {
+                    worker_callback(Err(format!(
+                        "failed to build HTTP client for COPY FROM: {err}"
+                    )));
+                    return Vec::new();
+                }
+            };
+            let source = HttpOneshotSource::new(client, url);
             SourceKind::Http(source)
         }
         ContentSource::AwsS3 {

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -72,6 +72,7 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use mz_expr::SafeMfpPlan;
 use mz_ore::cast::CastFrom;
+use mz_ore::error::ErrorExt;
 use mz_persist_client::Diagnostics;
 use mz_persist_client::batch::ProtoBatch;
 use mz_persist_client::cache::PersistClientCache;
@@ -1089,7 +1090,11 @@ impl From<csv_async::Error> for StorageErrorXKind {
 
 impl From<reqwest::Error> for StorageErrorXKind {
     fn from(err: reqwest::Error) -> Self {
-        StorageErrorXKind::Reqwest(err.to_string().into())
+        // Walk the source chain so that inner causes (like the custom DNS
+        // resolver's "Address resolved to a private IP" rejection) are
+        // visible. reqwest's top-level Display only says "error sending
+        // request for url ..." and hides the underlying cause.
+        StorageErrorXKind::Reqwest(err.to_string_with_causes().into())
     }
 }
 

--- a/src/storage-operators/src/oneshot_source/aws_source.rs
+++ b/src/storage-operators/src/oneshot_source/aws_source.rs
@@ -46,6 +46,7 @@ pub struct AwsS3Source {
     #[derivative(Debug = "ignore")]
     client: std::sync::OnceLock<mz_aws_util::s3::Client>,
     use_checksum: bool,
+    enforce_external_addresses: bool,
 }
 
 impl AwsS3Source {
@@ -55,6 +56,7 @@ impl AwsS3Source {
         context: ConnectionContext,
         uri: String,
         use_checksum: bool,
+        enforce_external_addresses: bool,
     ) -> Self {
         let uri = http::Uri::from_str(&uri).expect("validated URI in sequencing");
 
@@ -86,13 +88,19 @@ impl AwsS3Source {
             prefix,
             client: std::sync::OnceLock::new(),
             use_checksum,
+            enforce_external_addresses,
         }
     }
 
     pub async fn initialize(&self) -> Result<mz_aws_util::s3::Client, anyhow::Error> {
         let sdk_config = self
             .connection
-            .load_sdk_config(&self.context, self.connection_id, InTask::Yes)
+            .load_sdk_config(
+                &self.context,
+                self.connection_id,
+                InTask::Yes,
+                self.enforce_external_addresses,
+            )
             .await?;
 
         let mut s3_config_builder = aws_sdk_s3::config::Builder::from(&sdk_config)

--- a/src/storage-operators/src/oneshot_source/http_source.rs
+++ b/src/storage-operators/src/oneshot_source/http_source.rs
@@ -120,6 +120,67 @@ pub enum HttpChecksum {
     LastModified(String),
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `reqwest::dns::Name` has no public constructor, so we exercise
+    /// [`MzHttpResolver`] through a fully-built [`Client`]. `localhost`
+    /// resolves via /etc/hosts on supported platforms and stays inside the
+    /// resolver path (an IP literal would short-circuit DNS entirely).
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn build_http_client_rejects_localhost_when_enforced() {
+        let client = build_http_client(true).expect("build client");
+        let err = client
+            .get("http://localhost:1/")
+            .send()
+            .await
+            .expect_err("request must fail at DNS resolution");
+        // Walk the error chain for the resolver's PrivateAddress message —
+        // reqwest wraps it inside its connect error, so a `to_string()` on
+        // the top-level error is not enough.
+        let mut found = false;
+        let mut current: &dyn std::error::Error = &err;
+        loop {
+            if current.to_string().to_lowercase().contains("private") {
+                found = true;
+                break;
+            }
+            match current.source() {
+                Some(src) => current = src,
+                None => break,
+            }
+        }
+        assert!(found, "expected private-address rejection, got: {err:?}");
+    }
+
+    /// With enforcement off the resolver returns the loopback IP, so the
+    /// request reaches the connect stage and fails for a different reason
+    /// (port 1 is not listening). The point is that DNS does *not* fail.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn build_http_client_allows_localhost_when_not_enforced() {
+        let client = build_http_client(false).expect("build client");
+        let err = client
+            .get("http://localhost:1/")
+            .send()
+            .await
+            .expect_err("port 1 should not be listening");
+        let mut current: &dyn std::error::Error = &err;
+        loop {
+            assert!(
+                !current.to_string().to_lowercase().contains("private"),
+                "expected a connect error, not a DNS rejection: {err:?}"
+            );
+            match current.source() {
+                Some(src) => current = src,
+                None => break,
+            }
+        }
+    }
+}
+
 impl OneshotSource for HttpOneshotSource {
     type Object = HttpObject;
     type Checksum = HttpChecksum;

--- a/src/storage-operators/src/oneshot_source/http_source.rs
+++ b/src/storage-operators/src/oneshot_source/http_source.rs
@@ -9,11 +9,15 @@
 
 //! Generic HTTP oneshot source that will fetch a file from the public internet.
 
+use std::net::SocketAddr;
+use std::sync::Arc;
+
 use bytes::Bytes;
 use derivative::Derivative;
 use futures::TryStreamExt;
 use futures::stream::{BoxStream, StreamExt};
 use reqwest::Client;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -21,6 +25,44 @@ use crate::oneshot_source::util::IntoRangeHeaderValue;
 use crate::oneshot_source::{
     Encoding, OneshotObject, OneshotSource, StorageErrorX, StorageErrorXContext, StorageErrorXKind,
 };
+
+/// reqwest DNS resolver that delegates to [`mz_ore::netio::resolve_address`].
+///
+/// Only the IP resolution step is overridden — reqwest still uses the URL's
+/// original hostname for SNI and TLS certificate validation, so HTTPS works
+/// normally.
+#[derive(Debug)]
+struct MzHttpResolver {
+    enforce_external_addresses: bool,
+}
+
+impl Resolve for MzHttpResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let enforce = self.enforce_external_addresses;
+        Box::pin(async move {
+            let ips = mz_ore::netio::resolve_address(name.as_str(), enforce).await?;
+            // reqwest substitutes the conventional port (80/443) when the
+            // SocketAddr's port is 0 and no explicit port was given in the URL.
+            let addrs: Addrs = Box::new(
+                ips.into_iter()
+                    .map(|ip| SocketAddr::new(ip, 0))
+                    .collect::<Vec<_>>()
+                    .into_iter(),
+            );
+            Ok(addrs)
+        })
+    }
+}
+
+/// Build a reqwest [`Client`] for fetching `COPY FROM` URLs. This uses
+/// [`mz_ore::netio::resolve_address`] for DNS resolution.
+pub fn build_http_client(enforce_external_addresses: bool) -> Result<Client, reqwest::Error> {
+    Client::builder()
+        .dns_resolver(Arc::new(MzHttpResolver {
+            enforce_external_addresses,
+        }))
+        .build()
+}
 
 /// Generic oneshot source that fetches a file from a URL on the public internet.
 #[derive(Clone, Derivative)]

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -74,6 +74,7 @@ pub fn copy_to<'scope, F>(
     params: CopyToParameters,
     worker_callback: F,
     output_batch_count: u64,
+    enforce_external_addresses: bool,
 ) -> Rc<dyn Any>
 where
     F: FnOnce(Result<u64, String>) -> () + 'static,
@@ -98,6 +99,7 @@ where
             start_stream,
             params,
             output_batch_count,
+            enforce_external_addresses,
         ),
         S3SinkFormat::Parquet => render_upload_operator::<parquet::ParquetUploader>(
             scope.clone(),
@@ -111,6 +113,7 @@ where
             start_stream,
             params,
             output_batch_count,
+            enforce_external_addresses,
         ),
     };
 
@@ -123,6 +126,7 @@ where
         s3_key_manager,
         completion_stream,
         worker_callback,
+        enforce_external_addresses,
     );
 
     Rc::new(vec![start_token, upload_token, completion_token])
@@ -218,6 +222,7 @@ fn render_completion_operator<'scope, F>(
     s3_key_manager: S3KeyManager,
     completion_stream: StreamVec<'scope, Timestamp, Result<u64, String>>,
     worker_callback: F,
+    enforce_external_addresses: bool,
 ) -> PressOnDropButton
 where
     F: FnOnce(Result<u64, String>) -> () + 'static,
@@ -251,7 +256,12 @@ where
             if is_leader {
                 debug!(%sink_id, %worker_id, "s3 leader worker completion");
                 let sdk_config = aws_connection
-                    .load_sdk_config(&connection_context, connection_id, InTask::Yes)
+                    .load_sdk_config(
+                        &connection_context,
+                        connection_id,
+                        InTask::Yes,
+                        enforce_external_addresses,
+                    )
                     .await?;
 
                 let client = mz_aws_util::s3::new_client(&sdk_config);
@@ -308,6 +318,7 @@ fn render_upload_operator<'scope, T>(
     start_stream: StreamVec<'scope, Timestamp, Result<(), String>>,
     params: CopyToParameters,
     output_batch_count: u64,
+    enforce_external_addresses: bool,
 ) -> (
     StreamVec<'scope, Timestamp, Result<u64, String>>,
     PressOnDropButton,
@@ -346,7 +357,12 @@ where
         // fallible async block to use the `?` operator for convenience
         let res = async move {
             let sdk_config = aws_connection
-                .load_sdk_config(&connection_context, connection_id, InTask::Yes)
+                .load_sdk_config(
+                    &connection_context,
+                    connection_id,
+                    InTask::Yes,
+                    enforce_external_addresses,
+                )
                 .await?;
 
             // Map of an uploader per batch.

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -585,6 +585,7 @@ impl IcebergCatalogConnection<InlinedConnection> {
                 &storage_configuration.connection_context,
                 aws_ref.connection_id,
                 in_task,
+                ENFORCE_EXTERNAL_ADDRESSES.get(storage_configuration.config_set()),
             )
             .await
             .with_context(|| {
@@ -1059,6 +1060,7 @@ impl KafkaConnection {
                         &storage_configuration.connection_context,
                         aws.connection_id,
                         in_task,
+                        ENFORCE_EXTERNAL_ADDRESSES.get(storage_configuration.config_set()),
                     )
                     .await?,
             ),
@@ -2161,6 +2163,7 @@ impl MySqlConnection<InlinedConnection> {
                         &storage_configuration.connection_context,
                         aws_ref.connection_id,
                         in_task,
+                        ENFORCE_EXTERNAL_ADDRESSES.get(storage_configuration.config_set()),
                     )
                     .await?,
             ),

--- a/src/storage-types/src/connections/aws.rs
+++ b/src/storage-types/src/connections/aws.rs
@@ -326,6 +326,13 @@ impl AwsConnection {
             loader = loader.region(Region::new(region.clone()));
         }
         if let Some(endpoint) = &self.endpoint {
+            // The custom DNS resolver wired into the AWS HTTP client is only
+            // invoked for hostnames; IP-literal endpoints (e.g. `http://127.0.0.1`)
+            // bypass it. Validate IP literals here so they cannot circumvent
+            // the global-address enforcement.
+            if enforce_external_addresses && let Ok(url) = url::Url::parse(endpoint) {
+                mz_ore::netio::ensure_url_ip_global(&url)?;
+            }
             loader = loader.http_client(mz_aws_util::http_client_with_resolver(
                 enforce_external_addresses,
             ));

--- a/src/storage-types/src/connections/aws.rs
+++ b/src/storage-types/src/connections/aws.rs
@@ -267,6 +267,7 @@ impl AwsConnection {
         connection_context: &ConnectionContext,
         connection_id: CatalogItemId,
         in_task: InTask,
+        enforce_external_addresses: bool,
     ) -> Result<SdkConfig, anyhow::Error> {
         let connection_context = connection_context.clone();
         let this = self.clone();
@@ -298,7 +299,7 @@ impl AwsConnection {
                         })?,
                 ),
             };
-            this.load_sdk_config_from_credentials(credentials)
+            this.load_sdk_config_from_credentials(credentials, enforce_external_addresses)
                 .await
                 .with_context(|| {
                     format!(
@@ -318,12 +319,16 @@ impl AwsConnection {
     async fn load_sdk_config_from_credentials(
         &self,
         credentials: impl ProvideCredentials + 'static,
+        enforce_external_addresses: bool,
     ) -> Result<SdkConfig, anyhow::Error> {
         let mut loader = mz_aws_util::defaults().credentials_provider(credentials);
         if let Some(region) = &self.region {
             loader = loader.region(Region::new(region.clone()));
         }
         if let Some(endpoint) = &self.endpoint {
+            loader = loader.http_client(mz_aws_util::http_client_with_resolver(
+                enforce_external_addresses,
+            ));
             loader = loader.endpoint_url(endpoint);
         }
         Ok(loader.load().await)
@@ -334,12 +339,15 @@ impl AwsConnection {
         id: CatalogItemId,
         storage_configuration: &StorageConfiguration,
     ) -> Result<(), AwsConnectionValidationError> {
+        let enforce_external_addresses =
+            crate::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES.get(storage_configuration.config_set());
         let aws_config = self
             .load_sdk_config(
                 &storage_configuration.connection_context,
                 id,
                 // We are in a normal tokio context during validation, already.
                 InTask::No,
+                enforce_external_addresses,
             )
             .await?;
         let sts_client = aws_sdk_sts::Client::new(&aws_config);
@@ -358,7 +366,9 @@ impl AwsConnection {
                     external_id,
                 )
                 .await?;
-            let aws_config = self.load_sdk_config_from_credentials(credentials).await?;
+            let aws_config = self
+                .load_sdk_config_from_credentials(credentials, enforce_external_addresses)
+                .await?;
             let sts_client = aws_sdk_sts::Client::new(&aws_config);
             if sts_client.get_caller_identity().send().await.is_ok() {
                 return Err(AwsConnectionValidationError::RoleDoesNotRequireExternalId {

--- a/src/storage-types/src/sinks/s3_oneshot_sink.rs
+++ b/src/storage-types/src/sinks/s3_oneshot_sink.rs
@@ -39,13 +39,19 @@ pub async fn preflight(
     connection_details: &S3UploadInfo,
     connection_id: CatalogItemId,
     sink_id: GlobalId,
+    enforce_external_addresses: bool,
 ) -> Result<(), anyhow::Error> {
     info!(%sink_id, "s3 copy to initialization");
 
     let s3_key_manager = S3KeyManager::new(&sink_id, &connection_details.uri);
 
     let sdk_config = aws_connection
-        .load_sdk_config(&connection_context, connection_id, InTask::Yes)
+        .load_sdk_config(
+            &connection_context,
+            connection_id,
+            InTask::Yes,
+            enforce_external_addresses,
+        )
         .await?;
 
     let client = mz_aws_util::s3::new_client(&sdk_config);

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -499,6 +499,8 @@ pub(crate) fn build_oneshot_ingestion_dataflow(
         .storage_configuration
         .connection_context
         .clone();
+    let enforce_external_addresses = mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+        .get(storage_state.storage_configuration.config_set());
 
     let name = format!("Oneshot ingestion: {ingestion_id}");
     let tokens = timely_worker.dataflow_named(&name, |scope| {
@@ -510,6 +512,7 @@ pub(crate) fn build_oneshot_ingestion_dataflow(
             collection_id,
             collection_meta,
             description,
+            enforce_external_addresses,
             callback,
         )
     });

--- a/test/testdrive/connection-create-external.td
+++ b/test/testdrive/connection-create-external.td
@@ -71,4 +71,80 @@ $ kafka-ingest format=avro topic=csr_test key-format=avro key-schema=${keyschema
 contains:Address resolved to a private IP
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_copy_from_remote = true
+
+> CREATE TABLE copy_ssrf_target (a text, b text)
+
+# COPY FROM rejects non-http(s) schemes outright.
+! COPY INTO copy_ssrf_target FROM 'file:///etc/passwd' (FORMAT CSV);
+contains:only 'http://' and 'https://' urls are supported
+
+! COPY INTO copy_ssrf_target FROM 'ftp://example.com/file.csv' (FORMAT CSV);
+contains:only 'http://' and 'https://' urls are supported
+
+# IPv4 / IPv6 loopback literals bypass reqwest's DNS resolver and must be
+# caught by the upfront IP-literal check.
+! COPY INTO copy_ssrf_target FROM 'http://127.0.0.1:1/file.csv' (FORMAT CSV);
+contains:Address resolved to a private IP
+
+! COPY INTO copy_ssrf_target FROM 'http://[::1]:1/file.csv' (FORMAT CSV);
+contains:Address resolved to a private IP
+
+# IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`): on dual-stack sockets this
+# reaches loopback, so it must be rejected as IPv4 loopback.
+! COPY INTO copy_ssrf_target FROM 'http://[::ffff:127.0.0.1]:1/file.csv' (FORMAT CSV);
+contains:Address resolved to a private IP
+
+# Cloud instance metadata service is the canonical SSRF target. 169.254/16 is
+# link-local and must be rejected.
+! COPY INTO copy_ssrf_target FROM 'http://169.254.169.254/latest/meta-data/' (FORMAT CSV);
+contains:Address resolved to a private IP
+
+# Hostname resolving to loopback exercises the reqwest custom DNS resolver
+# path (as opposed to the upfront IP-literal check above).
+! COPY INTO copy_ssrf_target FROM 'http://localhost:1/file.csv' (FORMAT CSV);
+contains:Address resolved to a private IP
+
+> CREATE SECRET aws_ssrf_secret AS 'unused'
+
+! CREATE CONNECTION aws_ssrf_endpoint_v4 TO AWS (
+    ACCESS KEY ID = 'unused',
+    SECRET ACCESS KEY = SECRET aws_ssrf_secret,
+    ENDPOINT = 'http://127.0.0.1:1/',
+    REGION = 'us-east-1'
+  ) WITH (VALIDATE = true);
+contains:Address resolved to a private IP
+
+! CREATE CONNECTION aws_ssrf_endpoint_v6 TO AWS (
+    ACCESS KEY ID = 'unused',
+    SECRET ACCESS KEY = SECRET aws_ssrf_secret,
+    ENDPOINT = 'http://[::1]/',
+    REGION = 'us-east-1'
+  ) WITH (VALIDATE = true);
+contains:Address resolved to a private IP
+
+! CREATE CONNECTION aws_ssrf_endpoint_mapped TO AWS (
+    ACCESS KEY ID = 'unused',
+    SECRET ACCESS KEY = SECRET aws_ssrf_secret,
+    ENDPOINT = 'http://[::ffff:127.0.0.1]/',
+    REGION = 'us-east-1'
+  ) WITH (VALIDATE = true);
+contains:Address resolved to a private IP
+
+! CREATE CONNECTION aws_ssrf_endpoint_metadata TO AWS (
+    ACCESS KEY ID = 'unused',
+    SECRET ACCESS KEY = SECRET aws_ssrf_secret,
+    ENDPOINT = 'http://169.254.169.254/',
+    REGION = 'us-east-1'
+  ) WITH (VALIDATE = true);
+contains:Address resolved to a private IP
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_enforce_external_addresses = false
+
+# Sanity check: with enforcement disabled, a previously-rejected loopback
+# literal makes it past validation and instead fails at connect time. The
+# absence of the "private IP" message proves the dyncfg actually gates the
+# check.
+! COPY INTO copy_ssrf_target FROM 'http://127.0.0.1:1/file.csv' (FORMAT CSV);
+contains:Connection refused


### PR DESCRIPTION
Updates the HTTP clients used by COPY FROM and AWS CONNECTION to use `mz_ore::netio::resolve_address` by building the clients with custom resolvers. 

This also updates the implementation of `addr.is_global()` to cover additional cases and adds unit tests.

I've split the changes into separate commits to make it easier to review.

Addresses [SQL-193](https://linear.app/materializeinc/issue/SQL-193)
