### PR TITLE
docs: drive {{< version >}} from a single source-of-truth file

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -52,6 +52,10 @@ if ! [[ "$version" = *-dev* ]]; then
     sed -i.bak \
         "s/^Licensed Work:.*/Licensed Work:             Materialize Version v$version/" \
         LICENSE
+    sed -i.bak \
+        "s/^latest_stable:.*/latest_stable: v$version/" \
+        doc/user/data/release.yml
+    rm -f doc/user/data/release.yml.bak
 else
     # Rename all upgrade tests that reference `current_source` to explicitly
     # reference the version of the last release.

--- a/doc/user/data/release.yml
+++ b/doc/user/data/release.yml
@@ -1,0 +1,7 @@
+# Most recent stable Materialize release.
+#
+# Bumped by `bin/bump-version` when cutting a real (non-dev) release. The
+# `{{< version >}}` shortcode reads this value, so anything rendered from a
+# release tag advertises the version that tag corresponds to — independent
+# of frontmatter on `releases/v*.md`, which can lag the release branch.
+latest_stable: v26.22.0

--- a/doc/user/layouts/shortcodes/version.html
+++ b/doc/user/layouts/shortcodes/version.html
@@ -1,5 +1,1 @@
-{{- $releasesPage := site.GetPage "section" "releases" -}}
-{{- $publishedReleases := (where $releasesPage.Pages "Params.released" true) -}}
-{{- $latestPublishedRelease := (index $publishedReleases.ByDate.Reverse 0) -}}
-{{- $patch := default 0 $latestPublishedRelease.Params.patch -}}
-{{- $latestPublishedRelease.File.ContentBaseName -}}.{{- $patch -}}
+{{- site.Data.release.latest_stable -}}


### PR DESCRIPTION
## Problem

`doc/user/layouts/shortcodes/version.html` picks the "latest stable Materialize version" by iterating `releases/v*.md`, filtering on the `released: true` frontmatter, sorting by date, and emitting `{ContentBaseName}.{Params.patch}`. Both inputs (`released` and `patch`) are bumped by commits that land on `main` *after* a release tag is cut, so they never reach the release branch the tag sits on. Anything rendered from a release tag therefore sees a stale view: a not-yet-`released: true` current release, and stale `patch:` counters on earlier releases.

## Reproduce (entirely within this repo)

```bash
git fetch origin tag v26.22.0

git checkout v26.22.0 -- doc/user
( cd doc/user && hugo --config config.toml,config.skill.toml \
    --disableKinds sitemap,robotsTXT,taxonomy --destination /tmp/skill-v22 \
    --cleanDestinationDir --gc --quiet )

git checkout main -- doc/user
( cd doc/user && hugo --config config.toml,config.skill.toml \
    --disableKinds sitemap,robotsTXT,taxonomy --destination /tmp/skill-main \
    --cleanDestinationDir --gc --quiet )

diff -u /tmp/skill-v22/get-started/install-materialize-emulator/index.md \
        /tmp/skill-main/get-started/install-materialize-emulator/index.md
```

Relevant hunk:

```diff
- docker run ... materialize/materialized:v26.20.0    # rendered from v26.22.0 tag
+ docker run ... materialize/materialized:v26.22.0    # rendered from main
```

i.e. the `v26.22.0` release tag's own docs recommend the `v26.20.0` Docker image to users who follow the install instructions from a v26.22.0 build.

The asymmetry, traced:

| Where | When | Effect |
|-------|------|--------|
| `release: create doc file for v26.22` (51fa46dad0) | before cut | adds `releases/v26.22.md` with `released: false, rc: 1` |
| `v26.22.0` tag cut on `release-26.22` | release | tag captures the `released: false` state |
| `release: mark v26.22 as released` (58c8125c32) | after, on `main` | flips to `released: true` — never reaches the tag |
| `1e56ef0904` (`releases/v26.20.md` `patch: 0 → 2`) | after, on `main` | same shape — patch bumps for prior lines never reach `release-26.22` |

A user-visible regression of this is in [MaterializeInc/agent-skills#12](https://github.com/MaterializeInc/agent-skills/pull/12), which regenerates a docs skill bundle from the `v26.22.0` tag — the regenerated install instructions show `materialize/materialized:v26.20.0` where the previous (main-based) regen showed `:v26.22.0`.

## Fix

Drive `{{< version >}}` from a single source-of-truth data file `doc/user/data/release.yml`:

```yaml
latest_stable: v26.22.0
```

Bump that file from `bin/bump-version` when called with a real (non-dev) version — the same commit on the release branch that bumps `Cargo.toml` versions and the LICENSE line. The release branch's tag then sees the value it should, and `released:`/`patch:` frontmatter on `releases/v*.md` no longer drives anything beyond the release-notes page itself.

The Hugo template change is a one-liner; the `bin/bump-version` change is four lines guarded by the existing `! [[ "$version" = *-dev* ]]` block.

## Render parity check

Rendering main with the new shortcode emits `materialize/materialized:v26.22.0` — identical to the old shortcode's output today. No content diff.

## Follow-ups (not in this PR)

- The "release: mark vX.Y as released" automation that runs on `main` post-release should also bump `latest_stable:` so that main always advertises the most recent release. Happy to do this in a follow-up — point me at where that automation lives.
- The same fragility may exist in other shortcodes that read frontmatter via `where ... .Pages "Params.X" Y`. Worth a sweep.
