### PR TITLE
mcp: hint agents to prefer indexed objects

### DIFF
--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -555,7 +555,7 @@ schema information.
 | Field         | Type     | Meaning                                                                                  |
 | ------------- | -------- | ---------------------------------------------------------------------------------------- |
 | `object_name` | [`text`] | Fully qualified object name (database.schema.name).                                      |
-| `cluster`     | [`text`] | Cluster where the object computes or its index is hosted. The object can be read from any cluster. |
+| `cluster`     | [`text`] | Cluster where the object computes or its index is hosted. Reads from any cluster work, but only reads on this cluster benefit from the index. |
 | `description` | [`text`] | Index comment if available, otherwise object comment. Used as data product description.   |
 
 ## `mz_mcp_data_product_details`
@@ -567,7 +567,7 @@ with a JSON Schema describing each data product's columns and types.
 | Field         | Type     | Meaning                                                                                  |
 | ------------- | -------- | ---------------------------------------------------------------------------------------- |
 | `object_name` | [`text`] | Fully qualified object name (database.schema.name).                                      |
-| `cluster`     | [`text`] | Cluster where the object computes or its index is hosted. The object can be read from any cluster. |
+| `cluster`     | [`text`] | Cluster where the object computes or its index is hosted. Reads from any cluster work, but only reads on this cluster benefit from the index. |
 | `description` | [`text`] | Index comment if available, otherwise object comment. Used as data product description.   |
 | `schema`      | [`jsonb`]| JSON Schema describing the object's columns and types.                                   |
 

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -5271,7 +5271,7 @@ pub static MZ_MCP_DATA_PRODUCTS: LazyLock<BuiltinView> = LazyLock::new(|| Builti
         ),
         (
             "cluster",
-            "Cluster where the object computes or its index is hosted. The object can be read from any cluster.",
+            "Cluster where the object computes or its index is hosted. Reads from any cluster work, but only reads on this cluster benefit from the index.",
         ),
         (
             "description",
@@ -5326,7 +5326,7 @@ pub static MZ_MCP_DATA_PRODUCT_DETAILS: LazyLock<BuiltinView> = LazyLock::new(||
         ),
         (
             "cluster",
-            "Cluster where the object computes or its index is hosted. The object can be read from any cluster.",
+            "Cluster where the object computes or its index is hosted. Reads from any cluster work, but only reads on this cluster benefit from the index.",
         ),
         (
             "description",

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -600,9 +600,10 @@ fn endpoint_instructions(endpoint_type: McpEndpointType) -> Option<String> {
     match endpoint_type {
         McpEndpointType::Agent => Some(concat!(
             "You have access to Materialize data products via MCP. ",
-            "Prefer indexed objects first (served from memory), then materialized views ",
-            "(read from persistent storage). Querying plain views, unindexed sources, or tables ",
-            "triggers query-time computation that can consume significant cluster resources, avoid these.",
+            "Prefer indexed objects (served from memory) over materialized views ",
+            "(read from persistent storage). Indexes are cluster-local; if a data product's ",
+            "cluster differs from your session, pass the `cluster` parameter to `read_data_product` ",
+            "so the index is actually used.",
         ).to_string()),
         McpEndpointType::Developer => Some(concat!(
             "You are connected to the Materialize developer MCP server. ",

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -600,7 +600,7 @@ fn endpoint_instructions(endpoint_type: McpEndpointType) -> Option<String> {
     match endpoint_type {
         McpEndpointType::Agent => Some(concat!(
             "You have access to Materialize data products via MCP. ",
-            "Prefer indexed objects (served from memory) over materialized views ",
+            "Prefer indexed objects (served from memory) over unindexed materialized views ",
             "(read from persistent storage). Indexes are cluster-local; if a data product's ",
             "cluster differs from your session, pass the `cluster` parameter to `read_data_product` ",
             "so the index is actually used.",

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -598,7 +598,12 @@ async fn handle_mcp_method(
 /// These guide the AI agent on how to use the server correctly.
 fn endpoint_instructions(endpoint_type: McpEndpointType) -> Option<String> {
     match endpoint_type {
-        McpEndpointType::Agent => None,
+        McpEndpointType::Agent => Some(concat!(
+            "You have access to Materialize data products via MCP. ",
+            "Prefer indexed objects first (served from memory), then materialized views ",
+            "(read from persistent storage). Querying plain views, unindexed sources, or tables ",
+            "triggers query-time computation that can consume significant cluster resources, avoid these.",
+        ).to_string()),
         McpEndpointType::Developer => Some(concat!(
             "You are connected to the Materialize developer MCP server. ",
             "You have read-only access to system catalog tables (mz_*, pg_catalog, information_schema) ",

--- a/src/environmentd/tests/testdata/mcp/agent
+++ b/src/environmentd/tests/testdata/mcp/agent
@@ -16,7 +16,7 @@ mcp-agent
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}
 ----
 200 OK
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"materialize-mcp-agent","version":"<VERSION>"},"instructions":"You have access to Materialize data products via MCP. Prefer indexed objects first (served from memory), then materialized views (read from persistent storage). Querying plain views, unindexed sources, or tables triggers query-time computation that can consume significant cluster resources, avoid these."}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"materialize-mcp-agent","version":"<VERSION>"},"instructions":"You have access to Materialize data products via MCP. Prefer indexed objects (served from memory) over materialized views (read from persistent storage). Indexes are cluster-local; if a data product's cluster differs from your session, pass the `cluster` parameter to `read_data_product` so the index is actually used."}}
 
 # =============================================================================
 # Tools List (query tool disabled by default)

--- a/src/environmentd/tests/testdata/mcp/agent
+++ b/src/environmentd/tests/testdata/mcp/agent
@@ -16,7 +16,7 @@ mcp-agent
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}
 ----
 200 OK
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"materialize-mcp-agent","version":"<VERSION>"},"instructions":"You have access to Materialize data products via MCP. Prefer indexed objects (served from memory) over materialized views (read from persistent storage). Indexes are cluster-local; if a data product's cluster differs from your session, pass the `cluster` parameter to `read_data_product` so the index is actually used."}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"materialize-mcp-agent","version":"<VERSION>"},"instructions":"You have access to Materialize data products via MCP. Prefer indexed objects (served from memory) over unindexed materialized views (read from persistent storage). Indexes are cluster-local; if a data product's cluster differs from your session, pass the `cluster` parameter to `read_data_product` so the index is actually used."}}
 
 # =============================================================================
 # Tools List (query tool disabled by default)

--- a/src/environmentd/tests/testdata/mcp/agent
+++ b/src/environmentd/tests/testdata/mcp/agent
@@ -16,7 +16,7 @@ mcp-agent
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}
 ----
 200 OK
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"materialize-mcp-agent","version":"<VERSION>"}}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"materialize-mcp-agent","version":"<VERSION>"},"instructions":"You have access to Materialize data products via MCP. Prefer indexed objects first (served from memory), then materialized views (read from persistent storage). Querying plain views, unindexed sources, or tables triggers query-time computation that can consume significant cluster resources, avoid these."}}
 
 # =============================================================================
 # Tools List (query tool disabled by default)

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -317,14 +317,14 @@ query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_mcp_data_products' ORDER BY position
 ----
 object_name  text  Fully␠qualified␠object␠name␠(database.schema.name).
-cluster  text  Cluster␠where␠the␠object␠computes␠or␠its␠index␠is␠hosted.␠The␠object␠can␠be␠read␠from␠any␠cluster.
+cluster  text  Cluster␠where␠the␠object␠computes␠or␠its␠index␠is␠hosted.␠Reads␠from␠any␠cluster␠work,␠but␠only␠reads␠on␠this␠cluster␠benefit␠from␠the␠index.
 description  text  Index␠comment␠if␠available,␠otherwise␠object␠comment.␠Used␠as␠data␠product␠description.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_mcp_data_product_details' ORDER BY position
 ----
 object_name  text  Fully␠qualified␠object␠name␠(database.schema.name).
-cluster  text  Cluster␠where␠the␠object␠computes␠or␠its␠index␠is␠hosted.␠The␠object␠can␠be␠read␠from␠any␠cluster.
+cluster  text  Cluster␠where␠the␠object␠computes␠or␠its␠index␠is␠hosted.␠Reads␠from␠any␠cluster␠work,␠but␠only␠reads␠on␠this␠cluster␠benefit␠from␠the␠index.
 description  text  Index␠comment␠if␠available,␠otherwise␠object␠comment.␠Used␠as␠data␠product␠description.
 schema  jsonb  JSON␠Schema␠describing␠the␠object's␠columns␠and␠types.
 


### PR DESCRIPTION
As discussed adding a short instructions block to the MCP agent endpoint's `initialize` response, nudging agents to prefer indexed objects over materialized views. Pairs with the `indexedColumns` hint already surfaced by `get_data_product_details` so the agent has both session-level guidance and per-tool signals for picking the fast path.
