### PR TITLE
coord: remove O(n) table advancement loop from group_commit

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -504,15 +504,6 @@ impl Coordinator {
             }
         }
 
-        // Add table advancements for all tables.
-        let table_advancement_start = Instant::now();
-        for table in self.catalog().entries().filter(|entry| entry.is_table()) {
-            appends.entry(table.id()).or_default();
-        }
-        self.metrics
-            .group_commit_table_advancement_seconds
-            .observe(table_advancement_start.elapsed().as_secs_f64());
-
         // Consolidate all Rows for a given table. We do not consolidate the
         // staged batches, that's up to whoever staged them.
         let mut all_appends = Vec::with_capacity(appends.len());
@@ -556,8 +547,15 @@ impl Coordinator {
                 "Appending to tables, {modified_tables:?}, at {timestamp}, advancing to {advance_to}"
             );
         }
+
         // Instrument our table writes since they can block the coordinator.
         let histogram = self.metrics.append_table_duration_seconds.clone();
+
+        // NOTE: It is important that we append, even when there are no actual
+        // appends. This makes sure we periodically bump the upper of all
+        // tables, which is required to make them readable at the latest oracle
+        // read ts.
+
         let append_fut = self
             .controller
             .storage

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -55,7 +55,6 @@ pub struct Metrics {
     pub catalog_transact_seconds: HistogramVec,
     pub apply_catalog_implications_seconds: Histogram,
     pub group_commit_catalog_upper_seconds: Histogram,
-    pub group_commit_table_advancement_seconds: Histogram,
 }
 
 impl Metrics {
@@ -253,11 +252,6 @@ impl Metrics {
                 help: "The time it takes to advance the catalog shard upper during group commit.",
                 buckets: histogram_seconds_buckets(0.001, 32.0),
             )),
-            group_commit_table_advancement_seconds: registry.register(metric!(
-                name: "mz_group_commit_table_advancement_seconds",
-                help: "The time it takes to iterate over all catalog entries to find tables during group commit.",
-                buckets: histogram_seconds_buckets(0.001, 32.0),
-            ))
         }
     }
 

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -245,19 +245,17 @@ impl PersistTableWriteWorker {
         updates: Vec<(GlobalId, Vec<TableData>)>,
     ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        if updates.is_empty() {
-            tx.send(Ok(()))
-                .expect("rx has not been dropped at this point");
-            rx
-        } else {
-            self.send(PersistTableWriteCmd::Append {
-                write_ts,
-                advance_to,
-                updates,
-                tx,
-            });
-            rx
-        }
+        // Always send the append command to the txn-wal layer, even for empty
+        // updates. The txn-wal commit advances the logical upper of ALL
+        // registered data shards, which is needed for periodic group commits
+        // that have no actual data writes.
+        self.send(PersistTableWriteCmd::Append {
+            write_ts,
+            advance_to,
+            updates,
+            tx,
+        });
+        rx
     }
 
     /// Drops the handles associated with `ids` from this worker.


### PR DESCRIPTION
Remove the loop in `group_commit()` that iterated ALL catalog entries on every group commit to add empty advancement entries for every table. With ~20k+ tables, this was the dominant DDL bottleneck at ~23% of DDL time.

The txn-wal protocol makes explicit per-table advancement unnecessary: when any transaction commits to the txns shard, the logical upper of ALL registered data shards advances automatically, including those not involved in the transaction. The empty advancement entries were performing no useful work on the storage side.

Also removed the early-return optimization in PersistTableWriteWorker::append that skipped the txn-wal commit for empty updates. This ensures periodic group commits (with no actual data writes) still advance the txns shard upper, maintaining the property that table logical uppers advance even when no writes are happening.

Results at ~28k objects (optimized build):
- CREATE TABLE: 374ms → 131ms (65% faster)
- CREATE VIEW: ~96ms
- DROP TABLE: ~97ms
- DROP VIEW: ~86ms