### PR TITLE
compute: scaffold CollectionEdge for columnar dataflow edges

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -169,6 +169,7 @@ use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
 use mz_row_spine::{DatumSeq, RowRowBatcher, RowRowBuilder};
 
+mod columnar;
 pub mod context;
 pub(crate) mod errors;
 mod flat_map;

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -169,7 +169,7 @@ use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
 use mz_row_spine::{DatumSeq, RowRowBatcher, RowRowBuilder};
 
-mod columnar;
+pub(crate) mod columnar;
 pub mod context;
 pub(crate) mod errors;
 mod flat_map;
@@ -937,6 +937,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // We need to ensure that the raw collection exists, but do not have enough information
                 // here to cause that to happen.
                 let (oks, mut err) = bundle.collection.clone().unwrap();
+                let oks = oks.expect_vec();
                 self.insert_id(Id::Local(id), bundle);
                 let (oks_v, err_v) = variables.remove(&Id::Local(id)).unwrap();
 
@@ -992,6 +993,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
             for id in rec_ids.into_iter() {
                 let bundle = self.remove_id(Id::Local(id)).unwrap();
                 let (oks, err) = bundle.collection.unwrap();
+                let oks = oks.expect_vec();
                 self.insert_id(
                     Id::Local(id),
                     CollectionBundle::from_collections(
@@ -1317,8 +1319,11 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
             }
             Negate { input } => {
                 let input = expect_input(input);
-                let (oks, errs) = input.as_specific_collection(None, &self.config_set);
-                CollectionBundle::from_collections(oks.negate(), errs)
+                let (oks, errs) = input
+                    .collection
+                    .clone()
+                    .expect("Negate input must be an unarranged collection");
+                CollectionBundle::from_edge(oks.negate(), errs)
             }
             Threshold {
                 input,
@@ -1442,8 +1447,9 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     .collection
                     .as_mut()
                     .expect("CollectionBundle invariant");
-                let stream = self.log_operator_hydration_inner(oks.inner.clone(), lir_id);
-                *oks = stream.as_collection();
+                let oks_vec = oks.expect_vec_mut();
+                let stream = self.log_operator_hydration_inner(oks_vec.inner.clone(), lir_id);
+                *oks_vec = stream.as_collection();
             }
         }
     }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -164,6 +164,7 @@ use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
     ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors, OperatorHydration,
 };
+use crate::render::columnar::CollectionEdge;
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
@@ -937,7 +938,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // We need to ensure that the raw collection exists, but do not have enough information
                 // here to cause that to happen.
                 let (oks, mut err) = bundle.collection.clone().unwrap();
-                let oks = oks.expect_vec();
+                let oks = oks.into_vec();
                 self.insert_id(Id::Local(id), bundle);
                 let (oks_v, err_v) = variables.remove(&Id::Local(id)).unwrap();
 
@@ -993,7 +994,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
             for id in rec_ids.into_iter() {
                 let bundle = self.remove_id(Id::Local(id)).unwrap();
                 let (oks, err) = bundle.collection.unwrap();
-                let oks = oks.expect_vec();
+                let oks = oks.into_vec();
                 self.insert_id(
                     Id::Local(id),
                     CollectionBundle::from_collections(
@@ -1354,21 +1355,19 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                             .get(&self.config_set)
                             .try_into()
                             .expect("must fit");
-                        let os = os.expect_vec();
-                        crate::render::columnar::CollectionEdge::Vec(
-                            T::maybe_apply_temporal_bucketing(
-                                os.inner,
-                                self.as_of_frontier.clone(),
-                                summary,
-                            ),
-                        )
+                        let os = os.into_vec();
+                        CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
+                            os.inner,
+                            self.as_of_frontier.clone(),
+                            summary,
+                        ))
                     } else {
                         os
                     };
                     oks.push(os);
                     errs.push(es);
                 }
-                let oks = crate::render::columnar::CollectionEdge::concat_many(self.scope, oks);
+                let oks = CollectionEdge::concat_many(self.scope, oks);
                 let oks = if consolidate_output {
                     oks.consolidate_named("UnionConsolidation")
                 } else {
@@ -1451,9 +1450,16 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     .collection
                     .as_mut()
                     .expect("CollectionBundle invariant");
-                let oks_vec = oks.expect_vec_mut();
-                let stream = self.log_operator_hydration_inner(oks_vec.inner.clone(), lir_id);
-                *oks_vec = stream.as_collection();
+                match oks {
+                    CollectionEdge::Vec(c) => {
+                        let stream = self.log_operator_hydration_inner(c.inner.clone(), lir_id);
+                        *c = stream.as_collection();
+                    }
+                    CollectionEdge::Columnar(c) => {
+                        let stream = self.log_operator_hydration_inner(c.inner.clone(), lir_id);
+                        *c = stream.as_collection();
+                    }
+                }
             }
         }
     }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1340,8 +1340,10 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                 let mut oks = Vec::new();
                 let mut errs = Vec::new();
                 for (input, strategy) in inputs.into_iter().zip_eq(temporal_bucketing_strategies) {
-                    let (os, es) =
-                        expect_input(input).as_specific_collection(None, &self.config_set);
+                    let (os, es) = expect_input(input)
+                        .collection
+                        .clone()
+                        .expect("Union input must be an unarranged collection");
                     // Apply per-input temporal bucketing. No-op for `Direct`.
                     // Only consolidating Unions carry non-`Direct` strategies;
                     // see the `Union` arm of `lower_mir_expr_stack_safe`.
@@ -1352,10 +1354,13 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                             .get(&self.config_set)
                             .try_into()
                             .expect("must fit");
-                        T::maybe_apply_temporal_bucketing(
-                            os.inner,
-                            self.as_of_frontier.clone(),
-                            summary,
+                        let os = os.expect_vec();
+                        crate::render::columnar::CollectionEdge::Vec(
+                            T::maybe_apply_temporal_bucketing(
+                                os.inner,
+                                self.as_of_frontier.clone(),
+                                summary,
+                            ),
                         )
                     } else {
                         os
@@ -1363,15 +1368,14 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     oks.push(os);
                     errs.push(es);
                 }
-                let mut oks = differential_dataflow::collection::concatenate(self.scope, oks);
-                if consolidate_output {
-                    oks = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(
-                        oks,
-                        "UnionConsolidation",
-                    )
-                }
+                let oks = crate::render::columnar::CollectionEdge::concat_many(self.scope, oks);
+                let oks = if consolidate_output {
+                    oks.consolidate_named("UnionConsolidation")
+                } else {
+                    oks
+                };
                 let errs = differential_dataflow::collection::concatenate(self.scope, errs);
-                CollectionBundle::from_collections(oks, errs)
+                CollectionBundle::from_edge(oks, errs)
             }
             ArrangeBy {
                 input_key,

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -360,3 +360,197 @@ where
         )
         .as_collection()
 }
+
+#[cfg(test)]
+mod tests {
+    use differential_dataflow::input::Input;
+    use mz_ore::cast::CastFrom;
+    use mz_repr::{Datum, Timestamp};
+    use timely::dataflow::operators::Capture;
+    use timely::dataflow::operators::capture::{Event, Extract};
+
+    use super::*;
+
+    type RowBuilder = CapacityContainerBuilder<Vec<(Row, Timestamp, Diff)>>;
+    type CapturedRows = std::sync::mpsc::Receiver<Event<Timestamp, Vec<(Row, Timestamp, Diff)>>>;
+
+    fn extract_sorted(captured: CapturedRows) -> Vec<(Row, Timestamp, Diff)> {
+        let mut updates: Vec<_> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    fn test_rows() -> Vec<Row> {
+        vec![
+            Row::pack_slice(&[Datum::Int32(42), Datum::String("hello")]),
+            Row::pack_slice(&[Datum::Int64(100), Datum::Null]),
+            Row::pack_slice(&[Datum::True, Datum::False, Datum::Null]),
+            Row::default(),
+        ]
+    }
+
+    #[mz_ore::test]
+    fn round_trip_through_columnar() {
+        let rows = test_rows();
+        let expected: Vec<_> = {
+            let mut updates: Vec<_> = rows
+                .iter()
+                .enumerate()
+                .map(|(i, r)| (r.clone(), Timestamp::from(u64::cast_from(i / 2)), Diff::ONE))
+                .collect();
+            updates.sort();
+            updates
+        };
+        let captured = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let captured = columnar_to_vec(vec_to_columnar(collection)).inner.capture();
+                for (i, row) in rows.into_iter().enumerate() {
+                    input.advance_to(Timestamp::from(u64::cast_from(i / 2)));
+                    input.update(row, Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(2_u64));
+                input.flush();
+                captured
+            })
+        });
+        assert_eq!(extract_sorted(captured), expected);
+    }
+
+    #[mz_ore::test]
+    fn negate_flips_diffs_on_columnar_arm() {
+        let rows = test_rows();
+        let expected: Vec<_> = {
+            let mut updates: Vec<_> = rows
+                .iter()
+                .map(|r| (r.clone(), Timestamp::from(0_u64), -Diff::ONE))
+                .collect();
+            updates.sort();
+            updates
+        };
+        let captured = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let edge = CollectionEdge::Columnar(vec_to_columnar(collection)).negate();
+                assert!(matches!(edge, CollectionEdge::Columnar(_)));
+                let captured = edge.into_vec().inner.capture();
+                for row in rows {
+                    input.update(row, Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(1_u64));
+                input.flush();
+                captured
+            })
+        });
+        assert_eq!(extract_sorted(captured), expected);
+    }
+
+    #[mz_ore::test]
+    fn concat_many_mixed_upgrades_to_columnar() {
+        let rows = test_rows();
+        let expected: Vec<_> = {
+            let mut updates: Vec<_> = rows
+                .iter()
+                .map(|r| (r.clone(), Timestamp::from(0_u64), Diff::ONE))
+                .collect();
+            // The first row arrives on both inputs.
+            updates.push((rows[0].clone(), Timestamp::from(0_u64), Diff::ONE));
+            updates.sort();
+            updates
+        };
+        let captured = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input1, collection1) = scope.new_collection();
+                let (mut input2, collection2) = scope.new_collection();
+                let edge = CollectionEdge::concat_many(
+                    scope,
+                    [
+                        CollectionEdge::Vec(collection1),
+                        CollectionEdge::Columnar(vec_to_columnar(collection2)),
+                    ],
+                );
+                assert!(matches!(edge, CollectionEdge::Columnar(_)));
+                let captured = edge.into_vec().inner.capture();
+                let (first, rest) = rows.split_first().unwrap();
+                input1.update(first.clone(), Diff::ONE);
+                input2.update(first.clone(), Diff::ONE);
+                for row in rest {
+                    input1.update(row.clone(), Diff::ONE);
+                }
+                for input in [&mut input1, &mut input2] {
+                    input.advance_to(Timestamp::from(1_u64));
+                    input.flush();
+                }
+                captured
+            })
+        });
+        assert_eq!(extract_sorted(captured), expected);
+    }
+
+    #[mz_ore::test]
+    fn flat_map_datums_arms_agree() {
+        // Project the first datum of each row, exercising `max_demand` on both
+        // arms. The two captures must extract identical updates.
+        let rows = test_rows();
+        let (vec_captured, col_captured) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let mut captures = Vec::new();
+                for edge in [
+                    CollectionEdge::Vec(collection.clone()),
+                    CollectionEdge::Columnar(vec_to_columnar(collection)),
+                ] {
+                    let (oks, _errs) = edge.flat_map_datums::<RowBuilder, _>(
+                        1,
+                        |datums, t, d, ok_session, _err_session| {
+                            ok_session.give((Row::pack(datums.iter()), t, d));
+                            1
+                        },
+                    );
+                    captures.push(oks.capture());
+                }
+                let col = captures.pop().unwrap();
+                let vec = captures.pop().unwrap();
+                for row in rows {
+                    input.update(row, Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(1_u64));
+                input.flush();
+                (vec, col)
+            })
+        });
+        let vec_updates = extract_sorted(vec_captured);
+        assert_eq!(vec_updates, extract_sorted(col_captured));
+        // Each output row retains at most the first datum of its input.
+        assert!(vec_updates.iter().all(|(r, _, _)| r.iter().count() <= 1));
+    }
+
+    #[mz_ore::test]
+    fn consolidate_named_preserves_columnar() {
+        let row1 = Row::pack_slice(&[Datum::Int32(1)]);
+        let row2 = Row::pack_slice(&[Datum::Int32(2)]);
+        let expected = vec![(row1.clone(), Timestamp::from(0_u64), Diff::from(2))];
+        let captured = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let edge =
+                    CollectionEdge::Columnar(vec_to_columnar(collection)).consolidate_named("Test");
+                assert!(matches!(edge, CollectionEdge::Columnar(_)));
+                let captured = edge.into_vec().inner.capture();
+                // `row1` accumulates to a diff of two, `row2` cancels.
+                input.update(row1.clone(), Diff::ONE);
+                input.update(row1, Diff::ONE);
+                input.update(row2.clone(), Diff::ONE);
+                input.update(row2, -Diff::ONE);
+                input.advance_to(Timestamp::from(1_u64));
+                input.flush();
+                captured
+            })
+        });
+        assert_eq!(extract_sorted(captured), expected);
+    }
+}

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -56,11 +56,24 @@ where
     pub inner: Stream<'scope, T, Column<(D, T, R)>>,
 }
 
+impl<'scope, T, D, R> Clone for ColumnarCollection<'scope, T, D, R>
+where
+    T: Timestamp,
+    (D, T, R): Columnar,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
 /// A dataflow edge carrying records as either a row-based [`VecCollection`] or
 /// a [`ColumnarCollection`].
 ///
 /// Producers choose a variant; consumers must accept either. Mixing variants
 /// across a `concat` is rejected during the transition.
+#[derive(Clone)]
 pub enum CollectionEdge<'scope, T: RenderTimestamp> {
     /// Row-formatted collection. Today's default for every producer.
     Vec(VecCollection<'scope, T, Row, Diff>),
@@ -87,6 +100,42 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
                 // the first producer emits this variant.
                 todo!("CollectionEdge::Columnar::enter_region")
             }
+        }
+    }
+
+    /// Leaves a sub-region back to the outer scope.
+    pub fn leave_region<'outer>(self, outer: Scope<'outer, T>) -> CollectionEdge<'outer, T> {
+        match self {
+            CollectionEdge::Vec(c) => CollectionEdge::Vec(c.leave_region(outer)),
+            CollectionEdge::Columnar(_) => {
+                todo!("CollectionEdge::Columnar::leave_region")
+            }
+        }
+    }
+
+    /// Extracts the [`VecCollection`] arm, panicking on the columnar arm.
+    ///
+    /// This is a transitional fence used at consumer sites that have not yet
+    /// been converted to handle the columnar arm natively. Each Phase-B
+    /// consumer PR removes one call.
+    pub fn expect_vec(self) -> VecCollection<'scope, T, Row, Diff> {
+        match self {
+            CollectionEdge::Vec(c) => c,
+            CollectionEdge::Columnar(_) => panic!(
+                "CollectionEdge::expect_vec called on columnar arm; consumer must convert first"
+            ),
+        }
+    }
+
+    /// Borrows the [`VecCollection`] arm mutably, panicking on the columnar arm.
+    ///
+    /// Transitional fence; see [`Self::expect_vec`].
+    pub fn expect_vec_mut(&mut self) -> &mut VecCollection<'scope, T, Row, Diff> {
+        match self {
+            CollectionEdge::Vec(c) => c,
+            CollectionEdge::Columnar(_) => panic!(
+                "CollectionEdge::expect_vec_mut called on columnar arm; consumer must convert first"
+            ),
         }
     }
 

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -16,33 +16,32 @@
 //! # Migration model
 //!
 //! The migration is consumer-first: every Plan-node consumer learns to accept
-//! both variants before any producer emits the columnar variant. Once all
-//! consumers are ready, a single switch flips producers to columnar end-to-end.
+//! both variants before any producer emits the columnar variant. Producers can
+//! then flip to columnar one at a time.
 //!
 //! Within a Plan node, operators may freely materialize Vec collections; only
 //! the inter-node edge format is constrained. A decode from columnar to Vec at
 //! a consumer's input is acceptable only when the consumer would have decoded
 //! `Row` to [`mz_repr::Datum`] anyway. Pure passthrough consumers (Negate,
-//! Union) must round-trip the columnar variant without decoding.
+//! Union) round-trip the columnar variant without decoding.
 //!
-//! See `.claude/plans/columnar_consumer_first.md` for the staged plan.
+//! Consumers that have not yet learned the columnar form fall back to
+//! [`CollectionEdge::into_vec`], which decodes through the named
+//! `ColumnarToVec` operator. Repack seams therefore stay visible in dataflow
+//! introspection, so they can be found and retired.
 
-#![allow(dead_code)]
-// Phase A defines the type with `todo!()` arms that will be filled in when
-// producers begin emitting columnar batches.
-#![allow(clippy::todo)]
-
-use columnar::Columnar;
-use differential_dataflow::VecCollection;
+use columnar::{Columnar, Index};
+use differential_dataflow::{AsCollection, Collection, VecCollection};
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, Row};
 use mz_timely_util::columnar::Column;
+use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::operator::CollectionExt;
 use timely::ContainerBuilder;
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::operators::generic::{Operator, OutputBuilder};
 use timely::dataflow::{Scope, Stream, StreamVec};
-use timely::progress::Timestamp;
 
 use crate::render::RenderTimestamp;
 use crate::render::context::{ECB, Session};
@@ -52,35 +51,15 @@ use crate::typedefs::KeyBatcher;
 /// A columnar collection of `(D, T, R)` updates traveling on a compute
 /// dataflow edge.
 ///
-/// Mirrors differential's [`VecCollection<'scope, T, D, R>`] shape and
-/// parameters; the underlying container is [`Column<(D, T, R)>`] instead of
-/// `Vec<(D, T, R)>`.
-pub struct ColumnarCollection<'scope, T, D, R>
-where
-    T: Timestamp,
-    (D, T, R): Columnar,
-{
-    /// The underlying timely stream of columnar batches.
-    pub inner: Stream<'scope, T, Column<(D, T, R)>>,
-}
-
-impl<'scope, T, D, R> Clone for ColumnarCollection<'scope, T, D, R>
-where
-    T: Timestamp,
-    (D, T, R): Columnar,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
+/// Mirrors differential's [`VecCollection<'scope, T, D, R>`]; the underlying
+/// container is [`Column<(D, T, R)>`] instead of `Vec<(D, T, R)>`.
+pub type ColumnarCollection<'scope, T, D, R> = Collection<'scope, T, Column<(D, T, R)>>;
 
 /// A dataflow edge carrying records as either a row-based [`VecCollection`] or
 /// a [`ColumnarCollection`].
 ///
-/// Producers choose a variant; consumers must accept either. Mixing variants
-/// across a `concat` is rejected during the transition.
+/// Producers choose a variant; consumers must accept either. Variant-mixing
+/// `concat`s repack the row-based inputs and produce the columnar variant.
 #[derive(Clone)]
 pub enum CollectionEdge<'scope, T: RenderTimestamp> {
     /// Row-formatted collection. Today's default for every producer.
@@ -103,11 +82,7 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
     pub fn enter_region<'inner>(self, region: Scope<'inner, T>) -> CollectionEdge<'inner, T> {
         match self {
             CollectionEdge::Vec(c) => CollectionEdge::Vec(c.enter_region(region)),
-            CollectionEdge::Columnar(_) => {
-                // Sub-region entry for columnar collections will be wired when
-                // the first producer emits this variant.
-                todo!("CollectionEdge::Columnar::enter_region")
-            }
+            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(c.enter_region(region)),
         }
     }
 
@@ -115,42 +90,27 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
     pub fn leave_region<'outer>(self, outer: Scope<'outer, T>) -> CollectionEdge<'outer, T> {
         match self {
             CollectionEdge::Vec(c) => CollectionEdge::Vec(c.leave_region(outer)),
-            CollectionEdge::Columnar(_) => {
-                todo!("CollectionEdge::Columnar::leave_region")
-            }
+            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(c.leave_region(outer)),
         }
     }
 
-    /// Extracts the [`VecCollection`] arm, panicking on the columnar arm.
+    /// The edge as a row-based [`VecCollection`].
     ///
-    /// This is a transitional fence used at consumer sites that have not yet
-    /// been converted to handle the columnar arm natively. Each Phase-B
-    /// consumer PR removes one call.
-    pub fn expect_vec(self) -> VecCollection<'scope, T, Row, Diff> {
+    /// The Vec arm is returned as is. The columnar arm decodes through
+    /// [`columnar_to_vec`], which allocates an owned [`Row`] per record.
+    /// Consumers that can work on the columnar form directly should do so
+    /// instead of calling this.
+    pub fn into_vec(self) -> VecCollection<'scope, T, Row, Diff> {
         match self {
             CollectionEdge::Vec(c) => c,
-            CollectionEdge::Columnar(_) => panic!(
-                "CollectionEdge::expect_vec called on columnar arm; consumer must convert first"
-            ),
-        }
-    }
-
-    /// Borrows the [`VecCollection`] arm mutably, panicking on the columnar arm.
-    ///
-    /// Transitional fence; see [`Self::expect_vec`].
-    pub fn expect_vec_mut(&mut self) -> &mut VecCollection<'scope, T, Row, Diff> {
-        match self {
-            CollectionEdge::Vec(c) => c,
-            CollectionEdge::Columnar(_) => panic!(
-                "CollectionEdge::expect_vec_mut called on columnar arm; consumer must convert first"
-            ),
+            CollectionEdge::Columnar(c) => columnar_to_vec(c),
         }
     }
 
     /// Negates the diff on every record in this edge.
     ///
     /// Preserves variant. The columnar arm uses [`columnar_negate`], which
-    /// flips the diff column without decoding the data column.
+    /// negates diffs without decoding rows.
     pub fn negate(self) -> Self {
         match self {
             CollectionEdge::Vec(c) => CollectionEdge::Vec(c.negate()),
@@ -158,26 +118,30 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
         }
     }
 
-    /// Concatenates a collection of edges that all share the same variant.
+    /// Concatenates a collection of edges.
     ///
-    /// Mixing variants is rejected during the transition.
+    /// Edges of one shared variant concatenate natively. Mixed inputs upgrade
+    /// the row-based edges through [`vec_to_columnar`] and produce the
+    /// columnar variant. Repacking rows into columns copies bytes but
+    /// allocates no per-record `Row`s, so upgrading is the cheap direction.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
-        let mut vec_arm = Vec::new();
+        let mut vecs = Vec::new();
+        let mut cols = Vec::new();
         for edge in edges {
             match edge {
-                CollectionEdge::Vec(c) => vec_arm.push(c),
-                CollectionEdge::Columnar(_) => {
-                    // No producer emits the columnar arm yet; once one does,
-                    // this branch must either concatenate columnar streams or
-                    // reject mixed-variant inputs explicitly.
-                    todo!("CollectionEdge::concat_many: columnar arm");
-                }
+                CollectionEdge::Vec(c) => vecs.push(c),
+                CollectionEdge::Columnar(c) => cols.push(c),
             }
         }
-        CollectionEdge::Vec(differential_dataflow::collection::concatenate(scope, vec_arm))
+        if cols.is_empty() {
+            CollectionEdge::Vec(differential_dataflow::collection::concatenate(scope, vecs))
+        } else {
+            cols.extend(vecs.into_iter().map(vec_to_columnar));
+            CollectionEdge::Columnar(differential_dataflow::collection::concatenate(scope, cols))
+        }
     }
 
     /// Applies `logic` to each record in this edge, exposing the record as a
@@ -245,11 +209,41 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
                 });
                 (ok_stream, err_stream)
             }
-            CollectionEdge::Columnar(_) => {
-                // Implementation will iterate `Column<(Row, T, Diff)>::borrow()`
-                // via the `Rows<_>::Index` impl (yielding `&RowRef`) and call
-                // `DatumVec::borrow_with_limit(row_ref, max_demand)` per row.
-                todo!("CollectionEdge::flat_map_datums: columnar arm")
+            CollectionEdge::Columnar(c) => {
+                let scope = c.inner.scope();
+                let mut builder = OperatorBuilder::new("CollectionFlatMap".to_string(), scope);
+                let (ok_output, ok_stream) = builder.new_output();
+                let mut ok_output = OutputBuilder::<_, DCB>::from(ok_output);
+                let (err_output, err_stream) = builder.new_output();
+                let mut err_output = OutputBuilder::<_, ECB<T>>::from(err_output);
+                let mut input = builder.new_input(c.inner, Pipeline);
+                builder.build(move |_capabilities| {
+                    let mut datums = DatumVec::new();
+                    move |_frontiers| {
+                        let mut ok_output = ok_output.activate();
+                        let mut err_output = err_output.activate();
+                        input.for_each(|time, data| {
+                            // Retain the input capability to derive a `Capability` for each output;
+                            // the `Session` type alias is fixed to `Capability<T>`.
+                            let ok_cap = time.retain(0);
+                            let err_cap = time.retain(1);
+                            let mut ok_session = ok_output.session_with_builder(&ok_cap);
+                            let mut err_session = err_output.session_with_builder(&err_cap);
+                            // Rows are read from the borrowed column, never
+                            // materialized as owned `Row`s.
+                            for (v, t, d) in data.borrow().into_index_iter() {
+                                logic(
+                                    &mut datums.borrow_with_limit(v, max_demand),
+                                    Columnar::into_owned(t),
+                                    Columnar::into_owned(d),
+                                    &mut ok_session,
+                                    &mut err_session,
+                                );
+                            }
+                        });
+                    }
+                });
+                (ok_stream, err_stream)
             }
         }
     }
@@ -257,28 +251,112 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
     /// Consolidates updates in the edge, preserving variant.
     pub fn consolidate_named(self, name: &str) -> Self {
         match self {
-            CollectionEdge::Vec(c) => {
-                CollectionEdge::Vec(CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(c, name))
-            }
-            CollectionEdge::Columnar(_) => {
-                todo!("CollectionEdge::Columnar::consolidate_named")
+            CollectionEdge::Vec(c) => CollectionEdge::Vec(CollectionExt::consolidate_named::<
+                KeyBatcher<_, _, _>,
+            >(c, name)),
+            CollectionEdge::Columnar(c) => {
+                // TODO: Consolidate natively over columns. The pieces exist
+                // (`columnar_exchange`, the columnar merge batchers), which
+                // would avoid the row round-trip below.
+                let c = columnar_to_vec(c);
+                let c = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(c, name);
+                CollectionEdge::Columnar(vec_to_columnar(c))
             }
         }
     }
 }
 
-/// Negates the diff column of every batch in a [`ColumnarCollection`] without
-/// decoding the data column.
-pub fn columnar_negate<'scope, T, D, R>(
-    collection: ColumnarCollection<'scope, T, D, R>,
-) -> ColumnarCollection<'scope, T, D, R>
+/// Negates the diff of every record in a [`ColumnarCollection`].
+///
+/// Rows and times are pushed from their borrowed forms. Only the diff is
+/// materialized, and it is `Copy`.
+pub fn columnar_negate<'scope, T>(
+    collection: ColumnarCollection<'scope, T, Row, Diff>,
+) -> ColumnarCollection<'scope, T, Row, Diff>
 where
-    T: Timestamp,
-    (D, T, R): Columnar,
+    T: RenderTimestamp,
 {
-    // Implementation is deferred until the first producer emits the
-    // [`CollectionEdge::Columnar`] variant. The signature is fixed here so
-    // consumers can target it during the consumer-first phase.
-    let _ = collection;
-    todo!("columnar_negate: flip diff column in place over Column<(D, T, R)>")
+    collection
+        .inner
+        .unary::<ColumnBuilder<(Row, T, Diff)>, _, _, _>(
+            Pipeline,
+            "ColumnarNegate",
+            |_cap, _info| {
+                move |input, output| {
+                    input.for_each(|time, data| {
+                        let mut session = output.session_with_builder(&time);
+                        for (v, t, d) in data.borrow().into_index_iter() {
+                            let d = -Diff::into_owned(d);
+                            session.give((v, t, &d));
+                        }
+                    });
+                }
+            },
+        )
+        .as_collection()
+}
+
+/// Repacks a row-based collection into columnar batches.
+///
+/// A transitional seam-healer, visible in rendered dataflows as a
+/// `VecToColumnar` operator. Repacking copies row bytes but allocates no
+/// per-record `Row`s.
+pub fn vec_to_columnar<'scope, T>(
+    collection: VecCollection<'scope, T, Row, Diff>,
+) -> ColumnarCollection<'scope, T, Row, Diff>
+where
+    T: RenderTimestamp,
+{
+    collection
+        .inner
+        .unary::<ColumnBuilder<(Row, T, Diff)>, _, _, _>(
+            Pipeline,
+            "VecToColumnar",
+            |_cap, _info| {
+                move |input, output| {
+                    input.for_each(|time, data| {
+                        let mut session = output.session_with_builder(&time);
+                        for (v, t, d) in data.drain(..) {
+                            session.give((&v, &t, &d));
+                        }
+                    });
+                }
+            },
+        )
+        .as_collection()
+}
+
+/// Decodes columnar batches into a row-based collection.
+///
+/// A transitional seam-healer, visible in rendered dataflows as a
+/// `ColumnarToVec` operator. Decoding allocates an owned [`Row`] per record,
+/// so it should only guard consumers that have not yet learned the columnar
+/// form.
+pub fn columnar_to_vec<'scope, T>(
+    collection: ColumnarCollection<'scope, T, Row, Diff>,
+) -> VecCollection<'scope, T, Row, Diff>
+where
+    T: RenderTimestamp,
+{
+    collection
+        .inner
+        .unary::<CapacityContainerBuilder<Vec<(Row, T, Diff)>>, _, _, _>(
+            Pipeline,
+            "ColumnarToVec",
+            |_cap, _info| {
+                move |input, output| {
+                    input.for_each(|time, data| {
+                        let mut session = output.session(&time);
+                        for (v, t, d) in data.borrow().into_index_iter() {
+                            session.give((
+                                Columnar::into_owned(v),
+                                Columnar::into_owned(t),
+                                Columnar::into_owned(d),
+                            ));
+                        }
+                    });
+                }
+            },
+        )
+        .as_collection()
 }

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -11,7 +11,7 @@
 //!
 //! Defines [`CollectionEdge`], a wrapper that lets dataflow edges between Plan
 //! nodes carry either row-based ([`VecCollection`]) or columnar
-//! ([`mz_timely_util::columnar::Column`]) batches of `(Row, T, Diff)` updates.
+//! ([`ColumnarCollection`]) batches of `(D, T, R)` updates.
 //!
 //! # Migration model
 //!
@@ -32,29 +32,41 @@
 // producers begin emitting columnar batches.
 #![allow(clippy::todo)]
 
+use columnar::Columnar;
 use differential_dataflow::VecCollection;
 use mz_repr::{Diff, Row};
 use mz_timely_util::columnar::Column;
 use timely::dataflow::{Scope, Stream};
+use timely::progress::Timestamp;
 
 use crate::render::RenderTimestamp;
 
-/// Container for a columnar batch of `(Row, T, Diff)` updates traveling on a
-/// compute dataflow edge.
-pub type ColumnarBatch<T> = Column<(Row, T, Diff)>;
+/// A columnar collection of `(D, T, R)` updates traveling on a compute
+/// dataflow edge.
+///
+/// Mirrors differential's [`VecCollection<'scope, T, D, R>`] shape and
+/// parameters; the underlying container is [`Column<(D, T, R)>`] instead of
+/// `Vec<(D, T, R)>`.
+pub struct ColumnarCollection<'scope, T, D, R>
+where
+    T: Timestamp,
+    (D, T, R): Columnar,
+{
+    /// The underlying timely stream of columnar batches.
+    pub inner: Stream<'scope, T, Column<(D, T, R)>>,
+}
 
 /// A dataflow edge carrying records as either a row-based [`VecCollection`] or
-/// a columnar [`Stream`] of [`ColumnarBatch`]es.
+/// a [`ColumnarCollection`].
 ///
 /// Producers choose a variant; consumers must accept either. Mixing variants
-/// across a `concat` is rejected during the transition: see
-/// [`CollectionEdge::concat`].
+/// across a `concat` is rejected during the transition.
 pub enum CollectionEdge<'scope, T: RenderTimestamp> {
     /// Row-formatted collection. Today's default for every producer.
     Vec(VecCollection<'scope, T, Row, Diff>),
-    /// Columnar batch stream. Currently unused by any producer; reserved for
-    /// the producer flip at the end of the migration.
-    Columnar(Stream<'scope, T, ColumnarBatch<T>>),
+    /// Columnar collection. Currently unused by any producer; reserved for the
+    /// producer flip at the end of the migration.
+    Columnar(ColumnarCollection<'scope, T, Row, Diff>),
 }
 
 impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
@@ -62,7 +74,7 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
     pub fn scope(&self) -> Scope<'scope, T> {
         match self {
             CollectionEdge::Vec(c) => c.inner.scope(),
-            CollectionEdge::Columnar(s) => s.scope(),
+            CollectionEdge::Columnar(c) => c.inner.scope(),
         }
     }
 
@@ -71,8 +83,8 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
         match self {
             CollectionEdge::Vec(c) => CollectionEdge::Vec(c.enter_region(region)),
             CollectionEdge::Columnar(_) => {
-                // Sub-region entry for columnar batches will be wired when the
-                // first producer emits this variant.
+                // Sub-region entry for columnar collections will be wired when
+                // the first producer emits this variant.
                 todo!("CollectionEdge::Columnar::enter_region")
             }
         }
@@ -85,22 +97,23 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
     pub fn negate(self) -> Self {
         match self {
             CollectionEdge::Vec(c) => CollectionEdge::Vec(c.negate()),
-            CollectionEdge::Columnar(s) => CollectionEdge::Columnar(columnar_negate(s)),
+            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(columnar_negate(c)),
         }
     }
 }
 
-/// Negates the diff column of every batch in a columnar stream without
+/// Negates the diff column of every batch in a [`ColumnarCollection`] without
 /// decoding the data column.
-pub fn columnar_negate<'scope, T>(
-    stream: Stream<'scope, T, ColumnarBatch<T>>,
-) -> Stream<'scope, T, ColumnarBatch<T>>
+pub fn columnar_negate<'scope, T, D, R>(
+    collection: ColumnarCollection<'scope, T, D, R>,
+) -> ColumnarCollection<'scope, T, D, R>
 where
-    T: RenderTimestamp,
+    T: Timestamp,
+    (D, T, R): Columnar,
 {
     // Implementation is deferred until the first producer emits the
     // [`CollectionEdge::Columnar`] variant. The signature is fixed here so
     // consumers can target it during the consumer-first phase.
-    let _ = stream;
-    todo!("columnar_negate: flip diff column in place over Column<(Row, T, Diff)>")
+    let _ = collection;
+    todo!("columnar_negate: flip diff column in place over Column<(D, T, R)>")
 }

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -36,10 +36,12 @@ use columnar::Columnar;
 use differential_dataflow::VecCollection;
 use mz_repr::{Diff, Row};
 use mz_timely_util::columnar::Column;
+use mz_timely_util::operator::CollectionExt;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Timestamp;
 
 use crate::render::RenderTimestamp;
+use crate::typedefs::KeyBatcher;
 
 /// A columnar collection of `(D, T, R)` updates traveling on a compute
 /// dataflow edge.
@@ -147,6 +149,40 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
         match self {
             CollectionEdge::Vec(c) => CollectionEdge::Vec(c.negate()),
             CollectionEdge::Columnar(c) => CollectionEdge::Columnar(columnar_negate(c)),
+        }
+    }
+
+    /// Concatenates a collection of edges that all share the same variant.
+    ///
+    /// Mixing variants is rejected during the transition.
+    pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
+    where
+        I: IntoIterator<Item = Self>,
+    {
+        let mut vec_arm = Vec::new();
+        for edge in edges {
+            match edge {
+                CollectionEdge::Vec(c) => vec_arm.push(c),
+                CollectionEdge::Columnar(_) => {
+                    // No producer emits the columnar arm yet; once one does,
+                    // this branch must either concatenate columnar streams or
+                    // reject mixed-variant inputs explicitly.
+                    todo!("CollectionEdge::concat_many: columnar arm");
+                }
+            }
+        }
+        CollectionEdge::Vec(differential_dataflow::collection::concatenate(scope, vec_arm))
+    }
+
+    /// Consolidates updates in the edge, preserving variant.
+    pub fn consolidate_named(self, name: &str) -> Self {
+        match self {
+            CollectionEdge::Vec(c) => {
+                CollectionEdge::Vec(CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(c, name))
+            }
+            CollectionEdge::Columnar(_) => {
+                todo!("CollectionEdge::Columnar::consolidate_named")
+            }
         }
     }
 }

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -1,0 +1,106 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Columnar dataflow edge support.
+//!
+//! Defines [`CollectionEdge`], a wrapper that lets dataflow edges between Plan
+//! nodes carry either row-based ([`VecCollection`]) or columnar
+//! ([`mz_timely_util::columnar::Column`]) batches of `(Row, T, Diff)` updates.
+//!
+//! # Migration model
+//!
+//! The migration is consumer-first: every Plan-node consumer learns to accept
+//! both variants before any producer emits the columnar variant. Once all
+//! consumers are ready, a single switch flips producers to columnar end-to-end.
+//!
+//! Within a Plan node, operators may freely materialize Vec collections; only
+//! the inter-node edge format is constrained. A decode from columnar to Vec at
+//! a consumer's input is acceptable only when the consumer would have decoded
+//! `Row` to [`mz_repr::Datum`] anyway. Pure passthrough consumers (Negate,
+//! Union) must round-trip the columnar variant without decoding.
+//!
+//! See `.claude/plans/columnar_consumer_first.md` for the staged plan.
+
+#![allow(dead_code)]
+// Phase A defines the type with `todo!()` arms that will be filled in when
+// producers begin emitting columnar batches.
+#![allow(clippy::todo)]
+
+use differential_dataflow::VecCollection;
+use mz_repr::{Diff, Row};
+use mz_timely_util::columnar::Column;
+use timely::dataflow::{Scope, Stream};
+
+use crate::render::RenderTimestamp;
+
+/// Container for a columnar batch of `(Row, T, Diff)` updates traveling on a
+/// compute dataflow edge.
+pub type ColumnarBatch<T> = Column<(Row, T, Diff)>;
+
+/// A dataflow edge carrying records as either a row-based [`VecCollection`] or
+/// a columnar [`Stream`] of [`ColumnarBatch`]es.
+///
+/// Producers choose a variant; consumers must accept either. Mixing variants
+/// across a `concat` is rejected during the transition: see
+/// [`CollectionEdge::concat`].
+pub enum CollectionEdge<'scope, T: RenderTimestamp> {
+    /// Row-formatted collection. Today's default for every producer.
+    Vec(VecCollection<'scope, T, Row, Diff>),
+    /// Columnar batch stream. Currently unused by any producer; reserved for
+    /// the producer flip at the end of the migration.
+    Columnar(Stream<'scope, T, ColumnarBatch<T>>),
+}
+
+impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
+    /// The scope containing this edge.
+    pub fn scope(&self) -> Scope<'scope, T> {
+        match self {
+            CollectionEdge::Vec(c) => c.inner.scope(),
+            CollectionEdge::Columnar(s) => s.scope(),
+        }
+    }
+
+    /// Brings the edge into a sub-region of its current scope.
+    pub fn enter_region<'inner>(self, region: Scope<'inner, T>) -> CollectionEdge<'inner, T> {
+        match self {
+            CollectionEdge::Vec(c) => CollectionEdge::Vec(c.enter_region(region)),
+            CollectionEdge::Columnar(_) => {
+                // Sub-region entry for columnar batches will be wired when the
+                // first producer emits this variant.
+                todo!("CollectionEdge::Columnar::enter_region")
+            }
+        }
+    }
+
+    /// Negates the diff on every record in this edge.
+    ///
+    /// Preserves variant. The columnar arm uses [`columnar_negate`], which
+    /// flips the diff column without decoding the data column.
+    pub fn negate(self) -> Self {
+        match self {
+            CollectionEdge::Vec(c) => CollectionEdge::Vec(c.negate()),
+            CollectionEdge::Columnar(s) => CollectionEdge::Columnar(columnar_negate(s)),
+        }
+    }
+}
+
+/// Negates the diff column of every batch in a columnar stream without
+/// decoding the data column.
+pub fn columnar_negate<'scope, T>(
+    stream: Stream<'scope, T, ColumnarBatch<T>>,
+) -> Stream<'scope, T, ColumnarBatch<T>>
+where
+    T: RenderTimestamp,
+{
+    // Implementation is deferred until the first producer emits the
+    // [`CollectionEdge::Columnar`] variant. The signature is fixed here so
+    // consumers can target it during the consumer-first phase.
+    let _ = stream;
+    todo!("columnar_negate: flip diff column in place over Column<(Row, T, Diff)>")
+}

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -34,13 +34,19 @@
 
 use columnar::Columnar;
 use differential_dataflow::VecCollection;
-use mz_repr::{Diff, Row};
+use mz_repr::{DatumVec, DatumVecBorrow, Diff, Row};
 use mz_timely_util::columnar::Column;
 use mz_timely_util::operator::CollectionExt;
-use timely::dataflow::{Scope, Stream};
+use timely::ContainerBuilder;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::generic::OutputBuilder;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::{Scope, Stream, StreamVec};
 use timely::progress::Timestamp;
 
 use crate::render::RenderTimestamp;
+use crate::render::context::{ECB, Session};
+use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::KeyBatcher;
 
 /// A columnar collection of `(D, T, R)` updates traveling on a compute
@@ -172,6 +178,80 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
             }
         }
         CollectionEdge::Vec(differential_dataflow::collection::concatenate(scope, vec_arm))
+    }
+
+    /// Applies `logic` to each record in this edge, exposing the record as a
+    /// borrowed [`DatumVecBorrow`] and giving it ok and err output sessions.
+    ///
+    /// `max_demand` bounds the number of columns decoded per row; pass
+    /// `usize::MAX` to decode all columns.
+    ///
+    /// This is the canonical unified entry point for "decoding consumers"
+    /// (operators that read [`mz_repr::Datum`]s from each row anyway). The
+    /// Vec arm uses [`DatumVec::borrow_with_limit`] on each [`Row`]; the
+    /// Columnar arm iterates the columnar batch directly without going
+    /// through an owned [`Row`].
+    pub fn flat_map_datums<DCB, L>(
+        self,
+        max_demand: usize,
+        mut logic: L,
+    ) -> (
+        Stream<'scope, T, DCB::Container>,
+        StreamVec<'scope, T, (DataflowErrorSer, T, Diff)>,
+    )
+    where
+        DCB: ContainerBuilder,
+        L: for<'a> FnMut(
+                &'a mut DatumVecBorrow<'_>,
+                T,
+                Diff,
+                &mut Session<T, DCB>,
+                &mut Session<T, ECB<T>>,
+            ) -> usize
+            + 'static,
+    {
+        match self {
+            CollectionEdge::Vec(c) => {
+                let scope = c.inner.scope();
+                let mut builder = OperatorBuilder::new("CollectionFlatMap".to_string(), scope);
+                let (ok_output, ok_stream) = builder.new_output();
+                let mut ok_output = OutputBuilder::<_, DCB>::from(ok_output);
+                let (err_output, err_stream) = builder.new_output();
+                let mut err_output = OutputBuilder::<_, ECB<T>>::from(err_output);
+                let mut input = builder.new_input(c.inner, Pipeline);
+                builder.build(move |_capabilities| {
+                    let mut datums = DatumVec::new();
+                    move |_frontiers| {
+                        let mut ok_output = ok_output.activate();
+                        let mut err_output = err_output.activate();
+                        input.for_each(|time, data| {
+                            // Retain the input capability to derive a `Capability` for each output;
+                            // the `Session` type alias is fixed to `Capability<T>`.
+                            let ok_cap = time.retain(0);
+                            let err_cap = time.retain(1);
+                            let mut ok_session = ok_output.session_with_builder(&ok_cap);
+                            let mut err_session = err_output.session_with_builder(&err_cap);
+                            for (v, t, d) in data.drain(..) {
+                                logic(
+                                    &mut datums.borrow_with_limit(&v, max_demand),
+                                    t,
+                                    d,
+                                    &mut ok_session,
+                                    &mut err_session,
+                                );
+                            }
+                        });
+                    }
+                });
+                (ok_stream, err_stream)
+            }
+            CollectionEdge::Columnar(_) => {
+                // Implementation will iterate `Column<(Row, T, Diff)>::borrow()`
+                // via the `Rows<_>::Index` impl (yielding `&RowRef`) and call
+                // `DatumVec::borrow_with_limit(row_ref, max_demand)` per row.
+                todo!("CollectionEdge::flat_map_datums: columnar arm")
+            }
+        }
     }
 
     /// Consolidates updates in the edge, preserving variant.

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -270,6 +270,12 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 ///
 /// Rows and times are pushed from their borrowed forms. Only the diff is
 /// materialized, and it is `Copy`.
+///
+/// TODO: Rebuild only the diff column. Borrow the input column, build one owned
+/// negated diff column from the borrowed diffs, and re-encode using the borrowed
+/// row and time columns directly, so row and time bytes are copied once rather
+/// than pushed per record. The serialized (`Align` / `Bytes`) input case needs
+/// care, since all columns share a single buffer.
 pub fn columnar_negate<'scope, T>(
     collection: ColumnarCollection<'scope, T, Row, Diff>,
 ) -> ColumnarCollection<'scope, T, Row, Diff>

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -623,7 +623,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         &self,
         key_val: Option<(Vec<LirScalarExpr>, Option<Row>)>,
         max_demand: usize,
-        mut logic: L,
+        logic: L,
     ) -> (
         Stream<'scope, T, DCB::Container>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
@@ -652,38 +652,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 .collection
                 .clone()
                 .expect("Invariant violated: CollectionBundle contains no collection.");
-            let oks = oks.expect_vec();
-            let scope = oks.inner.scope();
-            let mut builder = OperatorBuilder::new("CollectionFlatMap".to_string(), scope);
-            let (ok_output, ok_stream) = builder.new_output();
-            let mut ok_output = OutputBuilder::<_, DCB>::from(ok_output);
-            let (err_output, err_stream) = builder.new_output();
-            let mut err_output = OutputBuilder::<_, ECB<T>>::from(err_output);
-            let mut input = builder.new_input(oks.inner, Pipeline);
-            builder.build(move |_capabilities| {
-                let mut datums = DatumVec::new();
-                move |_frontiers| {
-                    let mut ok_output = ok_output.activate();
-                    let mut err_output = err_output.activate();
-                    input.for_each(|time, data| {
-                        // Retain the input capability to derive a `Capability` for each output;
-                        // the `Session` type alias is fixed to `Capability<T>`.
-                        let ok_cap = time.retain(0);
-                        let err_cap = time.retain(1);
-                        let mut ok_session = ok_output.session_with_builder(&ok_cap);
-                        let mut err_session = err_output.session_with_builder(&err_cap);
-                        for (v, t, d) in data.drain(..) {
-                            logic(
-                                &mut datums.borrow_with_limit(&v, max_demand),
-                                t,
-                                d,
-                                &mut ok_session,
-                                &mut err_session,
-                            );
-                        }
-                    });
-                }
-            });
+            let (ok_stream, err_stream) = oks.flat_map_datums::<DCB, _>(max_demand, logic);
             let errs = errs.concat(err_stream.as_collection());
             (ok_stream, errs)
         }
@@ -1246,14 +1215,14 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
 /// Type alias for a timely output `Session` whose capability is a `Capability<T>`. The container
 /// builder `CB` is left to the caller; sessions can therefore drive consolidating, capacity, or
 /// (in the future) columnar output builders without changing call sites.
-type Session<'a, 'b, T, CB> =
+pub(crate) type Session<'a, 'b, T, CB> =
     timely::dataflow::operators::generic::Session<'a, 'b, T, CB, Capability<T>>;
 
 /// Container builder used for the err output of every flat_map variant. Pre-refactor the
 /// merged Ok/Err stream flowed through a [`ConsolidatingContainerBuilder`] before the
 /// `map_fallible` demux split it; we preserve that consolidation here so errors with the
 /// same `(error, time)` cancel within a batch rather than propagating to downstream.
-type ECB<T> = ConsolidatingContainerBuilder<Vec<(DataflowErrorSer, T, Diff)>>;
+pub(crate) type ECB<T> = ConsolidatingContainerBuilder<Vec<(DataflowErrorSer, T, Diff)>>;
 
 /// Number of output records the arrangement flat_map operators may produce before yielding.
 /// See [`ArrangementFlavor::flat_map`] for the fuel rationale; the constant is a pragmatic

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -576,7 +576,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .clone()
                     .expect("The unarranged collection doesn't exist.");
-                (oks.expect_vec(), errs)
+                (oks.into_vec(), errs)
             }
             Some(key) => {
                 let arranged = self.arranged.get(key).unwrap_or_else(|| {
@@ -1068,7 +1068,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .take()
                     .expect("Collection constructed above");
-                let oks = oks.expect_vec();
+                let oks = oks.into_vec();
                 // Apply temporal bucketing if the collection already existed on
                 // the bundle (e.g., from an upstream temporal Mfp or Get) and we
                 // haven't bucketed yet. This is the common path for temporal-MFP

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -48,6 +48,7 @@ use timely::progress::{Antichain, Timestamp};
 
 use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange, MzArrangeCore};
+use crate::render::columnar::CollectionEdge;
 use crate::render::errors::{DataflowErrorSer, ErrorLogger};
 use crate::render::{LinearJoinSpec, MaybeBucketByTime, RenderTimestamp};
 use crate::typedefs::{
@@ -442,7 +443,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
 #[derive(Clone)]
 pub struct CollectionBundle<'scope, T: RenderTimestamp> {
     pub collection: Option<(
-        VecCollection<'scope, T, Row, Diff>,
+        CollectionEdge<'scope, T>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     )>,
     pub arranged: BTreeMap<Vec<LirScalarExpr>, ArrangementFlavor<'scope, T>>,
@@ -452,6 +453,14 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// Construct a new collection bundle from update streams.
     pub fn from_collections(
         oks: VecCollection<'scope, T, Row, Diff>,
+        errs: VecCollection<'scope, T, DataflowErrorSer, Diff>,
+    ) -> Self {
+        Self::from_edge(CollectionEdge::Vec(oks), errs)
+    }
+
+    /// Construct a new collection bundle from a [`CollectionEdge`] and an error stream.
+    pub fn from_edge(
+        oks: CollectionEdge<'scope, T>,
         errs: VecCollection<'scope, T, DataflowErrorSer, Diff>,
     ) -> Self {
         Self {
@@ -488,7 +497,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// The scope containing the collection bundle.
     pub fn scope(&self) -> Scope<'scope, T> {
         if let Some((oks, _errs)) = &self.collection {
-            oks.inner.scope()
+            oks.scope()
         } else {
             self.arranged
                 .values()
@@ -562,10 +571,13 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         //
         // If it doesn't, we panic.
         match key {
-            None => self
-                .collection
-                .clone()
-                .expect("The unarranged collection doesn't exist."),
+            None => {
+                let (oks, errs) = self
+                    .collection
+                    .clone()
+                    .expect("The unarranged collection doesn't exist.");
+                (oks.expect_vec(), errs)
+            }
             Some(key) => {
                 let arranged = self.arranged.get(key).unwrap_or_else(|| {
                     panic!("The collection arranged by {:?} doesn't exist.", key)
@@ -640,6 +652,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 .collection
                 .clone()
                 .expect("Invariant violated: CollectionBundle contains no collection.");
+            let oks = oks.expect_vec();
             let scope = oks.inner.scope();
             let mut builder = OperatorBuilder::new("CollectionFlatMap".to_string(), scope);
             let (ok_output, ok_stream) = builder.new_output();
@@ -1075,7 +1088,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             } else {
                 oks
             };
-            self.collection = Some((oks, errs));
+            self.collection = Some((CollectionEdge::Vec(oks), errs));
         }
         for (key, _, thinning) in collections.arranged {
             if !self.arranged.contains_key(&key) {
@@ -1086,6 +1099,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .take()
                     .expect("Collection constructed above");
+                let oks = oks.expect_vec();
                 // Apply temporal bucketing if the collection already existed on
                 // the bundle (e.g., from an upstream temporal Mfp or Get) and we
                 // haven't bucketed yet. This is the common path for temporal-MFP
@@ -1116,7 +1130,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     use_paged_path,
                 );
                 let errs_concat: KeyCollection<_, _, _> = errs.clone().concat(errs_keyed).into();
-                self.collection = Some((passthrough, errs));
+                self.collection = Some((CollectionEdge::Vec(passthrough), errs));
                 let errs =
                     errs_concat.mz_arrange::<
                         ColumnationChunker<_>,

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -68,7 +68,7 @@ impl<'g, T: RenderTimestamp> Context<'g, T> {
             .lookup_id(mz_expr::Id::Global(sink.from))
             .expect("Sink source collection not loaded");
         let (ok_collection, mut err_collection) = if let Some((oks, errs)) = &bundle.collection {
-            (oks.clone().expect_vec(), errs.clone())
+            (oks.clone().into_vec(), errs.clone())
         } else {
             let (key, _arrangement) = bundle
                 .arranged

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -67,8 +67,8 @@ impl<'g, T: RenderTimestamp> Context<'g, T> {
         let bundle = self
             .lookup_id(mz_expr::Id::Global(sink.from))
             .expect("Sink source collection not loaded");
-        let (ok_collection, mut err_collection) = if let Some(collection) = &bundle.collection {
-            collection.clone()
+        let (ok_collection, mut err_collection) = if let Some((oks, errs)) = &bundle.collection {
+            (oks.clone().expect_vec(), errs.clone())
         } else {
             let (key, _arrangement) = bundle
                 .arranged


### PR DESCRIPTION
### Motivation

Today's row-based dataflow edges in compute force per-record consumer handling.
Switching producers to columnar first imposes an unpack tax on every consumer that is not yet columnar-aware; this PR begins a consumer-first migration that avoids the tax by making every consumer ready to absorb columnar batches before any producer emits them.

### Description

Adds `CollectionEdge<'scope, T>` with `Vec` and `Columnar` arms in `src/compute/src/render/columnar.rs`, plus a `columnar_negate` stub.
Scaffolding only: no producer emits the columnar variant, `CollectionBundle` is unchanged, and columnar arms carry `todo!()` bodies that land alongside the producer switch.
The design rule encoded in the API is that a columnar-to-row decode at a consumer's input is only acceptable when the consumer would have decoded `Row` to `Datum` anyway; passthrough consumers must round-trip columnar without decoding.