### PR TITLE
adapter: skip shardless builtins in forced migrations

### DIFF
--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -564,6 +564,10 @@ impl Migration {
         let objects = self
             .system_objects
             .iter()
+            // Skip objects that don't yet have a shard registered. These are brand-new builtins
+            // added in this version; the leader will allocate their shards during bootstrap, and
+            // there is nothing to evolve or replace.
+            .filter(|(_, info)| info.shard_id.is_some())
             .filter(|(_, info)| {
                 use Builtin::*;
                 match info.builtin {


### PR DESCRIPTION
Forced dev->dev evolution (#36251) iterates every Table/MV in the durable catalog, including brand-new builtins whose shards have not been registered yet. In read-only replicas this trips the "missing shard ID for builtin" bail in migrate_evolve_one, since the leader has not yet allocated the shard. Filter them out: there is nothing to evolve or replace for an object that does not yet exist in persist.

Fixes https://linear.app/materializeinc/issue/SQL-282

Follow-up to https://github.com/MaterializeInc/materialize/pull/36251

Nightly run: https://buildkite.com/materialize/nightly/builds/16506