### PR TITLE
txn-wal: box forget_at test body to fit tokio test stack

### DIFF
--- a/src/txn-wal/src/txns.rs
+++ b/src/txn-wal/src/txns.rs
@@ -1121,6 +1121,13 @@ mod tests {
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
     async fn forget_at() {
+        // Body is boxed because the debug-build async state machine for this
+        // test exceeds 2 MiB (~940 KiB single frame) and overflows the default
+        // tokio test thread stack.
+        Box::pin(forget_at_inner()).await
+    }
+
+    async fn forget_at_inner() {
         let client = PersistClient::new_for_tests().await;
         let mut txns = TxnsHandle::expect_open(client.clone()).await;
         let log = txns.new_log();


### PR DESCRIPTION
### Motivation

`cargo test -p mz-txn-wal` aborts with a stack overflow in `txns::tests::forget_at` on debug builds.
Disassembling the test's poll function shows the async state machine reserves a single ~940 KiB stack frame (`sub sp, sp, #0xea000 + #0x9a0` plus an inline stack-probe loop), nearly half the default 2 MiB tokio test thread stack. Once tokio worker, libtest harness, and panic-hook frames are added, the thread overflows.

The cause is debug-mode async lowering: every awaited child future is stored as a distinct field of the parent generator, with no slot reuse across yield points. `forget_at` awaits ~30 helpers, several of which themselves contain nested awaits, so the frame balloons. Release builds dedupe the slots and never hit this.

### Description

Move the test body into a separate `async fn forget_at_inner` and `Box::pin(...).await` it from the test entry point. The boxed future lives on the heap; only a `Pin<Box<…>>` sits on the test thread's stack.

### Verification

`cargo test -p mz-txn-wal` passes locally (28/28) under the default `RUST_MIN_STACK` of 2 MiB; previously this test aborted with SIGABRT. Other tests in the crate already fit within 2 MiB and are unchanged.
