### PR TITLE
expr: fix non-injective text_to_"char"/text_to_bytea uniqueness annotation

### DIFF
--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -48,7 +48,10 @@ fn cast_string_to_bool<'a>(a: &'a str) -> Result<bool, EvalError> {
 
 #[sqlfunc(
     sqlname = "text_to_\"char\"",
-    preserves_uniqueness = true,
+    // Not injective: only the first byte is kept (e.g. 'a' and 'abc' both
+    // collapse to 'a'::"char"), so inverse-cast canonicalization of
+    // `c::text = lit` would silently change results.
+    preserves_uniqueness = false,
     inverse = to_unary!(super::CastPgLegacyCharToString)
 )]
 fn cast_string_to_pg_legacy_char<'a>(a: &'a str) -> PgLegacyChar {
@@ -62,7 +65,12 @@ fn cast_string_to_pg_legacy_name<'a>(a: &'a str) -> PgLegacyName<String> {
 
 #[sqlfunc(
     sqlname = "text_to_bytea",
-    preserves_uniqueness = true,
+    // Not injective: `parse_bytes` accepts both hex (`\x..`) and the
+    // traditional textual encoding for the same bytes, so distinct text
+    // literals can map to the same bytea. Inverse-cast canonicalization of
+    // `b::text = lit` would otherwise rewrite to a comparison that ignores
+    // the actual textual form.
+    preserves_uniqueness = false,
     inverse = to_unary!(super::CastBytesToString)
 )]
 fn cast_string_to_bytes<'a>(a: &'a str) -> Result<Vec<u8>, EvalError> {

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -1416,3 +1416,51 @@ LIMIT 3 OFFSET 1;
 2  l2
 1  a
 1  l1
+
+# Regression test: `text_to_"char"` and `text_to_bytea` are non-injective and
+# must NOT be treated as uniqueness-preserving by cast inversion in
+# `invert_casts_on_expr_eq_literal_inner` (called from `CanonicalizeMfp` and
+# `literal_constraints`). Otherwise `f(col) = lit` is rewritten to
+# `col = f_inv(lit)` where `f_inv` collapses distinct literals, returning rows
+# whose `col::text` does not actually equal the literal.
+
+statement ok
+CREATE TABLE t_char_cast (c "char")
+
+statement ok
+INSERT INTO t_char_cast VALUES ('a'::"char")
+
+statement ok
+CREATE DEFAULT INDEX ON t_char_cast
+
+# 'a'::"char"::text = 'a' which does NOT equal 'abc' — expect 0 rows.
+query T rowsort
+SELECT c FROM t_char_cast WHERE c::text = 'abc'
+----
+
+# Sanity check: the truthful predicate still matches.
+query T rowsort
+SELECT c FROM t_char_cast WHERE c::text = 'a'
+----
+a
+
+statement ok
+CREATE TABLE t_bytea_cast (b bytea)
+
+statement ok
+INSERT INTO t_bytea_cast VALUES (E'\\x41'::bytea)
+
+statement ok
+CREATE DEFAULT INDEX ON t_bytea_cast
+
+# bytea_to_text always formats as hex ('\x41'), so b::text != 'A' — expect 0 rows.
+query T rowsort
+SELECT b FROM t_bytea_cast WHERE b::text = 'A'
+----
+
+# Sanity check: hex-formatted literal that round-trips truthfully.
+# (Sqllogictest formats a one-byte bytea 0x41 as the raw byte, i.e. `A`.)
+query T rowsort
+SELECT b FROM t_bytea_cast WHERE b::text = '\x41'
+----
+A


### PR DESCRIPTION
These casts were marked `preserves_uniqueness = true`, but neither is injective: `text_to_"char"` keeps only the first byte (so 'a' and 'abc' collapse to the same `"char"`), and `text_to_bytea` accepts both hex and traditional encodings for the same bytes. The annotation made `invert_casts_on_expr_eq_literal_inner` rewrite `col::text = lit` to `col = f_inv(lit)`, which can match rows whose `col::text` does not actually equal `lit` — producing wrong query answers via MFP canonicalization and index literal-constraint lookups.