### PR TITLE
mzbuild: Fix parsing --arch parameters, bump bootstrap version for xcompile

### DIFF
--- a/misc/completions/bash/_mzcompose
+++ b/misc/completions/bash/_mzcompose
@@ -43,7 +43,6 @@ _shtab_mzcompose_completion_option_strings=('-h' '--help')
 
 _shtab_mzcompose_pos_0_choices=('build' 'config' 'cp' 'create' 'describe' 'ls' 'list' 'description' 'down' 'events' 'exec' 'gen-shortcuts' 'help' 'images' 'kill' 'list-compositions' 'list-workflows' 'logs' 'pause' 'port' 'ps' 'pull' 'push' 'restart' 'rm' 'run' 'scale' 'start' 'stop' 'sql' 'top' 'unpause' 'up' 'web' 'completion')
 _shtab_mzcompose___sanitizer_choices=('address' 'hwaddress' 'cfi' 'thread' 'leak' 'undefined' 'none')
-_shtab_mzcompose___arch_choices=('X86_64' 'AARCH64')
 _shtab_mzcompose_completion_pos_0_choices=('bash' 'zsh' 'tcsh')
 
 _shtab_mzcompose_pos_0_nargs=A...

--- a/misc/completions/zsh/_mzcompose
+++ b/misc/completions/zsh/_mzcompose
@@ -58,7 +58,7 @@ _shtab_mzcompose_options=(
   "--optimized[build Rust binaries with the optimized profile (optimizations, no LTO, no debug symbols)]"
   "--coverage[whether to enable code coverage compilation flags]"
   "--sanitizer[whether to enable a sanitizer]:sanitizer:(address hwaddress cfi thread leak undefined none)"
-  "--arch[the CPU architecture to build for]:arch:(X86_64 AARCH64)"
+  "--arch[the CPU architecture to build for]:arch:"
   "--image-registry[the Docker image registry to pull images from and push images to]:image_registry:"
   "--image-prefix[a prefix to apply to all Docker image names]:image_prefix:"
 )

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -1500,12 +1500,22 @@ class Repository:
             type=Sanitizer,
             choices=Sanitizer,
         )
+
+        def _parse_arch(s: str) -> Arch:
+            try:
+                return Arch(s)
+            except ValueError:
+                valid = ", ".join(m.value for m in Arch)
+                raise argparse.ArgumentTypeError(
+                    f"invalid arch: {s!r} (choose from {valid})"
+                )
+
         parser.add_argument(
             "--arch",
             default=Arch.host(),
             help="the CPU architecture to build for",
-            type=Arch,
-            choices=Arch,
+            type=_parse_arch,
+            metavar="{" + ",".join(m.value for m in Arch) + "}",
         )
         parser.add_argument(
             "--image-registry",

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -217,7 +217,7 @@ def _bootstrap_darwin(arch: Arch) -> None:
     # Building in Docker for Mac is painfully slow, so we install a
     # cross-compiling toolchain on the host and use that instead.
 
-    BOOTSTRAP_VERSION = "6"
+    BOOTSTRAP_VERSION = "7"
     BOOTSTRAP_FILE = MZ_ROOT / "target-xcompile" / target(arch) / ".xcompile-bootstrap"
     try:
         contents = BOOTSTRAP_FILE.read_text()


### PR DESCRIPTION
Noticed with `bin/mzcompose --arch x86_64 --find testdrive run default`

Makes our target-xcompile pick up the latest https://github.com/MaterializeInc/homebrew-crosstools/pull/18