### PR TITLE
console [CNS-77]": render Object Explorer tree as snapshot streams in

### DIFF
--- a/console/src/api/materialize/SubscribeManager.ts
+++ b/console/src/api/materialize/SubscribeManager.ts
@@ -63,6 +63,13 @@ export interface SubscribeManagerOptions<
   flushInterval?: number;
   upsert?: UpsertSubscribeOptions<T>;
   select?: SelectFunction<T, R>;
+  /**
+   * When true, snapshot rows are pushed into `data` as they arrive instead of
+   * being held until the snapshot's closing progress message. Per-timestamp
+   * consolidation still applies once the snapshot completes. Use for subscribes
+   * where the UI benefits from showing rows incrementally during initial load.
+   */
+  eagerSnapshotFlush?: boolean;
 }
 
 export type SelectFunction<T extends object, R> = (row: SubscribeRow<T>) => R;
@@ -89,6 +96,7 @@ export class SubscribeManager<T extends object, R> implements Connectable {
   private listeners = new Set<() => void>();
   private columns: ColumnMetadata[] = [];
   private closeSocketOnComplete: boolean = false;
+  private eagerSnapshotFlush: boolean = false;
   private querySent: boolean = false;
   private currentTimestamp: number | undefined;
   /** Holds completed timestamp messages, waiting for the flush interval */
@@ -118,6 +126,7 @@ export class SubscribeManager<T extends object, R> implements Connectable {
     });
     this.upsert = options.upsert;
     this.closeSocketOnComplete = options.closeSocketOnComplete ?? false;
+    this.eagerSnapshotFlush = options.eagerSnapshotFlush ?? false;
     this.sqlRequest = options.request;
     this.flushInterval = options.flushInterval ?? this.flushInterval;
     this.select = options.select;
@@ -279,6 +288,26 @@ export class SubscribeManager<T extends object, R> implements Connectable {
     if (!this.querySent) return;
 
     const meta = extractSubscribeMetadata(payload, this.columns);
+    const row = mapRowToObject<T>(payload, this.columns, [
+      "mz_timestamp",
+      "mz_state",
+      "mz_progressed",
+    ]);
+
+    // During the initial snapshot, skip per-timestamp buffering so rows
+    // render as they arrive. Snapshot rows are conflict-free upserts.
+    if (this.eagerSnapshotFlush && !this.currentState.snapshotComplete) {
+      if (meta.mzProgressed) {
+        // First progress closes the snapshot phase.
+        this.flushSocketBuffer();
+        this.setState({ snapshotComplete: true });
+      } else {
+        this.closedTimestampBuffer.push({ ...meta, data: row });
+      }
+      this.currentTimestamp = meta.mzTimestamp;
+      return;
+    }
+
     if (this.currentTimestamp && meta.mzTimestamp > this.currentTimestamp) {
       // this timestamp is complete, flush it
       const updates = this.currentTimestampBuffer.get(this.currentTimestamp);
@@ -303,11 +332,6 @@ export class SubscribeManager<T extends object, R> implements Connectable {
     }
     // Track the new currently open timestamp.
     this.currentTimestamp = meta.mzTimestamp;
-    const row = mapRowToObject<T>(payload, this.columns, [
-      "mz_timestamp",
-      "mz_state",
-      "mz_progressed",
-    ]);
     const updates = this.currentTimestampBuffer.get(meta.mzTimestamp) ?? [];
     updates.push({
       ...meta,

--- a/console/src/api/materialize/useSubscribe.ts
+++ b/console/src/api/materialize/useSubscribe.ts
@@ -34,6 +34,8 @@ export type UseSubscribeOptions<T extends object, R> = {
   closeSocketOnComplete?: boolean;
   clusterName?: string;
   select?: SelectFunction<T, R>;
+  /** See {@link SubscribeManagerOptions.eagerSnapshotFlush}. */
+  eagerSnapshotFlush?: boolean;
 };
 
 export type UseSubscribeReturn<T> = {
@@ -130,6 +132,7 @@ export function useGlobalUpsertSubscribe<T extends object, R = SubscribeRow<T>>(
       },
       closeSocketOnComplete: options?.closeSocketOnComplete,
       select: options.select,
+      eagerSnapshotFlush: options.eagerSnapshotFlush,
     }),
   );
   useAutomaticallyConnectSocket<T, R>({

--- a/console/src/platform/object-explorer/ObjectExplorer.tsx
+++ b/console/src/platform/object-explorer/ObjectExplorer.tsx
@@ -237,7 +237,8 @@ export const ObjectExplorer = () => {
       />
       {isSchemaError || isObjectError ? (
         <Alert variant="error" message="An unexpected error has occurred" />
-      ) : !schemaSnapshotComplete || !objectSnapshotComplete ? (
+      ) : (!schemaSnapshotComplete && schemas.length === 0) ||
+        (!objectSnapshotComplete && objects.length === 0) ? (
         <LoadingContainer />
       ) : (
         <VStack

--- a/console/src/platform/object-explorer/allNamespaces.ts
+++ b/console/src/platform/object-explorer/allNamespaces.ts
@@ -48,6 +48,7 @@ export function useSubscribeToAllNamespaces() {
         databaseId: row.data.databaseId,
         schemaId: row.data.schemaId,
       }),
+    eagerSnapshotFlush: true,
   });
 }
 

--- a/console/src/store/allObjects.ts
+++ b/console/src/store/allObjects.ts
@@ -36,6 +36,7 @@ export function useSubscribeToAllObjects() {
     subscribe,
     select: (row) => row.data,
     upsertKey: (row) => row.data.id,
+    eagerSnapshotFlush: true,
   });
 }
 


### PR DESCRIPTION
The Object Explorer page can stall indefinitely on a spinner if the SUBSCRIBE's closing `mz_progressed` message is delayed by the server. The render gate `!snapshotComplete` waits for two messages where the second is a progress row, so quiet environments where progress ticks are sparse leave the user staring at a spinner — sometimes for many minutes — even though all the snapshot rows have already arrived.

Add an opt-in `eagerSnapshotFlush` mode to `SubscribeManager` that pushes snapshot rows straight into `data` as they arrive. Snapshot rows are conflict-free upserts so the consolidation that buffering provides isn't needed. Only enabled this on Object Explorer for (allObjects, allNamespaces)  so the page can render the tree when the data is available.

 Fixes [CNS-77 ](https://linear.app/materializeinc/issue/CNS-77/data-explorer-page-not-loading)