### PR TITLE
sql: keep sql_impl resolved IDs separate from statement dependencies SQL-296

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1009,14 +1009,9 @@ impl CatalogState {
             let session_catalog = state.for_system_session();
 
             let stmt = mz_sql::parse::parse(create_sql)?.into_element().ast;
-            let (stmt, mut resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;
-            let plan = mz_sql::plan::plan(
-                pcx,
-                &session_catalog,
-                stmt,
-                &Params::empty(),
-                &mut resolved_ids,
-            )?;
+            let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;
+            let (plan, _sql_impl_ids) =
+                mz_sql::plan::plan(pcx, &session_catalog, stmt, &Params::empty(), &resolved_ids)?;
 
             Ok((plan, resolved_ids))
         })
@@ -1030,8 +1025,9 @@ impl CatalogState {
         catalog: &ConnCatalog,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
         let stmt = mz_sql::parse::parse(create_sql)?.into_element().ast;
-        let (stmt, mut resolved_ids) = mz_sql::names::resolve(catalog, stmt)?;
-        let plan = mz_sql::plan::plan(pcx, catalog, stmt, &Params::empty(), &mut resolved_ids)?;
+        let (stmt, resolved_ids) = mz_sql::names::resolve(catalog, stmt)?;
+        let (plan, _sql_impl_ids) =
+            mz_sql::plan::plan(pcx, catalog, stmt, &Params::empty(), &resolved_ids)?;
 
         Ok((plan, resolved_ids))
     }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -955,15 +955,15 @@ impl SessionClient {
         let execute_plan = {
             let session = self.session.as_mut().expect("SessionClient invariant");
             let conn_catalog = catalog.for_session(session);
-            let (resolved_stmt, mut resolved_ids) =
+            let (resolved_stmt, resolved_ids) =
                 mz_sql::names::resolve(&conn_catalog, (**stmt).clone())?;
             let pcx = session.pcx();
-            let plan = mz_sql::plan::plan(
+            let (plan, _sql_impl_ids) = mz_sql::plan::plan(
                 Some(pcx),
                 &conn_catalog,
                 resolved_stmt,
                 params,
-                &mut resolved_ids,
+                &resolved_ids,
             )?;
             match plan {
                 Plan::Execute(plan) => plan,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -5077,6 +5077,7 @@ enum PlanStatement {
     Plan {
         plan: mz_sql::plan::Plan,
         resolved_ids: ResolvedIds,
+        sql_impl_resolved_ids: ResolvedIds,
     },
 }
 

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -246,8 +246,13 @@ impl Coordinator {
                     };
 
                     // Note: This plan is not guaranteed to run, it may get deferred again.
-                    self.sequence_plan(deferred.ctx, deferred.plan, resolved_ids)
-                        .await;
+                    self.sequence_plan(
+                        deferred.ctx,
+                        deferred.plan,
+                        resolved_ids,
+                        ResolvedIds::empty(),
+                    )
+                    .await;
                 }
             }
             DeferredOp::Write(DeferredWrite {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -322,7 +322,8 @@ impl Coordinator {
                     };
 
                     let conn_id = ctx.session().conn_id().clone();
-                    self.sequence_plan(ctx, plan, ResolvedIds::empty()).await;
+                    self.sequence_plan(ctx, plan, ResolvedIds::empty(), ResolvedIds::empty())
+                        .await;
                     // Part of the Command::Commit contract is that the Coordinator guarantees that
                     // it has cleared its transaction state for the connection.
                     self.clear_connection(&conn_id).await;
@@ -1420,7 +1421,7 @@ impl Coordinator {
         //   - In the handler for `Message::PurifiedStatementReady`, before we handle the purified statement.
         // If we add special handling for more types of `Statement`s, we'll need to ensure similar verification
         // occurs.
-        let (stmt, mut resolved_ids) = match stmt {
+        let (stmt, resolved_ids) = match stmt {
             // Various statements must be purified off the main coordinator thread of control.
             stmt if Self::must_spawn_purification(&stmt) => {
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
@@ -1580,8 +1581,11 @@ impl Coordinator {
             _ => (stmt, resolved_ids),
         };
 
-        match self.plan_statement(ctx.session(), stmt, &params, &mut resolved_ids) {
-            Ok(plan) => self.sequence_plan(ctx, plan, resolved_ids).await,
+        match self.plan_statement(ctx.session(), stmt, &params, &resolved_ids) {
+            Ok((plan, sql_impl_ids)) => {
+                self.sequence_plan(ctx, plan, resolved_ids, sql_impl_ids)
+                    .await
+            }
             Err(e) => ctx.retire(Err(e)),
         }
     }

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -522,8 +522,9 @@ pub(super) struct SubscribeSpec {
 impl SubscribeSpec {
     fn to_plan(&self, catalog: &dyn SessionCatalog) -> Result<SubscribePlan, anyhow::Error> {
         let parsed = mz_sql::parse::parse(self.sql)?.into_element();
-        let (stmt, mut resolved_ids) = mz_sql::names::resolve(catalog, parsed.ast)?;
-        let plan = mz_sql::plan::plan(None, catalog, stmt, &Params::empty(), &mut resolved_ids)?;
+        let (stmt, resolved_ids) = mz_sql::names::resolve(catalog, parsed.ast)?;
+        let (plan, _sql_impl_ids) =
+            mz_sql::plan::plan(None, catalog, stmt, &Params::empty(), &resolved_ids)?;
         match plan {
             Plan::Subscribe(plan) => Ok(plan),
             _ => bail!("unexpected plan type: {plan:?}"),

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -27,6 +27,7 @@ use mz_ore::{soft_assert_or_log, task};
 use mz_persist_client::usage::ShardsUsageReferenced;
 use mz_repr::{Datum, Diff, Row};
 use mz_sql::ast::Statement;
+use mz_sql::names::ResolvedIds;
 use mz_sql::pure::PurifiedStatement;
 use mz_storage_client::controller::IntrospectionType;
 use opentelemetry::trace::TraceContextExt;
@@ -751,8 +752,8 @@ impl Coordinator {
                 create_source_stmt,
                 subsources,
                 available_source_references,
-            } => {
-                self.plan_purified_create_source(
+            } => self
+                .plan_purified_create_source(
                     &ctx,
                     params,
                     create_progress_subsource_stmt,
@@ -761,13 +762,13 @@ impl Coordinator {
                     available_source_references,
                 )
                 .await
-            }
+                .map(|(plan, resolved_ids)| (plan, resolved_ids, ResolvedIds::empty())),
             PurifiedStatement::PurifiedAlterSourceAddSubsources {
                 source_name,
                 options,
                 subsources,
-            } => {
-                self.plan_purified_alter_source_add_subsource(
+            } => self
+                .plan_purified_alter_source_add_subsource(
                     ctx.session(),
                     params,
                     source_name,
@@ -775,16 +776,18 @@ impl Coordinator {
                     subsources,
                 )
                 .await
-            }
+                .map(|(plan, resolved_ids)| (plan, resolved_ids, ResolvedIds::empty())),
             PurifiedStatement::PurifiedAlterSourceRefreshReferences {
                 source_name,
                 available_source_references,
-            } => self.plan_purified_alter_source_refresh_references(
-                ctx.session(),
-                params,
-                source_name,
-                available_source_references,
-            ),
+            } => self
+                .plan_purified_alter_source_refresh_references(
+                    ctx.session(),
+                    params,
+                    source_name,
+                    available_source_references,
+                )
+                .map(|(plan, resolved_ids)| (plan, resolved_ids, ResolvedIds::empty())),
             o @ (PurifiedStatement::PurifiedAlterSource { .. }
             | PurifiedStatement::PurifiedCreateSink(..)
             | PurifiedStatement::PurifiedCreateTableFromSource { .. }) => {
@@ -807,14 +810,17 @@ impl Coordinator {
                 // Determine all dependencies, not just those in the statement
                 // itself.
                 let catalog = self.catalog().for_session(ctx.session());
-                let mut resolved_ids = mz_sql::names::visit_dependencies(&catalog, &stmt);
-                self.plan_statement(ctx.session(), stmt, &params, &mut resolved_ids)
-                    .map(|plan| (plan, resolved_ids))
+                let resolved_ids = mz_sql::names::visit_dependencies(&catalog, &stmt);
+                self.plan_statement(ctx.session(), stmt, &params, &resolved_ids)
+                    .map(|(plan, sql_impl_ids)| (plan, resolved_ids, sql_impl_ids))
             }
         };
 
         match plan {
-            Ok((plan, resolved_ids)) => self.sequence_plan(ctx, plan, resolved_ids).await,
+            Ok((plan, resolved_ids, sql_impl_ids)) => {
+                self.sequence_plan(ctx, plan, resolved_ids, sql_impl_ids)
+                    .await
+            }
             Err(e) => ctx.retire(Err(e)),
         }
     }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -105,6 +105,7 @@ impl Coordinator {
         mut ctx: ExecuteContext,
         plan: Plan,
         resolved_ids: ResolvedIds,
+        sql_impl_resolved_ids: ResolvedIds,
     ) -> LocalBoxFuture<'_, ()> {
         async move {
             let responses = ExecuteResponse::generated_from(&PlanKind::from(&plan));
@@ -202,6 +203,7 @@ impl Coordinator {
                 &plan,
                 target_cluster_id,
                 &resolved_ids,
+                &sql_impl_resolved_ids,
             ) {
                 return ctx.retire(Err(e.into()));
             }
@@ -377,7 +379,11 @@ impl Coordinator {
                         } else {
                             self.serialized_ddl.push_back(DeferredPlanStatement {
                                 ctx,
-                                ps: PlanStatement::Plan { plan, resolved_ids },
+                                ps: PlanStatement::Plan {
+                                    plan,
+                                    resolved_ids,
+                                    sql_impl_resolved_ids,
+                                },
                             });
                             return;
                         }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -361,13 +361,13 @@ impl Coordinator {
         global_id: GlobalId,
     ) -> Result<CreateSourcePlanBundle, AdapterError> {
         let catalog = self.catalog().for_session(session);
-        let mut resolved_ids = mz_sql::names::visit_dependencies(&catalog, &subsource_stmt);
+        let resolved_ids = mz_sql::names::visit_dependencies(&catalog, &subsource_stmt);
 
-        let plan = self.plan_statement(
+        let (plan, _sql_impl_ids) = self.plan_statement(
             session,
             Statement::CreateSubsource(subsource_stmt),
             params,
-            &mut resolved_ids,
+            &resolved_ids,
         )?;
         let plan = match plan {
             Plan::CreateSource(plan) => plan,
@@ -503,7 +503,7 @@ impl Coordinator {
         }
 
         let catalog = self.catalog().for_session(ctx.session());
-        let mut resolved_ids = mz_sql::names::visit_dependencies(&catalog, &source_stmt);
+        let resolved_ids = mz_sql::names::visit_dependencies(&catalog, &source_stmt);
 
         let propagated_with_options: Vec<_> = source_stmt
             .with_options
@@ -522,10 +522,10 @@ impl Coordinator {
             ctx.session(),
             Statement::CreateSource(source_stmt),
             &params,
-            &mut resolved_ids,
+            &resolved_ids,
         )? {
-            Plan::CreateSource(plan) => plan,
-            p => unreachable!("s must be CreateSourcePlan but got {:?}", p),
+            (Plan::CreateSource(plan), _sql_impl_ids) => plan,
+            (p, _) => unreachable!("s must be CreateSourcePlan but got {:?}", p),
         };
 
         let (item_id, global_id) = self.allocate_user_id().await?;
@@ -3509,7 +3509,7 @@ impl Coordinator {
             let catalog = self.catalog().for_system_session();
 
             // Resolve items in statement
-            let (mut create_conn_stmt, mut resolved_ids) =
+            let (mut create_conn_stmt, resolved_ids) =
                 mz_sql::names::resolve(&catalog, create_conn_stmt)
                     .map_err(|e| AdapterError::internal("ALTER CONNECTION", e))?;
 
@@ -3536,12 +3536,14 @@ impl Coordinator {
                 &catalog,
                 Statement::CreateConnection(create_conn_stmt),
                 &Params::empty(),
-                &mut resolved_ids,
+                &resolved_ids,
             )
             .map_err(|e| AdapterError::InvalidAlter("CONNECTION", e))?
             {
-                Plan::CreateConnection(plan) => plan,
-                _ => unreachable!("create source plan is only valid response"),
+                (Plan::CreateConnection(plan), _sql_impl_ids) => plan,
+                (p, _) => {
+                    unreachable!("create connection plan is only valid response, got {:?}", p)
+                }
             };
 
             // Parse statement.
@@ -3720,7 +3722,7 @@ impl Coordinator {
                 } = options.try_into()?;
 
                 // Resolve items in statement
-                let (mut create_source_stmt, mut resolved_ids) =
+                let (mut create_source_stmt, resolved_ids) =
                     create_sql_to_stmt_deps(self, ALTER_SOURCE, cur_entry.create_sql())?;
 
                 // Get all currently referred-to items
@@ -3935,12 +3937,14 @@ impl Coordinator {
                     &catalog,
                     Statement::CreateSource(create_source_stmt),
                     &Params::empty(),
-                    &mut resolved_ids,
+                    &resolved_ids,
                 )
                 .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
                 let plan = match planned {
-                    Plan::CreateSource(plan) => plan,
-                    _ => unreachable!("create source plan is only valid response"),
+                    (Plan::CreateSource(plan), _sql_impl_ids) => plan,
+                    (p, _) => {
+                        unreachable!("create source plan is only valid response, got {:?}", p)
+                    }
                 };
 
                 // Asserting that we've done the right thing with dependencies
@@ -4581,8 +4585,13 @@ impl Coordinator {
             crate::coord::PlanStatement::Statement { stmt, params } => {
                 self.handle_execute_inner(stmt, params, ctx).await;
             }
-            crate::coord::PlanStatement::Plan { plan, resolved_ids } => {
-                self.sequence_plan(ctx, plan, resolved_ids).await;
+            crate::coord::PlanStatement::Plan {
+                plan,
+                resolved_ids,
+                sql_impl_resolved_ids,
+            } => {
+                self.sequence_plan(ctx, plan, resolved_ids, sql_impl_resolved_ids)
+                    .await;
             }
         }
     }

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -28,17 +28,21 @@ use crate::util::describe;
 use crate::{AdapterError, ExecuteContext, ExecuteResponse, metrics};
 
 impl Coordinator {
+    /// Plans a statement and returns the plan along with any resolved IDs
+    /// discovered inside SQL-implemented function bodies. The extra IDs should
+    /// only be used for the `restrict_to_user_objects` RBAC check.
     pub(crate) fn plan_statement(
         &self,
         session: &Session,
         stmt: mz_sql::ast::Statement<Aug>,
         params: &mz_sql::plan::Params,
-        resolved_ids: &mut ResolvedIds,
-    ) -> Result<mz_sql::plan::Plan, AdapterError> {
+        resolved_ids: &ResolvedIds,
+    ) -> Result<(mz_sql::plan::Plan, ResolvedIds), AdapterError> {
         let pcx = session.pcx();
         let catalog = self.catalog().for_session(session);
-        let plan = mz_sql::plan::plan(Some(pcx), &catalog, stmt, params, resolved_ids)?;
-        Ok(plan)
+        let (plan, sql_impl_ids) =
+            mz_sql::plan::plan(Some(pcx), &catalog, stmt, params, resolved_ids)?;
+        Ok((plan, sql_impl_ids))
     }
 
     pub(crate) fn declare(

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -321,10 +321,11 @@ impl PeekClient {
         let conn_catalog = catalog.for_session(session);
         // (`resolved_ids` should be derivable from `stmt`. If `stmt` is later transformed to
         // remove/add IDs, then `resolved_ids` should be updated to also remove/add those IDs.)
-        let (stmt, mut resolved_ids) = mz_sql::names::resolve(&conn_catalog, (*stmt).clone())?;
+        let (stmt, resolved_ids) = mz_sql::names::resolve(&conn_catalog, (*stmt).clone())?;
 
         let pcx = session.pcx();
-        let plan = mz_sql::plan::plan(Some(pcx), &conn_catalog, stmt, &params, &mut resolved_ids)?;
+        let (plan, sql_impl_ids) =
+            mz_sql::plan::plan(Some(pcx), &conn_catalog, stmt, &params, &resolved_ids)?;
 
         /// What do we do with the result of the select?
         enum QueryPlan<'a> {
@@ -509,6 +510,7 @@ impl PeekClient {
             &plan,
             Some(target_cluster_id),
             &resolved_ids,
+            &sql_impl_ids,
         )?;
 
         if let Some((_, wait_future)) =

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -290,8 +290,8 @@ pub fn plan(
     catalog: &dyn SessionCatalog,
     stmt: Statement<Aug>,
     params: &Params,
-    resolved_ids: &mut ResolvedIds,
-) -> Result<Plan, PlanError> {
+    resolved_ids: &ResolvedIds,
+) -> Result<(Plan, ResolvedIds), PlanError> {
     let param_types = params
         // We need the `expected_types` here, not the `actual_types`! This is because
         // `expected_types` is how the parameter expression (e.g. `$1`) looks "from the outside":
@@ -457,14 +457,6 @@ pub fn plan(
         }
     };
 
-    // Merge resolved IDs discovered during planning (from sql_impl function
-    // bodies) into the caller's resolved_ids so the RBAC check sees them.
-    resolved_ids.extend_from(
-        &scx.sql_impl_resolved_ids
-            .lock()
-            .expect("planning is single-threaded"),
-    );
-
     if let Ok(plan) = &plan {
         mz_ore::soft_assert_no_log!(
             permitted_plans.contains(&PlanKind::from(plan)),
@@ -474,7 +466,17 @@ pub fn plan(
         );
     }
 
-    plan
+    // Return the plan along with any resolved IDs accumulated from sql_impl
+    // function bodies. These are kept separate from the main resolved_ids
+    // because they are implementation details of the functions, not real
+    // dependencies of the statement. They should only be used for the
+    // restrict_to_user_objects RBAC check.
+    let sql_impl_ids = scx
+        .sql_impl_resolved_ids
+        .lock()
+        .expect("planning is single-threaded")
+        .clone();
+    plan.map(|p| (p, sql_impl_ids))
 }
 
 pub fn plan_copy_from(
@@ -533,14 +535,14 @@ pub struct StatementContext<'a> {
     /// ambiguous. For example `NATURAL JOIN` or `SELECT *`. This is filled in as planning occurs.
     pub ambiguous_columns: RefCell<bool>,
     /// Accumulates resolved IDs from SQL-implemented function bodies (`sql_impl_func`,
-    /// `sql_impl_table_func`). These functions re-parse and re-resolve static SQL
-    /// strings during planning; without this accumulator, the resolved IDs from
-    /// those inner resolutions would be lost.
+    /// `sql_impl_table_func`). These are kept separate from the statement's main
+    /// `resolved_ids` because they are implementation details of the functions, not
+    /// real dependencies of the statement. They are only used for the
+    /// `restrict_to_user_objects` RBAC check.
     ///
     /// Uses `Arc<Mutex<_>>` so that cloned `StatementContext`s (as in `sql_impl`)
-    /// share the same underlying storage — mutations in the clone propagate back.
-    /// `Arc` (vs `Rc`) is needed because `StatementContext` must be `Send` for
-    /// use in async contexts, even though planning itself is synchronous.
+    /// share the same underlying storage. `Arc` (vs `Rc`) is needed because
+    /// `StatementContext` must be `Send`.
     pub sql_impl_resolved_ids: Arc<Mutex<ResolvedIds>>,
 }
 

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -393,6 +393,11 @@ pub fn check_usage(
 }
 
 /// Checks if a session is authorized to execute a plan. If not, an error is returned.
+///
+/// `sql_impl_resolved_ids` contains resolved IDs discovered inside SQL-implemented function
+/// bodies during planning. These are kept separate from `resolved_ids` because they are
+/// implementation details of the functions, not dependencies of the statement. They are
+/// only checked by the `restrict_to_user_objects` restriction.
 pub fn check_plan(
     catalog: &impl SessionCatalog,
     // Function mapping a connection ID to an authenticated role. The roles may have been dropped concurrently.
@@ -405,8 +410,14 @@ pub fn check_plan(
     plan: &Plan,
     target_cluster_id: Option<ClusterId>,
     resolved_ids: &ResolvedIds,
+    sql_impl_resolved_ids: &ResolvedIds,
 ) -> Result<(), UnauthorizedError> {
     rbac_check_preamble(catalog, session)?;
+
+    // Check sql_impl function body dependencies against restrict_to_user_objects.
+    // These are checked separately from the main resolved_ids because they are
+    // implementation details that should not affect dependency tracking.
+    check_restrict_to_user_objects(catalog, session, sql_impl_resolved_ids)?;
 
     let rbac_requirements = generate_rbac_requirements(
         catalog,

--- a/test/sqllogictest/rbac_mcp_agent.slt
+++ b/test/sqllogictest/rbac_mcp_agent.slt
@@ -94,6 +94,19 @@ SELECT * FROM agent_objects.transfer_windows;
 COMPLETE 1
 
 # =============================================================================
+# Regression test: views using SQL-implemented functions (has_table_privilege,
+# etc.) must not be rejected with "unstable dependencies". The sql_impl
+# resolved IDs are implementation details of the function, not real
+# dependencies of the view.
+# =============================================================================
+
+statement ok
+CREATE VIEW agent_objects.privilege_check AS SELECT has_table_privilege('agent', 'agent_objects.next_arrivals', 'SELECT') AS has_priv;
+
+statement ok
+DROP VIEW agent_objects.privilege_check;
+
+# =============================================================================
 # Test: mz_internal tables that ARE properly blocked by RBAC
 # These tables use MONITOR_SELECT or similar restricted access
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes the regression from #36480 where views using SQL-implemented functions (`has_table_privilege`, `has_cluster_privilege`, etc.) were rejected with "cannot create view with unstable dependencies."

- `plan()` now returns `(Plan, ResolvedIds)` where the second element contains IDs discovered inside `sql_impl` function bodies
- These are threaded separately through `plan_statement` → `sequence_plan` → `check_plan` → `check_restrict_to_user_objects`
- The main `resolved_ids` used for dependency tracking is never polluted with internal function implementation details
- Added regression test verifying `CREATE VIEW ... has_table_privilege(...)` succeeds

Fixes SQL-296.