### PR TITLE
ci: add retry-on-flake for docs-widgets-test

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -755,6 +755,16 @@ steps:
           queue: hetzner-aarch64-4cpu-8gb
         coverage: skip
         sanitizer: skip
+        # Fortify against intermittent agent timeouts and DockerHub/GHCR
+        # pull issues during the npm install step.
+        retry:
+          automatic:
+            - exit_status: -1 # Agent lost
+              limit: 2
+            - exit_status: 143 # SIGTERM (Buildkite timeout)
+              limit: 2
+            - exit_status: 255 # SSH/network
+              limit: 2
 
       - id: doc-examples
         label: Documentation Examples Code


### PR DESCRIPTION
## Summary

The `docs-widgets-test` step on PR #36436 failed with `exit status -1`
after running for 16 minutes, despite the test suite completing in
~10 seconds locally. This is consistent with the Buildkite agent being
lost or hitting the 15-minute step timeout while stuck on `npm install`
or similar infrastructure issues — not a real test failure.

Add automatic retries on exit codes `-1` (agent lost), `143` (SIGTERM
timeout), and `255` (SSH/network), matching the retry-on-flake pattern
already used elsewhere in this pipeline and in the nightly pipeline.

## Test plan

- [ ] CI is green on this PR
- [ ] Re-run of CI on PR #36436 now succeeds (or auto-retries through any
  transient agent issues)

---
_Generated by [Claude Code](https://claude.ai/code/session_013wJkgdvvTdde9hDebwnXfg)_