### PR TITLE
Use JWT detection for OIDC authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7334,6 +7334,7 @@ dependencies = [
  "enum-kinds",
  "futures",
  "itertools 0.14.0",
+ "jsonwebtoken",
  "mz-adapter",
  "mz-adapter-types",
  "mz-auth",

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -379,6 +379,7 @@ impl TestHarness {
         issuer: Option<String>,
         authentication_claim: Option<String>,
         expected_audiences: Option<Vec<String>>,
+        external_login_password_mz_system: Option<Password>,
     ) -> Self {
         let enable_tls = self.tls.is_some();
         self.listeners_config = ListenersConfig {
@@ -386,7 +387,7 @@ impl TestHarness {
                 "external".to_owned() => SqlListenerConfig {
                     addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
                     authenticator_kind: AuthenticatorKind::Oidc,
-                    allowed_roles: AllowedRoles::Normal,
+                    allowed_roles: AllowedRoles::NormalAndInternal,
                     enable_tls,
                 },
                 "internal".to_owned() => SqlListenerConfig {
@@ -401,7 +402,7 @@ impl TestHarness {
                     base: BaseListenerConfig {
                         addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
                         authenticator_kind: AuthenticatorKind::Oidc,
-                        allowed_roles: AllowedRoles::Normal,
+                        allowed_roles: AllowedRoles::NormalAndInternal,
                         enable_tls,
                     },
                     routes: HttpRoutesEnabled{
@@ -453,6 +454,12 @@ impl TestHarness {
                 "oidc_audience".to_string(),
                 serde_json::to_string(&expected_audiences).unwrap(),
             );
+        }
+
+        if let Some(external_login_password_mz_system) = external_login_password_mz_system {
+            self.external_login_password_mz_system = Some(external_login_password_mz_system);
+            self.system_parameter_defaults
+                .insert("enable_password_auth".to_string(), "true".to_string());
         }
 
         self

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -1390,7 +1390,12 @@ async fn test_auth_base_require_tls_oidc() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(oidc_server.issuer), Some("sub".to_string()), None)
+        .with_oidc_auth(
+            Some(oidc_server.issuer),
+            Some("sub".to_string()),
+            None,
+            None,
+        )
         .start()
         .await;
 
@@ -1404,7 +1409,7 @@ async fn test_auth_base_require_tls_oidc() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&jwt_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
@@ -1434,7 +1439,7 @@ async fn test_auth_base_require_tls_oidc() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&jwt_token)),
                 ssl_mode: SslMode::Disable,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(
@@ -1457,9 +1462,11 @@ async fn test_auth_base_require_tls_oidc() {
             TestCase::Pgwire {
                 user_to_auth_as: oidc_user,
                 user_reported_by_system: oidc_user,
-                password: Some(Cow::Borrowed("invalid-jwt-token")),
+                password: Some(Cow::Borrowed(
+                    "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIn0.invalidsig",
+                )),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "failed to validate JWT");
@@ -1472,7 +1479,7 @@ async fn test_auth_base_require_tls_oidc() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&expired_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "authentication credentials have expired");
@@ -1485,7 +1492,7 @@ async fn test_auth_base_require_tls_oidc() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&wrong_user_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "wrong user");
@@ -1498,7 +1505,7 @@ async fn test_auth_base_require_tls_oidc() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&wrong_issuer_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "invalid issuer");
@@ -1584,6 +1591,7 @@ async fn test_auth_oidc_audience_validation() {
             Some(oidc_server.issuer),
             Some("sub".to_string()),
             Some(expected_audiences.clone()),
+            None,
         )
         .start()
         .await;
@@ -1598,7 +1606,7 @@ async fn test_auth_oidc_audience_validation() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&valid_all_aud_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
@@ -1608,7 +1616,7 @@ async fn test_auth_oidc_audience_validation() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&valid_one_aud_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
@@ -1618,7 +1626,7 @@ async fn test_auth_oidc_audience_validation() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&wrong_aud_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "invalid audience");
@@ -1649,7 +1657,7 @@ async fn test_auth_oidc_audience_validation() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&no_aud_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "invalid audience");
@@ -1715,7 +1723,12 @@ async fn test_auth_oidc_audience_optional() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(oidc_server.issuer), Some("sub".to_string()), None)
+        .with_oidc_auth(
+            Some(oidc_server.issuer),
+            Some("sub".to_string()),
+            None,
+            None,
+        )
         .start()
         .await;
 
@@ -1729,7 +1742,7 @@ async fn test_auth_oidc_audience_optional() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&no_aud_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
@@ -1739,7 +1752,7 @@ async fn test_auth_oidc_audience_optional() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&valid_aud_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
@@ -1748,10 +1761,12 @@ async fn test_auth_oidc_audience_optional() {
     .await;
 }
 
-/// Tests OIDC password fallback.
+/// Tests password authentication when OIDC system parameters are also configured.
 ///
-/// This test verifies that when oidc_auth_enabled is false or not set,
-/// the OIDC authenticator falls back to password authentication.
+/// The harness `with_password_auth` call configures the SQL listener as
+/// `AuthenticatorKind::Password` even though OIDC issuer/claim system params are
+/// set; this test verifies that password auth still works in that combined
+/// configuration.
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)]
 async fn test_auth_oidc_password_fallback() {
@@ -1776,9 +1791,12 @@ async fn test_auth_oidc_password_fallback() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(oidc_server.issuer), Some("sub".to_string()), None)
-        .with_system_parameter_default("enable_password_auth".to_string(), "true".to_string())
-        .with_password_auth(Password("mz_system_password".to_owned()))
+        .with_oidc_auth(
+            Some(oidc_server.issuer),
+            Some("sub".to_string()),
+            None,
+            Some(Password("mz_system_password".to_owned())),
+        )
         .start()
         .await;
 
@@ -1803,26 +1821,16 @@ async fn test_auth_oidc_password_fallback() {
     let oidc_header_basic = make_header(Authorization::basic(oidc_user, user_password));
 
     run_tests(
-        "OIDC Password Fallback (oidc_auth_enabled=false or not set)",
+        "Password auth with OIDC params configured",
         &server,
         &[
-            // Password auth should work (oidc_auth_enabled not set, defaults to false)
+            // SQL Password auth should work when password isn't a JWT.
             TestCase::Pgwire {
                 user_to_auth_as: oidc_user,
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(user_password)),
                 ssl_mode: SslMode::Require,
                 options: None,
-                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
-                assert: Assert::Success,
-            },
-            // Explicitly set to false
-            TestCase::Pgwire {
-                user_to_auth_as: oidc_user,
-                user_reported_by_system: oidc_user,
-                password: Some(Cow::Borrowed(user_password)),
-                ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=false"),
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
@@ -1926,6 +1934,7 @@ async fn test_auth_oidc_issuer_and_audience_switch() {
             Some(oidc_server1.issuer.clone()),
             Some("sub".to_string()),
             Some(vec![audience1.to_string()]),
+            None,
         )
         .start()
         .await;
@@ -1945,7 +1954,6 @@ async fn test_auth_oidc_issuer_and_audience_switch() {
         .ssl_mode(SslMode::Require)
         .user(oidc_user)
         .password(&token1)
-        .options("--oidc_auth_enabled=true")
         .with_tls(make_tls())
         .await;
     assert!(
@@ -1961,7 +1969,6 @@ async fn test_auth_oidc_issuer_and_audience_switch() {
         .ssl_mode(SslMode::Require)
         .user(oidc_user)
         .password(&token2)
-        .options("--oidc_auth_enabled=true")
         .with_tls(make_tls())
         .await;
     assert!(
@@ -1993,7 +2000,6 @@ async fn test_auth_oidc_issuer_and_audience_switch() {
         .ssl_mode(SslMode::Require)
         .user(oidc_user)
         .password(&token2)
-        .options("--oidc_auth_enabled=true")
         .with_tls(make_tls())
         .await;
     assert!(
@@ -2009,7 +2015,6 @@ async fn test_auth_oidc_issuer_and_audience_switch() {
         .ssl_mode(SslMode::Require)
         .user(oidc_user)
         .password(&token1)
-        .options("--oidc_auth_enabled=true")
         .with_tls(make_tls())
         .await;
     assert!(
@@ -2063,6 +2068,7 @@ async fn test_auth_oidc_authentication_claim_switch() {
             Some(oidc_server.issuer.clone()),
             Some("sub".to_string()),
             None,
+            None,
         )
         .start()
         .await;
@@ -2078,7 +2084,7 @@ async fn test_auth_oidc_authentication_claim_switch() {
             user_reported_by_system: sub_user,
             password: Some(Cow::Borrowed(&token)),
             ssl_mode: SslMode::Require,
-            options: Some("--oidc_auth_enabled=true"),
+            options: None,
             configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
             assert: Assert::Success,
         }],
@@ -2101,7 +2107,7 @@ async fn test_auth_oidc_authentication_claim_switch() {
             user_reported_by_system: email_user,
             password: Some(Cow::Borrowed(&token)),
             ssl_mode: SslMode::Require,
-            options: Some("--oidc_auth_enabled=true"),
+            options: None,
             configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
             assert: Assert::Success,
         }],
@@ -2142,7 +2148,7 @@ async fn test_auth_oidc_required_issuer() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(None, Some("sub".to_string()), None)
+        .with_oidc_auth(None, Some("sub".to_string()), None, None)
         .start()
         .await;
 
@@ -2156,7 +2162,7 @@ async fn test_auth_oidc_required_issuer() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "OIDC issuer is not configured");
@@ -2211,6 +2217,7 @@ async fn test_auth_oidc_no_matching_authentication_claim() {
             Some(oidc_server.issuer),
             Some(invalid_claim.to_string()),
             None,
+            None,
         )
         .start()
         .await;
@@ -2225,7 +2232,7 @@ async fn test_auth_oidc_no_matching_authentication_claim() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(
@@ -2303,7 +2310,7 @@ async fn test_auth_oidc_fetch_error() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(issuer), Some("sub".to_string()), None)
+        .with_oidc_auth(Some(issuer), Some("sub".to_string()), None, None)
         .start()
         .await;
 
@@ -2317,7 +2324,7 @@ async fn test_auth_oidc_fetch_error() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&jwt_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "failed to fetch OIDC provider configuration");
@@ -4972,7 +4979,12 @@ async fn test_session_auth_does_not_override_credentials() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(oidc_server.issuer), Some("sub".to_string()), None)
+        .with_oidc_auth(
+            Some(oidc_server.issuer),
+            Some("sub".to_string()),
+            None,
+            None,
+        )
         .with_system_parameter_default("enable_password_auth".to_string(), "true".to_string())
         .start()
         .await;
@@ -5258,7 +5270,12 @@ async fn test_auth_autoprovision_oidc_audit_log() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(oidc_server.issuer), Some("sub".to_string()), None)
+        .with_oidc_auth(
+            Some(oidc_server.issuer),
+            Some("sub".to_string()),
+            None,
+            None,
+        )
         .start()
         .await;
 
@@ -5268,7 +5285,6 @@ async fn test_auth_autoprovision_oidc_audit_log() {
         .ssl_mode(SslMode::Require)
         .user(oidc_user)
         .password(&jwt_token)
-        .options("--oidc_auth_enabled=true")
         .with_tls(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
             Ok(b.set_verify(SslVerifyMode::NONE))
         })))
@@ -5356,7 +5372,12 @@ async fn test_auth_oidc_non_login_role() {
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(oidc_server.issuer), Some("sub".to_string()), None)
+        .with_oidc_auth(
+            Some(oidc_server.issuer),
+            Some("sub".to_string()),
+            None,
+            None,
+        )
         .start()
         .await;
 
@@ -5379,7 +5400,7 @@ async fn test_auth_oidc_non_login_role() {
                 user_reported_by_system: oidc_user,
                 password: Some(Cow::Borrowed(&jwt_token)),
                 ssl_mode: SslMode::Require,
-                options: Some("--oidc_auth_enabled=true"),
+                options: None,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::DbErr(Box::new(|err| {
                     assert_eq!(err.message(), "role is not allowed to login");
@@ -5421,7 +5442,7 @@ async fn test_auth_oidc_non_login_role() {
             user_reported_by_system: oidc_user,
             password: Some(Cow::Borrowed(&jwt_token)),
             ssl_mode: SslMode::Require,
-            options: Some("--oidc_auth_enabled=true"),
+            options: None,
             configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
             assert: Assert::Success,
         }],
@@ -5478,6 +5499,7 @@ async fn setup_group_sync_test() -> (
             Some(oidc_server.issuer.clone()),
             Some("sub".to_string()),
             None,
+            None,
         )
         .start()
         .await;
@@ -5523,7 +5545,6 @@ async fn oidc_connect(
         .ssl_mode(SslMode::Require)
         .user(GROUP_SYNC_USER)
         .password(token)
-        .options("--oidc_auth_enabled=true")
         .with_tls(make_insecure_tls())
         .await
         .map_err(|e| anyhow::anyhow!(e))
@@ -5781,7 +5802,6 @@ async fn test_oidc_group_sync_fail_open_sends_notice() {
         .ssl_mode(SslMode::Require)
         .user(GROUP_SYNC_USER)
         .password(&token)
-        .options("--oidc_auth_enabled=true")
         .notice_callback(move |n| notice_tx.send(n).expect("notice channel open"))
         .with_tls(make_insecure_tls())
         .await

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -20,6 +20,7 @@ csv-core.workspace = true
 enum-kinds.workspace = true
 futures.workspace = true
 itertools.workspace = true
+jsonwebtoken.workspace = true
 mz-adapter = { path = "../adapter" }
 mz-adapter-types = { path = "../adapter-types" }
 mz-auth = { path = "../auth", default-features = false }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -173,17 +173,8 @@ where
 
     let user = params.remove("user").unwrap_or_else(String::new);
     let options = parse_options(params.get("options").unwrap_or(&String::new()));
-
-    // If oidc_auth_enabled exists as an option, return its value and filter it from
-    // the remaining options.
-    let (oidc_auth_enabled, options) = extract_oidc_auth_enabled_from_options(options);
-    let authenticator = get_authenticator(
-        authenticator_kind,
-        frontegg,
-        oidc,
-        adapter_client.clone(),
-        oidc_auth_enabled,
-    );
+    let authenticator =
+        get_authenticator(authenticator_kind, frontegg, oidc, adapter_client.clone());
     // TODO move this somewhere it can be shared with HTTP
     let is_internal_user = INTERNAL_USER_NAMES.contains(&user);
     // this is a superset of internal users
@@ -253,49 +244,77 @@ where
             }
         }
         Authenticator::Oidc(oidc) => {
-            // OIDC authentication: JWT sent as password in cleartext flow
-            let jwt = match request_cleartext_password(conn).await {
+            // OIDC listener: accepts either a JWT (uses OIDC authentication) or a
+            // plain SQL password (uses SQL password authentication).
+            let password = match request_cleartext_password(conn).await {
                 Ok(password) => password,
                 Err(PasswordRequestError::IoError(e)) => return Err(e),
                 Err(PasswordRequestError::InvalidPasswordError(e)) => {
                     return conn.send(e).await;
                 }
             };
-            let auth_response = oidc.authenticate(&jwt, Some(&user)).await;
-            match auth_response {
-                Ok((mut claims, authenticated)) => {
-                    let groups = claims.groups.take();
-                    let session = adapter_client.new_session(
-                        SessionConfig {
-                            conn_id: conn.conn_id().clone(),
-                            uuid: conn_uuid,
-                            user: std::mem::take(&mut claims.user),
-                            client_ip: conn.peer_addr().clone(),
-                            external_metadata_rx: None,
-                            helm_chart_version,
-                            authenticator_kind,
-                            groups,
-                        },
-                        authenticated,
-                    );
-                    // No invalidation of the auth session once authenticated,
-                    // so auth session lasts indefinitely.
-                    (session, pending().right_future())
+            if is_jwt(&password) {
+                let auth_response = oidc.authenticate(&password, Some(&user)).await;
+                match auth_response {
+                    Ok((mut claims, authenticated)) => {
+                        let groups = claims.groups.take();
+                        let session = adapter_client.new_session(
+                            SessionConfig {
+                                conn_id: conn.conn_id().clone(),
+                                uuid: conn_uuid,
+                                user: std::mem::take(&mut claims.user),
+                                client_ip: conn.peer_addr().clone(),
+                                external_metadata_rx: None,
+                                helm_chart_version,
+                                authenticator_kind,
+                                groups,
+                            },
+                            authenticated,
+                        );
+                        // No invalidation of the auth session once authenticated,
+                        // so auth session lasts indefinitely.
+                        (session, pending().right_future())
+                    }
+                    Err(err) => {
+                        warn!(?err, "pgwire connection failed authentication");
+                        return conn.send(err.into_response()).await;
+                    }
                 }
-                Err(err) => {
-                    warn!(?err, "pgwire connection failed authentication");
-                    return conn.send(err.into_response()).await;
-                }
+            } else {
+                let session = match authenticate_with_password(
+                    conn,
+                    &adapter_client,
+                    user,
+                    Password(password),
+                    conn_uuid,
+                    helm_chart_version,
+                )
+                .await
+                {
+                    Ok(session) => session,
+                    Err(PasswordRequestError::IoError(e)) => return Err(e),
+                    Err(PasswordRequestError::InvalidPasswordError(e)) => {
+                        return conn.send(e).await;
+                    }
+                };
+                (session, pending().right_future())
             }
         }
         Authenticator::Password(adapter_client) => {
+            let password = match request_cleartext_password(conn).await {
+                Ok(password) => password,
+                Err(PasswordRequestError::IoError(e)) => return Err(e),
+                Err(PasswordRequestError::InvalidPasswordError(e)) => {
+                    return conn.send(e).await;
+                }
+            };
             let session = match authenticate_with_password(
                 conn,
                 &adapter_client,
                 user,
+                Password(password),
                 conn_uuid,
                 helm_chart_version,
-                authenticator_kind,
             )
             .await
             {
@@ -618,29 +637,10 @@ where
     }
 }
 
-/// Gets `oidc_auth_enabled` from options if it exists.
-/// Returns options with oidc_auth_enabled extracted
-/// and the oidc_auth_enabled value.
-fn extract_oidc_auth_enabled_from_options(
-    options: Result<Vec<(String, String)>, ()>,
-) -> (bool, Result<Vec<(String, String)>, ()>) {
-    let options = match options {
-        Ok(opts) => opts,
-        Err(_) => return (false, options),
-    };
-
-    let mut new_options = Vec::new();
-    let mut oidc_auth_enabled = false;
-
-    for (k, v) in options {
-        if k == "oidc_auth_enabled" {
-            oidc_auth_enabled = v.parse::<bool>().unwrap_or(false);
-        } else {
-            new_options.push((k, v));
-        }
-    }
-
-    (oidc_auth_enabled, Ok(new_options))
+/// Decides if a given password is a JWT by checking
+/// if we can decode its header.
+fn is_jwt(password: &str) -> bool {
+    jsonwebtoken::decode_header(password).is_ok()
 }
 
 /// Returns (name, value) session settings pairs from an options value.
@@ -769,21 +769,16 @@ where
 /// Helper for password-based authentication using AdapterClient
 /// and returns an authenticated session.
 async fn authenticate_with_password<A>(
-    conn: &mut FramedConn<A>,
+    conn: &FramedConn<A>,
     adapter_client: &mz_adapter::Client,
     user: String,
+    password: Password,
     conn_uuid: Uuid,
     helm_chart_version: Option<String>,
-    authenticator_kind: mz_auth::AuthenticatorKind,
 ) -> Result<Session, PasswordRequestError>
 where
     A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin,
 {
-    let password = match request_cleartext_password(conn).await {
-        Ok(password) => Password(password),
-        Err(e) => return Err(e),
-    };
-
     let authenticated = match adapter_client.authenticate(&user, &password).await {
         Ok(authenticated) => authenticated,
         Err(err) => {
@@ -802,7 +797,7 @@ where
             client_ip: conn.peer_addr().clone(),
             external_metadata_rx: None,
             helm_chart_version,
-            authenticator_kind,
+            authenticator_kind: mz_auth::AuthenticatorKind::Password,
             groups: None,
         },
         authenticated,
@@ -3199,9 +3194,6 @@ fn get_authenticator(
     frontegg: Option<FronteggAuthenticator>,
     oidc: GenericOidcAuthenticator,
     adapter_client: mz_adapter::Client,
-    // If oidc_auth_enabled exists as an option in the pgwire connection's
-    // `option` parameter
-    oidc_auth_option_enabled: bool,
 ) -> Authenticator {
     match authenticator_kind {
         listeners::AuthenticatorKind::Frontegg => Authenticator::Frontegg(frontegg.expect(
@@ -3209,15 +3201,7 @@ fn get_authenticator(
         )),
         listeners::AuthenticatorKind::Password => Authenticator::Password(adapter_client),
         listeners::AuthenticatorKind::Sasl => Authenticator::Sasl(adapter_client),
-        listeners::AuthenticatorKind::Oidc => {
-            if oidc_auth_option_enabled {
-                Authenticator::Oidc(oidc)
-            } else {
-                // Fallback to password authentication if oidc auth is not enabled
-                // through options.
-                Authenticator::Password(adapter_client)
-            }
-        }
+        listeners::AuthenticatorKind::Oidc => Authenticator::Oidc(oidc),
         listeners::AuthenticatorKind::None => Authenticator::None,
     }
 }
@@ -3588,6 +3572,23 @@ mod test {
         for test in tests {
             let got = split_options(test.input);
             assert_eq!(got, test.expect, "input: {}", test.input);
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_is_jwt() {
+        // A real JWT header decodes successfully.
+        assert!(is_jwt("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature"));
+        // Not JWTs: plain strings, wrong segment count, non-JSON headers.
+        for s in [
+            "",
+            "secure_password",
+            "p4ss.w0rd",
+            "aaa.bbb.ccc",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig.extra",
+        ] {
+            assert!(!is_jwt(s), "is_jwt({s:?})");
         }
     }
 }

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -3512,9 +3512,6 @@ def workflow_oidc_auth(c: Composition, parser: WorkflowArgumentParser) -> None:
         token = _fetch_hydra_jwt()
 
         print(f"Verifying OIDC pgwire login as {OIDC_CLIENT_ID}...")
-        # `-c oidc_auth_enabled=true` opts this connection into the OIDC
-        # authenticator. The role is auto-provisioned by environmentd on first
-        # login if it doesn't already exist.
         with (
             psycopg.connect(
                 host="127.0.0.1",
@@ -3522,7 +3519,6 @@ def workflow_oidc_auth(c: Composition, parser: WorkflowArgumentParser) -> None:
                 user=OIDC_CLIENT_ID,
                 password=token,
                 dbname="materialize",
-                options="-c oidc_auth_enabled=true",
                 connect_timeout=30,
             ) as conn,
             conn.cursor() as cur,
@@ -3540,7 +3536,6 @@ def workflow_oidc_auth(c: Composition, parser: WorkflowArgumentParser) -> None:
                 user=OIDC_CLIENT_ID,
                 password=bad_token,
                 dbname="materialize",
-                options="-c oidc_auth_enabled=true",
                 connect_timeout=30,
             ).close()
         except psycopg.OperationalError:


### PR DESCRIPTION
### Motivation

Before we'd explicitly separate SQL password authentication and OIDC authentication through a connection option when a user's AuthenticatorKind(decided by the listener json) is Oidc. However, we've since discovered many external clients like Looker, DBeaver, Terraform, and dbt don't support override PG connection options or make it hard to do so. 

Thus we change the behavior to branch on the authentication method based on if the password is a JWT. There is an edge case where we'll fail if a user's SQL password is a valid JWT. However since this is gated by the Oidc AuthenticatorKind and because it's not as likely, we accept this case.
