### PR TITLE
compute: fix PaddedTrace returning logical instead of physical compaction

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -210,7 +210,7 @@ where
     }
 
     fn get_physical_compaction(&mut self) -> AntichainRef<'_, Self::Time> {
-        self.trace.get_logical_compaction()
+        self.trace.get_physical_compaction()
     }
 
     fn map_batches<F: FnMut(&Self::Batch)>(&self, f: F) {


### PR DESCRIPTION
`get_physical_compaction` incorrectly delegated to `get_logical_compaction` on the inner trace, introduced in PR #27593.