### PR TITLE
agents: compress skill and CLAUDE.md descriptions

### DIFF
--- a/.agents/skills/mz-adapter-guide/SKILL.md
+++ b/.agents/skills/mz-adapter-guide/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: mz-adapter-guide
 description: >
-  Correctness invariants and architectural guidance for the adapter layer,
-  coordinator, pgwire, peek paths, and timestamp oracle. Trigger when the user
-  works on or asks questions about these subsystems — including "how does the
-  coordinator work", "what are read holds", "explain the peek path", "how does
-  timestamp selection work", "why does this query block". Also trigger when
-  editing files in src/adapter/, src/pgwire/, or src/timestamp-oracle/.
+  Correctness invariants + architecture: adapter, coordinator, pgwire, peek
+  paths, timestamp oracle. Trigger: questions about these subsystems —
+  "how does coordinator work", "what are read holds", "explain peek path",
+  "how does timestamp selection work", "why does this query block". Also
+  edits in src/adapter/, src/pgwire/, src/timestamp-oracle/.
 ---
 
 # Adapter Guide Skill

--- a/.agents/skills/mz-benchmark/SKILL.md
+++ b/.agents/skills/mz-benchmark/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: mz-benchmark
 description: >
-  Add, modify, or debug benchmark scenarios for measuring Materialize
-  performance. Covers three frameworks: Feature Benchmark (single-operation
-  micro-benchmarks), Scalability Test (SQL throughput under concurrency), and
-  Parallel Benchmark (sustained latency over time via scenarios.py). Trigger on
-  "benchmark", "feature benchmark", "scalability test", "parallel benchmark",
-  "performance regression", "micro-benchmark", "TPS", "latency test", or when
-  editing files in feature_benchmark/scenarios/, scalability/workload/workloads/,
-  or parallel_benchmark/scenarios.py. Note: this is about benchmark measurement
-  frameworks, not the parallel-workload stress-testing framework (which tests for
-  panics under concurrency, not performance).
+  Add/modify/debug Materialize perf benchmark scenarios. Three frameworks:
+  Feature Benchmark (single-op micro), Scalability Test (SQL throughput under
+  concurrency), Parallel Benchmark (sustained latency via scenarios.py).
+  Trigger: "benchmark", "feature benchmark", "scalability test",
+  "parallel benchmark", "performance regression", "micro-benchmark", "TPS",
+  "latency test", or edits in feature_benchmark/scenarios/,
+  scalability/workload/workloads/, parallel_benchmark/scenarios.py.
+  Note: measurement, not panic-stress (see mz-parallel-workload).
 ---
 
 # Benchmark Frameworks

--- a/.agents/skills/mz-commit/SKILL.md
+++ b/.agents/skills/mz-commit/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: mz-commit
 description: >
-  This skill should be used when the user wants to "commit", "prepare a commit",
-  "create a PR", "push", "open a pull request", or mentions committing,
-  pre-commit checks, or pull requests in the Materialize repository. Use this
-  skill even if the user just says "ship it" or "ready to merge" without being
-  specific. Note: for reviewing code, use mz-pr-review instead.
+  Trigger: "commit", "prepare commit", "create PR", "push", "open pull request",
+  or mentions committing, pre-commit checks, pull requests in Materialize. Also
+  "ship it", "ready to merge". For code review use mz-pr-review.
 ---
 
 # Committing in Materialize

--- a/.agents/skills/mz-debug-ci/SKILL.md
+++ b/.agents/skills/mz-debug-ci/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: mz-debug-ci
 description: >
-  Investigate CI failures on a PR using gh and bk CLI tools. Trigger when the
-  user asks about failing checks, Buildkite failures, or CI issues — including
-  casual phrases like "why is CI red", "build broken", "checks failing", "what
-  went wrong in CI", "nightly broke", "tests failing on this PR", or pastes a
-  Buildkite URL. Also trigger when the user mentions a specific PR number and
-  wants to understand why it's failing.
+  Investigate CI failures on PR via gh + bk CLI. Trigger: failing checks,
+  Buildkite failures, CI issues — "why is CI red", "build broken",
+  "checks failing", "what went wrong in CI", "nightly broke",
+  "tests failing on this PR", or pasted Buildkite URL. Also PR number +
+  why failing.
 argument-hint: <PR number or GitHub PR URL>
 ---
 

--- a/.agents/skills/mz-limits-test/SKILL.md
+++ b/.agents/skills/mz-limits-test/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: mz-limits-test
 description: >
-  This skill should be used when the user wants to add, modify, or debug a limits
-  test. Trigger when the user mentions "limits test", "Generator subclass",
-  "many objects", "scaling test", or wants to stress-test Materialize with large
-  numbers of objects (tables, views, sources, indexes, etc.). Also trigger when
-  the user edits test/limits/mzcompose.py.
+  Add/modify/debug limits test. Trigger: "limits test", "Generator subclass",
+  "many objects", "scaling test", or stress-test Materialize with many objects
+  (tables, views, sources, indexes). Also edits in test/limits/mzcompose.py.
 ---
 
 # Limits Test Framework

--- a/.agents/skills/mz-parallel-workload/SKILL.md
+++ b/.agents/skills/mz-parallel-workload/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: mz-parallel-workload
 description: >
-  Extend the parallel-workload stress-testing framework, which runs random SQL
-  actions concurrently to catch panics and unexpected errors (not performance
-  measurement — see mz-benchmark for that). Trigger when the user mentions
-  "parallel workload", "parallel-workload", "action.py" in the context of
-  parallel workload, or wants to test for panics or unexpected query errors under
-  concurrency. Use this skill even if the user just says "add this to parallel
-  workload" or references a bug that panics under concurrent DDL/DML.
+  Extend parallel-workload stress framework: random SQL concurrently to catch
+  panics + unexpected errors (not perf — see mz-benchmark). Trigger:
+  "parallel workload", "parallel-workload", "action.py" re parallel workload,
+  or testing panics/unexpected errors under concurrency. Also "add this to
+  parallel workload" or bug that panics under concurrent DDL/DML.
 ---
 
 # Extending Parallel Workload

--- a/.agents/skills/mz-platform-checks/SKILL.md
+++ b/.agents/skills/mz-platform-checks/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: mz-platform-checks
 description: >
-  This skill should be used when the user wants to create, modify, or debug a
-  platform check. Trigger when the user mentions "platform check", "platform-checks",
-  "upgrade check", "restart check", or wants to write a Check class that tests
-  feature survival across restarts/upgrades. Also trigger when the user edits files
-  in misc/python/materialize/checks/all_checks/.
+  Create/modify/debug platform check. Trigger: "platform check",
+  "platform-checks", "upgrade check", "restart check", or writing Check class
+  testing feature survival across restarts/upgrades. Also edits in
+  misc/python/materialize/checks/all_checks/.
 ---
 
 # Platform Checks

--- a/.agents/skills/mz-pr-review/SKILL.md
+++ b/.agents/skills/mz-pr-review/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: mz-pr-review
 description: >
-  Perform a local code review of the current branch's changes against Materialize
-  project standards. Trigger when the user says "review my code", "review my
-  changes", "check my diff", "does this look ok", "what do you think of this
-  PR", "code review", or asks you to look over changes before merging. Also
-  trigger when the user passes a PR number and wants feedback on quality, style,
-  or correctness.
+  Local code review of current branch vs Materialize standards. Trigger:
+  "review my code", "review my changes", "check my diff", "does this look ok",
+  "what do you think of this PR", "code review", or look over changes before
+  merging. Also PR number + wants feedback on quality, style, correctness.
 argument-hint: [base-branch]
 allowed-tools: [Bash, Read, Grep, Glob, Task]
 ---

--- a/.agents/skills/mz-profile/SKILL.md
+++ b/.agents/skills/mz-profile/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: mz-profile
 description: >
-  This skill should be used when the user wants to "profile Materialize",
-  "check memory usage", "analyze binary size", "debug performance", or
-  mentions profiling, samply, heaptrack, flame graphs, memory checking,
-  binary size analysis, slow queries, or high CPU/memory usage in the
-  Materialize repository. Use this skill even if the user just says
-  something is "slow" or "using too much memory" without explicitly
-  mentioning profiling.
+  Trigger: "profile Materialize", "check memory usage", "analyze binary size",
+  "debug performance", or mentions profiling, samply, heaptrack, flame graphs,
+  memory checking, binary size, slow queries, high CPU/memory in Materialize.
+  Also "slow" or "using too much memory" without explicit profile mention.
 ---
 
 # Profiling Materialize

--- a/.agents/skills/mz-query-tracing/SKILL.md
+++ b/.agents/skills/mz-query-tracing/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: mz-query-tracing
 description: >
-  Debug where time is spent during SQL execution using distributed tracing
-  (OpenTelemetry / Tempo). Trigger when the user asks "why is this query slow",
-  "where is the time going", "this SELECT takes forever", or wants a latency
-  breakdown for any SQL statement. Also trigger on mentions of tracing queries,
-  span analysis, Tempo traces, trace IDs, or opentelemetry_filter.
+  Debug SQL execution time via distributed tracing (OpenTelemetry / Tempo).
+  Trigger: "why is this query slow", "where is the time going",
+  "this SELECT takes forever", or latency breakdown for SQL statement. Also
+  tracing queries, span analysis, Tempo traces, trace IDs, opentelemetry_filter.
 ---
 
 # Query Tracing Skill

--- a/.agents/skills/mz-run/SKILL.md
+++ b/.agents/skills/mz-run/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: mz-run
 description: >
-  This skill should be used when the user wants to "run Materialize locally",
-  "start environmentd", "check compilation", "format code", "lint", "cargo
-  check", "cargo fmt", "cargo clippy", "bin/fmt", "bin/lint", or mentions
-  compiling, building, running, formatting, linting, log filters, jemalloc,
-  or CockroachDB setup in the Materialize repository. Use this skill even
-  if the user just says "how do I run this" or "it won't compile" without
-  being specific.
+  Trigger: "run Materialize locally", "start environmentd", "check compilation",
+  "format code", "lint", "cargo check", "cargo fmt", "cargo clippy", "bin/fmt",
+  "bin/lint", or mentions compiling, building, running, formatting, linting,
+  log filters, jemalloc, CockroachDB setup in Materialize. Also "how do I run
+  this" or "it won't compile".
 ---
 
 # Developing Materialize

--- a/.agents/skills/mz-test/SKILL.md
+++ b/.agents/skills/mz-test/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: mz-test
 description: >
-  General guide for running tests and choosing the right test framework in
-  Materialize. Trigger when the user wants to "run tests", "run testdrive",
-  "run sqllogictest", "run mzcompose", "run cargo test", "run pgtest",
-  "rewrite test results", "add a test", "reproduce a bug", "write a regression
-  test", or mentions testing, testdrive, sqllogictest, mzcompose, pgtest,
-  cargo test, nextest, flaky tests, or test failures. Use this skill even if the
-  user just says "test this" or "how do I verify this works" without naming a
-  specific framework. For deep guidance on specific frameworks, see the dedicated
-  skills: mz-platform-checks (upgrade/restart survival), mz-parallel-workload
-  (concurrent stress testing), and mz-limits-test (scaling to many objects).
+  Run tests + pick test framework in Materialize. Trigger: "run tests",
+  "run testdrive", "run sqllogictest", "run mzcompose", "run cargo test",
+  "run pgtest", "rewrite test results", "add a test", "reproduce a bug",
+  "write a regression test", or mentions testing, testdrive, sqllogictest,
+  mzcompose, pgtest, cargo test, nextest, flaky tests, test failures. Also
+  "test this" or "how do I verify this works". Specifics: mz-platform-checks
+  (upgrade/restart survival), mz-parallel-workload (concurrent stress),
+  mz-limits-test (many objects).
 ---
 
 # Testing Materialize

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,39 +2,40 @@
 
 ## Skills
 
-This repo's canonical agent skills live in `.agents/skills/`. The
-`.claude/skills` path is kept as a compatibility symlink for Claude Code.
-Before starting a task, check if a relevant `mz-*` skill exists — they encode
-project-specific conventions and save significant time.
+Canonical agent skills in `.agents/skills/`. `.claude/skills` is compat symlink
+for Claude Code. Check `mz-*` skill before tasks — encodes project conventions,
+saves time.
 
 ## Code navigation
 
-When tracing how an operation flows through the codebase, read these files first:
+For operation flow tracing, read first:
 
-* `doc/developer/generated/flows.md` — maps common operations (query lifecycle, source ingestion, MV creation, sink lifecycle, catalog DDL, timestamp selection, persist read/write, controller architecture) to exact `crate::module` paths in execution order.
-* `doc/developer/generated/<crate>/_crate.md` — per-crate overview with module structure, key types, and dependencies.
-* `doc/developer/generated/<crate>/<module>.md` — per-file documentation describing what each module provides.
+* `doc/developer/generated/flows.md` — maps operations (query lifecycle, source ingestion, MV creation, sink lifecycle, catalog DDL, timestamp selection, persist read/write, controller architecture) to `crate::module` paths in execution order.
+* `doc/developer/generated/<crate>/_crate.md` — per-crate overview: modules, key types, dependencies.
+* `doc/developer/generated/<crate>/<module>.md` — per-file docs.
 
 ## Dependency management
 
 ### Workspace dependencies
 
-All third-party dependency versions are declared in `[workspace.dependencies]` in the root `Cargo.toml`. Member crates reference them with `dep.workspace = true` or `dep = { workspace = true, optional = true }`.
+All third-party versions declared in `[workspace.dependencies]` in root
+`Cargo.toml`. Members use `dep.workspace = true` or
+`dep = { workspace = true, optional = true }`.
 
-* **Adding a new dependency**: add it to `[workspace.dependencies]` in the root `Cargo.toml` first, then use `dep.workspace = true` in the member crate.
-* **Never inline a version** in a member crate's `Cargo.toml` — `bin/lint-cargo` enforces this.
-* **Updating a version**: change it once in the root `Cargo.toml`.
-* Since Cargo unifies features workspace-wide, the workspace declaration includes the union of all features used across crates. Individual crates just use `dep.workspace = true`.
+* **Add new dep**: add to `[workspace.dependencies]` in root `Cargo.toml` first, then `dep.workspace = true` in member crate.
+* **Never inline version** in member `Cargo.toml` — `bin/lint-cargo` enforces.
+* **Update version**: change once in root `Cargo.toml`.
+* Cargo unifies features workspace-wide, so workspace declaration is union of all features across crates. Members just use `dep.workspace = true`.
 
 ### Cargo.lock
 
-Never regenerate the entire Cargo.lock. When adding or changing dependencies:
+Never regenerate full Cargo.lock. When changing deps:
 
-* **Adding a dep or changing features**: run `cargo check` — it adds/updates only what changed.
-* **Updating a specific crate**: use `cargo update -p <crate>` (optionally `--precise <version>`).
-* **Never run bare `cargo update`** — it bumps every semver-compatible dep in the workspace, causing unrelated breakage from transitive dependency changes.
-* **If the lock file was regenerated**, diff it before committing (`git diff Cargo.lock | grep '^[+-]version'`) and pin back any unintended bumps with `cargo update -p <crate> --precise <old-version>`.
+* **Add dep or change features**: run `cargo check` — updates only what changed.
+* **Update specific crate**: `cargo update -p <crate>` (optional `--precise <version>`).
+* **Never bare `cargo update`** — bumps every semver-compatible dep, causes unrelated breakage from transitive changes.
+* **If lock regenerated**, diff before commit (`git diff Cargo.lock | grep '^[+-]version'`) and pin back unintended bumps with `cargo update -p <crate> --precise <old-version>`.
 
 ### Licensing
 
-Two files control license policy and **must be kept in sync**: `deny.toml` (`[licenses].allow`) and `about.toml` (`accepted`). When a new dependency introduces a license not already allowed, add the SPDX identifier to both files.
+Two files control license policy, **keep in sync**: `deny.toml` (`[licenses].allow`) and `about.toml` (`accepted`). New dep with new license not already allowed: add SPDX identifier to both.


### PR DESCRIPTION
### Motivation

Skill descriptions in `.agents/skills/*/SKILL.md` and the project CLAUDE.md were verbose, costing tokens in every Claude Code session that loads the skill catalog.

### Description

Compress the `description:` frontmatter on all 12 `mz-*` skills and the prose in CLAUDE.md (AGENTS.md, via symlink) to caveman-terse form. Trigger keywords, technical terms, and file paths are preserved verbatim so skill matching is unaffected. Only fluff (articles, hedging, "this skill should be used when") is dropped. Skill body content is untouched.