### PR TITLE
console: fix snapshotting progress for kafka, mysql, and sql-server

### DIFF
--- a/console/src/platform/connectors/utils.ts
+++ b/console/src/platform/connectors/utils.ts
@@ -30,7 +30,8 @@ export const snapshotting = (connector: ConnectorStatusInfo) => {
   const supportsSnapshotting =
     connector.type === "postgres" ||
     connector.type === "kafka" ||
-    connector.type === "mysql";
+    connector.type === "mysql" ||
+    connector.type === "sql-server";
   return (
     supportsSnapshotting &&
     "snapshotCommitted" in connector &&

--- a/console/src/platform/connectors/utils.ts
+++ b/console/src/platform/connectors/utils.ts
@@ -28,7 +28,9 @@ const TB = 1024 * 1024 * 1024 * 1024;
  */
 export const snapshotting = (connector: ConnectorStatusInfo) => {
   const supportsSnapshotting =
-    connector.type === "postgres" || connector.type === "kakfa";
+    connector.type === "postgres" ||
+    connector.type === "kafka" ||
+    connector.type === "mysql";
   return (
     supportsSnapshotting &&
     "snapshotCommitted" in connector &&


### PR DESCRIPTION
### Motivation

This change fixes a typo in the connector type check and extends snapshotting support to MySQL and SQL Server connectors.

### Description

The `snapshotting` utility function checks which connector types support snapshotting. This PR makes three changes:

1. **Fixes typo**: Corrects `"kakfa"` to `"kafka"` in the connector type check
2. **Adds MySQL support**: Extends the snapshotting capability to MySQL connectors
3. **Adds SQL Server support**: Extends the snapshotting capability to SQL Server connectors

The function now properly supports snapshotting for PostgreSQL, Kafka, MySQL, and SQL Server connectors.

### Verification

The change is a straightforward logic update to the connector type check.

Slack thread: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1778180802303099?thread_ts=1778179065.259949&cid=CU7ELJ6E9

https://claude.ai/code/session_01VzBvnAPiZ31Yiq9ntf7UEi