### PR TITLE
sql: Fix panic in cardinality estimation when EXPECTED GROUP SIZE = 0

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -1411,6 +1411,7 @@ mod cardinality {
     use mz_repr::GlobalId;
 
     use ordered_float::OrderedFloat;
+    use tracing::{error, warn};
 
     use super::{Analysis, Arity, SubtreeSize, UniqueKeys};
 
@@ -1456,12 +1457,15 @@ mod cardinality {
             match self {
                 CardinalityEstimate::Estimate(OrderedFloat(f)) => {
                     let rounded = f.ceil();
-                    let flattened = usize::cast_from(
-                        u64::try_cast_from(rounded)
-                            .expect("positive and representable cardinality estimate"),
-                    );
 
-                    Some(flattened)
+                    if !rounded.is_normal() || rounded < 0.0 {
+                        warn!(
+                            "ignoring denormalized or negative cardinality estimate {f} rounded to {rounded}"
+                        );
+                    }
+
+                    // if we can't cast, the value is unknown
+                    u64::try_cast_from(rounded).map(usize::cast_from)
                 }
                 CardinalityEstimate::Unknown => None,
             }
@@ -1546,6 +1550,7 @@ mod cardinality {
 
         fn div(self, rhs: f64) -> Self::Output {
             use CardinalityEstimate::*;
+
             if let Estimate(lhs) = self {
                 Estimate(lhs / OrderedFloat(rhs))
             } else {
@@ -1590,6 +1595,11 @@ mod cardinality {
         fn flat_map(&self, tf: &TableFunc, input: CardinalityEstimate) -> CardinalityEstimate {
             match tf {
                 TableFunc::Wrap { types, width } => {
+                    // DBZ is harmless (produces inf, empty estimate), but still a broken invariant
+                    if *width == 0 {
+                        error!("cardinality estimation encountered TableFunc::Wrap with width 0");
+                    }
+
                     input * (f64::cast_lossy(types.len()) / f64::cast_lossy(*width))
                 }
                 _ => {
@@ -1800,8 +1810,10 @@ mod cardinality {
         ) -> CardinalityEstimate {
             // TODO(mgree): if no `group_key` is present, we can do way better
 
-            if let Some(group_size) = expected_group_size {
-                input / f64::cast_lossy(*group_size)
+            if let Some(expected_group_size) = expected_group_size {
+                // if expected group size is 0, treat it as 1 (to avoid DBZ/+inf estimates)
+                let group_size = u64::max(*expected_group_size, 1);
+                input / f64::cast_lossy(group_size)
             } else if group_key.is_empty() {
                 CardinalityEstimate::from(1.0)
             } else {
@@ -1823,8 +1835,10 @@ mod cardinality {
                 .and_then(|l| l.as_literal_int64())
                 .map_or(1, |l| std::cmp::max(0, l));
 
-            if let Some(group_size) = expected_group_size {
-                input * (f64::cast_lossy(k) / f64::cast_lossy(*group_size))
+            if let Some(expected_group_size) = expected_group_size {
+                // if expected group size is 0, treat it as 1 (to avoid DBZ/+inf estimates)
+                let group_size = u64::max(*expected_group_size, 1);
+                input * (f64::cast_lossy(k) / f64::cast_lossy(group_size))
             } else if group_key.is_empty() {
                 CardinalityEstimate::from(f64::cast_lossy(k))
             } else {

--- a/test/sqllogictest/transform/cardinality_estimate_panic.slt
+++ b/test/sqllogictest/transform/cardinality_estimate_panic.slt
@@ -1,3 +1,12 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 # EXPECTED GROUP SIZE = 0 causes division by zero in cardinality estimation -> Infinity -> panic in rounded().
 
 simple conn=mz_system,user=mz_system

--- a/test/sqllogictest/transform/cardinality_estimate_panic.slt
+++ b/test/sqllogictest/transform/cardinality_estimate_panic.slt
@@ -1,0 +1,69 @@
+# EXPECTED GROUP SIZE = 0 causes division by zero in cardinality estimation -> Infinity -> panic in rounded().
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_cardinality_estimates = true
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET optimizer_oneshot_stats_timeout TO '2s'
+----
+COMPLETE 0
+
+simple
+SET ENABLE_SESSION_CARDINALITY_ESTIMATES TO TRUE
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t_card_panic (a INT NOT NULL, b INT NOT NULL)
+
+statement ok
+CREATE TABLE t_card_panic2 (a INT NOT NULL)
+
+statement ok
+INSERT INTO t_card_panic SELECT x, x * 10 FROM generate_series(1, 100) AS x
+
+statement ok
+INSERT INTO t_card_panic2 SELECT x FROM generate_series(1, 100) AS x
+
+statement ok
+SELECT mz_unsafe.mz_sleep(5)
+
+# Reduce path: input / 0.0 = Infinity → panic in rounded()
+statement ok
+SELECT sub.a, sub.cnt
+FROM (
+    SELECT a, COUNT(*) AS cnt
+    FROM t_card_panic
+    GROUP BY a
+    OPTIONS (EXPECTED GROUP SIZE = 0)
+) sub
+JOIN t_card_panic2 ON sub.a = t_card_panic2.a
+
+# TopK path: input * (limit / 0.0) = Infinity
+statement ok
+SELECT sub.a, sub.b
+FROM (
+    SELECT a, b FROM t_card_panic
+    OPTIONS (LIMIT INPUT GROUP SIZE = 0)
+    ORDER BY b LIMIT 10
+) sub
+JOIN t_card_panic2 ON sub.a = t_card_panic2.a
+
+# Cleanup
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_cardinality_estimates = false
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET optimizer_oneshot_stats_timeout
+----
+COMPLETE 0
+
+statement ok
+DROP TABLE t_card_panic CASCADE
+
+statement ok
+DROP TABLE t_card_panic2 CASCADE


### PR DESCRIPTION
### Motivation

https://linear.app/materializeinc/issue/SQL-273/unexpected-panic-during-query-optimization-positive-and-representable

### Description

Fixes DBZ from `EXPECTED GROUP SIZE = 0` and hardens one other possible DBZ case (`TableFunc::Wrap` with `width == 0`). Adds the test from the issue.

### Verification

Test went from red to green.