### PR TITLE
self-managed release: Don't write self-managed compat. table anymore

### DIFF
--- a/misc/helm-charts/publish.sh
+++ b/misc/helm-charts/publish.sh
@@ -244,16 +244,7 @@ if [[ "$BUILDKITE_TAG" != *"-rc."* ]]; then
     yq -i ".terraform_aws_version= \"${TERRAFORM_VERSION[terraform-aws-materialize]}\"" $VERSIONS_YAML_PATH
   fi
 
-  OPERATOR_COMPAT_YAML_PATH=doc/user/data/self_managed/self_managed_operator_compatibility.yml
-  yq --prettyPrint --inplace ".rows = [{
-    \"Materialize Operator\": \"$BUILDKITE_TAG\",
-    \"orchestratord version\": \"$BUILDKITE_TAG\",
-    \"environmentd version\": \"$BUILDKITE_TAG\",
-    \"Release date\": \"$(date +%Y-%m-%d)\",
-    \"Notes\": \"\"
-  }] + .rows" $OPERATOR_COMPAT_YAML_PATH
-
-  git add $VERSIONS_YAML_PATH $OPERATOR_COMPAT_YAML_PATH
+  git add $VERSIONS_YAML_PATH
   git commit -m "docs: Bump self-managed to $BUILDKITE_TAG"
   git --no-pager diff HEAD~
   run_if_not_dry git push origin "HEAD:main"


### PR DESCRIPTION
Done by the automated release generation as well. Noticed in https://materializeinc.slack.com/archives/CPNFV9CVB/p1777668993296109