### PR TITLE
COPY FROM: disable http client redirect

### DIFF
--- a/doc/user/content/sql/copy-from.md
+++ b/doc/user/content/sql/copy-from.md
@@ -176,6 +176,13 @@ COPY INTO csv_table FROM 's3://my_bucket/my_data.csv' (FORMAT CSV, AWS CONNECTIO
 COPY INTO csv_table FROM '<s3 presigned URL>' (FORMAT CSV);
 ```
 
+{{< note >}}
+Materialize does not follow HTTP redirects when fetching from a URL. If the
+server returns a `3xx` response, the `COPY FROM` will fail rather than follow
+the `Location` header. Use the final URL directly (for example, the resolved
+presigned URL) instead of one that redirects.
+{{< /note >}}
+
 ## Privileges
 
 The privileges required to execute this statement are:

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -1078,6 +1078,8 @@ pub enum StorageErrorXKind {
     MfpEvalError(Arc<str>),
     #[error("no matching files found at the given url")]
     NoMatchingFiles,
+    #[error("server returned HTTP {0}; Redirects are not supported, use the final URL directly.")]
+    Redirect(u16),
     #[error("something went wrong: {0}")]
     Generic(String),
 }

--- a/src/storage-operators/src/oneshot_source/http_source.rs
+++ b/src/storage-operators/src/oneshot_source/http_source.rs
@@ -308,6 +308,7 @@ impl OneshotSource for HttpOneshotSource {
             // got back an HTTP 206?
 
             let response = request.send().await.context("get")?;
+            check_not_redirect(&response)?;
             let bytes_stream = response.bytes_stream().err_into();
 
             Ok::<_, StorageErrorX>(bytes_stream)

--- a/src/storage-operators/src/oneshot_source/http_source.rs
+++ b/src/storage-operators/src/oneshot_source/http_source.rs
@@ -56,12 +56,29 @@ impl Resolve for MzHttpResolver {
 
 /// Build a reqwest [`Client`] for fetching `COPY FROM` URLs. This uses
 /// [`mz_ore::netio::resolve_address`] for DNS resolution.
+///
+/// Redirects are disabled: the custom DNS resolver re-validates hostnames on
+/// every hop, but reqwest skips DNS for IP-literal targets, so a redirect to
+/// `http://127.0.0.1/` would bypass the SSRF check. Refusing to follow
+/// redirects closes that hole.
 pub fn build_http_client(enforce_external_addresses: bool) -> Result<Client, reqwest::Error> {
     Client::builder()
         .dns_resolver(Arc::new(MzHttpResolver {
             enforce_external_addresses,
         }))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
+}
+
+/// Returns an error if `response` is a 3xx redirect. Materialize disables
+/// redirect following on the HTTP client (see `build_http_client`) to close
+/// an SSRF hole, so callers must surface a meaningful error rather than
+/// letting the response fall through to header parsing.
+fn check_not_redirect(response: &reqwest::Response) -> Result<(), StorageErrorX> {
+    if response.status().is_redirection() {
+        return Err(StorageErrorXKind::Redirect(response.status().as_u16()).into());
+    }
+    Ok(())
 }
 
 /// Generic oneshot source that fetches a file from a URL on the public internet.
@@ -197,6 +214,8 @@ impl OneshotSource for HttpOneshotSource {
             .await
             .context("HEAD request")?;
 
+        check_not_redirect(&response)?;
+
         // Not all servers accept `HEAD` requests though, so we'll fallback to a `GET`
         // request and skip fetching the body.
         let headers = match response.error_for_status() {
@@ -210,6 +229,9 @@ impl OneshotSource for HttpOneshotSource {
                     .send()
                     .await
                     .context("GET request")?;
+
+                check_not_redirect(&response)?;
+
                 let headers = response.headers().clone();
 
                 // Immediately drop the response so we don't attempt to fetch the body.

--- a/test/copy/mzcompose.py
+++ b/test/copy/mzcompose.py
@@ -29,6 +29,7 @@ from materialize.mzcompose.composition import (
     Service,
     WorkflowArgumentParser,
 )
+from materialize.mzcompose.service import Service as DockerService
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc
 from materialize.mzcompose.services.minio import Minio as MinioService
@@ -49,6 +50,25 @@ SERVICES = [
     ),
     Testdrive(),
     Mc(),
+    DockerService(
+        name="redirect-server",
+        config={
+            "image": "python:3.12-slim",
+            "volumes": ["./redirect_server.py:/app/redirect_server.py"],
+            "command": ["python3", "-u", "/app/redirect_server.py"],
+            "ports": [8080],
+            "healthcheck": {
+                "test": [
+                    "CMD",
+                    "python3",
+                    "-c",
+                    "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')",
+                ],
+                "interval": "2s",
+                "start_period": "30s",
+            },
+        },
+    ),
 ]
 
 
@@ -183,7 +203,7 @@ def workflow_ci(c: Composition, _parser: WorkflowArgumentParser) -> None:
     """
     Workflows to run during CI
     """
-    for name in ["auth", "http", "copy-from-csv-header"]:
+    for name in ["auth", "http", "copy-from-csv-header", "copy-from-ssrf-redirect"]:
         with c.test_case(name):
             c.workflow(name)
 
@@ -424,6 +444,39 @@ def workflow_test_github_9627(c: Composition):
         after = int(result[0][0])
 
         assert before < after, f"read frontier is stuck, {before} >= {after}"
+
+
+def workflow_copy_from_ssrf_redirect(c: Composition) -> None:
+    """Regression: COPY FROM must not follow redirects to private IPs."""
+    c.up("materialized", "redirect-server")
+
+    c.sql(
+        "ALTER SYSTEM SET enable_copy_from_remote = true;",
+        port=6877,
+        user="mz_system",
+    )
+    c.sql("CREATE TABLE ssrf_target (a text)")
+
+    copy_succeeded = True
+    try:
+        c.sql(
+            "COPY INTO ssrf_target FROM "
+            "'http://redirect-server:8080/redirect-to-docker-ip' (FORMAT CSV)"
+        )
+    except Exception as e:
+        err = e
+        print(f"--- Err: {e}")
+        copy_succeeded = False
+
+    if copy_succeeded:
+        rows = c.sql_query("SELECT a FROM ssrf_target")
+        assert rows != [
+            ("ssrf_bypass_confirmed",)
+        ], "SSRF: redirect to private IP was followed and data was exfiltrated"
+    else:
+        assert (
+            "302" in str(err) or "redirect" in str(err).lower()
+        ), f"unexpected error: {err}"
 
 
 def workflow_copy_from_csv_header(c: Composition) -> None:

--- a/test/copy/redirect_server.py
+++ b/test/copy/redirect_server.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import socket
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+CONTAINER_IP = socket.gethostbyname(socket.gethostname())
+CSV_DATA = b"ssrf_bypass_confirmed\n"
+
+
+class RedirectHandler(BaseHTTPRequestHandler):
+    def do_HEAD(self):
+        self._handle(include_body=False)
+
+    def do_GET(self):
+        self._handle(include_body=True)
+
+    def _handle(self, include_body: bool) -> None:
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+
+        elif self.path == "/data.csv":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/csv")
+            self.send_header("Content-Length", str(len(CSV_DATA)))
+            self.end_headers()
+            if include_body:
+                self.wfile.write(CSV_DATA)
+
+        elif self.path == "/redirect-to-docker-ip":
+            self.send_response(302)
+            self.send_header("Location", f"http://{CONTAINER_IP}:8080/data.csv")
+            self.end_headers()
+
+        elif self.path == "/redirect-to-loopback":
+            self.send_response(302)
+            self.send_header("Location", "http://127.0.0.1:8080/data.csv")
+            self.end_headers()
+
+        elif self.path == "/redirect-to-metadata":
+            self.send_response(302)
+            self.send_header("Location", "http://169.254.169.254/latest/meta-data/")
+            self.end_headers()
+
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        sys.stderr.write(
+            f"[redirect-server] {self.client_address[0]} - {format % args}\n"
+        )
+        sys.stderr.flush()
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 8080), RedirectHandler).serve_forever()


### PR DESCRIPTION
Disable redirects in HTTP client used by COPY FROM

- Add meaningful user error on redirect detection
- Add @def-'s mzcompose test
- Add note to COPY FROM doc that redirects are not followed

Fixes: [SS-121](https://linear.app/materializeinc/issue/SS-121) 