### PR TITLE
persist: copy S3 SDK bytes out of hyper pool buffers

### DIFF
--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -451,7 +451,11 @@ impl Blob for S3Blob {
                 }
 
                 while let Some(data) = object.body.next().await {
-                    body_parts.push(data.context("s3 get body err")?);
+                    let data = data.context("s3 get body err")?;
+                    // Copy out of the hyper pool buffer so we don't pin the
+                    // entire shared backing allocation for the lifetime of the
+                    // returned blob.
+                    body_parts.push(Bytes::copy_from_slice(&data));
                 }
 
                 let body_elapsed = body_start.elapsed();


### PR DESCRIPTION
### Motivation

Follow-up to #36305. Dropping the `MetricsRegion<u8>` copy left the SDK `Bytes` chunks slicing into hyper's shared pool buffers. Each pool buffer stays alive as long as any chunk borrows it, so a returned blob pins the full backing allocation. Profile shows the RSS regression plus extra time in `SegmentedBytes::advance` / `get_bytes` from walking many small fragments.

### Description

Push each chunk through `Bytes::copy_from_slice` so the resulting `Bytes` owns a private allocation. Hyper's pool buffer can be released as soon as the chunk lands in `SegmentedBytes`. Cheaper than the old `MetricsRegion` round-trip and avoids the lgalloc fallback.

### Verification

`cargo check -p mz-persist`, `cargo clippy -p mz-persist --all-targets -- -D warnings`, `bin/ci-builder run stable bin/lint`.