### PR TITLE
ci(scratch-aws-access): cut assume-role session from 12h to 2h

### DIFF
--- a/ci/plugins/scratch-aws-access/hooks/pre-command
+++ b/ci/plugins/scratch-aws-access/hooks/pre-command
@@ -15,7 +15,7 @@ set -euo pipefail
 
 ci_unimportant_heading "Assuming scratch AWS role"
 
-creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --duration-seconds 43200 --role-session-name ci)
+creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --duration-seconds 7200 --role-session-name ci)
 
 AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< "$creds")
 AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< "$creds")


### PR DESCRIPTION
## Summary

The \`scratch-aws-access\` Buildkite plugin requests a **12 h** STS session when assuming the \`ci\` role in the scratch account. CI jobs rarely exceed ~2 h. If those creds leak (test logs, \`printenv\` in a malicious test step, exfil from the agent host, …) they stay valid for half a day.

This PR cuts \`--duration-seconds 43200\` → \`7200\`.

## Coordination

Pair with [\`MaterializeInc/i2#3267\`](https://github.com/MaterializeInc/i2/pull/3267), which cuts \`max_session_duration\` on \`mz-scratch-ci-role\` to match. **Land this PR first** — otherwise this client keeps asking for 12 h and the role-side cap in i2 rejects it.

Tracking: i2 [SEC-573](https://linear.app/materializeinc/issue/SEC-573) / SEC-566 audit.

## Test plan

- [ ] Trigger a representative CI job after merge; confirm it succeeds with a 2 h session
- [ ] If any pipeline genuinely runs >2 h end-to-end (release pipeline?), confirm we know which ones and have a plan (re-assume mid-run, or bump the cap up slightly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)