### PR TITLE
adapter: Fix `set_statement_execution_cluster` to not panic from a concurrent cluster drop

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -170,10 +170,12 @@ impl Coordinator {
                 Err(_) => (None, None),
             };
 
-            if let (Some(cluster_id), Some(statement_id)) =
-                (target_cluster_id, ctx.extra().contents())
-            {
-                self.set_statement_execution_cluster(statement_id, cluster_id);
+            if let (Some(cluster_id), Some(cluster_name), Some(statement_id)) = (
+                target_cluster_id,
+                target_cluster_name.clone(),
+                ctx.extra().contents(),
+            ) {
+                self.set_statement_execution_cluster(statement_id, cluster_id, cluster_name);
             }
 
             let session_catalog = self.catalog.for_session(ctx.session());

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -172,8 +172,12 @@ impl Coordinator {
                     ended_record.reason,
                 );
             }
-            FrontendStatementLoggingEvent::SetCluster { id, cluster_id } => {
-                self.set_statement_execution_cluster(id, cluster_id);
+            FrontendStatementLoggingEvent::SetCluster {
+                id,
+                cluster_id,
+                cluster_name,
+            } => {
+                self.set_statement_execution_cluster(id, cluster_id, cluster_name);
             }
             FrontendStatementLoggingEvent::SetTimestamp { id, timestamp } => {
                 self.set_statement_execution_timestamp(id, timestamp);
@@ -524,16 +528,19 @@ impl Coordinator {
             .push((update, Diff::ONE));
     }
 
-    /// Set the `cluster_id` for a statement, once it's known.
+    /// Set the `cluster_id` and `cluster_name` for a statement, once they're known.
     ///
-    /// TODO(peek-seq): We could do cluster resolution and packing in the frontend task, and just
-    /// send over the rows.
+    /// The name is resolved by the caller (from the same catalog snapshot that selected the
+    /// cluster), rather than re-resolved here from `cluster_id`. This avoids a panic when the
+    /// cluster was concurrently dropped, and logs the name as it was at selection time.
+    ///
+    /// TODO(peek-seq): We could do the packing in the frontend task, and just send over the rows.
     pub(crate) fn set_statement_execution_cluster(
         &mut self,
         id: StatementLoggingId,
         cluster_id: ClusterId,
+        cluster_name: String,
     ) {
-        let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
         self.mutate_record(id, |record| {
             record.cluster_name = Some(cluster_name);
             record.cluster_id = Some(cluster_id);

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -481,7 +481,7 @@ impl PeekClient {
 
         // Log cluster selection
         if let Some(logging_id) = &statement_logging_id {
-            self.log_set_cluster(*logging_id, target_cluster_id);
+            self.log_set_cluster(*logging_id, target_cluster_id, target_cluster_name.clone());
         }
 
         coord::catalog_serving::check_cluster_restrictions(

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -492,10 +492,15 @@ impl PeekClient {
         &self,
         id: StatementLoggingId,
         cluster_id: mz_controller_types::ClusterId,
+        cluster_name: String,
     ) {
         self.coordinator_client
             .send(Command::FrontendStatementLogging(
-                FrontendStatementLoggingEvent::SetCluster { id, cluster_id },
+                FrontendStatementLoggingEvent::SetCluster {
+                    id,
+                    cluster_id,
+                    cluster_name,
+                },
             ));
     }
 

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -835,6 +835,7 @@ pub enum FrontendStatementLoggingEvent {
     SetCluster {
         id: StatementLoggingId,
         cluster_id: ClusterId,
+        cluster_name: String,
     },
     /// Set the execution timestamp for a statement
     SetTimestamp {

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4119,6 +4119,63 @@ def workflow_cluster_drop_concurrent(
                 assert not thread.is_alive(), f"Thread {thread.name} is still running"
 
 
+def workflow_test_drop_cluster_during_peeks(c: Composition) -> None:
+    """Race peeks against DROP/CREATE of their target cluster; environmentd
+    must not panic in `set_statement_execution_cluster`."""
+
+    with c.override(Materialized()):
+        c.up("materialized")
+
+        c.sql(
+            """
+            ALTER SYSTEM SET statement_logging_max_sample_rate = 1.0;
+            ALTER SYSTEM SET statement_logging_default_sample_rate = 1.0;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        c.sql("CREATE CLUSTER victim SIZE 'scale=1,workers=1'")
+
+        stop = [False]
+
+        def peek_loop() -> None:
+            while not stop[0]:
+                try:
+                    with c.sql_cursor() as cur:
+                        cur.execute("SET auto_route_catalog_queries = false")
+                        cur.execute("SET cluster = victim")
+                        while not stop[0]:
+                            cur.execute("SELECT 1")
+                            cur.fetchone()
+                except DatabaseError:
+                    pass
+
+        def churn_loop() -> None:
+            while not stop[0]:
+                try:
+                    with c.sql_cursor() as cur:
+                        cur.execute("DROP CLUSTER IF EXISTS victim CASCADE")
+                        cur.execute("CREATE CLUSTER victim SIZE 'scale=1,workers=1'")
+                except DatabaseError:
+                    pass
+
+        threads = [
+            PropagatingThread(target=peek_loop, name=f"peek-{i}") for i in range(8)
+        ] + [PropagatingThread(target=churn_loop, name="churn")]
+        for t in threads:
+            t.start()
+        try:
+            time.sleep(30)
+        finally:
+            stop[0] = True
+            for t in threads:
+                t.join(timeout=10)
+
+        with c.sql_cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone() == (1,)
+
+
 def workflow_test_refresh_mv_warmup(
     c: Composition, parser: WorkflowArgumentParser
 ) -> None:


### PR DESCRIPTION
Fixes [SQL-303](https://linear.app/materializeinc/issue/SQL-303/thread-coordinator-panicked-at-srcadaptersrccatalogstaters89232).

`set_statement_execution_cluster` re-resolved the cluster name from
cluster_id, which panicked when the cluster was concurrently dropped.
Both callers already resolve the name from the snapshot that selected
the cluster, so pass it in directly instead of re-resolving.

(An earlier version of the PR did a different thing, which was not very nice. The current version should be uncontroversial and easier to review.)