### PR TITLE
sql: parse EXECUTE UNIT TEST

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1307,7 +1307,8 @@ impl Coordinator {
                     | Statement::RevokeRole(_)
                     | Statement::Update(_)
                     | Statement::ValidateConnection(_)
-                    | Statement::Comment(_) => {
+                    | Statement::Comment(_)
+                    | Statement::ExecuteUnitTest(_) => {
                         let txn_status = ctx.session_mut().transaction_mut();
 
                         // If we're not in an implicit transaction and we could generate exactly one

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -289,6 +289,7 @@ Message
 Metadata
 Minute
 Minutes
+Mock
 Mode
 Month
 Months
@@ -472,6 +473,7 @@ Task
 Tasks
 Temp
 Temporary
+Test
 Text
 Then
 Tick
@@ -499,6 +501,7 @@ Unbounded
 Uncommitted
 Union
 Unique
+Unit
 Unknown
 Unnest
 Until

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -5115,10 +5115,9 @@ impl<T: AstInfo> AstDisplay for ExecuteUnitTestStatement<T> {
             f.write_str(" AT TIME ");
             f.write_node(at_time);
         }
-        for mock in &self.mocks {
-            f.write_str(" MOCK ");
+        for (i, mock) in self.mocks.iter().enumerate() {
+            f.write_str(if i == 0 { " MOCK " } else { ", MOCK " });
             f.write_node(mock);
-            f.write_str(",");
         }
         f.write_str(" EXPECTED ");
         f.write_node(&self.expected);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -105,6 +105,7 @@ pub enum Statement<T: AstInfo> {
     Close(CloseStatement),
     Prepare(PrepareStatement<T>),
     Execute(ExecuteStatement<T>),
+    ExecuteUnitTest(ExecuteUnitTestStatement<T>),
     Deallocate(DeallocateStatement),
     Raise(RaiseStatement),
     GrantRole(GrantRoleStatement<T>),
@@ -184,6 +185,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::Fetch(stmt) => f.write_node(stmt),
             Statement::Prepare(stmt) => f.write_node(stmt),
             Statement::Execute(stmt) => f.write_node(stmt),
+            Statement::ExecuteUnitTest(stmt) => f.write_node(stmt),
             Statement::Deallocate(stmt) => f.write_node(stmt),
             Statement::Raise(stmt) => f.write_node(stmt),
             Statement::GrantRole(stmt) => f.write_node(stmt),
@@ -268,6 +270,7 @@ pub fn statement_kind_label_value(kind: StatementKind) -> &'static str {
         StatementKind::Close => "close",
         StatementKind::Prepare => "prepare",
         StatementKind::Execute => "execute",
+        StatementKind::ExecuteUnitTest => "execute_unit_test",
         StatementKind::Deallocate => "deallocate",
         StatementKind::Raise => "raise",
         StatementKind::GrantRole => "grant_role",
@@ -5091,6 +5094,72 @@ impl<T: AstInfo> AstDisplay for ExecuteStatement<T> {
     }
 }
 impl_display_t!(ExecuteStatement);
+
+/// `EXECUTE UNIT TEST ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExecuteUnitTestStatement<T: AstInfo> {
+    pub name: Ident,
+    pub target: T::ItemName,
+    pub at_time: Option<Expr<T>>,
+    pub mocks: Vec<MockViewDef<T>>,
+    pub expected: ExpectedResultDef<T>,
+}
+
+impl<T: AstInfo> AstDisplay for ExecuteUnitTestStatement<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("EXECUTE UNIT TEST ");
+        f.write_node(&self.name);
+        f.write_str(" FOR ");
+        f.write_node(&self.target);
+        if let Some(at_time) = &self.at_time {
+            f.write_str(" AT TIME ");
+            f.write_node(at_time);
+        }
+        for mock in &self.mocks {
+            f.write_str(" MOCK ");
+            f.write_node(mock);
+        }
+        f.write_str(" EXPECTED");
+        f.write_node(&self.expected);
+    }
+}
+impl_display_t!(ExecuteUnitTestStatement);
+
+/// Mock view definition for EXECUTE UNIT TEST
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MockViewDef<T: AstInfo> {
+    pub name: T::ItemName,
+    pub columns: Vec<ColumnDef<T>>,
+    pub query: Query<T>,
+}
+
+impl<T: AstInfo> AstDisplay for MockViewDef<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        f.write_str("(");
+        f.write_node(&display::comma_separated(&self.columns));
+        f.write_str(") AS ");
+        f.write_node(&self.query);
+    }
+}
+impl_display_t!(MockViewDef);
+
+/// Expected result definition for EXECUTE UNIT TEST
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExpectedResultDef<T: AstInfo> {
+    pub columns: Vec<ColumnDef<T>>,
+    pub query: Query<T>,
+}
+
+impl<T: AstInfo> AstDisplay for ExpectedResultDef<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("(");
+        f.write_node(&display::comma_separated(&self.columns));
+        f.write_str(") AS ");
+        f.write_node(&self.query);
+    }
+}
+impl_display_t!(ExpectedResultDef);
 
 /// `DEALLOCATE ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -5118,8 +5118,9 @@ impl<T: AstInfo> AstDisplay for ExecuteUnitTestStatement<T> {
         for mock in &self.mocks {
             f.write_str(" MOCK ");
             f.write_node(mock);
+            f.write_str(",");
         }
-        f.write_str(" EXPECTED");
+        f.write_str(" EXPECTED ");
         f.write_node(&self.expected);
     }
 }
@@ -5138,8 +5139,9 @@ impl<T: AstInfo> AstDisplay for MockViewDef<T> {
         f.write_node(&self.name);
         f.write_str("(");
         f.write_node(&display::comma_separated(&self.columns));
-        f.write_str(") AS ");
+        f.write_str(") AS (");
         f.write_node(&self.query);
+        f.write_str(")");
     }
 }
 impl_display_t!(MockViewDef);
@@ -5155,8 +5157,9 @@ impl<T: AstInfo> AstDisplay for ExpectedResultDef<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("(");
         f.write_node(&display::comma_separated(&self.columns));
-        f.write_str(") AS ");
+        f.write_str(") AS (");
         f.write_node(&self.query);
+        f.write_str(")");
     }
 }
 impl_display_t!(ExpectedResultDef);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -9432,36 +9432,16 @@ impl<'a> Parser<'a> {
             None
         };
 
-        // Parse MOCK definitions (0 or more). Each MOCK clause must be
-        // followed by a comma — including the last one, before the trailing
-        // `EXPECTED` clause.
+        // Parse MOCK definitions (0 or more). Like CTEs, MOCK clauses are
+        // comma-separated; no comma appears before the trailing `EXPECTED`
+        // clause.
         let mut mocks = Vec::new();
-        while self.parse_keyword(MOCK) {
-            let mock_name = self.parse_raw_name()?;
-
-            self.expect_token(&Token::LParen)?;
-            let columns = self.parse_comma_separated(|parser| {
-                Ok(ColumnDef {
-                    name: parser.parse_identifier()?,
-                    data_type: parser.parse_data_type()?,
-                    collation: None,
-                    options: vec![],
-                })
-            })?;
-            self.expect_token(&Token::RParen)?;
-
-            self.expect_keyword(AS)?;
-            self.expect_token(&Token::LParen)?;
-            let query = self.parse_query()?;
-            self.expect_token(&Token::RParen)?;
-
-            mocks.push(MockViewDef {
-                name: mock_name,
-                columns,
-                query,
-            });
-
-            self.expect_token(&Token::Comma)?;
+        if self.parse_keyword(MOCK) {
+            mocks.push(self.parse_mock_view_def()?);
+            while self.consume_token(&Token::Comma) {
+                self.expect_keyword(MOCK)?;
+                mocks.push(self.parse_mock_view_def()?);
+            }
         }
 
         self.expect_keyword(EXPECTED)?;
@@ -9494,6 +9474,34 @@ impl<'a> Parser<'a> {
             mocks,
             expected,
         }))
+    }
+
+    /// Parse a single `MOCK <name> (<cols>) AS (<query>)` definition,
+    /// assuming the leading `MOCK` keyword has already been consumed.
+    fn parse_mock_view_def(&mut self) -> Result<MockViewDef<Raw>, ParserError> {
+        let name = self.parse_raw_name()?;
+
+        self.expect_token(&Token::LParen)?;
+        let columns = self.parse_comma_separated(|parser| {
+            Ok(ColumnDef {
+                name: parser.parse_identifier()?,
+                data_type: parser.parse_data_type()?,
+                collation: None,
+                options: vec![],
+            })
+        })?;
+        self.expect_token(&Token::RParen)?;
+
+        self.expect_keyword(AS)?;
+        self.expect_token(&Token::LParen)?;
+        let query = self.parse_query()?;
+        self.expect_token(&Token::RParen)?;
+
+        Ok(MockViewDef {
+            name,
+            columns,
+            query,
+        })
     }
 
     /// Parse a `DEALLOCATE` statement, assuming that the `DEALLOCATE` token

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -9396,6 +9396,12 @@ impl<'a> Parser<'a> {
     /// Parse a `EXECUTE` statement, assuming that the `EXECUTE` token
     /// has already been consumed.
     fn parse_execute(&mut self) -> Result<Statement<Raw>, ParserError> {
+        // Check if this is EXECUTE UNIT TEST
+        if self.parse_keywords(&[UNIT, TEST]) {
+            return self.parse_execute_unit_test();
+        }
+
+        // Otherwise parse as regular EXECUTE (prepared statement)
         let name = self.parse_identifier()?;
         let params = if self.consume_token(&Token::LParen) {
             let params = self.parse_comma_separated(Parser::parse_expr)?;
@@ -9405,6 +9411,93 @@ impl<'a> Parser<'a> {
             Vec::new()
         };
         Ok(Statement::Execute(ExecuteStatement { name, params }))
+    }
+
+    /// Parse an `EXECUTE UNIT TEST` statement, assuming that the
+    /// `EXECUTE UNIT TEST` tokens have already been consumed.
+    fn parse_execute_unit_test(&mut self) -> Result<Statement<Raw>, ParserError> {
+        // Parse test name
+        let name = self.parse_identifier()?;
+
+        // Expect FOR keyword
+        self.expect_keyword(FOR)?;
+
+        // Parse target view name
+        let target = self.parse_raw_name()?;
+
+        // Parse optional AT TIME clause
+        let at_time = if self.parse_keywords(&[AT, TIME]) {
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+
+        // Parse MOCK definitions (0 or more)
+        let mut mocks = Vec::new();
+        while self.parse_keyword(MOCK) {
+            let mock_name = self.parse_raw_name()?;
+
+            // Parse column definitions
+            self.expect_token(&Token::LParen)?;
+            let columns = self.parse_comma_separated(|parser| {
+                Ok(ColumnDef {
+                    name: parser.parse_identifier()?,
+                    data_type: parser.parse_data_type()?,
+                    collation: None,
+                    options: vec![],
+                })
+            })?;
+            self.expect_token(&Token::RParen)?;
+
+            // Parse AS
+            self.expect_keyword(AS)?;
+
+            // Parse query
+            let query = self.parse_query()?;
+
+            mocks.push(MockViewDef {
+                name: mock_name,
+                columns,
+                query,
+            });
+
+            // Consume optional comma
+            let _ = self.consume_token(&Token::Comma);
+        }
+
+        // Parse EXPECTED definition (required, exactly 1)
+        self.expect_keyword(EXPECTED)?;
+
+        // Parse column definitions
+        self.expect_token(&Token::LParen)?;
+        let expected_columns = self.parse_comma_separated(|parser| {
+            Ok(ColumnDef {
+                name: parser.parse_identifier()?,
+                data_type: parser.parse_data_type()?,
+                collation: None,
+                options: vec![],
+            })
+        })?;
+        self.expect_token(&Token::RParen)?;
+
+        // Parse AS
+        self.expect_keyword(AS)?;
+
+        // Parse query
+        let expected_query = self.parse_query()?;
+
+        let expected = ExpectedResultDef {
+            columns: expected_columns,
+            query: expected_query,
+        };
+
+        Ok(Statement::ExecuteUnitTest(ExecuteUnitTestStatement {
+            name,
+            target,
+            at_time,
+            mocks,
+            expected,
+        }))
     }
 
     /// Parse a `DEALLOCATE` statement, assuming that the `DEALLOCATE` token

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -9432,12 +9432,13 @@ impl<'a> Parser<'a> {
             None
         };
 
-        // Parse MOCK definitions (0 or more)
+        // Parse MOCK definitions (0 or more). Each MOCK clause must be
+        // followed by a comma — including the last one, before the trailing
+        // `EXPECTED` clause.
         let mut mocks = Vec::new();
         while self.parse_keyword(MOCK) {
             let mock_name = self.parse_raw_name()?;
 
-            // Parse column definitions
             self.expect_token(&Token::LParen)?;
             let columns = self.parse_comma_separated(|parser| {
                 Ok(ColumnDef {
@@ -9449,11 +9450,10 @@ impl<'a> Parser<'a> {
             })?;
             self.expect_token(&Token::RParen)?;
 
-            // Parse AS
             self.expect_keyword(AS)?;
-
-            // Parse query
+            self.expect_token(&Token::LParen)?;
             let query = self.parse_query()?;
+            self.expect_token(&Token::RParen)?;
 
             mocks.push(MockViewDef {
                 name: mock_name,
@@ -9461,14 +9461,11 @@ impl<'a> Parser<'a> {
                 query,
             });
 
-            // Consume optional comma
-            let _ = self.consume_token(&Token::Comma);
+            self.expect_token(&Token::Comma)?;
         }
 
-        // Parse EXPECTED definition (required, exactly 1)
         self.expect_keyword(EXPECTED)?;
 
-        // Parse column definitions
         self.expect_token(&Token::LParen)?;
         let expected_columns = self.parse_comma_separated(|parser| {
             Ok(ColumnDef {
@@ -9480,11 +9477,10 @@ impl<'a> Parser<'a> {
         })?;
         self.expect_token(&Token::RParen)?;
 
-        // Parse AS
         self.expect_keyword(AS)?;
-
-        // Parse query
+        self.expect_token(&Token::LParen)?;
         let expected_query = self.parse_query()?;
+        self.expect_token(&Token::RParen)?;
 
         let expected = ExpectedResultDef {
             columns: expected_columns,

--- a/src/sql-parser/tests/testdata/prepare
+++ b/src/sql-parser/tests/testdata/prepare
@@ -35,11 +35,123 @@ EXECUTE a (a, 'b', 1 + 2)
 Execute(ExecuteStatement { name: Ident("a"), params: [Identifier([Ident("a")]), Value(String("b")), Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }] })
 
 parse-statement
-EXECUTE UNIT TEST t1 FOR v MOCK a (x int4) AS (SELECT 1), MOCK b (y int4) AS (SELECT 2), EXPECTED (z int4) AS (SELECT 3)
+EXECUTE UNIT TEST t1 FOR v MOCK a (x int4) AS (SELECT 1), MOCK b (y int4) AS (SELECT 2) EXPECTED (z int4) AS (SELECT 3)
 ----
-EXECUTE UNIT TEST t1 FOR v MOCK a(x int4) AS (SELECT 1), MOCK b(y int4) AS (SELECT 2), EXPECTED (z int4) AS (SELECT 3)
+EXECUTE UNIT TEST t1 FOR v MOCK a(x int4) AS (SELECT 1), MOCK b(y int4) AS (SELECT 2) EXPECTED (z int4) AS (SELECT 3)
 =>
 ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t1"), target: Name(UnresolvedItemName([Ident("v")])), at_time: None, mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("a")])), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }, MockViewDef { name: Name(UnresolvedItemName([Ident("b")])), columns: [ColumnDef { name: Ident("y"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("z"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("3")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# Zero MOCK clauses — the MOCK list is optional.
+parse-statement
+EXECUTE UNIT TEST t FOR v EXPECTED (x int4) AS (SELECT 1)
+----
+EXECUTE UNIT TEST t FOR v EXPECTED (x int4) AS (SELECT 1)
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t"), target: Name(UnresolvedItemName([Ident("v")])), at_time: None, mocks: [], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# Single MOCK clause — no comma anywhere between the MOCK list and EXPECTED.
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS (SELECT 1) EXPECTED (y int4) AS (SELECT 2)
+----
+EXECUTE UNIT TEST t FOR v MOCK m(x int4) AS (SELECT 1) EXPECTED (y int4) AS (SELECT 2)
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t"), target: Name(UnresolvedItemName([Ident("v")])), at_time: None, mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("m")])), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("y"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# AT TIME clause sits between FOR and the MOCK list.
+parse-statement
+EXECUTE UNIT TEST t FOR v AT TIME mz_now() MOCK m (x int4) AS (SELECT 1) EXPECTED (y int4) AS (SELECT 2)
+----
+EXECUTE UNIT TEST t FOR v AT TIME mz_now() MOCK m(x int4) AS (SELECT 1) EXPECTED (y int4) AS (SELECT 2)
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t"), target: Name(UnresolvedItemName([Ident("v")])), at_time: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })), mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("m")])), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("y"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# Qualified target and mock names round-trip through display.
+parse-statement
+EXECUTE UNIT TEST t FOR materialize.public.customers MOCK materialize.internal.customers (id int8, name text) AS (SELECT 1, 'a') EXPECTED (id int8, name text) AS (SELECT 1, 'a')
+----
+EXECUTE UNIT TEST t FOR materialize.public.customers MOCK materialize.internal.customers(id int8, name text) AS (SELECT 1, 'a') EXPECTED (id int8, name text) AS (SELECT 1, 'a')
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t"), target: Name(UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("customers")])), at_time: None, mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("materialize"), Ident("internal"), Ident("customers")])), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int8")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("name"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(String("a")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int8")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("name"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(String("a")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# Inner queries can use VALUES / nested parens — the outer parens still match.
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS (SELECT * FROM (VALUES (1), (2)) AS sub(x)) EXPECTED (x int4) AS (SELECT * FROM (VALUES (1)) AS sub(x))
+----
+EXECUTE UNIT TEST t FOR v MOCK m(x int4) AS (SELECT * FROM (VALUES (1), (2)) AS sub (x)) EXPECTED (x int4) AS (SELECT * FROM (VALUES (1)) AS sub (x))
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t"), target: Name(UnresolvedItemName([Ident("v")])), at_time: None, mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("m")])), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Values(Values([[Value(Number("1"))], [Value(Number("2"))]])), order_by: [], limit: None, offset: None }, alias: Some(TableAlias { name: Ident("sub"), columns: [Ident("x")], strict: false }) }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Values(Values([[Value(Number("1"))]])), order_by: [], limit: None, offset: None }, alias: Some(TableAlias { name: Ident("sub"), columns: [Ident("x")], strict: false }) }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# Inner queries can use WITH (CTEs).
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS (WITH cte AS (SELECT 1) SELECT * FROM cte) EXPECTED (x int4) AS (SELECT 1)
+----
+EXECUTE UNIT TEST t FOR v MOCK m(x int4) AS (WITH cte AS (SELECT 1) SELECT * FROM cte) EXPECTED (x int4) AS (SELECT 1)
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t"), target: Name(UnresolvedItemName([Ident("v")])), at_time: None, mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("m")])), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("cte"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("cte")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# Inner queries can use UNION.
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS (SELECT 1 UNION ALL SELECT 2) EXPECTED (x int4) AS (SELECT 1)
+----
+EXECUTE UNIT TEST t FOR v MOCK m(x int4) AS (SELECT 1 UNION ALL SELECT 2) EXPECTED (x int4) AS (SELECT 1)
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t"), target: Name(UnresolvedItemName([Ident("v")])), at_time: None, mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("m")])), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: SetOperation { op: Union, all: true, left: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), right: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }) }, order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+# Negative: missing comma between consecutive MOCK clauses.
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK a (x int4) AS (SELECT 1) MOCK b (y int4) AS (SELECT 2) EXPECTED (z int4) AS (SELECT 3)
+----
+error: Expected EXPECTED, found MOCK
+EXECUTE UNIT TEST t FOR v MOCK a (x int4) AS (SELECT 1) MOCK b (y int4) AS (SELECT 2) EXPECTED (z int4) AS (SELECT 3)
+                                                        ^
+
+# Negative: trailing comma after last MOCK, before EXPECTED.
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK a (x int4) AS (SELECT 1), EXPECTED (z int4) AS (SELECT 3)
+----
+error: Expected MOCK, found EXPECTED
+EXECUTE UNIT TEST t FOR v MOCK a (x int4) AS (SELECT 1), EXPECTED (z int4) AS (SELECT 3)
+                                                         ^
+
+# Negative: leading comma before first MOCK.
+parse-statement
+EXECUTE UNIT TEST t FOR v , MOCK a (x int4) AS (SELECT 1) EXPECTED (z int4) AS (SELECT 3)
+----
+error: Expected EXPECTED, found comma
+EXECUTE UNIT TEST t FOR v , MOCK a (x int4) AS (SELECT 1) EXPECTED (z int4) AS (SELECT 3)
+                          ^
+
+# Negative: missing parens around the MOCK query.
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS SELECT 1 EXPECTED (z int4) AS (SELECT 2)
+----
+error: Expected left parenthesis, found SELECT
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS SELECT 1 EXPECTED (z int4) AS (SELECT 2)
+                                             ^
+
+# Negative: missing parens around the EXPECTED query.
+parse-statement
+EXECUTE UNIT TEST t FOR v EXPECTED (z int4) AS SELECT 1
+----
+error: Expected left parenthesis, found SELECT
+EXECUTE UNIT TEST t FOR v EXPECTED (z int4) AS SELECT 1
+                                               ^
+
+# Negative: missing FOR keyword.
+parse-statement
+EXECUTE UNIT TEST t v EXPECTED (z int4) AS (SELECT 1)
+----
+error: Expected FOR, found identifier "v"
+EXECUTE UNIT TEST t v EXPECTED (z int4) AS (SELECT 1)
+                    ^
+
+# Negative: missing EXPECTED clause.
+parse-statement
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS (SELECT 1)
+----
+error: Expected EXPECTED, found EOF
+EXECUTE UNIT TEST t FOR v MOCK m (x int4) AS (SELECT 1)
+                                                       ^
 
 parse-statement
 DEALLOCATE a

--- a/src/sql-parser/tests/testdata/prepare
+++ b/src/sql-parser/tests/testdata/prepare
@@ -35,6 +35,13 @@ EXECUTE a (a, 'b', 1 + 2)
 Execute(ExecuteStatement { name: Ident("a"), params: [Identifier([Ident("a")]), Value(String("b")), Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }] })
 
 parse-statement
+EXECUTE UNIT TEST t1 FOR v MOCK a (x int4) AS (SELECT 1), MOCK b (y int4) AS (SELECT 2), EXPECTED (z int4) AS (SELECT 3)
+----
+EXECUTE UNIT TEST t1 FOR v MOCK a(x int4) AS (SELECT 1), MOCK b(y int4) AS (SELECT 2), EXPECTED (z int4) AS (SELECT 3)
+=>
+ExecuteUnitTest(ExecuteUnitTestStatement { name: Ident("t1"), target: Name(UnresolvedItemName([Ident("v")])), at_time: None, mocks: [MockViewDef { name: Name(UnresolvedItemName([Ident("a")])), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }, MockViewDef { name: Name(UnresolvedItemName([Ident("b")])), columns: [ColumnDef { name: Ident("y"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }], expected: ExpectedResultDef { columns: [ColumnDef { name: Ident("z"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("3")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } } })
+
+parse-statement
 DEALLOCATE a
 ----
 DEALLOCATE a

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -328,6 +328,7 @@ impl Plan {
             StatementKind::Update => &[PlanKind::ReadThenWrite],
             StatementKind::ValidateConnection => &[PlanKind::ValidateConnection],
             StatementKind::AlterRetainHistory => &[PlanKind::AlterRetainHistory],
+            StatementKind::ExecuteUnitTest => &[],
         }
     }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -257,6 +257,12 @@ pub fn describe(
             scl::describe_inspect_shard(&scx, stmt)?
         }
         Statement::ValidateConnection(stmt) => validate::describe_validate_connection(&scx, stmt)?,
+        Statement::ExecuteUnitTest(_) => {
+            return Err(PlanError::Unsupported {
+                feature: "EXECUTE UNIT TEST statement".to_string(),
+                discussion_no: None,
+            });
+        }
     };
 
     let desc = desc.with_params(scx.finalize_param_types()?);
@@ -444,6 +450,12 @@ pub fn plan(
         Statement::Raise(stmt) => raise::plan_raise(scx, stmt),
         Statement::Show(ShowStatement::InspectShard(stmt)) => scl::plan_inspect_shard(scx, stmt),
         Statement::ValidateConnection(stmt) => validate::plan_validate_connection(scx, stmt),
+        Statement::ExecuteUnitTest(_) => {
+            return Err(PlanError::Unsupported {
+                feature: "EXECUTE UNIT TEST statement".to_string(),
+                discussion_no: None,
+            });
+        }
     };
 
     if let Ok(plan) = &plan {
@@ -1146,6 +1158,7 @@ impl<T: mz_sql_parser::ast::AstInfo> From<&Statement<T>> for StatementClassifica
             Statement::Raise(_) => Other,
             Statement::Show(ShowStatement::InspectShard(_)) => Other,
             Statement::ValidateConnection(_) => Other,
+            Statement::ExecuteUnitTest(_) => Other,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds parser support for `EXECUTE UNIT TEST`, a SQL-level construct for
declarative unit testing of views and materialized views. The plan side returns
`unsupported`.

## Syntax

```sql
 EXECUTE UNIT TEST <test_name>
      FOR <target_name>
      [AT TIME <expr>]
      [MOCK <mock_name> ( <col_def> [, ...] ) AS ( <query> ) ,]...
      EXPECTED ( <col_def> [, ...] ) AS ( <query> )
```

- `<test_name>` — identifier, reported in test output.
- `FOR <view>` — fully-qualified name of the view or materialized view
  under test.
- `AT TIME <expr>` *(optional)* — time at which to evaluate the view, for
  testing temporal logic.
- `MOCK <input_view> (cols) AS <query>` *(zero or more)* — substitutes
  `<input_view>` with the rows produced by `<query>` for the duration of
  this test. Column list defines the schema the test expects from the
  mocked input.
- `EXPECTED (cols) AS <query>` *(required, exactly one)* — the rows the
  view under test must produce.

## Example

```sql
  EXECUTE UNIT TEST t FOR v
      MOCK a(x int) AS (SELECT 1),
      MOCK b(y int) AS (SELECT 2)
      EXPECTED (z int) AS (SELECT 3);
```

## Scope

- New keywords: `UNIT`, `TEST`, `MOCK`, `EXPECTED` (`src/sql-lexer`).
- New AST nodes: `ExecuteUnitTestStatement`, `MockViewDef`,
  `ExpectedResultDef` (`src/sql-parser/ast/defs/statement.rs`).
- Parser entry from `EXECUTE UNIT TEST ...` (`src/sql-parser/parser.rs`).
- Plan side returns `unsupported` — execution is intentionally out of
  scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)