### PR TITLE
console: maintained objects freshness diagnosis

### DIFF
--- a/console/src/api/materialize/maintained-objects/constants.ts
+++ b/console/src/api/materialize/maintained-objects/constants.ts
@@ -9,15 +9,14 @@
 
 /**
  * Object types we treat as "maintained" — sources, materialized views,
- * indexes, sinks, and tables. Values match `mz_objects.type` (and the
- * hyphenated form used by `mz_object_fully_qualified_names.object_type`).
+ * indexes, and sinks. Values match `mz_objects.type` (and the hyphenated
+ * form used by `mz_object_fully_qualified_names.object_type`).
  */
 export const MAINTAINED_OBJECT_TYPES = [
   "source",
   "materialized-view",
   "index",
   "sink",
-  "table",
 ] as const;
 
 export type MaintainedObjectType = (typeof MAINTAINED_OBJECT_TYPES)[number];

--- a/console/src/api/materialize/maintained-objects/criticalPath.test.sql.ts
+++ b/console/src/api/materialize/maintained-objects/criticalPath.test.sql.ts
@@ -1,0 +1,242 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  executeSqlHttp,
+  QUICKSTART_CLUSTER,
+} from "~/test/sql/materializeSqlClient";
+import { testdrive } from "~/test/sql/mzcompose";
+
+import { SEARCH_PATH } from "../executeSql";
+import { buildCriticalPathLiveQuery, CriticalPathRow } from "./criticalPath";
+
+/** Creates the test catalog tables that the query reads from. */
+const seedCatalogSql = (testSchema: string) => `
+      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
+      > CREATE SCHEMA ${testSchema};
+      > CREATE TABLE ${testSchema}.mz_materialization_dependencies (
+          object_id TEXT NOT NULL,
+          dependency_id TEXT NOT NULL
+        );
+      > CREATE TABLE ${testSchema}.mz_wallclock_global_lag_recent_history (
+          object_id TEXT NOT NULL,
+          lag INTERVAL,
+          occurred_at TIMESTAMP
+        );
+      > CREATE TABLE ${testSchema}.mz_object_dependencies (
+          object_id TEXT NOT NULL,
+          referenced_object_id TEXT NOT NULL
+        );
+      > CREATE TABLE ${testSchema}.mz_objects (
+          id TEXT NOT NULL,
+          type TEXT,
+          cluster_id TEXT
+        );
+      > CREATE TABLE ${testSchema}.mz_object_fully_qualified_names (
+          id TEXT NOT NULL,
+          name TEXT,
+          schema_name TEXT,
+          database_name TEXT
+        );
+      > CREATE TABLE ${testSchema}.mz_clusters (
+          id TEXT NOT NULL,
+          name TEXT
+        );
+      > CREATE TABLE ${testSchema}.mz_sources (
+          id TEXT NOT NULL,
+          type TEXT
+        );`;
+
+// Bucket size large enough that all seed rows in the same `now()` second land
+// in one bucket — the probe-peak snapshot returns every object's lag from
+// that bucket.
+const TEST_BUCKET_MS = 60 * 60 * 1000;
+
+const runQuery = async (
+  testSchema: string,
+  probeId: string,
+  lookbackMinutes = 60,
+) => {
+  const compiled = buildCriticalPathLiveQuery(
+    probeId,
+    lookbackMinutes,
+    TEST_BUCKET_MS,
+  );
+  const result = await executeSqlHttp(compiled, {
+    sessionVariables: {
+      cluster: QUICKSTART_CLUSTER,
+      search_path: `${testSchema}, ${SEARCH_PATH}`,
+    },
+  });
+  return result.rows as CriticalPathRow[];
+};
+
+describe("buildCriticalPathLiveQuery", () => {
+  /**
+   * Linear chain — probe at u3, two upstream hops back to source u1.
+   *
+   *                ┌──────────────────┐
+   *                │   u1  src · 2s   │  source
+   *                └────────┬─────────┘
+   *                         │
+   *                         ▼
+   *                ┌──────────────────┐
+   *                │   u2  mid · 5s   │
+   *                └────────┬─────────┘
+   *                         │
+   *                         ▼
+   *                ┌──────────────────┐
+   *                │  u3  probe · 8s  │  ← queried object
+   *                └──────────────────┘
+   *
+   * Expectation: two chain edges (u1→u2 and u2→u3), both isBottleneck=true,
+   * each row carrying its own lag and full metadata.
+   */
+  it("walks a linear chain back to the source", async () => {
+    const testSchema = "test_critical_path";
+
+    await testdrive(`${seedCatalogSql(testSchema)}
+      > INSERT INTO ${testSchema}.mz_materialization_dependencies VALUES
+          ('u3', 'u2'),
+          ('u2', 'u1');
+      > INSERT INTO ${testSchema}.mz_wallclock_global_lag_recent_history VALUES
+          ('u1', INTERVAL '2 SECONDS', now()),
+          ('u2', INTERVAL '5 SECONDS', now()),
+          ('u3', INTERVAL '8 SECONDS', now());
+      > INSERT INTO ${testSchema}.mz_objects VALUES
+          ('u1', 'source', 'c1'),
+          ('u2', 'materialized-view', 'c1'),
+          ('u3', 'materialized-view', 'c1');
+      > INSERT INTO ${testSchema}.mz_object_fully_qualified_names VALUES
+          ('u1', 'src', 'public', 'mz'),
+          ('u2', 'mid', 'public', 'mz'),
+          ('u3', 'probe', 'public', 'mz');
+      > INSERT INTO ${testSchema}.mz_clusters VALUES ('c1', 'compute');
+    `);
+
+    const rows = (await runQuery(testSchema, "u3")).sort((a, b) =>
+      a.id.localeCompare(b.id),
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      id: "u1",
+      childId: "u2",
+      name: "src",
+      objectType: "source",
+      clusterName: "compute",
+      isBottleneck: true,
+      parentSourceId: null,
+    });
+    expect(rows[0].lag?.toPostgres()).toBe("2 seconds");
+    expect(rows[1]).toMatchObject({
+      id: "u2",
+      childId: "u3",
+      name: "mid",
+      objectType: "materialized-view",
+      isBottleneck: true,
+    });
+    expect(rows[1].lag?.toPostgres()).toBe("5 seconds");
+  });
+
+  /**
+   * Tied bottlenecks — three sources all at 4s feeding the probe.
+   *
+   *      ┌────────┐  ┌────────┐  ┌────────┐
+   *      │ u1·4s  │  │ u2·4s  │  │ u3·4s  │  all tied
+   *      └────┬───┘  └────┬───┘  └────┬───┘
+   *           │           │           │
+   *           └───────────┼───────────┘
+   *                       ▼
+   *             ┌──────────────────┐
+   *             │  u9  probe · 5s  │
+   *             └──────────────────┘
+   *
+   * Expectation: all three rows have isBottleneck=true. No arbitrary
+   * tie-breaking — every input that ties for max lag stays on the chain.
+   */
+  it("flags every input tied for max lag as a chain bottleneck", async () => {
+    const testSchema = "test_critical_path";
+
+    await testdrive(`${seedCatalogSql(testSchema)}
+      > INSERT INTO ${testSchema}.mz_materialization_dependencies VALUES
+          ('u9', 'u1'),
+          ('u9', 'u2'),
+          ('u9', 'u3');
+      > INSERT INTO ${testSchema}.mz_wallclock_global_lag_recent_history VALUES
+          ('u1', INTERVAL '4 SECONDS', now()),
+          ('u2', INTERVAL '4 SECONDS', now()),
+          ('u3', INTERVAL '4 SECONDS', now()),
+          ('u9', INTERVAL '5 SECONDS', now());
+      > INSERT INTO ${testSchema}.mz_objects VALUES
+          ('u1', 'source', NULL),
+          ('u2', 'source', NULL),
+          ('u3', 'source', NULL),
+          ('u9', 'materialized-view', NULL);
+      > INSERT INTO ${testSchema}.mz_object_fully_qualified_names VALUES
+          ('u1', 'a', 'public', 'mz'),
+          ('u2', 'b', 'public', 'mz'),
+          ('u3', 'c', 'public', 'mz'),
+          ('u9', 'probe', 'public', 'mz');
+    `);
+
+    const rows = (await runQuery(testSchema, "u9")).sort((a, b) =>
+      a.id.localeCompare(b.id),
+    );
+    expect(rows.map((r) => r.id)).toEqual(["u1", "u2", "u3"]);
+    expect(rows.every((r) => r.isBottleneck)).toBe(true);
+  });
+
+  /**
+   * Off-path sibling — probe has one chain input and one slower-but-not-
+   * bottleneck input. Both are returned, distinguished by isBottleneck.
+   *
+   *    ┌─────────────────┐         ┌─────────────────┐
+   *    │ u_fast src · 5s │         │ u_slow src · 1s │
+   *    │  (bottleneck)   │         │   (off-path)    │
+   *    └────────┬────────┘         └────────┬────────┘
+   *             │                           │
+   *             └─────────────┬─────────────┘
+   *                           ▼
+   *                ┌──────────────────┐
+   *                │  u9  probe · 6s  │
+   *                └──────────────────┘
+   *
+   * Expectation: u_fast has isBottleneck=true (it's pinning the probe's
+   * frontier). u_slow has isBottleneck=false but is still in the result so
+   * the DAG can render it as a grey off-path sibling.
+   */
+  it("returns slower siblings as off-path inputs of chain nodes", async () => {
+    const testSchema = "test_critical_path";
+
+    await testdrive(`${seedCatalogSql(testSchema)}
+      > INSERT INTO ${testSchema}.mz_materialization_dependencies VALUES
+          ('u9', 'u_fast'),
+          ('u9', 'u_slow');
+      > INSERT INTO ${testSchema}.mz_wallclock_global_lag_recent_history VALUES
+          ('u_fast', INTERVAL '5 SECONDS', now()),
+          ('u_slow', INTERVAL '1 SECOND', now()),
+          ('u9', INTERVAL '6 SECONDS', now());
+      > INSERT INTO ${testSchema}.mz_objects VALUES
+          ('u_fast', 'source', NULL),
+          ('u_slow', 'source', NULL),
+          ('u9', 'materialized-view', NULL);
+      > INSERT INTO ${testSchema}.mz_object_fully_qualified_names VALUES
+          ('u_fast', 'fast', 'public', 'mz'),
+          ('u_slow', 'slow', 'public', 'mz'),
+          ('u9', 'probe', 'public', 'mz');
+    `);
+
+    const rows = await runQuery(testSchema, "u9");
+    const fast = rows.find((r) => r.id === "u_fast");
+    const slow = rows.find((r) => r.id === "u_slow");
+    expect(fast?.isBottleneck).toBe(true);
+    expect(slow?.isBottleneck).toBe(false);
+  });
+});

--- a/console/src/api/materialize/maintained-objects/criticalPath.ts
+++ b/console/src/api/materialize/maintained-objects/criticalPath.ts
@@ -1,0 +1,316 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { QueryKey } from "@tanstack/react-query";
+import { CompiledQuery, RawBuilder, sql } from "kysely";
+
+import {
+  escapedLiteral as lit,
+  executeSqlV2,
+  IPostgresInterval,
+  queryBuilder,
+} from "~/api/materialize";
+
+import { MAINTAINED_OBJECT_TYPES } from "./constants";
+
+const MAINTAINED_OBJECT_TYPES_SQL = sql.raw(
+  MAINTAINED_OBJECT_TYPES.map((t) => `'${t}'`).join(", "),
+);
+
+export interface CriticalPathRow {
+  id: string;
+  childId: string;
+  name: string;
+  objectType: string;
+  schemaName: string;
+  databaseName: string | null;
+  clusterId: string | null;
+  clusterName: string | null;
+  /** This node's lag at the snapshot moment used to draw the chain. */
+  lag: IPostgresInterval | null;
+  /** The consumer's lag at the same snapshot moment. */
+  targetLag: IPostgresInterval | null;
+  isBottleneck: boolean;
+  parentSourceId: string | null;
+  /** This node's max lag in the lookback window, independent of the chain snapshot. */
+  peakLag: IPostgresInterval | null;
+  /** Observation time of `peakLag`. */
+  peakLagAt: Date | null;
+}
+
+/**
+ * `per_object_lag` CTE definition for when the user has not selected a
+ * timestamp on the freshness chart. `buildCriticalPathQuery` splices this
+ * fragment into the critical path query via its `${perObjectLag}` placeholder;
+ * the fragment also declares the `probe_peak_bucket` CTE it depends on.
+ *
+ * Gets each object's lag observation inside the chart bucket where the
+ * queried object's lag peaked over the lookback window.
+ */
+const perObjectLagCteAtProbePeak = (
+  objectId: string,
+  lookbackMinutes: number,
+  bucketSizeMs: number,
+) => {
+  const lookback = sql.raw(`${lookbackMinutes}`);
+  const bucketMs = sql.raw(`${bucketSizeMs}`);
+  // `DISTINCT ON (object_id)` picks the probe's peak-lag bucket;
+  // `LIMIT` isn't reliable inside `WITH MUTUALLY RECURSIVE`. The
+  // `::timestamptz` cast pins the CTE column type.
+  return sql`probe_peak_bucket(bucket_start timestamptz) AS (
+    SELECT DISTINCT ON (object_id) date_bin(
+        INTERVAL '${bucketMs} MILLISECONDS',
+        occurred_at,
+        TIMESTAMP '1970-01-01'
+      )::timestamptz
+    FROM mz_wallclock_global_lag_recent_history
+    WHERE object_id = ${lit(objectId)}
+      AND occurred_at + INTERVAL '${lookback} MINUTES' >= mz_now()
+    ORDER BY object_id, lag DESC NULLS LAST
+  ),
+  per_object_lag(object_id text, lag interval) AS (
+    SELECT DISTINCT ON (h.object_id) h.object_id, h.lag
+    FROM mz_wallclock_global_lag_recent_history h, probe_peak_bucket b
+    WHERE h.occurred_at >= b.bucket_start
+      AND h.occurred_at < b.bucket_start + INTERVAL '${bucketMs} MILLISECONDS'
+    ORDER BY h.object_id, h.lag DESC
+  )`;
+};
+
+/**
+ * `per_object_lag` CTE definition for when the user has selected (locked) a
+ * timestamp on the freshness chart. `buildCriticalPathQuery` splices this
+ * fragment into the critical path query via its `${perObjectLag}` placeholder.
+ *
+ * Gets each object's most recent lag observation inside the chart bucket
+ * containing the selected timestamp.
+ */
+const perObjectLagCteAtTime = (timestamp: Date, bucketSizeMs: number) => {
+  const tsLit = sql.lit(timestamp.toISOString());
+  const bucketMs = sql.raw(`${bucketSizeMs}`);
+  return sql`per_object_lag(object_id text, lag interval) AS (
+    SELECT DISTINCT ON (object_id) object_id, lag
+    FROM mz_wallclock_global_lag_recent_history
+    WHERE occurred_at >= date_bin(
+        INTERVAL '${bucketMs} MILLISECONDS',
+        ${tsLit}::timestamptz,
+        TIMESTAMP '1970-01-01'
+      )
+      AND occurred_at < date_bin(
+        INTERVAL '${bucketMs} MILLISECONDS',
+        ${tsLit}::timestamptz,
+        TIMESTAMP '1970-01-01'
+      ) + INTERVAL '${bucketMs} MILLISECONDS'
+    ORDER BY object_id, lag DESC
+  )`;
+};
+
+/**
+ * Given an object ID, walks the critical path back to its sources and returns
+ * one row per chain edge plus the immediate off-path siblings of each chain
+ * node. The two callers — `buildCriticalPathLiveQuery` and
+ * `buildCriticalPathAtTimeQuery` — parameterize this template by passing a
+ * different `per_object_lag` CTE definition.
+ *
+ * 1) For each child, pick its slowest input(s) — the bottlenecks
+ * 2) Walk backwards from the queried object along bottleneck edges
+ * 3) Restrict to inputs of nodes on the chain (queried object + ancestors)
+ * 4) Join object metadata, cluster name, subsource → parent redirection,
+ *    and per-node window-pMAX (independent of the chain snapshot)
+ */
+const buildCriticalPathQuery = (
+  objectId: string,
+  lookbackMinutes: number,
+  perObjectLag: RawBuilder<unknown>,
+): CompiledQuery<CriticalPathRow> => {
+  const lookback = sql.raw(`${lookbackMinutes}`);
+  return sql<CriticalPathRow>`
+WITH MUTUALLY RECURSIVE
+  -- mz_materialization_dependencies covers sinks (which read from MVs/sources)
+  -- as well as compute objects. Restrict both ends of the edge to maintained
+  -- object types so tables drop out of the chain.
+  input_of(source text, target text) AS (
+    SELECT md.dependency_id, md.object_id
+    FROM mz_materialization_dependencies md
+    JOIN mz_objects src ON src.id = md.dependency_id
+      AND src.type IN (${MAINTAINED_OBJECT_TYPES_SQL})
+    JOIN mz_objects tgt ON tgt.id = md.object_id
+      AND tgt.type IN (${MAINTAINED_OBJECT_TYPES_SQL})
+  ),
+  ${perObjectLag},
+  -- Per-node max lag in the lookback window and when it occurred.
+  -- Joined onto the SELECT below as per-node badge metadata.
+  per_object_peak(object_id text, peak_lag interval, peak_at timestamptz) AS (
+    SELECT DISTINCT ON (object_id)
+      object_id, lag, occurred_at::timestamptz
+    FROM mz_wallclock_global_lag_recent_history
+    WHERE occurred_at + INTERVAL '${lookback} MINUTES' >= mz_now()
+    ORDER BY object_id, lag DESC NULLS LAST, occurred_at DESC
+  ),
+  max_input_lag(target text, max_lag interval) AS (
+    SELECT i.target, max(p.lag)
+    FROM input_of i
+    JOIN per_object_lag p ON p.object_id = i.source
+    GROUP BY i.target
+  ),
+  crit_input(source text, target text) AS (
+    SELECT i.source, i.target
+    FROM input_of i
+    JOIN per_object_lag p ON p.object_id = i.source
+    JOIN max_input_lag m ON m.target = i.target
+    WHERE p.lag IS NOT DISTINCT FROM m.max_lag
+  ),
+  -- Seed with (objectId, objectId) so its direct inputs land in the result.
+  delayed_by(source text, target text) AS (
+    SELECT ${lit(objectId)}, ${lit(objectId)}
+    UNION
+    SELECT ci.source, ci.target
+    FROM delayed_by db
+    JOIN crit_input ci ON db.source = ci.target
+  ),
+  chain_targets(target text) AS (
+    SELECT DISTINCT target FROM delayed_by
+  ),
+  -- Subsources are filtered out of the maintained-objects list, so the panel
+  -- redirects drawer links to the parent source.
+  subsource_parents(subsource_id text, parent_id text) AS (
+    SELECT od.object_id, od.referenced_object_id
+    FROM mz_object_dependencies od
+    JOIN mz_sources cs ON cs.id = od.object_id AND cs.type = 'subsource'
+    JOIN mz_sources ps ON ps.id = od.referenced_object_id
+      AND ps.id LIKE 'u%'
+  )
+SELECT
+  i.source AS "id",
+  i.target AS "childId",
+  fqn.name AS "name",
+  o.type AS "objectType",
+  fqn.schema_name AS "schemaName",
+  fqn.database_name AS "databaseName",
+  c.id AS "clusterId",
+  c.name AS "clusterName",
+  ls.lag AS "lag",
+  lt.lag AS "targetLag",
+  EXISTS (
+    SELECT 1 FROM crit_input ci
+    WHERE ci.source = i.source AND ci.target = i.target
+  ) AS "isBottleneck",
+  sp.parent_id AS "parentSourceId",
+  pk.peak_lag AS "peakLag",
+  pk.peak_at AS "peakLagAt"
+FROM input_of i
+JOIN chain_targets ct ON ct.target = i.target
+JOIN mz_objects o ON o.id = i.source
+JOIN mz_object_fully_qualified_names fqn ON fqn.id = i.source
+LEFT JOIN mz_clusters c ON c.id = o.cluster_id
+LEFT JOIN per_object_lag ls ON ls.object_id = i.source
+LEFT JOIN per_object_lag lt ON lt.object_id = i.target
+LEFT JOIN subsource_parents sp ON sp.subsource_id = i.source
+LEFT JOIN per_object_peak pk ON pk.object_id = i.source
+ORDER BY ls.lag DESC NULLS LAST
+  `.compile(queryBuilder);
+};
+
+/**
+ * Compiles the critical-path query for default mode (the user has not
+ * locked a timestamp on the freshness chart). The chain is snapshotted
+ * from the bucket where the probe's lag peaked in the lookback window.
+ */
+export const buildCriticalPathLiveQuery = (
+  objectId: string,
+  lookbackMinutes: number,
+  bucketSizeMs: number,
+): CompiledQuery<CriticalPathRow> =>
+  buildCriticalPathQuery(
+    objectId,
+    lookbackMinutes,
+    perObjectLagCteAtProbePeak(objectId, lookbackMinutes, bucketSizeMs),
+  );
+
+/**
+ * Compiles the critical-path query for the user's selected `timestamp`. Each
+ * node's lag is read from the bucket aligned to that timestamp, so the chain
+ * matches what the freshness chart drew at that point. `lookbackMinutes` is
+ * only used to compute the per-node `peakLag` badge.
+ */
+export const buildCriticalPathAtTimeQuery = (
+  objectId: string,
+  timestamp: Date,
+  bucketSizeMs: number,
+  lookbackMinutes: number,
+): CompiledQuery<CriticalPathRow> =>
+  buildCriticalPathQuery(
+    objectId,
+    lookbackMinutes,
+    perObjectLagCteAtTime(timestamp, bucketSizeMs),
+  );
+
+/**
+ * Fetches the critical path for default mode (no user-selected timestamp).
+ * The chain is snapshotted from the bucket where the probe's lag peaked in
+ * the lookback window.
+ */
+export const fetchCriticalPathLive = ({
+  objectId,
+  lookbackMinutes,
+  bucketSizeMs,
+  queryKey,
+  requestOptions,
+}: {
+  objectId: string;
+  lookbackMinutes: number;
+  bucketSizeMs: number;
+  queryKey: QueryKey;
+  requestOptions?: RequestInit;
+}) =>
+  executeSqlV2({
+    queries: buildCriticalPathLiveQuery(
+      objectId,
+      lookbackMinutes,
+      bucketSizeMs,
+    ),
+    queryKey,
+    requestOptions,
+    requestTimeoutMs: 30_000,
+    sessionVariables: { transaction_isolation: "serializable" },
+  });
+
+/**
+ * Fetches the critical path at the user's selected `timestamp` — each node's
+ * lag is read from the chart bucket containing it, so the chain matches what
+ * the chart drew at that point. `lookbackMinutes` is only used to compute
+ * the per-node `peakLag` badge.
+ */
+export const fetchCriticalPathAtTime = ({
+  objectId,
+  timestamp,
+  bucketSizeMs,
+  lookbackMinutes,
+  queryKey,
+  requestOptions,
+}: {
+  objectId: string;
+  timestamp: Date;
+  bucketSizeMs: number;
+  lookbackMinutes: number;
+  queryKey: QueryKey;
+  requestOptions?: RequestInit;
+}) =>
+  executeSqlV2({
+    queries: buildCriticalPathAtTimeQuery(
+      objectId,
+      timestamp,
+      bucketSizeMs,
+      lookbackMinutes,
+    ),
+    queryKey,
+    requestOptions,
+    requestTimeoutMs: 30_000,
+    sessionVariables: { transaction_isolation: "serializable" },
+  });

--- a/console/src/components/FreshnessGraph/FreshnessGraph.tsx
+++ b/console/src/components/FreshnessGraph/FreshnessGraph.tsx
@@ -16,6 +16,7 @@ import { scaleLinear, scaleTime } from "@visx/scale";
 import { LinePath } from "@visx/shape";
 import { useTooltip, useTooltipInPortal } from "@visx/tooltip";
 import { max } from "d3";
+import debounce from "lodash.debounce";
 import React, { PointerEvent } from "react";
 
 import { NULL_LAG_TEXT } from "~/api/materialize/freshness/lagHistory";
@@ -37,6 +38,7 @@ import { formatDurationForAxis, formatInterval } from "~/utils/format";
 import {
   buildXYGraphLayoutProps,
   calculateTooltipPosition,
+  eventToTimestamp,
   findNearestDatum,
   niceTicks,
   relativeTimeTickFormat,
@@ -49,6 +51,8 @@ const MARGIN = { top: 20, right: 8, bottom: 36, left: 44 };
 const MAX_LAG_MS = 86_400_000; // 24 hours
 const X_TICK_COUNT = 4;
 const Y_TICK_COUNT = 4;
+
+export type FreshnessGraphVariant = "static" | "interactive";
 
 export type FreshnessGraphProps = {
   bucketSizeMs: number;
@@ -63,6 +67,13 @@ export type FreshnessGraphProps = {
     lineData: GraphLineSeries;
   }) => React.ReactNode;
   maxTooltipLines?: number;
+  /** Controls cursor styling and pointer affordances. Defaults to `"static"`. */
+  variant?: FreshnessGraphVariant;
+  /** Fires as the cursor scrubs across the graph. Debounced (150ms). */
+  onPointMove?: (timestamp: number | null) => void;
+  onPointClick?: (timestamp: number | null) => void;
+  selectedTimestamp?: number | null;
+  isLocked?: boolean;
 };
 
 export const FreshnessGraph = (props: FreshnessGraphProps) => {
@@ -223,6 +234,17 @@ const FreshnessGraphInner = (
 
   const { cursor, handleCursorMove, hideCursor } = useCursorState();
 
+  // The marker tracks the cursor synchronously; the parent is notified on a
+  // debounce so scrubbing doesn't fire a query on every pixel.
+  const [hoverTimestamp, setHoverTimestamp] = React.useState<number | null>(
+    null,
+  );
+  const { onPointMove } = props;
+  const debouncedPointSelect = React.useMemo(
+    () => debounce((ts: number) => onPointMove?.(ts), 150),
+    [onPointMove],
+  );
+
   const handleTooltip = React.useCallback(
     (event: PointerEvent) => {
       const svgPoint = localPoint(event);
@@ -354,14 +376,60 @@ const FreshnessGraphInner = (
         ))}
         <GraphEventOverlay
           {...graphEventOverlayProps}
+          style={{
+            cursor:
+              props.variant === "interactive"
+                ? props.isLocked
+                  ? "pointer"
+                  : "crosshair"
+                : "default",
+          }}
           onPointerMove={(event) => {
             handleCursorMove(event);
             handleTooltip(event);
+            if (props.isLocked || !props.onPointMove) return;
+            const ts = eventToTimestamp({
+              event,
+              xScale,
+              startTime: props.startTime,
+              endTime: props.endTime,
+            });
+            if (ts === null) return;
+            setHoverTimestamp(ts);
+            debouncedPointSelect(ts);
           }}
           onPointerLeave={() => {
             hideCursor();
             hideTooltip();
           }}
+          onClick={
+            props.onPointClick
+              ? (event) => {
+                  if (props.isLocked) {
+                    props.onPointClick?.(null);
+                    return;
+                  }
+                  const ts = eventToTimestamp({
+                    event,
+                    xScale,
+                    startTime: props.startTime,
+                    endTime: props.endTime,
+                  });
+                  if (ts !== null) props.onPointClick?.(ts);
+                }
+              : undefined
+          }
+        />
+        <SelectedMarker
+          timestamp={
+            props.isLocked
+              ? props.selectedTimestamp
+              : (hoverTimestamp ?? props.selectedTimestamp)
+          }
+          xScale={xScale}
+          y1={graphLineCursorProps.graphTop}
+          y2={graphLineCursorProps.graphBottom}
+          color={colors.accent.brightPurple}
         />
         {cursor && <GraphLineCursor point={cursor} {...graphLineCursorProps} />}
         {tooltipOpen && tooltipData && (
@@ -460,5 +528,33 @@ const FreshnessGraphInner = (
         </GraphTooltip>
       )}
     </>
+  );
+};
+
+const SelectedMarker = ({
+  timestamp,
+  xScale,
+  y1,
+  y2,
+  color,
+}: {
+  timestamp: number | null | undefined;
+  xScale: (value: number) => number;
+  y1: number;
+  y2: number;
+  color: string;
+}) => {
+  if (timestamp == null) return null;
+  return (
+    <line
+      x1={xScale(timestamp)}
+      x2={xScale(timestamp)}
+      y1={y1}
+      y2={y2}
+      stroke={color}
+      strokeWidth={2}
+      strokeDasharray="4 3"
+      pointerEvents="none"
+    />
   );
 };

--- a/console/src/components/graphComponents.tsx
+++ b/console/src/components/graphComponents.tsx
@@ -129,6 +129,8 @@ export const GraphEventOverlay = (props: {
   height: number;
   onPointerMove: (event: React.PointerEvent<SVGRectElement>) => void;
   onPointerLeave: (event: React.PointerEvent<SVGRectElement>) => void;
+  onClick?: (event: React.MouseEvent<SVGRectElement>) => void;
+  style?: React.CSSProperties;
   x: number;
   y: number;
 }) => {

--- a/console/src/config/flexibleDeploymentFlags.ts
+++ b/console/src/config/flexibleDeploymentFlags.ts
@@ -12,9 +12,7 @@
  * is too big, we default all flags to true and specify the ones we want
  * to disable.
  */
-export const disabledFlexibleDeploymentFlags: Record<string, boolean> = {
-  "maintained-objects-ui-50": false,
-};
+export const disabledFlexibleDeploymentFlags: Record<string, boolean> = {};
 
 export const flexibleDeploymentFlags = new Proxy(
   {},

--- a/console/src/hooks/useChartLegend.ts
+++ b/console/src/hooks/useChartLegend.ts
@@ -23,7 +23,15 @@ export function useChartLegend({
 }) {
   const [visibleLegendItems, setVisibleLegendItems] = React.useState<
     Set<string>
-  >(new Set(allLegendItems));
+  >(() => new Set(allLegendItems));
+
+  // Reset visibility when the legend keys change (e.g. chart reused for a different object).
+  const allKey = allLegendItems.join("\0");
+  const [prevAllKey, setPrevAllKey] = React.useState(allKey);
+  if (prevAllKey !== allKey) {
+    setPrevAllKey(allKey);
+    setVisibleLegendItems(new Set(allLegendItems));
+  }
 
   const toggleLegendItem = (
     key: string,

--- a/console/src/hooks/useSyncObjectToSearchParams.ts
+++ b/console/src/hooks/useSyncObjectToSearchParams.ts
@@ -78,7 +78,7 @@ export const useSyncObjectToSearchParams = (
   object: Record<string, any>,
   pathPrefix: string | undefined = undefined,
 ) => {
-  const { pathname } = useLocation();
+  const { pathname, state } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
@@ -87,7 +87,8 @@ export const useSyncObjectToSearchParams = (
     }
     const newSearchParams = encodeObjectAsSearchParams(object);
     if (newSearchParams.toString() !== searchParams.toString()) {
-      setSearchParams(newSearchParams, { replace: true });
+      // setSearchParams drops state unless forwarded
+      setSearchParams(newSearchParams, { replace: true, state });
     }
-  }, [searchParams, setSearchParams, object, pathname, pathPrefix]);
+  }, [searchParams, setSearchParams, object, pathname, pathPrefix, state]);
 };

--- a/console/src/platform/environment-overview/MemDiskUtilization.tsx
+++ b/console/src/platform/environment-overview/MemDiskUtilization.tsx
@@ -43,9 +43,10 @@ import { useRegionSlug } from "~/store/environments";
 import { MaterializeTheme } from "~/theme";
 import { notNullOrUndefined } from "~/util";
 import { formatDate } from "~/utils/dateFormat";
+import { formatPercentage } from "~/utils/format";
 
 import { useClusterMemDiskUtilization } from "./queries";
-import { MemDiskUtilizationStatus, ThresholdPercentages } from "./utils";
+import { ThresholdPercentages, utilizationStatusToColor } from "./utils";
 
 const UTILIZATION_STATUS_TO_DESCRIPTION = {
   optimal: "The cluster is performing optimally.",
@@ -53,25 +54,6 @@ const UTILIZATION_STATUS_TO_DESCRIPTION = {
   underProvisioned:
     "The cluster is at risk of crash looping due to running out of memory and disk. Consider increasing the size of your cluster.",
 };
-
-const utilizationStatusToColor = (
-  utilizationStatus: MemDiskUtilizationStatus,
-  colors: MaterializeTheme["colors"],
-) => {
-  switch (utilizationStatus) {
-    case "empty":
-      return colors.foreground.tertiary;
-    case "optimal":
-      return colors.green[400];
-    case "suboptimal":
-      return colors.yellow[600];
-    case "underProvisioned":
-      return colors.accent.red;
-  }
-};
-
-const formatPercentage = (percentage: number) =>
-  `${(percentage * 100).toFixed(2)}%`;
 
 const buildReplicaTickMarks = ({
   thresholdPercentages,

--- a/console/src/platform/environment-overview/utils.ts
+++ b/console/src/platform/environment-overview/utils.ts
@@ -11,6 +11,7 @@ import {
   Bucket,
   OfflineEvent,
 } from "~/api/materialize/cluster/replicaUtilizationHistory";
+import { MaterializeTheme } from "~/theme";
 
 // Console-specific categories of a cluster. Compute implies the cluster has compute objects only, storage likewise, and hybrid means both.
 export type ClusterCategory = "compute" | "storage" | "hybrid" | "empty";
@@ -73,9 +74,25 @@ const COMPUTE_AND_HYBRID_THRESHOLD_PERCENTAGES = {
 /**
  * Generic thresholds for replicas that don't have compute objects.
  */
-const DEFAULT_THRESHOLD_PERCENTAGES = {
+export const DEFAULT_THRESHOLD_PERCENTAGES = {
   optimal: 0.7,
   suboptimal: 0.85,
+};
+
+export const utilizationStatusToColor = (
+  status: MemDiskUtilizationStatus,
+  colors: MaterializeTheme["colors"],
+) => {
+  switch (status) {
+    case "empty":
+      return colors.foreground.tertiary;
+    case "optimal":
+      return colors.green[400];
+    case "suboptimal":
+      return colors.yellow[600];
+    case "underProvisioned":
+      return colors.accent.red;
+  }
 };
 
 export function calculateClusterCategory({

--- a/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
+++ b/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
@@ -1,0 +1,378 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Card,
+  HStack,
+  SimpleGrid,
+  Spinner,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import React from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+import { Bucket } from "~/api/materialize/cluster/replicaUtilizationHistory";
+import TextLink from "~/components/TextLink";
+import {
+  calculateMemDiskUtilizationStatus,
+  DEFAULT_THRESHOLD_PERCENTAGES,
+  utilizationStatusToColor,
+} from "~/platform/environment-overview/utils";
+import { absoluteClusterPath } from "~/platform/routeHelpers";
+import { useAllClusters } from "~/store/allClusters";
+import { useRegionSlug } from "~/store/environments";
+import WarningIcon from "~/svg/WarningIcon";
+import { MaterializeTheme } from "~/theme";
+import { pluralize } from "~/util";
+import { formatDate } from "~/utils/dateFormat";
+import { formatPercentage } from "~/utils/format";
+
+import { RenderableNode } from "./criticalPathRenderable";
+import { ReplicaInWindow, useClusterBucketsInWindow } from "./queries";
+import { useJourneyLinkState } from "./useJourneyLinkState";
+
+type Cluster = NonNullable<RenderableNode["cluster"]>;
+
+const MetricCard = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  return (
+    <Card
+      px={3}
+      py={2}
+      borderWidth="1px"
+      borderColor={colors.border.primary}
+      borderRadius="md"
+    >
+      <VStack align="stretch" spacing={2}>
+        <Text textStyle="text-small" color={colors.foreground.secondary}>
+          {label}
+        </Text>
+        {children}
+      </VStack>
+    </Card>
+  );
+};
+
+const MetricBarCard = ({
+  label,
+  fraction,
+}: {
+  label: string;
+  fraction: number | null;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const status = calculateMemDiskUtilizationStatus({
+    thresholdPercentages: DEFAULT_THRESHOLD_PERCENTAGES,
+    peakMemDiskUtilizationPercent: fraction,
+  });
+  const isCritical = status === "underProvisioned";
+  const barColor = utilizationStatusToColor(status, colors);
+  const widthPct = fraction === null ? 0 : Math.min(1, fraction) * 100;
+  return (
+    <MetricCard label={label}>
+      <HStack spacing={1} align="center">
+        {isCritical && (
+          <WarningIcon
+            boxSize="3"
+            color={colors.accent.red}
+            aria-label="critical"
+          />
+        )}
+        <Text
+          textStyle="text-ui-med"
+          color={isCritical ? colors.accent.red : undefined}
+        >
+          {fraction === null ? "—" : formatPercentage(fraction)}
+        </Text>
+      </HStack>
+      <Box
+        width="100%"
+        height="2"
+        borderRadius="full"
+        bg={colors.background.secondary}
+        overflow="hidden"
+      >
+        <Box
+          height="100%"
+          width={`${widthPct}%`}
+          borderRadius="full"
+          bg={barColor}
+          transition="width 0.3s ease"
+        />
+      </Box>
+    </MetricCard>
+  );
+};
+
+const EmptyStateCard = ({ children }: { children: React.ReactNode }) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  return (
+    <Card
+      px={3}
+      py={3}
+      borderWidth="1px"
+      borderColor={colors.border.primary}
+      borderRadius="md"
+    >
+      <Text textStyle="text-small" color={colors.foreground.secondary}>
+        {children}
+      </Text>
+    </Card>
+  );
+};
+
+const ClusterMetricsHeader = ({
+  node,
+  pageObjectId,
+  timestamp,
+}: {
+  node: RenderableNode;
+  pageObjectId: string;
+  timestamp: Date | null;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const journeyLinkState = useJourneyLinkState(pageObjectId);
+  const objectLinkTarget = `../${node.parentSourceId ?? node.id}`;
+  return (
+    <VStack align="stretch" spacing={1}>
+      <Text textStyle="heading-sm" noOfLines={1} title={node.name}>
+        Cluster metrics for{" "}
+        {node.isProbe ? (
+          node.name
+        ) : (
+          <TextLink
+            as={RouterLink}
+            to={objectLinkTarget}
+            relative="path"
+            state={journeyLinkState}
+          >
+            {node.name}
+          </TextLink>
+        )}
+        {timestamp && (
+          <Text as="span" color={colors.foreground.secondary} ml={2}>
+            at {formatDate(timestamp, "h:mm:ss a")}
+          </Text>
+        )}
+      </Text>
+      <Text textStyle="text-small" color={colors.foreground.secondary}>
+        Memory and CPU on the replica hosting the node you selected above.
+      </Text>
+    </VStack>
+  );
+};
+
+const ClusterMetricCard = ({ cluster }: { cluster: Cluster }) => {
+  const regionSlug = useRegionSlug();
+  return (
+    <MetricCard label="Cluster">
+      <TextLink
+        as={RouterLink}
+        to={absoluteClusterPath(regionSlug, cluster)}
+        textStyle="text-ui-med"
+        noOfLines={1}
+      >
+        {cluster.name}
+      </TextLink>
+    </MetricCard>
+  );
+};
+
+const ReplicaInfoCard = ({
+  replica,
+  isDropped,
+}: {
+  replica: Bucket;
+  isDropped: boolean;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  return (
+    <MetricCard label="Replica">
+      <HStack spacing={1} flexWrap="wrap">
+        <Text textStyle="text-ui-med">{replica.name}</Text>
+        {replica.size && (
+          <Text textStyle="text-small" color={colors.foreground.secondary}>
+            ({replica.size})
+          </Text>
+        )}
+        {isDropped && (
+          <Text textStyle="text-small" color={colors.foreground.secondary}>
+            (dropped)
+          </Text>
+        )}
+      </HStack>
+    </MetricCard>
+  );
+};
+
+const ReplicaMetricsRow = ({
+  cluster,
+  replica,
+  isDropped,
+}: {
+  cluster: Cluster;
+  replica: Bucket;
+  isDropped: boolean;
+}) => (
+  <SimpleGrid columns={2} spacing={3}>
+    <ClusterMetricCard cluster={cluster} />
+    <ReplicaInfoCard replica={replica} isDropped={isDropped} />
+    <MetricBarCard label="Memory" fraction={replica.maxMemory.percent} />
+    <MetricBarCard label="CPU" fraction={replica.maxCpu.percent} />
+  </SimpleGrid>
+);
+
+const ReplicaMetricsList = ({
+  cluster,
+  replicas,
+  isLoading,
+  isError,
+}: {
+  cluster: Cluster | null;
+  replicas: Bucket[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) => {
+  const { getClusterById } = useAllClusters();
+  if (cluster === null) {
+    return (
+      <EmptyStateCard>This object does not run on a cluster.</EmptyStateCard>
+    );
+  }
+  if (isLoading) return <Spinner size="sm" />;
+  if (isError) {
+    return <EmptyStateCard>Failed to load cluster metrics.</EmptyStateCard>;
+  }
+  if (!replicas || replicas.length === 0) {
+    return <EmptyStateCard>Inactive — replication factor 0</EmptyStateCard>;
+  }
+  const liveReplicaIds = new Set(
+    getClusterById(cluster.id)?.replicas.map((r) => r.id) ?? [],
+  );
+  return (
+    <VStack align="stretch" spacing={3}>
+      {replicas.map((replica) => (
+        <ReplicaMetricsRow
+          key={replica.replicaId}
+          cluster={cluster}
+          replica={replica}
+          isDropped={!liveReplicaIds.has(replica.replicaId)}
+        />
+      ))}
+    </VStack>
+  );
+};
+
+const DroppedReplicasFooter = ({
+  windowReplicas,
+  lockedReplicas,
+}: {
+  windowReplicas: ReplicaInWindow[];
+  lockedReplicas: Bucket[];
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const lockedIds = new Set(lockedReplicas.map((r) => r.replicaId));
+  const dropped = windowReplicas.filter((r) => !lockedIds.has(r.replicaId));
+  if (dropped.length === 0) return null;
+  return (
+    <Card px={3} py={2} bg={colors.background.secondary} borderRadius="md">
+      <HStack spacing={2} flexWrap="wrap">
+        <Text textStyle="text-small">
+          {dropped.length} {pluralize(dropped.length, "replica", "replicas")}{" "}
+          dropped in this window:
+        </Text>
+        {dropped.map((r, i) => (
+          <Text
+            key={r.replicaId}
+            textStyle="text-small"
+            color={colors.foreground.secondary}
+          >
+            {r.name}
+            {r.size && ` (${r.size})`} · Last seen{" "}
+            {formatDate(r.lastSeenAt, "h:mm:ss a")}
+            {i < dropped.length - 1 && " ·"}
+          </Text>
+        ))}
+      </HStack>
+    </Card>
+  );
+};
+
+export interface CriticalPathClusterMetricsProps {
+  node: RenderableNode;
+  pageObjectId: string;
+  timestamp: Date | null;
+  bucketSizeMs: number;
+  lookbackMs: number;
+}
+
+export const CriticalPathClusterMetrics = ({
+  node,
+  pageObjectId,
+  timestamp,
+  bucketSizeMs,
+  lookbackMs,
+}: CriticalPathClusterMetricsProps) => {
+  const clusterId = node.cluster?.id ?? null;
+  const {
+    data: bucketsByReplicaId,
+    isLoading,
+    isError,
+  } = useClusterBucketsInWindow({
+    clusterId,
+    lookbackMs,
+    bucketSizeMs,
+    anchorTimestamp: timestamp,
+  });
+
+  const targetBucketStartMs =
+    Math.floor((timestamp ?? new Date()).getTime() / bucketSizeMs) *
+    bucketSizeMs;
+  const buckets = Object.values(bucketsByReplicaId ?? {});
+  const replicas = buckets.flatMap((bs) =>
+    bs.filter((b) => b.bucketStart.getTime() === targetBucketStartMs),
+  );
+  const replicasInWindow: ReplicaInWindow[] = buckets
+    .flatMap((bs) => bs.slice(-1))
+    .map(({ replicaId, name, size, bucketEnd }) => ({
+      replicaId,
+      name,
+      size,
+      lastSeenAt: bucketEnd,
+    }));
+
+  return (
+    <VStack align="stretch" spacing={3} width="100%">
+      <ClusterMetricsHeader
+        node={node}
+        pageObjectId={pageObjectId}
+        timestamp={timestamp}
+      />
+      <ReplicaMetricsList
+        cluster={node.cluster}
+        replicas={replicas}
+        isLoading={isLoading}
+        isError={isError}
+      />
+      <DroppedReplicasFooter
+        windowReplicas={replicasInWindow}
+        lockedReplicas={replicas}
+      />
+    </VStack>
+  );
+};

--- a/console/src/platform/maintained-objects/CriticalPathGraph.tsx
+++ b/console/src/platform/maintained-objects/CriticalPathGraph.tsx
@@ -1,0 +1,261 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Center,
+  HStack,
+  Spinner,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import React from "react";
+
+import { Canvas, GraphEdgeContainer, STROKE_WIDTH } from "~/components/Graph";
+import { useDagreGraph } from "~/hooks/useDagreGraph";
+import { MaterializeTheme } from "~/theme";
+
+import { CriticalPathClusterMetrics } from "./CriticalPathClusterMetrics";
+import { CriticalPathGraphNode } from "./CriticalPathGraphNode";
+import { buildGraphView } from "./criticalPathRenderable";
+import {
+  CriticalPathData,
+  MaintainedObjectListItem,
+  useCriticalPath,
+} from "./queries";
+
+const NODE_WIDTH = 160;
+const NODE_HEIGHT = 56;
+const RANK_SEP = 32;
+const DEFAULT_VISIBLE_DEPTH = 2;
+
+export interface CriticalPathGraphProps {
+  probe: MaintainedObjectListItem;
+  /** Null = live (pMAX over `lookbackMinutes`). */
+  timestamp: Date | null;
+  bucketSizeMs: number;
+  lookbackMinutes: number;
+}
+
+const LoadingSpinner = () => (
+  <Center height="200px" width="100%">
+    <Spinner size="sm" />
+  </Center>
+);
+
+export const CriticalPathGraph = ({
+  probe,
+  timestamp,
+  bucketSizeMs,
+  lookbackMinutes,
+}: CriticalPathGraphProps) => {
+  const { data, isLoading } = useCriticalPath({
+    objectId: probe.id,
+    timestamp,
+    bucketSizeMs,
+    lookbackMinutes,
+  });
+
+  if (isLoading || !data) return <LoadingSpinner />;
+  if (data.rows.length === 0) return <EmptyCriticalPath />;
+  return (
+    <CriticalPathGraphInner
+      probe={probe}
+      data={data}
+      timestamp={timestamp}
+      bucketSizeMs={bucketSizeMs}
+      lookbackMs={lookbackMinutes * 60 * 1000}
+    />
+  );
+};
+
+const EmptyCriticalPath = () => {
+  const { colors } = useTheme<MaterializeTheme>();
+  return (
+    <Center height="120px" width="100%">
+      <Text textStyle="text-small" color={colors.foreground.secondary}>
+        No upstream dependencies.
+      </Text>
+    </Center>
+  );
+};
+
+const CriticalPathGraphInner = ({
+  probe,
+  data,
+  timestamp,
+  bucketSizeMs,
+  lookbackMs,
+}: {
+  probe: MaintainedObjectListItem;
+  data: CriticalPathData;
+  timestamp: Date | null;
+  bucketSizeMs: number;
+  lookbackMs: number;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const [expandedBottleneckId, setExpandedBottleneckId] = React.useState<
+    string | null
+  >(null);
+  const [selectedNodeId, setSelectedNodeId] = React.useState<string | null>(
+    null,
+  );
+  const [visibleDepth, setVisibleDepth] = React.useState(DEFAULT_VISIBLE_DEPTH);
+
+  const { nodes, edges, hiddenChainCount } = React.useMemo(
+    () => buildGraphView(data, probe, expandedBottleneckId, visibleDepth),
+    [data, probe, expandedBottleneckId, visibleDepth],
+  );
+
+  const dagreNodes = React.useMemo(
+    () =>
+      nodes.map((n) => ({
+        id: n.id,
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+      })),
+    [nodes],
+  );
+
+  const dagreEdges = React.useMemo(
+    () => edges.map((r) => ({ parentId: r.id, childId: r.childId })),
+    [edges],
+  );
+
+  const {
+    graph,
+    nodePositionMap,
+    height,
+    width,
+    orderedGraphEdges,
+    clampPoints,
+  } = useDagreGraph({
+    nodes: dagreNodes,
+    edges: dagreEdges,
+    selectedNodeId: undefined,
+    ranksep: RANK_SEP,
+  });
+
+  if (!width || !height) return <LoadingSpinner />;
+
+  const isExpanded = visibleDepth > DEFAULT_VISIBLE_DEPTH;
+  const toggle = (id: string) => (curr: string | null) =>
+    curr === id ? null : id;
+  const displayedNode =
+    nodes.find((n) => n.id === selectedNodeId) ??
+    nodes.find((n) => n.isProbe) ??
+    nodes[0];
+
+  return (
+    <VStack align="stretch" width="100%" spacing={4}>
+      {(hiddenChainCount > 0 || isExpanded) && (
+        <HStack justify="flex-end">
+          <Text
+            as="button"
+            textStyle="text-small"
+            color={colors.accent.brightPurple}
+            cursor="pointer"
+            _hover={{ textDecoration: "underline" }}
+            onClick={() =>
+              setVisibleDepth(isExpanded ? DEFAULT_VISIBLE_DEPTH : Infinity)
+            }
+          >
+            {isExpanded
+              ? "Collapse"
+              : `+ ${hiddenChainCount} more upstream paths`}
+          </Text>
+        </HStack>
+      )}
+      <Box
+        position="relative"
+        width="100%"
+        height={`${height + 40}px`}
+        overflow="hidden"
+      >
+        <Canvas width={width} height={height} selectedNode={null}>
+          {nodes.map((node) => {
+            const dagreNode = graph.node(node.id);
+            const position = nodePositionMap.get(node.id);
+            if (!dagreNode || !position) return null;
+            return (
+              <CriticalPathGraphNode
+                key={node.id}
+                node={node}
+                pageObjectId={probe.id}
+                expanded={expandedBottleneckId === node.id}
+                selected={selectedNodeId === node.id}
+                left={position.left}
+                top={position.top}
+                width={dagreNode.width}
+                height={dagreNode.height}
+                onToggleExpand={() => setExpandedBottleneckId(toggle(node.id))}
+                onSelect={() => setSelectedNodeId(toggle(node.id))}
+              />
+            );
+          })}
+          <GraphEdgeContainer width={width} height={height}>
+            {orderedGraphEdges.map((e) => {
+              const dagreEdge = graph.edge(e);
+              const parentPosition = nodePositionMap.get(e.v);
+              if (!dagreEdge || !parentPosition) return null;
+              const [first, ...rest] = clampPoints(dagreEdge.points);
+              const points = [
+                { x: first.x, y: parentPosition.bottom },
+                ...rest,
+              ];
+              const isOffPath = !edges.find(
+                (re) => re.id === e.v && re.childId === e.w,
+              )?.isBottleneck;
+              return (
+                <CriticalPathEdgeLine
+                  key={`${e.v}->${e.w}`}
+                  points={points}
+                  isOffPath={isOffPath}
+                />
+              );
+            })}
+          </GraphEdgeContainer>
+        </Canvas>
+      </Box>
+      {displayedNode && (
+        <CriticalPathClusterMetrics
+          node={displayedNode}
+          pageObjectId={probe.id}
+          timestamp={timestamp}
+          bucketSizeMs={bucketSizeMs}
+          lookbackMs={lookbackMs}
+        />
+      )}
+    </VStack>
+  );
+};
+
+const CriticalPathEdgeLine = ({
+  points,
+  isOffPath,
+}: {
+  points: { x: number; y: number }[];
+  isOffPath: boolean;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const [start, ...rest] = points;
+  const end = rest.pop();
+  if (!end) return null;
+  const controlPoints = rest.map((p) => `${p.x},${p.y}`).join(" ");
+  return (
+    <path
+      d={`M${start.x},${start.y} S ${controlPoints} ${end.x},${end.y}`}
+      stroke={isOffPath ? colors.border.secondary : colors.foreground.secondary}
+      strokeWidth={STROKE_WIDTH}
+      strokeDasharray={isOffPath ? "4 4" : undefined}
+      fill="none"
+    />
+  );
+};

--- a/console/src/platform/maintained-objects/CriticalPathGraphNode.tsx
+++ b/console/src/platform/maintained-objects/CriticalPathGraphNode.tsx
@@ -1,0 +1,223 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Text,
+  Tooltip,
+  useColorModeValue,
+  useTheme,
+} from "@chakra-ui/react";
+import React from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+import { MaterializeTheme } from "~/theme";
+import { sumPostgresIntervalMs } from "~/util";
+import { formatDate } from "~/utils/dateFormat";
+import { formatIntervalShort } from "~/utils/format";
+
+import { NodeKind, RenderableNode } from "./criticalPathRenderable";
+import { useJourneyLinkState } from "./useJourneyLinkState";
+
+const useNodeColors = (node: RenderableNode) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  // Soft mint / dark forest — matches the design's "healthy" tint, less
+  // saturated than `background.success` would feel here.
+  const healthyBg = useColorModeValue("#F0FDF4", "#1F352A");
+  // Soft cream-yellow / dark amber — less harsh than `background.warn` and
+  // closer to the design's upstream-blocked tint.
+  const upstreamBg = useColorModeValue("#FFFCF0", "#352F1A");
+
+  const borderByKind: Record<NodeKind, string> = {
+    primary: colors.accent.red,
+    healthy: colors.accent.green,
+    upstream: colors.accent.orange,
+    offPath: colors.border.secondary,
+  };
+  const bgByKind: Record<NodeKind, string> = {
+    primary: colors.background.error,
+    healthy: healthyBg,
+    upstream: upstreamBg,
+    offPath: colors.background.primary,
+  };
+
+  // The probe itself uses purple-dashed border — except when it stands out as
+  // the primary bottleneck (red) or its lag is healthy (green).
+  const probeOverridesKind = node.kind === "upstream";
+  const borderColor =
+    node.isProbe && probeOverridesKind
+      ? colors.accent.brightPurple
+      : borderByKind[node.kind];
+  const bg = node.isProbe ? colors.background.primary : bgByKind[node.kind];
+
+  return { borderColor, bg };
+};
+
+export interface CriticalPathGraphNodeProps {
+  node: RenderableNode;
+  /** Id of the object the page is currently rendering. Used to extend the
+   *  breadcrumb journey when navigating to a different node. */
+  pageObjectId: string;
+  /** True when the user has clicked the off-path counter to splice in
+   *  this bottleneck's siblings. */
+  expanded: boolean;
+  /** True when the user has clicked the node body to read the full name —
+   *  lifts to natural height with a raised z-index. */
+  selected: boolean;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  onToggleExpand: () => void;
+  onSelect: () => void;
+}
+
+export const CriticalPathGraphNode = ({
+  node,
+  pageObjectId,
+  expanded,
+  selected,
+  left,
+  top,
+  width,
+  height,
+  onToggleExpand,
+  onSelect,
+}: CriticalPathGraphNodeProps) => {
+  const { colors, shadows } = useTheme<MaterializeTheme>();
+  const { borderColor, bg } = useNodeColors(node);
+  const lagText = node.lag ? formatIntervalShort(node.lag) : "—";
+  const borderStyle = node.isProbe || expanded ? "dashed" : "solid";
+  const isOffPath = node.kind === "offPath";
+
+  // Only show the window-peak badge when the snapshot lag doesn't already
+  // reflect this node's worst moment.
+  const lagMs = node.lag ? sumPostgresIntervalMs(node.lag) : 0;
+  const peakMs = node.peakLag ? sumPostgresIntervalMs(node.peakLag) : 0;
+  const showPeakBadge = node.peakLag !== null && peakMs > lagMs * 1.05;
+
+  const journeyLinkState = useJourneyLinkState(pageObjectId);
+  const objectLinkTarget = `../${node.parentSourceId ?? node.id}`;
+
+  return (
+    <Box
+      position="absolute"
+      left={`${left}px`}
+      top={`${top}px`}
+      width={`${width}px`}
+      minHeight={`${height}px`}
+      height={selected ? "auto" : `${height}px`}
+      zIndex={selected ? 10 : 1}
+      boxShadow={selected ? shadows.input.focus : undefined}
+      borderRadius="md"
+      borderWidth="2px"
+      borderStyle={borderStyle}
+      borderColor={borderColor}
+      bg={bg}
+      opacity={isOffPath ? 0.65 : 1}
+      px={3}
+      py={1}
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      overflow={selected ? "visible" : "hidden"}
+      cursor="pointer"
+      transition="box-shadow 0.15s, transform 0.15s"
+      _hover={{
+        boxShadow: selected ? shadows.input.focus : shadows.level1,
+      }}
+      onClick={onSelect}
+    >
+      {node.isProbe ? (
+        <Text
+          textStyle="text-ui-med"
+          noOfLines={selected ? undefined : 1}
+          wordBreak={selected ? "break-all" : undefined}
+        >
+          {node.name}
+        </Text>
+      ) : (
+        <Text
+          as={RouterLink}
+          to={objectLinkTarget}
+          relative="path"
+          state={journeyLinkState}
+          onClick={(e) => e.stopPropagation()}
+          textStyle="text-ui-med"
+          noOfLines={selected ? undefined : 1}
+          wordBreak={selected ? "break-all" : undefined}
+          _hover={{
+            color: colors.accent.brightPurple,
+            textDecoration: "underline",
+          }}
+        >
+          {node.name}
+        </Text>
+      )}
+      <Text
+        textStyle="text-small"
+        color={colors.foreground.secondary}
+        noOfLines={selected ? undefined : 1}
+      >
+        {lagText}
+        {showPeakBadge && node.peakLag && (
+          <>
+            {" · "}
+            <Tooltip
+              label={
+                node.peakLagAt
+                  ? `Peak lag in window observed at ${formatDate(node.peakLagAt, "h:mm:ss a")}`
+                  : "Peak lag observed in the lookback window"
+              }
+              placement="top"
+              hasArrow
+            >
+              <Box as="span" color={colors.foreground.tertiary} fontSize="xs">
+                peak {formatIntervalShort(node.peakLag)}
+                {node.peakLagAt && ` @ ${formatDate(node.peakLagAt, "h:mm a")}`}
+              </Box>
+            </Tooltip>
+          </>
+        )}
+        {node.objectType === "source" && (
+          <>
+            {" · "}
+            <Box
+              as="span"
+              bg={colors.background.secondary}
+              color={colors.foreground.secondary}
+              px="1"
+              py="0.5"
+              borderRadius="sm"
+              fontSize="xs"
+            >
+              source
+            </Box>
+          </>
+        )}
+        {node.offPathCount > 0 && (
+          <>
+            {" · "}
+            <Box
+              as="span"
+              cursor="pointer"
+              textDecoration="underline"
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                onToggleExpand();
+              }}
+            >
+              {node.offPathCount} off-path
+            </Box>
+          </>
+        )}
+      </Text>
+    </Box>
+  );
+};

--- a/console/src/platform/maintained-objects/FreshnessBreakdownStrip.tsx
+++ b/console/src/platform/maintained-objects/FreshnessBreakdownStrip.tsx
@@ -1,0 +1,61 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { HStack, Text, useTheme } from "@chakra-ui/react";
+import React from "react";
+
+import { MaterializeTheme } from "~/theme";
+import { formatDurationForAxis } from "~/utils/format";
+
+import { FreshnessBreakdown } from "./freshnessBreakdown";
+
+export const FreshnessBreakdownStrip = ({
+  breakdown,
+}: {
+  breakdown: FreshnessBreakdown;
+}) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const { selfDelayMs, maxInputMs, isSelfBottleneck, dominantUpstreamNames } =
+    breakdown;
+  const upstreamLabel =
+    dominantUpstreamNames.length > 0
+      ? `${formatDurationForAxis(maxInputMs)} from ${dominantUpstreamNames.join(", ")}`
+      : `${formatDurationForAxis(maxInputMs)} upstream`;
+
+  return (
+    <HStack
+      width="100%"
+      px={3}
+      py={2}
+      borderRadius="md"
+      bg={colors.background.secondary}
+      spacing={1}
+      flexWrap="wrap"
+    >
+      <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
+        Output lag breakdown:
+      </Text>
+      <Text
+        textStyle="text-ui-med"
+        color={isSelfBottleneck ? colors.foreground.primary : colors.accent.red}
+      >
+        {upstreamLabel}
+      </Text>
+      <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
+        +
+      </Text>
+      <Text
+        textStyle="text-ui-med"
+        color={isSelfBottleneck ? colors.accent.red : colors.foreground.primary}
+      >
+        {formatDurationForAxis(selfDelayMs)} self-delay
+      </Text>
+    </HStack>
+  );
+};

--- a/console/src/platform/maintained-objects/MaintainedObjectsLayout.tsx
+++ b/console/src/platform/maintained-objects/MaintainedObjectsLayout.tsx
@@ -19,6 +19,8 @@ import { MaintainedObjectListItem, useMaintainedObjectsList } from "./queries";
 export interface MaintainedObjectsOutletContext {
   data: MaintainedObjectListItem[];
   isLoading: boolean;
+  lookbackMinutes: number;
+  setLookbackMinutes: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const MaintainedObjectsLayout = () => {
@@ -42,7 +44,14 @@ export const MaintainedObjectsLayout = () => {
         setLookbackMinutes={setLookbackMinutes}
       />
       <Outlet
-        context={{ data, isLoading } satisfies MaintainedObjectsOutletContext}
+        context={
+          {
+            data,
+            isLoading,
+            lookbackMinutes,
+            setLookbackMinutes,
+          } satisfies MaintainedObjectsOutletContext
+        }
       />
     </>
   );

--- a/console/src/platform/maintained-objects/ObjectDetailDrawer.tsx
+++ b/console/src/platform/maintained-objects/ObjectDetailDrawer.tsx
@@ -15,11 +15,12 @@ import { SideDrawer } from "~/components/SideDrawer";
 
 import { MaintainedObjectsOutletContext } from "./MaintainedObjectsLayout";
 import { ObjectDetailPanel } from "./ObjectDetailPanel";
+import { ObjectJourneyBreadcrumb } from "./ObjectJourneyBreadcrumb";
 
 export const ObjectDetailDrawer = () => {
   const { objectId } = useParams<{ objectId: string }>();
   const navigate = useNavigate();
-  const { data, isLoading } =
+  const { data, isLoading, lookbackMinutes, setLookbackMinutes } =
     useOutletContext<MaintainedObjectsOutletContext>();
 
   const item = data.find((o) => o.id === objectId) ?? null;
@@ -30,12 +31,23 @@ export const ObjectDetailDrawer = () => {
     <SideDrawer
       isOpen
       onClose={handleClose}
-      title={item?.name}
+      title={
+        item ? (
+          <ObjectJourneyBreadcrumb
+            currentId={item.id}
+            currentName={item.name}
+          />
+        ) : undefined
+      }
       width="66%"
       trapFocus={false}
     >
       {item ? (
-        <ObjectDetailPanel item={item} />
+        <ObjectDetailPanel
+          item={item}
+          lookbackMinutes={lookbackMinutes}
+          setLookbackMinutes={setLookbackMinutes}
+        />
       ) : (
         <Center py={10}>
           {isLoading ? <Spinner data-testid="loading-spinner" /> : null}

--- a/console/src/platform/maintained-objects/ObjectDetailPanel.tsx
+++ b/console/src/platform/maintained-objects/ObjectDetailPanel.tsx
@@ -17,12 +17,21 @@ import { MaintainedObjectListItem } from "./queries";
 
 export interface ObjectDetailPanelProps {
   item: MaintainedObjectListItem;
+  lookbackMinutes: number;
+  setLookbackMinutes: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export const ObjectDetailPanel = ({ item }: ObjectDetailPanelProps) => {
+export const ObjectDetailPanel = ({
+  item,
+  lookbackMinutes,
+  setLookbackMinutes,
+}: ObjectDetailPanelProps) => {
   return (
     <Box p={4}>
-      <ObjectDetailsCard item={item} />
+      <ObjectDetailsCard
+        item={item}
+        freshnessLookbackMinutes={lookbackMinutes}
+      />
       <Tabs mt={6}>
         <TabList mb={6}>
           <Tab>Definition</Tab>
@@ -33,7 +42,11 @@ export const ObjectDetailPanel = ({ item }: ObjectDetailPanelProps) => {
             <ObjectMetadata item={item} />
           </TabPanel>
           <TabPanel px={0}>
-            <ObjectFreshness item={item} />
+            <ObjectFreshness
+              item={item}
+              timePeriodMinutes={lookbackMinutes}
+              setTimePeriodMinutes={setLookbackMinutes}
+            />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/console/src/platform/maintained-objects/ObjectDetailsCard.tsx
+++ b/console/src/platform/maintained-objects/ObjectDetailsCard.tsx
@@ -21,6 +21,7 @@ import { Link as RouterLink } from "react-router-dom";
 
 import { createNamespace } from "~/api/materialize";
 import { OUTDATED_THRESHOLD_SECONDS } from "~/api/materialize/cluster/materializationLag";
+import StatusPill from "~/components/StatusPill";
 import TextLink from "~/components/TextLink";
 import { DetailItem } from "~/platform/connectors/AsideBox";
 import { absoluteClusterPath } from "~/platform/routeHelpers";
@@ -30,7 +31,13 @@ import { MaterializeTheme } from "~/theme";
 import { pluralize } from "~/util";
 import { formatIntervalShort } from "~/utils/format";
 
-import { MaintainedObjectListItem } from "./queries";
+import {
+  bucketForHydration,
+  HYDRATION_LABELS,
+  STATUS_COLOR_SCHEMES,
+} from "./filters";
+import { pMaxFromHistory } from "./freshnessHistory";
+import { MaintainedObjectListItem, useObjectFreshnessHistory } from "./queries";
 
 const OUTDATED_MS = OUTDATED_THRESHOLD_SECONDS * 1_000;
 const WARNING_MS = OUTDATED_MS / 2;
@@ -41,9 +48,13 @@ const formatReplicaName = (replica: { name: string; size: string | null }) =>
 
 export interface ObjectDetailsCardProps {
   item: MaintainedObjectListItem;
+  freshnessLookbackMinutes: number;
 }
 
-export const ObjectDetailsCard = ({ item }: ObjectDetailsCardProps) => {
+export const ObjectDetailsCard = ({
+  item,
+  freshnessLookbackMinutes,
+}: ObjectDetailsCardProps) => {
   const { colors } = useTheme<MaterializeTheme>();
   const regionSlug = useRegionSlug();
   const { getClusterById } = useAllClusters();
@@ -51,6 +62,14 @@ export const ObjectDetailsCard = ({ item }: ObjectDetailsCardProps) => {
   const cluster = item.cluster ? getClusterById(item.cluster.id) : undefined;
   const namespace = createNamespace(item.databaseName, item.schemaName);
   const replicas = cluster?.replicas ?? [];
+
+  const { data: freshness } = useObjectFreshnessHistory({
+    objectId: item.id,
+    lookbackMs: freshnessLookbackMinutes * 60 * 1000,
+  });
+  const badgeLag = freshness
+    ? pMaxFromHistory(freshness.historicalData, item.id)
+    : item.lag;
 
   return (
     <Card
@@ -61,9 +80,18 @@ export const ObjectDetailsCard = ({ item }: ObjectDetailsCardProps) => {
       borderColor={colors.border.primary}
     >
       <VStack align="start" spacing={4} width="100%">
-        <HStack spacing={3} alignItems="center">
-          <Text textStyle="heading-lg">{item.name}</Text>
-          <LagBadge lag={item.lag} />
+        <HStack spacing={3} alignItems="center" width="100%" minW={0}>
+          <Text
+            textStyle="heading-lg"
+            noOfLines={1}
+            title={item.name}
+            minW={0}
+            flex="1"
+          >
+            {item.name}
+          </Text>
+          <LagBadge lag={badgeLag} />
+          <HydrationBadge item={item} />
         </HStack>
 
         <Text textStyle="heading-sm" color={colors.foreground.secondary}>
@@ -115,6 +143,19 @@ export const ObjectDetailsCard = ({ item }: ObjectDetailsCardProps) => {
   );
 };
 
+const HydrationBadge = ({ item }: { item: MaintainedObjectListItem }) => {
+  const bucket = bucketForHydration(item.hydratedReplicas, item.totalReplicas);
+  if (!bucket) return null;
+  return (
+    <StatusPill
+      status={bucket}
+      label={HYDRATION_LABELS[bucket]}
+      colorScheme={STATUS_COLOR_SCHEMES[bucket]}
+      flexShrink={0}
+    />
+  );
+};
+
 const LagBadge = ({ lag }: { lag: MaintainedObjectListItem["lag"] }) => {
   const { colors } = useTheme<MaterializeTheme>();
   if (!lag) return null;
@@ -134,6 +175,8 @@ const LagBadge = ({ lag }: { lag: MaintainedObjectListItem["lag"] }) => {
       borderRadius="full"
       bg={bg}
       color={colors.foreground.primaryButtonLabel}
+      whiteSpace="nowrap"
+      flexShrink={0}
     >
       {formatIntervalShort(lag.value)} behind
     </Text>

--- a/console/src/platform/maintained-objects/ObjectFreshness.tsx
+++ b/console/src/platform/maintained-objects/ObjectFreshness.tsx
@@ -7,25 +7,158 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { Center, Text, useTheme } from "@chakra-ui/react";
+import {
+  Card,
+  Divider,
+  HStack,
+  Tag,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
 import React from "react";
 
+import { calculateBucketSizeFromLookback } from "~/api/materialize/freshness/lagHistory";
+import TimePeriodSelect from "~/components/TimePeriodSelect";
 import { MaterializeTheme } from "~/theme";
+import { formatDate } from "~/utils/dateFormat";
 
-import { MaintainedObjectListItem } from "./queries";
+import { LOOKBACK_OPTIONS } from "./constants";
+import { CriticalPathGraph } from "./CriticalPathGraph";
+import { computeFreshnessBreakdown } from "./freshnessBreakdown";
+import { FreshnessBreakdownStrip } from "./FreshnessBreakdownStrip";
+import { peakLagTimestampFromHistory } from "./freshnessHistory";
+import { ObjectFreshnessChart } from "./ObjectFreshnessChart";
+import {
+  MaintainedObjectListItem,
+  useCriticalPath,
+  useObjectFreshnessHistory,
+} from "./queries";
 
 export interface ObjectFreshnessProps {
   item: MaintainedObjectListItem;
+  timePeriodMinutes: number;
+  setTimePeriodMinutes: React.Dispatch<React.SetStateAction<number>>;
 }
 
-// TODO: Add freshness graphs
-export const ObjectFreshness = (_props: ObjectFreshnessProps) => {
+export const ObjectFreshness = ({
+  item,
+  timePeriodMinutes,
+  setTimePeriodMinutes,
+}: ObjectFreshnessProps) => {
   const { colors } = useTheme<MaterializeTheme>();
+  const [lockedTimestamp, setLockedTimestamp] = React.useState<Date | null>(
+    null,
+  );
+
+  // A lock from a previous lookback can fall outside the new window,
+  // leaving the marker off-chart and the chain query empty. Reset on change.
+  React.useEffect(() => {
+    setLockedTimestamp(null);
+  }, [timePeriodMinutes]);
+
+  const bucketSizeMs = calculateBucketSizeFromLookback(
+    timePeriodMinutes * 60 * 1000,
+  );
+
+  // Default anchor: the bucket where this object's lag peaked in the
+  // window. The history call is already cached by `ObjectFreshnessChart`,
+  // so React Query dedupes it.
+  const { data: freshnessHistory } = useObjectFreshnessHistory({
+    objectId: item.id,
+    lookbackMs: timePeriodMinutes * 60 * 1000,
+  });
+  const autoAnchorTimestamp = peakLagTimestampFromHistory(
+    freshnessHistory?.historicalData ?? [],
+    item.id,
+  );
+
+  const isLocked = lockedTimestamp !== null;
+  const anchorTimestamp = lockedTimestamp ?? autoAnchorTimestamp;
+
+  const { data: criticalPath } = useCriticalPath({
+    objectId: item.id,
+    timestamp: anchorTimestamp,
+    bucketSizeMs,
+    lookbackMinutes: timePeriodMinutes,
+  });
+  const breakdown = computeFreshnessBreakdown(criticalPath?.directInputs ?? []);
+
+  // Sources ingest from external systems and have no Materialize-internal
+  // upstream chain to walk — hide the critical path section for them.
+  const hasUpstreamChain = item.objectType !== "source";
+
   return (
-    <Center py={10}>
-      <Text textStyle="text-base" color={colors.foreground.secondary}>
-        Freshness graphs placeholder
-      </Text>
-    </Center>
+    <VStack align="start" spacing={6} width="100%">
+      <Card
+        p={5}
+        width="100%"
+        borderRadius="md"
+        border="1px"
+        borderColor={colors.border.primary}
+      >
+        <VStack align="start" spacing={4} width="100%">
+          <HStack width="100%" justify="space-between" align="start">
+            <VStack align="start" spacing={1}>
+              <Text textStyle="heading-sm">Freshness</Text>
+              <Text textStyle="text-small" color={colors.foreground.secondary}>
+                The graph below shows the highest latencies over time. Pick a
+                point on the freshness graph to visualize the critical path of
+                lag on upstream dependencies on this object.
+              </Text>
+            </VStack>
+            <TimePeriodSelect
+              timePeriodMinutes={timePeriodMinutes}
+              setTimePeriodMinutes={setTimePeriodMinutes}
+              options={LOOKBACK_OPTIONS}
+            />
+          </HStack>
+
+          <ObjectFreshnessChart
+            objectId={item.id}
+            timePeriodMinutes={timePeriodMinutes}
+            onTimestampLock={setLockedTimestamp}
+            selectedTimestamp={anchorTimestamp}
+            isLocked={isLocked}
+          />
+
+          {hasUpstreamChain && (
+            <>
+              <Divider />
+
+              <HStack width="100%" justify="space-between" align="center">
+                <Text textStyle="heading-sm">Critical path</Text>
+                {anchorTimestamp && (
+                  <Tag
+                    size="sm"
+                    borderRadius="md"
+                    bg={
+                      isLocked
+                        ? colors.background.accent
+                        : colors.background.info
+                    }
+                    color={
+                      isLocked ? colors.accent.brightPurple : colors.accent.blue
+                    }
+                  >
+                    {isLocked ? "Locked at " : "Peak at "}
+                    {formatDate(anchorTimestamp, "h:mm:ss a")}
+                  </Tag>
+                )}
+              </HStack>
+
+              {breakdown && <FreshnessBreakdownStrip breakdown={breakdown} />}
+
+              <CriticalPathGraph
+                probe={item}
+                timestamp={anchorTimestamp}
+                bucketSizeMs={bucketSizeMs}
+                lookbackMinutes={timePeriodMinutes}
+              />
+            </>
+          )}
+        </VStack>
+      </Card>
+    </VStack>
   );
 };

--- a/console/src/platform/maintained-objects/ObjectFreshnessChart.tsx
+++ b/console/src/platform/maintained-objects/ObjectFreshnessChart.tsx
@@ -1,0 +1,88 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { Center, Spinner, Text, useTheme } from "@chakra-ui/react";
+import React from "react";
+
+import { FreshnessGraph } from "~/components/FreshnessGraph/FreshnessGraph";
+import { MaterializeTheme } from "~/theme";
+
+import { useObjectFreshnessHistory } from "./queries";
+
+export interface ObjectFreshnessChartProps {
+  objectId: string;
+  timePeriodMinutes: number;
+  onTimestampSelect?: (timestamp: Date | null) => void;
+  onTimestampLock?: (timestamp: Date | null) => void;
+  selectedTimestamp?: Date | null;
+  isLocked?: boolean;
+}
+
+export const ObjectFreshnessChart = ({
+  objectId,
+  timePeriodMinutes,
+  onTimestampSelect,
+  onTimestampLock,
+  selectedTimestamp,
+  isLocked,
+}: ObjectFreshnessChartProps) => {
+  const { colors } = useTheme<MaterializeTheme>();
+
+  const lookbackMs = timePeriodMinutes * 60 * 1000;
+
+  const { data, isLoading } = useObjectFreshnessHistory({
+    objectId,
+    lookbackMs,
+  });
+
+  if (isLoading || !data) {
+    return (
+      <Center height="180px" width="100%">
+        <Spinner size="sm" />
+      </Center>
+    );
+  }
+  if (data.historicalData.length === 0) {
+    return (
+      <Center height="180px" width="100%">
+        <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
+          No freshness data available for this time period.
+        </Text>
+      </Center>
+    );
+  }
+
+  const isInteractive = Boolean(onTimestampSelect || onTimestampLock);
+
+  return (
+    <FreshnessGraph
+      bucketSizeMs={data.bucketSizeMs}
+      xAccessor={(d) => d.timestamp}
+      lines={data.lines}
+      data={data.historicalData}
+      startTime={data.startTime}
+      endTime={data.endTime}
+      variant={isInteractive ? "interactive" : "static"}
+      onPointMove={
+        onTimestampSelect
+          ? (ts) => onTimestampSelect(ts !== null ? new Date(ts) : null)
+          : undefined
+      }
+      onPointClick={
+        onTimestampLock
+          ? (ts) => onTimestampLock(ts !== null ? new Date(ts) : null)
+          : undefined
+      }
+      selectedTimestamp={selectedTimestamp?.getTime() ?? null}
+      isLocked={isLocked}
+    />
+  );
+};
+
+export default ObjectFreshnessChart;

--- a/console/src/platform/maintained-objects/ObjectJourneyBreadcrumb.tsx
+++ b/console/src/platform/maintained-objects/ObjectJourneyBreadcrumb.tsx
@@ -1,0 +1,65 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { HStack, Text, useTheme } from "@chakra-ui/react";
+import React from "react";
+import { Link as RouterLink, useLocation } from "react-router-dom";
+
+import TextLink from "~/components/TextLink";
+import { ChevronRightIcon } from "~/icons";
+import { useAllObjects } from "~/store/allObjects";
+import { MaterializeTheme } from "~/theme";
+
+export interface ObjectJourneyBreadcrumbProps {
+  currentId: string;
+  currentName: string;
+}
+
+export const ObjectJourneyBreadcrumb = ({
+  currentId,
+  currentName,
+}: ObjectJourneyBreadcrumbProps) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const { state } = useLocation();
+  const journey: string[] = state?.journey ?? [];
+  const visibleJourney = journey.filter((id) => id !== currentId);
+
+  const { data: allObjects } = useAllObjects();
+  const nameById = React.useMemo(
+    () => new Map(allObjects.map((o) => [o.id, o.name])),
+    [allObjects],
+  );
+
+  return (
+    <HStack spacing={1} minWidth={0}>
+      {visibleJourney.map((id, i) => (
+        <React.Fragment key={`${id}-${i}`}>
+          <TextLink
+            as={RouterLink}
+            to={`../${id}`}
+            relative="path"
+            state={{ journey: visibleJourney.slice(0, i) }}
+            textStyle="heading-sm"
+            noOfLines={1}
+          >
+            {nameById.get(id) ?? id}
+          </TextLink>
+          <ChevronRightIcon
+            boxSize="4"
+            color={colors.foreground.secondary}
+            aria-hidden
+          />
+        </React.Fragment>
+      ))}
+      <Text textStyle="heading-sm" noOfLines={1} title={currentName}>
+        {currentName}
+      </Text>
+    </HStack>
+  );
+};

--- a/console/src/platform/maintained-objects/constants.ts
+++ b/console/src/platform/maintained-objects/constants.ts
@@ -8,9 +8,9 @@
 // by the Apache License, Version 2.0.
 
 /**
- * Lookback window options (in minutes) for the maintained-objects freshness
- * filter. Capped at 24 hours to match the retention of
- * `mz_wallclock_global_lag_recent_history`.
+ * Lookback window options (in minutes) shared across the maintained-objects
+ * list page and the per-object freshness drawer. Capped at 24 hours to match
+ * the retention of `mz_wallclock_global_lag_recent_history`.
  */
 export const LOOKBACK_OPTIONS: Record<string, string> = {
   "1": "Live",

--- a/console/src/platform/maintained-objects/criticalPathRenderable.test.ts
+++ b/console/src/platform/maintained-objects/criticalPathRenderable.test.ts
@@ -1,0 +1,180 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import parse from "postgres-interval";
+
+import { CriticalPathRow } from "~/api/materialize/maintained-objects/criticalPath";
+
+import { buildGraphView } from "./criticalPathRenderable";
+import { CriticalPathData, MaintainedObjectListItem } from "./queries";
+
+const buildRow = (
+  overrides: Partial<CriticalPathRow> = {},
+): CriticalPathRow => ({
+  id: "u1",
+  childId: "probe",
+  name: "input1",
+  objectType: "materialized-view",
+  schemaName: "public",
+  databaseName: "materialize",
+  clusterId: "u1",
+  clusterName: "default",
+  lag: parse("00:00:01"),
+  targetLag: parse("00:00:10"),
+  isBottleneck: true,
+  parentSourceId: null,
+  peakLag: null,
+  peakLagAt: null,
+  ...overrides,
+});
+
+const buildProbe = (
+  overrides: Partial<MaintainedObjectListItem> = {},
+): MaintainedObjectListItem => ({
+  id: "probe",
+  name: "probe_object",
+  schemaName: "public",
+  databaseName: "materialize",
+  objectType: "materialized-view",
+  sourceType: null,
+  cluster: null,
+  hydratedReplicas: 1,
+  totalReplicas: 1,
+  lag: { value: parse("00:00:10"), ms: 10_000 },
+  ...overrides,
+});
+
+const buildData = (rows: CriticalPathRow[]): CriticalPathData => ({
+  rows,
+  directInputs: rows.filter((r) => r.childId === "probe"),
+});
+
+describe("buildGraphView", () => {
+  it("walks a linear chain", () => {
+    // probe(10s) ← a(8s) ← b(5s)
+    const data = buildData([
+      buildRow({
+        id: "a",
+        childId: "probe",
+        name: "a",
+        lag: parse("00:00:08"),
+      }),
+      buildRow({ id: "b", childId: "a", name: "b", lag: parse("00:00:05") }),
+    ]);
+    const view = buildGraphView(data, buildProbe(), null, 5);
+
+    expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "probe"]);
+    expect(view.edges).toHaveLength(2);
+    expect(view.hiddenChainCount).toBe(0);
+  });
+
+  it("hides chain nodes past visibleDepth and reports hiddenChainCount", () => {
+    // probe ← a ← b ← c (depths 1, 2, 3); visibleDepth=2 hides c.
+    const data = buildData([
+      buildRow({ id: "a", childId: "probe", name: "a" }),
+      buildRow({ id: "b", childId: "a", name: "b" }),
+      buildRow({ id: "c", childId: "b", name: "c" }),
+    ]);
+    const view = buildGraphView(data, buildProbe(), null, 2);
+
+    expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "probe"]);
+    expect(view.hiddenChainCount).toBe(1);
+  });
+
+  it("flags the chain node with the largest self-delay as primary", () => {
+    // probe(10s) ← a(8s) ← b(2s)
+    // self-delays: probe=2, a=6, b=2 → a wins.
+    const data = buildData([
+      buildRow({
+        id: "a",
+        childId: "probe",
+        name: "a",
+        lag: parse("00:00:08"),
+      }),
+      buildRow({ id: "b", childId: "a", name: "b", lag: parse("00:00:02") }),
+    ]);
+    const view = buildGraphView(data, buildProbe(), null, 5);
+
+    expect(view.nodes.find((n) => n.id === "a")?.kind).toBe("primary");
+    expect(view.nodes.find((n) => n.id === "probe")?.kind).not.toBe("primary");
+  });
+
+  it("classifies a probe with lag within 2s as healthy, not primary", () => {
+    // Even though the probe is the only candidate (largest self-delay), the
+    // healthy threshold takes precedence — we don't flag bottlenecks on
+    // objects that are within the freshness target.
+    const view = buildGraphView(
+      buildData([]),
+      buildProbe({ lag: { value: parse("00:00:01"), ms: 1_000 } }),
+      null,
+      5,
+    );
+    expect(view.nodes.find((n) => n.id === "probe")?.kind).toBe("healthy");
+  });
+
+  it("returns just the probe when there is no chain", () => {
+    // E.g. a source with no in-Materialize upstream — the probe ends up
+    // labelled as its own primary because its lag is past the healthy bar.
+    const view = buildGraphView(buildData([]), buildProbe(), null, 5);
+
+    expect(view.nodes).toHaveLength(1);
+    expect(view.nodes[0].id).toBe("probe");
+    expect(view.nodes[0].kind).toBe("primary");
+    expect(view.edges).toHaveLength(0);
+    expect(view.hiddenChainCount).toBe(0);
+  });
+
+  it("counts off-path siblings on the chain node", () => {
+    // `a` is the chain node; sib1 and sib2 also feed probe but are off-path.
+    const data = buildData([
+      buildRow({ id: "a", childId: "probe", name: "a", isBottleneck: true }),
+      buildRow({
+        id: "sib1",
+        childId: "probe",
+        name: "sib1",
+        isBottleneck: false,
+      }),
+      buildRow({
+        id: "sib2",
+        childId: "probe",
+        name: "sib2",
+        isBottleneck: false,
+      }),
+    ]);
+    const view = buildGraphView(data, buildProbe(), null, 5);
+
+    expect(view.nodes.find((n) => n.id === "a")?.offPathCount).toBe(2);
+    // Off-path siblings aren't rendered until the chain node is expanded.
+    expect(view.nodes.find((n) => n.id === "sib1")).toBeUndefined();
+  });
+
+  it("splices off-path siblings in when a bottleneck is expanded", () => {
+    const data = buildData([
+      buildRow({ id: "a", childId: "probe", name: "a", isBottleneck: true }),
+      buildRow({
+        id: "sib1",
+        childId: "probe",
+        name: "sib1",
+        isBottleneck: false,
+      }),
+      buildRow({
+        id: "sib2",
+        childId: "probe",
+        name: "sib2",
+        isBottleneck: false,
+      }),
+    ]);
+    const view = buildGraphView(data, buildProbe(), "a", 5);
+
+    expect(view.nodes.find((n) => n.id === "sib1")?.kind).toBe("offPath");
+    expect(view.nodes.find((n) => n.id === "sib2")?.kind).toBe("offPath");
+    // Chain edge a→probe + two off-path edges.
+    expect(view.edges).toHaveLength(3);
+  });
+});

--- a/console/src/platform/maintained-objects/criticalPathRenderable.ts
+++ b/console/src/platform/maintained-objects/criticalPathRenderable.ts
@@ -1,0 +1,313 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { IPostgresInterval } from "~/api/materialize";
+import { CriticalPathRow } from "~/api/materialize/maintained-objects/criticalPath";
+import { sumPostgresIntervalMs } from "~/util";
+
+import { CriticalPathData, MaintainedObjectListItem } from "./queries";
+
+export type NodeKind = "primary" | "upstream" | "offPath" | "healthy";
+
+export interface RenderableNode {
+  id: string;
+  name: string;
+  lag: IPostgresInterval | null;
+  isProbe: boolean;
+  kind: NodeKind;
+  /** Count of off-path sibling inputs sharing the same child as this node. */
+  offPathCount: number;
+  objectType: string | null;
+  /** For subsources, the parent source id — link targets should use this. */
+  parentSourceId: string | null;
+  /** Cluster the node runs on. Null for objects without a cluster (tables). */
+  cluster: { id: string; name: string } | null;
+  /** Max lag this node observed in the lookback window. */
+  peakLag: IPostgresInterval | null;
+  /** Timestamp of `peakLag`. */
+  peakLagAt: Date | null;
+}
+
+/** A node renders green ("healthy") when its lag is within this threshold. */
+const HEALTHY_LAG_MS = 2000;
+
+const lagMs = (lag: IPostgresInterval | null) =>
+  lag ? sumPostgresIntervalMs(lag) : 0;
+
+const isHealthyLag = (lag: IPostgresInterval | null) =>
+  lag !== null && lagMs(lag) <= HEALTHY_LAG_MS;
+
+/** Three Maps describing the critical-path subgraph.
+ *
+ *  Built once from `data.rows` so the rest of `buildGraphView` can look up
+ *  node info, chain edges, and depth by id, instead of rescanning every row
+ *  each time it needs them.
+ *
+ *   - `nodeById`            — keyed by node id, maps to a representative row
+ *                             carrying the node's metadata (name, lag, type).
+ *   - `chainParentsByChild` — keyed by child id, maps to the child's parent
+ *                             ids on the critical path (off-path excluded).
+ *   - `depthById`           — keyed by node id, maps to hops from the probe
+ *                             along chain edges. Probe is depth 0.
+ */
+interface ChainMaps {
+  nodeById: Map<string, CriticalPathRow>;
+  chainParentsByChild: Map<string, string[]>;
+  depthById: Map<string, number>;
+}
+
+const buildChainMaps = (
+  rows: CriticalPathRow[],
+  probeId: string,
+): ChainMaps => {
+  // Build map of node id → metadata row.
+  const nodeById = new Map<string, CriticalPathRow>();
+  // Build map of child id → its parent ids on the critical path.
+  const chainParentsByChild = new Map<string, string[]>();
+  for (const r of rows) {
+    if (!nodeById.has(r.id)) nodeById.set(r.id, r);
+    if (!r.isBottleneck) continue;
+    const parents = chainParentsByChild.get(r.childId) ?? [];
+    parents.push(r.id);
+    chainParentsByChild.set(r.childId, parents);
+  }
+
+  // Build map of node id → hops from probe along chain edges (BFS upstream).
+  // Queue carries (id, depth) tuples so we never need to re-look up depth.
+  const depthById = new Map<string, number>([[probeId, 0]]);
+  const queue: [string, number][] = [[probeId, 0]];
+  let head = 0;
+  while (head < queue.length) {
+    const [childId, childDepth] = queue[head++];
+    for (const parentId of chainParentsByChild.get(childId) ?? []) {
+      if (depthById.has(parentId)) continue;
+      depthById.set(parentId, childDepth + 1);
+      queue.push([parentId, childDepth + 1]);
+    }
+  }
+
+  return { nodeById, chainParentsByChild, depthById };
+};
+
+/** Returns every chain node tied at the largest self-delay (own lag − max parent lag). */
+const findPrimaryBottlenecks = (
+  lagMsByChainId: Map<string, number>,
+  chainParentsByChild: Map<string, string[]>,
+  probeLagMs: number,
+): Set<string> => {
+  if (probeLagMs <= 0) return new Set();
+
+  const withSelfDelay = [...lagMsByChainId.entries()].map(([id, lag]) => {
+    const parents = chainParentsByChild.get(id) ?? [];
+    const maxParentLag = Math.max(
+      0,
+      ...parents.map((p) => lagMsByChainId.get(p) ?? 0),
+    );
+    return { id, selfDelay: lag - maxParentLag };
+  });
+
+  const maxSelfDelay = Math.max(0, ...withSelfDelay.map((x) => x.selfDelay));
+  if (maxSelfDelay <= 0) return new Set();
+
+  return new Set(
+    withSelfDelay.filter((x) => x.selfDelay === maxSelfDelay).map((x) => x.id),
+  );
+};
+
+const classifyNode = ({
+  id,
+  lag,
+  primaryIds,
+}: {
+  id: string;
+  lag: IPostgresInterval | null;
+  primaryIds: Set<string>;
+}): NodeKind => {
+  if (isHealthyLag(lag)) return "healthy";
+  if (primaryIds.has(id)) return "primary";
+  return "upstream";
+};
+
+/** For each visible chain node, count its non-bottleneck siblings. */
+const computeOffPathCounts = (
+  rows: CriticalPathRow[],
+  chainNodeIds: string[],
+): Map<string, number> => {
+  const result = new Map<string, number>();
+  for (const id of chainNodeIds) {
+    const childId = rows.find((r) => r.id === id && r.isBottleneck)?.childId;
+    if (!childId) continue;
+    result.set(
+      id,
+      rows.filter((r) => r.childId === childId && !r.isBottleneck).length,
+    );
+  }
+  return result;
+};
+
+export interface GraphView {
+  nodes: RenderableNode[];
+  edges: CriticalPathRow[];
+  /** Chain nodes past `visibleDepth`. Drives the "Show N more" CTA. */
+  hiddenChainCount: number;
+}
+
+/** Turns the critical-path query result into the DAG the UI renders.
+ *
+ *  Three things happen here:
+ *
+ *   1. Chain — pick the queried object plus its critical-path ancestors, cut
+ *      off at `visibleDepth` hops. Anything past that becomes `hiddenChainCount`
+ *      and drives the "Show N more upstream" CTA.
+ *   2. Primary marker — tag the chain node with the largest self-delay as
+ *      `primary` so it renders red.
+ *   3. Off-path expansion — if `expandedBottleneckId` is set, splice that node's
+ *      non-bottleneck siblings in as extra nodes/edges so the user can see what
+ *      other inputs feed the same downstream child.
+ */
+export const buildGraphView = (
+  data: CriticalPathData,
+  probe: MaintainedObjectListItem,
+  expandedBottleneckId: string | null,
+  visibleDepth: number,
+): GraphView => {
+  const { nodeById, chainParentsByChild, depthById } = buildChainMaps(
+    data.rows,
+    probe.id,
+  );
+  const isVisibleChainNode = (id: string) => {
+    const d = depthById.get(id);
+    return d !== undefined && d <= visibleDepth;
+  };
+
+  // Visible chain nodes (probe itself excluded — it's added separately as the
+  // probe node).
+  const visibleChainIds = [...depthById.keys()].filter(
+    (id) => id !== probe.id && isVisibleChainNode(id),
+  );
+  // −1 to exclude the probe itself, which is at depth 0.
+  const hiddenChainCount = depthById.size - visibleChainIds.length - 1;
+
+  const probeLag = probe.lag?.value ?? null;
+  const probeLagMs = lagMs(probeLag);
+  const allChainIds = [...depthById.keys()].filter((id) => id !== probe.id);
+  const lagMsByChainId = new Map<string, number>([
+    ...allChainIds.map(
+      (id) => [id, lagMs(nodeById.get(id)?.lag ?? null)] as const,
+    ),
+    [probe.id, probeLagMs],
+  ]);
+  const primaryIds = findPrimaryBottlenecks(
+    lagMsByChainId,
+    chainParentsByChild,
+    probeLagMs,
+  );
+
+  const offPathCountById = computeOffPathCounts(data.rows, visibleChainIds);
+
+  // Read the probe's peak from any row mentioning it as source or target.
+  const probeRow =
+    data.rows.find((r) => r.id === probe.id) ??
+    data.rows.find((r) => r.childId === probe.id);
+  const probeNode: RenderableNode = {
+    id: probe.id,
+    name: probe.name,
+    lag: probeLag,
+    isProbe: true,
+    kind: classifyNode({
+      id: probe.id,
+      lag: probeLag,
+      primaryIds,
+    }),
+    offPathCount: 0,
+    objectType: probe.objectType,
+    parentSourceId: null,
+    cluster: probe.cluster,
+    peakLag: probeRow?.peakLag ?? null,
+    peakLagAt: probeRow?.peakLagAt ?? null,
+  };
+  const chainNodes: RenderableNode[] = visibleChainIds.flatMap((id) => {
+    const r = nodeById.get(id);
+    if (!r) return [];
+    return [
+      {
+        id,
+        name: r.name,
+        lag: r.lag,
+        isProbe: false,
+        kind: classifyNode({
+          id,
+          lag: r.lag,
+          primaryIds,
+        }),
+        offPathCount: offPathCountById.get(id) ?? 0,
+        objectType: r.objectType,
+        parentSourceId: r.parentSourceId,
+        cluster:
+          r.clusterId && r.clusterName
+            ? { id: r.clusterId, name: r.clusterName }
+            : null,
+        peakLag: r.peakLag,
+        peakLagAt: r.peakLagAt,
+      },
+    ];
+  });
+  const chainEdges = data.rows.filter(
+    (r) =>
+      r.isBottleneck &&
+      isVisibleChainNode(r.id) &&
+      isVisibleChainNode(r.childId),
+  );
+
+  // No bottleneck expanded → chain only.
+  if (!expandedBottleneckId || !isVisibleChainNode(expandedBottleneckId)) {
+    return {
+      nodes: [probeNode, ...chainNodes],
+      edges: chainEdges,
+      hiddenChainCount,
+    };
+  }
+
+  // Splice in the expanded bottleneck's off-path siblings.
+  const expandedChildId = data.rows.find(
+    (r) => r.id === expandedBottleneckId && r.isBottleneck,
+  )?.childId;
+  if (!expandedChildId) {
+    return {
+      nodes: [probeNode, ...chainNodes],
+      edges: chainEdges,
+      hiddenChainCount,
+    };
+  }
+  const offPathEdges = data.rows.filter(
+    (r) => r.childId === expandedChildId && !r.isBottleneck,
+  );
+  const offPathNodes: RenderableNode[] = offPathEdges.map((r) => ({
+    id: r.id,
+    name: r.name,
+    lag: r.lag,
+    isProbe: false,
+    kind: "offPath",
+    offPathCount: 0,
+    objectType: r.objectType,
+    parentSourceId: r.parentSourceId,
+    cluster:
+      r.clusterId && r.clusterName
+        ? { id: r.clusterId, name: r.clusterName }
+        : null,
+    peakLag: r.peakLag,
+    peakLagAt: r.peakLagAt,
+  }));
+
+  return {
+    nodes: [probeNode, ...chainNodes, ...offPathNodes],
+    edges: [...chainEdges, ...offPathEdges],
+    hiddenChainCount,
+  };
+};

--- a/console/src/platform/maintained-objects/freshnessBreakdown.test.ts
+++ b/console/src/platform/maintained-objects/freshnessBreakdown.test.ts
@@ -1,0 +1,141 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import parse from "postgres-interval";
+
+import { CriticalPathRow } from "~/api/materialize/maintained-objects/criticalPath";
+
+import { computeFreshnessBreakdown } from "./freshnessBreakdown";
+
+const buildRow = (
+  overrides: Partial<CriticalPathRow> = {},
+): CriticalPathRow => ({
+  id: "u1",
+  childId: "probe",
+  name: "input1",
+  objectType: "materialized-view",
+  schemaName: "public",
+  databaseName: "materialize",
+  clusterId: "u1",
+  clusterName: "default",
+  lag: parse("00:00:01"),
+  targetLag: parse("00:00:10"),
+  isBottleneck: false,
+  parentSourceId: null,
+  peakLag: null,
+  peakLagAt: null,
+  ...overrides,
+});
+
+describe("computeFreshnessBreakdown", () => {
+  it("returns null when there are no upstream rows", () => {
+    expect(computeFreshnessBreakdown([])).toBeNull();
+  });
+
+  it("returns null when targetLag is missing", () => {
+    expect(
+      computeFreshnessBreakdown([buildRow({ targetLag: null })]),
+    ).toBeNull();
+  });
+
+  it("returns null when target lag is below the noise floor", () => {
+    // targetLag of 500ms is below `BREAKDOWN_MIN_LAG_MS` (1s).
+    expect(
+      computeFreshnessBreakdown([buildRow({ targetLag: parse("00:00:00.5") })]),
+    ).toBeNull();
+  });
+
+  it("returns null when self-delay is non-positive (max input ≥ target)", () => {
+    // Sometimes the input lag pMAX exceeds the target's pMAX in different
+    // windows — there's nothing useful to attribute as self-delay.
+    expect(
+      computeFreshnessBreakdown([
+        buildRow({
+          targetLag: parse("00:00:10"),
+          lag: parse("00:00:11"),
+        }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("splits target lag into max-upstream + self-delay", () => {
+    const breakdown = computeFreshnessBreakdown([
+      buildRow({
+        id: "u1",
+        name: "fast_input",
+        lag: parse("00:00:02"),
+        targetLag: parse("00:00:10"),
+      }),
+      buildRow({
+        id: "u2",
+        name: "slow_input",
+        lag: parse("00:00:06"),
+        targetLag: parse("00:00:10"),
+      }),
+    ]);
+    expect(breakdown).toMatchObject({
+      maxInputMs: 6_000,
+      selfDelayMs: 4_000,
+      isSelfBottleneck: false,
+      dominantUpstreamIds: ["u2"],
+      dominantUpstreamNames: ["slow_input"],
+    });
+  });
+
+  it("flags self-bottleneck when self-delay exceeds max upstream", () => {
+    const breakdown = computeFreshnessBreakdown([
+      buildRow({
+        lag: parse("00:00:02"),
+        targetLag: parse("00:00:11"),
+      }),
+    ]);
+    // 11s target − 2s upstream = 9s self, which exceeds 2s max upstream.
+    expect(breakdown).toMatchObject({
+      maxInputMs: 2_000,
+      selfDelayMs: 9_000,
+      isSelfBottleneck: true,
+    });
+  });
+
+  it("lists every input tied for max as a dominant upstream", () => {
+    const breakdown = computeFreshnessBreakdown([
+      buildRow({ id: "a", name: "a", lag: parse("00:00:05") }),
+      buildRow({ id: "b", name: "b", lag: parse("00:00:05") }),
+      buildRow({ id: "c", name: "c", lag: parse("00:00:01") }),
+    ]);
+    expect(breakdown?.dominantUpstreamIds).toEqual(["a", "b"]);
+    expect(breakdown?.dominantUpstreamNames).toEqual(["a", "b"]);
+  });
+
+  it("treats null input lags as zero when computing max upstream", () => {
+    // A row that hasn't reported lag yet shouldn't pin maxInputMs to 0 if
+    // another sibling has a real measurement.
+    const breakdown = computeFreshnessBreakdown([
+      buildRow({ id: "a", name: "a", lag: null }),
+      buildRow({ id: "b", name: "b", lag: parse("00:00:04") }),
+    ]);
+    expect(breakdown?.maxInputMs).toBe(4_000);
+    expect(breakdown?.dominantUpstreamIds).toEqual(["b"]);
+  });
+
+  it("returns no dominant upstreams when every input has null lag", () => {
+    // No measured input → maxInputMs is 0, so there's no chain bottleneck to
+    // name; we still surface the breakdown so the chip can show 0s upstream.
+    const breakdown = computeFreshnessBreakdown([
+      buildRow({ id: "a", lag: null }),
+      buildRow({ id: "b", lag: null }),
+    ]);
+    expect(breakdown).toMatchObject({
+      maxInputMs: 0,
+      isSelfBottleneck: true,
+      dominantUpstreamIds: [],
+      dominantUpstreamNames: [],
+    });
+  });
+});

--- a/console/src/platform/maintained-objects/freshnessBreakdown.ts
+++ b/console/src/platform/maintained-objects/freshnessBreakdown.ts
@@ -1,0 +1,50 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { CriticalPathRow } from "~/api/materialize/maintained-objects/criticalPath";
+import { sumPostgresIntervalMs } from "~/util";
+
+export interface FreshnessBreakdown {
+  selfDelayMs: number;
+  maxInputMs: number;
+  isSelfBottleneck: boolean;
+  /** Object ids of immediate upstreams tied for max input lag (the chain
+   *  bottleneck at the first hop). Use these to color the corresponding nodes. */
+  dominantUpstreamIds: string[];
+  /** Display names of those same upstreams, used by the breakdown strip. */
+  dominantUpstreamNames: string[];
+}
+
+/** Don't show breakdown for objects that are essentially fresh — tiny
+ *  rounding-level numbers just add noise. */
+const BREAKDOWN_MIN_LAG_MS = 1000;
+
+export const computeFreshnessBreakdown = (
+  data: CriticalPathRow[],
+): FreshnessBreakdown | null => {
+  if (data.length === 0) return null;
+  const consumerLag = data[0]?.targetLag;
+  if (!consumerLag) return null;
+  const consumerLagMs = sumPostgresIntervalMs(consumerLag);
+  if (consumerLagMs < BREAKDOWN_MIN_LAG_MS) return null;
+  const inputsMs = data.map((r) => (r.lag ? sumPostgresIntervalMs(r.lag) : 0));
+  const maxInputMs = Math.max(0, ...inputsMs);
+  const selfDelayMs = consumerLagMs - maxInputMs;
+  if (selfDelayMs <= 0) return null;
+  const dominant = data.filter(
+    (r, i) => maxInputMs > 0 && inputsMs[i] === maxInputMs,
+  );
+  return {
+    selfDelayMs,
+    maxInputMs,
+    isSelfBottleneck: selfDelayMs > maxInputMs,
+    dominantUpstreamIds: dominant.map((r) => r.id),
+    dominantUpstreamNames: dominant.map((r) => r.name),
+  };
+};

--- a/console/src/platform/maintained-objects/freshnessHistory.test.ts
+++ b/console/src/platform/maintained-objects/freshnessHistory.test.ts
@@ -1,0 +1,80 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import parse from "postgres-interval";
+
+import {
+  LagHistoryRow,
+  pMaxFromHistory,
+  transformObjectFreshnessHistory,
+} from "./freshnessHistory";
+
+const buildRow = (overrides: Partial<LagHistoryRow> = {}): LagHistoryRow => ({
+  bucketStart: new Date("2026-05-05T00:00:00Z"),
+  objectId: "u101",
+  lag: parse("00:00:00"),
+  schemaName: "public",
+  objectName: "orders_mv",
+  ...overrides,
+});
+
+describe("transformObjectFreshnessHistory", () => {
+  it("transforms rows into a chart-ready shape", () => {
+    const rows = [
+      buildRow({
+        bucketStart: new Date("2026-05-05T00:00:00Z"),
+        lag: parse("00:00:30"),
+      }),
+      buildRow({
+        bucketStart: new Date("2026-05-05T00:30:00Z"),
+        lag: null,
+      }),
+    ];
+
+    const { historicalData, lines, startTime, endTime } =
+      transformObjectFreshnessHistory(rows, 60 * 60 * 1000);
+
+    expect(historicalData[0]!.lag.u101).toMatchObject({
+      queryable: true,
+      totalMs: 30_000,
+    });
+    expect(historicalData[1]!.lag.u101).toMatchObject({ queryable: false });
+    expect(lines[0]!.label).toBe("public.orders_mv");
+    expect(startTime).toBe(new Date("2026-05-05T00:00:00Z").getTime());
+    expect(endTime).toBe(new Date("2026-05-05T00:30:00Z").getTime());
+  });
+
+  it("returns an empty shape when there are no rows", () => {
+    const result = transformObjectFreshnessHistory([], 60 * 60 * 1000);
+    expect(result.historicalData).toEqual([]);
+    expect(result.lines).toEqual([]);
+  });
+});
+
+describe("pMaxFromHistory", () => {
+  it("returns the largest queryable lag, ignoring non-queryable buckets", () => {
+    const { historicalData } = transformObjectFreshnessHistory(
+      [
+        buildRow({ lag: parse("00:00:30") }),
+        buildRow({ lag: null }),
+        buildRow({ lag: parse("00:02:00") }),
+      ],
+      60 * 60 * 1000,
+    );
+    expect(pMaxFromHistory(historicalData, "u101")?.ms).toBe(120_000);
+  });
+
+  it("returns null when there are no queryable buckets", () => {
+    const { historicalData } = transformObjectFreshnessHistory(
+      [buildRow({ lag: null })],
+      60 * 60 * 1000,
+    );
+    expect(pMaxFromHistory(historicalData, "u101")).toBeNull();
+  });
+});

--- a/console/src/platform/maintained-objects/freshnessHistory.ts
+++ b/console/src/platform/maintained-objects/freshnessHistory.ts
@@ -1,0 +1,122 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  formatFullyQualifiedObjectName,
+  IPostgresInterval,
+} from "~/api/materialize";
+import { calculateBucketSizeFromLookback } from "~/api/materialize/freshness/lagHistory";
+import { DataPoint, GraphLineSeries } from "~/components/FreshnessGraph/types";
+import { sumPostgresIntervalMs } from "~/util";
+
+export interface LagHistoryRow {
+  bucketStart: Date;
+  objectId: string;
+  lag: IPostgresInterval | null;
+  schemaName: string | null;
+  objectName: string | null;
+}
+
+export interface ObjectFreshnessHistory {
+  historicalData: DataPoint[];
+  lines: GraphLineSeries[];
+  bucketSizeMs: number;
+  startTime: number;
+  endTime: number;
+}
+
+export const transformObjectFreshnessHistory = (
+  rows: LagHistoryRow[],
+  lookbackMs: number,
+): ObjectFreshnessHistory => {
+  const bucketSizeMs = calculateBucketSizeFromLookback(lookbackMs);
+
+  const historicalData: DataPoint[] = rows.map((row) => ({
+    timestamp: row.bucketStart.getTime(),
+    lag: {
+      [row.objectId]: row.lag
+        ? {
+            queryable: true as const,
+            totalMs: sumPostgresIntervalMs(row.lag),
+            interval: row.lag,
+            schemaName: row.schemaName,
+            objectName: row.objectName,
+          }
+        : {
+            queryable: false as const,
+            schemaName: row.schemaName,
+            objectName: row.objectName,
+          },
+    },
+  }));
+
+  const lastRow = rows.at(-1);
+  const lines: GraphLineSeries[] = lastRow
+    ? [
+        {
+          key: lastRow.objectId,
+          label: formatFullyQualifiedObjectName({
+            schemaName: lastRow.schemaName ?? "",
+            name: lastRow.objectName ?? "",
+          }),
+          yAccessor: (d: DataPoint) => {
+            const lagInfo = d.lag[lastRow.objectId];
+            return lagInfo?.queryable ? lagInfo.totalMs : null;
+          },
+        },
+      ]
+    : [];
+
+  return {
+    historicalData,
+    lines,
+    bucketSizeMs,
+    startTime: historicalData.at(0)?.timestamp ?? 0,
+    endTime: historicalData.at(-1)?.timestamp ?? 0,
+  };
+};
+
+export interface PMaxLag {
+  value: IPostgresInterval;
+  ms: number;
+}
+
+export const pMaxFromHistory = (
+  historicalData: DataPoint[],
+  objectId: string,
+): PMaxLag | null => {
+  let maxMs = -1;
+  let maxInterval: IPostgresInterval | null = null;
+  for (const point of historicalData) {
+    const lagInfo = point.lag[objectId];
+    if (lagInfo?.queryable && lagInfo.totalMs > maxMs) {
+      maxMs = lagInfo.totalMs;
+      maxInterval = lagInfo.interval;
+    }
+  }
+  return maxInterval ? { value: maxInterval, ms: maxMs } : null;
+};
+
+/** Timestamp of the bucket where the object's lag was highest, or `null`
+ *  if the history has no queryable lag for the object. */
+export const peakLagTimestampFromHistory = (
+  historicalData: DataPoint[],
+  objectId: string,
+): Date | null => {
+  let maxMs = -1;
+  let maxTs: number | null = null;
+  for (const point of historicalData) {
+    const lagInfo = point.lag[objectId];
+    if (lagInfo?.queryable && lagInfo.totalMs > maxMs) {
+      maxMs = lagInfo.totalMs;
+      maxTs = point.timestamp;
+    }
+  }
+  return maxTs !== null ? new Date(maxTs) : null;
+};

--- a/console/src/platform/maintained-objects/queries.ts
+++ b/console/src/platform/maintained-objects/queries.ts
@@ -10,11 +10,25 @@
 import { useQuery } from "@tanstack/react-query";
 import React from "react";
 
+import {
+  buildQueryKeyPart,
+  buildRegionQueryKey,
+} from "~/api/buildQueryKeySchema";
 import { IPostgresInterval, isSystemId } from "~/api/materialize";
+import {
+  Bucket,
+  fetchReplicaUtilizationHistory,
+} from "~/api/materialize/cluster/replicaUtilizationHistory";
+import { fetchLagHistory } from "~/api/materialize/freshness/lagHistory";
 import {
   MAINTAINED_OBJECT_TYPES,
   MaintainedObjectType,
 } from "~/api/materialize/maintained-objects/constants";
+import {
+  CriticalPathRow,
+  fetchCriticalPathAtTime,
+  fetchCriticalPathLive,
+} from "~/api/materialize/maintained-objects/criticalPath";
 import {
   buildHydrationAggregateQuery,
   HydrationAggregateRow,
@@ -31,6 +45,8 @@ import {
 import { sourceQueryKeys } from "~/platform/sources/queries";
 import { useAllObjects } from "~/store/allObjects";
 import { sumPostgresIntervalMs } from "~/util";
+
+import { transformObjectFreshnessHistory } from "./freshnessHistory";
 
 /** Cluster the object is maintained on. `null` for tables, which aren't
  *  bound to a cluster. */
@@ -204,3 +220,193 @@ export function useObjectSourceStatistics(sourceId: string) {
     },
   });
 }
+
+const freshnessHistoryQueryKey = (objectId: string, lookbackMs: number) =>
+  [
+    ...buildRegionQueryKey("maintainedObjects"),
+    buildQueryKeyPart("freshnessHistory", { objectId, lookbackMs }),
+  ] as const;
+
+export function useObjectFreshnessHistory({
+  objectId,
+  lookbackMs,
+}: {
+  objectId: string;
+  lookbackMs: number;
+}) {
+  return useQuery({
+    queryKey: freshnessHistoryQueryKey(objectId, lookbackMs),
+    queryFn: async ({ queryKey, signal }) => {
+      const { rows } = await fetchLagHistory({
+        params: {
+          lookback: { type: "historical", lookbackMs },
+          objectIds: [objectId],
+        },
+        requestOptions: { signal },
+        queryKey,
+      });
+      return transformObjectFreshnessHistory(rows, lookbackMs);
+    },
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}
+
+export interface CriticalPathData {
+  rows: CriticalPathRow[];
+  /** Immediate direct upstream inputs for the object. */
+  directInputs: CriticalPathRow[];
+}
+
+type CriticalPathMode =
+  | { kind: "live"; lookbackMinutes: number; bucketSizeMs: number }
+  | {
+      kind: "atTime";
+      timestamp: Date;
+      bucketSizeMs: number;
+      lookbackMinutes: number;
+    };
+
+const criticalPathQueryKey = (objectId: string, mode: CriticalPathMode) =>
+  [
+    ...buildRegionQueryKey("maintainedObjects"),
+    buildQueryKeyPart("criticalPath", {
+      objectId,
+      mode:
+        mode.kind === "live"
+          ? {
+              kind: "live",
+              lookbackMinutes: mode.lookbackMinutes,
+              bucketSizeMs: mode.bucketSizeMs,
+            }
+          : {
+              kind: "atTime",
+              timestamp: mode.timestamp.toISOString(),
+              bucketSizeMs: mode.bucketSizeMs,
+              lookbackMinutes: mode.lookbackMinutes,
+            },
+    }),
+  ] as const;
+
+export function useCriticalPath({
+  objectId,
+  timestamp,
+  bucketSizeMs,
+  lookbackMinutes,
+}: {
+  objectId: string | undefined;
+  timestamp: Date | null;
+  bucketSizeMs: number;
+  lookbackMinutes: number;
+}) {
+  const isLive = timestamp === null;
+  const mode: CriticalPathMode = isLive
+    ? { kind: "live", lookbackMinutes, bucketSizeMs }
+    : { kind: "atTime", timestamp, bucketSizeMs, lookbackMinutes };
+  return useQuery({
+    queryKey: criticalPathQueryKey(objectId ?? "", mode),
+    queryFn: ({ queryKey, signal }) =>
+      fetchCriticalPath({
+        objectId: objectId!,
+        mode,
+        signal,
+        queryKey,
+      }),
+    enabled: !!objectId,
+    staleTime: isLive ? 30_000 : Infinity,
+    refetchInterval: isLive ? 30_000 : false,
+  });
+}
+
+const fetchCriticalPath = async ({
+  objectId,
+  mode,
+  signal,
+  queryKey,
+}: {
+  objectId: string;
+  mode: CriticalPathMode;
+  signal: AbortSignal | undefined;
+  queryKey: readonly unknown[];
+}): Promise<CriticalPathData> => {
+  const result =
+    mode.kind === "live"
+      ? await fetchCriticalPathLive({
+          objectId,
+          lookbackMinutes: mode.lookbackMinutes,
+          bucketSizeMs: mode.bucketSizeMs,
+          queryKey,
+          requestOptions: { signal },
+        })
+      : await fetchCriticalPathAtTime({
+          objectId,
+          timestamp: mode.timestamp,
+          bucketSizeMs: mode.bucketSizeMs,
+          lookbackMinutes: mode.lookbackMinutes,
+          queryKey,
+          requestOptions: { signal },
+        });
+
+  const rows = result.rows;
+  const directInputs = rows.filter(
+    (r) => r.childId === objectId && r.id !== objectId,
+  );
+  return { rows, directInputs };
+};
+
+export interface ReplicaInWindow {
+  replicaId: string;
+  name: string;
+  size: string | null;
+  lastSeenAt: Date;
+}
+
+/** Returns each replica's metric buckets in a `lookbackMs`-long window
+ *  ending at `anchorTimestamp` (or now if `anchorTimestamp` is null).
+ *  Polls every 30s when anchored to now; otherwise stays static. */
+export const useClusterBucketsInWindow = ({
+  clusterId,
+  lookbackMs,
+  bucketSizeMs,
+  anchorTimestamp,
+}: {
+  clusterId: string | null;
+  lookbackMs: number;
+  bucketSizeMs: number;
+  anchorTimestamp: Date | null;
+}) => {
+  const isLive = anchorTimestamp === null;
+  const anchorMs = (anchorTimestamp ?? new Date()).getTime();
+  const startMs =
+    Math.floor((anchorMs - lookbackMs) / bucketSizeMs) * bucketSizeMs;
+
+  return useQuery({
+    queryKey: [
+      ...buildRegionQueryKey("maintainedObjects"),
+      buildQueryKeyPart("clusterBucketsInWindow", {
+        clusterId: clusterId ?? "",
+        startMs,
+        bucketSizeMs,
+      }),
+    ],
+    queryFn: async ({
+      queryKey,
+      signal,
+    }): Promise<Record<string, Bucket[]>> => {
+      if (clusterId === null) return {};
+      const { bucketsByReplicaId } = await fetchReplicaUtilizationHistory({
+        params: {
+          clusterIds: [clusterId],
+          startDate: new Date(startMs).toISOString(),
+          bucketSizeMs,
+        },
+        queryKey,
+        requestOptions: { signal },
+      });
+      return bucketsByReplicaId;
+    },
+    enabled: !!clusterId,
+    staleTime: isLive ? 30_000 : Infinity,
+    refetchInterval: isLive ? 30_000 : false,
+  });
+};

--- a/console/src/platform/maintained-objects/useJourneyLinkState.ts
+++ b/console/src/platform/maintained-objects/useJourneyLinkState.ts
@@ -1,0 +1,21 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { useLocation } from "react-router-dom";
+
+/** Soft cap so the breadcrumb can't grow without bound on long drill-downs. */
+const JOURNEY_CAP = 5;
+
+/** Returns the `state` value to pass to a `<Link>` that drills from the
+ *  current object to another, extending the breadcrumb trail. */
+export const useJourneyLinkState = (pageObjectId: string) => {
+  const { state } = useLocation();
+  const journey: string[] = state?.journey ?? [];
+  return { journey: [...journey, pageObjectId].slice(-JOURNEY_CAP) };
+};

--- a/console/src/utils/format.ts
+++ b/console/src/utils/format.ts
@@ -215,6 +215,9 @@ export function formatDurationForAxis(durationMs: number): string {
   }
 }
 
+export const formatPercentage = (percentage: number) =>
+  `${(percentage * 100).toFixed(2)}%`;
+
 /** Units exposed in human-readable duration controls (filters, inputs). */
 export type DurationUnit = "seconds" | "minutes" | "hours";
 

--- a/console/src/utils/graph.ts
+++ b/console/src/utils/graph.ts
@@ -24,6 +24,24 @@ export function niceTicks(start: number, stop: number, desiredCount: number) {
   return ticks(niceStart, niceStop, desiredCount);
 }
 
+/** Map a pointer event to its cursor timestamp in ms, clamped to `[startTime, endTime]`. Returns `null` only when the event has no coordinates. */
+export function eventToTimestamp({
+  event,
+  xScale,
+  startTime,
+  endTime,
+}: {
+  event: PointerEvent | MouseEvent;
+  xScale: { invert: (x: number) => Date };
+  startTime: number;
+  endTime: number;
+}): number | null {
+  const svgPoint = localPoint(event);
+  if (!svgPoint) return null;
+  const ms = xScale.invert(svgPoint.x).getTime();
+  return Math.min(Math.max(ms, startTime), endTime);
+}
+
 // This function was copied and then modified from the visx XYchart:
 // https://github.com/airbnb/visx/blob/6edbde496fc461094f6b3c60e8ec86c4b720b4f5/packages/visx-xychart/src/utils/findNearestDatumSingleDimension.ts#L7
 export function findNearestDatum<


### PR DESCRIPTION


### Motivation
Freshness graphs for maintained objects that show the critical path of lag from upstream dependencies on that object. Critical path is shown as a DAG. Fixes [CNS-52](https://linear.app/materializeinc/issue/CNS-52/objects-freshness-visualizations) 


### Description

A user can pick the a point in time in Freshness graph to see the critical path of objects and their respective lag and a table of immediate upstream dependencies. The lookback window on table corresponds to the lookback window in the freshness graph as well to let the user look at freshness few hours back or few minutes back. In that window, they can look at the critical path at a point in time on freshness graph. Design for the DAG: https://dependency-timeline-mz.lovable.app/

I didn't follow this pixel perfect but used the color schemes for the nodes. Since it's really hard to pinpoint to one particular object that it is causing the delay. 

### Different UI scenarios
* Objects with healthy freshness around 2 seconds

https://github.com/user-attachments/assets/e8669359-fd93-4859-984d-b28f53320c23



* Objects with a delay from source at a particular timestamp
<img width="1504" height="737" alt="image" src="https://github.com/user-attachments/assets/644d4d97-46f8-47c2-a1d8-52be99154ac1" />



* Showing delay being introduced  in the critical chain from sources (hence marked red). If a node is yellow then that means (it's lag is > 2s, it's self delay is less than the max self delay in the chain i.e the lag is inherited from the parent). Showing delay being introduced from the sources and the children inheriting them. 

https://github.com/user-attachments/assets/72119b6b-bf77-4f7a-90a0-cde409227f9e


* Self delay of an object
<img width="994" height="711" alt="image" src="https://github.com/user-attachments/assets/229c1ca5-1a69-41bf-b7d7-0d9fc0cb9431" />



*Cluster metrics for the object at a timestamp
<img width="1667" height="1086" alt="image" src="https://github.com/user-attachments/assets/b9b065ec-03cb-4a6f-bdfe-d1d765ef2c1d" />


* Breadcrumbs
<img width="813" height="91" alt="image" src="https://github.com/user-attachments/assets/159df754-5e36-482a-9da1-15f4dcb3a50e" />


###  Tips For Reviewer
- All the changes in this PR are post `Freshness Chart` commit. I have broken down most changes by commit so they can be reviewed on their own.

The most review intensive commits are:

- `CriticalPathQuery`:
This is a recursive sql query to trace the chain for the object's backward to determine "what makes the object slow", returning every edge along the chain plus the immediate off-path siblings of each chain node so the UI can show both the spine and what else feeds into it.

- `Critical path DAG`:
This commit deals with transforming the results from the query into a renderable DAG. I would review the files in this order:
- `criticalPathRenderable.ts` has a helper function `buildGraphView` (at the bottom of the file, would recommend reading from here) that takes all the other helpers to return the nodes and edges needed for the graph.  Here is the flow how buildGraphView works 
```
┌─────────────────────────────────────────────────────────┐
│                                                            │
│  ─ CriticalPathData.rows  ← useCriticalPath() query      │
│  ─ probe (MaintainedObjectListItem)                      │
│  ─ visibleDepth           ← React state                  │
│  ─ expandedBottleneckId   ← React state                  │
└───────────────────────────┬─────────────────────────────┘
                            │
                            ▼
┌─────────────────────────────────────────────────────────┐
│  buildGraphView                             │
│                                                          │
│  ┌────────────────────────────────────────────────────┐ │
│  │ STEP 1 — pick the chain                             │ │
│  │ ────────────────────────────────────────────────── │ │
│  │ helper: buildChainMaps                              │ │
│  │   ↳ nodeById             (id → row metadata)        │ │
│  │   ↳ chainParentsByChild  (child → bottleneck dads)  │ │
│  │   ↳ depthById            (BFS hops from probe)      │ │
│  │                                                     │ │
│  │ filter depthById ≤ visibleDepth                     │ │
│  │   ↳ visibleChainIds                                 │ │
│  │   ↳ hiddenChainCount     (drives "Show N more")    │ │
│  └────────────────────────────────────────────────────┘ │
│                            │                             │
│                            ▼                             │
│  ┌────────────────────────────────────────────────────┐ │
│  │ STEP 2 — classify each node                         │ │
│  │ ────────────────────────────────────────────────── │ │
│  │ helper: findPrimaryBottleneck                       │ │
│  │   ↳ primaryId  (chain node w/ largest self-delay)   │ │
│  │ helper: computeOffPathCounts                        │ │
│  │   ↳ offPathCountById  (drives "+N off-path" chip)   │ │
│  │ helper: classifyNode  (called per node)             │ │
│  │   ↳ kind = healthy | primary | upstream             │ │
│  │                                                     │ │
│  │ assemble: probeNode + chainNodes (RenderableNode[]) │ │
│  │ assemble: chainEdges (filtered CriticalPathRow[])   │ │
│  └────────────────────────────────────────────────────┘ │
│                            │                             │
│                            ▼                             │
│  ┌────────────────────────────────────────────────────┐ │
│  │ STEP 3 — extend the node to show it's offPath siblings    │ │
│  │ ────────────────────────────────────────────────── │ │
│  │ if expandedBottleneckId is set AND visible:         │ │
│  │   ↳ look up its downstream child                    │ │
│  │   ↳ pull rows where childId === that & !bottleneck  │ │
│  │   ↳ splice in as offPath nodes + dashed edges       │ │
│  │ else: skip (chain-only result)                      │ │
│  └────────────────────────────────────────────────────┘ │
└───────────────────────────┬─────────────────────────────┘
                            │
                            ▼
┌─────────────────────────────────────────────────────────┐
│  OUTPUT: GraphView                                       │
│  ─ nodes: RenderableNode[]   (probe + chain + offPath)   │
│  ─ edges: CriticalPathRow[]  (chain + offPath edges)     │
│  ─ hiddenChainCount                                      │
└───────────────────────────┬─────────────────────────────┘
                            │
                            ▼
┌─────────────────────────────────────────────────────────┐
│  CriticalPathGraph  (component, wires render)            │
│  ─ useDagreGraph(nodes, edges)  → x/y positions          │
│  ─ <CriticalPathGraphNode>      per node                 │
│  ─ <CriticalPathEdgeLine>       per edge (dashed=offPath)│
│  ─ "Show N more upstream" button + "N off-path" link     │
└───────────────────────────┬─────────────────────────────┘
                            │ user clicks
                            ▼
┌─────────────────────────────────────────────────────────┐
│  React state setters                                     │
│  ─ "Show N more"  → setVisibleDepth(Infinity)            │
│  ─ "N off-path"   → setExpandedBottleneckId(node.id)     │
└───────────────────────────┬─────────────────────────────┘
                            │
                            └──► re-render → buildGraphView runs again

```


* `Freshness breakdown chip` :  If there is a self lag of an object then it highlights that on the graph
* Cluster metrics: we needed to show cluster metrics so reused some infrastructure from replicaUtilizationHistory to show cluster metrics for the object as a point in time
* Added a breadcrumbs component: If a user is looking at the DAG, then needs to drilldown and look at their journey breadcrumbs help navigate that. Since it is navigating to a different page, so it was a little hacky to showcase that journey.

