### PR TITLE
design: add design doc for mz v2 SDLC

### DIFF
--- a/doc/developer/design/20260506_mz_v2.md
+++ b/doc/developer/design/20260506_mz_v2.md
@@ -456,7 +456,7 @@ We acknowledge that dbt has strengths `mz` will not replicate at launch — its 
 
 ## Open Questions
 
-- **Is `models/` the right directory name?** The name is borrowed from dbt, where everything inside really is a data model. In `mz`, `models/` also contains secrets, connections, sources, tables, and sinks — none of which are "data models" in the dbt sense. We need *some* directory to scope database-namespaced objects so that the global-namespace top-level directories (`clusters/`, `roles/`, `network-policies/`) are unambiguous: without it, a `clusters/` directory could be either the cluster object kind or a database literally named `clusters`. The mechanism is right; the name might not be. Candidates include `databases/`, `schemas/`, `objects/`, or a different word entirely.
+- **Is `models/` the right directory name?** The name is borrowed from dbt, where everything inside really is a data model. In `mz`, `models/` also contains secrets, connections, sources, tables, and sinks — none of which are "data models" in the dbt sense. We need *some* directory to scope database-namespaced objects so that the global-namespace top-level directories (`clusters/`, `roles/`, `network-policies/`) are unambiguous: without it, a `clusters/` directory could be either the cluster object kind or a database literally named `clusters`.
 
 ## Out of Scope
 

--- a/doc/developer/design/20260506_mz_v2.md
+++ b/doc/developer/design/20260506_mz_v2.md
@@ -1,0 +1,512 @@
+# `mz`: A Software Development Lifecycle for Materialize
+
+- Associated: TBD
+
+<!--
+"v2" is shorthand for this rebuild; throughout the document the tool is
+referred to as `mz`.
+-->
+
+## Success Criteria
+
+A product-qualified user, starting with existing SQL, can set up a local development environment, validate their work, and deploy to production in one hour.
+
+## Solution Proposal
+
+### Overview
+
+`mz` is Materialize's first-party developer toolchain — local development, unit testing, and operational deployments — delivered as a single statically linked binary. It is an opinionated software development lifecycle for software engineers building on Materialize: the project layout, profile model, and lifecycle commands are prescriptive by design. The same `mz` works against every Materialize deployment scenario: Materialize Cloud, self-managed Materialize, and the local emulator.
+
+Materialize powers operational workloads. The output of a Materialize pipeline is a sink driving a live product, a dashboard backing a customer-facing application, or another team's production input — not a batch table refreshed overnight. The teams who build these systems are software engineers, and they expect a modern SDLC: local iteration that runs in seconds, type-checked SQL, unit tests, blue/green deployments, and CI gates that catch regressions before they reach production. None of these are optional for operational systems where a dropped object is a customer-visible outage.
+
+Today the de-facto tool in this space is dbt, but the fit is poor in two ways. First, dbt's roadmap has moved away from Materialize: Materialize is not on dbt Cloud, with no timeline; Materialize is not supported by dbt Fusion, with no timeline. Second, and more fundamentally, dbt is built for analytic engineers, while Materialize is most valuable when used by software engineers building operational systems. The features those engineers need — local development, easy testing, reliable deployments — are not native to dbt. Our current recommended deployment pattern, for example, asks users to author dbt macros to orchestrate blue/green; a tool designed for software engineers from first principles can offer a substantially better experience. We are no longer willing to outsource our primary developer interface to a tool optimized for a different audience.
+
+`mz` is the answer: a Materialize-native SDLC built around the primitives operational workloads actually need. Compilation, type-checking, unit tests, and `EXPLAIN` all run locally — fast enough to gate every CI run and safe enough to hand to AI coding agents in a sandbox without production credentials. Production deploys go through staging schemas and clusters, atomic `ALTER ... SWAP`, and resumable deployment; nothing in production is mutated in place during a deploy. Schemas can be marked stable, in which case their materialized views are evolved via Materialize's replacement protocol so cross-team consumers — the foundation of data meshes and ontologies — are insulated from upstream churn.
+
+`mz` separates work into three layers. The **inner loop** — `compile`, `test`, `explain` — runs entirely locally with no remote Materialize in the path; it is what gates CI runs and what AI coding agents can execute in a sandbox without production credentials. **Scratch deployments** with `dev` push the views you have changed to a per-developer throwaway database on the target Materialize so iteration happens against real production data without affecting anyone else. The **outer loop** — `stage`, `wait`, `deploy`, `abort` — handles production: every change lands first in a parallel staging environment, is validated, and then atomically swapped in.
+
+### Project model
+
+An `mz` project is a directory tree. The tree is the manifest: there is no separate registry of objects, no `ref()` function, and no templating layer. Everything `mz` needs to act on a project lives in the directory plus the active profile, so two clones of the same repository on two machines produce identical compile results.
+
+**Directory as namespace.** Files under `models/` are arranged as `models/<database>/<schema>/<object>.sql`, and the path is the object's fully qualified name. Every namespaced object lives here: views, materialized views, tables, sources, sinks, connections, and secrets. Each file holds the DDL for one object and any `EXECUTE UNIT TEST` blocks that validate it; test code lives next to the code under test rather than in a parallel directory.
+
+Resources that live in the global Materialize namespace — clusters (Materialize's units of compute, distinct from databases), roles, and network policies — get their own top-level directories alongside `models/`. Each resource kind uses whichever file format reads most naturally: SQL where users author DDL, TOML where users describe configuration.
+
+A typical project on disk:
+
+```
+my-project/
+├── project.toml
+├── types.lock
+├── target/                                  # build artifacts (gitignored)
+├── clusters/
+│   └── primary.toml
+├── roles/
+│   └── reader.toml
+├── network-policies/
+│   └── office.toml
+└── models/
+    └── materialize/
+        ├── materialize.sql                  # database mod file
+        ├── raw.sql                          # raw schema mod file
+        ├── public.sql                       # public schema mod file
+        ├── ontology.sql                     # ontology schema mod file: SET api = stable;
+        ├── sinks.sql                        # sinks schema mod file
+        ├── raw/
+        │   ├── pg_password.sql              # CREATE SECRET
+        │   ├── postgres.sql                 # CREATE CONNECTION
+        │   ├── orders_source.sql            # CREATE SOURCE
+        │   └── orders.sql                   # CREATE TABLE FROM SOURCE
+        ├── public/
+        │   ├── customers.sql                # CREATE VIEW
+        │   ├── daily_revenue.sql            # CREATE MATERIALIZED VIEW + inline unit tests
+        │   └── daily_revenue__staging.sql   # staging profile override
+        ├── ontology/
+        │   └── customer_ltv.sql             # CREATE MATERIALIZED VIEW (stable API)
+        └── sinks/
+            └── revenue.sql                  # CREATE SINK
+```
+
+**Database and schema mod files.** Both databases and schemas can have an optional **mod file** holding statements that configure the namespace itself, separate from the objects living inside it. The convention is the same at both levels: the mod file shares its name with the namespace it governs. The pattern — a `foo.sql` file beside a `foo/` directory — is borrowed from Rust's module system, where `foo.rs` and a sibling `foo/` directory together define module `foo`.
+
+- A **database mod file** lives at `models/<db>/<db>.sql` — inside the database directory, sharing its name. It typically contains database-level grants and comments.
+- A **schema mod file** lives at `models/<db>/<schema>.sql` — alongside the schema's own directory of objects. It can contain schema-level grants, comments, and `SET api = stable;`, which declares the schema a stable API surface (see [API stability boundaries](#api-stability-boundaries)).
+
+```sql
+-- models/materialize/ontology.sql
+SET api = stable;
+```
+
+Mod files are applied during `apply` and re-applied during `stage`, so the configuration follows the namespace through every blue/green swap — staging databases and schemas inherit the same grants, comments, and settings as the production namespaces they replace. `compile` parses and validates mod files like every other file, and rejects ones that contain object DDL: mod files are for namespace-level configuration only.
+
+**Real SQL.** Every file is parsed with Materialize's actual SQL parser. There is no Jinja or other macro language in the path. This makes parse and type-check errors precise — they point to real line and column positions in the file the user authored — and it means the file on disk is exactly the file Materialize will execute. Dependencies between objects within the project are inferred from the SQL itself.
+
+**Dependency resolution.** When a SQL statement names another object, `mz` resolves the name against the project's directory tree using the same rules a Materialize session would, anchored on the file's location. Unqualified names resolve to the file's own schema; schema-qualified names resolve within the file's database; fully qualified `database.schema.object` names cross databases.
+
+```sql
+-- in models/materialize/public/daily_revenue.sql
+
+CREATE MATERIALIZED VIEW daily_revenue AS
+SELECT *
+FROM orders                                  -- materialize.public.orders
+                                             --   (unqualified → same schema)
+JOIN raw.customers USING (customer_id)       -- materialize.raw.customers
+                                             --   (schema-qualified → same database)
+JOIN warehouse.public.regions USING (region) -- warehouse.public.regions
+                                             --   (fully qualified → cross-database)
+;
+```
+
+`compile` resolves every reference to a fully-qualified name and verifies that the target exists somewhere in the project (or in `types.lock`). A name that cannot be resolved is a compile error — there is no Materialize-side fallback or implicit search path beyond the schema the file lives in.
+
+The directory-as-namespace convention is inspired by Java's Maven layout, where a class's package is determined by its directory path under `src/main/java/`. Here, an object's database and schema are determined by the file's path under `models/`. The benefit is the same one Maven gets: any reference can be located by walking the tree, and there is no separate manifest of where things live.
+
+**`project.toml`.** Top-level configuration is a small, hand-editable TOML file: project name, default Materialize Docker image (used by `test` and `explain`), declared external dependencies (objects the project consumes but does not own), and default cluster/replica policies. External dependencies are declared explicitly because `mz` needs to know what to capture in `types.lock`; dependencies between objects within the project are not declared because the SQL already says so.
+
+**Profiles.** A separate, user-local `profiles.toml` defines named connection profiles — host, port, user, password (or secret reference), optional `http_host` for MCP. The active profile is selected explicitly with `--profile`, with an environment variable, or with a per-directory default written by `mz profile set`. That default lives in a small `.mzprofile` file at the project root; the convention is to gitignore it so each developer keeps their own preferred default, but checking it in is supported when a project wants a single shared default. `profiles.toml` itself is always user-local and is never checked in; the project stays environment-agnostic.
+
+**Profile variants.** When per-environment differences cannot be avoided — most often a `CREATE CONNECTION` or `CREATE SECRET` that has to point at different infrastructure in prod and staging — they are expressed as sibling files rather than templating. The unsuffixed file is the default and applies to any profile that does not have a more specific variant; a file suffixed `__<profile>` replaces the default when that profile is active. Every variant is validated regardless of which profile is active, so a typo in a staging variant fails CI for every environment, not only staging.
+
+```sql
+-- models/materialize/raw/postgres.sql  (default — used by prod)
+CREATE CONNECTION postgres TO POSTGRES (
+    HOST 'pg.prod.acme.internal',
+    PORT 5432,
+    USER 'materialize',
+    PASSWORD SECRET pg_password,
+    SSL MODE 'require'
+);
+```
+
+```sql
+-- models/materialize/raw/postgres__staging.sql  (override — used when --profile staging)
+CREATE CONNECTION postgres TO POSTGRES (
+    HOST 'pg.staging.acme.internal',
+    PORT 5432,
+    USER 'materialize',
+    PASSWORD SECRET pg_password,
+    SSL MODE 'require'
+);
+```
+
+When `mz` is run with `--profile staging`, the staging variant is loaded and the default is skipped; for any other profile, the default applies. Object names, types, and dependencies are required to match across variants — variants change configuration values, not project structure.
+
+**Profile suffixes.** A profile can declare a suffix that `mz` appends to every database and cluster name in the project. The use case is sharing a single physical Materialize between environments — for example, hosting prod and staging on the same Materialize instance without standing up a second one:
+
+```toml
+# profiles.toml
+
+[profiles.prod]
+host = "materialize.acme.internal"
+port = 6875
+user = "deployer_prod"
+# no suffix; databases and clusters use their literal project names
+
+[profiles.staging]
+host = "materialize.acme.internal"   # same physical instance as prod
+port = 6875
+user = "deployer_staging"
+profile_suffix = "_staging"
+```
+
+A project whose database is `materialize` and whose cluster is `primary` targets `materialize_staging` and `primary_staging` under the staging profile, living alongside the unsuffixed prod versions on the same Materialize. The suffix flows through every command that names a database or cluster: `apply` creates the suffixed objects, `dev` overlays into them, and `stage` builds its deploy-id-suffixed staging schemas inside the suffixed database. The user owns the delimiter — the value `_staging` is taken literally rather than wrapped — so any naming convention works.
+
+Profile variants and profile suffixes are orthogonal: variants change the SQL contents of individual files; suffixes change the namespaces those files target. Projects often use both — a variant to point a Postgres connection at a different host, and a suffix to keep the resulting database and cluster isolated from the prod ones.
+
+**Profile variables.** For lightweight per-profile differences that do not justify a full file variant, the project can declare `psql`-style variables and bind them per profile. Variables live in `project.toml` (alongside the project, not in the user-local profile credentials), under `[profiles.<name>.variables]`:
+
+```toml
+# project.toml
+
+[profiles.prod.variables]
+ingest_cluster = "ingest_prod"
+
+[profiles.staging.variables]
+ingest_cluster = "ingest_staging"
+```
+
+SQL files reference them with the standard psql `:` prefix:
+
+```sql
+-- models/materialize/raw/orders_source.sql
+CREATE SOURCE orders_source
+    IN CLUSTER :ingest_cluster
+    FROM POSTGRES CONNECTION postgres (PUBLICATION 'mz_source');
+```
+
+Substitution happens before parsing, so `mz`'s parser sees fully resolved SQL and never knows variables existed. Variables can only substitute literal text — they cannot conditionally include or exclude statements. The dividing line between the three profile mechanisms: use a **variable** to substitute a value (a cluster name, a numeric tuning); use a **variant** when the SQL itself differs structurally (a connection targeting a different driver, a view with different filter logic); use a **suffix** to keep entire databases and clusters isolated by name on a shared Materialize.
+
+**`types.lock`.** A pinned, on-disk schema of every external dependency the project consumes, plus the source tables `mz` auto-discovers from `CREATE TABLE FROM SOURCE` statements. `mz lock` generates the file by querying a live Materialize once; everything downstream — `compile`, `test`, editor diagnostics — type-checks against the lock file with no remote in the loop. `types.lock` is checked in alongside the SQL.
+
+**Secret resolution.** Secrets are declared as `CREATE SECRET` files under `models/<db>/<schema>/` like any other namespaced object. The secret value can be an inline string literal, but in any project that is committed to source control it is one of two client-side resolution functions instead:
+
+```sql
+-- models/materialize/raw/pg_password.sql
+CREATE SECRET pg_password AS env_var('PG_PASSWORD');
+
+-- alternative: pull from AWS Secrets Manager
+CREATE SECRET pg_password AS aws_secret('prod/postgres/password');
+```
+
+`env_var` reads from the process environment. `aws_secret` reads from AWS Secrets Manager using the AWS profile configured on the active `mz` profile. Both are resolved on the client at `apply secrets` time, not at `compile` time, so the inner loop never needs access to a real secret value and CI runs and agent sandboxes do not need production credentials to type-check or test code that consumes secrets. Function calls `mz` does not recognize — for example Materialize's own server-side secret functions — pass through unchanged.
+
+**Project boundary.** A project is the unit on which `stage`, `deploy`, and `abort` operate. Multiple `mz` projects can target the same Materialize cluster without conflict; cross-project consumers depend on each other through stable API schemas (see [API stability boundaries](#api-stability-boundaries)).
+
+### Compilation artifacts and incremental compilation
+
+`target/` holds the compiler's persistent state: a SQLite database recording what `compile` learned about the project on its last run. Semantically, the database stores the resolved schema of every project-owned object, the project's full dependency graph and its topological order, the parsed representation of each file, and content hashes used to detect what has changed since the previous compile. The on-disk table layout is an implementation detail; what matters at the design level is that the cache captures everything later commands need to know about the project without re-deriving it from SQL.
+
+Compilation is incremental. Subsequent `compile` runs re-parse and re-check only the files whose hashes have moved, so the inner loop stays fast as a project grows from dozens to thousands of objects. The same incremental cache is what lets the LSP server publish diagnostics and resolve completions while a developer types — neither would be feasible if every keystroke required re-parsing the entire project.
+
+SQLite is a deliberate choice. The LSP server is a long-running process that needs to answer go-to-definition, completion, and diagnostic queries on every keystroke; backing it with a queryable database means it asks the same compiler the CLI does, rather than maintaining a parallel in-memory copy or re-parsing on every request. SQLite also makes the cache inspectable — when something looks wrong, a developer can open `target/` with any SQLite client and see exactly what `mz` thinks the project looks like. The cache is git-ignored and always safe to delete; the next `compile` rebuilds it from the SQL files alone.
+
+Type-checking itself is performed by Materialize's `mz-sql` crate, embedded in `mz` and invoked in-process — there is no emulator container or remote Materialize in the path. `compile` parses with the same parser Materialize uses and resolves types with the same type-checker, both running inside the `mz` binary. This is what makes the inner loop fast enough to back an LSP that runs on every keystroke. The version-compatibility tradeoff that comes with this choice is discussed in [Alternatives](#alternatives).
+
+### The `_mz_deploy` database
+
+`_mz_deploy` is a Materialize database created by `setup` that holds everything `mz` persists about the live environment. Semantically, it stores a content hash for every object in the last deployed production state (so `stage` can diff a project against production without re-reading every object's DDL), the deploy IDs and metadata for staging deployments still in flight (suffixes, timestamps, deferred sinks, replacement materialized view instructions), and a chronological log of every `stage`, `deploy`, and `abort` event with its actor and outcome. A `production` view exposes the current snapshot directly. The on-disk table layout is an implementation detail; what matters at the design level is that the database is the source of truth for "what does production look like, and what are people in the middle of changing about it."
+
+The database lives inside Materialize itself rather than in the project on disk because deployment state is shared. Two engineers staging concurrent changes need to see each other to detect conflicts; a fresh CI clone needs the production snapshot before anything lands in `target/`. Storing the metadata in the cluster being deployed to means the question "what is happening with this Materialize?" has exactly one answer that everyone consults.
+
+`mz` cannot run its bookkeeping queries on `mz_catalog_server` — that cluster is reserved for builtin objects, and `_mz_deploy`'s tables are user-defined. `setup` therefore provisions a dedicated `_mz_deploy_server` cluster, and `mz` pins every metadata read and write to it. The dedicated cluster also keeps `mz`'s own work isolated from user compute: a heavily loaded user cluster cannot starve a `deploy`, and a stuck `mz` query cannot interfere with production workloads. `_mz_deploy_server` is sized for `mz`'s own queries and is not intended for general-purpose use; it can be resized with standard `ALTER CLUSTER` if its workload grows.
+
+`_mz_deploy` is queryable by users like any other Materialize database. The same psql session that runs business queries can `SELECT` against the deployment log to audit who shipped what, or join it against application metadata. The three roles provisioned by `setup` — `materialize_deployer`, `materialize_developer`, `materialize_monitor` — gate write, overlay, and read access respectively; only `setup` itself requires elevated privileges to bootstrap them.
+
+### Local-first validation
+
+The inner loop runs entirely on the developer's machine. No command in this layer requires a connection to a remote Materialize, and every command is fast enough to run on every keystroke, every commit, and every CI step.
+
+**`compile`.** Parses every `.sql` file in the project with Materialize's actual SQL parser, resolves the dependency graph from the parsed statements, performs a topological sort, and type-checks each statement using internal type information for objects the project owns and `types.lock` for objects it consumes. A passing `compile` is a guarantee that the project will not fail at the SQL parsing or planning stage when it reaches Materialize. Compilation is incremental: re-runs only re-check the files that changed.
+
+Beyond syntax and types, `compile` enforces project-level invariants that rule out classes of operational mistakes before they reach a real Materialize:
+
+- **Storage and compute live in separate schemas.** Views and materialized views cannot share a schema with storage objects (sources, sinks, tables). The directory layout makes this explicit — `models/<db>/raw/` holds inputs, `models/<db>/public/` holds derived views — and `compile` rejects projects that violate it.
+- **Storage and compute live on separate clusters.** Indexes and materialized views cannot run on the same cluster as storage objects. Source ingestion and sink publication are isolated from the compute clusters that serve queries, so a hot query workload cannot starve a source and a slow source cannot stall a query path.
+- **Stateful objects cannot be dropped accidentally.** Sources, sinks, and tables are stateful, and removing their SQL file is not, by itself, a request to drop them. There is no path through `apply` or `stage` that will silently delete a source, sink, or table. The only way to drop one is the explicit `mz delete` command, which names the object and removes it from both the live Materialize and the project on disk.
+
+**`test`.** Discovers `EXECUTE UNIT TEST` blocks declared inline next to each view, validates that mocked dependencies and expected results match the real schema, and runs each test in an ephemeral Materialize emulator container. The test machinery rewrites the target view to read from the mocks instead of real upstream tables, runs the view, and compares the result to `EXPECTED` via a symmetric difference query. Tests pass if the result is empty. The emulator container is shared across `test` and `explain` invocations on the same host and reused between runs.
+
+`EXECUTE UNIT TEST` is a new statement type, recognized by the `mz` parser and ignored by Materialize itself. A test block names a target with `FOR`, declares one or more `MOCK` clauses (one per direct dependency of the target, with the column types the mock substitutes for), and an `EXPECTED` clause defining the rows the view should produce. An optional `AT TIME` clause sets the value of `mz_now()` during the test, for views that use temporal filters. Tests live in the same `.sql` file as the view they exercise:
+
+```sql
+-- models/materialize/public/daily_revenue.sql
+
+CREATE MATERIALIZED VIEW daily_revenue AS
+SELECT date_trunc('day', placed_at) AS day,
+       sum(total_cents) / 100.0 AS revenue
+FROM materialize.raw.orders
+GROUP BY 1;
+
+EXECUTE UNIT TEST happy_path
+FOR materialize.public.daily_revenue
+MOCK materialize.raw.orders(placed_at timestamp, total_cents bigint) AS (
+    SELECT * FROM VALUES
+        ('2026-01-01 09:00'::timestamp, 1000),
+        ('2026-01-02 12:00'::timestamp, 5000)
+),
+EXPECTED(day timestamp, revenue numeric) AS (
+    SELECT * FROM VALUES
+        ('2026-01-01'::timestamp, 10.00),
+        ('2026-01-02'::timestamp, 50.00)
+);
+```
+
+Mock names can be unqualified, schema-qualified, or fully qualified — partial names resolve relative to the target view. Column types are normalized before comparison, so common aliases (`int`/`int4`/`integer`, `bigint`/`int8`, `text`/`varchar`) are interchangeable.
+
+**`explain`.** Runs `EXPLAIN` against a target materialized view or named index in the same emulator container `test` uses. Dependencies are staged as stubs so the target can plan in isolation; the plan is what Materialize itself will produce when the object is deployed. This lets users sanity-check an MV's plan before staging anything to a real cluster.
+
+**`types.lock` as the offline contract.** The lock file is what makes the inner loop offline. It pins the column schemas of every external dependency the project consumes — declared explicitly in `project.toml` or auto-discovered for source tables — so type-checking a project's SQL never needs to talk to a database. `mz lock` regenerates it against a live Materialize when external schemas change, and the file is checked in alongside the SQL it validates.
+
+**Agent and CI safety.** Because nothing in this layer touches a shared environment, the inner loop is the natural sandbox for both CI and AI coding agents. CI runs `compile` and `test` on every pull request and never needs a production credential to do so. Coding agents — running locally or in remote sandboxes — can author SQL, validate it, and iterate against test results without ever holding credentials to a real Materialize. The inner loop is the boundary between code that is safe to run and code that is ready to deploy.
+
+### Scratch deployments: `dev` overlays
+
+The inner loop catches type errors and tests view logic against mocked inputs, but at some point a developer needs to see the views they are writing run against real production data. `mz dev` provides this without giving the developer write access to anything anyone else depends on.
+
+`mz dev` deploys the views and materialized views the developer has changed, and only those, into a personal overlay database on the target Materialize. The overlay database is named `<project_database>__<profile>` — a developer using profile `alice` against a project whose database is `app` gets an overlay database called `app__alice`. References inside the changed views are rewritten so that unchanged dependencies resolve to production, external dependencies and `IN CLUSTER` clauses pass through unchanged, and only the dirty views land in the overlay. The result is a database that looks exactly like production except for the views the developer is iterating on.
+
+Tables, sources, sinks, connections, and secrets are not overlaid. `apply` owns those, and overlays are throwaway by design. Each run of `mz dev` drops the overlay and rebuilds it from scratch — there is no incremental state to maintain, no migrations to author, and no reconciliation logic for the user to understand. Typical iterations take seconds. `mz dev --down` tears the overlay down completely.
+
+Authorization is scoped: running `dev` requires the `materialize_developer` role, which grants `CREATEDB` on the target Materialize and read access to the project's production schemas. Developers can run `dev` against any environment whose profile they are authorized for, but their overlays are isolated by name and by the schemas the role can write to.
+
+Scratch deployments sit between the inner loop and the outer loop. They are the right tool when a change is too dependent on real upstream data to validate with mocks, but not yet ready to be deployed. They are the wrong tool for shipping work to other people; that is what `stage` and `deploy` exist for.
+
+### Blue/green deployments
+
+Production deploys never mutate live objects in place. Every change goes through a parallel staging environment, is validated under real input, and is then atomically swapped into production. The mechanism is built directly on Materialize's primitives — staging schemas and clusters, atomic `ALTER ... SWAP`, and the replacement materialized view protocol — and exposed through four commands: `stage`, `wait`, `deploy`, and `abort`.
+
+**`stage`.** Compiles the project, diffs it against the last deployed snapshot of production (a hash per object), and deploys the objects whose definition or dependencies changed into staging schemas and clusters. Staging resources are suffixed with a deploy ID — for a deployment with id `abc123`, the project's `public` schema becomes `public_abc123` and any cluster named `primary` becomes `primary_abc123`. Unchanged objects are not redeployed at all. Tables and sources are not recreated; they are owned by `apply` and cannot be re-bootstrapped without losing data. Sinks are deferred to the `deploy` step, since a sink should not start producing until the deployment is live. If staging fails, all resources created during the attempt are rolled back automatically.
+
+**`wait`.** Blocks until every staging cluster is hydrated and within a configurable lag threshold of its sources. The threshold defaults to five minutes; it can be tightened or loosened per deploy. Waiting exists because hydration is an operational concern: deploying before staging clusters have caught up would cut traffic over to a cold replica, and hydration time depends on the size of the upstream data, which `mz` cannot infer locally.
+
+**`deploy`.** Atomically swaps staging into production inside a single transaction. Schemas and clusters are exchanged via `ALTER ... SWAP`, so for the duration of the swap an object's name resolves to either the old or the new definition but never to nothing. Once the swap commits, `deploy` performs a second phase of work — creating deferred sinks, applying replacement materialized views in stable schemas (see below), repointing sinks that depended on swapped objects, recording the deployment timestamp, and dropping the now-detached old resources. The two-phase structure is what enables `deploy` to be **resumable**: if the process is interrupted after the swap but before the cleanup completes, re-running the same `deploy` command detects the post-swap state and picks up where it left off.
+
+**`abort`.** Drops a staging deployment without deploying it. Equivalent to `git branch -D` for staging — it is the right choice when a change is no longer wanted, when staging fails for reasons unrelated to `mz`, or when garbage-collecting an old deploy ID.
+
+**Concurrent deploys.** Multiple staging deployments can exist at once. Their schemas and clusters are suffix-isolated, so two unrelated deployments do not interact at all. When two deployments touch the same schemas or clusters, conflict detection runs at `deploy` time: if production was modified after a staging deployment was created, the second deployment's `deploy` is rejected with a conflict error and must be re-staged against the new production state. The first deployment to deploy wins.
+
+**Rollback.** There is no dedicated rollback command. To revert a deployment, the developer reverts the project source and deploys the result through the same `stage`/`deploy` flow. The atomicity of `deploy` covers what the swap covers — schemas, clusters, and indexes return to their prior definitions in a single catalog operation — and is sufficient for the common case of incorrect view logic caught quickly.
+
+The atomicity does not, however, undo work that escaped the swap. A replacement materialized view in a stable schema is forward-only: a revert produces another replacement (the original logic re-applied), not a return to the prior catalog state. Sinks that have already emitted to Kafka or Iceberg cannot be un-emitted; reverting creates a new sink generation that emits the corrected output. Tables and sources are owned by `apply`, not `stage`, so any change to them survives a revert and must be reverted separately. Conflict detection applies to reverts the same way it applies to forward deploys: if any other deployment landed between the bad deploy and the revert, the revert must be re-staged. Revert-and-redeploy is the right tool for incorrect logic; it is not a substitute for the operator judgment required when a deploy has already had external side effects.
+
+### API stability boundaries
+
+Schema-swap deployment is correct for objects whose only consumers live inside the same project — `stage` can detect every dependent, redeploy them as part of the same deployment, and the swap is atomic. It is not correct for consumers that live in *other* projects. Those consumers see their upstream object disappear and reappear at swap time, and `mz` has no way to redeploy them because it does not own them. The same problem appears for any consumer that lives outside `mz` entirely: a dashboard, an application, an external sink, a sync into another system.
+
+Operational data meshes and ontologies are built on exactly these cross-project, cross-system consumers. A team publishes a materialized view that other teams build on. Those downstream teams cannot redeploy themselves every time an upstream definition changes, and they cannot tolerate the upstream object disappearing for the duration of a swap. A schema-swap deployment is, for them, an outage.
+
+`mz` solves this by letting a schema **opt out of blue/green swap** in favor of an in-place replacement protocol. A stable schema's materialized views are evolved using Materialize's `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` operation rather than recreated and swapped — every MV's catalog identity is preserved through the change, so cross-project and external consumers never see the object disappear.
+
+#### Declaring a stable schema
+
+Stability is declared in the schema's mod file. For schema `ontology` in database `materialize`, the mod file is `models/materialize/ontology.sql`, and it contains a single statement:
+
+```sql
+-- models/materialize/ontology.sql
+SET api = stable;
+```
+
+The mod file is applied during `apply` and re-applied to staging schemas during `stage`, so the configuration follows the schema regardless of how many times it gets swapped or recreated. There is no other place to declare stability — the choice is local to the schema and lives next to the materialized views it governs.
+
+#### Replacement materialized views
+
+When `stage` sees a changed materialized view in a stable schema, it does not recreate the MV in a staging schema and swap it into production. Instead, it records a **replacement**: an `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` operation that `deploy` will execute after the main schema swap completes. The replacement protocol updates the MV's computation in place and preserves its identity — downstream consumers continue to read from the same object, by the same name, with the same catalog id, throughout the operation. Nothing observable to a downstream consumer changes other than the data the MV produces.
+
+The protocol imposes a compatibility constraint on the new definition: the output schema of the replacement must be a superset of the existing one. Replacement can add columns, but it cannot remove or retype them.
+
+#### Restrictions on stable schemas
+
+Stable schemas come with three constraints that fall out of the protocol:
+
+- **Only `stable` is recognized.** The design leaves room for additional API levels (for example a stricter `frozen` that disallows even backward-compatible additions) but does not implement any of them today.
+- **Materialized-view-only.** Stable schemas may contain only materialized views. Tables, regular views, sinks, sources, secrets, and connections are forbidden — nothing else has an in-place replacement protocol, and only a materialized view's computation can be evolved without changing its identity.
+- **No new objects after the schema is marked stable.** Once a schema has `SET api = stable`, `mz` allows existing materialized views to be modified but rejects new ones. A new MV cannot be introduced via the replacement protocol (there is nothing to replace) and cannot be introduced via blue/green swap (the swap would replace the entire schema, breaking the stable-identity contract for every existing consumer). This is a limitation we expect to lift: once Materialize supports `ALTER MATERIALIZED VIEW ... SET SCHEMA`, `mz` can stage a new MV in a sibling schema and atomically move it into the stable schema. Until then, stable schemas have a fixed roster of materialized views from the moment they are marked stable.
+
+Replacement materialized views also do **not** propagate dirtiness to their dependents (see [Deployment internals](#deployment-internals)). Dependents are not redeployed because they do not need to be — the MV they depend on still exists, with the same identity, after the replacement. This is what makes stability composable: a project that depends on another project's stable schema gets the benefit automatically, without any coordination.
+
+### Deployment internals
+
+The previous sections described `stage`, `wait`, `deploy`, and `abort` at the user-facing level. This section goes one layer deeper: how `mz` decides what to redeploy, how it protects against conflicting deployments, what blue/green actually does at the SQL level, and the special handling sinks receive.
+
+#### Computing what to redeploy
+
+`stage` does not redeploy objects whose contents have not changed, and it does not stop at the immediate diff: when an object changes, every downstream object affected by that change needs to be redeployed, and in some cases entire schemas and clusters are recreated as a unit so the swap can be atomic. `mz` computes this transitive closure with a Datalog fixed-point computation over the project's dependency graph.
+
+Three predicates are derived:
+
+- `DirtyStmt(O)` — object `O` must be reprocessed.
+- `DirtyCluster(C)` — cluster `C` must be cloned into staging.
+- `DirtySchema(D, S)` — schema `S` in database `D` must be redeployed atomically.
+
+The rules:
+
+```datalog
+% Statement dirtiness
+DirtyStmt(O) :- ChangedStmt(O).
+DirtyStmt(O) :- StmtUsesCluster(O, C), DirtyCluster(C).
+DirtyStmt(O) :- DependsOn(O, P), DirtyStmt(P), NOT IsChangedReplacement(P).
+DirtyStmt(O) :- DirtySchema(Db, Sch), ObjectInSchema(O, Db, Sch).
+
+% Cluster dirtiness
+DirtyCluster(C) :- ChangedStmt(O), StmtUsesCluster(O, C), NOT IsSink(O), ClusterBoundary(C).
+DirtyCluster(C) :- ChangedStmt(O), IndexUsesCluster(O, _, C), NOT IsSink(O), ClusterBoundary(C).
+
+% Schema dirtiness
+DirtySchema(Db, Sch) :- DirtyStmt(O), ObjectInSchema(O, Db, Sch), NOT IsSink(O).
+```
+
+Several behaviors fall out of these rules:
+
+- **Schemas redeploy atomically.** Any dirty object makes its entire schema dirty, and any dirty schema pulls in every object inside it. The swap unit is the schema, not the individual object, which is what makes blue/green deploys cleanly atomic — partial schemas never exist.
+- **Replacement MVs cap dirtiness propagation.** A changed materialized view in a stable schema (see [API stability boundaries](#api-stability-boundaries)) is redeployed via the in-place replacement protocol, and its dependents are *not* marked dirty by it. This is the mechanism that lets cross-team consumers stay stable through upstream churn.
+- **Indexes do not escalate.** An index whose cluster is dirty does not force the indexed object to be redeployed; indexes are physical optimizations that can be recreated independently.
+- **Sinks are excluded from schema and cluster dirtiness.** A dirty sink does not pull its schema or cluster into redeployment because sinks are not part of the atomic swap (see "Sinks" below).
+
+#### Merge protection
+
+Multiple developers may stage deployments concurrently against the same Materialize. As long as the deployments touch disjoint schemas and clusters, they do not interact. When they overlap, `deploy` detects the conflict at the schema level and rejects any deployment whose production schemas have changed since it was staged.
+
+The check runs at deploy time as a single SQL query against `_mz_deploy`:
+
+```sql
+SELECT p.database, p.schema, p.deploy_id, p.deployed_at
+FROM _mz_deploy.public.production p
+JOIN _mz_deploy.public.deployments d USING (database, schema)
+WHERE d.deploy_id = $1 AND p.deployed_at > d.staged_at;
+```
+
+For every (database, schema) the deployment touches, the query asks: has a different deployment deployed into this schema *after* this deployment was staged? If any row comes back, the deployment is rejected with a conflict error and the developer must re-stage against current production. If no row comes back, the swap is safe to proceed.
+
+The rule is "first to deploy wins": the developer whose `deploy` lands first installs their changes; any other in-flight deployment that overlaps must re-stage. `--force` is available for the case where the operator knows they want to override the check, but it is the wrong default — it discards another deployer's work without merging it.
+
+#### Blue/green mechanics
+
+For every dirty schema and every dirty cluster, `stage` creates a corresponding staging copy:
+
+- For each dirty schema, a new schema is created with the same name plus the deploy ID suffix (`public_abc123`). The schema's mod file (e.g., `SET api = stable`) is re-applied so the staging schema inherits the same configuration.
+- For each dirty cluster, a new cluster is created by cloning the source cluster's configuration (size, replicas, options) and appending the deploy ID suffix.
+- Each dirty object's DDL is rewritten to reference the staging names where appropriate (for intra-schema dependencies), and the rewritten DDL is executed inside the staging schema and on the staging cluster.
+
+`deploy` runs the swap inside a single transaction. For each dirty schema, the production schema and the staging schema are exchanged with `ALTER SCHEMA ... SWAP`; the equivalent operation runs for clusters. From the perspective of any reader, the schema's name resolves to either the old or the new contents, never to nothing — the swap is a single catalog operation. Once the transaction commits, post-swap work runs: replacement materialized views in stable schemas are applied with `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT`, deferred sinks are created, pre-existing sinks that depended on swapped objects are repointed, and the now-detached old schemas and clusters are dropped.
+
+#### Sinks
+
+Sinks are special because they have side effects outside Materialize. A sink writes to Kafka or Iceberg; a sink that flips on and off during a deploy emits visible side effects (duplicate records, gaps, schema churn) that downstream consumers cannot easily handle. Sinks therefore receive different treatment than other objects:
+
+- **New sinks are deferred.** A sink declared in the project but not yet present in production is not created during `stage`. The project only records that the sink should exist; `deploy` creates it after the schema swap commits, so the sink starts producing exactly when its dependencies become live in production.
+- **Pre-existing sinks are repointed.** A sink that already exists in production and depends on an object being swapped is detached from the old object and re-attached to the new one with `ALTER SINK ... SET FROM`. This keeps the sink's identity stable across the deploy — its catalog id, its progress in the external system, and its configuration are all preserved.
+- **Sink changes do not redeploy a schema or cluster.** Because sinks are excluded from schema and cluster dirtiness, adding or modifying a sink does not force any other object to be redeployed, and the sink-specific work happens entirely in the post-swap phase. This keeps sinks responsive to small, frequent changes without dragging the rest of a schema along for the ride.
+
+### Authoring surfaces
+
+`mz` is not only a CLI; it is also a set of long-running services that surface the same project model to editors, AI coding agents, and interactive shells. Each surface is exposed as an `mz` subcommand so that there is a single binary to install and a single project model in play, regardless of how the user is interacting with it.
+
+**`lsp` — editor integration.** `mz lsp` starts a Language Server Protocol server over stdio. Any editor that speaks LSP — VS Code, Neovim, Helix, JetBrains — gets the same set of capabilities for `.sql` files in an `mz` project: parse-error diagnostics published on every keystroke, go-to-definition that jumps to the file declaring an object, and column- and identifier-level completions scoped to the file's actual dependencies. The server reuses the same compiler the CLI does, so a diagnostic in the editor and a `compile` failure in CI are guaranteed to be the same error.
+
+**`mcp` — agent integration.** `mz mcp` exposes Materialize's developer MCP server through the active profile — a thin pass-through to the native MCP endpoint rather than a re-implementation, so users do not have to configure credentials in two places.
+
+**`sql` — interactive psql.** `mz sql` launches `psql` configured against the active profile, with all of the profile's connection settings — host, port, user, password, SSL, and any per-profile psql options — wired in. It is the right tool for ad-hoc investigation, one-off queries, and any task that calls for a real interactive shell instead of a compiled project. Trailing arguments are passed through to `psql` unchanged, so `mz sql -- -c 'SELECT 1'` and `mz sql -- -f migrations.sql` work as expected.
+
+The three surfaces share the same profile model and the same project model. Switching profiles, projects, or environments updates all of them at once, because there is only one configuration to update.
+
+### Operational primitives
+
+The blue/green flow assumes the infrastructure those views run on already exists. Clusters need to be created, roles granted, network policies applied, secrets populated, connections opened, sources started, and tables provisioned. These are prerequisites of a deployment, not part of one — they have different lifetimes than views, different blast radius profiles, and in many cases different owners. `mz` keeps them outside the blue/green path and exposes them through three commands.
+
+**`apply`.** Declaratively reconciles the infrastructure objects in the project against the live Materialize. With no subcommand, `apply` walks the resource kinds in dependency order — clusters, roles, network policies, secrets, connections, sources, tables — creating what is missing and reconciling drift in what already exists. Each step is idempotent, so re-running `apply` converges to the same state. Each step can also be invoked individually (`apply clusters`, `apply roles`, etc.) for surgical updates. The command supports `--dry-run` for previewing the SQL it would execute and `--output json` for machine-readable plans, both of which are useful for code review and CI.
+
+`apply` does not own materialized views or regular views. Those go through `stage` and `deploy`, where they get blue/green safety. Tables and sources stay under `apply` because they are stateful — recreating them would discard data — and sinks stay outside `apply` because they belong to the deployment lifecycle they participate in.
+
+**`setup`.** Bootstraps the Materialize cluster the first time `mz` is used against it. `setup` creates the `_mz_deploy` database that tracks deployment metadata, the tables and views inside it, three project-wide roles (`materialize_deployer`, `materialize_developer`, `materialize_monitor`), and a dedicated `_mz_deploy_server` cluster used as the stable connection target for `mz`'s own bookkeeping queries. `setup` must be run once per Materialize, by a superuser, before any other `mz` command can act on that environment. After that, ordinary deployer, developer, and monitor users use `mz` normally — no further elevated privileges are needed.
+
+**`debug`.** Verifies that the active profile can connect to its target Materialize, that the user has the role grants `mz` expects, and that the deployment metadata `setup` provisions is reachable. It is the first command to run when something is misbehaving and the right command to wire into onboarding scripts: a passing `debug` is the precondition for everything else `mz` does.
+
+### Runtime targets
+
+`mz` works against three deployment scenarios from the same project on disk:
+
+- **Materialize Cloud** — the managed offering. The active profile points at a cloud region's pgwire endpoint, and (for `mcp`) the region's HTTP API hostname.
+- **Self-managed Materialize** — a Materialize installation a customer or partner runs in their own infrastructure. The profile points at whatever host and port that installation exposes; everything else is identical.
+- **Local emulator** — a single-node Materialize running in Docker on the developer's machine. Useful for end-to-end validation outside CI and for environments where a remote Materialize is unavailable.
+
+The project model, the inner loop, the blue/green deploy flow, and the authoring surfaces are invariant across all three. What differs is only the contents of the active profile — host, port, credentials, and (where applicable) HTTP host. Switching environments is a profile change, not a workflow change.
+
+## Minimal Viable Prototype
+
+A working prototype implements the full architecture end-to-end and has been exercised against real Materialize instances on Cloud, self-managed, and the local emulator. The prototype covers every command described in the [Command Reference](#appendix-a-command-reference): the project model and `init`/`new`; the inner loop (`compile`, `test`, `explain`); the scratch deployment path (`dev`); the outer loop (`stage`, `wait`, `deploy`, `abort`); the operational primitives (`apply`, `setup`, `debug`); the authoring surfaces (`lsp`, `mcp`, `sql`); and the supporting commands (`lock`, `list`, `log`, `describe`, `delete`, `profile`).
+
+The prototype is deliberately scoped to the architecture in this document, not to a polished product. Diagnostic messages, error recovery, performance under large projects, packaging, and editor-extension distribution are all areas that need iteration before a public release. The prototype's value is validating the design — that the layered architecture (project model → inner loop → scratch → outer loop), the API stability protocol, and the runtime-target abstraction hold up under realistic use — and providing a concrete artifact for stakeholders to read and run before committing to the larger investment.
+
+## Alternatives
+
+**Stay with dbt and document patterns.** The status quo is dbt plus user-authored macros to orchestrate Materialize-specific behavior — most prominently, blue/green orchestration via macros and run hooks. We have invested in this approach and continue to support it. It is not a viable long-term answer: the macros are fragile, hard to support, and the gaps grow as Materialize adds operational features (replacement MVs, stable APIs, hydration-aware deployment) that have no natural expression in dbt's model. Documenting the patterns more thoroughly does not change the underlying mismatch between dbt's audience and Materialize's.
+
+We acknowledge that dbt has strengths `mz` will not replicate at launch — its package ecosystem, generated documentation site, exposures, and schema-test taxonomy are all real benefits to teams that use them. Where those benefits matter, dbt remains a reasonable choice and `mz` and dbt can target the same Materialize. `mz` exists for the operational core of a Materialize project, not as a general-purpose replacement for everything dbt does.
+
+**Wait for dbt Cloud or dbt Fusion support.** If Materialize were on dbt Cloud or supported by dbt Fusion, the case for building `mz` would be weaker. But neither is on dbt's roadmap with a timeline we can plan around, and even if they were, the audience and capability mismatches described above would remain. Waiting cedes the developer experience to a third party and to a schedule we do not control, and it does not address the software-engineering audience at all.
+
+**Build `mz` as a wrapper around dbt.** A thin layer on top of dbt — providing a CLI entry point and pre-packaged macros for Materialize-specific concerns — would reuse dbt's project model and lower our maintenance burden. We rejected this path. Wrapping dbt inherits its mental model (which targets analytic engineers), its templating layer (which we do not want), and its lifecycle (which assumes batch refreshes). The seams between the wrapper and dbt would surface every time the user hit a Materialize-specific feature, and the wrapper would have to grow until it was a competing implementation anyway.
+
+**Web-only deployment console.** Make `stage`, `deploy`, and `abort` web-UI operations rather than CLI commands. This would lower the barrier for a first-time user but raise it for every other audience — CI pipelines, AI agents, and software engineers who already live at the terminal. A CLI is a strict superset: a web UI can be added on top of `mz` later if there is demand.
+
+**Per-Materialize SDLC tools maintained by individual customers.** The path we have today: every team that builds operational systems on Materialize ends up writing their own scaffolding. This produces a large surface area of inconsistent, unsupported tooling and asks each team to solve the same problems independently. It is what `mz` exists to replace.
+
+**Use the Materialize emulator for compilation instead of embedding `mz-sql`.** `compile` could type-check by handing each statement to a local Materialize emulator container rather than running the type-checker in-process. We rejected this for two reasons. First, it would make Docker a hard dependency of the inner loop. The point of compiling locally is to stay fast and lightweight; bolting Docker to the front of it gives that up. Second, in benchmarking, the emulator path was nearly 300× slower than the embedded crate, slow enough to make LSP-backed authoring (compile-on-keystroke) unworkable. The remaining concern with the embedded approach is version skew between the crate and the target Materialize, but the only thing `mz` uses the crate for is type-checking, and an MV's output schema should be stable across Materialize versions.
+
+## Open Questions
+
+- **Is `models/` the right directory name?** The name is borrowed from dbt, where everything inside really is a data model. In `mz`, `models/` also contains secrets, connections, sources, tables, and sinks — none of which are "data models" in the dbt sense. We need *some* directory to scope database-namespaced objects so that the global-namespace top-level directories (`clusters/`, `roles/`, `network-policies/`) are unambiguous: without it, a `clusters/` directory could be either the cluster object kind or a database literally named `clusters`. The mechanism is right; the name might not be. Candidates include `databases/`, `schemas/`, `objects/`, or a different word entirely.
+
+## Out of Scope
+
+- **Replacing dbt for analytic pipelines.** Teams running analytic workloads on dbt should continue to do so. `mz` and dbt can target the same Materialize cluster.
+- **Cloud-account administration.** Managing organizations, regions, users, app passwords, and account-level secrets is the responsibility of other tools and surfaces. `mz` operates inside an existing Materialize environment, not above it.
+- **Data movement outside Materialize.** `mz` does not orchestrate upstream pipelines, schedule extracts, or manage non-Materialize systems.
+- **Deployment observability.** `mz` reports the outcome of its own commands, but it does not provide dashboards, metrics, or alerting for the deployments it produces. Existing Materialize observability surfaces own that.
+- **Multi-region deployment coordination.** `mz` deploys to one Materialize at a time. Coordinating changes across multiple regions or environments is the responsibility of the caller (typically CI).
+- **Dedicated rollback.** There is no `mz rollback` command. Reverting a deployment is done by reverting the project source and deploying the result; the same blue/green path applies, so the rollback is itself atomic.
+
+## Appendix A: Command Reference
+
+This appendix is a quick reference. It covers each command's purpose and the mental model behind it; full flag enumeration lives in `mz <cmd> --help`.
+
+### Project lifecycle
+
+- **`init`** — Scaffold the current directory as an `mz` project. Derives the project name from the directory, creates the standard layout (`models/`, `clusters/`, `roles/`, `network-policies/`), writes `project.toml`, a `.gitignore`, and a starter `README.md`, and initializes a git repository (use `--no-git` to skip).
+- **`new`** — Same as `init`, but creates a new directory rather than initializing the current one. `mz new my-project` is the typical form.
+- **`compile`** — Parse, dependency-resolve, topologically sort, and type-check every SQL file in the project against `types.lock`. No remote database is contacted. A passing `compile` is a guarantee that the project will not fail at the SQL parsing or planning stage when deployed. Use `-v` to print the dependency graph and full SQL plan.
+- **`lock`** — Refresh `types.lock` by querying the active profile's Materialize for the schemas of declared external dependencies and auto-discovered source tables. Run after upstream schemas change. Requires a live database.
+- **`list`** — List the project's active staging deployments along with their deploy IDs and creation timestamps. Useful for finding the deployment to deploy or abort.
+- **`log`** — Show the deployment log for the project: a chronological record of `stage`, `deploy`, and `abort` events with timestamps and outcomes. The audit trail for who deployed what and when.
+- **`describe`** — Inspect the project model. Enumerates objects, their dependencies, and their resolved fully-qualified names. Useful for understanding what `mz` will act on before running `apply` or `stage`.
+- **`delete`** — Drop a project-managed object from both the live Materialize and the project on disk. The dual operation removes the SQL file and runs the matching `DROP`.
+
+### Inner loop
+
+- **`test`** — Discover `EXECUTE UNIT TEST` blocks across the project, validate them against `types.lock`, and run each one in a Materialize emulator container. Mock columns are checked against real schemas; results are compared via symmetric difference — passing tests return zero rows. Supports `--junit-xml` for CI integration and a filter argument (`mz test 'materialize.public.*'`) for running a subset.
+- **`explain`** — Run `EXPLAIN` against a project's materialized view (or a named index on any object) in the same emulator container `test` uses. Dependencies are staged as stubs so the target plans in isolation; the resulting plan is what Materialize will produce when the object is deployed for real.
+
+### Authoring surfaces
+
+- **`lsp`** — Start a Language Server Protocol server over stdio. Provides parse-error diagnostics, go-to-definition, and column-/identifier-level completions for `.sql` files in an `mz` project. Reuses the same compiler the CLI does, so LSP errors and `compile` errors are guaranteed to match.
+- **`mcp`** — A thin pass-through to Materialize's native developer MCP endpoint, using the active profile's credentials. Wired into MCP clients (Claude Code, Cursor, Claude Desktop) like any other MCP server. Not a re-implementation — `mz` only forwards requests so users do not configure credentials in two places.
+- **`sql`** — Launch an interactive `psql` session configured against the active profile. Arguments after `--` are forwarded to `psql` unchanged.
+
+### Infrastructure
+
+- **`apply`** — Reconcile the project's infrastructure objects against the live Materialize. Creates missing resources, reconciles drift in existing ones, and is idempotent across re-runs. With no subcommand, walks every kind in dependency order: clusters → roles → network policies → secrets → connections → sources → tables. Subcommands (`apply clusters`, `apply roles`, `apply network-policies`, `apply secrets`, `apply connections`, `apply sources`, `apply tables`) target one kind at a time. Supports `--dry-run` and `--output json` for previews.
+- **`setup`** — Bootstrap a Materialize cluster for `mz`: create the `_mz_deploy` database and tracking tables, the `materialize_deployer` / `materialize_developer` / `materialize_monitor` roles, and the dedicated `_mz_deploy_server` cluster used as the connection target for `mz`'s metadata queries. Idempotent. Must be run once per Materialize, by a superuser.
+- **`debug`** — Verify that the active profile can connect to its target Materialize and that the user has the role grants `mz` expects. The first command to run when something is misbehaving and a useful precondition for onboarding scripts.
+- **`profile`** — Manage connection profiles (`profile list`, `profile set`, `profile show`). Profiles live in a user-local `profiles.toml` and select the active environment for every other command. `profile set` records the chosen default in a `.mzprofile` file at the project root — typically gitignored so developers can pick their own defaults, optionally checked in for a shared project default.
+
+### Scratch deployment
+
+- **`dev`** — Deploy the views and materialized views the developer has changed into a personal overlay database (`<project_db>__<profile>`) on the target Materialize, splicing them in front of unchanged production dependencies. Every run drops and rebuilds the overlay; `mz dev --down` tears it down. Requires the `materialize_developer` role.
+
+### Production deployment
+
+- **`stage`** — Diff the project against the last deployed production snapshot and deploy the changed objects (and their dependents) into staging schemas and clusters suffixed with a deploy ID. Tables and sources are not recreated; sinks are deferred to `deploy`. Supports `--dry-run` and `--output json`.
+- **`wait`** — Block until every staging cluster in a deployment is hydrated and within a configurable lag threshold. `deploy` invokes `wait` implicitly unless `--no-ready-check` is set; `wait` is also exposed as a standalone command for explicit gating.
+- **`deploy`** — Atomically swap a staging deployment into production via `ALTER ... SWAP`, apply replacement materialized views in stable schemas, create deferred sinks, repoint sinks that depended on swapped objects, and drop the now-detached old resources. Resumable: if interrupted after the swap but before cleanup completes, re-running the same command picks up where it left off.
+- **`abort`** — Drop a staging deployment without deploying it. Equivalent to `git branch -D` for staging.


### PR DESCRIPTION
Concept and architecture guide for `mz`, an opinionated SDLC for Materialize: project model, local-first validation, scratch deployments, blue/green deploys, API stability boundaries, and authoring surfaces.

Rendered link: https://github.com/sjwiesman/materialize/blob/0b7d00ec77547eeb7eb859edcb7b47117eddeefc/doc/developer/design/20260506_mz_v2.md

