### PR TITLE
expr: fix date_bin off-by-one for sources exactly on a bin boundary before origin

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2024,10 +2024,15 @@ where
         )
     })?;
 
-    let mut tm_delta = tm_diff - tm_diff % stride_ns;
+    let remainder = tm_diff % stride_ns;
+    let mut tm_delta = tm_diff - remainder;
 
-    if sub_stride {
-        tm_delta -= stride_ns;
+    if sub_stride && remainder != 0 {
+        tm_delta = tm_delta.checked_sub(stride_ns).ok_or_else(|| {
+            EvalError::DateBinOutOfRange(
+                "source and origin must not differ more than 2^63 nanoseconds".into(),
+            )
+        })?;
     }
 
     let res = origin

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -87,6 +87,32 @@ SELECT date_bin('5 min'::interval, timestamp '2020-02-01 01:01:01', timestamp '2
 ----
 2020-02-01 00:57:30
 
+# source before origin, exactly on a bin boundary
+query T
+SELECT date_bin('5 min'::interval, timestamp '1969-12-31 23:55:00', timestamp '1970-01-01 00:00:00');
+----
+1969-12-31 23:55:00
+
+query T
+SELECT date_bin('1 hour'::interval, timestamp '1970-01-01 00:00:00', timestamp '1970-01-01 01:00:00');
+----
+1970-01-01 00:00:00
+
+query T
+SELECT date_bin('10 min'::interval, timestamp '1969-12-31 23:40:00', timestamp '1970-01-01 00:00:00');
+----
+1969-12-31 23:40:00
+
+# source before origin, not on a bin boundary
+query T
+SELECT date_bin('5 min'::interval, timestamp '1969-12-31 23:56:30', timestamp '1970-01-01 00:00:00');
+----
+1969-12-31 23:55:00
+
+# i64::MIN nanosecond boundary must error, not silently wrap
+query error source and origin must not differ more than 2\^63 nanoseconds
+SELECT date_bin('1 hour'::interval, timestamp '1677-09-21 00:12:43.145224192', timestamp '1970-01-01 00:00:00');
+
 # disallow > day intervals
 query error timestamps cannot be binned into intervals containing months or years
 SELECT date_bin('5 months'::interval, timestamp '2020-02-01 01:01:01', timestamp '2001-01-01');

--- a/test/sqllogictest/timestamptz.slt
+++ b/test/sqllogictest/timestamptz.slt
@@ -89,6 +89,32 @@ SELECT date_bin('5 min'::interval, timestamptz '2020-02-01 01:01:01+00', timesta
 ----
 2020-02-01 00:57:30+00
 
+# source before origin, exactly on a bin boundary
+query T
+SELECT date_bin('5 min'::interval, timestamptz '1969-12-31 23:55:00+00', timestamptz '1970-01-01 00:00:00+00');
+----
+1969-12-31 23:55:00+00
+
+query T
+SELECT date_bin('1 hour'::interval, timestamptz '1970-01-01 00:00:00+00', timestamptz '1970-01-01 01:00:00+00');
+----
+1970-01-01 00:00:00+00
+
+query T
+SELECT date_bin('10 min'::interval, timestamptz '1969-12-31 23:40:00+00', timestamptz '1970-01-01 00:00:00+00');
+----
+1969-12-31 23:40:00+00
+
+# source before origin, not on a bin boundary
+query T
+SELECT date_bin('5 min'::interval, timestamptz '1969-12-31 23:56:30+00', timestamptz '1970-01-01 00:00:00+00');
+----
+1969-12-31 23:55:00+00
+
+# i64::MIN nanosecond boundary must error, not silently wrap
+query error source and origin must not differ more than 2\^63 nanoseconds
+SELECT date_bin('1 hour'::interval, timestamptz '1677-09-21 00:12:43.145224192+00', timestamptz '1970-01-01 00:00:00+00');
+
 # disallow > day intervals
 query error timestamps cannot be binned into intervals containing months or years
 SELECT date_bin('5 months'::interval, timestamptz '2020-02-01 01:01:01+00', timestamptz '2001-01-01');


### PR DESCRIPTION
When `source < origin` and `tm_diff` was an exact multiple of the stride, the unconditional `tm_delta -= stride_ns` shifted the result back a whole extra bin. Also use `checked_sub` so that the `i64::MIN` nanosecond boundary surfaces `DateBinOutOfRange` instead of silently wrapping.