### PR TITLE
Remove `enable_guard_subquery_tablefunc` feature flag

### DIFF
--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -224,7 +224,6 @@ impl From<&OptimizerConfig> for mz_sql::plan::HirToMirConfig {
         Self {
             enable_new_outer_join_lowering: config.features.enable_new_outer_join_lowering,
             enable_variadic_left_join_lowering: config.features.enable_variadic_left_join_lowering,
-            enable_guard_subquery_tablefunc: config.features.enable_guard_subquery_tablefunc,
             enable_cast_elimination: config.features.enable_cast_elimination,
             enable_simplify_quantified_comparisons: config
                 .features

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -95,7 +95,6 @@ optimizer_feature_flags!({
     // Use `EquivalenceClassesWithholdingErrors` instead of raw
     // `EquivalenceClasses` during eq prop for joins.
     enable_eq_classes_withholding_errors: bool,
-    enable_guard_subquery_tablefunc: bool,
     // Enable consolidation of unions that happen immediately after negate.
     //
     // The refinement happens in the LIR ⇒ LIR phase.

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -139,7 +139,6 @@ pub struct Config {
     pub enable_new_outer_join_lowering: bool,
     /// Enable outer join lowering implemented in database-issues#7561.
     pub enable_variadic_left_join_lowering: bool,
-    pub enable_guard_subquery_tablefunc: bool,
     pub enable_cast_elimination: bool,
     pub enable_simplify_quantified_comparisons: bool,
 }
@@ -149,7 +148,6 @@ impl Default for Config {
         Self {
             enable_new_outer_join_lowering: false,
             enable_variadic_left_join_lowering: false,
-            enable_guard_subquery_tablefunc: false,
             enable_cast_elimination: false,
             enable_simplify_quantified_comparisons: false,
         }
@@ -161,7 +159,6 @@ impl From<&SystemVars> for Config {
         Self {
             enable_new_outer_join_lowering: vars.enable_new_outer_join_lowering(),
             enable_variadic_left_join_lowering: vars.enable_variadic_left_join_lowering(),
-            enable_guard_subquery_tablefunc: vars.enable_guard_subquery_tablefunc(),
             enable_cast_elimination: vars.enable_cast_elimination(),
             enable_simplify_quantified_comparisons: vars.enable_simplify_quantified_comparisons(),
         }
@@ -1998,34 +1995,19 @@ fn apply_scalar_subquery(
                     None,
                 );
 
-                let use_guard = context.config.enable_guard_subquery_tablefunc;
-
                 // Errors should result from counts > 1.
-                let errors = if use_guard {
-                    counts
-                        .flat_map(
-                            mz_expr::TableFunc::GuardSubquerySize {
-                                column_type: col_type.clone().scalar_type,
-                            },
-                            vec![MirScalarExpr::column(inner_arity)],
-                        )
-                        .project(
-                            (0..inner_arity)
-                                .chain(Some(inner_arity + 1))
-                                .collect::<Vec<_>>(),
-                        )
-                } else {
-                    counts
-                        .filter(vec![MirScalarExpr::column(inner_arity).call_binary(
-                            MirScalarExpr::literal_ok(Datum::Int64(1), ReprScalarType::Int64),
-                            func::Gt,
-                        )])
-                        .project((0..inner_arity).collect::<Vec<_>>())
-                        .map_one(MirScalarExpr::literal(
-                            Err(mz_expr::EvalError::MultipleRowsFromSubquery),
-                            ReprScalarType::from(&col_type.scalar_type),
-                        ))
-                };
+                let errors = counts
+                    .flat_map(
+                        mz_expr::TableFunc::GuardSubquerySize {
+                            column_type: col_type.clone().scalar_type,
+                        },
+                        vec![MirScalarExpr::column(inner_arity)],
+                    )
+                    .project(
+                        (0..inner_arity)
+                            .chain(Some(inner_arity + 1))
+                            .collect::<Vec<_>>(),
+                    );
                 // Return `get_select` and any errors added in.
                 Ok::<_, PlanError>(get_select.union(errors))
             })?;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4858,7 +4858,6 @@ pub fn unplan_create_cluster(
         }) => {
             let schedule = unplan_cluster_schedule(schedule);
             let OptimizerFeatureOverrides {
-                enable_guard_subquery_tablefunc: _,
                 enable_consolidate_after_union_negate: _,
                 enable_reduce_mfp_fusion: _,
                 enable_cardinality_estimates: _,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -620,7 +620,6 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
             types: v.types,
             // The ones that are initialized with `Default::default()` are not wired up to EXPLAIN.
             features: OptimizerFeatureOverrides {
-                enable_guard_subquery_tablefunc: Default::default(),
                 enable_eager_delta_joins: v.enable_eager_delta_joins,
                 enable_new_outer_join_lowering: v.enable_new_outer_join_lowering,
                 enable_variadic_left_join_lowering: v.enable_variadic_left_join_lowering,

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1773,12 +1773,6 @@ feature_flags!(
     },
     // Actual feature flags
     {
-        name: enable_guard_subquery_tablefunc,
-        desc: "Whether HIR -> MIR lowering should use a new tablefunc to guard subquery sizes",
-        default: true,
-        enable_for_item_parsing: false,
-    },
-    {
         name: enable_binary_date_bin,
         desc: "the binary version of date_bin function",
         default: false,
@@ -2280,7 +2274,6 @@ feature_flags!(
 impl From<&super::SystemVars> for OptimizerFeatures {
     fn from(vars: &super::SystemVars) -> Self {
         Self {
-            enable_guard_subquery_tablefunc: vars.enable_guard_subquery_tablefunc(),
             enable_consolidate_after_union_negate: vars.enable_consolidate_after_union_negate(),
             enable_eager_delta_joins: vars.enable_eager_delta_joins(),
             enable_new_outer_join_lowering: vars.enable_new_outer_join_lowering(),
@@ -2325,7 +2318,6 @@ mod tests {
         let false_features = OptimizerFeatures::default();
         let OptimizerFeatures {
             enable_eq_classes_withholding_errors,
-            enable_guard_subquery_tablefunc,
             enable_consolidate_after_union_negate,
             enable_eager_delta_joins,
             enable_letrec_fixpoint_analysis,
@@ -2356,7 +2348,6 @@ mod tests {
         }
 
         set_var!(enable_eq_classes_withholding_errors);
-        set_var!(enable_guard_subquery_tablefunc);
         set_var!(enable_consolidate_after_union_negate);
         set_var!(enable_eager_delta_joins);
         set_var!(enable_letrec_fixpoint_analysis);


### PR DESCRIPTION
The `enable_guard_subquery_tablefunc` feature flag was introduced when we brought the table func that stands in to guard subquery sizes. That seems to have worked out well, and the flag is no longer needed.