### PR TITLE
adapter: restore RTR error humanization

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -373,24 +373,10 @@ impl Coordinator {
                         Ok(Some(fut)) => {
                             let catalog = Arc::clone(&self.catalog);
                             task::spawn(|| "determine real time recent timestamp", async move {
-                                let rtr_name = |id: &GlobalId| {
-                                    catalog
-                                        .try_get_entry_by_global_id(id)
-                                        .map(|e| e.name().item.clone())
-                                        .unwrap_or_else(|| id.to_string())
-                                };
-                                let result = match fut.await {
-                                    Ok(ts) => Ok(Some(ts)),
-                                    Err(
-                                        mz_storage_types::controller::StorageError::RtrTimeout(id),
-                                    ) => Err(AdapterError::RtrTimeout(rtr_name(&id))),
-                                    Err(
-                                        mz_storage_types::controller::StorageError::RtrDropFailure(
-                                            id,
-                                        ),
-                                    ) => Err(AdapterError::RtrDropFailure(rtr_name(&id))),
-                                    Err(e) => Err(AdapterError::from(e)),
-                                };
+                                let result =
+                                    Coordinator::await_real_time_recent_timestamp(catalog, fut)
+                                        .await
+                                        .map(Some);
                                 let _ = tx.send(result);
                             });
                         }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -371,8 +371,26 @@ impl Coordinator {
 
                     match result {
                         Ok(Some(fut)) => {
+                            let catalog = Arc::clone(&self.catalog);
                             task::spawn(|| "determine real time recent timestamp", async move {
-                                let result = fut.await.map(Some).map_err(AdapterError::from);
+                                let rtr_name = |id: &GlobalId| {
+                                    catalog
+                                        .try_get_entry_by_global_id(id)
+                                        .map(|e| e.name().item.clone())
+                                        .unwrap_or_else(|| id.to_string())
+                                };
+                                let result = match fut.await {
+                                    Ok(ts) => Ok(Some(ts)),
+                                    Err(
+                                        mz_storage_types::controller::StorageError::RtrTimeout(id),
+                                    ) => Err(AdapterError::RtrTimeout(rtr_name(&id))),
+                                    Err(
+                                        mz_storage_types::controller::StorageError::RtrDropFailure(
+                                            id,
+                                        ),
+                                    ) => Err(AdapterError::RtrDropFailure(rtr_name(&id))),
+                                    Err(e) => Err(AdapterError::from(e)),
+                                };
                                 let _ = tx.send(result);
                             });
                         }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -96,7 +96,7 @@ use timely::progress::Antichain;
 use tokio::sync::{oneshot, watch};
 use tracing::{Instrument, Span, info, warn};
 
-use crate::catalog::{self, ConnCatalog, DropObjectInfo, UpdatePrivilegeVariant};
+use crate::catalog::{self, Catalog, ConnCatalog, DropObjectInfo, UpdatePrivilegeVariant};
 use crate::command::{ExecuteResponse, Response};
 use crate::coord::appends::{BuiltinTableAppendNotify, DeferredOp, DeferredPlan, PendingWriteTxn};
 use crate::coord::read_then_write::validate_read_then_write_dependencies;
@@ -2357,6 +2357,32 @@ impl Coordinator {
             .await?;
 
         Ok(Some(r))
+    }
+
+    pub(crate) async fn await_real_time_recent_timestamp<F>(
+        catalog: Arc<Catalog>,
+        fut: F,
+    ) -> Result<Timestamp, AdapterError>
+    where
+        F: Future<Output = Result<Timestamp, StorageError>>,
+    {
+        fut.await
+            .map_err(|error| Self::real_time_recent_timestamp_error(&catalog, error))
+    }
+
+    fn real_time_recent_timestamp_error(catalog: &Catalog, error: StorageError) -> AdapterError {
+        let rtr_name = |id: &GlobalId| {
+            catalog
+                .try_get_entry_by_global_id(id)
+                .map(|e| e.name().item.clone())
+                .unwrap_or_else(|| id.to_string())
+        };
+
+        match error {
+            StorageError::RtrTimeout(id) => AdapterError::RtrTimeout(rtr_name(&id)),
+            StorageError::RtrDropFailure(id) => AdapterError::RtrDropFailure(rtr_name(&id)),
+            error => error.into(),
+        }
     }
 
     /// Checks to see if the session needs a real time recency timestamp and if so returns

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -16,7 +16,7 @@ use mz_controller_types::ClusterId;
 use mz_expr::CollectionPlan;
 use mz_ore::instrument;
 use mz_repr::explain::ExplainFormat;
-use mz_repr::{Datum, GlobalId, Row};
+use mz_repr::{Datum, Row};
 use mz_sql::plan::{self};
 use mz_sql::session::metadata::SessionMetadata;
 use tracing::{Instrument, Span};
@@ -188,22 +188,8 @@ impl Coordinator {
                 Ok(StageResult::Handle(mz_ore::task::spawn(
                     || "explain timestamp real time recency",
                     async move {
-                        let rtr_name = |id: &GlobalId| {
-                            catalog
-                                .try_get_entry_by_global_id(id)
-                                .map(|e| e.name().item.clone())
-                                .unwrap_or_else(|| id.to_string())
-                        };
-                        let real_time_recency_ts = match fut.await {
-                            Ok(ts) => ts,
-                            Err(mz_storage_types::controller::StorageError::RtrTimeout(id)) => {
-                                return Err(AdapterError::RtrTimeout(rtr_name(&id)));
-                            }
-                            Err(mz_storage_types::controller::StorageError::RtrDropFailure(id)) => {
-                                return Err(AdapterError::RtrDropFailure(rtr_name(&id)));
-                            }
-                            Err(e) => return Err(e.into()),
-                        };
+                        let real_time_recency_ts =
+                            Coordinator::await_real_time_recent_timestamp(catalog, fut).await?;
                         let stage = ExplainTimestampStage::Finish(ExplainTimestampFinish {
                             validity,
                             format,

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
@@ -14,7 +16,7 @@ use mz_controller_types::ClusterId;
 use mz_expr::CollectionPlan;
 use mz_ore::instrument;
 use mz_repr::explain::ExplainFormat;
-use mz_repr::{Datum, Row};
+use mz_repr::{Datum, GlobalId, Row};
 use mz_sql::plan::{self};
 use mz_sql::session::metadata::SessionMetadata;
 use tracing::{Instrument, Span};
@@ -181,11 +183,27 @@ impl Coordinator {
 
         match fut {
             Some(fut) => {
+                let catalog = Arc::clone(&self.catalog);
                 let span = Span::current();
                 Ok(StageResult::Handle(mz_ore::task::spawn(
                     || "explain timestamp real time recency",
                     async move {
-                        let real_time_recency_ts = fut.await?;
+                        let rtr_name = |id: &GlobalId| {
+                            catalog
+                                .try_get_entry_by_global_id(id)
+                                .map(|e| e.name().item.clone())
+                                .unwrap_or_else(|| id.to_string())
+                        };
+                        let real_time_recency_ts = match fut.await {
+                            Ok(ts) => ts,
+                            Err(mz_storage_types::controller::StorageError::RtrTimeout(id)) => {
+                                return Err(AdapterError::RtrTimeout(rtr_name(&id)));
+                            }
+                            Err(mz_storage_types::controller::StorageError::RtrDropFailure(id)) => {
+                                return Err(AdapterError::RtrDropFailure(rtr_name(&id)));
+                            }
+                            Err(e) => return Err(e.into()),
+                        };
                         let stage = ExplainTimestampStage::Finish(ExplainTimestampFinish {
                             validity,
                             format,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -758,11 +758,27 @@ impl Coordinator {
 
         match fut {
             Some(fut) => {
+                let catalog = Arc::clone(&self.catalog);
                 let span = Span::current();
                 Ok(StageResult::Handle(mz_ore::task::spawn(
                     || "peek real time recency",
                     async move {
-                        let real_time_recency_ts = fut.await?;
+                        let rtr_name = |id: &GlobalId| {
+                            catalog
+                                .try_get_entry_by_global_id(id)
+                                .map(|e| e.name().item.clone())
+                                .unwrap_or_else(|| id.to_string())
+                        };
+                        let real_time_recency_ts = match fut.await {
+                            Ok(ts) => ts,
+                            Err(mz_storage_types::controller::StorageError::RtrTimeout(id)) => {
+                                return Err(AdapterError::RtrTimeout(rtr_name(&id)));
+                            }
+                            Err(mz_storage_types::controller::StorageError::RtrDropFailure(id)) => {
+                                return Err(AdapterError::RtrDropFailure(rtr_name(&id)));
+                            }
+                            Err(e) => return Err(e.into()),
+                        };
                         let stage = PeekStage::TimestampReadHold(PeekStageTimestampReadHold {
                             validity,
                             plan,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -763,22 +763,8 @@ impl Coordinator {
                 Ok(StageResult::Handle(mz_ore::task::spawn(
                     || "peek real time recency",
                     async move {
-                        let rtr_name = |id: &GlobalId| {
-                            catalog
-                                .try_get_entry_by_global_id(id)
-                                .map(|e| e.name().item.clone())
-                                .unwrap_or_else(|| id.to_string())
-                        };
-                        let real_time_recency_ts = match fut.await {
-                            Ok(ts) => ts,
-                            Err(mz_storage_types::controller::StorageError::RtrTimeout(id)) => {
-                                return Err(AdapterError::RtrTimeout(rtr_name(&id)));
-                            }
-                            Err(mz_storage_types::controller::StorageError::RtrDropFailure(id)) => {
-                                return Err(AdapterError::RtrDropFailure(rtr_name(&id)));
-                            }
-                            Err(e) => return Err(e.into()),
-                        };
+                        let real_time_recency_ts =
+                            Coordinator::await_real_time_recent_timestamp(catalog, fut).await?;
                         let stage = PeekStage::TimestampReadHold(PeekStageTimestampReadHold {
                             validity,
                             plan,


### PR DESCRIPTION
The staged sequencer refactor propagated RtrTimeout and RtrDropFailure as generic StorageError, losing the humanized display, detail text, and correct SQL state (QUERY_CANCELED / UNDEFINED_OBJECT). Convert them to the dedicated AdapterError variants before propagating.

lost in #27693