### PR TITLE
storage: fix get_active_replicas_for_object for sinks and top-level ingestions

### DIFF
--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -739,16 +739,15 @@ impl Instance {
     /// object (ingestion, ingestion export (aka. subsource), or export).
     pub fn get_active_replicas_for_object(&self, id: &GlobalId) -> BTreeSet<ReplicaId> {
         if let Some(ingestion_id) = self.ingestion_exports.get(id) {
-            // Right now, only ingestions can have per-replica scheduling decisions.
             match self.active_ingestions.get(ingestion_id) {
                 Some(ingestion) => ingestion.active_replicas.clone(),
-                None => {
-                    // The ingestion has already been compacted away (aka. stopped).
-                    BTreeSet::new()
-                }
+                None => BTreeSet::new(),
             }
+        } else if let Some(ingestion) = self.active_ingestions.get(id) {
+            ingestion.active_replicas.clone()
+        } else if let Some(export) = self.active_exports.get(id) {
+            export.active_replicas.clone()
         } else {
-            // For non-ingestion objects, all replicas are active
             self.replicas.keys().copied().collect()
         }
     }
@@ -959,5 +958,37 @@ impl ReplicaTask {
         if let StorageCommand::Hello { nonce } = command {
             *nonce = Uuid::new_v4();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn active_replicas_for_export() {
+        let reg = mz_ore::metrics::MetricsRegistry::new();
+        let ctrl = mz_cluster_client::metrics::ControllerMetrics::new(&reg);
+        let sm = mz_storage_client::metrics::StorageControllerMetrics::new(&reg, ctrl);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut inst = Instance::new(
+            None,
+            sm.for_instance(mz_storage_types::instances::StorageInstanceId::System(0)),
+            mz_ore::now::NOW_ZERO.clone(),
+            tx,
+        );
+
+        let r1 = ReplicaId::User(1);
+        let sink = GlobalId::User(100);
+        inst.active_exports.insert(
+            sink,
+            ActiveExport {
+                active_replicas: BTreeSet::from([r1]),
+            },
+        );
+        assert_eq!(
+            inst.get_active_replicas_for_object(&sink),
+            BTreeSet::from([r1]),
+        );
     }
 }

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -748,7 +748,7 @@ impl Instance {
         } else if let Some(export) = self.active_exports.get(id) {
             export.active_replicas.clone()
         } else {
-            self.replicas.keys().copied().collect()
+            BTreeSet::new()
         }
     }
 }

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -991,4 +991,64 @@ mod tests {
             BTreeSet::from([r1]),
         );
     }
+
+    /// Exposes the `dropped_objects` leak: when an object is no longer tracked
+    /// in `active_ingestions` / `active_exports` (e.g. after `allow_compaction`
+    /// during a drop), `get_active_replicas_for_object` falls through to
+    /// `replicas.keys()`. The caller in `drop_*_unvalidated` then records every
+    /// replica in `dropped_objects` — but phantom replicas that never ran the
+    /// object will never reply with `DroppedId`, so the entry leaks forever.
+    /// Both removal paths in `lib.rs` (`DroppedId` handling and replica-drop
+    /// cleanup) require either a `DroppedId` from the listed replica or the id
+    /// to still be in `active_exports` / `active_ingestions`, and neither holds
+    /// once compaction has run.
+    ///
+    /// The safe answer is `BTreeSet::new()`; this test fails today and will
+    /// pass once the fall-through is fixed.
+    #[mz_ore::test(tokio::test)]
+    async fn unknown_object_does_not_overclaim_replicas() {
+        let reg = mz_ore::metrics::MetricsRegistry::new();
+        let ctrl = mz_cluster_client::metrics::ControllerMetrics::new(&reg);
+        let sm = mz_storage_client::metrics::StorageControllerMetrics::new(&reg, ctrl);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut inst = Instance::new(
+            None,
+            sm.for_instance(mz_storage_types::instances::StorageInstanceId::System(0)),
+            mz_ore::now::NOW_ZERO.clone(),
+            tx,
+        );
+
+        let r1 = ReplicaId::User(1);
+        let r2 = ReplicaId::User(2);
+        inst.replicas.insert(r1, fake_replica());
+        inst.replicas.insert(r2, fake_replica());
+
+        let id = GlobalId::User(100);
+        assert!(!inst.active_exports.contains_key(&id));
+        assert!(!inst.active_ingestions.contains_key(&id));
+        assert!(!inst.ingestion_exports.contains_key(&id));
+
+        assert_eq!(
+            inst.get_active_replicas_for_object(&id),
+            BTreeSet::new(),
+            "compacted/unknown object must not over-claim replicas: \
+             phantom replicas never reply with DroppedId, leaking the \
+             dropped_objects entry indefinitely",
+        );
+    }
+
+    fn fake_replica() -> Replica {
+        let (command_tx, _command_rx) = mpsc::unbounded_channel();
+        let task = mz_ore::task::spawn(|| "fake-replica", async {});
+        Replica {
+            config: ReplicaConfig {
+                build_info: &mz_build_info::DUMMY_BUILD_INFO,
+                location: ClusterReplicaLocation { ctl_addrs: vec![] },
+                grpc_client: GrpcClientParameters::default(),
+            },
+            command_tx,
+            task: task.abort_on_drop(),
+            connected: Arc::new(AtomicBool::new(false)),
+        }
+    }
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1888,6 +1888,35 @@ impl StorageController for Controller {
         // For ingestions, we fabricate a new hold that will propagate through
         // the cluster and then back to us.
 
+        // Capture the active replicas for objects before set_hold_policies to avoid racing
+        // absorb_compaction.
+        let mut active_replicas_for_object: BTreeMap<GlobalId, BTreeSet<ReplicaId>> =
+            BTreeMap::new();
+        for id in ingestions_to_drop.iter().chain(collections_to_drop.iter()) {
+            let collection = self
+                .collections
+                .get(id)
+                .expect("list populated after checking that self.collections contains it");
+
+            let instance = match &collection.extra_state {
+                CollectionStateExtra::Ingestion(ingestion) => Some(ingestion.instance_id),
+                CollectionStateExtra::Export(export) => Some(export.cluster_id()),
+                CollectionStateExtra::None => None,
+            }
+            .and_then(|i| self.instances.get(&i));
+
+            // Record which replicas were running a collection, so that we can
+            // match DroppedId messages against them and eventually remove state
+            // from self.dropped_objects
+            if let Some(instance) = instance {
+                let active_replicas = instance.get_active_replicas_for_object(id);
+                if !active_replicas.is_empty() {
+                    let prev = active_replicas_for_object.insert(*id, active_replicas);
+                    assert_none!(prev, "duplicate object id {id}");
+                }
+            }
+        }
+
         // We don't explicitly remove read capabilities! Downgrading the
         // frontier of the source to `[]` (the empty Antichain), will propagate
         // to the storage dependencies.
@@ -1943,39 +1972,27 @@ impl StorageController for Controller {
                 .remove(id)
                 .expect("list populated after checking that self.collections contains it");
 
-            let instance = match &collection.extra_state {
-                CollectionStateExtra::Ingestion(ingestion) => Some(ingestion.instance_id),
-                CollectionStateExtra::Export(export) => Some(export.cluster_id()),
-                CollectionStateExtra::None => None,
-            }
-            .and_then(|i| self.instances.get(&i));
-
-            // Record which replicas were running a collection, so that we can
-            // match DroppedId messages against them and eventually remove state
-            // from self.dropped_objects
-            if let Some(instance) = instance {
-                let active_replicas = instance.get_active_replicas_for_object(id);
-                if !active_replicas.is_empty() {
-                    // The remap collection of an ingestion doesn't have extra
-                    // state and doesn't have an instance_id, but we still get
-                    // upper updates for them, so want to make sure to populate
-                    // dropped_ids.
-                    // TODO(aljoscha): All this is a bit icky. But here we are
-                    // for now...
-                    match &collection.data_source {
-                        DataSource::Ingestion(ingestion_desc) => {
-                            if *id != ingestion_desc.remap_collection_id {
-                                self.dropped_objects.insert(
-                                    ingestion_desc.remap_collection_id,
-                                    active_replicas.clone(),
-                                );
-                            }
+            // Populate `self.dropped_objects` with the active replicas captured before `set_hold_policies`.
+            if let Some(active_replicas) = active_replicas_for_object.remove(id) {
+                // The remap collection of an ingestion doesn't have extra
+                // state and doesn't have an instance_id, but we still get
+                // upper updates for them, so want to make sure to populate
+                // dropped_ids.
+                // TODO(aljoscha): All this is a bit icky. But here we are
+                // for now...
+                match &collection.data_source {
+                    DataSource::Ingestion(ingestion_desc) => {
+                        if *id != ingestion_desc.remap_collection_id {
+                            self.dropped_objects.insert(
+                                ingestion_desc.remap_collection_id,
+                                active_replicas.clone(),
+                            );
                         }
-                        _ => {}
                     }
-
-                    self.dropped_objects.insert(*id, active_replicas);
+                    _ => {}
                 }
+
+                self.dropped_objects.insert(*id, active_replicas);
             }
         }
 
@@ -2007,6 +2024,34 @@ impl StorageController for Controller {
 
         // TODO: ideally we'd advance the write frontier ourselves here, but this function's
         // not yet marked async.
+
+        // Capture active replicas before set_hold_policies to avoid racing absorb_compaction.
+        let mut active_replicas_for_object: BTreeMap<GlobalId, BTreeSet<ReplicaId>> =
+            BTreeMap::new();
+        for id in sinks_to_drop.iter() {
+            let collection = self
+                .collections
+                .get(id)
+                .expect("list populated after checking that self.collections contains it");
+
+            let instance = match &collection.extra_state {
+                CollectionStateExtra::Ingestion(ingestion) => Some(ingestion.instance_id),
+                CollectionStateExtra::Export(export) => Some(export.cluster_id()),
+                CollectionStateExtra::None => None,
+            }
+            .and_then(|i| self.instances.get(&i));
+
+            // Record how many replicas were running an export, so that we can
+            // match `DroppedId` messages against it and eventually remove state
+            // from `self.dropped_objects`.
+            if let Some(instance) = instance {
+                let active_replicas = instance.get_active_replicas_for_object(id);
+                if !active_replicas.is_empty() {
+                    let prev = active_replicas_for_object.insert(*id, active_replicas);
+                    assert_none!(prev, "duplicate object id {id}");
+                }
+            }
+        }
 
         // We don't explicitly remove read capabilities! Downgrading the
         // frontier of the source to `[]` (the empty Antichain), will propagate
@@ -2050,26 +2095,13 @@ impl StorageController for Controller {
         // Remove collection/export state
         for id in sinks_to_drop.iter() {
             tracing::info!(%id, "dropping export state");
-            let collection = self
-                .collections
+            self.collections
                 .remove(id)
                 .expect("list populated after checking that self.collections contains it");
 
-            let instance = match &collection.extra_state {
-                CollectionStateExtra::Ingestion(ingestion) => Some(ingestion.instance_id),
-                CollectionStateExtra::Export(export) => Some(export.cluster_id()),
-                CollectionStateExtra::None => None,
-            }
-            .and_then(|i| self.instances.get(&i));
-
-            // Record how many replicas were running an export, so that we can
-            // match `DroppedId` messages against it and eventually remove state
-            // from `self.dropped_objects`.
-            if let Some(instance) = instance {
-                let active_replicas = instance.get_active_replicas_for_object(id);
-                if !active_replicas.is_empty() {
-                    self.dropped_objects.insert(*id, active_replicas);
-                }
+            // Populate `self.dropped_objects` with active replicas captured before `set_hold_policies`.
+            if let Some(active_replicas) = active_replicas_for_object.remove(id) {
+                self.dropped_objects.insert(*id, active_replicas);
             }
         }
 


### PR DESCRIPTION
Continuing the work that @def- started in https://github.com/MaterializeInc/materialize/pull/36327

This PR addresses a DroppedIds leak in the storage controller.


# Motivation
From @def- :
> Since https://github.com/MaterializeInc/materialize/pull/32066 sinks have per-replica scheduling on multi-replica clusters, but get_active_replicas_for_object still fell through to the "all replicas" branch for any non-ingestion-export ID. This caused drop_sinks_unvalidated to expect DroppedId from all replicas when only one was running the sink, leaking entries in dropped_objects indefinitely.
>
> Add the missing branches for top-level ingestion IDs and export (sink) IDs to mirror the scheduling logic in update_scheduling/active_replicas.

Additionally, the default branch in `get_active_replicas_for_object` returned all replicas. This seems incorrect, as the function is only called for Ingestion/Export, and if the GlobalId hasn't matched the 3 previous branches, it means the id is not in the active maps.  So it's either unknown or compacted. The default branch should return BTreeSet::new() in that case, otherwise this would also leak DroppedIds.

To avoid racing `set_hold_policies`, collection ids being dropped must be collected first before adjusting hold policies.