### PR TITLE
compute, timely-util: tech debt cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8332,6 +8332,7 @@ dependencies = [
  "columnar",
  "columnation",
  "criterion",
+ "custom-labels",
  "differential-dataflow",
  "either",
  "futures-util",

--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -154,6 +154,13 @@ where
         let minimum_frontier = Antichain::from_elem(Tr::Time::minimum());
         if PartialOrder::less_than(&minimum_frontier.borrow(), &trace_since) {
             self.padded_since = Some(minimum_frontier);
+            debug_assert!(
+                PartialOrder::less_than(
+                    &self.padded_since.as_ref().unwrap().borrow(),
+                    &self.trace.get_logical_compaction(),
+                ),
+                "padded_since must be strictly less than the inner trace's logical compaction",
+            );
         }
         self
     }
@@ -192,6 +199,10 @@ where
             if PartialOrder::less_than(&padded_since.borrow(), &frontier) {
                 *padded_since = frontier.to_owned();
             }
+            debug_assert!(
+                PartialOrder::less_than(&padded_since.borrow(), &trace_since),
+                "padded_since must remain strictly less than the inner trace's logical compaction",
+            );
         } else {
             self.padded_since = None;
             self.trace.set_logical_compaction(frontier);

--- a/src/compute/src/command_channel.rs
+++ b/src/compute/src/command_channel.rs
@@ -91,53 +91,53 @@ pub fn render(timely_worker: &mut TimelyWorker) -> (Sender, Receiver) {
     timely_worker.dataflow_named::<u64, _, _>("command_channel", {
         let activator = Arc::clone(&activator);
         move |scope| {
-            let scope = scope.with_label();
+            scope.with_label(|scope| {
+                source(scope, "command_channel::source", |cap, info| {
+                    let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
+                    *activator.lock().expect("poisoned") = Some(sync_activator);
 
-            source(scope, "command_channel::source", |cap, info| {
-                let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
-                *activator.lock().expect("poisoned") = Some(sync_activator);
+                    let worker_id = scope.index();
+                    let peers = scope.peers();
 
-                let worker_id = scope.index();
-                let peers = scope.peers();
+                    // Only worker 0 broadcasts commands, other workers must drop their capability
+                    // to avoid holding up dataflow progress.
+                    let mut capability = (worker_id == 0).then_some(cap);
 
-                // Only worker 0 broadcasts commands, other workers must drop their capability to
-                // avoid holding up dataflow progress.
-                let mut capability = (worker_id == 0).then_some(cap);
+                    move |output| {
+                        let Some(cap) = &mut capability else {
+                            // Non-leader workers will still receive `UpdateConfiguration` commands
+                            // and we must drain those to not leak memory.
+                            while let Ok((cmd, _nonce)) = input_rx.try_recv() {
+                                assert_ne!(worker_id, 0);
+                                assert!(matches!(cmd, ComputeCommand::UpdateConfiguration(_)));
+                            }
+                            return;
+                        };
 
-                move |output| {
-                    let Some(cap) = &mut capability else {
-                        // Non-leader workers will still receive `UpdateConfiguration` commands and
-                        // we must drain those to not leak memory.
-                        while let Ok((cmd, _nonce)) = input_rx.try_recv() {
-                            assert_ne!(worker_id, 0);
-                            assert!(matches!(cmd, ComputeCommand::UpdateConfiguration(_)));
+                        assert_eq!(worker_id, 0);
+
+                        let input: Vec<_> = input_rx.try_iter().collect();
+                        for (cmd, nonce) in input {
+                            let worker_cmds =
+                                split_command(cmd, peers).map(|(idx, cmd)| (idx, cmd, nonce));
+                            output.session(&cap).give_iterator(worker_cmds);
+
+                            cap.downgrade(&(cap.time() + 1));
                         }
-                        return;
-                    };
-
-                    assert_eq!(worker_id, 0);
-
-                    let input: Vec<_> = input_rx.try_iter().collect();
-                    for (cmd, nonce) in input {
-                        let worker_cmds =
-                            split_command(cmd, peers).map(|(idx, cmd)| (idx, cmd, nonce));
-                        output.session(&cap).give_iterator(worker_cmds);
-
-                        cap.downgrade(&(cap.time() + 1));
                     }
-                }
-            })
-            .sink(
-                Exchange::new(|(idx, _, _)| u64::cast_from(*idx)),
-                "command_channel::sink",
-                move |(input, _)| {
-                    input.for_each(|_time, data| {
-                        for (_idx, cmd, nonce) in data.drain(..) {
-                            let _ = output_tx.send((cmd, nonce));
-                        }
-                    });
-                },
-            );
+                })
+                .sink(
+                    Exchange::new(|(idx, _, _)| u64::cast_from(*idx)),
+                    "command_channel::sink",
+                    move |(input, _)| {
+                        input.for_each(|_time, data| {
+                            for (_idx, cmd, nonce) in data.drain(..) {
+                                let _ = output_tx.send((cmd, nonce));
+                            }
+                        });
+                    },
+                );
+            });
         }
     });
 

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -127,77 +127,77 @@ pub(crate) struct LoggingTraces {
 impl LoggingContext<'_> {
     fn construct_dataflow(&mut self) -> BTreeMap<LogVariant, TraceBundle> {
         self.worker.dataflow_named("Dataflow: logging", |scope| {
-            let scope = scope.with_label();
+            scope.with_label(|scope| {
+                let mut collections = BTreeMap::new();
 
-            let mut collections = BTreeMap::new();
+                let super::timely::Return {
+                    collections: timely_collections,
+                } = super::timely::construct(
+                    scope,
+                    self.config,
+                    self.t_event_queue.clone(),
+                    Rc::clone(&self.shared_state),
+                    self.storage_log_reader.take(),
+                );
+                collections.extend(timely_collections);
 
-            let super::timely::Return {
-                collections: timely_collections,
-            } = super::timely::construct(
-                scope,
-                self.config,
-                self.t_event_queue.clone(),
-                Rc::clone(&self.shared_state),
-                self.storage_log_reader.take(),
-            );
-            collections.extend(timely_collections);
+                let super::reachability::Return {
+                    collections: reachability_collections,
+                } = super::reachability::construct(scope, self.config, self.r_event_queue.clone());
+                collections.extend(reachability_collections);
 
-            let super::reachability::Return {
-                collections: reachability_collections,
-            } = super::reachability::construct(scope, self.config, self.r_event_queue.clone());
-            collections.extend(reachability_collections);
+                let super::differential::Return {
+                    collections: differential_collections,
+                } = super::differential::construct(
+                    scope,
+                    self.config,
+                    self.d_event_queue.clone(),
+                    Rc::clone(&self.shared_state),
+                );
+                collections.extend(differential_collections);
 
-            let super::differential::Return {
-                collections: differential_collections,
-            } = super::differential::construct(
-                scope,
-                self.config,
-                self.d_event_queue.clone(),
-                Rc::clone(&self.shared_state),
-            );
-            collections.extend(differential_collections);
+                let super::compute::Return {
+                    collections: compute_collections,
+                } = super::compute::construct(
+                    scope.clone(),
+                    scope.activations(),
+                    self.config,
+                    self.c_event_queue.clone(),
+                    Rc::clone(&self.shared_state),
+                );
+                collections.extend(compute_collections);
 
-            let super::compute::Return {
-                collections: compute_collections,
-            } = super::compute::construct(
-                scope.clone(),
-                scope.activations(),
-                self.config,
-                self.c_event_queue.clone(),
-                Rc::clone(&self.shared_state),
-            );
-            collections.extend(compute_collections);
+                let super::prometheus::Return {
+                    collections: prometheus_collections,
+                } = super::prometheus::construct(
+                    scope,
+                    self.config,
+                    self.metrics_registry.clone(),
+                    self.now,
+                    self.start_offset,
+                    Rc::clone(&self.worker_config),
+                    self.workers_per_process,
+                );
+                collections.extend(prometheus_collections);
 
-            let super::prometheus::Return {
-                collections: prometheus_collections,
-            } = super::prometheus::construct(
-                scope,
-                self.config,
-                self.metrics_registry.clone(),
-                self.now,
-                self.start_offset,
-                Rc::clone(&self.worker_config),
-                self.workers_per_process,
-            );
-            collections.extend(prometheus_collections);
+                let errs = scope.scoped("logging errors", |scope| {
+                    let collection: KeyCollection<_, DataflowErrorSer, Diff> =
+                        VecCollection::empty(scope).into();
+                    collection
+                        .mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, _>("Arrange logging err")
+                        .trace
+                });
 
-            let errs = scope.scoped("logging errors", |scope| {
-                let collection: KeyCollection<_, DataflowErrorSer, Diff> =
-                    VecCollection::empty(scope).into();
-                collection
-                    .mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, _>("Arrange logging err")
-                    .trace
-            });
-
-            let traces = collections
-                .into_iter()
-                .map(|(log, collection)| {
-                    let bundle = TraceBundle::new(collection.trace, errs.clone())
-                        .with_drop(collection.token);
-                    (log, bundle)
-                })
-                .collect();
-            traces
+                let traces = collections
+                    .into_iter()
+                    .map(|(log, collection)| {
+                        let bundle = TraceBundle::new(collection.trace, errs.clone())
+                            .with_drop(collection.token);
+                        (log, bundle)
+                    })
+                    .collect();
+                traces
+            })
         })
     }
 

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -218,322 +218,326 @@ pub fn build_compute_dataflow(
     let build_name = format!("BuildRegion: {}", &dataflow.debug_name);
 
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
-        let scope = scope.with_label();
+        scope.with_label(|scope| {
+            // The scope.clone() occurs to allow import in the region.
+            // We build a region here to establish a pattern of a scope inside the dataflow,
+            // so that other similar uses (e.g. with iterative scopes) do not require weird
+            // alternate type signatures.
+            let mut imported_sources = Vec::new();
+            let mut tokens: BTreeMap<_, Rc<dyn Any>> = BTreeMap::new();
+            let output_probe = MzProbeHandle::default();
 
-        // The scope.clone() occurs to allow import in the region.
-        // We build a region here to establish a pattern of a scope inside the dataflow,
-        // so that other similar uses (e.g. with iterative scopes) do not require weird
-        // alternate type signatures.
-        let mut imported_sources = Vec::new();
-        let mut tokens: BTreeMap<_, Rc<dyn Any>> = BTreeMap::new();
-        let output_probe = MzProbeHandle::default();
+            scope.clone().region_named(&input_name, |region| {
+                // Import declared sources into the rendering context.
+                for (source_id, import) in dataflow.source_imports.iter() {
+                    region.region_named(&format!("Source({:?})", source_id), |inner| {
+                        let mut read_schema = None;
+                        let mut mfp = import.desc.arguments.operators.clone().map(|mut ops| {
+                            // If enabled, we read from Persist with a `RelationDesc` that
+                            // omits uneeded columns.
+                            if apply_demands {
+                                let demands = ops.demand();
+                                let new_desc = import
+                                    .desc
+                                    .storage_metadata
+                                    .relation_desc
+                                    .apply_demand(&demands);
+                                let new_arity = demands.len();
+                                let remap: BTreeMap<_, _> = demands
+                                    .into_iter()
+                                    .enumerate()
+                                    .map(|(new, old)| (old, new))
+                                    .collect();
+                                ops.permute_fn(|old_idx| remap[&old_idx], new_arity);
+                                read_schema = Some(new_desc);
+                            }
 
-        scope.clone().region_named(&input_name, |region| {
-            // Import declared sources into the rendering context.
-            for (source_id, import) in dataflow.source_imports.iter() {
-                region.region_named(&format!("Source({:?})", source_id), |inner| {
-                    let mut read_schema = None;
-                    let mut mfp = import.desc.arguments.operators.clone().map(|mut ops| {
-                        // If enabled, we read from Persist with a `RelationDesc` that
-                        // omits uneeded columns.
-                        if apply_demands {
-                            let demands = ops.demand();
-                            let new_desc = import
-                                .desc
-                                .storage_metadata
-                                .relation_desc
-                                .apply_demand(&demands);
-                            let new_arity = demands.len();
-                            let remap: BTreeMap<_, _> = demands
-                                .into_iter()
-                                .enumerate()
-                                .map(|(new, old)| (old, new))
-                                .collect();
-                            ops.permute_fn(|old_idx| remap[&old_idx], new_arity);
-                            read_schema = Some(new_desc);
+                            mz_expr::MfpPlan::create_from(ops)
+                                .expect("Linear operators should always be valid")
+                        });
+
+                        let snapshot_mode =
+                            if import.with_snapshot || !subscribe_snapshot_optimization {
+                                SnapshotMode::Include
+                            } else {
+                                compute_state.metrics.inc_subscribe_snapshot_optimization();
+                                SnapshotMode::Exclude
+                            };
+                        let suppress_early_progress_as_of = dataflow.as_of.clone();
+
+                        // Note: For correctness, we require that sources only emit times advanced by
+                        // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
+                        let (mut ok_stream, err_stream, token) =
+                            persist_source::persist_source::<DataflowErrorSer>(
+                                inner,
+                                *source_id,
+                                Arc::clone(&compute_state.persist_clients),
+                                &compute_state.txns_ctx,
+                                import.desc.storage_metadata.clone(),
+                                read_schema,
+                                dataflow.as_of.clone(),
+                                snapshot_mode,
+                                until.clone(),
+                                mfp.as_mut(),
+                                compute_state.dataflow_max_inflight_bytes(),
+                                start_signal.clone().into_send_future(),
+                                ErrorHandler::Halt("compute_import"),
+                            );
+
+                        // If `mfp` is non-identity, we need to apply what remains.
+                        // For the moment, assert that it is either trivial or `None`.
+                        assert!(mfp.map(|x| x.is_identity()).unwrap_or(true));
+
+                        // To avoid a memory spike during arrangement hydration (database-issues#6368), need to
+                        // ensure that the first frontier we report into the dataflow is beyond the
+                        // `as_of`.
+                        if let Some(as_of) = suppress_early_progress_as_of {
+                            ok_stream = suppress_early_progress(ok_stream, as_of);
                         }
 
-                        mz_expr::MfpPlan::create_from(ops)
-                            .expect("Linear operators should always be valid")
+                        if ENABLE_COMPUTE_LOGICAL_BACKPRESSURE.get(&compute_state.worker_config) {
+                            // Apply logical backpressure to the source.
+                            let limit = COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES
+                                .get(&compute_state.worker_config);
+                            let slack = COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK
+                                .get(&compute_state.worker_config)
+                                .as_millis()
+                                .try_into()
+                                .expect("must fit");
+
+                            let stream = ok_stream.limit_progress(
+                                output_probe.clone(),
+                                slack,
+                                limit,
+                                import.upper.clone(),
+                                name.clone(),
+                            );
+                            ok_stream = stream;
+                        }
+
+                        // Attach a probe reporting the input frontier.
+                        let input_probe =
+                            compute_state.input_probe_for(*source_id, dataflow.export_ids());
+                        ok_stream = ok_stream.probe_with(&input_probe);
+
+                        let (oks, errs) = (
+                            ok_stream
+                                .as_collection()
+                                .leave_region(region)
+                                .leave_region(scope),
+                            err_stream
+                                .as_collection()
+                                .leave_region(region)
+                                .leave_region(scope),
+                        );
+
+                        imported_sources.push((mz_expr::Id::Global(*source_id), (oks, errs)));
+
+                        // Associate returned tokens with the source identifier.
+                        tokens.insert(*source_id, Rc::new(token));
                     });
+                }
+            });
 
-                    let snapshot_mode = if import.with_snapshot || !subscribe_snapshot_optimization
-                    {
-                        SnapshotMode::Include
-                    } else {
-                        compute_state.metrics.inc_subscribe_snapshot_optimization();
-                        SnapshotMode::Exclude
-                    };
-                    let suppress_early_progress_as_of = dataflow.as_of.clone();
-
-                    // Note: For correctness, we require that sources only emit times advanced by
-                    // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
-                    let (mut ok_stream, err_stream, token) =
-                        persist_source::persist_source::<DataflowErrorSer>(
-                            inner,
-                            *source_id,
-                            Arc::clone(&compute_state.persist_clients),
-                            &compute_state.txns_ctx,
-                            import.desc.storage_metadata.clone(),
-                            read_schema,
-                            dataflow.as_of.clone(),
-                            snapshot_mode,
-                            until.clone(),
-                            mfp.as_mut(),
-                            compute_state.dataflow_max_inflight_bytes(),
-                            start_signal.clone().into_send_future(),
-                            ErrorHandler::Halt("compute_import"),
-                        );
-
-                    // If `mfp` is non-identity, we need to apply what remains.
-                    // For the moment, assert that it is either trivial or `None`.
-                    assert!(mfp.map(|x| x.is_identity()).unwrap_or(true));
-
-                    // To avoid a memory spike during arrangement hydration (database-issues#6368), need to
-                    // ensure that the first frontier we report into the dataflow is beyond the
-                    // `as_of`.
-                    if let Some(as_of) = suppress_early_progress_as_of {
-                        ok_stream = suppress_early_progress(ok_stream, as_of);
-                    }
-
-                    if ENABLE_COMPUTE_LOGICAL_BACKPRESSURE.get(&compute_state.worker_config) {
-                        // Apply logical backpressure to the source.
-                        let limit = COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES
-                            .get(&compute_state.worker_config);
-                        let slack = COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK
-                            .get(&compute_state.worker_config)
-                            .as_millis()
-                            .try_into()
-                            .expect("must fit");
-
-                        let stream = ok_stream.limit_progress(
-                            output_probe.clone(),
-                            slack,
-                            limit,
-                            import.upper.clone(),
-                            name.clone(),
-                        );
-                        ok_stream = stream;
-                    }
-
-                    // Attach a probe reporting the input frontier.
-                    let input_probe =
-                        compute_state.input_probe_for(*source_id, dataflow.export_ids());
-                    ok_stream = ok_stream.probe_with(&input_probe);
-
-                    let (oks, errs) = (
-                        ok_stream
-                            .as_collection()
-                            .leave_region(region)
-                            .leave_region(scope),
-                        err_stream
-                            .as_collection()
-                            .leave_region(region)
-                            .leave_region(scope),
+            // If there exists a recursive expression, we'll need to use a non-region scope,
+            // in order to support additional timestamp coordinates for iteration.
+            if recursive {
+                scope.clone().iterative::<PointStamp<u64>, _, _>(|region| {
+                    let mut context = Context::for_dataflow_in(
+                        &dataflow,
+                        region.clone(),
+                        compute_state,
+                        until,
+                        dataflow_expiration,
                     );
 
-                    imported_sources.push((mz_expr::Id::Global(*source_id), (oks, errs)));
+                    for (id, (oks, errs)) in imported_sources.into_iter() {
+                        let bundle = crate::render::CollectionBundle::from_collections(
+                            oks.enter(region),
+                            errs.enter(region),
+                        );
+                        // Associate collection bundle with the source identifier.
+                        context.insert_id(id, bundle);
+                    }
 
-                    // Associate returned tokens with the source identifier.
-                    tokens.insert(*source_id, Rc::new(token));
+                    // Import declared indexes into the rendering context.
+                    for (idx_id, idx) in &dataflow.index_imports {
+                        let input_probe =
+                            compute_state.input_probe_for(*idx_id, dataflow.export_ids());
+                        let snapshot_mode = if idx.with_snapshot || !subscribe_snapshot_optimization
+                        {
+                            SnapshotMode::Include
+                        } else {
+                            compute_state.metrics.inc_subscribe_snapshot_optimization();
+                            SnapshotMode::Exclude
+                        };
+                        context.import_index(
+                            scope,
+                            compute_state,
+                            &mut tokens,
+                            input_probe,
+                            *idx_id,
+                            &idx.desc,
+                            &idx.typ,
+                            snapshot_mode,
+                            start_signal.clone(),
+                        );
+                    }
+
+                    // Build declared objects.
+                    for object in dataflow.objects_to_build {
+                        let bundle = context.scope.clone().region_named(
+                            &format!("BuildingObject({:?})", object.id),
+                            |region| {
+                                let depends = object.plan.depends();
+                                let in_let = object.plan.is_recursive();
+                                context
+                                    .enter_region(region, Some(&depends))
+                                    .render_recursive_plan(
+                                        object.id,
+                                        0,
+                                        object.plan,
+                                        // recursive plans _must_ have bodies in a let
+                                        BindingInfo::Body { in_let },
+                                    )
+                                    .leave_region(context.scope)
+                            },
+                        );
+                        let global_id = object.id;
+
+                        context.log_dataflow_global_id(
+                            *bundle
+                                .scope()
+                                .addr()
+                                .first()
+                                .expect("Dataflow root id must exist"),
+                            global_id,
+                        );
+                        context.insert_id(Id::Global(object.id), bundle);
+                    }
+
+                    // Export declared indexes.
+                    for (idx_id, dependencies, idx) in indexes {
+                        context.export_index_iterative(
+                            scope,
+                            compute_state,
+                            &tokens,
+                            dependencies,
+                            idx_id,
+                            &idx,
+                            &output_probe,
+                        );
+                    }
+
+                    // Export declared sinks.
+                    for (sink_id, dependencies, sink) in sinks {
+                        context.export_sink(
+                            compute_state,
+                            &tokens,
+                            dependencies,
+                            sink_id,
+                            &sink,
+                            start_signal.clone(),
+                            &output_probe,
+                            scope,
+                        );
+                    }
+                });
+            } else {
+                scope.clone().region_named(&build_name, |region| {
+                    let mut context = Context::for_dataflow_in(
+                        &dataflow,
+                        region.clone(),
+                        compute_state,
+                        until,
+                        dataflow_expiration,
+                    );
+
+                    for (id, (oks, errs)) in imported_sources.into_iter() {
+                        let bundle = crate::render::CollectionBundle::from_collections(
+                            oks.enter_region(region),
+                            errs.enter_region(region),
+                        );
+                        // Associate collection bundle with the source identifier.
+                        context.insert_id(id, bundle);
+                    }
+
+                    // Import declared indexes into the rendering context.
+                    for (idx_id, idx) in &dataflow.index_imports {
+                        let input_probe =
+                            compute_state.input_probe_for(*idx_id, dataflow.export_ids());
+                        let snapshot_mode = if idx.with_snapshot || !subscribe_snapshot_optimization
+                        {
+                            SnapshotMode::Include
+                        } else {
+                            compute_state.metrics.inc_subscribe_snapshot_optimization();
+                            SnapshotMode::Exclude
+                        };
+                        context.import_index(
+                            scope,
+                            compute_state,
+                            &mut tokens,
+                            input_probe,
+                            *idx_id,
+                            &idx.desc,
+                            &idx.typ,
+                            snapshot_mode,
+                            start_signal.clone(),
+                        );
+                    }
+
+                    // Build declared objects.
+                    for object in dataflow.objects_to_build {
+                        let bundle = context.scope.clone().region_named(
+                            &format!("BuildingObject({:?})", object.id),
+                            |region| {
+                                let depends = object.plan.depends();
+                                context
+                                    .enter_region(region, Some(&depends))
+                                    .render_plan(object.id, object.plan)
+                                    .leave_region(context.scope)
+                            },
+                        );
+                        let global_id = object.id;
+                        context.log_dataflow_global_id(
+                            *bundle
+                                .scope()
+                                .addr()
+                                .first()
+                                .expect("Dataflow root id must exist"),
+                            global_id,
+                        );
+                        context.insert_id(Id::Global(object.id), bundle);
+                    }
+
+                    // Export declared indexes.
+                    for (idx_id, dependencies, idx) in indexes {
+                        context.export_index(
+                            compute_state,
+                            &tokens,
+                            dependencies,
+                            idx_id,
+                            &idx,
+                            &output_probe,
+                        );
+                    }
+
+                    // Export declared sinks.
+                    for (sink_id, dependencies, sink) in sinks {
+                        context.export_sink(
+                            compute_state,
+                            &tokens,
+                            dependencies,
+                            sink_id,
+                            &sink,
+                            start_signal.clone(),
+                            &output_probe,
+                            scope,
+                        );
+                    }
                 });
             }
         });
-
-        // If there exists a recursive expression, we'll need to use a non-region scope,
-        // in order to support additional timestamp coordinates for iteration.
-        if recursive {
-            scope.clone().iterative::<PointStamp<u64>, _, _>(|region| {
-                let mut context = Context::for_dataflow_in(
-                    &dataflow,
-                    region.clone(),
-                    compute_state,
-                    until,
-                    dataflow_expiration,
-                );
-
-                for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter(region),
-                        errs.enter(region),
-                    );
-                    // Associate collection bundle with the source identifier.
-                    context.insert_id(id, bundle);
-                }
-
-                // Import declared indexes into the rendering context.
-                for (idx_id, idx) in &dataflow.index_imports {
-                    let input_probe = compute_state.input_probe_for(*idx_id, dataflow.export_ids());
-                    let snapshot_mode = if idx.with_snapshot || !subscribe_snapshot_optimization {
-                        SnapshotMode::Include
-                    } else {
-                        compute_state.metrics.inc_subscribe_snapshot_optimization();
-                        SnapshotMode::Exclude
-                    };
-                    context.import_index(
-                        scope,
-                        compute_state,
-                        &mut tokens,
-                        input_probe,
-                        *idx_id,
-                        &idx.desc,
-                        &idx.typ,
-                        snapshot_mode,
-                        start_signal.clone(),
-                    );
-                }
-
-                // Build declared objects.
-                for object in dataflow.objects_to_build {
-                    let bundle = context.scope.clone().region_named(
-                        &format!("BuildingObject({:?})", object.id),
-                        |region| {
-                            let depends = object.plan.depends();
-                            let in_let = object.plan.is_recursive();
-                            context
-                                .enter_region(region, Some(&depends))
-                                .render_recursive_plan(
-                                    object.id,
-                                    0,
-                                    object.plan,
-                                    // recursive plans _must_ have bodies in a let
-                                    BindingInfo::Body { in_let },
-                                )
-                                .leave_region(context.scope)
-                        },
-                    );
-                    let global_id = object.id;
-
-                    context.log_dataflow_global_id(
-                        *bundle
-                            .scope()
-                            .addr()
-                            .first()
-                            .expect("Dataflow root id must exist"),
-                        global_id,
-                    );
-                    context.insert_id(Id::Global(object.id), bundle);
-                }
-
-                // Export declared indexes.
-                for (idx_id, dependencies, idx) in indexes {
-                    context.export_index_iterative(
-                        scope,
-                        compute_state,
-                        &tokens,
-                        dependencies,
-                        idx_id,
-                        &idx,
-                        &output_probe,
-                    );
-                }
-
-                // Export declared sinks.
-                for (sink_id, dependencies, sink) in sinks {
-                    context.export_sink(
-                        compute_state,
-                        &tokens,
-                        dependencies,
-                        sink_id,
-                        &sink,
-                        start_signal.clone(),
-                        &output_probe,
-                        scope,
-                    );
-                }
-            });
-        } else {
-            scope.clone().region_named(&build_name, |region| {
-                let mut context = Context::for_dataflow_in(
-                    &dataflow,
-                    region.clone(),
-                    compute_state,
-                    until,
-                    dataflow_expiration,
-                );
-
-                for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter_region(region),
-                        errs.enter_region(region),
-                    );
-                    // Associate collection bundle with the source identifier.
-                    context.insert_id(id, bundle);
-                }
-
-                // Import declared indexes into the rendering context.
-                for (idx_id, idx) in &dataflow.index_imports {
-                    let input_probe = compute_state.input_probe_for(*idx_id, dataflow.export_ids());
-                    let snapshot_mode = if idx.with_snapshot || !subscribe_snapshot_optimization {
-                        SnapshotMode::Include
-                    } else {
-                        compute_state.metrics.inc_subscribe_snapshot_optimization();
-                        SnapshotMode::Exclude
-                    };
-                    context.import_index(
-                        scope,
-                        compute_state,
-                        &mut tokens,
-                        input_probe,
-                        *idx_id,
-                        &idx.desc,
-                        &idx.typ,
-                        snapshot_mode,
-                        start_signal.clone(),
-                    );
-                }
-
-                // Build declared objects.
-                for object in dataflow.objects_to_build {
-                    let bundle = context.scope.clone().region_named(
-                        &format!("BuildingObject({:?})", object.id),
-                        |region| {
-                            let depends = object.plan.depends();
-                            context
-                                .enter_region(region, Some(&depends))
-                                .render_plan(object.id, object.plan)
-                                .leave_region(context.scope)
-                        },
-                    );
-                    let global_id = object.id;
-                    context.log_dataflow_global_id(
-                        *bundle
-                            .scope()
-                            .addr()
-                            .first()
-                            .expect("Dataflow root id must exist"),
-                        global_id,
-                    );
-                    context.insert_id(Id::Global(object.id), bundle);
-                }
-
-                // Export declared indexes.
-                for (idx_id, dependencies, idx) in indexes {
-                    context.export_index(
-                        compute_state,
-                        &tokens,
-                        dependencies,
-                        idx_id,
-                        &idx,
-                        &output_probe,
-                    );
-                }
-
-                // Export declared sinks.
-                for (sink_id, dependencies, sink) in sinks {
-                    context.export_sink(
-                        compute_state,
-                        &tokens,
-                        dependencies,
-                        sink_id,
-                        &sink,
-                        start_signal.clone(),
-                        &output_probe,
-                        scope,
-                    );
-                }
-            });
-        }
     });
 }
 

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -175,117 +175,118 @@ pub(crate) fn setup_command_sequencer<'w>(
     timely_worker.dataflow_named::<(), _, _>("command_sequencer", {
         let activator = Rc::clone(&activator);
         move |scope| {
-            let scope = scope.with_label();
-            // Create a stream of commands received from `input_rx`.
-            //
-            // The output commands are tagged by worker ID and command index, allowing downstream
-            // operators to ensure their correct relative order.
-            let stream = source(scope, "command_sequencer::source", |cap, info| {
-                *activator.borrow_mut() = Some(scope.activator_for(info.address));
+            scope.with_label(|scope| {
+                // Create a stream of commands received from `input_rx`.
+                //
+                // The output commands are tagged by worker ID and command index, allowing downstream
+                // operators to ensure their correct relative order.
+                let stream = source(scope, "command_sequencer::source", |cap, info| {
+                    *activator.borrow_mut() = Some(scope.activator_for(info.address));
 
-                let worker_id = scope.index();
-                let mut cmd_index = 0;
-                let mut capability = Some(cap);
-
-                move |output| {
-                    let Some(cap) = capability.clone() else {
-                        return;
-                    };
-
-                    let mut session = output.session(&cap);
-                    loop {
-                        match input_rx.try_recv() {
-                            Ok(command) => {
-                                let cmd = IndexedCommand {
-                                    index: cmd_index,
-                                    command,
-                                };
-                                session.give((worker_id, cmd));
-                                cmd_index += 1;
-                            }
-                            Err(mpsc::TryRecvError::Empty) => break,
-                            Err(mpsc::TryRecvError::Disconnected) => {
-                                // Drop our capability to shut down.
-                                capability = None;
-                                break;
-                            }
-                        }
-                    }
-                }
-            });
-
-            // Sequence all commands through a single worker to establish a unique order.
-            //
-            // The output commands are tagged by a command index, allowing downstream operators to
-            // ensure their correct relative order.
-            let stream = stream.unary_frontier(
-                Exchange::new(|_| 0),
-                "command_sequencer::sequencer",
-                |cap, _info| {
+                    let worker_id = scope.index();
                     let mut cmd_index = 0;
                     let mut capability = Some(cap);
 
-                    // For each worker, keep an ordered list of pending commands, as well as the
-                    // current index of the next command.
-                    let mut pending_commands = vec![(BTreeSet::new(), 0); scope.peers()];
-
-                    move |(input, frontier), output| {
+                    move |output| {
                         let Some(cap) = capability.clone() else {
                             return;
                         };
 
-                        input.for_each(|_time, data| {
-                            for (worker_id, cmd) in data.drain(..) {
-                                pending_commands[worker_id].0.insert(cmd);
+                        let mut session = output.session(&cap);
+                        loop {
+                            match input_rx.try_recv() {
+                                Ok(command) => {
+                                    let cmd = IndexedCommand {
+                                        index: cmd_index,
+                                        command,
+                                    };
+                                    session.give((worker_id, cmd));
+                                    cmd_index += 1;
+                                }
+                                Err(mpsc::TryRecvError::Empty) => break,
+                                Err(mpsc::TryRecvError::Disconnected) => {
+                                    // Drop our capability to shut down.
+                                    capability = None;
+                                    break;
+                                }
                             }
+                        }
+                    }
+                });
+
+                // Sequence all commands through a single worker to establish a unique order.
+                //
+                // The output commands are tagged by a command index, allowing downstream operators to
+                // ensure their correct relative order.
+                let stream = stream.unary_frontier(
+                    Exchange::new(|_| 0),
+                    "command_sequencer::sequencer",
+                    |cap, _info| {
+                        let mut cmd_index = 0;
+                        let mut capability = Some(cap);
+
+                        // For each worker, keep an ordered list of pending commands, as well as the
+                        // current index of the next command.
+                        let mut pending_commands = vec![(BTreeSet::new(), 0); scope.peers()];
+
+                        move |(input, frontier), output| {
+                            let Some(cap) = capability.clone() else {
+                                return;
+                            };
+
+                            input.for_each(|_time, data| {
+                                for (worker_id, cmd) in data.drain(..) {
+                                    pending_commands[worker_id].0.insert(cmd);
+                                }
+                            });
+
+                            let mut session = output.session(&cap);
+                            for (commands, next_idx) in &mut pending_commands {
+                                while commands.first().is_some_and(|c| c.index == *next_idx) {
+                                    let mut cmd = commands.pop_first().unwrap();
+                                    cmd.index = cmd_index;
+                                    session.give(cmd);
+
+                                    *next_idx += 1;
+                                    cmd_index += 1;
+                                }
+                            }
+
+                            let _ = session;
+
+                            if frontier.is_empty() {
+                                // Drop our capability to shut down.
+                                capability = None;
+                            }
+                        }
+                    },
+                );
+
+                // Broadcast the ordered commands to all workers.
+                let stream = stream.broadcast();
+
+                // Sink the stream back into `output_tx`.
+                stream.sink(Pipeline, "command_sequencer::sink", {
+                    // Keep an ordered list of pending commands, as well as the current index of the
+                    // next command.
+                    let mut pending_commands = BTreeSet::new();
+                    let mut next_idx = 0;
+
+                    move |(input, _frontier)| {
+                        input.for_each(|_time, data| {
+                            pending_commands.extend(data.drain(..));
                         });
 
-                        let mut session = output.session(&cap);
-                        for (commands, next_idx) in &mut pending_commands {
-                            while commands.first().is_some_and(|c| c.index == *next_idx) {
-                                let mut cmd = commands.pop_first().unwrap();
-                                cmd.index = cmd_index;
-                                session.give(cmd);
-
-                                *next_idx += 1;
-                                cmd_index += 1;
-                            }
-                        }
-
-                        let _ = session;
-
-                        if frontier.is_empty() {
-                            // Drop our capability to shut down.
-                            capability = None;
+                        while pending_commands
+                            .first()
+                            .is_some_and(|c| c.index == next_idx)
+                        {
+                            let cmd = pending_commands.pop_first().unwrap();
+                            let _ = output_tx.send(cmd.command);
+                            next_idx += 1;
                         }
                     }
-                },
-            );
-
-            // Broadcast the ordered commands to all workers.
-            let stream = stream.broadcast();
-
-            // Sink the stream back into `output_tx`.
-            stream.sink(Pipeline, "command_sequencer::sink", {
-                // Keep an ordered list of pending commands, as well as the current index of the
-                // next command.
-                let mut pending_commands = BTreeSet::new();
-                let mut next_idx = 0;
-
-                move |(input, _frontier)| {
-                    input.for_each(|_time, data| {
-                        pending_commands.extend(data.drain(..));
-                    });
-
-                    while pending_commands
-                        .first()
-                        .is_some_and(|c| c.index == next_idx)
-                    {
-                        let cmd = pending_commands.pop_first().unwrap();
-                        let _ = output_tx.send(cmd.command);
-                        next_idx += 1;
-                    }
-                }
+                });
             });
         }
     });

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -242,195 +242,199 @@ pub fn build_ingestion_dataflow(
     let debug_name = primary_source_id.to_string();
     let name = format!("Source dataflow: {debug_name}");
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, root_scope| {
-        let root_scope = root_scope.with_label();
+        root_scope.with_label(|root_scope| {
+            // Here we need to create two scopes. One timestamped with `()`, which is the root scope,
+            // and one timestamped with `mz_repr::Timestamp` which is the final scope of the dataflow.
+            // Refer to the module documentation for an explanation of this structure.
+            // The scope.clone() occurs to allow import in the region.
+            root_scope.clone().scoped(&name, |mz_scope| {
+                let debug_name = format!("{debug_name}-sources");
 
-        // Here we need to create two scopes. One timestamped with `()`, which is the root scope,
-        // and one timestamped with `mz_repr::Timestamp` which is the final scope of the dataflow.
-        // Refer to the module documentation for an explanation of this structure.
-        // The scope.clone() occurs to allow import in the region.
-        root_scope.clone().scoped(&name, |mz_scope| {
-            let debug_name = format!("{debug_name}-sources");
+                let mut tokens = vec![];
 
-            let mut tokens = vec![];
+                let (feedback_handle, feedback) = mz_scope.feedback(Default::default());
 
-            let (feedback_handle, feedback) = mz_scope.feedback(Default::default());
-
-            let connection = description.desc.connection.clone();
-            tracing::info!(
-                id = %primary_source_id,
-                as_of = %as_of.pretty(),
-                resume_uppers = ?resume_uppers,
-                source_resume_uppers = ?source_resume_uppers,
-                "timely-{worker_id} building {} source pipeline", connection.name(),
-            );
-
-            let busy_signal = if dyncfgs::SUSPENDABLE_SOURCES
-                .get(storage_state.storage_configuration.config_set())
-            {
-                Arc::new(Semaphore::new(1))
-            } else {
-                Arc::new(Semaphore::new(Semaphore::MAX_PERMITS))
-            };
-
-            let base_source_config = RawSourceCreationConfig {
-                name: format!("{}-{}", connection.name(), primary_source_id),
-                id: primary_source_id,
-                source_exports: description.source_exports.clone(),
-                timestamp_interval: description.desc.timestamp_interval,
-                worker_id: mz_scope.index(),
-                worker_count: mz_scope.peers(),
-                now_fn: storage_state.now.clone(),
-                metrics: storage_state.metrics.clone(),
-                as_of: as_of.clone(),
-                resume_uppers: resume_uppers.clone(),
-                source_resume_uppers,
-                remap_metadata: description.remap_metadata.clone(),
-                persist_clients: Arc::clone(&storage_state.persist_clients),
-                statistics: storage_state
-                    .aggregated_statistics
-                    .get_ingestion_stats(&primary_source_id),
-                shared_remap_upper: Rc::clone(
-                    &storage_state.source_uppers[&description.remap_collection_id],
-                ),
-                // This might quite a large clone, but its just during rendering
-                config: storage_state.storage_configuration.clone(),
-                remap_collection_id: description.remap_collection_id,
-                busy_signal: Arc::clone(&busy_signal),
-            };
-
-            let (outputs, source_health, source_tokens) = match connection {
-                GenericSourceConnection::Kafka(c) => crate::render::sources::render_source(
-                    mz_scope,
-                    root_scope,
-                    &debug_name,
-                    c,
-                    description.clone(),
-                    feedback,
-                    storage_state,
-                    base_source_config,
-                ),
-                GenericSourceConnection::Postgres(c) => crate::render::sources::render_source(
-                    mz_scope,
-                    root_scope,
-                    &debug_name,
-                    c,
-                    description.clone(),
-                    feedback,
-                    storage_state,
-                    base_source_config,
-                ),
-                GenericSourceConnection::MySql(c) => crate::render::sources::render_source(
-                    mz_scope,
-                    root_scope,
-                    &debug_name,
-                    c,
-                    description.clone(),
-                    feedback,
-                    storage_state,
-                    base_source_config,
-                ),
-                GenericSourceConnection::SqlServer(c) => crate::render::sources::render_source(
-                    mz_scope,
-                    root_scope,
-                    &debug_name,
-                    c,
-                    description.clone(),
-                    feedback,
-                    storage_state,
-                    base_source_config,
-                ),
-                GenericSourceConnection::LoadGenerator(c) => crate::render::sources::render_source(
-                    mz_scope,
-                    root_scope,
-                    &debug_name,
-                    c,
-                    description.clone(),
-                    feedback,
-                    storage_state,
-                    base_source_config,
-                ),
-            };
-            tokens.extend(source_tokens);
-
-            let mut upper_streams = vec![];
-            let mut health_streams = Vec::with_capacity(source_health.len() + outputs.len());
-            health_streams.extend(source_health);
-            for (export_id, (ok, err)) in outputs {
-                let export = &description.source_exports[&export_id];
-                let source_data = ok.map(Ok).concat(err.map(Err));
-
-                let metrics = storage_state.metrics.get_source_persist_sink_metrics(
-                    export_id,
-                    primary_source_id,
-                    worker_id,
-                    &export.storage_metadata.data_shard,
-                );
-
+                let connection = description.desc.connection.clone();
                 tracing::info!(
                     id = %primary_source_id,
-                    "timely-{worker_id}: persisting export {} of {}",
-                    export_id,
-                    primary_source_id
+                    as_of = %as_of.pretty(),
+                    resume_uppers = ?resume_uppers,
+                    source_resume_uppers = ?source_resume_uppers,
+                    "timely-{worker_id} building {} source pipeline", connection.name(),
                 );
-                let (upper_stream, errors, sink_tokens) = crate::render::persist_sink::render(
-                    mz_scope,
-                    export_id,
-                    export.storage_metadata.clone(),
-                    source_data,
-                    storage_state,
-                    metrics,
-                    Arc::clone(&busy_signal),
-                );
-                upper_streams.push(upper_stream);
-                tokens.extend(sink_tokens);
 
-                let sink_health = errors.map(move |err: Rc<anyhow::Error>| {
-                    let halt_status =
-                        HealthStatusUpdate::halting(err.display_with_causes().to_string(), None);
-                    HealthStatusMessage {
-                        id: None,
-                        namespace: StatusNamespace::Internal,
-                        update: halt_status,
+                let busy_signal = if dyncfgs::SUSPENDABLE_SOURCES
+                    .get(storage_state.storage_configuration.config_set())
+                {
+                    Arc::new(Semaphore::new(1))
+                } else {
+                    Arc::new(Semaphore::new(Semaphore::MAX_PERMITS))
+                };
+
+                let base_source_config = RawSourceCreationConfig {
+                    name: format!("{}-{}", connection.name(), primary_source_id),
+                    id: primary_source_id,
+                    source_exports: description.source_exports.clone(),
+                    timestamp_interval: description.desc.timestamp_interval,
+                    worker_id: mz_scope.index(),
+                    worker_count: mz_scope.peers(),
+                    now_fn: storage_state.now.clone(),
+                    metrics: storage_state.metrics.clone(),
+                    as_of: as_of.clone(),
+                    resume_uppers: resume_uppers.clone(),
+                    source_resume_uppers,
+                    remap_metadata: description.remap_metadata.clone(),
+                    persist_clients: Arc::clone(&storage_state.persist_clients),
+                    statistics: storage_state
+                        .aggregated_statistics
+                        .get_ingestion_stats(&primary_source_id),
+                    shared_remap_upper: Rc::clone(
+                        &storage_state.source_uppers[&description.remap_collection_id],
+                    ),
+                    // This might quite a large clone, but its just during rendering
+                    config: storage_state.storage_configuration.clone(),
+                    remap_collection_id: description.remap_collection_id,
+                    busy_signal: Arc::clone(&busy_signal),
+                };
+
+                let (outputs, source_health, source_tokens) = match connection {
+                    GenericSourceConnection::Kafka(c) => crate::render::sources::render_source(
+                        mz_scope,
+                        root_scope,
+                        &debug_name,
+                        c,
+                        description.clone(),
+                        feedback,
+                        storage_state,
+                        base_source_config,
+                    ),
+                    GenericSourceConnection::Postgres(c) => crate::render::sources::render_source(
+                        mz_scope,
+                        root_scope,
+                        &debug_name,
+                        c,
+                        description.clone(),
+                        feedback,
+                        storage_state,
+                        base_source_config,
+                    ),
+                    GenericSourceConnection::MySql(c) => crate::render::sources::render_source(
+                        mz_scope,
+                        root_scope,
+                        &debug_name,
+                        c,
+                        description.clone(),
+                        feedback,
+                        storage_state,
+                        base_source_config,
+                    ),
+                    GenericSourceConnection::SqlServer(c) => crate::render::sources::render_source(
+                        mz_scope,
+                        root_scope,
+                        &debug_name,
+                        c,
+                        description.clone(),
+                        feedback,
+                        storage_state,
+                        base_source_config,
+                    ),
+                    GenericSourceConnection::LoadGenerator(c) => {
+                        crate::render::sources::render_source(
+                            mz_scope,
+                            root_scope,
+                            &debug_name,
+                            c,
+                            description.clone(),
+                            feedback,
+                            storage_state,
+                            base_source_config,
+                        )
                     }
-                });
-                health_streams.push(sink_health.leave(root_scope));
-            }
+                };
+                tokens.extend(source_tokens);
 
-            mz_scope
-                .concatenate(upper_streams)
-                .connect_loop(feedback_handle);
+                let mut upper_streams = vec![];
+                let mut health_streams = Vec::with_capacity(source_health.len() + outputs.len());
+                health_streams.extend(source_health);
+                for (export_id, (ok, err)) in outputs {
+                    let export = &description.source_exports[&export_id];
+                    let source_data = ok.map(Ok).concat(err.map(Err));
 
-            let health_stream = root_scope.concatenate(health_streams);
-            let health_token = crate::healthcheck::health_operator(
-                root_scope,
-                storage_state.now.clone(),
-                resume_uppers
-                    .iter()
-                    .filter_map(|(id, frontier)| {
-                        // If the collection isn't closed, then we will remark it as Starting as
-                        // the dataflow comes up.
-                        (!frontier.is_empty()).then_some(*id)
-                    })
-                    .collect(),
-                primary_source_id,
-                "source",
-                health_stream,
-                crate::healthcheck::DefaultWriter {
-                    command_tx: storage_state.internal_cmd_tx.clone(),
-                    updates: Rc::clone(&storage_state.shared_status_updates),
-                },
+                    let metrics = storage_state.metrics.get_source_persist_sink_metrics(
+                        export_id,
+                        primary_source_id,
+                        worker_id,
+                        &export.storage_metadata.data_shard,
+                    );
+
+                    tracing::info!(
+                        id = %primary_source_id,
+                        "timely-{worker_id}: persisting export {} of {}",
+                        export_id,
+                        primary_source_id
+                    );
+                    let (upper_stream, errors, sink_tokens) = crate::render::persist_sink::render(
+                        mz_scope,
+                        export_id,
+                        export.storage_metadata.clone(),
+                        source_data,
+                        storage_state,
+                        metrics,
+                        Arc::clone(&busy_signal),
+                    );
+                    upper_streams.push(upper_stream);
+                    tokens.extend(sink_tokens);
+
+                    let sink_health = errors.map(move |err: Rc<anyhow::Error>| {
+                        let halt_status = HealthStatusUpdate::halting(
+                            err.display_with_causes().to_string(),
+                            None,
+                        );
+                        HealthStatusMessage {
+                            id: None,
+                            namespace: StatusNamespace::Internal,
+                            update: halt_status,
+                        }
+                    });
+                    health_streams.push(sink_health.leave(root_scope));
+                }
+
+                mz_scope
+                    .concatenate(upper_streams)
+                    .connect_loop(feedback_handle);
+
+                let health_stream = root_scope.concatenate(health_streams);
+                let health_token = crate::healthcheck::health_operator(
+                    root_scope,
+                    storage_state.now.clone(),
+                    resume_uppers
+                        .iter()
+                        .filter_map(|(id, frontier)| {
+                            // If the collection isn't closed, then we will remark it as Starting as
+                            // the dataflow comes up.
+                            (!frontier.is_empty()).then_some(*id)
+                        })
+                        .collect(),
+                    primary_source_id,
+                    "source",
+                    health_stream,
+                    crate::healthcheck::DefaultWriter {
+                        command_tx: storage_state.internal_cmd_tx.clone(),
+                        updates: Rc::clone(&storage_state.shared_status_updates),
+                    },
+                    storage_state
+                        .storage_configuration
+                        .parameters
+                        .record_namespaced_errors,
+                    dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
+                        .get(storage_state.storage_configuration.config_set()),
+                );
+                tokens.push(health_token);
+
                 storage_state
-                    .storage_configuration
-                    .parameters
-                    .record_namespaced_errors,
-                dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
-                    .get(storage_state.storage_configuration.config_set()),
-            );
-            tokens.push(health_token);
-
-            storage_state
-                .source_tokens
-                .insert(primary_source_id, tokens);
+                    .source_tokens
+                    .insert(primary_source_id, tokens);
+            })
         })
     });
 }
@@ -446,36 +450,36 @@ pub fn build_export_dataflow(
     let debug_name = id.to_string();
     let name = format!("Source dataflow: {debug_name}");
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
-        let scope = scope.with_label();
+        scope.with_label(|scope| {
+            let mut tokens = vec![];
+            let (health_stream, sink_tokens) =
+                crate::render::sinks::render_sink(scope, storage_state, id, &description);
+            tokens.extend(sink_tokens);
 
-        let mut tokens = vec![];
-        let (health_stream, sink_tokens) =
-            crate::render::sinks::render_sink(scope, storage_state, id, &description);
-        tokens.extend(sink_tokens);
+            // Note that sinks also have only 1 active worker, which simplifies the work that
+            // `health_operator` has to do internally.
+            let health_token = crate::healthcheck::health_operator(
+                scope,
+                storage_state.now.clone(),
+                [id].into_iter().collect(),
+                id,
+                "sink",
+                health_stream,
+                crate::healthcheck::DefaultWriter {
+                    command_tx: storage_state.internal_cmd_tx.clone(),
+                    updates: Rc::clone(&storage_state.shared_status_updates),
+                },
+                storage_state
+                    .storage_configuration
+                    .parameters
+                    .record_namespaced_errors,
+                dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
+                    .get(storage_state.storage_configuration.config_set()),
+            );
+            tokens.push(health_token);
 
-        // Note that sinks also have only 1 active worker, which simplifies the work that
-        // `health_operator` has to do internally.
-        let health_token = crate::healthcheck::health_operator(
-            scope,
-            storage_state.now.clone(),
-            [id].into_iter().collect(),
-            id,
-            "sink",
-            health_stream,
-            crate::healthcheck::DefaultWriter {
-                command_tx: storage_state.internal_cmd_tx.clone(),
-                updates: Rc::clone(&storage_state.shared_status_updates),
-            },
-            storage_state
-                .storage_configuration
-                .parameters
-                .record_namespaced_errors,
-            dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
-                .get(storage_state.storage_configuration.config_set()),
-        );
-        tokens.push(health_token);
-
-        storage_state.sink_tokens.insert(id, tokens);
+            storage_state.sink_tokens.insert(id, tokens);
+        });
     });
 }
 
@@ -504,17 +508,18 @@ pub(crate) fn build_oneshot_ingestion_dataflow(
 
     let name = format!("Oneshot ingestion: {ingestion_id}");
     let tokens = timely_worker.dataflow_named(&name, |scope| {
-        let scope = scope.with_label();
-        mz_storage_operators::oneshot_source::render(
-            scope,
-            Arc::clone(&storage_state.persist_clients),
-            connection_context,
-            collection_id,
-            collection_meta,
-            description,
-            enforce_external_addresses,
-            callback,
-        )
+        scope.with_label(|scope| {
+            mz_storage_operators::oneshot_source::render(
+                scope,
+                Arc::clone(&storage_state.persist_clients),
+                connection_context,
+                collection_id,
+                collection_meta,
+                description,
+                enforce_external_addresses,
+                callback,
+            )
+        })
     });
     let ingestion_description = OneshotIngestionDescription {
         tokens,

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -23,6 +23,7 @@ bincode.workspace = true
 bytemuck.workspace = true
 columnar.workspace = true
 columnation.workspace = true
+custom-labels.workspace = true
 differential-dataflow.workspace = true
 either.workspace = true
 futures-util.workspace = true

--- a/src/timely-util/src/columnation.rs
+++ b/src/timely-util/src/columnation.rs
@@ -96,6 +96,11 @@ impl<T: Columnation> ColumnationStack<T> {
     ///
     /// The element can be read by indexing.
     pub fn copy(&mut self, item: &T) {
+        // SAFETY: `Region::copy` returns an item whose owned-looking allocations alias into
+        // `self.inner`. We push it into `self.local`, which is a tombstone vector: every code
+        // path that drops or shortens `self.local` (`clear`, `Drop`, `retain_from`) calls
+        // `set_len(0)` first, so Rust's `Drop` glue never runs on these aliasing elements.
+        // The aliased contents remain valid until `self.inner.clear()` is invoked.
         unsafe {
             self.local.push(self.inner.copy(item));
         }
@@ -103,6 +108,10 @@ impl<T: Columnation> ColumnationStack<T> {
 
     /// Empties the collection.
     pub fn clear(&mut self) {
+        // SAFETY: `set_len(0)` is sound because shrinking is always valid; doing it before
+        // `inner.clear()` ensures Rust's `Drop` glue does not run on elements that alias into
+        // the region. `Region::clear` is then safe to call because no live `Region::copy`
+        // results remain in `self.local`.
         unsafe {
             self.local.set_len(0);
             self.inner.clear();
@@ -182,6 +191,9 @@ impl<T: Columnation> ColumnationStack<T> {
 impl<A: Columnation, B: Columnation> ColumnationStack<(A, B)> {
     /// Copies a destructured tuple `(A, B)` into this column stack.
     pub fn copy_destructured(&mut self, t1: &A, t2: &B) {
+        // SAFETY: Same reasoning as `copy`: `Region::copy_destructured` returns aliasing
+        // contents valid for the lifetime of `self.inner`; `self.local`'s `Drop` glue is
+        // skipped via `set_len(0)` in `clear`/`Drop`/`retain_from`.
         unsafe {
             self.local.push(self.inner.copy_destructured(t1, t2));
         }
@@ -191,6 +203,9 @@ impl<A: Columnation, B: Columnation> ColumnationStack<(A, B)> {
 impl<A: Columnation, B: Columnation, C: Columnation> ColumnationStack<(A, B, C)> {
     /// Copies a destructured tuple `(A, B, C)` into this column stack.
     pub fn copy_destructured(&mut self, r0: &A, r1: &B, r2: &C) {
+        // SAFETY: Same reasoning as `copy`: `Region::copy_destructured` returns aliasing
+        // contents valid for the lifetime of `self.inner`; `self.local`'s `Drop` glue is
+        // skipped via `set_len(0)` in `clear`/`Drop`/`retain_from`.
         unsafe {
             self.local.push(self.inner.copy_destructured(r0, r1, r2));
         }

--- a/src/timely-util/src/reclock.rs
+++ b/src/timely-util/src/reclock.rs
@@ -194,9 +194,17 @@ use timely::progress::{Antichain, Timestamp};
 /// into the corresponding `reclocked` collection varying over some time `IntoTime` using the
 /// provided `remap` collection.
 ///
-/// In order for the operator to read the `source` collection a `Pusher` is returned which can be
-/// used with timely's capture facilities to connect a collection from a foreign scope to this
-/// operator.
+/// # Pusher contract
+///
+/// The returned `Box<dyn Push<...>>` is the operator's source-side input. The operator activates
+/// only when the pusher pushes data or progress, so the caller **must** drive it from the foreign
+/// `FromTime` scope (typically by feeding `capture()` events into it). If the pusher is dropped
+/// without ever being used, the operator never observes a `FromTime` frontier advance and its
+/// `reclocked` output frontier stays pinned at `as_of`, which presents as a silent deadlock at
+/// the consumer.
+///
+/// To signal end of input, drop the pusher: this advances the source frontier to the empty
+/// antichain and lets the operator drain.
 pub fn reclock<'scope, D, FromTime, IntoTime, R>(
     remap_collection: VecCollection<'scope, IntoTime, FromTime, Overflowing<i64>>,
     as_of: Antichain<IntoTime>,

--- a/src/timely-util/src/scope_label.rs
+++ b/src/timely-util/src/scope_label.rs
@@ -16,7 +16,7 @@
 //! Scopes with profiling labels set at schedule time.
 //!
 //! [`ScopeExt::with_label`] wraps the body of a dataflow in a same-timestamp subgraph and
-//! installs that subgraph as a [`LabelledOperator`]. Whenever the resulting operator is
+//! installs that subgraph as a `LabelledOperator`. Whenever the resulting operator is
 //! scheduled, its child operators are scheduled inside a `custom_labels` scope that sets
 //! `timely-scope=<scope name>`. CPU profilers that read the `custom_labels` thread-local state
 //! (e.g., PolarSignals) attribute samples taken during the subgraph's execution to that label.

--- a/src/timely-util/src/scope_label.rs
+++ b/src/timely-util/src/scope_label.rs
@@ -14,20 +14,111 @@
 // limitations under the License.
 
 //! Scopes with profiling labels set at schedule time.
+//!
+//! [`ScopeExt::with_label`] wraps the body of a dataflow in a same-timestamp subgraph and
+//! installs that subgraph as a [`LabelledOperator`]. Whenever the resulting operator is
+//! scheduled, its child operators are scheduled inside a `custom_labels` scope that sets
+//! `timely-scope=<scope name>`. CPU profilers that read the `custom_labels` thread-local state
+//! (e.g., PolarSignals) attribute samples taken during the subgraph's execution to that label.
+//!
+//! The previous in-place `Scope` wrapper (pre-timely-v4) is no longer expressible against
+//! the v4 API, since `Scope` is now a concrete struct. The current implementation introduces
+//! one extra subgraph layer per call site, with the associated progress-tracking overhead.
+
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use timely::dataflow::Scope;
-use timely::progress::Timestamp;
+use timely::progress::operate::{Connectivity, FrontierInterest, SharedProgress};
+use timely::progress::{Operate, Timestamp};
+use timely::scheduling::Schedule;
 
-/// Extension trait for timely [`Scope`] that allows one to convert a scope into one that sets its
-/// name as a profiling label before scheduling its child operators.
-pub trait ScopeExt: Sized {
-    fn with_label(self) -> Self;
+/// Wraps an [`Operate`] so that each `schedule()` call on the initialized object runs within
+/// a `custom_labels` scope tagged `timely-scope=<label>`.
+struct LabelledOperator<O> {
+    label: String,
+    inner: O,
 }
 
-impl<'scope, T: Timestamp> ScopeExt for Scope<'scope, T> {
-    fn with_label(self) -> Self {
-        // TODO(mcsherry): figure out what this is meant to do, and help do it.
-        // Restoring labelling via `scoped_raw` is the likely path forward.
-        self
+impl<T: Timestamp, O: Operate<T>> Operate<T> for LabelledOperator<O> {
+    fn local(&self) -> bool {
+        self.inner.local()
+    }
+
+    fn inputs(&self) -> usize {
+        self.inner.inputs()
+    }
+
+    fn outputs(&self) -> usize {
+        self.inner.outputs()
+    }
+
+    fn notify_me(&self) -> &[FrontierInterest] {
+        self.inner.notify_me()
+    }
+
+    fn initialize(
+        self: Box<Self>,
+    ) -> (
+        Connectivity<T::Summary>,
+        Rc<RefCell<SharedProgress<T>>>,
+        Box<dyn Schedule>,
+    ) {
+        let LabelledOperator { label, inner } = *self;
+        let (connectivity, progress, schedule) = Box::new(inner).initialize();
+        let labelled = LabelledSchedule {
+            label,
+            inner: schedule,
+        };
+        (connectivity, progress, Box::new(labelled))
+    }
+}
+
+/// Wrapper around an initialized [`Schedule`] that sets a profiling label on each call.
+struct LabelledSchedule {
+    label: String,
+    inner: Box<dyn Schedule>,
+}
+
+impl Schedule for LabelledSchedule {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn path(&self) -> &[usize] {
+        self.inner.path()
+    }
+
+    #[inline(always)]
+    fn schedule(&mut self) -> bool {
+        custom_labels::with_label("timely-scope", &self.label, || self.inner.schedule())
+    }
+}
+
+/// Extension trait for timely [`Scope`] that runs `func` inside a labelled subgraph,
+/// causing CPU profile samples taken during operator scheduling within `func` to be
+/// attributed to the parent scope's name via the `timely-scope` label.
+pub trait ScopeExt<T: Timestamp>: Sized {
+    /// Runs `func` inside a labelled same-timestamp subgraph using the current scope's name.
+    fn with_label<R, F>(self, func: F) -> R
+    where
+        F: for<'a> FnOnce(Scope<'a, T>) -> R;
+}
+
+impl<T: Timestamp> ScopeExt<T> for Scope<'_, T> {
+    fn with_label<R, F>(self, func: F) -> R
+    where
+        F: for<'a> FnOnce(Scope<'a, T>) -> R,
+    {
+        let label = self.name();
+        // `scoped_raw` lets us intercept the to-be-installed subgraph and wrap it before
+        // handing it to `OperatorSlot::install`. This is the only v4 hook that gives access
+        // to the operator object behind a child scope.
+        let (result, subgraph, slot) = self.scoped_raw::<T, R, _>(&label, func);
+        slot.install(Box::new(LabelledOperator {
+            label,
+            inner: subgraph,
+        }));
+        result
     }
 }


### PR DESCRIPTION
### Motivation

Bundle of mechanical cleanups identified during a tech-debt audit of `src/compute` and `src/timely-util` ([CLU-81](https://linear.app/materializeinc/issue/CLU-81)). One PR to avoid spam; each item is independent and can be reviewed in isolation by file.

### Description

* **timely-util/columnation**: add `SAFETY` comments on every `unsafe` block in `ColumnationStack` (`copy`, `clear`, two `copy_destructured`). Project rule: every `unsafe` needs a `SAFETY` justification. Invariant: `Region::copy` returns aliasing items; `local: Vec<T>` is a tombstone whose `Drop` glue is suppressed via `set_len(0)` before drop.

* **timely-util/reclock**: document the pusher contract under a `# Pusher contract` heading. The function returns a `Box<dyn Push<...>>` that callers must drive — if it is dropped without ever being used, the operator silently deadlocks at the consumer.

* **timely-util/scope_label**: re-implement the `timely-scope` profiling label that was gutted in the timely v4 upgrade (was a no-op `with_label(self) -> Self`). New design wraps the body of a dataflow in a same-timestamp subgraph installed as a `LabelledOperator`; each `schedule()` call runs inside a `custom_labels` scope tagged `timely-scope=<name>`. The pre-v4 in-place `Scope` wrapper is no longer expressible (timely v4 made `Scope` a concrete struct), so the API changes from `let scope = scope.with_label();` to `scope.with_label(|scope| { ... })`. All seven call sites in compute and storage are migrated. There is one extra subgraph layer per dataflow now, with associated progress-tracking overhead.

* **compute/arrangement**: add `debug_assert!` for the `PaddedTrace` invariant (`padded_since` strictly less than the inner trace's logical compaction frontier) at both mutation sites in `into_padded` and `set_logical_compaction`. The invariant was previously comment-only and unenforced.

The large line counts in the storage/compute `render.rs` files are mostly `cargo fmt` re-indentation from wrapping the dataflow body in a closure; the actual semantic change at each site is one extra level of nesting.

### Verification

* `cargo check --workspace` passes.
* `cargo clippy --workspace --all-targets -- -D warnings` passes.
* `bin/lint` rustfmt step passes (other unrelated lint failures: missing `buf`, `trufflehog`, `protobuf` tooling in this environment).