### PR TITLE
ci: Nightly/test fixes (2026-05-07)

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -402,7 +402,7 @@ def get_variable_system_parameters(
             "arrangement_size_history_collection_interval", "1h", ["1s", "10s", "1h"]
         ),
         VariableSystemParameter(
-            "arrangement_size_history_retention_period", "7d", ["1m", "1h", "7d"]
+            "arrangement_size_history_retention_period", "7d", ["1min", "1h", "7d"]
         ),
         VariableSystemParameter(
             "persist_validate_part_bounds_on_read", "false", ["true", "false"]

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1551,7 +1551,7 @@ class FlipFlagsAction(Action):
             "'1h'",
         ]
         self.flags_with_values["arrangement_size_history_retention_period"] = [
-            "'1m'",
+            "'1min'",
             "'1h'",
             "'7d'",
         ]

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1266,7 +1266,6 @@ source materialize.public.t1 (u1, storage):
 
 binding constraints:
 lower:
-  (Storage inputs: [u1]): [<TIMESTAMP>]
   (Isolation level: StrictSerializable): [<TIMESTAMP>]\n";
 
     let row = client

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -338,6 +338,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn emits_multiple_containers() {
         let mut builder: ConsolidatingColumnBuilder<u64, u64, i64> = Default::default();
         // Enough distinct rows to fill the SoA accumulator past the output target multiple

--- a/test/pg-cdc-old-syntax/alter-table-after-source.td
+++ b/test/pg-cdc-old-syntax/alter-table-after-source.td
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/7900 is fixed
+$ skip-if
+SELECT true
+
 #
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created
 #

--- a/test/sqllogictest/distinct_arrangements.slt
+++ b/test/sqllogictest/distinct_arrangements.slt
@@ -1057,10 +1057,12 @@ JOIN mz_introspection.mz_dataflow_operator_dataflows mdod ON mash.operator_id = 
 GROUP BY mdod.name
 ORDER BY mdod.name
 ----
-AccumulableErrorCheck  2
+AccumulableErrorCheck  3
 Arrange␠ReduceMinsMaxes  1
-ArrangeAccumulable␠[val:␠empty]  2
-ReduceAccumulable  2
+ArrangeAccumulable␠[val:␠empty]  3
+ArrangeBy[[Column(0,␠"operator_id")]]  2
+ArrangeBy[[Column(1,␠"dataflow_id")]]  2
+ReduceAccumulable  3
 ReduceMinsMaxes  1
 ReduceMinsMaxes␠Error␠Check  1
 


### PR DESCRIPTION
Mostly follow-ups to #36214, except the pg-cdc flake which is old
https://github.com/MaterializeInc/materialize/pull/36340 caused Miri to time out
Based on this run: https://buildkite.com/materialize/nightly/builds/16340

Test run: https://buildkite.com/materialize/nightly/builds/16341 & https://buildkite.com/materialize/nightly/builds/16343 Edit: all green