### PR TITLE
mcp: add Prometheus metrics for requests, tool calls, and tool call durations

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -122,6 +122,7 @@ mod catalog;
 mod cluster;
 mod console;
 mod mcp;
+pub mod mcp_metrics;
 mod memory;
 mod metrics;
 mod metrics_public;
@@ -159,6 +160,7 @@ pub struct HttpConfig {
     pub concurrent_webhook_req: Arc<tokio::sync::Semaphore>,
     pub metrics: Metrics,
     pub metrics_registry: MetricsRegistry,
+    pub mcp_metrics: mcp_metrics::McpMetrics,
     pub allowed_roles: AllowedRoles,
     pub internal_route_config: Arc<InternalRouteConfig>,
     pub routes_enabled: HttpRoutesEnabled,
@@ -214,6 +216,7 @@ impl HttpServer {
             concurrent_webhook_req,
             metrics,
             metrics_registry,
+            mcp_metrics,
             allowed_roles,
             internal_route_config,
             routes_enabled,
@@ -433,11 +436,16 @@ impl HttpServer {
         }
 
         if routes_enabled.metrics {
+            // Clone into the closure so the outer `metrics_registry` binding
+            // stays available for other route blocks below (e.g. MCP metric
+            // registration).
+            let metrics_registry_for_handler = metrics_registry.clone();
             let metrics_router = Router::new()
                 .route(
                     "/metrics",
                     routing::get(move |headers: HeaderMap| async move {
-                        mz_http_util::handle_prometheus(&metrics_registry, headers).await
+                        mz_http_util::handle_prometheus(&metrics_registry_for_handler, headers)
+                            .await
                     }),
                 )
                 .route(
@@ -528,6 +536,7 @@ impl HttpServer {
                 .layer(Extension(active_connection_counter.clone()))
                 .layer(Extension(HelmChartVersion(helm_chart_version.clone())))
                 .layer(Extension(mcp_allowed_origins))
+                .layer(Extension(mcp_metrics))
                 .layer(
                     CorsLayer::new()
                         .allow_methods(Method::POST)

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -507,9 +507,10 @@ async fn handle_mcp_request(
 
     let request_id = request.id.clone().unwrap_or(serde_json::Value::Null);
 
-    // Spawn task for fault isolation, with a timeout safety net. The inner
-    // function returns the response paired with a status label so that
-    // requests_total is recorded with the actual outcome.
+    // Spawn task for fault isolation, with a timeout safety net.
+    // `abort_on_drop` propagates the timeout to the task itself; without
+    // it the task orphans and the SQL query keeps running in the
+    // background after the client gives up.
     let metrics_inner = metrics.clone();
     let result = tokio::time::timeout(
         MCP_REQUEST_TIMEOUT,
@@ -523,7 +524,8 @@ async fn handle_mcp_request(
                 metrics_inner,
             )
             .await
-        }),
+        })
+        .abort_on_drop(),
     )
     .await;
 
@@ -813,10 +815,7 @@ async fn handle_tools_call(
     max_response_size: usize,
     metrics: &McpMetrics,
 ) -> Result<McpResult, McpRequestError> {
-    // The guard records `tool_calls_total` and observes
-    // `tool_call_duration_seconds` on drop, so the metrics are recorded
-    // even if the future is cancelled (e.g. by the outer
-    // `tokio::time::timeout`) before the match below returns.
+    // Drop-recording so metrics survive task cancellation.
     let mut guard = ToolCallGuard::new(metrics, endpoint_type.as_label(), params.to_string());
 
     let result = match (endpoint_type, params) {

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -48,7 +48,7 @@ use thiserror::Error;
 use tracing::{debug, warn};
 
 use crate::http::AuthedClient;
-use crate::http::mcp_metrics::McpMetrics;
+use crate::http::mcp_metrics::{McpMetrics, ToolCallGuard};
 use crate::http::sql::{SqlRequest, SqlResponse, SqlResult, execute_request};
 
 // To add a new tool: add entry to tools/list, add handler function, add dispatch case.
@@ -466,7 +466,7 @@ async fn handle_mcp_request(
     };
     if !enabled {
         debug!(endpoint = %endpoint_type, "MCP endpoint disabled by feature flag");
-        record_request("EndpointDisabled");
+        record_request("endpoint_disabled");
         return StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
 
@@ -547,7 +547,7 @@ async fn handle_mcp_request(
                     .into(),
                 ),
             };
-            (response, "Timeout")
+            (response, "timeout")
         }
     };
 
@@ -813,12 +813,11 @@ async fn handle_tools_call(
     max_response_size: usize,
     metrics: &McpMetrics,
 ) -> Result<McpResult, McpRequestError> {
-    let endpoint_label = endpoint_type.as_label();
-    let tool_label = params.to_string();
-    let timer = metrics
-        .tool_call_duration
-        .with_label_values(&[endpoint_label, &tool_label])
-        .start_timer();
+    // The guard records `tool_calls_total` and observes
+    // `tool_call_duration_seconds` on drop, so the metrics are recorded
+    // even if the future is cancelled (e.g. by the outer
+    // `tokio::time::timeout`) before the match below returns.
+    let mut guard = ToolCallGuard::new(metrics, endpoint_type.as_label(), params.to_string());
 
     let result = match (endpoint_type, params) {
         (McpEndpointType::Agent, ToolsCallParams::GetDataProducts(_)) => {
@@ -855,15 +854,10 @@ async fn handle_tools_call(
         ))),
     };
 
-    let status_label = match &result {
+    guard.set_status(match &result {
         Ok(_) => "ok",
         Err(e) => e.error_type(),
-    };
-    metrics
-        .tool_calls
-        .with_label_values(&[endpoint_label, &tool_label, status_label])
-        .inc();
-    timer.observe_duration();
+    });
 
     result
 }

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -48,6 +48,7 @@ use thiserror::Error;
 use tracing::{debug, warn};
 
 use crate::http::AuthedClient;
+use crate::http::mcp_metrics::McpMetrics;
 use crate::http::sql::{SqlRequest, SqlResponse, SqlResult, execute_request};
 
 // To add a new tool: add entry to tools/list, add handler function, add dispatch case.
@@ -363,12 +364,20 @@ enum McpEndpointType {
     Developer,
 }
 
+impl McpEndpointType {
+    /// Static label for metrics. Avoids per-request allocation that would
+    /// come from going through `Display`.
+    fn as_label(self) -> &'static str {
+        match self {
+            McpEndpointType::Agent => "agent",
+            McpEndpointType::Developer => "developer",
+        }
+    }
+}
+
 impl std::fmt::Display for McpEndpointType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            McpEndpointType::Agent => write!(f, "agent"),
-            McpEndpointType::Developer => write!(f, "developer"),
-        }
+        f.write_str(self.as_label())
     }
 }
 
@@ -382,13 +391,14 @@ pub async fn handle_mcp_method_not_allowed() -> impl IntoResponse {
 pub async fn handle_mcp_agent(
     headers: HeaderMap,
     Extension(allowed_origins): Extension<Arc<Vec<HeaderValue>>>,
+    Extension(metrics): Extension<McpMetrics>,
     client: AuthedClient,
     Json(body): Json<McpRequest>,
 ) -> axum::response::Response {
     if let Some(resp) = validate_origin(&headers, &allowed_origins) {
         return resp;
     }
-    handle_mcp_request(client, body, McpEndpointType::Agent)
+    handle_mcp_request(client, body, McpEndpointType::Agent, metrics)
         .await
         .into_response()
 }
@@ -397,13 +407,14 @@ pub async fn handle_mcp_agent(
 pub async fn handle_mcp_developer(
     headers: HeaderMap,
     Extension(allowed_origins): Extension<Arc<Vec<HeaderValue>>>,
+    Extension(metrics): Extension<McpMetrics>,
     client: AuthedClient,
     Json(body): Json<McpRequest>,
 ) -> axum::response::Response {
     if let Some(resp) = validate_origin(&headers, &allowed_origins) {
         return resp;
     }
-    handle_mcp_request(client, body, McpEndpointType::Developer)
+    handle_mcp_request(client, body, McpEndpointType::Developer, metrics)
         .await
         .into_response()
 }
@@ -435,7 +446,17 @@ async fn handle_mcp_request(
     mut client: AuthedClient,
     request: McpRequest,
     endpoint_type: McpEndpointType,
+    metrics: McpMetrics,
 ) -> impl IntoResponse {
+    let endpoint_label = endpoint_type.as_label();
+    let method_label = request.method.to_string();
+    let record_request = |status: &str| {
+        metrics
+            .requests
+            .with_label_values(&[endpoint_label, &method_label, status])
+            .inc();
+    };
+
     // Check the per-endpoint feature flag via a catalog snapshot, similar to frontend_peek.rs.
     let catalog = client.client.catalog_snapshot("mcp").await;
     let dyncfgs = catalog.system_config().dyncfgs();
@@ -445,6 +466,7 @@ async fn handle_mcp_request(
     };
     if !enabled {
         debug!(endpoint = %endpoint_type, "MCP endpoint disabled by feature flag");
+        record_request("EndpointDisabled");
         return StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
 
@@ -479,12 +501,16 @@ async fn handle_mcp_request(
     // Handle notifications (no response needed)
     if is_notification {
         debug!(method = %request.method, "Received notification (no response will be sent)");
+        record_request("ok");
         return StatusCode::OK.into_response();
     }
 
     let request_id = request.id.clone().unwrap_or(serde_json::Value::Null);
 
-    // Spawn task for fault isolation, with a timeout safety net.
+    // Spawn task for fault isolation, with a timeout safety net. The inner
+    // function returns the response paired with a status label so that
+    // requests_total is recorded with the actual outcome.
+    let metrics_inner = metrics.clone();
     let result = tokio::time::timeout(
         MCP_REQUEST_TIMEOUT,
         mz_ore::task::spawn(|| "mcp_request", async move {
@@ -494,13 +520,14 @@ async fn handle_mcp_request(
                 endpoint_type,
                 query_tool_enabled,
                 max_response_size,
+                metrics_inner,
             )
             .await
         }),
     )
     .await;
 
-    let response = match result {
+    let (response, status_label): (McpResponse, &'static str) = match result {
         Ok(inner) => inner,
         Err(_elapsed) => {
             warn!(
@@ -508,7 +535,7 @@ async fn handle_mcp_request(
                 timeout = ?MCP_REQUEST_TIMEOUT,
                 "MCP request timed out",
             );
-            McpResponse {
+            let response = McpResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: request_id,
                 result: None,
@@ -519,10 +546,12 @@ async fn handle_mcp_request(
                     ))
                     .into(),
                 ),
-            }
+            };
+            (response, "Timeout")
         }
     };
 
+    record_request(status_label);
     (StatusCode::OK, Json(response)).into_response()
 }
 
@@ -532,7 +561,8 @@ async fn handle_mcp_request_inner(
     endpoint_type: McpEndpointType,
     query_tool_enabled: bool,
     max_response_size: usize,
-) -> McpResponse {
+    metrics: McpMetrics,
+) -> (McpResponse, &'static str) {
     // Extract request ID (guaranteed to be Some since notifications are filtered earlier)
     let request_id = request.id.clone().unwrap_or(serde_json::Value::Null);
 
@@ -542,10 +572,16 @@ async fn handle_mcp_request_inner(
         endpoint_type,
         query_tool_enabled,
         max_response_size,
+        &metrics,
     )
     .await;
 
-    match result {
+    let status_label = match &result {
+        Ok(_) => "ok",
+        Err(e) => e.error_type(),
+    };
+
+    let response = match result {
         Ok(result_value) => McpResponse {
             jsonrpc: JSONRPC_VERSION.to_string(),
             id: request_id,
@@ -567,7 +603,9 @@ async fn handle_mcp_request_inner(
                 error: Some(e.into()),
             }
         }
-    }
+    };
+
+    (response, status_label)
 }
 
 async fn handle_mcp_method(
@@ -576,6 +614,7 @@ async fn handle_mcp_method(
     endpoint_type: McpEndpointType,
     query_tool_enabled: bool,
     max_response_size: usize,
+    metrics: &McpMetrics,
 ) -> Result<McpResult, McpRequestError> {
     // Validate JSON-RPC version
     if request.jsonrpc != JSONRPC_VERSION {
@@ -600,6 +639,7 @@ async fn handle_mcp_method(
                 endpoint_type,
                 query_tool_enabled,
                 max_response_size,
+                metrics,
             )
             .await
         }
@@ -771,8 +811,16 @@ async fn handle_tools_call(
     endpoint_type: McpEndpointType,
     query_tool_enabled: bool,
     max_response_size: usize,
+    metrics: &McpMetrics,
 ) -> Result<McpResult, McpRequestError> {
-    match (endpoint_type, params) {
+    let endpoint_label = endpoint_type.as_label();
+    let tool_label = params.to_string();
+    let timer = metrics
+        .tool_call_duration
+        .with_label_values(&[endpoint_label, &tool_label])
+        .start_timer();
+
+    let result = match (endpoint_type, params) {
         (McpEndpointType::Agent, ToolsCallParams::GetDataProducts(_)) => {
             get_data_products(client, max_response_size).await
         }
@@ -805,7 +853,19 @@ async fn handle_tools_call(
             "{} is not available on {} endpoint",
             tool, endpoint
         ))),
-    }
+    };
+
+    let status_label = match &result {
+        Ok(_) => "ok",
+        Err(e) => e.error_type(),
+    };
+    metrics
+        .tool_calls
+        .with_label_values(&[endpoint_label, &tool_label, status_label])
+        .inc();
+    timer.observe_duration();
+
+    result
 }
 
 /// Execute SQL via `execute_request` from sql.rs.

--- a/src/environmentd/src/http/mcp_metrics.rs
+++ b/src/environmentd/src/http/mcp_metrics.rs
@@ -18,7 +18,7 @@
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::stats::histogram_seconds_buckets;
-use prometheus::{HistogramVec, IntCounterVec};
+use prometheus::{HistogramTimer, HistogramVec, IntCounterVec};
 
 /// Metrics emitted by the MCP HTTP handlers.
 ///
@@ -32,6 +32,56 @@ pub struct McpMetrics {
     pub tool_calls: IntCounterVec,
     /// Duration of MCP `tools/call` invocations by endpoint type and tool name.
     pub tool_call_duration: HistogramVec,
+}
+
+/// RAII guard for a single `tools/call` invocation. On drop, increments
+/// `tool_calls_total` with the current status and observes
+/// `tool_call_duration_seconds` via the embedded [`HistogramTimer`]'s own
+/// drop. Designed so that if the surrounding future is dropped before
+/// completion (e.g. by `tokio::time::timeout`), the metric still records
+/// with the default `"cancelled"` status instead of being silently lost.
+pub struct ToolCallGuard<'a> {
+    metrics: &'a McpMetrics,
+    endpoint_label: &'static str,
+    tool_label: String,
+    status: &'static str,
+    /// `HistogramTimer::drop` observes the duration into the histogram, so
+    /// holding the timer here means we get the duration recorded for both
+    /// normal completion and early drop.
+    _timer: HistogramTimer,
+}
+
+impl<'a> ToolCallGuard<'a> {
+    /// Starts a new tool call: begins the duration timer and reserves the
+    /// counter increment that will happen on drop.
+    pub fn new(metrics: &'a McpMetrics, endpoint_label: &'static str, tool_label: String) -> Self {
+        let timer = metrics
+            .tool_call_duration
+            .with_label_values(&[endpoint_label, &tool_label])
+            .start_timer();
+        Self {
+            metrics,
+            endpoint_label,
+            tool_label,
+            status: "cancelled",
+            _timer: timer,
+        }
+    }
+
+    /// Records the outcome of the call. Callers should set this on the
+    /// normal completion path right before the guard is dropped.
+    pub fn set_status(&mut self, status: &'static str) {
+        self.status = status;
+    }
+}
+
+impl Drop for ToolCallGuard<'_> {
+    fn drop(&mut self) {
+        self.metrics
+            .tool_calls
+            .with_label_values(&[self.endpoint_label, &self.tool_label, self.status])
+            .inc();
+    }
 }
 
 impl McpMetrics {
@@ -142,7 +192,8 @@ mod tests {
 
         let gathered = registry.gather();
 
-        // requests_total: 3 metrics with distinct label sets.
+        // requests_total: 3 increments produce 2 distinct label sets (the
+        // first two share labels and so collapse into the same series).
         let requests = gathered
             .iter()
             .find(|m| m.name() == "mz_mcp_requests_total")

--- a/src/environmentd/src/http/mcp_metrics.rs
+++ b/src/environmentd/src/http/mcp_metrics.rs
@@ -1,0 +1,169 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Prometheus metrics for the MCP HTTP endpoints.
+//!
+//! Tracks request counts, tool call counts, and tool call durations,
+//! labeled by endpoint type (`agent` / `developer`) and either the
+//! JSON-RPC method name or the MCP tool name. The status label is `ok`
+//! for successful calls and the `McpRequestError` error type
+//! (e.g. `ToolNotFound`, `DataProductNotFound`) for failures.
+
+use mz_ore::metric;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::stats::histogram_seconds_buckets;
+use prometheus::{HistogramVec, IntCounterVec};
+
+/// Metrics emitted by the MCP HTTP handlers.
+///
+/// Cheaply `Clone`: Prometheus collector handles are `Arc`-shared internally,
+/// so the struct can be cloned freely and stored as an axum `Extension`.
+#[derive(Debug, Clone)]
+pub struct McpMetrics {
+    /// Total MCP requests by endpoint type, JSON-RPC method, and status.
+    pub requests: IntCounterVec,
+    /// Total MCP `tools/call` invocations by endpoint type, tool name, and status.
+    pub tool_calls: IntCounterVec,
+    /// Duration of MCP `tools/call` invocations by endpoint type and tool name.
+    pub tool_call_duration: HistogramVec,
+}
+
+impl McpMetrics {
+    pub fn register_into(registry: &MetricsRegistry) -> Self {
+        Self {
+            requests: registry.register(metric!(
+                name: "mz_mcp_requests_total",
+                help: "Total number of MCP requests received.",
+                var_labels: ["endpoint_type", "method", "status"],
+            )),
+            tool_calls: registry.register(metric!(
+                name: "mz_mcp_tool_calls_total",
+                help: "Total number of MCP tools/call invocations.",
+                var_labels: ["endpoint_type", "tool_name", "status"],
+            )),
+            tool_call_duration: registry.register(metric!(
+                name: "mz_mcp_tool_call_duration_seconds",
+                help: "Duration of MCP tools/call invocations in seconds.",
+                var_labels: ["endpoint_type", "tool_name"],
+                buckets: histogram_seconds_buckets(0.000_128, 8.0),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::McpMetrics;
+    use mz_ore::metrics::MetricsRegistry;
+
+    /// All three metrics register cleanly and show up in the gathered output
+    /// with the expected names. `IntCounterVec` / `HistogramVec` families
+    /// only appear in `gather()` after at least one label combination has
+    /// been observed, so each metric is touched once before gathering.
+    #[mz_ore::test]
+    fn test_register_into() {
+        let registry = MetricsRegistry::new();
+        let metrics = McpMetrics::register_into(&registry);
+
+        metrics
+            .requests
+            .with_label_values(&["agent", "initialize", "ok"])
+            .inc_by(0);
+        metrics
+            .tool_calls
+            .with_label_values(&["agent", "read_data_product", "ok"])
+            .inc_by(0);
+        metrics
+            .tool_call_duration
+            .with_label_values(&["agent", "read_data_product"])
+            .observe(0.0);
+
+        let names: Vec<String> = registry
+            .gather()
+            .iter()
+            .map(|m| m.name().to_string())
+            .collect();
+
+        assert!(
+            names.iter().any(|n| n == "mz_mcp_requests_total"),
+            "mz_mcp_requests_total should be registered, got: {names:?}",
+        );
+        assert!(
+            names.iter().any(|n| n == "mz_mcp_tool_calls_total"),
+            "mz_mcp_tool_calls_total should be registered, got: {names:?}",
+        );
+        assert!(
+            names
+                .iter()
+                .any(|n| n == "mz_mcp_tool_call_duration_seconds"),
+            "mz_mcp_tool_call_duration_seconds should be registered, got: {names:?}",
+        );
+    }
+
+    /// Incrementing each counter with realistic label values produces the
+    /// expected counts in the gathered output.
+    #[mz_ore::test]
+    fn test_record_metrics() {
+        let registry = MetricsRegistry::new();
+        let metrics = McpMetrics::register_into(&registry);
+
+        metrics
+            .requests
+            .with_label_values(&["agent", "tools/call", "ok"])
+            .inc();
+        metrics
+            .requests
+            .with_label_values(&["agent", "tools/call", "ok"])
+            .inc();
+        metrics
+            .requests
+            .with_label_values(&["developer", "initialize", "ok"])
+            .inc();
+
+        metrics
+            .tool_calls
+            .with_label_values(&["agent", "read_data_product", "ok"])
+            .inc();
+        metrics
+            .tool_calls
+            .with_label_values(&["agent", "read_data_product", "DataProductNotFound"])
+            .inc();
+
+        metrics
+            .tool_call_duration
+            .with_label_values(&["agent", "read_data_product"])
+            .observe(0.123);
+
+        let gathered = registry.gather();
+
+        // requests_total: 3 metrics with distinct label sets.
+        let requests = gathered
+            .iter()
+            .find(|m| m.name() == "mz_mcp_requests_total")
+            .expect("requests metric present");
+        assert_eq!(requests.get_metric().len(), 2);
+
+        // tool_calls_total: 2 distinct label sets (one for each status).
+        let tool_calls = gathered
+            .iter()
+            .find(|m| m.name() == "mz_mcp_tool_calls_total")
+            .expect("tool_calls metric present");
+        assert_eq!(tool_calls.get_metric().len(), 2);
+
+        // tool_call_duration_seconds: one observation in one bucket set.
+        let duration = gathered
+            .iter()
+            .find(|m| m.name() == "mz_mcp_tool_call_duration_seconds")
+            .expect("tool_call_duration metric present");
+        assert_eq!(
+            duration.get_metric()[0].get_histogram().get_sample_count(),
+            1
+        );
+    }
+}

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -384,6 +384,7 @@ impl Listeners {
 
         let metrics_registry = config.metrics_registry.clone();
         let metrics = http::Metrics::register_into(&metrics_registry, "mz_http");
+        let mcp_metrics = http::mcp_metrics::McpMetrics::register_into(&metrics_registry);
         let mut http_listener_handles = BTreeMap::new();
         for (name, listener) in self.http {
             let authenticator_kind = listener.config.authenticator_kind();
@@ -407,6 +408,7 @@ impl Listeners {
                 concurrent_webhook_req: webhook_concurrency_limit.semaphore(),
                 metrics: metrics.clone(),
                 metrics_registry: metrics_registry.clone(),
+                mcp_metrics: mcp_metrics.clone(),
                 allowed_roles: listener.config.allowed_roles(),
                 internal_route_config: Arc::clone(&internal_route_config),
                 routes_enabled: listener.config.routes.clone(),

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5721,6 +5721,172 @@ fn test_mcp_agent_with_data_product() {
     );
 }
 
+/// Verifies that MCP requests update the Prometheus counters and that
+/// tool calls record a histogram observation.
+#[mz_ore::test]
+fn test_mcp_metrics() {
+    let server = test_util::TestHarness::default()
+        .with_mcp_routes(true, false)
+        .with_system_parameter_default("enable_mcp_agent".to_string(), "true".to_string())
+        .start_blocking();
+
+    let agents_url = format!("http://{}/api/mcp/agent", server.http_local_addr());
+
+    // Exercise three distinct request shapes:
+    //   1. `initialize`: succeeds.
+    //   2. `tools/list`: succeeds.
+    //   3. `tools/call` for `read_data_product` with a nonexistent name:
+    //      the request itself completes with an MCP error
+    //      (`DataProductNotFound`), which both `requests_total` and
+    //      `tool_calls_total` should reflect via the status label.
+
+    let (status, _) = mcp_post(
+        &agents_url,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "metrics-test", "version": "0"}
+            }
+        }),
+    );
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _) = mcp_post(
+        &agents_url,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _) = mcp_post(
+        &agents_url,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "read_data_product",
+                "arguments": {"name": "nonexistent_product"}
+            }
+        }),
+    );
+    assert_eq!(status, StatusCode::OK);
+
+    // Helper: look up a counter value by exact (endpoint, method/tool, status)
+    // label combination. Panics with a helpful message if not found, so test
+    // failures point at the missing label set rather than a generic `None`.
+    fn find_counter(
+        gathered: &[prometheus::proto::MetricFamily],
+        metric_name: &str,
+        labels: &[(&str, &str)],
+    ) -> f64 {
+        let family = gathered
+            .iter()
+            .find(|m| m.name() == metric_name)
+            .unwrap_or_else(|| panic!("metric family {} should be present", metric_name));
+        for metric in family.get_metric() {
+            let matches_all = labels.iter().all(|(name, want)| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|l| l.name() == *name && l.value() == *want)
+            });
+            if matches_all {
+                return metric.get_counter().value();
+            }
+        }
+        panic!(
+            "no {} entry matching labels {:?} in {:?}",
+            metric_name,
+            labels,
+            family
+                .get_metric()
+                .iter()
+                .map(|m| m
+                    .get_label()
+                    .iter()
+                    .map(|l| (l.name().to_string(), l.value().to_string()))
+                    .collect::<Vec<_>>())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    let gathered = server.metrics_registry().gather();
+
+    // requests_total: one entry per (endpoint, method, status). The
+    // tools/call request failed at the tool level, so its status label is
+    // the McpRequestError error_type, not "ok".
+    assert_eq!(
+        find_counter(
+            &gathered,
+            "mz_mcp_requests_total",
+            &[
+                ("endpoint_type", "agent"),
+                ("method", "initialize"),
+                ("status", "ok"),
+            ],
+        ),
+        1.0,
+    );
+    assert_eq!(
+        find_counter(
+            &gathered,
+            "mz_mcp_requests_total",
+            &[
+                ("endpoint_type", "agent"),
+                ("method", "tools/list"),
+                ("status", "ok"),
+            ],
+        ),
+        1.0,
+    );
+    assert_eq!(
+        find_counter(
+            &gathered,
+            "mz_mcp_requests_total",
+            &[
+                ("endpoint_type", "agent"),
+                ("method", "tools/call"),
+                ("status", "DataProductNotFound"),
+            ],
+        ),
+        1.0,
+    );
+
+    // tool_calls_total: one entry per (endpoint, tool_name, status).
+    assert_eq!(
+        find_counter(
+            &gathered,
+            "mz_mcp_tool_calls_total",
+            &[
+                ("endpoint_type", "agent"),
+                ("tool_name", "read_data_product"),
+                ("status", "DataProductNotFound"),
+            ],
+        ),
+        1.0,
+    );
+
+    // tool_call_duration_seconds: the single tools/call above should
+    // produce exactly one histogram observation.
+    let duration = gathered
+        .iter()
+        .find(|m| m.name() == "mz_mcp_tool_call_duration_seconds")
+        .expect("mz_mcp_tool_call_duration_seconds should be present");
+    let total_samples: u64 = duration
+        .get_metric()
+        .iter()
+        .map(|m| m.get_histogram().get_sample_count())
+        .sum();
+    assert_eq!(
+        total_samples, 1,
+        "tool_call_duration_seconds should record exactly 1 sample",
+    );
+}
+
 /// Tests runtime toggling of MCP feature flags.
 #[mz_ore::test]
 fn test_mcp_agent_runtime_flag_toggle() {


### PR DESCRIPTION
Fixes https://linear.app/materializeinc/issue/DEX-2/mcp-add-observability-metrics