### PR TITLE
[sql] fix restrict_to_user_objects bypasses in SHOW COLUMNS and EXPLAIN ANALYZE

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -248,6 +248,7 @@ pub struct ConnCatalog<'a> {
     prepared_statements: Option<&'a BTreeMap<String, PreparedStatement>>,
     portals: Option<&'a BTreeMap<String, Portal>>,
     notices_tx: UnboundedSender<AdapterNotice>,
+    restrict_to_user_objects: bool,
 }
 
 impl ConnCatalog<'_> {
@@ -1671,6 +1672,10 @@ impl ExprHumanizer for ConnCatalog<'_> {
 impl SessionCatalog for ConnCatalog<'_> {
     fn active_role_id(&self) -> &RoleId {
         &self.role_id
+    }
+
+    fn restrict_to_user_objects(&self) -> bool {
+        self.restrict_to_user_objects
     }
 
     fn get_prepared_statement_desc(&self, name: &str) -> Option<&StatementDesc> {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -355,6 +355,7 @@ impl CatalogState {
             prepared_statements: Some(session.prepared_statements()),
             portals: Some(session.portals()),
             notices_tx: session.retain_notice_transmitter(),
+            restrict_to_user_objects: session.vars().restrict_to_user_objects(),
         }
     }
 
@@ -378,6 +379,7 @@ impl CatalogState {
             prepared_statements: None,
             portals: None,
             notices_tx,
+            restrict_to_user_objects: false,
         }
     }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -351,6 +351,14 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync + ConnectionR
     /// Returns the set of supported AWS PrivateLink availability zone ids.
     fn aws_privatelink_availability_zones(&self) -> Option<BTreeSet<String>>;
 
+    /// Returns true if the session has `restrict_to_user_objects` active.
+    ///
+    /// Defaults to false so that non-session catalog implementations (e.g. those used during
+    /// catalog rehydration) are unaffected.
+    fn restrict_to_user_objects(&self) -> bool {
+        false
+    }
+
     /// Returns system vars
     fn system_vars(&self) -> &SystemVars;
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -575,6 +575,18 @@ impl<'a> StatementContext<'a> {
         self.pcx.ok_or_else(|| sql_err!("no plan context"))
     }
 
+    /// Records resolved IDs from a SQL-implemented expression body (e.g. a SHOW
+    /// command's inner query or an EXPLAIN ANALYZE query) into the accumulator
+    /// checked by `restrict_to_user_objects`. These are kept separate from the
+    /// statement's main `resolved_ids` because they are implementation details,
+    /// not real dependencies.
+    pub(crate) fn record_sql_impl_ids(&self, ids: &ResolvedIds) {
+        self.sql_impl_resolved_ids
+            .lock()
+            .expect("planning is single-threaded")
+            .extend_from(ids);
+    }
+
     pub fn allocate_full_name(&self, name: PartialItemName) -> Result<FullItemName, PlanError> {
         let (database, schema): (RawDatabaseSpecifier, String) = match (name.database, name.schema)
         {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -891,12 +891,22 @@ pub fn plan_explain_analyze_object(
         .full_name_str();
     let explainee = plan_explainee(scx, statement.explainee, params)?;
 
-    match explainee {
-        plan::Explainee::Index(_index_id) => (),
-        plan::Explainee::MaterializedView(_item_id) => (),
-        _ => {
-            return Err(sql_err!("EXPLAIN ANALYZE queries for this explainee type",));
+    let check_ownership = |item_id: &CatalogItemId, item_type: &str| -> Result<(), PlanError> {
+        if scx.catalog.restrict_to_user_objects() {
+            let item = scx.catalog.get_item(item_id);
+            if item.owner_id() != *scx.catalog.active_role_id() {
+                let full_name = scx.catalog.resolve_full_name(item.name());
+                return Err(sql_err!("must be owner of {item_type} {full_name}"));
+            }
         }
+        Ok(())
+    };
+    match &explainee {
+        plan::Explainee::Index(item_id) => check_ownership(item_id, "INDEX")?,
+        plan::Explainee::MaterializedView(item_id) => {
+            check_ownership(item_id, "MATERIALIZED VIEW")?
+        }
+        _ => return Err(sql_err!("EXPLAIN ANALYZE queries for this explainee type",)),
     };
 
     // generate SQL query
@@ -1097,7 +1107,8 @@ ORDER BY {order_by}"#
 
         Ok(Plan::Select(SelectPlan::immediate(rows, typ)))
     } else {
-        let (show_select, _resolved_ids) = ShowSelect::new_from_bare_query(scx, query)?;
+        let (show_select, resolved_ids) = ShowSelect::new_from_bare_query(scx, query)?;
+        scx.record_sql_impl_ids(&resolved_ids);
         show_select.plan()
     }
 }
@@ -1469,7 +1480,8 @@ ORDER BY {order_by}"#
 
         Ok(Plan::Select(SelectPlan::immediate(rows, typ)))
     } else {
-        let (show_select, _resolved_ids) = ShowSelect::new_from_bare_query(scx, query)?;
+        let (show_select, resolved_ids) = ShowSelect::new_from_bare_query(scx, query)?;
+        scx.record_sql_impl_ids(&resolved_ids);
         show_select.plan()
     }
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -741,6 +741,7 @@ pub fn show_columns<'a>(
         Some("position"),
         Some(&["name", "nullable", "type", "comment"]),
     )?;
+    scx.record_sql_impl_ids(&new_resolved_ids);
     Ok(ShowColumnsSelect {
         id: entry.id(),
         show_select,

--- a/test/sqllogictest/rbac_mcp_agent.slt
+++ b/test/sqllogictest/rbac_mcp_agent.slt
@@ -628,6 +628,46 @@ db error: ERROR: access to system object mz_show_clusters is restricted
 DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
 
 # =============================================================================
+# Test: SHOW COLUMNS is blocked when restrict_to_user_objects is active (SQL-301)
+# =============================================================================
+
+simple conn=agent_restricted,user=agent
+SHOW COLUMNS FROM agent_objects.next_arrivals;
+----
+db error: ERROR: access to system object mz_show_columns is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+# Regression test: SHOW COLUMNS succeeds for the non-restricted agent (positive
+# side of the SQL-301 fix). The system catalog IDs from the inner query land
+# in sql_impl_resolved_ids — not resolved_ids — and therefore do not generate
+# spurious privilege errors or "unstable dependencies" for unrestricted sessions.
+simple conn=agent,user=agent
+SELECT count(*) FROM (SHOW COLUMNS FROM agent_objects.next_arrivals);
+----
+2
+COMPLETE 1
+
+# =============================================================================
+# Test: EXPLAIN ANALYZE is blocked when restrict_to_user_objects is active (SQL-301)
+# =============================================================================
+
+simple conn=agent_restricted,user=agent
+EXPLAIN ANALYZE HINTS FOR MATERIALIZED VIEW agent_objects.next_arrivals;
+----
+db error: ERROR: must be owner of MATERIALIZED VIEW materialize.agent_objects.next_arrivals
+
+simple conn=agent_restricted,user=agent
+EXPLAIN ANALYZE MEMORY FOR MATERIALIZED VIEW agent_objects.next_arrivals;
+----
+db error: ERROR: must be owner of MATERIALIZED VIEW materialize.agent_objects.next_arrivals
+
+simple conn=agent_restricted,user=agent
+EXPLAIN ANALYZE CLUSTER MEMORY;
+----
+db error: ERROR: access to system object mz_arrangement_sizes_per_worker is restricted
+DETAIL: Access to system catalog objects is restricted for this role. Contact your administrator if you need access.
+
+# =============================================================================
 # Test: pg_catalog access is blocked when restrict_to_user_objects is active
 # =============================================================================
 


### PR DESCRIPTION
Problem:
SHOW COLUMNS FROM <user_table> and EXPLAIN ANALYZE were bypassing the restrict_to_user_objects check because their inner query resolved IDs were never propagated into sql_impl_resolved_ids.

Solution:
- Add restrict_to_user_objects to the SessionCatalog trait so the planner can query the current session's restriction state during planning.
- Fix show_columns() to call record_sql_impl_ids() after building the inner ShowSelect, so mz_show_columns reaches check_restrict_to_user_objects.
- Fix plan_explain_analyze_object() to perform an owner check first, then propagate the inner query IDs.
- Fix plan_explain_analyze_cluster() to propagate its inner query IDs.

Testing:
- Add regression tests
- Negative tests verify the restriction fires
- Positive test verifies SHOW COLUMNS still works for non-restricted sessions

Fixes SQL-301.
