### PR TITLE
sqllogictest: Make execution less noisy

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -227,8 +227,6 @@ def main() -> int:
                     _macos_codesign(program)
             if sys.platform != "darwin":
                 print("Ignoring --enable-mac-codesigning since we're not on macOS")
-        else:
-            print("Disabled macOS Codesigning")
 
         if args.wrapper:
             command = shlex.split(args.wrapper)
@@ -416,7 +414,8 @@ def main() -> int:
     os.setpgid(child_pid, child_pid)
 
     # Then, spawn the desired command.
-    print(f"$ {' '.join(command)}")
+    if args.program != "sqllogictest":
+        print(f"$ {' '.join(command)}")
     if args.program == "environmentd":
         # Automatically restart `environmentd` after it halts, but not more than
         # once every 5s to prevent hot loops. This simulates what happens when

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -105,7 +105,7 @@ struct Args {
         long,
         env = "LOG_FILTER",
         value_name = "FILTER",
-        default_value = "warn"
+        default_value = "mz_adapter::catalog::open=error,mz_persist_client::internal::gc=error,mz_persist_client::rpc=error,warn"
     )]
     pub log_filter: CloneableEnvFilter,
 }

--- a/test/sqllogictest/mz-support-privileges.slt
+++ b/test/sqllogictest/mz-support-privileges.slt
@@ -64,7 +64,7 @@ COMPLETE 1
 simple conn=mz_support,user=mz_support
 SHOW log_filter;
 ----
-warn
+mz_persist_client::internal::gc=error,mz_adapter::catalog::open=error,mz_persist_client::rpc=error,warn
 COMPLETE 1
 
 # The mz_support user cannot ALTER SYSTEM SET public system vars.


### PR DESCRIPTION
After:
```
$ bin/sqllogictest test/sqllogictest/aclitem.slt
$ cargo build --bin clusterd --bin sqllogictest
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.61s
--- test/sqllogictest/aclitem.slt
    PASS: success=72 total=72
```
Before:
```
$ bin/sqllogictest test/sqllogictest/aclitem.slt
$ cargo build --bin clusterd --bin sqllogictest
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.69s
Disabled macOS Codesigning
$ /home/deen/git/materialize3/mzbuild/bin/sqllogictest --postgres-url=postgres://root@localhost:26257/materialize --system-parameter-default=unsafe_enable_unsafe_functions=true;allow_real_time_recency=true;constraint_based_timestamp_selection=verify;enable_compute_peek_response_stash=true;enable_0dt_deployment_panic_after_timeout=true;enable_0dt_deployment_sources=true;enable_alter_swap=true;enable_case_literal_transform=false;enable_cast_elimination=true;enable_coalesce_case_transform=true;enable_columnar_lgalloc=false;enable_columnation_lgalloc=false;enable_compute_correction_v2=true;enable_compute_logical_backpressure=true;enable_connection_validation_syntax=true;enable_copy_to_expr=true;enable_copy_from_remote=true;enable_create_table_from_source=true;enable_eager_delta_joins=true;enable_envelope_debezium_in_subscribe=true;enable_expressions_in_limit_syntax=true;enable_iceberg_sink=true;enable_introspection_subscribes=true;enable_kafka_sink_partition_by=true;enable_lgalloc=false;enable_load_generator_counter=true;enable_logical_compaction_window=true;enable_multi_worker_storage_persist_sink=true;enable_multi_replica_sources=true;enable_rbac_checks=true;enable_reduce_mfp_fusion=true;enable_refresh_every_mvs=true;enable_replacement_materialized_views=true;enable_cluster_schedule_refresh=true;enable_sql_server_source=true;enable_s3_tables_region_check=false;enable_statement_lifecycle_logging=true;enable_storage_introspection_logs=true;enable_compute_temporal_bucketing=true;enable_variadic_left_join_lowering=true;enable_worker_core_affinity=true;grpc_client_http2_keep_alive_timeout=5s;ore_overflowing_behavior=panic;unsafe_enable_table_keys=true;with_0dt_deployment_max_wait=1800s;persist_next_listen_batch_retryer_clamp=16s;persist_next_listen_batch_retryer_initial_backoff=100ms;persist_next_listen_batch_retryer_fixed_sleep=1200ms;persist_enable_arrow_lgalloc_noncc_sizes=true;persist_enable_s3_lgalloc_noncc_sizes=true;compute_correction_v2_chain_proportionality=3;compute_correction_v2_chunk_size=8192;compute_dataflow_max_inflight_bytes=134217728;compute_hydration_concurrency=2;compute_replica_expiration_offset=3d;compute_apply_column_demands=true;compute_peek_response_stash_threshold_bytes=1048576;compute_subscribe_snapshot_optimization=true;enable_compute_sync_mv_sink=true;enable_password_auth=true;enable_frontend_peek_sequencing=true;enable_frontend_subscribes=true;enable_upsert_v2=false;default_timestamp_interval=1s;force_source_table_syntax=false;persist_batch_columnar_format=structured;persist_batch_delete_enabled=true;persist_batch_structured_order=true;persist_batch_builder_structured=true;persist_batch_structured_key_lower_len=256;persist_batch_max_run_len=4;persist_catalog_force_compaction_fuel=1024;persist_catalog_force_compaction_wait=1s;persist_stats_audit_percent=100;persist_stats_audit_panic=true;persist_encoding_enable_dictionary=true;persist_fast_path_limit=1000;persist_fast_path_order=true;persist_gc_use_active_gc=true;persist_gc_min_versions=16;persist_gc_max_versions=128000;persist_inline_writes_single_max_bytes=4096;persist_inline_writes_total_max_bytes=1048576;persist_pubsub_client_enabled=true;persist_pubsub_push_diff_enabled=true;persist_record_compactions=true;persist_record_schema_id=true;persist_rollup_use_active_rollup=true;persist_blob_target_size=16777216;persist_compaction_memory_bound_bytes=83886080;persist_enable_incremental_compaction=true;persist_use_critical_since_catalog=true;persist_use_critical_since_snapshot=false;persist_use_critical_since_source=false;persist_part_decode_format=arrow;persist_blob_cache_scale_with_threads=true;persist_state_update_lease_timeout=1s;persist_validate_part_bounds_on_read=false;persist_validate_part_bounds_on_write=false;statement_logging_default_sample_rate=1.0;statement_logging_max_data_credit=;statement_logging_max_sample_rate=1.0;statement_logging_target_data_rate=;storage_reclock_to_latest=true;storage_source_decode_fuel=100000;storage_statistics_collection_interval=1000;storage_statistics_interval=2000;storage_use_continual_feedback_upsert=true test/sqllogictest/aclitem.slt
2026-05-06T16:03:47.632504Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=constraint_based_timestamp_selection
2026-05-06T16:03:47.632576Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=enable_columnar_lgalloc
2026-05-06T16:03:47.632677Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=enable_kafka_sink_partition_by
2026-05-06T16:03:47.632831Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_batch_builder_structured
2026-05-06T16:03:47.632842Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_batch_columnar_format
2026-05-06T16:03:47.632868Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_batch_structured_order
2026-05-06T16:03:47.632913Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_enable_arrow_lgalloc_noncc_sizes
2026-05-06T16:03:47.632932Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_enable_s3_lgalloc_noncc_sizes
2026-05-06T16:03:47.633005Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_record_compactions
2026-05-06T16:03:47.633016Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_record_schema_id
2026-05-06T16:03:47.633117Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=storage_reclock_to_latest
--- test/sqllogictest/aclitem.slt
2026-05-06T16:03:56.251569Z  WARN mz_persist_client::rpc: pubsub connection err: status: 'Unknown error', self: "h2 protocol error: error reading a body from connection"
2026-05-06T16:03:56.251813Z  WARN mz_persist_client::rpc: pubsub connection err: status: 'Unknown error', self: "h2 protocol error: error reading a body from connection"
2026-05-06T16:03:56.251977Z  WARN mz_persist_client::rpc: pubsub connection err: status: 'Unknown error', self: "h2 protocol error: error reading a body from connection"
2026-05-06T16:03:56.287483Z  WARN mz_persist_client::rpc: pubsub connection err: status: 'Unknown error', self: "h2 protocol error: error reading a body from connection"
2026-05-06T16:03:56.481258Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=constraint_based_timestamp_selection
2026-05-06T16:03:56.481335Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=enable_columnar_lgalloc
2026-05-06T16:03:56.481432Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=enable_kafka_sink_partition_by
2026-05-06T16:03:56.481572Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_batch_builder_structured
2026-05-06T16:03:56.481582Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_batch_columnar_format
2026-05-06T16:03:56.481608Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_batch_structured_order
2026-05-06T16:03:56.481649Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_enable_arrow_lgalloc_noncc_sizes
2026-05-06T16:03:56.481668Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_enable_s3_lgalloc_noncc_sizes
2026-05-06T16:03:56.481738Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_record_compactions
2026-05-06T16:03:56.481749Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=persist_record_schema_id
2026-05-06T16:03:56.481833Z  WARN mz_adapter::catalog::open: cannot load unknown system parameter from catalog storage to set default parameter name=storage_reclock_to_latest
    PASS: success=72 total=72
PASS: success=72 total=72
2026-05-06T16:04:11.429577Z  WARN mz_persist_client::rpc: pubsub connection err: status: 'Unknown error', self: "h2 protocol error: error reading a body from connection"
2026-05-06T16:04:11.431196Z  WARN mz_persist_client::rpc: pubsub connection err: status: 'Unknown error', self: "h2 protocol error: error reading a body from connection"
2026-05-06T16:04:11.434269Z  WARN mz_persist_client::rpc: pubsub connection err: status: 'Unknown error', self: "h2 protocol error: error reading a body from connection"
```