### PR TITLE
adapter: thread bare ReadHolds through ComputeController::peek

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 
 use differential_dataflow::consolidation::consolidate;
 use itertools::Itertools;
-use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_cluster_client::ReplicaId;
 use mz_compute_client::controller::PeekNotification;
@@ -36,6 +35,8 @@ use mz_expr::{
     RowSetFinishingIncremental, permutation_for_arrangement,
 };
 use mz_ore::cast::CastFrom;
+use mz_ore::collections::CollectionExt;
+use mz_ore::soft_assert_eq_or_log;
 use mz_ore::str::{StrExt, separated};
 use mz_ore::task;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -731,94 +732,144 @@ impl crate::coord::Coordinator {
         // build a dataflow and drop it once the peek is issued. The peeks are also constructed
         // differently.
 
-        // If we must build the view, ship the dataflow.
-        let (peek_command, drop_dataflow, is_fast_path, peek_target, strategy) = match fast_path {
-            PeekPlan::FastPath(FastPathPlan::PeekExisting(
-                _coll_id,
-                idx_id,
-                literal_constraints,
-                map_filter_project,
-            )) => (
-                (literal_constraints, timestamp, map_filter_project),
-                None,
-                true,
-                PeekTarget::Index { id: idx_id },
-                StatementExecutionStrategy::FastPath,
-            ),
-            PeekPlan::FastPath(FastPathPlan::PeekPersist(
-                coll_id,
-                literal_constraint,
-                map_filter_project,
-            )) => {
-                let peek_command = (
-                    literal_constraint.map(|r| vec![r]),
-                    timestamp,
+        // Acquire a read hold for the peek target so its `since` cannot advance past
+        // `timestamp` before `compute.peek()` runs. On the slow path we ship the dataflow
+        // first: the implied hold from `create_dataflow` pins the new collection's `since`
+        // at `as_of`, so the subsequent `acquire_read_hold` lands at `as_of <= timestamp`.
+        let (peek_command, drop_dataflow, is_fast_path, peek_target, strategy, read_hold) =
+            match fast_path {
+                PeekPlan::FastPath(FastPathPlan::PeekExisting(
+                    _coll_id,
+                    idx_id,
+                    literal_constraints,
                     map_filter_project,
-                );
-                let metadata = self
-                    .controller
-                    .storage
-                    .collection_metadata(coll_id)
-                    .expect("storage collection for fast-path peek")
-                    .clone();
-                (
-                    peek_command,
-                    None,
-                    true,
-                    PeekTarget::Persist {
-                        id: coll_id,
-                        metadata,
-                    },
-                    StatementExecutionStrategy::PersistFastPath,
-                )
-            }
-            PeekPlan::SlowPath(PeekDataflowPlan {
-                desc: dataflow,
-                // n.b. this index_id identifies a transient index the
-                // caller created, so it is guaranteed to be on
-                // `compute_instance`.
-                id: index_id,
-                key: index_key,
-                permutation: index_permutation,
-                thinned_arity: index_thinned_arity,
-            }) => {
-                let output_ids = dataflow.export_ids().collect();
+                )) => {
+                    let read_hold = self
+                        .controller
+                        .compute
+                        .acquire_read_hold(compute_instance, idx_id)
+                        .map_err(
+                            AdapterError::concurrent_dependency_drop_from_collection_update_error,
+                        )?;
+                    (
+                        (literal_constraints, timestamp, map_filter_project),
+                        None,
+                        true,
+                        PeekTarget::Index { id: idx_id },
+                        StatementExecutionStrategy::FastPath,
+                        read_hold,
+                    )
+                }
+                PeekPlan::FastPath(FastPathPlan::PeekPersist(
+                    coll_id,
+                    literal_constraint,
+                    map_filter_project,
+                )) => {
+                    let peek_command = (
+                        literal_constraint.map(|r| vec![r]),
+                        timestamp,
+                        map_filter_project,
+                    );
+                    let metadata = self
+                        .controller
+                        .storage
+                        .collection_metadata(coll_id)
+                        .expect("storage collection for fast-path peek")
+                        .clone();
+                    let read_hold = self
+                        .controller
+                        .storage_collections
+                        .acquire_read_holds(vec![coll_id])
+                        .map_err(AdapterError::concurrent_dependency_drop_from_collection_missing)?
+                        .into_element();
+                    (
+                        peek_command,
+                        None,
+                        true,
+                        PeekTarget::Persist {
+                            id: coll_id,
+                            metadata,
+                        },
+                        StatementExecutionStrategy::PersistFastPath,
+                        read_hold,
+                    )
+                }
+                PeekPlan::SlowPath(PeekDataflowPlan {
+                    desc: dataflow,
+                    // n.b. this index_id identifies a transient index the
+                    // caller created, so it is guaranteed to be on
+                    // `compute_instance`.
+                    id: index_id,
+                    key: index_key,
+                    permutation: index_permutation,
+                    thinned_arity: index_thinned_arity,
+                }) => {
+                    // The slow-path peek read-hold strategy below acquires a hold for
+                    // `index_id` only. That is sufficient today because slow-path peek
+                    // dataflows have a single export equal to `index_id`. If we ever
+                    // ship multi-output dataflows on this path, the hold acquisition
+                    // needs to be revisited.
+                    let exports: Vec<GlobalId> = dataflow.export_ids().collect();
+                    soft_assert_eq_or_log!(
+                        exports.as_slice(),
+                        &[index_id],
+                        "slow-path peek dataflow must export exactly [index_id]",
+                    );
+                    if exports.as_slice() != [index_id] {
+                        return Err(AdapterError::internal(
+                            "peek error",
+                            format!(
+                                "slow-path peek dataflow exports {exports:?}, expected [{index_id}]",
+                            ),
+                        ));
+                    }
 
-                // Very important: actually create the dataflow (here, so we can destructure).
-                self.controller
-                    .compute
-                    .create_dataflow(compute_instance, dataflow, None)
-                    .map_err(
-                        AdapterError::concurrent_dependency_drop_from_dataflow_creation_error,
-                    )?;
-                self.initialize_compute_read_policies(
-                    output_ids,
-                    compute_instance,
-                    // Disable compaction so that nothing can compact before the peek occurs below.
-                    CompactionWindow::DisableCompaction,
-                )
-                .await;
+                    // Very important: actually create the dataflow (here, so we can destructure).
+                    self.controller
+                        .compute
+                        .create_dataflow(compute_instance, dataflow, None)
+                        .map_err(
+                            AdapterError::concurrent_dependency_drop_from_dataflow_creation_error,
+                        )?;
 
-                // Create an identity MFP operator.
-                let mut map_filter_project = mz_expr::MapFilterProject::new(source_arity);
-                map_filter_project.permute_fn(
-                    |c| index_permutation[c],
-                    index_key.len() + index_thinned_arity,
-                );
-                let map_filter_project = mfp_to_safe_plan(map_filter_project)?;
+                    // Acquire a bare hold on the freshly-shipped index. On failure we must
+                    // drop the dataflow ourselves, otherwise it leaks.
+                    let acquire_result = self
+                        .controller
+                        .compute
+                        .acquire_read_hold(compute_instance, index_id)
+                        .map_err(
+                            AdapterError::concurrent_dependency_drop_from_collection_update_error,
+                        );
+                    let read_hold = match acquire_result {
+                        Ok(hold) => hold,
+                        Err(e) => {
+                            self.drop_compute_collections(vec![(compute_instance, index_id)]);
+                            return Err(e);
+                        }
+                    };
 
-                (
-                    (None, timestamp, map_filter_project),
-                    Some(index_id),
-                    false,
-                    PeekTarget::Index { id: index_id },
-                    StatementExecutionStrategy::Standard,
-                )
-            }
-            PeekPlan::FastPath(_) => {
-                unreachable!()
-            }
-        };
+                    // Create an identity MFP operator.
+                    let mut map_filter_project = mz_expr::MapFilterProject::new(source_arity);
+                    map_filter_project.permute_fn(
+                        |c| index_permutation[c],
+                        index_key.len() + index_thinned_arity,
+                    );
+                    let map_filter_project = mfp_to_safe_plan(map_filter_project)?;
+
+                    (
+                        (None, timestamp, map_filter_project),
+                        Some(index_id),
+                        false,
+                        PeekTarget::Index { id: index_id },
+                        StatementExecutionStrategy::Standard,
+                        read_hold,
+                    )
+                }
+                PeekPlan::FastPath(_) => {
+                    unreachable!()
+                }
+            };
 
         // Endpoints for sending and receiving peek responses.
         let (rows_tx, rows_rx) = tokio::sync::oneshot::channel();
@@ -839,7 +890,8 @@ impl crate::coord::Coordinator {
         let peek_result_desc =
             RelationDesc::new(intermediate_result_type, peek_result_column_names);
 
-        self.controller
+        let peek_result = self
+            .controller
             .compute
             .peek(
                 compute_instance,
@@ -850,10 +902,18 @@ impl crate::coord::Coordinator {
                 peek_result_desc,
                 finishing.clone(),
                 map_filter_project,
+                read_hold,
                 target_replica,
                 rows_tx,
             )
-            .map_err(AdapterError::concurrent_dependency_drop_from_peek_error)?;
+            .map_err(AdapterError::concurrent_dependency_drop_from_peek_error);
+        if let Err(e) = peek_result {
+            // If we shipped a transient dataflow above, drop it now to avoid leaking it.
+            if let Some(index_id) = drop_dataflow {
+                self.drop_compute_collections(vec![(compute_instance, index_id)]);
+            }
+            return Err(e);
+        }
 
         // Register the pending peek only after compute.peek() succeeds. If it
         // fails (e.g. concurrent replica/cluster drop), inserting first would
@@ -875,9 +935,13 @@ impl crate::coord::Coordinator {
 
         let duration_histogram = self.metrics.row_set_finishing_seconds();
 
-        // If a dataflow was created, drop it once the peek command is sent.
+        // If a dataflow was created, drop it now that the peek is queued. This is
+        // required: `add_collection` installs implied/warmup holds owned by the
+        // controller and only released via `drop_collections`, so without this call
+        // the transient dataflow's `since` would stay pinned at `as_of` forever. The
+        // peek's own read hold keeps the collection alive on the cluster until the
+        // response arrives.
         if let Some(index_id) = drop_dataflow {
-            self.remove_compute_ids_from_timeline(vec![(compute_instance, index_id)]);
             self.drop_compute_collections(vec![(compute_instance, index_id)]);
         }
 

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -279,22 +279,6 @@ impl Coordinator {
         became_empty
     }
 
-    pub(crate) fn remove_compute_ids_from_timeline<I>(&mut self, ids: I) -> Vec<Timeline>
-    where
-        I: IntoIterator<Item = (ComputeInstanceId, GlobalId)>,
-    {
-        let mut empty_timelines = BTreeSet::new();
-        for (compute_instance, id) in ids {
-            for (timeline, TimelineState { read_holds, .. }) in &mut self.global_timelines {
-                read_holds.remove_compute_collection(compute_instance, id);
-                if read_holds.is_empty() {
-                    empty_timelines.insert(timeline.clone());
-                }
-            }
-        }
-        empty_timelines.into_iter().collect()
-    }
-
     #[instrument(level = "debug")]
     pub(crate) async fn advance_timelines(&mut self) {
         let global_timelines = std::mem::take(&mut self.global_timelines);

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -812,6 +812,22 @@ impl AdapterError {
         }
     }
 
+    pub fn concurrent_dependency_drop_from_collection_update_error(
+        e: compute_error::CollectionUpdateError,
+    ) -> Self {
+        use compute_error::CollectionUpdateError::*;
+        match e {
+            InstanceMissing(id) => AdapterError::ConcurrentDependencyDrop {
+                dependency_kind: "cluster",
+                dependency_id: id.to_string(),
+            },
+            CollectionMissing(id) => AdapterError::ConcurrentDependencyDrop {
+                dependency_kind: "collection",
+                dependency_id: id.to_string(),
+            },
+        }
+    }
+
     pub fn concurrent_dependency_drop_from_peek_error(
         e: mz_compute_client::controller::error::PeekError,
     ) -> AdapterError {
@@ -829,7 +845,9 @@ impl AdapterError {
                 dependency_kind: "replica",
                 dependency_id: id.to_string(),
             },
-            e @ SinceViolation(_) => AdapterError::internal("peek error", e),
+            e @ (ReadHoldIdMismatch(_) | SinceViolation(_)) => {
+                AdapterError::internal("peek error", e)
+            }
         }
     }
 

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -394,6 +394,7 @@ impl ShouldTerminateGracefully for PeekError {
     fn should_terminate_gracefully(&self) -> bool {
         match self {
             PeekError::SinceViolation(_)
+            | PeekError::ReadHoldIdMismatch(_)
             | PeekError::InstanceMissing(_)
             | PeekError::CollectionMissing(_)
             | PeekError::ReplicaMissing(_) => false,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -48,7 +48,6 @@ use mz_dyncfg::ConfigSet;
 use mz_expr::RowSetFinishing;
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
-use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -854,6 +853,11 @@ impl ComputeController {
     }
 
     /// Initiate a peek request for the contents of the given collection at `timestamp`.
+    ///
+    /// The caller supplies a `read_hold` for the peek target — via
+    /// [`ComputeController::acquire_read_hold`] for `PeekTarget::Index`, or via the storage
+    /// collections for `PeekTarget::Persist`. The hold keeps the collection's `since` at
+    /// `<= timestamp` until the peek completes.
     pub fn peek(
         &self,
         instance_id: ComputeInstanceId,
@@ -864,6 +868,7 @@ impl ComputeController {
         result_desc: RelationDesc,
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
+        read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
     ) -> Result<(), PeekError> {
@@ -878,14 +883,11 @@ impl ComputeController {
             }
         }
 
-        // Validation: peek target
-        let read_hold = match &peek_target {
-            PeekTarget::Index { id } => instance.acquire_read_hold(*id)?,
-            PeekTarget::Persist { id, .. } => self
-                .storage_collections
-                .acquire_read_holds(vec![*id])?
-                .into_element(),
-        };
+        // Validation: the read hold must target this collection and must hold its `since`
+        // at `<= timestamp`.
+        if read_hold.id() != peek_target.id() {
+            return Err(ReadHoldIdMismatch(read_hold.id()));
+        }
         if !read_hold.since().less_equal(&timestamp) {
             return Err(SinceViolation(peek_target.id()));
         }

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -153,6 +153,9 @@ pub enum PeekError {
     /// The replica that the peek was issued against does not exist.
     #[error("replica does not exist: {0}")]
     ReplicaMissing(ReplicaId),
+    /// The caller-supplied read hold is for a different collection than the peek target.
+    #[error("read hold ID does not match peeked collection: {0}")]
+    ReadHoldIdMismatch(GlobalId),
     /// The read hold that was passed in is for a later time than the peek's timestamp.
     #[error("peek timestamp is not beyond the since of collection: {0}")]
     SinceViolation(GlobalId),


### PR DESCRIPTION
Before, slow-path peek dataflows piggy-backed on the adapter machinery
meant for long-lived objects. We'd call
`initialize_compute_read_policies(DisableCompaction)` on the transient
index, which set `ReadPolicy::ValidFrom(as_of)` on the compute collection
and parked an entry in `TimelineState.read_holds` (the structure that
tracks holds for catalog objects). Then, inside
`ComputeController::peek`, the compute controller would acquire its own
hold for the duration of the peek. After the peek finished the adapter
had to remember to clean the timeline entry back up.

That dance was redundant -- `Instance::add_collection` already installs
an implied hold pinning the new collection's `since` at `as_of`, so the
`ValidFrom` policy and the timeline entry weren't actually buying us
anything -- and it had a latent leak: on the peek error path the
timeline entry was never released.

Now the adapter acquires a single bare `ReadHold` for the peek target
and threads it through `ComputeController::peek`. No `TimelineState`
bookkeeping, no second acquire inside the controller, and the leak is
gone by construction. The fast-path branches (`PeekExisting`,
`PeekPersist`) acquire and thread their own holds the same way for
uniformity.

`ComputeController::peek` now requires a caller-supplied `ReadHold`
instead of acquiring one itself. The id-mismatch and
`since <= timestamp` checks both surface as graceful `PeekError`
variants (`ReadHoldIdMismatch`, `SinceViolation`) rather than panics.
On the slow path the adapter additionally `soft_assert`s -- with a
runtime fallback that returns `AdapterError::internal` -- that the
dataflow exports exactly the one transient index id we acquire a hold
for; this documents the single-output assumption baked into the new
hold strategy. The dead `remove_compute_ids_from_timeline` helper --
slow-path peek was its only caller -- goes away.

