### PR TITLE
catalog: propagate RoleAuth.updated_at in UpdateFrom

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -336,6 +336,7 @@ impl UpdateFrom<durable::RoleAuth> for RoleAuth {
     fn update_from(&mut self, from: durable::RoleAuth) {
         self.role_id = from.role_id;
         self.password_hash = from.password_hash;
+        self.updated_at = from.updated_at;
     }
 }
 


### PR DESCRIPTION
`ALTER ROLE ... PASSWORD` updates the in-memory RoleAuth via a paired retraction + addition that reuses the existing value and calls update_from, but didn't set the `updated_at` value.