### PR TITLE
console: fix  WebSocket race and route-remount data flicker

### DIFF
--- a/console/src/api/materialize/SubscribeManager.ts
+++ b/console/src/api/materialize/SubscribeManager.ts
@@ -141,6 +141,10 @@ export class SubscribeManager<T extends object, R> implements Connectable {
     );
   };
 
+  setRequest = (request: SqlRequest) => {
+    this.sqlRequest = request;
+  };
+
   disconnect = () => {
     clearInterval(this.flushIntervalHandle);
     this.socket.disconnect();

--- a/console/src/api/materialize/WebsocketConnectionManager.test.ts
+++ b/console/src/api/materialize/WebsocketConnectionManager.test.ts
@@ -205,6 +205,33 @@ describe("WebsocketConnectionManager", () => {
       vi.advanceTimersByTime(5000);
       expect(mockTarget.reconnect).not.toHaveBeenCalled();
     });
+
+    it("does not start a second connect while a handshake is in progress", () => {
+      const store = getStore();
+      store.set(
+        environmentsWithHealth,
+        new Map([
+          ["aws/us-east-1", createHealthyEnvironment("localhost:6875")],
+        ]) as unknown as EnvironmentsWithHealth,
+      );
+
+      // Constructor starts a connect; handshake is still in progress.
+      manager = new WebsocketConnectionManager(
+        mockTarget,
+        store,
+        reconnectionStateAtom,
+      );
+      expect(mockTarget.reconnect).toHaveBeenCalledTimes(1);
+
+      // Overlapping reconnect is dropped while the handshake is in progress.
+      manager.reconnect();
+      expect(mockTarget.reconnect).toHaveBeenCalledTimes(1);
+
+      // Once the handshake completes, the next reconnect proceeds.
+      mockTarget.simulateOpen();
+      manager.reconnect();
+      expect(mockTarget.reconnect).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("destroy", () => {

--- a/console/src/api/materialize/WebsocketConnectionManager.ts
+++ b/console/src/api/materialize/WebsocketConnectionManager.ts
@@ -81,6 +81,8 @@ export class WebsocketConnectionManager {
   private hasEverConnected = false;
   private retryTimer: ReturnType<typeof setTimeout> | undefined;
   private initialized = false;
+  /** Set while a connect is mid-handshake. Reentry would strand the CONNECTING socket on Safari. */
+  private connectInFlight = false;
 
   private unsubscribeFromClose: (() => void) | undefined;
   private unsubscribeFromOpen: (() => void) | undefined;
@@ -148,17 +150,15 @@ export class WebsocketConnectionManager {
   private handleEnvironmentChange = () => {
     const currentEnvironment = this.getCurrentEnvironment();
     const nowHealthy = this.isEnvironmentHealthy(currentEnvironment);
-    const prevHealthy = this.isHealthy;
 
     this.isHealthy = nowHealthy;
 
-    // Update http address if environment is enabled
     if (currentEnvironment?.state === "enabled") {
       this.currentHttpAddress = currentEnvironment.httpAddress;
     }
 
     if (nowHealthy) {
-      if (!prevHealthy || !this.target.isConnected()) {
+      if (!this.target.isConnected()) {
         this.resumeConnection();
       }
     } else {
@@ -192,6 +192,7 @@ export class WebsocketConnectionManager {
   // --- Target event handlers ---
 
   private handleTargetClose = () => {
+    this.connectInFlight = false;
     if (this.isHealthy) {
       this.scheduleRetry();
     }
@@ -199,11 +200,17 @@ export class WebsocketConnectionManager {
   };
 
   private handleTargetOpen = () => {
+    this.connectInFlight = false;
     this.hasEverConnected = true;
     this.retryAttempt = 0;
     this.clearRetryTimer();
     this.notifyStateChange();
   };
+
+  /** Tear down and reopen the socket. Used on SQL request changes. */
+  reconnect() {
+    this.attemptConnection();
+  }
 
   // --- Retry scheduling ---
 
@@ -225,18 +232,18 @@ export class WebsocketConnectionManager {
   }
 
   private attemptConnection() {
-    if (this.target.isConnected()) return;
-    if (this.currentHttpAddress) {
-      const sessionVariables = this.options.getSessionVariables?.({
-        hasEverConnected: this.hasEverConnected,
-      });
-      try {
-        this.target.reconnect(this.currentHttpAddress, sessionVariables);
-      } catch {
-        // If the WebSocket constructor throws (e.g. network blocked),
-        // schedule another retry
-        this.scheduleRetry();
-      }
+    if (this.connectInFlight) return;
+    if (!this.currentHttpAddress) return;
+
+    const sessionVariables = this.options.getSessionVariables?.({
+      hasEverConnected: this.hasEverConnected,
+    });
+    this.connectInFlight = true;
+    try {
+      this.target.reconnect(this.currentHttpAddress, sessionVariables);
+    } catch {
+      this.connectInFlight = false;
+      this.scheduleRetry();
     }
   }
 

--- a/console/src/api/materialize/useSubscribe.ts
+++ b/console/src/api/materialize/useSubscribe.ts
@@ -141,7 +141,13 @@ export function useGlobalUpsertSubscribe<T extends object, R = SubscribeRow<T>>(
   React.useEffect(() => {
     const cleanup = subscribe.onChange(() => {
       const snapshot = subscribe.getSnapshot();
-      if (getStore().get(options.atom) === snapshot) return;
+      const current = getStore().get(options.atom);
+      if (current === snapshot) return;
+
+      // Hold cached atom data through a fresh manager's empty pre-snapshot state.
+      const snapshotIsEmptyPreload =
+        !snapshot.snapshotComplete && !snapshot.data.length && !snapshot.error;
+      if (snapshotIsEmptyPreload && current.data.length) return;
 
       setValue(snapshot);
     });

--- a/console/src/hooks/useAutomaticallyConnectSocket.ts
+++ b/console/src/hooks/useAutomaticallyConnectSocket.ts
@@ -19,7 +19,6 @@ import {
   ReconnectionState,
   WebsocketConnectionManager,
 } from "~/api/materialize/WebsocketConnectionManager";
-import { currentEnvironmentState } from "~/store/environments";
 
 // Atom for reconnection state - can be shared across components if needed
 export const reconnectionStateAtom = atom<ReconnectionState>({
@@ -74,27 +73,16 @@ export const useAutomaticallyConnectSocket = <T extends object, R>({
     };
   }, [target, store, getSessionVariablesRef]);
 
-  // Handle request changes for subscribe queries
-  const currentEnvironment = useAtomValue(currentEnvironmentState);
   const previousRequest = usePrevious(request);
 
   React.useEffect(() => {
     if (!subscribe || !request) return;
     if (previousRequest === request) return;
-    if (currentEnvironment?.state !== "enabled") return;
-
-    subscribe.connect(
-      request,
-      currentEnvironment.httpAddress,
-      getSessionVariablesRef.current?.({ hasEverConnected: false }),
-    );
-  }, [
-    subscribe,
-    request,
-    previousRequest,
-    currentEnvironment,
-    getSessionVariablesRef,
-  ]);
+    subscribe.setRequest(request);
+    // The manager owns the initial connect; only force a reconnect on changes.
+    if (previousRequest === undefined) return;
+    managerRef.current?.reconnect();
+  }, [subscribe, request, previousRequest]);
 
   return { reconnectionState };
 };


### PR DESCRIPTION

This fixes [CNS-77](https://linear.app/materializeinc/issue/CNS-77/data-explorer-page-not-loading) where the data explorer spinner keeps spinning for a while. Reported by @sjwiesman  and @frankmcsherry , I have only been able to repro this in Safari. Iterated in this draft fix PR: https://github.com/MaterializeInc/materialize/pull/36613 , there is a race condition in the websocket hook useEffects that initiates the Websocket connection and the second effect kills the `CONNECTING` socket. I refactored to route the `useAutomaticallyConnectWebsocket` reconnect signals in the Websocket Connection Manager and added a guard to serialize the overlapping triggers.


Fixed another bug that happens when a user navigates away from Data Explorer page and comes back, it reloads the page. Coming back to Data Explorer, opens a new Websocket connection and reset the state that clobbered the existing snapshot. Fixed the hook `useGlobalUpsertSubscribe` to hold the cached snapshot until new manager has the data. 


### Verification

- Added a test for the race condition
Before:

https://github.com/user-attachments/assets/58c2b834-f76d-4158-b4f2-ef330172bb64



- Videos of the fix here


https://github.com/user-attachments/assets/8c12d53f-6d0b-48c1-8ae4-b5a433ba2ee9

