### PR TITLE
mcp: rename 'required' to 'indexedColumns' in data product schema

### DIFF
--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -5345,7 +5345,7 @@ SELECT * FROM (
         COALESCE(cts_idx.comment, cts_obj.comment) AS description,
         COALESCE(jsonb_build_object(
         'type', 'object',
-        'required', jsonb_agg(distinct ccol.name) FILTER (WHERE ccol.position = ic.on_position),
+        'indexedColumns', jsonb_agg(distinct ccol.name) FILTER (WHERE ccol.position = ic.on_position),
         'properties', jsonb_strip_nulls(jsonb_object_agg(
             ccol.name,
             CASE


### PR DESCRIPTION
Renaming the JSON Schema field from `required` to `indexedColumns` in` mz_mcp_data_product_details` to accurately reflect what it means (the indexed columns of a data product, not a JSON Schema validation constraint), addressing the confusion raised in Slack.