### PR TITLE
[sql] Fix SHOW command bypass in restrict_to_user_objects

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -946,8 +946,13 @@ impl<'a> ShowSelect<'a> {
         order: Option<&str>,
         projection: Option<&[&str]>,
     ) -> Result<ShowSelect<'a>, PlanError> {
-        Self::new_with_resolved_ids(scx, query, filter, order, projection)
-            .map(|(show_select, _)| show_select)
+        let (show_select, new_resolved_ids) =
+            Self::new_with_resolved_ids(scx, query, filter, order, projection)?;
+        scx.sql_impl_resolved_ids
+            .lock()
+            .expect("planning is single-threaded")
+            .extend_from(&new_resolved_ids);
+        Ok(show_select)
     }
 
     fn new_with_resolved_ids(

--- a/test/sqllogictest/rbac_mcp_agent.slt
+++ b/test/sqllogictest/rbac_mcp_agent.slt
@@ -566,18 +566,53 @@ db error: ERROR: access to system object mz_clusters is restricted
 DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
 
 # =============================================================================
-# Test: SHOW commands are NOT YET blocked by restrict_to_user_objects
+# Test: SHOW commands are blocked by restrict_to_user_objects
 # SHOW commands are rewritten to SELECT on mz_internal.mz_show_* views during
-# planning, but their resolved IDs go through ShowSelect's own resolution path
-# which does not flow through the restrict check. This is a known limitation.
+# planning. Their resolved IDs are now propagated via scx.sql_impl_resolved_ids
+# so the restrict check catches them.
 # =============================================================================
 
-# SHOW DATABASES still works (known limitation — SHOW uses separate resolution)
 simple conn=agent_restricted,user=agent
 SELECT count(*) > 0 FROM (SHOW DATABASES);
 ----
-t
-COMPLETE 1
+db error: ERROR: access to system object mz_show_databases is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+simple conn=agent_restricted,user=agent
+SELECT count(*) > 0 FROM (SHOW SCHEMAS);
+----
+db error: ERROR: access to system object mz_show_schemas is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+simple conn=agent_restricted,user=agent
+SELECT count(*) > 0 FROM (SHOW TABLES);
+----
+db error: ERROR: access to system object mz_show_tables is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+simple conn=agent_restricted,user=agent
+SELECT count(*) > 0 FROM (SHOW VIEWS);
+----
+db error: ERROR: access to system object mz_show_views is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+simple conn=agent_restricted,user=agent
+SELECT count(*) > 0 FROM (SHOW MATERIALIZED VIEWS);
+----
+db error: ERROR: access to system object mz_show_materialized_views is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+simple conn=agent_restricted,user=agent
+SELECT count(*) > 0 FROM (SHOW INDEXES);
+----
+db error: ERROR: access to system object mz_show_indexes is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+simple conn=agent_restricted,user=agent
+SELECT count(*) > 0 FROM (SHOW CLUSTERS);
+----
+db error: ERROR: access to system object mz_show_clusters is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
 
 # =============================================================================
 # Test: pg_catalog access is blocked when restrict_to_user_objects is active


### PR DESCRIPTION
Problem:
SHOW commands are rewritten to SELECT queries against mz_internal.mz_show_* system views during planning. However, the resolved IDs from those inner names::resolve() calls were discarded by ShowSelect::new(), so the mz_show_* view IDs never reached check_restrict_to_user_objects().

Solution:
Propagate the resolved IDs from ShowSelect::new() into scx.sql_impl_resolved_ids (the same accumulator used for SQL-implemented functions).

At the end of plan(), those IDs are merged into the statement-level resolved_ids and flow to the RBAC check, which then blocks the mz_show_* system views correctly.

Testing:
Updates rbac_mcp_agent.slt for this case
