### PR TITLE
docs: update DDL-only transactions to GA status

### DIFF
--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -12,8 +12,7 @@ Materialize supports multi-statement[^ddltxn] transaction blocks for:
 - [**read-only** statements](#read-only-transactions);
 - [**write-only** (specifically, insert-only)
   statements](#write-only-transactions);
-- [**DDL-only** (specifically, `CREATE TABLE FROM SOURCE` (and optionally,
-  `CREATE SOURCE`) statements)](#ddl-only-transactions). (***Private Preview***)
+- [**DDL-only** statements](#ddl-only-transactions).
 
 See [Details](#details) for more information.
 
@@ -39,8 +38,7 @@ Option | Description
 Multi-statement transactions in Materialize are [**read-only**
 transactions](#read-only-transactions), [**write-only**
 transactions](#write-only-transactions), or [**DDL-only**
-transactions](#ddl-only-transactions) (*Private Preview*) as determined by
-either:
+transactions](#ddl-only-transactions) as determined by either:
 
 - The first statement after the `BEGIN`, or
 - The [`READ ONLY`](#begin-option-read-only) option is specified.
@@ -163,11 +161,14 @@ statements.
 
 ### DDL-only transactions
 
-{{< private-preview />}}
-
 In Materialize, a DDL-only transaction block is a transaction that can contain
-multiple [`CREATE TABLE ... FROM SOURCE`](/sql/create-table/) (and optionally,
-[`CREATE SOURCE`](/sql/create-source/)) statements.[^ddltxn]
+multiple DDL statements. The following DDL statements are allowed in DDL-only
+transactions:
+
+- [`ALTER ... RENAME`](/sql/alter-schema/#rename-schema) (e.g., `ALTER TABLE ... RENAME`, `ALTER SCHEMA ... RENAME`)
+- [`ALTER ... SWAP`](/sql/alter-schema/#swap-with) (e.g., `ALTER SCHEMA ... SWAP`)
+- [`CREATE TABLE ... FROM SOURCE`](/sql/create-table/)
+- [`CREATE SOURCE`](/sql/create-source/)
 
 In practice, use DDL transaction blocks to create multiple tables from a source
 in a single transaction. On a successful [`COMMIT`](/sql/commit/), all objects

--- a/doc/user/content/sql/commit.md
+++ b/doc/user/content/sql/commit.md
@@ -25,15 +25,14 @@ COMMIT;
 
 Transactions in Materialize are **read-only** transactions, **write-only**
 (more specifically, **insert-only**) transactions, or **DDL-only**
-transactions (***Private Preview***).
+transactions.
 
 For a [write-only (i.e., insert-only)
 transaction](/sql/begin/#write-only-transactions), all statements in the
 transaction are committed at the same timestamp.
 
-For a [DDL-only transaction](/sql/begin/#ddl-only-transactions) (***Private
-Preview***), all statements in the transaction are committed at the same
-timestamp.
+For a [DDL-only transaction](/sql/begin/#ddl-only-transactions), all
+statements in the transaction are committed at the same timestamp.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Remove Private Preview flags from DDL-only transactions documentation since the feature is enabled by default as of v26.13
- Add the complete list of supported DDL statements in transactions:
  - `ALTER ... RENAME`
  - `ALTER ... SWAP`
  - `CREATE TABLE ... FROM SOURCE`
  - `CREATE SOURCE`
- Update both `BEGIN` and `COMMIT` reference pages for consistency

## Test plan

- [ ] Verify docs build passes in CI
- [ ] Review rendered documentation for correct formatting

Slack thread: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1778181160197879?thread_ts=1778174048.981789&cid=CU7ELJ6E9

https://claude.ai/code/session_01AvGCN9WbsQ5kQ2o2k4bMo3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvGCN9WbsQ5kQ2o2k4bMo3)_