### PR TITLE
console: ranked fuzzy search + auto-sized cluster dropdown

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -89,6 +89,7 @@
     "launchdarkly-js-client-sdk": "^3.9.0",
     "lodash.debounce": "^4.0.8",
     "markdown-table": "^3.0.4",
+    "match-sorter": "^8.0.0",
     "mitt": "^3.0.1",
     "oidc-client-ts": "^3.4.1",
     "openapi-fetch": "^0.17.0",

--- a/console/src/platform/shell/ClusterDropdown.test.ts
+++ b/console/src/platform/shell/ClusterDropdown.test.ts
@@ -1,0 +1,70 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { rankClusters } from "./ClusterDropdown";
+
+describe("rankClusters", () => {
+  const clusters = [
+    { name: "quickstart" },
+    { name: "prod" },
+    { name: "production-analytics" },
+    { name: "production-analytics-prod" },
+    { name: "staging-cluster" },
+    { name: "mz_introspection" },
+  ];
+
+  it("returns the original options reference when input is empty", () => {
+    // Identity check: empty input must not reorder or copy the list, so the
+    // dropdown's first render shows the caller's order (alphabetized by the
+    // ShellHeader).
+    expect(rankClusters(clusters, "")).toBe(clusters);
+  });
+
+  it("ranks exact match above starts-with above contains", () => {
+    expect(rankClusters(clusters, "prod").map((c) => c.name)).toEqual([
+      "prod",
+      "production-analytics",
+      "production-analytics-prod",
+    ]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(rankClusters(clusters, "PROD").map((c) => c.name)).toEqual([
+      "prod",
+      "production-analytics",
+      "production-analytics-prod",
+    ]);
+  });
+
+  it("matches acronyms (e.g. `qs` -> `quickstart`)", () => {
+    expect(rankClusters(clusters, "qs").map((c) => c.name)).toEqual([
+      "quickstart",
+    ]);
+  });
+
+  it("ranks substring matches above subsequence-only matches", () => {
+    // `mz_introspection` contains the substring "intro";
+    // `production-analytics-prod` only matches "intro" as a non-contiguous
+    // subsequence (i…n…t…r…o), so it should rank lower.
+    expect(rankClusters(clusters, "intro").map((c) => c.name)).toEqual([
+      "mz_introspection",
+      "production-analytics-prod",
+    ]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(rankClusters(clusters, "xyz")).toEqual([]);
+  });
+
+  it("filters single-match queries down to just the matching option", () => {
+    expect(rankClusters(clusters, "stag").map((c) => c.name)).toEqual([
+      "staging-cluster",
+    ]);
+  });
+});

--- a/console/src/platform/shell/ClusterDropdown.tsx
+++ b/console/src/platform/shell/ClusterDropdown.tsx
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+import { matchSorter } from "match-sorter";
 import React from "react";
 
 import SearchableSelect from "~/components/SearchableSelect/SearchableSelect";
@@ -21,19 +22,54 @@ export type ClusterDropdownProps = {
   isLoading: boolean;
 };
 
+/**
+ * Rank cluster options against the user's search input using match-sorter's
+ * default thresholds (CASE_SENSITIVE_EQUAL > EQUAL > STARTS_WITH >
+ * WORD_STARTS_WITH > CONTAINS > ACRONYM > MATCHES). Returns the original
+ * `options` reference unchanged when `inputValue` is empty so the menu's
+ * first-render order is stable.
+ *
+ * Exported for unit testing.
+ */
+export function rankClusters(
+  options: ClusterOption[],
+  inputValue: string,
+): ClusterOption[] {
+  if (!inputValue) return options;
+  return matchSorter(options, inputValue, { keys: ["name"] });
+}
+
 const ClusterDropdown = (props: ClusterDropdownProps) => {
+  // Control react-select's input value so we can re-rank options on each
+  // keystroke (see `rankClusters` above for the ranking strategy).
+  const [inputValue, setInputValue] = React.useState("");
+
+  const rankedOptions = React.useMemo(
+    () => rankClusters(props.options, inputValue),
+    [props.options, inputValue],
+  );
+
   return (
     <SearchableSelect<{ name: string }>
       label="Cluster"
       ariaLabel="Cluster"
       isDisabled={props.isDisabled}
       placeholder="Select one"
-      options={props.options}
+      options={rankedOptions}
       onChange={(value) => value && props.onChange(value.name)}
       value={{ name: props.value }}
       isLoading={props.isLoading}
       containerWidth="280px"
-      menuWidth="400px"
+      // Intentionally omit `menuWidth` so the popover auto-sizes to the
+      // longest cluster name (falls back to theme default
+      // `width: fit-content`, `minWidth: 240px`). The previous hard-coded
+      // value truncated long cluster names on Edge/Firefox; Safari was
+      // forgiving thanks to `-webkit-line-clamp` quirks.
+      inputValue={inputValue}
+      onInputChange={(newValue) => setInputValue(newValue)}
+      // match-sorter already filtered + ranked the options above, so disable
+      // react-select's default substring filter.
+      filterOption={null}
     />
   );
 };

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -616,7 +616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
   checksum: 10c0/30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
@@ -10922,6 +10922,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"match-sorter@npm:^8.0.0":
+  version: 8.3.0
+  resolution: "match-sorter@npm:8.3.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.8"
+    remove-accents: "npm:0.5.0"
+  checksum: 10c0/e71a7aa75e87d356867a12f61af7cf9236806d6c58550d7b057f567ff7baa177a7b0f1311cbce528797043cd75463274db43a8139002ba708401e4a84dce1083
+  languageName: node
+  linkType: hard
+
 "materialize-console@workspace:.":
   version: 0.0.0-use.local
   resolution: "materialize-console@workspace:."
@@ -11041,6 +11051,7 @@ __metadata:
     lint-staged: "npm:^16.2.7"
     lodash.debounce: "npm:^4.0.8"
     markdown-table: "npm:^3.0.4"
+    match-sorter: "npm:^8.0.0"
     miragejs: "npm:^0.1.48"
     mitt: "npm:^3.0.1"
     module-alias: "npm:^2.3.4"
@@ -12953,6 +12964,13 @@ __metadata:
   version: 0.2.7
   resolution: "relateurl@npm:0.2.7"
   checksum: 10c0/c248b4e3b32474f116a804b537fa6343d731b80056fb506dffd91e737eef4cac6be47a65aae39b522b0db9d0b1011d1a12e288d82a109ecd94a5299d82f6573a
+  languageName: node
+  linkType: hard
+
+"remove-accents@npm:0.5.0":
+  version: 0.5.0
+  resolution: "remove-accents@npm:0.5.0"
+  checksum: 10c0/a75321aa1b53d9abe82637115a492770bfe42bb38ed258be748bf6795871202bc8b4badff22013494a7029f5a241057ad8d3f72adf67884dbe15a9e37e87adc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context

Per Crane's feedback in [#console-team Slack](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1778690013659759):
- The cluster dropdown was too narrow to display longer cluster names on Edge and Firefox (Safari was unaffected, masking the issue).
- Cluster search did substring-only filtering, with no ranking — typing `prod` made the user scroll past `production-analytics-prod` to find `prod`.

## Changes

**`console/src/platform/shell/ClusterDropdown.tsx`**

- Replaces react-select's default substring filter with [`match-sorter`](https://www.npmjs.com/package/match-sorter), which ranks results by `CASE_SENSITIVE_EQUAL > EQUAL > STARTS_WITH > WORD_STARTS_WITH > CONTAINS > ACRONYM > MATCHES`. Typing `prod` now surfaces `prod` above `production-analytics`, which surfaces above `production-analytics-prod`.
- Controls react-select's `inputValue` so options can be re-ranked on every keystroke, and sets `filterOption={null}` to disable the now-redundant default filter.
- Drops the hard-coded `menuWidth` so the popover falls back to the theme default (`width: fit-content`, `minWidth: 240px`) and auto-sizes to the longest cluster name. The prior fixed width still truncated longer names; Safari was forgiving thanks to `-webkit-line-clamp` quirks, which is why the bug didn't show there.
- Extracts the ranking logic into an exported `rankClusters(options, inputValue)` helper so it can be tested in isolation.

**`console/package.json`**

- Adds `match-sorter@^8.0.0` (~3 KB gzipped, no transitive bloat).

## Tests

New file: `console/src/platform/shell/ClusterDropdown.test.ts` — 7 cases covering:

- Empty input returns the original `options` reference unchanged (so first render stays stable in the caller's order).
- Exact match ranks above starts-with, which ranks above contains.
- Case-insensitive (`PROD` matches the same as `prod`).
- Acronym match (`qs` → `quickstart`).
- Substring matches rank above subsequence-only matches (`intro` → `mz_introspection` before `production-analytics-prod`).
- No-match query returns an empty list.
- Single-match query filters down correctly.

Run with: `yarn test --run src/platform/shell/ClusterDropdown.test.ts`

## Verification

- ✅ `yarn typecheck` clean
- ✅ `yarn lint` clean
- ✅ `yarn test` for the new file — 7/7 passing locally
- ⏳ Visual smoke test in `yarn start` — please confirm during review, since I haven't verified the live dropdown behavior

## ⚠️ AI-assisted

This PR was drafted with Claude assistance. Please review thoroughly — particularly the controlled-input logic around react-select (`inputValue` / `onInputChange`), which can have subtle bugs when the user selects an option or blurs the input.
