### PR TITLE
SS-112 Kafka Sink: add check at planning time for non-positive `TOPIC METADATA REFRESH INTERVAL`

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1228,7 +1228,7 @@ fn plan_kafka_source_connection(
     if topic_metadata_refresh_interval < Duration::from_secs(1) {
         // This is a librdkafka-enforced restriction that, if violated,
         // would result in a runtime error for the source.
-        sql_bail!("TOPIC METADATA REFRESH INTERVAL cannot be less than 1 second");
+        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be at least 1 second");
     }
     let metadata_columns = include_metadata
         .into_iter()
@@ -3810,7 +3810,7 @@ fn kafka_sink_builder(
     } else if topic_metadata_refresh_interval < MIN_KAFKA_TOPIC_METADATA_REFRESH_INTERVAL {
         // We enforce a minimum of 1 second here to prevent excessive refreshes, and ensure that
         // tokio::time::interval receives a valid (positive) duration.
-        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be at least one second");
+        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be at least 1 second");
     }
 
     let assert_positive = |val: Option<i32>, name: &str| {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1225,6 +1225,11 @@ fn plan_kafka_source_connection(
         // would result in a runtime error for the source.
         sql_bail!("TOPIC METADATA REFRESH INTERVAL cannot be greater than 1 hour");
     }
+    if topic_metadata_refresh_interval < Duration::from_secs(1) {
+        // This is a librdkafka-enforced restriction that, if violated,
+        // would result in a runtime error for the source.
+        sql_bail!("TOPIC METADATA REFRESH INTERVAL cannot be less than 1 second");
+    }
     let metadata_columns = include_metadata
         .into_iter()
         .flat_map(|item| match item {
@@ -3805,7 +3810,7 @@ fn kafka_sink_builder(
     } else if topic_metadata_refresh_interval < MIN_KAFKA_TOPIC_METADATA_REFRESH_INTERVAL {
         // We enforce a minimum of 1 second here to prevent excessive refreshes, and ensure that
         // tokio::time::interval receives a valid (positive) duration.
-        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be greater than one second");
+        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be at least one second");
     }
 
     let assert_positive = |val: Option<i32>, name: &str| {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3799,6 +3799,10 @@ fn kafka_sink_builder(
         // This is a librdkafka-enforced restriction that, if violated,
         // would result in a runtime error for the source.
         sql_bail!("TOPIC METADATA REFRESH INTERVAL cannot be greater than 1 hour");
+    } else if topic_metadata_refresh_interval <= Duration::new(0, 0) {
+        // A non-positive refresh interval doesn't make sense, and would also cause tokio to panic
+        // at runtime.
+        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be greater than zero");
     }
 
     let assert_positive = |val: Option<i32>, name: &str| {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -178,6 +178,9 @@ mod connection;
 // more strict.
 const MAX_NUM_COLUMNS: usize = 256;
 
+const MAX_KAFKA_TOPIC_METADATA_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const MIN_KAFKA_TOPIC_METADATA_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+
 static MANAGED_REPLICA_PATTERN: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| regex::Regex::new(r"^r(\d)+$").unwrap());
 
@@ -3795,14 +3798,14 @@ fn kafka_sink_builder(
 
     let topic_name = topic.ok_or_else(|| sql_err!("KAFKA CONNECTION must specify TOPIC"))?;
 
-    if topic_metadata_refresh_interval > Duration::from_secs(60 * 60) {
+    if topic_metadata_refresh_interval > MAX_KAFKA_TOPIC_METADATA_REFRESH_INTERVAL {
         // This is a librdkafka-enforced restriction that, if violated,
         // would result in a runtime error for the source.
         sql_bail!("TOPIC METADATA REFRESH INTERVAL cannot be greater than 1 hour");
-    } else if topic_metadata_refresh_interval <= Duration::new(0, 0) {
-        // A non-positive refresh interval doesn't make sense, and would also cause tokio to panic
-        // at runtime.
-        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be greater than zero");
+    } else if topic_metadata_refresh_interval < MIN_KAFKA_TOPIC_METADATA_REFRESH_INTERVAL {
+        // We enforce a minimum of 1 second here to prevent excessive refreshes, and ensure that
+        // tokio::time::interval receives a valid (positive) duration.
+        sql_bail!("TOPIC METADATA REFRESH INTERVAL must be greater than one second");
     }
 
     let assert_positive = |val: Option<i32>, name: &str| {

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -41,6 +41,17 @@ contains:column referenced in KEY does not exist: f2
   ENVELOPE DEBEZIUM
 contains:LEGACY IDs option is not supported
 
+! CREATE SINK zero_interval_sink
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM v1
+  INTO KAFKA CONNECTION kafka_conn (
+    TOPIC 'testdrive-kafka-sink-zero-interval-${testdrive.seed}',
+    TOPIC METADATA REFRESH INTERVAL '0s'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+contains:TOPIC METADATA REFRESH INTERVAL must be greater than zero
+
 #
 # Sink dependencies
 #

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -50,7 +50,7 @@ contains:LEGACY IDs option is not supported
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:TOPIC METADATA REFRESH INTERVAL must be greater than zero
+contains:TOPIC METADATA REFRESH INTERVAL must be greater than one second
 
 #
 # Sink dependencies

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -50,7 +50,7 @@ contains:LEGACY IDs option is not supported
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:TOPIC METADATA REFRESH INTERVAL must be at least one second
+contains:TOPIC METADATA REFRESH INTERVAL must be at least 1 second
 
 #
 # Sink dependencies

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -50,7 +50,7 @@ contains:LEGACY IDs option is not supported
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:TOPIC METADATA REFRESH INTERVAL must be greater than one second
+contains:TOPIC METADATA REFRESH INTERVAL must be at least one second
 
 #
 # Sink dependencies

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -73,4 +73,4 @@ contains:TOPIC METADATA REFRESH INTERVAL cannot be greater than 1 hour
     TOPIC 'testdrive-thetopic-${testdrive.seed}',
     TOPIC METADATA REFRESH INTERVAL '1ms'
   )
-contains:TOPIC METADATA REFRESH INTERVAL cannot be less than 1 second
+contains:TOPIC METADATA REFRESH INTERVAL must be at least 1 second

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -66,3 +66,11 @@ contains:cannot convert negative interval to duration
     TOPIC METADATA REFRESH INTERVAL '1hr 1ms'
   )
 contains:TOPIC METADATA REFRESH INTERVAL cannot be greater than 1 hour
+
+! CREATE SOURCE bad_topic_metadata_refresh_interval
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (
+    TOPIC 'testdrive-thetopic-${testdrive.seed}',
+    TOPIC METADATA REFRESH INTERVAL '1ms'
+  )
+contains:TOPIC METADATA REFRESH INTERVAL cannot be less than 1 second


### PR DESCRIPTION
A non positive duration causes the `tokio::time::interval` class to panic on creation. Panicking is bad and we should just reject the statement at planning time
