### PR TITLE
feat(orchestratord): [CLO-46] add app_name() to ManagedResource trait for consistent app.kubernetes.io/name labeling.

### DIFF
--- a/src/cloud-resources/src/crd.rs
+++ b/src/cloud-resources/src/crd.rs
@@ -71,11 +71,19 @@ pub trait ManagedResource: Resource<DynamicType = ()> + Sized {
         BTreeMap::new()
     }
 
+    fn app_name(&self) -> Option<&str> {
+        None
+    }
+
     fn managed_resource_meta(&self, name: String) -> ObjectMeta {
+        let mut labels = self.default_labels();
+        if let Some(app) = self.app_name() {
+            labels.insert("app.kubernetes.io/name".to_owned(), app.to_owned());
+        }
         ObjectMeta {
             namespace: Some(self.meta().namespace.clone().unwrap()),
             name: Some(name),
-            labels: Some(self.default_labels()),
+            labels: Some(labels),
             owner_references: Some(vec![owner_reference(self)]),
             ..Default::default()
         }

--- a/src/cloud-resources/src/crd/balancer.rs
+++ b/src/cloud-resources/src/crd/balancer.rs
@@ -177,5 +177,9 @@ pub mod v1alpha1 {
                 ("materialize.cloud/app".to_owned(), "balancerd".to_owned()),
             ])
         }
+
+        fn app_name(&self) -> Option<&str> {
+            Some("balancerd")
+        }
     }
 }

--- a/src/cloud-resources/src/crd/console.rs
+++ b/src/cloud-resources/src/crd/console.rs
@@ -169,5 +169,9 @@ pub mod v1alpha1 {
                 ("materialize.cloud/app".to_owned(), "console".to_owned()),
             ])
         }
+
+        fn app_name(&self) -> Option<&str> {
+            Some("console")
+        }
     }
 }

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -652,6 +652,10 @@ pub mod v1alpha1 {
                 ),
             ])
         }
+
+        fn app_name(&self) -> Option<&str> {
+            Some("environmentd")
+        }
     }
 }
 

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -1282,19 +1282,12 @@ fn create_environmentd_statefulset_object(
         ..Default::default()
     };
 
-    let mut statefulset_labels = mz.default_labels();
-    statefulset_labels.insert(
-        "app.kubernetes.io/name".to_owned(),
-        "environmentd".to_string(),
-    );
-
     StatefulSet {
         metadata: ObjectMeta {
             annotations: Some(btreemap! {
                 "materialize.cloud/generation".to_owned() => generation.to_string(),
                 "materialize.cloud/force".to_owned() => mz.spec.force_rollout.to_string(),
             }),
-            labels: Some(statefulset_labels),
             ..mz.managed_resource_meta(mz.environmentd_statefulset_name(generation))
         },
         spec: Some(statefulset_spec),

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -1132,6 +1132,10 @@ fn create_environmentd_statefulset_object(
         mz.environmentd_app_name(),
     );
     pod_template_labels.insert("app".to_owned(), "environmentd".to_string());
+    pod_template_labels.insert(
+        "app.kubernetes.io/name".to_owned(),
+        "environmentd".to_string(),
+    );
     pod_template_labels.extend(
         mz.spec
             .pod_labels
@@ -1278,12 +1282,19 @@ fn create_environmentd_statefulset_object(
         ..Default::default()
     };
 
+    let mut statefulset_labels = mz.default_labels();
+    statefulset_labels.insert(
+        "app.kubernetes.io/name".to_owned(),
+        "environmentd".to_string(),
+    );
+
     StatefulSet {
         metadata: ObjectMeta {
             annotations: Some(btreemap! {
                 "materialize.cloud/generation".to_owned() => generation.to_string(),
                 "materialize.cloud/force".to_owned() => mz.spec.force_rollout.to_string(),
             }),
+            labels: Some(statefulset_labels),
             ..mz.managed_resource_meta(mz.environmentd_statefulset_name(generation))
         },
         spec: Some(statefulset_spec),


### PR DESCRIPTION
As a platform engineer monitoring the Materialize Cloud cluster, 
I want the environmentd StatefulSet and its pods to have the standard app.kubernetes.io/name label, 
so that the workload and its running instances are consistently discoverable and selectable alongside the rest of the resources in the cluster that already follow this Kubernetes best practice.

### Motivation

Most of Materialize's Deployments and pods have the label `app.kubernetes.io/name` set.
Environmentd StatefulSet and Pods do not have the label `app.kubernetes.io/name` set, and that makes them harder to find and select; particularly when it comes to observability (logs and metrics).

After this change, Environmentd StatefulSets and Pods will have the same labels as most other Deployments, StatefulSets, and Pods, making them easier to find and select. That best practice is useful and handy for observability.

### Description

This change creates `app.kubernetes.io/name` labels with value `environmentd` and assigns them to Pod templates and StatefulSets.

### Verification

After this change is deployed in the staging environment, the commands `kubectl config use-context mzcloud-staging-us-east-1-0` and `kubectl get deployments,pods -A -l app.kubernetes.io/name=environmentd` will return resources (before this change, they return no resources).

### Obs.:

This change requires another change in the `cloud` repository to "bump up" the submodule pointer.