### PR TITLE
ci(scratch-aws-access): tag AssumeRole sessions with --source-identity

### DIFF
--- a/ci/plugins/scratch-aws-access/hooks/pre-command
+++ b/ci/plugins/scratch-aws-access/hooks/pre-command
@@ -15,11 +15,8 @@ set -euo pipefail
 
 ci_unimportant_heading "Assuming scratch AWS role"
 
-# Tag the session with the Buildkite job ID so CloudTrail attributes the
-# session to a specific build step. Falls back to a stable "unknown" so
-# the call still succeeds outside Buildkite (local dev). AWS source-identity
-# regex: [a-zA-Z0-9+=,.@_/-]+, max 64 chars; BUILDKITE_JOB_ID is a UUID.
-source_identity="${BUILDKITE_JOB_ID:-unknown}"
+# Tag the session with the CI job ID so CloudTrail can attribute it.
+source_identity="${BUILDKITE_JOB_ID:-${GITHUB_RUN_ID:-unknown}}"
 
 creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --duration-seconds 43200 --role-session-name ci --source-identity "$source_identity")
 

--- a/ci/plugins/scratch-aws-access/hooks/pre-command
+++ b/ci/plugins/scratch-aws-access/hooks/pre-command
@@ -15,7 +15,13 @@ set -euo pipefail
 
 ci_unimportant_heading "Assuming scratch AWS role"
 
-creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --duration-seconds 43200 --role-session-name ci)
+# Tag the session with the Buildkite job ID so CloudTrail attributes the
+# session to a specific build step. Falls back to a stable "unknown" so
+# the call still succeeds outside Buildkite (local dev). AWS source-identity
+# regex: [a-zA-Z0-9+=,.@_/-]+, max 64 chars; BUILDKITE_JOB_ID is a UUID.
+source_identity="${BUILDKITE_JOB_ID:-unknown}"
+
+creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --duration-seconds 43200 --role-session-name ci --source-identity "$source_identity")
 
 AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< "$creds")
 AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< "$creds")


### PR DESCRIPTION
## Summary

Every CI session today appears in CloudTrail under role-session-name \`ci\` — indistinguishable from every other CI session. Adding \`--source-identity \"\$BUILDKITE_JOB_ID\"\` makes each AssumeRole call attributable to a specific job, and unlocks future trust-policy conditions on \`sts:SourceIdentity\` (e.g., "only this build-step can use this role").

## Test plan

- [ ] After both PRs merge, run a representative job; confirm it succeeds (no AccessDenied)
- [ ] Check CloudTrail \`AssumeRole\` events: \`sourceIdentity\` field should contain the BUILDKITE_JOB_ID UUID
- [ ] Verify the local-dev fallback (\`BUILDKITE_JOB_ID\` unset) still succeeds with \`unknown\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)