### PR TITLE
expr: fix list_length_max stopping at first NULL sibling

### DIFF
--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -279,11 +279,13 @@ impl EagerBinaryFunc for ListLengthMax {
     #[allow(clippy::as_conversions)]
     fn call<'a>(&self, (a, b): Self::Input<'a>, _: &'a RowArena) -> Self::Output<'a> {
         fn max_len_on_layer(i: DatumList<'_>, on_layer: i64) -> Option<usize> {
-            let mut i = i.iter();
+            let i = i.iter();
             if on_layer > 1 {
                 let mut max_len = None;
-                while let Some(Datum::List(i)) = i.next() {
-                    max_len = std::cmp::max(max_len_on_layer(i, on_layer - 1), max_len);
+                for d in i {
+                    if let Datum::List(i) = d {
+                        max_len = std::cmp::max(max_len_on_layer(i, on_layer - 1), max_len);
+                    }
                 }
                 max_len
             } else {

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1017,6 +1017,21 @@ SELECT (list_length_max((LIST[NULL]::INT LIST LIST), 2))::text
 ----
 NULL
 
+query R
+SELECT list_length_max(LIST[NULL, LIST[1, 2, 3]]::INT LIST LIST, 2)
+----
+3
+
+query R
+SELECT list_length_max(LIST[NULL, LIST[1, 2, 3], NULL, LIST[1, 2, 3, 4, 5]]::INT LIST LIST, 2)
+----
+5
+
+query R
+SELECT list_length_max(LIST[NULL, LIST[LIST[1, 2, 3, 4]]]::INT LIST LIST LIST, 3)
+----
+4
+
 # 🔬🔬🔬 errors
 
 query error invalid layer: 2; must use value within \[1, 1\]


### PR DESCRIPTION
The recursive helper `max_len_on_layer` used `while let Some(Datum::List(i)) = i.next()`, which broke out of the loop at the first NULL element instead of skipping it. For list-of-lists values with a NULL sibling before a non-NULL one, this returned NULL or an undersized maximum.

Iterate over all siblings and skip non-list datums so the deeper lengths of later non-NULL elements are observed. Adds SLT coverage placing NULL before non-NULL sublists at layers 2 and 3.

Bug introduced in #3757.