### PR TITLE
test/cluster: relax controller response queue flake threshold

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2706,7 +2706,9 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert send_count > 10, f"got {send_count}"
     recv_count = metrics.get_value("mz_compute_controller_response_recv_count")
     assert recv_count > 10, f"got {recv_count}"
-    assert send_count - recv_count < 10, f"got {send_count}, {recv_count}"
+    # recv within 50% of send: channel invariant gives recv <= send, and we
+    # want the controller to have drained at least half of what was sent.
+    assert recv_count >= send_count / 2, f"got {send_count}, {recv_count}"
     count = metrics.get_value("mz_compute_controller_hydration_queue_size")
     assert count == 0, f"got {count}"
 


### PR DESCRIPTION
The `test_compute_controller_metrics` test asserts that the difference between the compute controller's response send and recv counts is below 10, intending to verify that the controller drains its replica response channel.

The threshold is an arbitrary absolute number that does not scale with replica response rate or scrape jitter.
The controller processes responses in a `select!` loop alongside other work, so a burst of frontier responses arriving between scrapes can produce a transient backlog larger than 10 even on a healthy controller.
A slow CI runner observed 164 sent and 130 received, well within healthy operation but tripping the assert (CLU-78).

Replace the absolute threshold with a ratio check: recv must be at least half of send.
The existing `recv_count > 10` assert already rules out a controller that fired recv only once at startup.
`recv <= send` is a channel invariant so no upper bound check is needed.

Fixes CLU-78.