### PR TITLE
[MySQL] add additional test cases for mysql cdc SS-122

### DIFF
--- a/test/mysql-cdc-old-syntax/15-create-source.td
+++ b/test/mysql-cdc-old-syntax/15-create-source.td
@@ -106,3 +106,9 @@ contains: unknown
 
 > SELECT * FROM baz.t2;
 5
+
+# Verify that using the new CREATE TABLE FROM SOURCE syntax fails when binlog_row_metadata is not FULL
+> CREATE SOURCE da_new FROM MYSQL CONNECTION mysqc;
+
+! CREATE TABLE t1_new FROM SOURCE da_new (REFERENCE public.t1);
+contains: binlog_row_metadata

--- a/test/mysql-cdc-old-syntax/35-exclude-columns.td
+++ b/test/mysql-cdc-old-syntax/35-exclude-columns.td
@@ -30,6 +30,12 @@ CREATE TABLE t1 (f1 INTEGER, f2 GEOMETRY, f3 POINT, f4 VARCHAR(64), f5 INT);
 
 INSERT INTO t1 VALUES (1, ST_GeomFromText('LINESTRING(0 0,1 1,2 2)'), ST_GeomFromText('POINT(1 1)'), 'test', 1);
 
+CREATE TABLE accounts (id INTEGER NOT NULL, title_id INTEGER, country_id INTEGER NOT NULL, email varchar(80) NOT NULL, alternate_email varchar(80), password varchar(80), first_name varchar(40), middle_name varchar(40), last_name varchar(40), display_name varchar(100), profile_image varchar(80) NOT NULL, language varchar(5) NOT NULL, gender text NOT NULL, mobile_phone varchar(20), birthdate date, id_phrase varchar(45), admin int4, verified int4, theme text, status text, created timestamp NOT NULL, modified timestamp NOT NULL, deleted timestamp);
+
+INSERT INTO accounts VALUES (1, 10, 1, 'alice@example.com', 'alice.alt@example.com', 'hashed_pw_1', 'Alice', 'M', 'Smith', 'Alice Smith', 'images/alice.jpg', 'en', 'female', '555-1234', '1990-03-15', 'phrase1', 0, 1, 'default', 'active', '2024-01-10 08:00:00', '2024-01-10 08:00:00', NULL);
+INSERT INTO accounts VALUES (2, 11, 2, 'bob@example.com', NULL, 'hashed_pw_2', 'Bob', NULL, 'Jones', 'Bob Jones', 'images/bob.jpg', 'fr', 'male', '555-5678', '1985-07-22', 'phrase2', 0, 1, 'dark', 'active', '2024-02-14 09:30:00', '2024-02-14 09:30:00', NULL);
+INSERT INTO accounts VALUES (3, 12, 3, 'carol@example.com', 'carol.work@example.com', 'hashed_pw_3', 'Carol', 'A', 'Williams', 'Carol Williams', 'images/carol.jpg', 'de', 'female', NULL, '1992-11-05', NULL, 1, 0, 'light', 'inactive', '2024-03-20 14:15:00', '2024-04-01 10:00:00', '2024-04-01 10:00:00');
+
 ! CREATE SOURCE da_other
   FROM MYSQL CONNECTION mysqc
   FOR TABLES (public.t1);
@@ -44,9 +50,28 @@ contains:invalid EXCLUDE COLUMNS option value: column name 't1.f2' must have at 
 
 > CREATE SOURCE da
   FROM MYSQL CONNECTION mysqc (
-    EXCLUDE COLUMNS (public.t1.f2, public.t1.f3, public.t1.f5)
+    EXCLUDE COLUMNS (public.t1.f2, public.t1.f3, public.t1.f5, public.accounts.password)
   )
-  FOR TABLES (public.t1);
+  FOR TABLES (public.t1, public.accounts);
+
+> SELECT id, email, first_name, last_name, birthdate, deleted FROM accounts ORDER BY id;
+1 "alice@example.com" "Alice" "Smith" "1990-03-15" <null>
+2 "bob@example.com" "Bob" "Jones" "1985-07-22" <null>
+3 "carol@example.com" "Carol" "Williams" "1992-11-05" "2024-04-01 10:00:00"
+
+! SELECT password FROM accounts;
+contains: column "password" does not exist
+
+# Insert new accounts post-snapshot
+$ mysql-execute name=mysql
+USE public;
+INSERT INTO accounts VALUES (4, 13, 4, 'dave@example.com', NULL, 'hashed_pw_4', 'Dave', NULL, 'Brown', 'Dave Brown', 'images/dave.jpg', 'es', 'male', '555-9012', '1988-06-30', 'phrase4', 0, 1, 'default', 'active', '2024-05-01 11:00:00', '2024-05-01 11:00:00', NULL);
+
+> SELECT id, email, first_name, last_name, birthdate, deleted FROM accounts ORDER BY id;
+1 "alice@example.com" "Alice" "Smith" "1990-03-15" <null>
+2 "bob@example.com" "Bob" "Jones" "1985-07-22" <null>
+3 "carol@example.com" "Carol" "Williams" "1992-11-05" "2024-04-01 10:00:00"
+4 "dave@example.com" "Dave" "Brown" "1988-06-30" <null>
 
 # Insert the same data post-snapshot
 $ mysql-execute name=mysql

--- a/test/mysql-cdc/35-exclude-columns.td
+++ b/test/mysql-cdc/35-exclude-columns.td
@@ -30,6 +30,12 @@ CREATE TABLE t1 (f1 INTEGER, f2 GEOMETRY, f3 POINT, f4 VARCHAR(64));
 
 INSERT INTO t1 VALUES (1, ST_GeomFromText('LINESTRING(0 0,1 1,2 2)'), ST_GeomFromText('POINT(1 1)'), 'test');
 
+CREATE TABLE accounts (id INTEGER NOT NULL, title_id INTEGER, country_id INTEGER NOT NULL, email varchar(80) NOT NULL, alternate_email varchar(80), password varchar(80), first_name varchar(40), middle_name varchar(40), last_name varchar(40), display_name varchar(100), profile_image varchar(80) NOT NULL, language varchar(5) NOT NULL, gender text NOT NULL, mobile_phone varchar(20), birthdate date, id_phrase varchar(45), admin int4, verified int4, theme text, status text, created timestamp NOT NULL, modified timestamp NOT NULL, deleted timestamp);
+
+INSERT INTO accounts VALUES (1, 10, 1, 'alice@example.com', 'alice.alt@example.com', 'hashed_pw_1', 'Alice', 'M', 'Smith', 'Alice Smith', 'images/alice.jpg', 'en', 'female', '555-1234', '1990-03-15', 'phrase1', 0, 1, 'default', 'active', '2024-01-10 08:00:00', '2024-01-10 08:00:00', NULL);
+INSERT INTO accounts VALUES (2, 11, 2, 'bob@example.com', NULL, 'hashed_pw_2', 'Bob', NULL, 'Jones', 'Bob Jones', 'images/bob.jpg', 'fr', 'male', '555-5678', '1985-07-22', 'phrase2', 0, 1, 'dark', 'active', '2024-02-14 09:30:00', '2024-02-14 09:30:00', NULL);
+INSERT INTO accounts VALUES (3, 12, 3, 'carol@example.com', 'carol.work@example.com', 'hashed_pw_3', 'Carol', 'A', 'Williams', 'Carol Williams', 'images/carol.jpg', 'de', 'female', NULL, '1992-11-05', NULL, 1, 0, 'light', 'inactive', '2024-03-20 14:15:00', '2024-04-01 10:00:00', '2024-04-01 10:00:00');
+
 > CREATE SOURCE da
   FROM MYSQL CONNECTION mysqc;
 ! CREATE TABLE t1 FROM SOURCE da (REFERENCE public.t1);
@@ -39,6 +45,27 @@ contains: unsupported type
 contains: duplicated column name references in table
 
 > CREATE TABLE t1 FROM SOURCE da (REFERENCE public.t1) WITH (EXCLUDE COLUMNS (f2, f3));
+
+> CREATE TABLE accounts FROM SOURCE da (REFERENCE public.accounts) WITH (EXCLUDE COLUMNS (password));
+
+> SELECT id, email, first_name, last_name, birthdate, deleted FROM accounts ORDER BY id;
+1 "alice@example.com" "Alice" "Smith" "1990-03-15" <null>
+2 "bob@example.com" "Bob" "Jones" "1985-07-22" <null>
+3 "carol@example.com" "Carol" "Williams" "1992-11-05" "2024-04-01 10:00:00"
+
+! SELECT password FROM accounts;
+contains: column "password" does not exist
+
+# Insert new accounts post-snapshot
+$ mysql-execute name=mysql
+USE public;
+INSERT INTO accounts VALUES (4, 13, 4, 'dave@example.com', NULL, 'hashed_pw_4', 'Dave', NULL, 'Brown', 'Dave Brown', 'images/dave.jpg', 'es', 'male', '555-9012', '1988-06-30', 'phrase4', 0, 1, 'default', 'active', '2024-05-01 11:00:00', '2024-05-01 11:00:00', NULL);
+
+> SELECT id, email, first_name, last_name, birthdate, deleted FROM accounts ORDER BY id;
+1 "alice@example.com" "Alice" "Smith" "1990-03-15" <null>
+2 "bob@example.com" "Bob" "Jones" "1985-07-22" <null>
+3 "carol@example.com" "Carol" "Williams" "1992-11-05" "2024-04-01 10:00:00"
+4 "dave@example.com" "Dave" "Brown" "1988-06-30" <null>
 
 # Insert the same data post-snapshot
 $ mysql-execute name=mysql


### PR DESCRIPTION
Adds a few more cases for good measure to mysql cdc testing, particularly a different arrangement of excluded columns and a way to overify that `binlog_row_metadata` is correctly configured for all tests.
