### PR TITLE
docs: PrivateLink troubleshooting for NLB security group enforcement

### DIFF
--- a/doc/user/layouts/shortcodes/network-security/privatelink-kafka.md
+++ b/doc/user/layouts/shortcodes/network-security/privatelink-kafka.md
@@ -44,9 +44,11 @@ and retrieve the AWS principal needed to configure the AWS PrivateLink service.
 
     **Remarks**:
 
-    a. Network Load Balancers do not have associated security groups. Therefore, the security groups for your targets must use IP addresses to allow traffic.
+    a. Network Load Balancers do not have associated security groups by default. Therefore, the security groups for your targets must use IP addresses to allow traffic.
 
     b. You can't use the security groups for the clients as a source in the security groups for the targets. Therefore, the security groups for your targets must use the IP addresses of the clients to allow traffic. For more details, check the [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html).
+
+    c. If you have associated a [security group with your Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html) and enabled **Enforce inbound rules on PrivateLink traffic**, the NLB's inbound rules will be applied to traffic arriving from Materialize's VPC endpoint. In that case, the source IPs are private IPs from Materialize's VPC — **not** the IPs of any client (e.g., `kcat` or a Kafka client running from a workstation or bastion host) that you might use to verify connectivity to the brokers directly. Inbound rules that only permit your own test traffic will silently block Materialize, even when your own connectivity tests succeed. To resolve this, either disable **Enforce inbound rules on PrivateLink traffic**, or add inbound rules to the NLB's security group that permit the relevant ports (each broker's listener port and the health check port) from a source that covers Materialize's VPC endpoint traffic.
 
 1. Create a VPC [endpoint service](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html) and associate it with the **Network Load Balancer** that you’ve just created.
 

--- a/doc/user/layouts/shortcodes/network-security/privatelink-mysql.md
+++ b/doc/user/layouts/shortcodes/network-security/privatelink-mysql.md
@@ -19,9 +19,11 @@
 
     **Remarks**:
 
-    a. Network Load Balancers do not have associated security groups. Therefore, the security groups for your targets must use IP addresses to allow traffic.
+    a. Network Load Balancers do not have associated security groups by default. Therefore, the security groups for your targets must use IP addresses to allow traffic.
 
     b. You can't use the security groups for the clients as a source in the security groups for the targets. Therefore, the security groups for your targets must use the IP addresses of the clients to allow traffic. For more details, check the [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html).
+
+    c. If you have associated a [security group with your Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html) and enabled **Enforce inbound rules on PrivateLink traffic**, the NLB's inbound rules will be applied to traffic arriving from Materialize's VPC endpoint. In that case, the source IPs are private IPs from Materialize's VPC — **not** the IPs of any client (e.g., `mysql` running from a workstation or bastion host) that you might use to verify connectivity to the database directly. Inbound rules that only permit your own test traffic will silently block Materialize, even when your own connectivity tests succeed. To resolve this, either disable **Enforce inbound rules on PrivateLink traffic**, or add inbound rules to the NLB's security group that permit the relevant ports (the listener port and the health check port) from a source that covers Materialize's VPC endpoint traffic.
 
 1. #### Create a Network Load Balancer (NLB)
     Create a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-network-load-balancer.html) that is **enabled for the same subnets** that the RDS instance is in.

--- a/doc/user/layouts/shortcodes/network-security/privatelink-postgres.md
+++ b/doc/user/layouts/shortcodes/network-security/privatelink-postgres.md
@@ -19,9 +19,11 @@
 
     **Remarks**:
 
-    a. Network Load Balancers do not have associated security groups. Therefore, the security groups for your targets must use IP addresses to allow traffic.
+    a. Network Load Balancers do not have associated security groups by default. Therefore, the security groups for your targets must use IP addresses to allow traffic.
 
     b. You can't use the security groups for the clients as a source in the security groups for the targets. Therefore, the security groups for your targets must use the IP addresses of the clients to allow traffic. For more details, check the [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html).
+
+    c. If you have associated a [security group with your Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html) and enabled **Enforce inbound rules on PrivateLink traffic**, the NLB's inbound rules will be applied to traffic arriving from Materialize's VPC endpoint. In that case, the source IPs are private IPs from Materialize's VPC — **not** the IPs of any client (e.g., `psql` running from a workstation or bastion host) that you might use to verify connectivity to the database directly. Inbound rules that only permit your own test traffic will silently block Materialize, even when your own connectivity tests succeed. To resolve this, either disable **Enforce inbound rules on PrivateLink traffic**, or add inbound rules to the NLB's security group that permit the relevant ports (the listener port and the health check port) from a source that covers Materialize's VPC endpoint traffic.
 
 1. #### Create a Network Load Balancer (NLB)
     Create a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-network-load-balancer.html) that is **enabled for the same subnets** that the RDS or Aurora instance is in.


### PR DESCRIPTION
## Motivation

Customer hit a silent PrivateLink failure: `psql` from their bastion worked, but Materialize source creation failed. Their NLB security group had **Enforce inbound rules on PrivateLink traffic** enabled with rules that only allowed their own test IPs — traffic from Materialize's VPC endpoint arrives with different source IPs, so it was silently dropped.

Our docs don't mention this, and still claim "NLBs do not have associated security groups" (no longer true since AWS added the feature in 2023).

Slack thread: https://materializeinc.slack.com/archives/C08K5GHRV1S/p1779207642559229

## Changes

In each of the three PrivateLink setup shortcodes (PostgreSQL, MySQL, Kafka):

- Soften remark (a.) to "...do not have associated security groups **by default**."
- Add remark (c.) describing the **Enforce inbound rules on PrivateLink traffic** failure mode and how to fix it.
