### PR TITLE
  console [CNS-62]: Add tooltip and disable Create New button dropdown

### DIFF
--- a/console/src/layouts/NavBar/CreateObjectButton.tsx
+++ b/console/src/layouts/NavBar/CreateObjectButton.tsx
@@ -27,7 +27,6 @@ import useCanCreateCluster from "~/api/materialize/cluster/useCanCreateCluster";
 import useCanCreateObjects from "~/api/materialize/useCanCreateObjects";
 import { AppConfigSwitch } from "~/config/AppConfigSwitch";
 import { regionPath } from "~/platform/routeHelpers";
-import { NEW_SOURCE_BUTTON_DISABLED_MESSAGE } from "~/platform/sources/constants";
 import { useRegionSlug } from "~/store/environments";
 import { PlusIcon } from "~/svg/PlusIcon";
 import { MaterializeTheme } from "~/theme";
@@ -101,32 +100,38 @@ export const CreateObjectButton = (props: CreateObjectButtonProps) => {
             >
               Create a new...
             </Text>
-            {canCreateCluster && (
-              <CreateObjectLink
-                to={newClusterPath}
-                onClick={() =>
-                  track("New Cluster Clicked", {
-                    source: "Navbar create button",
-                  })
-                }
-              >
-                Cluster
-              </CreateObjectLink>
-            )}
-            {canCreate && (
-              <CreateObjectLink
-                ref={initialFocusRef}
-                to={newSourcePath}
-                state={{ previousPage: location.pathname }}
-                onClick={() =>
-                  track("New Source Clicked", {
-                    source: "Navbar create button",
-                  })
-                }
-              >
-                Source
-              </CreateObjectLink>
-            )}
+            <CreateObjectLink
+              to={newClusterPath}
+              disabledTooltip={
+                canCreateCluster
+                  ? undefined
+                  : "You do not have permission to create clusters."
+              }
+              onClick={() =>
+                track("New Cluster Clicked", {
+                  source: "Navbar create button",
+                })
+              }
+            >
+              Cluster
+            </CreateObjectLink>
+            <CreateObjectLink
+              ref={initialFocusRef}
+              to={newSourcePath}
+              state={{ previousPage: location.pathname }}
+              disabledTooltip={
+                canCreate
+                  ? undefined
+                  : "You do not have permission to create sources."
+              }
+              onClick={() =>
+                track("New Source Clicked", {
+                  source: "Navbar create button",
+                })
+              }
+            >
+              Source
+            </CreateObjectLink>
             <AppConfigSwitch
               cloudConfigElement={({ runtimeConfig }) =>
                 runtimeConfig.isImpersonating ? null : (
@@ -147,11 +152,16 @@ export const CreateObjectButton = (props: CreateObjectButtonProps) => {
 };
 
 export const CreateObjectLink = forwardRef<
-  LinkProps & { isDisabled?: boolean },
+  LinkProps & { disabledTooltip?: string },
   "a"
 >(
   (
-    { children, to, state, isDisabled }: LinkProps & { isDisabled?: boolean },
+    {
+      children,
+      to,
+      state,
+      disabledTooltip,
+    }: LinkProps & { disabledTooltip?: string },
     ref,
   ) => {
     const buttonProps = {
@@ -161,9 +171,9 @@ export const CreateObjectLink = forwardRef<
       width: "100%",
       borderRadius: "none",
     };
-    if (isDisabled) {
+    if (disabledTooltip) {
       return (
-        <Tooltip label={NEW_SOURCE_BUTTON_DISABLED_MESSAGE}>
+        <Tooltip label={disabledTooltip}>
           <Button {...buttonProps} isDisabled>
             <Text color="foreground.secondary" textStyle="text-ui-med">
               {children}

--- a/console/src/platform/sources/constants.ts
+++ b/console/src/platform/sources/constants.ts
@@ -9,6 +9,3 @@
 
 export const SOURCES_FETCH_ERROR_MESSAGE =
   "An error occurred loading source data.";
-
-export const NEW_SOURCE_BUTTON_DISABLED_MESSAGE =
-  "New source syntax must be enabled to use source creation.";


### PR DESCRIPTION
## Papercut Fixes: [CNS-62](https://linear.app/materializeinc/issue/CNS-62/empty-dropdown-when-create-new-button-is-pressed)

- Grey out items you can't create if the user doesn't have permissions with the tooltip. Fixes
Generated by [Papercut Factory](https://github.com/MaterializeInc/console-papercut-factory/actions/runs/25387901339)



### Verification

<img width="780" height="493" alt="image" src="https://github.com/user-attachments/assets/4bc6904b-485e-4e65-8944-8792a39de78d" />

