### PR TITLE
[SS-69] use updated iceberg-rust fork. new auth hooks for S3 Tables REST and S3 FileIO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+dependencies = [
+ "serde",
+ "serde-big-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2940,7 +2950,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c298552016db86f0d49e5de09818dd86c536f66095013cc415f4f85744033f"
 dependencies = [
- "erased-serde",
+ "erased-serde 0.3.26",
  "lazy_static",
  "regex",
  "serde",
@@ -3197,6 +3207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,6 +3327,18 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fastnum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
+dependencies = [
+ "bnum",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4251,8 +4284,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.7.0"
-source = "git+https://github.com/MaterializeInc/iceberg-rust.git?rev=c31a98afe789#c31a98afe789b0dcfd2ab9cc23e2ecf5120aaaac"
+version = "0.9.0"
+source = "git+https://github.com/MaterializeInc/iceberg-rust.git?rev=cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92#cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -4275,22 +4308,19 @@ dependencies = [
  "chrono",
  "derive_builder",
  "expect-test",
+ "fastnum",
  "flate2",
  "fnv",
  "futures",
  "itertools 0.13.0",
  "moka",
  "murmur3",
- "num-bigint",
  "once_cell",
- "opendal",
  "ordered-float 4.6.0",
  "parquet",
  "rand 0.8.5",
- "reqsign",
  "reqwest",
  "roaring",
- "rust_decimal",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -4300,6 +4330,7 @@ dependencies = [
  "strum",
  "tokio",
  "typed-builder 0.20.1",
+ "typetag",
  "url",
  "uuid",
  "zstd",
@@ -4307,13 +4338,10 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.7.0"
-source = "git+https://github.com/MaterializeInc/iceberg-rust.git?rev=c31a98afe789#c31a98afe789b0dcfd2ab9cc23e2ecf5120aaaac"
+version = "0.9.0"
+source = "git+https://github.com/MaterializeInc/iceberg-rust.git?rev=cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92#cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92"
 dependencies = [
  "async-trait",
- "aws-credential-types",
- "aws-sigv4",
- "aws-types",
  "chrono",
  "http 1.4.0",
  "iceberg",
@@ -4326,6 +4354,24 @@ dependencies = [
  "tracing",
  "typed-builder 0.20.1",
  "uuid",
+]
+
+[[package]]
+name = "iceberg-storage-opendal"
+version = "0.9.0"
+source = "git+https://github.com/MaterializeInc/iceberg-rust.git?rev=cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92#cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "iceberg",
+ "opendal",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "typetag",
+ "url",
 ]
 
 [[package]]
@@ -4493,6 +4539,15 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ipnet"
@@ -8177,6 +8232,8 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-sts",
+ "aws-sigv4",
+ "aws-smithy-runtime-api",
  "aws-types",
  "base64 0.22.1",
  "bytes",
@@ -8189,6 +8246,7 @@ dependencies = [
  "http 1.4.0",
  "iceberg",
  "iceberg-catalog-rest",
+ "iceberg-storage-opendal",
  "insta",
  "itertools 0.14.0",
  "mysql_async",
@@ -11067,6 +11125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "git+https://github.com/MaterializeInc/serde-value.git#a84c6b71825efaffb332c0d19f18c2bdf9ee7b40"
@@ -12658,10 +12725,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde 0.4.10",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tz-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,8 +366,9 @@ hyper-0-14 = { package = "hyper", version = "0.14", features = ["client", "tcp"]
 hyper-openssl = "0.10.2"
 hyper-util = "0.1.20"
 tower-service = "0.3.3"
-iceberg = "0.7.0"
-iceberg-catalog-rest = "0.7.0"
+iceberg = "0.9.0"
+iceberg-catalog-rest = "0.9.0"
+iceberg-storage-opendal = { version = "0.9.0", default-features = false, features = ["opendal-s3"] }
 imbl = { version = "7.0.0", features = ["serde"] }
 include_dir = "0.7.4"
 indexmap = { version = "2.10.0", default-features = false, features = ["std"] }
@@ -621,9 +622,10 @@ tiberius = { git = "https://github.com/MaterializeInc/tiberius", rev="64ca594cc2
 async-compression = { git = "https://github.com/MaterializeInc/async-compression.git", rev = "fe7411eb6104a02a89e2c3a76ab326dd6594214d" }
 
 # Custom iceberg features for mz
-# All changes should go to the `mz_changes` branch.
-iceberg = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "c31a98afe789" }
-iceberg-catalog-rest = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "c31a98afe789" }
+# All changes should go to the `kynan-mz_changes_v0.9.0` branch.
+iceberg = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92" }
+iceberg-catalog-rest = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92" }
+iceberg-storage-opendal = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "cd7349fb1fa9d640eaeb9f39d85d7cebc089fa92" }
 
 # Custom duckdb crate to support mz needs
 # All changes should go to the `mz_changes` branch.

--- a/deny.toml
+++ b/deny.toml
@@ -128,6 +128,8 @@ skip = [
     { name = "fallible-iterator", version = "0.3.0" },
     # arrow
     { name = "hashbrown", version = "0.16.1" },
+    # Used by dynfmt; iceberg/typetag pulls in v0.4.
+    { name = "erased-serde", version = "0.3.26" },
 ]
 
 [[bans.deny]]

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -20,6 +20,8 @@ async-trait.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
 aws-sdk-sts.workspace = true
+aws-sigv4.workspace = true
+aws-smithy-runtime-api.workspace = true
 aws-types.workspace = true
 bytes.workspace = true
 columnation.workspace = true
@@ -74,6 +76,7 @@ uuid = { workspace = true, features = ["serde", "v4"] }
 base64.workspace = true
 iceberg.workspace = true
 iceberg-catalog-rest.workspace = true
+iceberg-storage-opendal.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -13,18 +13,24 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
-use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
+use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, sign};
+use aws_sigv4::sign::v4;
+// Aliased to avoid colliding with `mz_ccsr::tls::Identity`.
+use aws_smithy_runtime_api::client::identity::Identity as AwsIdentity;
+use http::{HeaderName, HeaderValue};
 use iceberg::Catalog;
 use iceberg::CatalogBuilder;
-use iceberg::io::{
-    AwsCredential, AwsCredentialLoad, CustomAwsCredentialLoader, S3_ACCESS_KEY_ID,
-    S3_DISABLE_EC2_METADATA, S3_REGION, S3_SECRET_ACCESS_KEY,
-};
+use iceberg::io::{S3_ACCESS_KEY_ID, S3_DISABLE_EC2_METADATA, S3_REGION, S3_SECRET_ACCESS_KEY};
 use iceberg_catalog_rest::{
-    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE, RestCatalogBuilder,
+    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE, RequestAuthenticator, RestCatalogBuilder,
+};
+use iceberg_storage_opendal::{
+    AwsCredential, AwsCredentialLoad, CustomAwsCredentialLoader, OpenDalStorageFactory,
 };
 use itertools::Itertools;
 use mz_ccsr::tls::{Certificate, Identity};
@@ -51,6 +57,7 @@ use rdkafka::ClientContext;
 use rdkafka::config::FromClientConfigAndContext;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use regex::Regex;
+use reqwest::Request;
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio::net;
 use tokio::runtime::Handle;
@@ -89,11 +96,11 @@ const REST_CATALOG_PROP_CREDENTIAL: &str = "credential";
 struct AwsSdkCredentialLoader {
     /// The underlying AWS SDK credentials provider. For assume role auth, this provider
     /// already handles the full chain: ambient creds -> jump role -> user role.
-    provider: aws_credential_types::provider::SharedCredentialsProvider,
+    provider: SharedCredentialsProvider,
 }
 
 impl AwsSdkCredentialLoader {
-    fn new(provider: aws_credential_types::provider::SharedCredentialsProvider) -> Self {
+    fn new(provider: SharedCredentialsProvider) -> Self {
         Self { provider }
     }
 }
@@ -126,6 +133,96 @@ impl AwsCredentialLoad for AwsSdkCredentialLoader {
             session_token: creds.session_token().map(|s| s.to_string()),
             expires_in: creds.expiry().map(|t| t.into()),
         }))
+    }
+}
+
+/// Signs each outgoing REST-catalog request with AWS SigV4.
+///
+/// Holds a [`SharedCredentialsProvider`] (not static `Credentials`) so each
+/// request signs with refreshable creds from Materialize's chain
+/// (ambient -> jump role -> user role w/ external ID).
+struct Sigv4Authenticator {
+    provider: SharedCredentialsProvider,
+    region: String,
+    /// The AWS signing name. `"s3tables"` for AWS S3 Tables REST catalog.
+    signing_name: String,
+}
+
+impl std::fmt::Debug for Sigv4Authenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sigv4Authenticator")
+            .field("region", &self.region)
+            .field("signing_name", &self.signing_name)
+            .finish_non_exhaustive()
+    }
+}
+
+fn sigv4_err(e: impl Into<anyhow::Error>) -> iceberg::Error {
+    iceberg::Error::new(iceberg::ErrorKind::DataInvalid, "AWS SigV4").with_source(e)
+}
+
+#[async_trait]
+impl RequestAuthenticator for Sigv4Authenticator {
+    async fn authenticate_request(&self, req: &mut Request) -> iceberg::Result<()> {
+        let creds = self
+            .provider
+            .provide_credentials()
+            .await
+            .map_err(sigv4_err)?;
+        let identity: AwsIdentity = creds.into();
+        let params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(&self.region)
+            .name(&self.signing_name)
+            .time(SystemTime::now())
+            .settings(SigningSettings::default())
+            .build()
+            .map_err(sigv4_err)?
+            .into();
+        let body: Vec<u8> = req
+            .body()
+            .and_then(|b| b.as_bytes())
+            .map(|b| b.to_vec())
+            .unwrap_or_default();
+        let headers: Vec<(&str, &str)> = req
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.to_str().unwrap_or("")))
+            .collect();
+        let signable = SignableRequest::new(
+            req.method().as_str(),
+            req.url().as_str(),
+            headers.into_iter(),
+            SignableBody::Bytes(&body),
+        )
+        .map_err(sigv4_err)?;
+        let (instructions, _sig) = sign(signable, &params).map_err(sigv4_err)?.into_parts();
+        let (new_headers, new_query) = instructions.into_parts();
+        for header in new_headers {
+            let mut value = HeaderValue::from_str(header.value()).map_err(sigv4_err)?;
+            value.set_sensitive(header.sensitive());
+            req.headers_mut()
+                .insert(HeaderName::from_static(header.name()), value);
+        }
+        if !new_query.is_empty() {
+            let url = req.url_mut();
+            let mut pairs = url.query_pairs_mut();
+            for (name, value) in new_query {
+                pairs.append_pair(name, &value);
+            }
+        }
+        Ok(())
+    }
+
+    // SigV4 is stateless: nothing to cache, invalidate, or refresh.
+    async fn ensure_cached(&self) -> iceberg::Result<()> {
+        Ok(())
+    }
+    async fn invalidate_cache(&self) -> iceberg::Result<()> {
+        Ok(())
+    }
+    async fn regenerate_cache(&self) -> iceberg::Result<()> {
+        Ok(())
     }
 }
 
@@ -606,7 +703,7 @@ impl IcebergCatalogConnection<InlinedConnection> {
             .unwrap_or_else(|| "us-east-1".to_string());
 
         let mut props = vec![
-            (S3_REGION.to_string(), aws_region),
+            (S3_REGION.to_string(), aws_region.clone()),
             (S3_DISABLE_EC2_METADATA.to_string(), "true".to_string()),
             (
                 REST_CATALOG_PROP_WAREHOUSE.to_string(),
@@ -631,11 +728,35 @@ impl IcebergCatalogConnection<InlinedConnection> {
             ));
         }
 
-        // Build the catalog with aws_config for REST API signing.
-        // For AssumeRole auth, we also add a FileIO extension so OpenDAL can
-        // use our credential chain for S3 object access.
+        // Sign REST catalog requests with the Materialize AWS credential chain
+        // via a custom `RequestAuthenticator`. For AssumeRole auth, also feed
+        // the chain to OpenDAL's S3 loader so data-file IO uses the same creds.
+        let credentials_provider = aws_config
+            .credentials_provider()
+            .ok_or_else(|| anyhow!("aws_config missing credentials provider"))?;
+
+        let authenticator = Arc::new(Sigv4Authenticator {
+            provider: credentials_provider.clone(),
+            region: aws_region.clone(),
+            signing_name: "s3tables".to_string(),
+        });
+
+        let customized_credential_load = if matches!(aws_auth, AwsAuth::AssumeRole(_)) {
+            Some(CustomAwsCredentialLoader::new(Arc::new(
+                AwsSdkCredentialLoader::new(credentials_provider),
+            )))
+        } else {
+            None
+        };
+
+        let storage_factory = Arc::new(OpenDalStorageFactory::S3 {
+            configured_scheme: "s3".to_string(),
+            customized_credential_load,
+        });
+
         let catalog = RestCatalogBuilder::default()
-            .with_aws_config(aws_config.clone())
+            .with_storage_factory(storage_factory)
+            .with_authenticator(authenticator)
             .load("IcebergCatalog", props.into_iter().collect())
             .await
             .with_context(|| {
@@ -645,18 +766,6 @@ impl IcebergCatalogConnection<InlinedConnection> {
                     aws_ref.connection_id, self.uri, s3tables.warehouse
                 )
             })?;
-
-        let catalog = if matches!(aws_auth, AwsAuth::AssumeRole(_)) {
-            let credentials_provider = aws_config
-                .credentials_provider()
-                .ok_or_else(|| anyhow!("aws_config missing credentials provider"))?;
-            let file_io_loader = CustomAwsCredentialLoader::new(Arc::new(
-                AwsSdkCredentialLoader::new(credentials_provider),
-            ));
-            catalog.with_file_io_extension(file_io_loader)
-        } else {
-            catalog
-        };
 
         Ok(Arc::new(catalog))
     }
@@ -691,6 +800,14 @@ impl IcebergCatalogConnection<InlinedConnection> {
         }
 
         let catalog = RestCatalogBuilder::default()
+            .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: "s3".to_string(),
+                // Polaris returns a config with:
+                //   s3.access-key-id, s3.secret-access-key, s3.endpoint, ...
+                // `iceberg-rust` forwards these props to `opendal`.
+                // N.B. This is not confirmed to work with other catalog & storage implementations.
+                customized_credential_load: None,
+            }))
             .load("IcebergCatalog", props.into_iter().collect())
             .await
             .map_err(|e| anyhow!("failed to create Iceberg catalog: {e}"))?;


### PR DESCRIPTION
In preparation for sinking to GCP's Lakehouse, I've pulled in the stable release `v0.9.0` for `iceberg-rust` and added a `RequestAuthenticator` trait for customizing auth support.

Auth options:
- AWS SigV4 (_now in this PR, previously in our `iceberg-rust` fork_)
- GCP (_via `gcp_auth` in an upcoming PR_)

----

This PR is still in _Draft_ state because it depends on `iceberg-rust` changes that have not yet been reviewed. (e.g. https://github.com/MaterializeInc/iceberg-rust/pull/1)