### PR TITLE
[Source Versioning] Set `enable_create_table_from_source` to default true

### DIFF
--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2167,7 +2167,7 @@ feature_flags!(
     {
         name: enable_create_table_from_source,
         desc: "Whether to allow CREATE TABLE .. FROM SOURCE syntax.",
-        default: false,
+        default: true,
         enable_for_item_parsing: true,
     },
     {


### PR DESCRIPTION
As mentioned in team meeting, we should set this to true for self-managed.