### PR TITLE
docker: bump Ubuntu base to noble-20260410

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -10,7 +10,7 @@
 # Stage 1: Build a minimum CI Builder image that we can use for the initial
 # steps like `mkpipeline` and `Build`, as well as any tests that are self
 # contained and use other Docker images.
-FROM ubuntu:noble-20260210.1 AS ci-builder-min
+FROM ubuntu:noble-20260410 AS ci-builder-min
 
 WORKDIR /workdir
 
@@ -400,7 +400,7 @@ RUN mkdir /cargo && chmod 777 /cargo
 VOLUME /cargo
 
 # Stage 3: Build a lightweight CI Builder image for console/playwright jobs.
-FROM ubuntu:noble-20260324 AS ci-builder-console
+FROM ubuntu:noble-20260410 AS ci-builder-console
 
 ARG ARCH_GCC
 ARG ARCH_GO

--- a/misc/images/ubuntu-base/Dockerfile
+++ b/misc/images/ubuntu-base/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:noble-20260210.1
+FROM ubuntu:noble-20260410
 
 # Ensure any Rust binaries that crash print a backtrace.
 ENV RUST_BACKTRACE=1


### PR DESCRIPTION
### Motivation

Amazon Inspector flagged [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789) (OpenSSL heap buffer overflow in X.509 OCTET STRING handling) on the published `environmentd` image. The vulnerability is Low severity, 32-bit-only, and not reachable from our 64-bit binaries, but the system `libssl3` package in the image is several Ubuntu patch revisions behind. The fix ships in `libssl3 3.0.13-0ubuntu3.9`, which is included starting with `noble-20260410`.

The bump also clears 59 other deb-package CVEs (Grype scan drops from 139 findings to 79 on `ubuntu:noble-20260410` vs `noble-20260210.1`).

### Description

Bumps `ubuntu:noble-20260210.1` → `ubuntu:noble-20260410` in:
- `misc/images/ubuntu-base/Dockerfile` (runtime base for `environmentd`, `clusterd`, `balancerd`, etc.)
- `ci/builder/Dockerfile` line 13 (`ci-builder-min`)

Also rolls `ci-builder-console` (line 403) from `noble-20260324` to the same tag for consistency.

#### Why manual

Dependabot has not proposed a bump for `/misc/images/ubuntu-base` since the manual 26.04 → 24.04 LTS rollback in #35329 (~10 missed weekly cycles). The tag-tracker likely got confused by the non-Dependabot rollback commit. `/ci/builder` got a partial bump via #36083 but only for `ci-builder-console` (line 403), leaving `ci-builder-min` (line 13) stale. Worth a separate look at why Dependabot is silent on this directory.

### Verification

- Grype scan of `materialize/environmentd:v26.23.3` (pre-bump) confirms CVE-2026-31789 against `libssl3t64 3.0.13-0ubuntu3.7` and `openssl 3.0.13-0ubuntu3.7`.
- Grype scan of `ubuntu:noble-20260410` confirms those packages move to `3.0.13-0ubuntu3.9` and the CVE is no longer reported.
- `bin/fmt` clean. Local `bin/lint` failures (`check-helm-docs.sh`, `check-zizmor.sh`, `check-cargo.sh`, `check-mzcompose-files.sh`) are pre-existing and unrelated to this diff (verified `git diff main..HEAD` only touches the two Dockerfiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)