### PR TITLE
adapter: Prevent `enable_variadic_left_join` from firing on cross-joins

### DIFF
--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -196,8 +196,9 @@ pub(crate) fn attempt_left_join_magic(
                 inc_metrics("voj_5");
                 return Ok(None);
             }
-            // Only columns not from the outer scope introduce bindings.
-            if left >= oa {
+            // Only columns not from the outer scope introduce bindings (`oa <= left`)
+            // And `left` needs to be a column in the left relation (`left < oa + ba`)
+            if oa <= left && left < oa + ba {
                 if let Some(bound) = bound_input {
                     // If left references come from different inputs, bail out.
                     if bound_to[left] != bound {

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -176,7 +176,7 @@ pub(crate) fn attempt_left_join_magic(
         // then we can fish out values from that input. If it equates values
         // across multiple inputs, we would need to fish out valid tuples and
         // no idea how we would get those w/o doing a join or a cartesian product.
-        let equations = if let Some(list) = decompose_equations(&on) {
+        let equations = if let Some(list) = decompose_equations(&on, oa + ba) {
             list
         } else {
             tracing::debug!(case = 4, index, "attempt_left_join_magic");
@@ -395,7 +395,11 @@ use mz_expr::func::variadic::{And, Or};
 use mz_expr::{BinaryFunc, VariadicFunc};
 
 /// If `predicate` can be decomposed as any number of `col(x) = col(y)` expressions anded together, return them.
-fn decompose_equations(predicate: &MirScalarExpr) -> Option<Vec<(usize, usize)>> {
+/// Excludes equations where both columns are `>= lhs_cutoff`.
+fn decompose_equations(
+    predicate: &MirScalarExpr,
+    lhs_cutoff: usize,
+) -> Option<Vec<(usize, usize)>> {
     let mut equations = Vec::new();
 
     let mut todo = vec![predicate];
@@ -415,9 +419,9 @@ fn decompose_equations(predicate: &MirScalarExpr) -> Option<Vec<(usize, usize)>>
                 if let (MirScalarExpr::Column(c1, _name1), MirScalarExpr::Column(c2, _name2)) =
                     (&**expr1, &**expr2)
                 {
-                    if c1 < c2 {
+                    if c1 < c2 && *c1 < lhs_cutoff {
                         equations.push((*c1, *c2));
-                    } else {
+                    } else if *c2 < lhs_cutoff {
                         equations.push((*c2, *c1));
                     }
                 } else {

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -176,7 +176,7 @@ pub(crate) fn attempt_left_join_magic(
         // then we can fish out values from that input. If it equates values
         // across multiple inputs, we would need to fish out valid tuples and
         // no idea how we would get those w/o doing a join or a cartesian product.
-        let equations = if let Some(list) = decompose_equations(&on, oa + ba) {
+        let equations = if let Some(list) = decompose_left_to_right_equations(&on, oa + ba) {
             list
         } else {
             tracing::debug!(case = 4, index, "attempt_left_join_magic");
@@ -395,8 +395,8 @@ use mz_expr::func::variadic::{And, Or};
 use mz_expr::{BinaryFunc, VariadicFunc};
 
 /// If `predicate` can be decomposed as any number of `col(x) = col(y)` expressions anded together, return them.
-/// Excludes equations where both columns are `>= lhs_cutoff`.
-fn decompose_equations(
+/// In order to only find _useful_ equations, one column must be `< lhs_cutoff` and one must be `>= lhs_cutoff`.
+fn decompose_left_to_right_equations(
     predicate: &MirScalarExpr,
     lhs_cutoff: usize,
 ) -> Option<Vec<(usize, usize)>> {
@@ -419,9 +419,9 @@ fn decompose_equations(
                 if let (MirScalarExpr::Column(c1, _name1), MirScalarExpr::Column(c2, _name2)) =
                     (&**expr1, &**expr2)
                 {
-                    if c1 < c2 && *c1 < lhs_cutoff {
+                    if c1 < c2 && *c1 < lhs_cutoff && lhs_cutoff <= *c2 {
                         equations.push((*c1, *c2));
-                    } else if *c2 < lhs_cutoff {
+                    } else if *c2 < lhs_cutoff && lhs_cutoff <= *c1 {
                         equations.push((*c2, *c1));
                     }
                 } else {

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -176,7 +176,7 @@ pub(crate) fn attempt_left_join_magic(
         // then we can fish out values from that input. If it equates values
         // across multiple inputs, we would need to fish out valid tuples and
         // no idea how we would get those w/o doing a join or a cartesian product.
-        let (mut equations, mut non_crossing_equations) =
+        let (equations, non_crossing_equations) =
             if let Some(list) = decompose_left_to_right_equations(&on, oa + ba) {
                 list
             } else {

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -176,13 +176,24 @@ pub(crate) fn attempt_left_join_magic(
         // then we can fish out values from that input. If it equates values
         // across multiple inputs, we would need to fish out valid tuples and
         // no idea how we would get those w/o doing a join or a cartesian product.
-        let equations = if let Some(list) = decompose_left_to_right_equations(&on, oa + ba) {
-            list
-        } else {
-            tracing::debug!(case = 4, index, "attempt_left_join_magic");
-            inc_metrics("voj_4");
+        let (mut equations, mut non_crossing_equations) =
+            if let Some(list) = decompose_left_to_right_equations(&on, oa + ba) {
+                list
+            } else {
+                tracing::debug!(case = 4, index, "attempt_left_join_magic");
+                inc_metrics("voj_4");
+                return Ok(None);
+            };
+
+        if !non_crossing_equations.is_empty() {
+            // TODO(mgree) This case isn't _impossible_, but it's complicated.
+            // We have equations that cross from left to right, but we also have
+            // left-left or right-right equations. Making sure we get exactly the
+            // right results here is hard enough that we don't attempt it.
+            tracing::debug!(case = 8, index, "attempt_left_join_magic");
+            inc_metrics("voj_8");
             return Ok(None);
-        };
+        }
 
         // We now need to see if all left columns exist in some input relation,
         // and that all right columns are actually in the right relation. Idk.
@@ -399,8 +410,20 @@ use mz_expr::{BinaryFunc, VariadicFunc};
 fn decompose_left_to_right_equations(
     predicate: &MirScalarExpr,
     lhs_cutoff: usize,
-) -> Option<Vec<(usize, usize)>> {
-    let mut equations = Vec::new();
+) -> Option<(Vec<(usize, usize)>, Vec<(usize, usize)>)> {
+    let mut crossing_equations = Vec::new();
+    let mut non_crossing_equations = Vec::new();
+
+    let mut push_equation = |c1: usize, c2: usize| {
+        let l = usize::min(c1, c2);
+        let r = usize::max(c1, c2);
+
+        if l < lhs_cutoff && lhs_cutoff <= r {
+            crossing_equations.push((l, r))
+        } else {
+            non_crossing_equations.push((l, r))
+        }
+    };
 
     let mut todo = vec![predicate];
     while let Some(expr) = todo.pop() {
@@ -419,11 +442,7 @@ fn decompose_left_to_right_equations(
                 if let (MirScalarExpr::Column(c1, _name1), MirScalarExpr::Column(c2, _name2)) =
                     (&**expr1, &**expr2)
                 {
-                    if c1 < c2 && *c1 < lhs_cutoff && lhs_cutoff <= *c2 {
-                        equations.push((*c1, *c2));
-                    } else if *c2 < lhs_cutoff && lhs_cutoff <= *c1 {
-                        equations.push((*c2, *c1));
-                    }
+                    push_equation(*c1, *c2);
                 } else {
                     return None;
                 }
@@ -434,18 +453,25 @@ fn decompose_left_to_right_equations(
     }
 
     // Remove duplicates
-    equations.sort();
-    equations.dedup();
+    crossing_equations.sort();
+    crossing_equations.dedup();
+    non_crossing_equations.sort();
+    non_crossing_equations.dedup();
 
     // Ensure that every rhs column c2 appears only once. Otherwise, we have at
     // least two lhs columns c1 and c1' that are rendered equal by the same c2
     // column. The VOJ lowering will then produce a plan that will incorrectly
     // push down a local filter c1 = c1' to the lhs (see database-issues#7892).
-    if equations.iter().duplicates_by(|(_, c)| c).next().is_some() {
+    if crossing_equations
+        .iter()
+        .duplicates_by(|(_, c)| c)
+        .next()
+        .is_some()
+    {
         return None;
     }
 
-    Some(equations)
+    Some((crossing_equations, non_crossing_equations))
 }
 
 /// Turns column equation into idiomatic Rust equation, where nulls equate.

--- a/test/sqllogictest/variadic_outer_join.slt
+++ b/test/sqllogictest/variadic_outer_join.slt
@@ -298,3 +298,154 @@ SELECT a.k, b.x, b.y, b.k, c.k
 FROM (a LEFT JOIN b ON a.k = b.k AND b.x = b.y) LEFT JOIN c ON a.k = c.k
 ----
 1  NULL  NULL  NULL  NULL
+
+# Additional cases covered by the non-crossing bail-out, plus a few
+# "good path" cases that VOJ should handle via augmentation. Each
+# query is run with the variadic lowering disabled (baseline) and
+# enabled (verify VOJ doesn't diverge from the SQL-correct result).
+
+# Auxiliary table for cases that need a two-column right.
+statement ok
+CREATE TABLE d (k1 int, k2 int)
+
+statement ok
+INSERT INTO d VALUES (1, 2), (5, 5)
+
+# --- baselines (VOJ disabled) ---
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_variadic_left_join_lowering TO false
+----
+COMPLETE 0
+
+# B. LHS-LHS in the inner ON, referencing the inner left relation `b`.
+# Without bail-out: iter 1 augmentation ignores b.x = b.y, so the b rows
+# with b.x != b.y (i.e., (3,7,200) and (5,6,1)) get filtered away by
+# the post-filter and never appear with the expected NULL c.k.
+query IIIII rowsort
+SELECT b.x, b.y, b.k, a.k, c.k
+FROM (b LEFT JOIN a ON b.x = b.y AND b.k = a.k) LEFT JOIN c ON b.k = c.k
+----
+3  7  200  NULL  NULL
+5  5  100  NULL  100
+5  6  1  NULL  NULL
+
+# C. LHS-LHS in the outer ON, referencing body columns folded in from
+# the first right. Iter 1 matches a.k=1 against b.k=1 from (5,6,1), so
+# the body row is (1, 5, 6, 1). Iter 2's ON has b.k = c.k AND b.x = b.y;
+# without bail-out the b.x = b.y conjunct kills every product row,
+# including the augmented one that should yield (1, 5, 6, 1, NULL).
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN c ON b.k = c.k AND b.x = b.y
+----
+1  5  6  1  NULL
+
+# D. RHS-RHS in the outer ON. Without bail-out the augmented d row has
+# (d.k1 = val, d.k2 = NULL), so d.k1 = d.k2 evaluates to NULL and the
+# augmented row gets filtered out.
+query IIIIII rowsort
+SELECT a.k, b.x, b.y, b.k, d.k1, d.k2
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN d ON a.k = d.k1 AND d.k1 = d.k2
+----
+1  5  6  1  NULL  NULL
+
+# Positive cases: crossing-only equations that VOJ should actually
+# handle via augmentation.
+
+# E. Simple two-join chain, both joins bound to `a`.
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN c ON a.k = c.k
+----
+1  5  6  1  NULL
+
+# F. Iter 2 bound to the prior right (`b`) rather than to `a`. The
+# body row (1, 5, 6, 1) has b.k = 1, which is not in c.k, so the
+# augmentation should add an augmented (c.k = 1) row that matches it.
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN c ON b.k = c.k
+----
+1  5  6  1  NULL
+
+# G. Multi-column crossing equation in iter 1, single-column in iter 2.
+# Exercises tuple-shaped left_vals / right_vals: only b row (5,5,100)
+# matches d row (5,5), the rest get augmented null d cols.
+query IIIIII rowsort
+SELECT b.x, b.y, b.k, d.k1, d.k2, c.k
+FROM (b LEFT JOIN d ON b.x = d.k1 AND b.y = d.k2) LEFT JOIN c ON b.k = c.k
+----
+3  7  200  NULL  NULL  NULL
+5  5  100  5  5  100
+5  6  1  NULL  NULL  NULL
+
+# H. Duplicate LHS column (`a.k = d.k1 AND a.k = d.k2`). Bound to `a`,
+# left_vals is a tuple of two copies of a.k, right_vals is (d.k1, d.k2).
+# For a.k = 1, the tuple (1, 1) is not in d's (d.k1, d.k2) = {(1,2),(5,5)},
+# so a.k = 1 should be unmatched and d cols should be NULL.
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, d.k1
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN d ON a.k = d.k1 AND a.k = d.k2
+----
+1  5  6  1  NULL
+
+# --- same queries with VOJ enabled; results must match the baselines ---
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_variadic_left_join_lowering TO true
+----
+COMPLETE 0
+
+# B.
+query IIIII rowsort
+SELECT b.x, b.y, b.k, a.k, c.k
+FROM (b LEFT JOIN a ON b.x = b.y AND b.k = a.k) LEFT JOIN c ON b.k = c.k
+----
+3  7  200  NULL  NULL
+5  5  100  NULL  100
+5  6  1  NULL  NULL
+
+# C.
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN c ON b.k = c.k AND b.x = b.y
+----
+1  5  6  1  NULL
+
+# D.
+query IIIIII rowsort
+SELECT a.k, b.x, b.y, b.k, d.k1, d.k2
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN d ON a.k = d.k1 AND d.k1 = d.k2
+----
+1  5  6  1  NULL  NULL
+
+# E.
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN c ON a.k = c.k
+----
+1  5  6  1  NULL
+
+# F.
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN c ON b.k = c.k
+----
+1  5  6  1  NULL
+
+# G.
+query IIIIII rowsort
+SELECT b.x, b.y, b.k, d.k1, d.k2, c.k
+FROM (b LEFT JOIN d ON b.x = d.k1 AND b.y = d.k2) LEFT JOIN c ON b.k = c.k
+----
+3  7  200  NULL  NULL  NULL
+5  5  100  5  5  100
+5  6  1  NULL  NULL  NULL
+
+# H.
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, d.k1
+FROM (a LEFT JOIN b ON a.k = b.k) LEFT JOIN d ON a.k = d.k1 AND a.k = d.k2
+----
+1  5  6  1  NULL

--- a/test/sqllogictest/variadic_outer_join.slt
+++ b/test/sqllogictest/variadic_outer_join.slt
@@ -37,123 +37,61 @@ ALTER SYSTEM SET enable_variadic_left_join_lowering TO false
 COMPLETE 0
 
 query T multiline
-EXPLAIN PHYSICAL PLAN FOR
+EXPLAIN OPTIMIZED PLAN FOR
 SELECT a.k, b.x, b.y, b.k, c.k
 FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k
 ----
 Explained Query:
   With
     cte l0 =
-      Join::Linear
-        linear_stage[0]
-          closure
-            project=(#3, #0..=#2)
-          lookup={ relation=0, key=[] }
-          stream={ key=[], thinning=(#0..=#2) }
-        source={ relation=1, key=[] }
-        ArrangeBy
-          raw=true
-          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          Get::PassArrangements materialize.public.a
-            raw=true
-        ArrangeBy
-          raw=true
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
-          Get::Collection materialize.public.b
-            raw=true
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          ReadStorage materialize.public.a
+        ArrangeBy keys=[[]]
+          Filter (#0 = #1)
+            ReadStorage materialize.public.b
     cte l1 =
       Union
-        Get::PassArrangements l0
-          raw=true
-        Join::Linear
-          final_closure
-            project=(#0..=#3)
-            map=(null, null, null)
-          linear_stage[0]
-            lookup={ relation=1, key=[#0] }
-            stream={ key=[#0], thinning=() }
-          source={ relation=0, key=[#0] }
-          ArrangeBy
-            raw=true
-            arrangements[0]={ key=[#0], permutation=id, thinning=() }
-            Union consolidate_output=true
-              Negate
-                ArrangeBy
-                  input_key=[#0]
-                  raw=true
-                  Reduce::Distinct
-                    key_plan=id
-                    val_plan
-                      project=()
-                    Get::Collection l0
-                      project=(#0)
-                      raw=true
-              ArrangeBy
-                input_key=[#0]
-                raw=true
-                Reduce::Distinct
-                  key_plan=id
-                  val_plan
-                    project=()
-                  Get::PassArrangements materialize.public.a
-                    raw=true
-          ArrangeBy
-            raw=true
-            arrangements[0]={ key=[#0], permutation=id, thinning=() }
-            Get::PassArrangements materialize.public.a
-              raw=true
+        Get l0
+        Project (#0, #2..=#4)
+          Map (null, null, null)
+            Join on=(#0 = #1) type=differential
+              ArrangeBy keys=[[#0]]
+                Union
+                  Negate
+                    Distinct project=[#0]
+                      Project (#0)
+                        Get l0
+                  Distinct project=[#0]
+                    ReadStorage materialize.public.a
+              ArrangeBy keys=[[#0]]
+                ReadStorage materialize.public.a
     cte l2 =
-      ArrangeBy
-        raw=true
-        arrangements[0]={ key=[#3{k}], permutation={#0: #1, #1: #2, #2: #3, #3: #0}, thinning=(#0..=#2) }
-        Get::Collection l1
-          filter=((#3{k}) IS NOT NULL)
-          raw=true
+      ArrangeBy keys=[[#3{k}]]
+        Filter (#3{k}) IS NOT NULL
+          Get l1
     cte l3 =
-      Join::Linear
-        linear_stage[0]
-          closure
-            project=(#1..=#3, #0)
-          lookup={ relation=1, key=[#0{k}] }
-          stream={ key=[#3{k}], thinning=(#0..=#2) }
-        source={ relation=0, key=[#3{k}] }
-        Get::PassArrangements l2
-          raw=true
-          arrangements[0]={ key=[#3{k}], permutation={#0: #1, #1: #2, #2: #3, #3: #0}, thinning=(#0..=#2) }
-        ArrangeBy
-          raw=true
-          arrangements[0]={ key=[#0{k}], permutation=id, thinning=() }
-          Get::Collection materialize.public.c
-            raw=true
+      Project (#0..=#3)
+        Join on=(#3{k} = #4{k}) type=differential
+          Get l2
+          ArrangeBy keys=[[#0{k}]]
+            Filter (#0{k}) IS NOT NULL
+              ReadStorage materialize.public.c
   Return
     Union
-      Mfp
-        project=(#0..=#4)
-        map=(null)
-        Union consolidate_output=true
+      Map (null)
+        Union
           Negate
-            Join::Linear
-              linear_stage[0]
-                closure
-                  project=(#1..=#3, #0)
-                lookup={ relation=0, key=[#3{k}] }
-                stream={ key=[#0], thinning=() }
-              source={ relation=1, key=[#0] }
-              Get::PassArrangements l2
-                raw=true
-                arrangements[0]={ key=[#3{k}], permutation={#0: #1, #1: #2, #2: #3, #3: #0}, thinning=(#0..=#2) }
-              Reduce::Distinct
-                key_plan=id
-                val_plan
-                  project=()
-                Get::Collection l3
-                  project=(#3)
-                  raw=true
-          Get::PassArrangements l1
-            raw=true
-      Get::Collection l3
-        project=(#0..=#3, #3)
-        raw=true
+            Project (#0..=#3)
+              Join on=(#3{k} = #4) type=differential
+                Get l2
+                ArrangeBy keys=[[#0]]
+                  Distinct project=[#0]
+                    Project (#3)
+                      Get l3
+          Get l1
+      Project (#0..=#3, #3)
+        Get l3
 
 Source materialize.public.a
 Source materialize.public.b
@@ -181,125 +119,67 @@ ALTER SYSTEM SET enable_variadic_left_join_lowering TO true
 COMPLETE 0
 
 query T multiline
-EXPLAIN PHYSICAL PLAN FOR
+EXPLAIN OPTIMIZED PLAN FOR
 SELECT a.k, b.x, b.y, b.k, c.k
 FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k
 ----
 Explained Query:
-  Join::Delta
-    plan_path[0]
-      delta_stage[1]
-        closure
-          project=(#1, #4..=#6, #8)
-          map=(case when (#7) IS NULL then null else #0 end)
-        lookup={ relation=2, key=[#0] }
-        stream={ key=[case when (#2) IS NULL then null else #1 end], thinning=(#0..=#5) }
-      delta_stage[0]
-        closure
-          project=(#0, #3, #4, #6..=#8)
-          map=((#4) IS NULL, case when #5 then null else #1 end, case when #5 then null else #2 end, case when #5 then null else #3 end)
-        lookup={ relation=1, key=[] }
-        stream={ key=[], thinning=(#0) }
-      source={ relation=0, key=[] }
-    plan_path[1]
-      delta_stage[1]
-        closure
-          project=(#4, #0..=#3)
-        lookup={ relation=0, key=[] }
-        stream={ key=[], thinning=(#0..=#3) }
-      delta_stage[0]
-        closure
-          project=(#3..=#5, #7)
-          map=(case when (#6) IS NULL then null else #0 end)
-        lookup={ relation=2, key=[#0] }
-        stream={ key=[case when (#1) IS NULL then null else #0 end], thinning=(#0..=#4) }
-      initial_closure
-        project=(#2, #3, #5..=#7)
-        map=((#3) IS NULL, case when #4 then null else #0 end, case when #4 then null else #1 end, case when #4 then null else #2 end)
-      source={ relation=1, key=[] }
-    plan_path[2]
-      delta_stage[1]
-        closure
-          project=(#4, #1..=#3, #0)
-        lookup={ relation=0, key=[] }
-        stream={ key=[], thinning=(#0..=#3) }
-      delta_stage[0]
-        closure
-          project=(#1, #7..=#9)
-          map=((#5) IS NULL, case when #6 then null else #2 end, case when #6 then null else #3 end, case when #6 then null else #4 end)
-        lookup={ relation=1, key=[case when (#3) IS NULL then null else #2 end] }
-        stream={ key=[#0], thinning=(#1) }
-      initial_closure
-        project=(#0, #2)
-        map=(case when (#1) IS NULL then null else #0 end)
-      source={ relation=2, key=[#0] }
-    ArrangeBy
-      raw=true
-      arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-      Get::PassArrangements materialize.public.a
-        raw=true
-    ArrangeBy
-      raw=true
-      arrangements[0]={ key=[], permutation=id, thinning=(#0..=#3) }
-      arrangements[1]={ key=[case when (#3) IS NULL then null else #2 end], permutation={#0: #1, #1: #2, #2: #3, #3: #4}, thinning=(#0..=#3) }
+  With
+    cte l0 =
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          ReadStorage materialize.public.a
+        ArrangeBy keys=[[]]
+          Filter (#0 = #1)
+            ReadStorage materialize.public.b
+    cte l1 =
       Union
-        Get::Collection materialize.public.b
-          project=(#0..=#3)
-          filter=((#0 = #1))
-          map=(true)
-          raw=true
-        Mfp
-          project=(#1, #0, #2, #3)
-          map=(null, null, null)
-          input_key=#0
-          Reduce::Distinct
-            key_plan=id
-            val_plan
-              project=()
-            Union
-              Get::Collection materialize.public.b
-                project=(#0)
-                filter=((null OR (#0) IS NULL))
-                raw=true
-              Constant
-                - (null)
-    ArrangeBy
-      raw=true
-      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Union
-        Get::Collection materialize.public.c
-          project=(#0, #1)
-          map=(true)
-          raw=true
-        Mfp
-          project=(#0, #1)
-          map=(null)
-          input_key=#0
-          Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
-            ArrangeBy
-              raw=false
-              arrangements[0]={ key=[#0], permutation=id, thinning=() }
-              Union consolidate_output=true
-                Negate
-                  Get::Collection materialize.public.c
-                    raw=true
-                ArrangeBy
-                  input_key=[#0]
-                  raw=true
-                  Reduce::Distinct
-                    key_plan=id
-                    val_plan
-                      project=()
-                    Union
-                      Get::Collection materialize.public.b
-                        project=(#2)
-                        raw=true
-                      Constant
-                        - (null)
+        Get l0
+        Project (#0, #2..=#4)
+          Map (null, null, null)
+            Join on=(#0 = #1) type=differential
+              ArrangeBy keys=[[#0]]
+                Union
+                  Negate
+                    Distinct project=[#0]
+                      Project (#0)
+                        Get l0
+                  Distinct project=[#0]
+                    ReadStorage materialize.public.a
+              ArrangeBy keys=[[#0]]
+                ReadStorage materialize.public.a
+    cte l2 =
+      ArrangeBy keys=[[#3{k}]]
+        Filter (#3{k}) IS NOT NULL
+          Get l1
+    cte l3 =
+      Project (#0..=#3)
+        Join on=(#3{k} = #4{k}) type=differential
+          Get l2
+          ArrangeBy keys=[[#0{k}]]
+            Filter (#0{k}) IS NOT NULL
+              ReadStorage materialize.public.c
+  Return
+    Union
+      Map (null)
+        Union
+          Negate
+            Project (#0..=#3)
+              Join on=(#3{k} = #4) type=differential
+                Get l2
+                ArrangeBy keys=[[#0]]
+                  Distinct project=[#0]
+                    Project (#3)
+                      Get l3
+          Get l1
+      Project (#0..=#3, #3)
+        Get l3
 
 Source materialize.public.a
+Source materialize.public.b
+  filter=((#0 = #1))
 Source materialize.public.c
-  filter=((#0) IS NOT NULL)
+  filter=((#0{k}) IS NOT NULL)
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/variadic_outer_join.slt
+++ b/test/sqllogictest/variadic_outer_join.slt
@@ -198,3 +198,28 @@ SELECT a.k, b.k, b.x, c.k
 FROM (a LEFT JOIN b ON a.k = b.k AND b.x = b.y) LEFT JOIN c ON a.k = c.k
 ----
 1  NULL  NULL  NULL
+
+statement ok
+INSERT INTO b VALUES (5, 6, 1)
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_variadic_left_join_lowering TO false
+----
+COMPLETE 0
+
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k AND b.x = b.y) LEFT JOIN c ON a.k = c.k
+----
+1  NULL  NULL  NULL  NULL
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_variadic_left_join_lowering TO true
+----
+COMPLETE 0
+
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k AND b.x = b.y) LEFT JOIN c ON a.k = c.k
+----
+1  NULL  NULL  NULL  NULL

--- a/test/sqllogictest/variadic_outer_join.slt
+++ b/test/sqllogictest/variadic_outer_join.slt
@@ -218,6 +218,81 @@ ALTER SYSTEM SET enable_variadic_left_join_lowering TO true
 ----
 COMPLETE 0
 
+query T multiline
+EXPLAIN SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON a.k = b.k AND b.x = b.y) LEFT JOIN c ON a.k = c.k
+----
+Explained Query:
+  →With
+    cte l0 =
+      →Arrange (#0{k})
+        →Fused with Child Map/Filter/Project
+          Filter: (#0{k}) IS NOT NULL
+            →Read materialize.public.a
+    cte l1 =
+      →Differential Join %1 » %0
+        Join stage 0 in %0 with lookup key #0{k}
+        →Arranged l0
+        →Arrange (#2{k})
+          →Read materialize.public.b
+    cte l2 =
+      →Union
+        →Map/Filter/Project
+          Project: #0..=#3
+          Map: null, null, null
+            →Consolidating Union
+              →Negate Diffs
+                →Differential Join %1 » %0
+                  Join stage 0 in %0 with lookup key #0{k}
+                  →Arranged l0
+                  →Distinct GroupAggregate
+                    →Fused with Child Map/Filter/Project
+                      Project: #0
+                        →Read l1
+              →Stream materialize.public.a
+        →Fused with Child Map/Filter/Project
+          Project: #0..=#2, #0
+            →Read l1
+    cte l3 =
+      →Arrange (#0{k})
+        →Fused with Child Map/Filter/Project
+          Filter: (#0{k}) IS NOT NULL
+            →Read l2
+    cte l4 =
+      →Differential Join %0 » %1
+        Join stage 0 in %1 with lookup key #0{k}
+        →Arranged l3
+        →Arrange (#0{k})
+          →Read materialize.public.c
+  →Return
+    →Union
+      →Map/Filter/Project
+        Project: #0..=#4
+        Map: null
+          →Consolidating Union
+            →Negate Diffs
+              →Differential Join %1 » %0
+                Join stage 0 in %0 with lookup key #0{k}
+                →Arranged l3
+                →Distinct GroupAggregate
+                  →Fused with Child Map/Filter/Project
+                    Project: #0
+                      →Read l4
+            →Stream l2
+      →Fused with Child Map/Filter/Project
+        Project: #0..=#3, #0
+          →Read l4
+
+Source materialize.public.a
+Source materialize.public.b
+  filter=((#0 = #1) AND (#2{k}) IS NOT NULL)
+Source materialize.public.c
+  filter=((#0{k}) IS NOT NULL)
+
+Target cluster: quickstart
+
+EOF
+
 query IIIII rowsort
 SELECT a.k, b.x, b.y, b.k, c.k
 FROM (a LEFT JOIN b ON a.k = b.k AND b.x = b.y) LEFT JOIN c ON a.k = c.k

--- a/test/sqllogictest/variadic_outer_join.slt
+++ b/test/sqllogictest/variadic_outer_join.slt
@@ -1,0 +1,314 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE a (k int)
+
+statement ok
+CREATE TABLE b (x int, y int, k int)
+
+statement ok
+CREATE TABLE c (k int)
+
+statement ok
+INSERT INTO a VALUES (1)
+
+# Only (5, 5, 100) satisfies the b.x = b.y filter.
+statement ok
+INSERT INTO b VALUES (5, 5, 100), (3, 7, 200)
+
+statement ok
+INSERT INTO c VALUES (100)
+
+# Baseline: with the variadic LEFT JOIN lowering disabled, the generic
+# outer-join lowering classifies `b.x = b.y` as a right-local filter and
+# produces the correct single-row result.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_variadic_left_join_lowering TO false
+----
+COMPLETE 0
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k
+----
+Explained Query:
+  With
+    cte l0 =
+      Join::Linear
+        linear_stage[0]
+          closure
+            project=(#3, #0..=#2)
+          lookup={ relation=0, key=[] }
+          stream={ key=[], thinning=(#0..=#2) }
+        source={ relation=1, key=[] }
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+          Get::PassArrangements materialize.public.a
+            raw=true
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
+          Get::Collection materialize.public.b
+            raw=true
+    cte l1 =
+      Union
+        Get::PassArrangements l0
+          raw=true
+        Join::Linear
+          final_closure
+            project=(#0..=#3)
+            map=(null, null, null)
+          linear_stage[0]
+            lookup={ relation=1, key=[#0] }
+            stream={ key=[#0], thinning=() }
+          source={ relation=0, key=[#0] }
+          ArrangeBy
+            raw=true
+            arrangements[0]={ key=[#0], permutation=id, thinning=() }
+            Union consolidate_output=true
+              Negate
+                ArrangeBy
+                  input_key=[#0]
+                  raw=true
+                  Reduce::Distinct
+                    key_plan=id
+                    val_plan
+                      project=()
+                    Get::Collection l0
+                      project=(#0)
+                      raw=true
+              ArrangeBy
+                input_key=[#0]
+                raw=true
+                Reduce::Distinct
+                  key_plan=id
+                  val_plan
+                    project=()
+                  Get::PassArrangements materialize.public.a
+                    raw=true
+          ArrangeBy
+            raw=true
+            arrangements[0]={ key=[#0], permutation=id, thinning=() }
+            Get::PassArrangements materialize.public.a
+              raw=true
+    cte l2 =
+      ArrangeBy
+        raw=true
+        arrangements[0]={ key=[#3{k}], permutation={#0: #1, #1: #2, #2: #3, #3: #0}, thinning=(#0..=#2) }
+        Get::Collection l1
+          filter=((#3{k}) IS NOT NULL)
+          raw=true
+    cte l3 =
+      Join::Linear
+        linear_stage[0]
+          closure
+            project=(#1..=#3, #0)
+          lookup={ relation=1, key=[#0{k}] }
+          stream={ key=[#3{k}], thinning=(#0..=#2) }
+        source={ relation=0, key=[#3{k}] }
+        Get::PassArrangements l2
+          raw=true
+          arrangements[0]={ key=[#3{k}], permutation={#0: #1, #1: #2, #2: #3, #3: #0}, thinning=(#0..=#2) }
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[#0{k}], permutation=id, thinning=() }
+          Get::Collection materialize.public.c
+            raw=true
+  Return
+    Union
+      Mfp
+        project=(#0..=#4)
+        map=(null)
+        Union consolidate_output=true
+          Negate
+            Join::Linear
+              linear_stage[0]
+                closure
+                  project=(#1..=#3, #0)
+                lookup={ relation=0, key=[#3{k}] }
+                stream={ key=[#0], thinning=() }
+              source={ relation=1, key=[#0] }
+              Get::PassArrangements l2
+                raw=true
+                arrangements[0]={ key=[#3{k}], permutation={#0: #1, #1: #2, #2: #3, #3: #0}, thinning=(#0..=#2) }
+              Reduce::Distinct
+                key_plan=id
+                val_plan
+                  project=()
+                Get::Collection l3
+                  project=(#3)
+                  raw=true
+          Get::PassArrangements l1
+            raw=true
+      Get::Collection l3
+        project=(#0..=#3, #3)
+        raw=true
+
+Source materialize.public.a
+Source materialize.public.b
+  filter=((#0 = #1))
+Source materialize.public.c
+  filter=((#0{k}) IS NOT NULL)
+
+Target cluster: quickstart
+
+EOF
+
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k
+----
+1  5  5  100  100
+
+# Re-enable the variadic lowering (the system default) and re-run the
+# same query. The expected result is unchanged.
+# But we have observed a buggy extra NULL-enriched row (in comments below)
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_variadic_left_join_lowering TO true
+----
+COMPLETE 0
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k
+----
+Explained Query:
+  Join::Delta
+    plan_path[0]
+      delta_stage[1]
+        closure
+          project=(#1, #4..=#6, #8)
+          map=(case when (#7) IS NULL then null else #0 end)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[case when (#2) IS NULL then null else #1 end], thinning=(#0..=#5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #6..=#8)
+          map=((#4) IS NULL, case when #5 then null else #1 end, case when #5 then null else #2 end, case when #5 then null else #3 end)
+        lookup={ relation=1, key=[] }
+        stream={ key=[], thinning=(#0) }
+      source={ relation=0, key=[] }
+    plan_path[1]
+      delta_stage[1]
+        closure
+          project=(#4, #0..=#3)
+        lookup={ relation=0, key=[] }
+        stream={ key=[], thinning=(#0..=#3) }
+      delta_stage[0]
+        closure
+          project=(#3..=#5, #7)
+          map=(case when (#6) IS NULL then null else #0 end)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[case when (#1) IS NULL then null else #0 end], thinning=(#0..=#4) }
+      initial_closure
+        project=(#2, #3, #5..=#7)
+        map=((#3) IS NULL, case when #4 then null else #0 end, case when #4 then null else #1 end, case when #4 then null else #2 end)
+      source={ relation=1, key=[] }
+    plan_path[2]
+      delta_stage[1]
+        closure
+          project=(#4, #1..=#3, #0)
+        lookup={ relation=0, key=[] }
+        stream={ key=[], thinning=(#0..=#3) }
+      delta_stage[0]
+        closure
+          project=(#1, #7..=#9)
+          map=((#5) IS NULL, case when #6 then null else #2 end, case when #6 then null else #3 end, case when #6 then null else #4 end)
+        lookup={ relation=1, key=[case when (#3) IS NULL then null else #2 end] }
+        stream={ key=[#0], thinning=(#1) }
+      initial_closure
+        project=(#0, #2)
+        map=(case when (#1) IS NULL then null else #0 end)
+      source={ relation=2, key=[#0] }
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+      Get::PassArrangements materialize.public.a
+        raw=true
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[], permutation=id, thinning=(#0..=#3) }
+      arrangements[1]={ key=[case when (#3) IS NULL then null else #2 end], permutation={#0: #1, #1: #2, #2: #3, #3: #4}, thinning=(#0..=#3) }
+      Union
+        Get::Collection materialize.public.b
+          project=(#0..=#3)
+          filter=((#0 = #1))
+          map=(true)
+          raw=true
+        Mfp
+          project=(#1, #0, #2, #3)
+          map=(null, null, null)
+          input_key=#0
+          Reduce::Distinct
+            key_plan=id
+            val_plan
+              project=()
+            Union
+              Get::Collection materialize.public.b
+                project=(#0)
+                filter=((null OR (#0) IS NULL))
+                raw=true
+              Constant
+                - (null)
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Union
+        Get::Collection materialize.public.c
+          project=(#0, #1)
+          map=(true)
+          raw=true
+        Mfp
+          project=(#0, #1)
+          map=(null)
+          input_key=#0
+          Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
+            ArrangeBy
+              raw=false
+              arrangements[0]={ key=[#0], permutation=id, thinning=() }
+              Union consolidate_output=true
+                Negate
+                  Get::Collection materialize.public.c
+                    raw=true
+                ArrangeBy
+                  input_key=[#0]
+                  raw=true
+                  Reduce::Distinct
+                    key_plan=id
+                    val_plan
+                      project=()
+                    Union
+                      Get::Collection materialize.public.b
+                        project=(#2)
+                        raw=true
+                      Constant
+                        - (null)
+
+Source materialize.public.a
+Source materialize.public.c
+  filter=((#0) IS NOT NULL)
+
+Target cluster: quickstart
+
+EOF
+
+query IIIII rowsort
+SELECT a.k, b.x, b.y, b.k, c.k
+FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k
+----
+1  5  5  100  100
+
+# 1  NULL  NULL  NULL  NULL

--- a/test/sqllogictest/variadic_outer_join.slt
+++ b/test/sqllogictest/variadic_outer_join.slt
@@ -192,3 +192,9 @@ FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k
 1  5  5  100  100
 
 # 1  NULL  NULL  NULL  NULL
+
+query IIII rowsort
+SELECT a.k, b.k, b.x, c.k
+FROM (a LEFT JOIN b ON a.k = b.k AND b.x = b.y) LEFT JOIN c ON a.k = c.k
+----
+1  NULL  NULL  NULL


### PR DESCRIPTION
### Motivation

Fixes https://linear.app/materializeinc/issue/SQL-286/enable-variadic-left-join-lowering-causes-wrong-results.

### Description

When trying to apply the variadic left join lowering (`attempt_left_join_magic`), we try to identify a column in the right-hand side of the `LEFT JOIN` that is equated to a `bound_input` in the left-hand side. The code correctly checked that the right-hand side was in the right relation, but only ensured that the left-hand side was uncorrelated. When presented with a cross join (as in the original bug report, `SELECT a.k, b.x, b.y, b.k, c.k FROM (a LEFT JOIN b ON b.x = b.y) LEFT JOIN c ON b.k = c.k`, we must plan `a LEFT JOIN b ON b.x = b.y` as a cross-join), we will attempt the lowering---when in fact we should not.

The fix is simple: make sure that the left column is actually in the left-hand side.

**UPDATE**: @def- found another, somewhat related bug. When there are self-equations `decompose_equations` will return them, and then later logic can generates a `left_vals` that doesn't distinguish between equations between left and right (useful) and just equations on the right (useless). I've renamed `decompose_equations` to `decompose_left_to_right_equations` and made it only return equations that cross its new `lhs_cutoff` parameter.

**UPDATE 2**: @def- found _another_ bug, this time induced by my putative fix. Conservatively, we should not run the VOJ lowering when there are any "non-crossing" equations. (It's not impossible, but the logic is tricky enough that I don't want to attempt it.) We can make a follow-up issue if that seems worthwhile, but there is a `TODO` in the code for now.

### Verification

Repros from the bug report and followup bug report went red to green. No need for other SLT rewrites (i.e., doesn't break existing examples).