### PR TITLE
release: block v26.23.0 helm chart publication

### DIFF
--- a/doc/user/content/releases/v26.23.md
+++ b/doc/user/content/releases/v26.23.md
@@ -3,7 +3,7 @@ title: Materialize v26.23
 date: 2026-05-06
 released: true
 patch: 0
-publish_helm_chart: true
+publish_helm_chart: false
 build:
   render: never
 ---


### PR DESCRIPTION
## Summary

Set `publish_helm_chart: false` on [`doc/user/content/releases/v26.23.md`](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/releases/v26.23.md) so that the Friday 14:00 UTC [publish-helm-charts](https://buildkite.com/materialize/publish-helm-charts) schedule does **not** publish the v26.23.0 Helm chart on 2026-05-08.

## Context

- Schedule: [Fridays 14:00 UTC](https://buildkite.com/materialize/publish-helm-charts/settings/schedules/54d4d054-6ee5-450f-9574-5ec3d10d30b9) — next run 2026-05-08T14:00:00Z.
- Pre-PR `bin/helm-chart-version-to-publish` (against `origin/main` `cdeb677f66`) emitted `v26.23.0` — confirming the chart was queued for tomorrow's run.
- Post-PR (this branch) the same script emits no version, confirming the block.
- The `materialize/materialized:v26.23.0` Docker image is present (pushed 2026-05-06), so the block is the only thing standing between v26.23.0 and helm chart publication.

## Test plan

- [ ] Merge before 2026-05-08 14:00 UTC.
- [ ] After merge, run `bin/helm-chart-version-to-publish` on `main` and confirm no output.
- [ ] After Friday's scheduled run, confirm that the [latest publish-helm-charts build](https://buildkite.com/materialize/publish-helm-charts) is a no-op for v26.23.0.