### PR TITLE
adapter: cascade dependents when dropping replica-targeted MVs

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -549,6 +549,17 @@ impl CatalogState {
         let object_id = ObjectId::ClusterReplica((cluster_id, replica_id));
         if !seen.contains(&object_id) {
             seen.insert(object_id.clone());
+            // Materialized views that target this replica are implicitly
+            // dropped with it, so cascade to their dependents to avoid leaving
+            // dangling references.
+            let cluster = self.get_cluster(cluster_id);
+            for item_id in cluster.bound_objects() {
+                if let CatalogItem::MaterializedView(mv) = self.get_entry(item_id).item()
+                    && mv.target_replica == Some(replica_id)
+                {
+                    dependents.extend_from_slice(&self.item_dependents(*item_id, seen));
+                }
+            }
             dependents.push(object_id);
         }
         dependents

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -3015,16 +3015,17 @@ impl ObjectsToDrop {
                 // through the plan stage.
                 let mut seen: BTreeSet<ObjectId> =
                     self.items.iter().copied().map(ObjectId::Item).collect();
-                for (_id, entry) in state.get_entries() {
+                for item_id in &cluster.bound_objects {
+                    let entry = state.get_entry(item_id);
                     if let CatalogItem::MaterializedView(mv) = entry.item()
                         && mv.target_replica == Some(replica_id)
-                        && !seen.contains(&ObjectId::Item(entry.id()))
+                        && !seen.contains(&ObjectId::Item(*item_id))
                     {
-                        tracing::warn!(
+                        tracing::info!(
                             "implicitly dropping materialized view {} because target replica was dropped",
                             entry.name().item,
                         );
-                        for dep in state.item_dependents(entry.id(), &mut seen) {
+                        for dep in state.item_dependents(*item_id, &mut seen) {
                             if let ObjectId::Item(dep_id) = dep {
                                 self.items.push(dep_id);
                             }

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -3006,16 +3006,28 @@ impl ObjectsToDrop {
                 // Implicitly drop materialized views that target this replica.
                 // When the target replica is gone, no replica advances the
                 // persist shard's upper frontier, causing reads to hang.
+                //
+                // Also cascade to anything depending on the implicitly-dropped
+                // MV so we don't leave dangling references in the catalog.
+                // Plan-driven drops already include these via
+                // `cluster_replica_dependents`; this branch handles internal
+                // callers that build `Op::DropObjects` directly without going
+                // through the plan stage.
+                let mut seen: BTreeSet<ObjectId> =
+                    self.items.iter().copied().map(ObjectId::Item).collect();
                 for (_id, entry) in state.get_entries() {
-                    if let CatalogItem::MaterializedView(mv) = entry.item() {
-                        if mv.target_replica == Some(replica_id)
-                            && !self.items.contains(&entry.id())
-                        {
-                            tracing::warn!(
-                                "implicitly dropping materialized view {} because target replica was dropped",
-                                entry.name().item,
-                            );
-                            self.items.push(entry.id());
+                    if let CatalogItem::MaterializedView(mv) = entry.item()
+                        && mv.target_replica == Some(replica_id)
+                        && !seen.contains(&ObjectId::Item(entry.id()))
+                    {
+                        tracing::warn!(
+                            "implicitly dropping materialized view {} because target replica was dropped",
+                            entry.name().item,
+                        );
+                        for dep in state.item_dependents(entry.id(), &mut seen) {
+                            if let ObjectId::Item(dep_id) = dep {
+                                self.items.push(dep_id);
+                            }
                         }
                     }
                 }

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -3021,7 +3021,7 @@ impl ObjectsToDrop {
                         && mv.target_replica == Some(replica_id)
                         && !seen.contains(&ObjectId::Item(*item_id))
                     {
-                        tracing::info!(
+                        info!(
                             "implicitly dropping materialized view {} because target replica was dropped",
                             entry.name().item,
                         );

--- a/test/sqllogictest/materialized_view_replica_targeted.slt
+++ b/test/sqllogictest/materialized_view_replica_targeted.slt
@@ -140,13 +140,41 @@ SELECT * FROM mv1
 110
 
 
-# Cleanup
+# Test: dropping the target replica cascades to dependents of the implicitly-
+# dropped MV. See database-issues#11288 / SQL-266.
 
 statement ok
 DROP MATERIALIZED VIEW mv1;
 
 statement ok
 DROP MATERIALIZED VIEW mv2;
+
+statement ok
+CREATE MATERIALIZED VIEW mv_cascade IN CLUSTER test REPLICA r1 AS SELECT sum(a) AS s FROM t
+
+statement ok
+CREATE VIEW v_on_cascade AS SELECT s * 2 AS doubled FROM mv_cascade
+
+statement ok
+CREATE MATERIALIZED VIEW mv_on_cascade AS SELECT s + 100 AS plus100 FROM mv_cascade
+
+statement ok
+CREATE INDEX idx_on_cascade ON mv_cascade (s)
+
+statement ok
+DROP CLUSTER REPLICA test.r1
+
+statement error unknown catalog item 'mv_cascade'
+SELECT * FROM mv_cascade
+
+statement error unknown catalog item 'v_on_cascade'
+SELECT * FROM v_on_cascade
+
+statement error unknown catalog item 'mv_on_cascade'
+SELECT * FROM mv_on_cascade
+
+
+# Cleanup
 
 statement ok
 DROP TABLE t CASCADE


### PR DESCRIPTION
### Motivation

Fixes database-issues#11288.

When a target replica is dropped, the targeted materialized view is implicitly dropped along with it.
The cascade to dependents of that MV was missing, so any view, materialized view, or index that depended on the implicitly-dropped MV was left referencing a non-existent catalog entry.
In debug builds the post-transaction consistency check tripped on `MissingUses` and panicked; in release builds subsequent reads against the orphaned dependent panicked or errored.

### Description

Fixed in two places:

* `cluster_replica_dependents` in `src/adapter/src/catalog/state.rs` now walks targeted MVs and includes their `item_dependents` in the returned set.
  This makes the plan-driven drop path produce a correct `DropObjectsPlan` and surface a `CascadeDroppedObject` notice for the dependents.
* `ObjectsToDrop::add_item` in `src/adapter/src/catalog/transact.rs` extends the implicit-MV addition with `item_dependents` of the targeted MV.
  The plan path already includes them via the change above; this is a backstop for internal callers (e.g. `drop_reconfiguration_replicas`) that build `Op::DropObjects` directly without going through the plan stage.

The bespoke `*_dependents` family in `state.rs` is fragile.
A fix-point worklist with per-object-kind direct-edge enumeration plus a single topo-sort would localize this knowledge and is tracked separately as a follow-up.

### Verification

Added a regression case to `test/sqllogictest/materialized_view_replica_targeted.slt` covering view, materialized-view, and index dependents of a replica-targeted MV when the target replica is dropped.