### PR TITLE
sql: place NULL rows last in EXPLAIN ANALYZE CLUSTER output

### DIFF
--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -1248,10 +1248,10 @@ GROUP BY om.global_id"#));
                     ]);
 
                     order_by.extend([
-                        "max_operator_memory_ratio DESC",
-                        "max_operator_records_ratio DESC",
-                        "om.worker_memory DESC",
-                        "worker_records DESC",
+                        "max_operator_memory_ratio DESC NULLS LAST",
+                        "max_operator_records_ratio DESC NULLS LAST",
+                        "om.worker_memory DESC NULLS LAST",
+                        "worker_records DESC NULLS LAST",
                     ]);
 
                     if set_worker_id {
@@ -1289,7 +1289,10 @@ GROUP BY pomt.global_id
                         "pg_size_pretty(omt.total_memory) AS total_memory",
                         "omt.total_records AS total_records",
                     ]);
-                    order_by.extend(["omt.total_memory DESC", "total_records DESC"]);
+                    order_by.extend([
+                        "omt.total_memory DESC NULLS LAST",
+                        "total_records DESC NULLS LAST",
+                    ]);
                 }
             }
             ExplainAnalyzeComputationProperty::Cpu => {
@@ -1383,7 +1386,10 @@ GROUP BY oc.global_id"#,));
                         "oac.total_ns / 1000 * '1 microsecond'::interval AS total_elapsed",
                     ]);
 
-                    order_by.extend(["max_operator_cpu_ratio DESC", "worker_elapsed DESC"]);
+                    order_by.extend([
+                        "max_operator_cpu_ratio DESC NULLS LAST",
+                        "worker_elapsed DESC NULLS LAST",
+                    ]);
 
                     if set_worker_id {
                         order_by.push("worker_id");
@@ -1416,7 +1422,7 @@ GROUP BY poct.global_id
                     from.push("LEFT JOIN object_cpu_totals oct USING (global_id)");
                     columns
                         .push("oct.total_ns / 1000 * '1 microsecond'::interval AS total_elapsed");
-                    order_by.extend(["total_elapsed DESC"]);
+                    order_by.extend(["total_elapsed DESC NULLS LAST"]);
                 }
             }
         }

--- a/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
+++ b/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
@@ -1209,7 +1209,10 @@ SELECT
 FROM
     mz_introspection.mz_mappable_objects AS mo
         LEFT JOIN object_memory_totals AS omt USING(global_id)
-ORDER BY total_memory DESC, total_records DESC, mo.name DESC;
+ORDER BY
+    total_memory DESC NULLS LAST,
+    total_records DESC NULLS LAST,
+    mo.name DESC;
 EOF
 
 query T multiline
@@ -1270,7 +1273,11 @@ FROM
     mz_introspection.mz_mappable_objects AS mo
         LEFT JOIN object_memory_totals AS omt USING(global_id)
         LEFT JOIN object_cpu_totals AS oct USING(global_id)
-ORDER BY total_memory DESC, total_records DESC, total_elapsed DESC, mo.name DESC;
+ORDER BY
+    total_memory DESC NULLS LAST,
+    total_records DESC NULLS LAST,
+    total_elapsed DESC NULLS LAST,
+    mo.name DESC;
 EOF
 
 query T multiline
@@ -1495,13 +1502,13 @@ FROM
         LEFT JOIN object_average_memory AS oam USING(global_id)
 WHERE om.worker_id = oc.worker_id
 ORDER BY
-    max_operator_cpu_ratio DESC,
-    worker_elapsed DESC,
+    max_operator_cpu_ratio DESC NULLS LAST,
+    worker_elapsed DESC NULLS LAST,
     worker_id,
-    max_operator_memory_ratio DESC,
-    max_operator_records_ratio DESC,
-    worker_memory DESC,
-    worker_records DESC,
+    max_operator_memory_ratio DESC NULLS LAST,
+    max_operator_records_ratio DESC NULLS LAST,
+    worker_memory DESC NULLS LAST,
+    worker_records DESC NULLS LAST,
     mo.name DESC;
 EOF
 


### PR DESCRIPTION

### Motivation
Explain analyze cluster and memory was placing null rows first
Fixes [CNS-65](https://linear.app/materializeinc/issue/CNS-65/nit-explain-analyze-cluster-memory-sorts-by-memory-descending-but-null)

### Description

Fixed the sorting order for Explain Analyze output
<img width="2436" height="918" alt="image" src="https://github.com/user-attachments/assets/f65db63f-01eb-4312-b81d-873ca6aa4081" />

