### PR TITLE
persist: coalesce S3 chunks into a single Bytes per part

### DIFF
--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -27,7 +27,7 @@ use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_types::region::Region;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures_util::stream::FuturesOrdered;
 use futures_util::{FutureExt, StreamExt};
 use mz_ore::bytes::SegmentedBytes;
@@ -443,24 +443,39 @@ impl Blob for S3Blob {
 
                 // Request the body.
                 let body_start = Instant::now();
-                let mut body_parts: Vec<Bytes> = Vec::new();
 
-                if let Some(len @ ..=-1) = object.content_length() {
-                    tracing::trace!(?len, "found invalid content-length");
-                    get_invalid_resp.inc();
-                }
+                // Coalesce all hyper chunks for this part into a single contiguous
+                // allocation. Pushing each SDK `Bytes` chunk separately into
+                // `SegmentedBytes` yields hundreds of segments per blob, which makes
+                // every parquet `ChunkReader::get_bytes` call O(N) and dominates CPU
+                // in `SegmentedBytes::advance`/`get_bytes` during decode. Copying
+                // also releases the hyper pool buffer so it doesn't stay pinned for
+                // the lifetime of the blob.
+                let mut buf = match object.content_length() {
+                    Some(len @ 1..) => BytesMut::with_capacity(usize::cast_from(
+                        u64::try_from(len).expect("positive integer"),
+                    )),
+                    Some(len @ ..=-1) => {
+                        tracing::trace!(?len, "found invalid content-length");
+                        get_invalid_resp.inc();
+                        BytesMut::new()
+                    }
+                    Some(0) | None => BytesMut::new(),
+                };
 
                 while let Some(data) = object.body.next().await {
                     let data = data.context("s3 get body err")?;
-                    // Copy out of the hyper pool buffer so we don't pin the
-                    // entire shared backing allocation for the lifetime of the
-                    // returned blob.
-                    body_parts.push(Bytes::copy_from_slice(&data));
+                    buf.extend_from_slice(&data);
                 }
 
                 let body_elapsed = body_start.elapsed();
                 min_body_elapsed.observe(body_elapsed, "s3 download part body");
 
+                let body_parts = if buf.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![buf.freeze()]
+                };
                 Ok::<_, anyhow::Error>(body_parts)
             };
 


### PR DESCRIPTION
Follow-up to #36305 / #36451.
Those PRs left each hyper chunk pushed into `SegmentedBytes` as its own `Bytes`, so a returned blob contained hundreds of small segments per part.
Parquet `ChunkReader::get_bytes` walks the segment list per read, so decode CPU ended up dominated by `SegmentedBytes::advance` / `get_bytes` — over 85% of on-CPU time on a storage replica in production profiles, with `decode_and_mfp` cumulative ~471 s vs. `decode_kv` only ~3 s.

This change extends every chunk into a pre-sized `BytesMut` and freezes to a single `Bytes`, so each part contributes one segment.
The hyper pool buffer is still copied out of immediately, preserving the RSS fix from #36451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)