### PR TITLE
Reapply "[docs] document restrict_to_user_objects for MCP agent isolation (#36563)

### DIFF
--- a/doc/user/content/headless/mcp-agent-query-tool-warning.md
+++ b/doc/user/content/headless/mcp-agent-query-tool-warning.md
@@ -2,5 +2,6 @@
 headless: true
 ---
 
-Enabling the `query` tool can have performance impact, information leakage via
-query execution errors, catalog-level discovery of operational metadata.
+Enabling the `query` tool can impact performance, leak information via query
+execution errors, and, by default, allow catalog-level discovery of operational
+metadata through system catalog access.

--- a/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
@@ -13,7 +13,7 @@ menu:
 
 ### `get_data_products`
 
-Discover all available data products. Returns a lightweight list with name,
+Discovers all available data products. Returns a lightweight list with name,
 cluster, and description for each product.
 
 **Parameters:** None.
@@ -38,7 +38,7 @@ cluster, and description for each product.
 
 ### `get_data_product_details`
 
-Get the full details for a specific data product, including its JSON schema
+Returns the full details for a specific data product, including its JSON schema
 with column names, types, and descriptions.
 
 | Parameter | Type | Required | Description |
@@ -65,7 +65,7 @@ with column names, types, and descriptions.
 
 ### `read_data_product`
 
-Read rows from a data product.
+Reads rows from a data product.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -93,27 +93,26 @@ Read rows from a data product.
 
 ### `query`
 
-The `query` tool is **disabled by default** because it lets the
-agent run arbitrary SQL against data products. To enable it, set the
-[`enable_mcp_agent_query_tool`
-configuration](/integrations/mcp-server/mcp-agent-config/#enable_mcp_agent_query_tool)
-system parameter to `true`.
-
-To restrict which objects an agent role can query (e.g., prevent access to
-system catalog views), see [Restricting access to user objects
-only](/integrations/mcp-server/mcp-agent/#restrict-to-user-objects).
-
 {{< warning >}}
 {{% include-headless "/headless/mcp-agent-query-tool-warning" %}}
 {{< /warning >}}
 
-Execute a SQL `SELECT` statement against your data products. Useful for
-joining multiple data products together that are hosted on the same cluster.
+Allows the agent to run arbitrary `SELECT` statements (including joins) against
+**any** object for which it has `SELECT` privileges (not just the discoverable
+objects). It is disabled by default.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cluster` | string | Yes | Exact cluster name from the data product details. |
 | `sql_query` | string | Yes | PostgreSQL-compatible `SELECT` statement. |
+
+To enable the tool, set the [`enable_mcp_agent_query_tool`
+configuration](/integrations/mcp-server/mcp-agent-config/#enable_mcp_agent_query_tool)
+system parameter to `true`.
+
+To prevent an agent from querying the system catalog objects (`mz_catalog.*`,
+`mz_internal.*`, `pg_catalog.*`, and `information_schema.*`), see [Restrict
+`query` tool access to user objects only](#restrict-to-user-objects).
 
 **Example response:**
 
@@ -131,4 +130,39 @@ joining multiple data products together that are hosted on the same cluster.
     "isError": false
   }
 }
+```
+
+#### Restricting `query` tool access to user objects only {#restrict-to-user-objects}
+
+When the [`query` tool](/integrations/mcp-server/mcp-agent-tools/#query) is
+enabled, a role can, by default, query any object for which it has `SELECT`
+privileges, including system catalog objects (`mz_catalog.*`, `mz_internal.*`,
+`pg_catalog.*`, and `information_schema.*`). 
+
+To prevent an agent role from reading system catalog objects, a **superuser**
+can set the `restrict_to_user_objects` parameter to `true` on both the
+functional role and each individual agent role. Setting the parameter on the
+functional role is recommended as a precaution in case the role is ever used
+directly to run queries. Because role configuration in Materialize is not
+inherited, the parameter must be set explicitly on each individual agent role:
+
+```mzsql
+ALTER ROLE mcp_agent SET restrict_to_user_objects = true;
+ALTER ROLE my_agent SET restrict_to_user_objects = true;
+```
+
+This setting takes effect on the next connection. Once active:
+
+- Queries referencing system catalog objects are rejected with a permission
+  error.
+- Data product discovery (`get_data_products`, `get_data_product_details`,
+  `read_data_product`) continues to work normally.
+- The restriction cannot be bypassed by the role itself; only a superuser can
+  change or remove it.
+
+To remove the restriction for an agent, a superuser can reset the parameter (or
+set it to `false`):
+
+```mzsql
+ALTER ROLE mcp_agent RESET restrict_to_user_objects;
 ```

--- a/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
@@ -137,7 +137,7 @@ To prevent an agent from querying the system catalog objects (`mz_catalog.*`,
 When the [`query` tool](/integrations/mcp-server/mcp-agent-tools/#query) is
 enabled, a role can, by default, query any object for which it has `SELECT`
 privileges, including system catalog objects (`mz_catalog.*`, `mz_internal.*`,
-`pg_catalog.*`, and `information_schema.*`). 
+`pg_catalog.*`, and `information_schema.*`).
 
 To prevent an agent role from reading system catalog objects, a **superuser**
 can set the `restrict_to_user_objects` parameter to `true` on both the

--- a/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
@@ -164,5 +164,5 @@ To remove the restriction for an agent, a superuser can reset the parameter (or
 set it to `false`):
 
 ```mzsql
-ALTER ROLE mcp_agent RESET restrict_to_user_objects;
+ALTER ROLE my_agent RESET restrict_to_user_objects;
 ```

--- a/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent-tools.md
@@ -99,6 +99,10 @@ agent run arbitrary SQL against data products. To enable it, set the
 configuration](/integrations/mcp-server/mcp-agent-config/#enable_mcp_agent_query_tool)
 system parameter to `true`.
 
+To restrict which objects an agent role can query (e.g., prevent access to
+system catalog views), see [Restricting access to user objects
+only](/integrations/mcp-server/mcp-agent/#restrict-to-user-objects).
+
 {{< warning >}}
 {{% include-headless "/headless/mcp-agent-query-tool-warning" %}}
 {{< /warning >}}

--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -557,6 +557,42 @@ configuration](/integrations/mcp-server/mcp-agent-config/#enable_mcp_agent_query
 
 {{< /note >}}
 
+### Restricting access to user objects only {#restrict-to-user-objects}
+
+When the [`query` tool](/integrations/mcp-server/mcp-agent-tools/#query) is
+enabled, a role can, by default, query any object for which it has `SELECT`
+privileges, including system catalog views. To prevent an agent role from reading
+system catalog tables (`mz_catalog`, `mz_internal`, `pg_catalog`,
+`information_schema`), a superuser can set the `restrict_to_user_objects` role
+default:
+
+```mzsql
+ALTER ROLE mcp_agent SET restrict_to_user_objects = true;
+```
+
+In Materialize, role configuration is not inherited—only role privileges are.
+To ensure individual agent roles are also restricted, set
+`restrict_to_user_objects` directly on each agent role:
+
+```mzsql
+ALTER ROLE my_agent SET restrict_to_user_objects = true;
+```
+
+This setting takes effect on the next connection. Once active:
+
+- Queries referencing system catalog objects are rejected with a permission
+  error.
+- Data product discovery (`get_data_products`, `get_data_product_details`,
+  `read_data_product`) continues to work normally.
+- The restriction cannot be bypassed by the role itself; only a superuser can
+  change or remove it.
+
+To remove the restriction (as superuser):
+
+```mzsql
+ALTER ROLE mcp_agent RESET restrict_to_user_objects;
+```
+
 ## Related pages
 
 - [`materialize-agent` MCP Server available

--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -551,47 +551,14 @@ either natural language or SQL:
 
 {{< note >}}
 
-By default, queries with joins are disabled. To enable, see
-[`enable_mcp_agent_query_tool`
-configuration](/integrations/mcp-server/mcp-agent-config/#enable_mcp_agent_query_tool).
+By default, the [`query` tool](/integrations/mcp-server/mcp-agent-tools/#query),
+which allows arbitrary `SELECT` queries (including joins) on **all** objects for
+which the agent has `SELECT` privileges (not just the discoverable products), is
+disabled. To enable it, set the [`enable_mcp_agent_query_tool`
+configuration](/integrations/mcp-server/mcp-agent-tools/#query).
 
 {{< /note >}}
 
-### Restricting access to user objects only {#restrict-to-user-objects}
-
-When the [`query` tool](/integrations/mcp-server/mcp-agent-tools/#query) is
-enabled, a role can, by default, query any object for which it has `SELECT`
-privileges, including system catalog views. To prevent an agent role from reading
-system catalog tables (`mz_catalog`, `mz_internal`, `pg_catalog`,
-`information_schema`), a superuser can set the `restrict_to_user_objects` role
-default:
-
-```mzsql
-ALTER ROLE mcp_agent SET restrict_to_user_objects = true;
-```
-
-In Materialize, role configuration is not inherited—only role privileges are.
-To ensure individual agent roles are also restricted, set
-`restrict_to_user_objects` directly on each agent role:
-
-```mzsql
-ALTER ROLE my_agent SET restrict_to_user_objects = true;
-```
-
-This setting takes effect on the next connection. Once active:
-
-- Queries referencing system catalog objects are rejected with a permission
-  error.
-- Data product discovery (`get_data_products`, `get_data_product_details`,
-  `read_data_product`) continues to work normally.
-- The restriction cannot be bypassed by the role itself; only a superuser can
-  change or remove it.
-
-To remove the restriction (as superuser):
-
-```mzsql
-ALTER ROLE mcp_agent RESET restrict_to_user_objects;
-```
 
 ## Related pages
 


### PR DESCRIPTION
Add a subsection to the MCP agent RBAC docs explaining how a superuser can use `ALTER ROLE ... SET restrict_to_user_objects = true` to prevent an agent role from reading system catalog tables while keeping data product discovery working normally.
