### PR TITLE
expr: canonicalize round_numeric output to remove negative zero

### DIFF
--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -121,6 +121,10 @@ fn round_numeric(mut a: Numeric) -> Numeric {
         return a;
     }
     numeric::cx_datum().round(&mut a);
+    // Canonicalize: `dec`'s round preserves the sign on zero results, so e.g.
+    // `round(-0.4)` yields `-0`. munge_numeric strips that, ensuring row
+    // encodings match decimal equality.
+    numeric::munge_numeric(&mut a).unwrap();
     a
 }
 

--- a/test/sqllogictest/numeric.slt
+++ b/test/sqllogictest/numeric.slt
@@ -1026,6 +1026,33 @@ SELECT round (-0.10212864, -900)
 ----
 0
 
+# Rounding a small negative numeric to zero must canonicalize away the sign
+# bit; otherwise the result is `-0`, which renders incorrectly via the text
+# cast and survives as a distinct row encoding from `0`.
+query T
+SELECT round(-0.4::numeric)::text
+----
+0
+
+query T
+SELECT round(-0.49::numeric, 0)::text
+----
+0
+
+query T
+SELECT round(-0.000001::numeric, 2)::text
+----
+0
+
+query T
+SELECT v::text FROM (
+    SELECT round(-0.4::numeric) AS v
+    UNION
+    SELECT 0::numeric
+) t
+----
+0
+
 # ceil
 
 query RRR


### PR DESCRIPTION
`dec::Context::round` preserves the sign bit when a negative fractional value rounds to zero, producing `-0` from e.g. `round(-0.4)`. Numeric row encoding includes the sign bit, so the unmunged result diverges from `0` under bytewise row identity (DISTINCT, UNION, GROUP BY, joins) even though decimal `=` treats them as equal, and the text cast renders the value as `-0`.

Run `munge_numeric` after rounding, matching every other scale-changing op in this file.