### PR TITLE
console: guard useAuth() in OIDC routes when init fails

### DIFF
--- a/console/src/platform/UnauthenticatedRoutes.tsx
+++ b/console/src/platform/UnauthenticatedRoutes.tsx
@@ -27,6 +27,11 @@ import { OidcCallback } from "./auth/OidcCallback";
 const OidcAuthGuard = ({ children }: React.PropsWithChildren) => {
   const auth = useAuth();
 
+  // OIDC initialization failed — `OidcProviderWrapper` rendered us without
+  // an `AuthProvider` so password sign-in still works. Skip the OIDC checks
+  // and let the user reach the app via their password session cookie.
+  if (!auth) return <>{children}</>;
+
   if (auth.isLoading || hasAuthParams()) {
     return <LoadingScreen />;
   }

--- a/console/src/platform/auth/OidcCallback.tsx
+++ b/console/src/platform/auth/OidcCallback.tsx
@@ -18,6 +18,11 @@ import { useAuth } from "~/external-library-wrappers/oidc";
 // render in one place.
 export const OidcCallback = () => {
   const auth = useAuth();
+  // OIDC initialization failed — there's nothing to complete here, so send
+  // the user back to the login page.
+  if (!auth) {
+    return <Navigate to={LOGIN_PATH} replace />;
+  }
   if (auth.error) {
     const message = auth.error.message?.trim() || "Sign-in failed";
     const params = new URLSearchParams({ [LOGIN_ERROR_PARAM]: message });


### PR DESCRIPTION
#36193 made OidcProviderWrapper render without `<AuthProvider>` when OIDC initialization fails so password sign-in still works, but OidcAuthGuard and OidcCallback still deref `auth` unconditionally and crash with TypeError. Add `!auth` guards matching the pattern already used in SsoLoginLink: OidcAuthGuard falls through to children (so a valid password session cookie still reaches the app), and OidcCallback redirects to LOGIN_PATH since there's nothing to complete without an AuthProvider.