### PR TITLE
sql: register mz_mcp_agents and mz_mcp_developer in ApplicationNameHint

### DIFF
--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -37,6 +37,7 @@ use mz_adapter_types::dyncfgs::{
 use mz_repr::namespaces::{self, SYSTEM_SCHEMAS};
 use mz_sql::parse::parse;
 use mz_sql::session::metadata::SessionMetadata;
+use mz_sql::session::vars::{APPLICATION_NAME, Var, VarInput};
 use mz_sql_parser::ast::display::{AstDisplay, escaped_string_literal};
 use mz_sql_parser::ast::visit::{self, Visit};
 use mz_sql_parser::ast::{Raw, RawItemName};
@@ -449,6 +450,20 @@ async fn handle_mcp_request(
 
     let query_tool_enabled = ENABLE_MCP_AGENT_QUERY_TOOL.get(dyncfgs);
     let max_response_size = MCP_MAX_RESPONSE_SIZE.get(dyncfgs);
+
+    // Tag MCP-originated sessions so they're distinguishable in
+    // mz_session_history / mz_statement_execution_history. set_default lets a
+    // caller still override via `?options={"application_name":"..."}`
+    let app_name = match endpoint_type {
+        McpEndpointType::Agent => "mz_mcp_agents",
+        McpEndpointType::Developer => "mz_mcp_developer",
+    };
+    client
+        .client
+        .session()
+        .vars_mut()
+        .set_default(APPLICATION_NAME.name(), VarInput::Flat(app_name))
+        .expect("application_name is a known session var");
 
     let user = client.client.session().user().name.clone();
     let is_notification = request.id.is_none();

--- a/src/sql/src/session/hint.rs
+++ b/src/sql/src/session/hint.rs
@@ -37,6 +37,10 @@ const D_BEAVER_LABEL: &str = "dbeaver";
 const MZ_VSCODE_LABEL: &str = "mz_vscode";
 /// Prometheus label for [`ApplicationNameHint::MzGrafanaIntegration`].
 const MZ_GRAFANA_LABEL: &str = "mz_grafana";
+/// Prometheus label for [`ApplicationNameHint::MzMcpAgent`].
+const MZ_MCP_AGENT_LABEL: &str = "mz_mcp_agents";
+/// Prometheus label for [`ApplicationNameHint::MzMcpDeveloper`].
+const MZ_MCP_DEVELOPER_LABEL: &str = "mz_mcp_developer";
 
 /// A hint for what application is making a request to the adapter.
 ///
@@ -77,6 +81,10 @@ pub enum ApplicationNameHint {
     MzVscode(Private),
     /// Request came from our Grafana integration.
     MzGrafanaIntegration(Private),
+    /// Request came from the MCP agent endpoint.
+    MzMcpAgent(Private),
+    /// Request came from the MCP developer endpoint.
+    MzMcpDeveloper(Private),
 }
 
 impl ApplicationNameHint {
@@ -94,6 +102,8 @@ impl ApplicationNameHint {
             "tableplus" => ApplicationNameHint::TablePlus(Private),
             "mz_vscode" => ApplicationNameHint::MzVscode(Private),
             "mz_grafana_integration" => ApplicationNameHint::MzGrafanaIntegration(Private),
+            "mz_mcp_agents" => ApplicationNameHint::MzMcpAgent(Private),
+            "mz_mcp_developer" => ApplicationNameHint::MzMcpDeveloper(Private),
             // Terraform provides the version as a suffix.
             x if x.starts_with("terraform-provider-materialize") => {
                 ApplicationNameHint::TerraformProviderMaterialize(Private)
@@ -124,6 +134,8 @@ impl ApplicationNameHint {
             ApplicationNameHint::TablePlus(_) => TABLE_PLUS_LABEL,
             ApplicationNameHint::MzVscode(_) => MZ_VSCODE_LABEL,
             ApplicationNameHint::MzGrafanaIntegration(_) => MZ_GRAFANA_LABEL,
+            ApplicationNameHint::MzMcpAgent(_) => MZ_MCP_AGENT_LABEL,
+            ApplicationNameHint::MzMcpDeveloper(_) => MZ_MCP_DEVELOPER_LABEL,
             ApplicationNameHint::TerraformProviderMaterialize(_) => {
                 TERRAFORM_PROVIDER_MATERIALIZE_LABEL
             }


### PR DESCRIPTION
Follow-up to #36530.

The two new `application_name` values set by the MCP handler (`mz_mcp_agents`, `mz_mcp_developer`) were not registered in `ApplicationNameHint::from_str`, so they fell through to the `Unrecognized` variant in Prometheus metrics. This adds the two variants so MCP traffic gets proper labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)