### PR TITLE
expr: lossy text casts don't preserve uniqueness

### DIFF
--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -55,7 +55,7 @@ fn cast_string_to_pg_legacy_char<'a>(a: &'a str) -> PgLegacyChar {
     PgLegacyChar(a.as_bytes().get(0).copied().unwrap_or(0))
 }
 
-#[sqlfunc(sqlname = "text_to_name", preserves_uniqueness = true)]
+#[sqlfunc(sqlname = "text_to_name", preserves_uniqueness = false)]
 fn cast_string_to_pg_legacy_name<'a>(a: &'a str) -> PgLegacyName<String> {
     PgLegacyName(strconv::parse_pg_legacy_name(a))
 }
@@ -817,7 +817,7 @@ impl EagerUnaryFunc for CastStringToVarChar {
     }
 
     fn preserves_uniqueness(&self) -> bool {
-        !self.fail_on_len || self.length.is_none()
+        self.length.is_none()
     }
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {


### PR DESCRIPTION
text_to_name truncates to 63 bytes (parse_pg_legacy_name) and text_to_varchar(n) with fail_on_len=false truncates to n chars, so both can collapse distinct inputs to the same output. Stop claiming preserves_uniqueness for these cases to prevent downstream consumers of unique-key metadata (ReduceElision, join inference, etc.) from making incorrect transformations.