### PR TITLE
Oidc password authentication on uninitialized Oidc fix

### DIFF
--- a/console/src/components/OidcConnectModal.tsx
+++ b/console/src/components/OidcConnectModal.tsx
@@ -26,7 +26,7 @@ import {
 } from "~/components/copyableComponents";
 import McpConnectInstructions from "~/components/McpConnectInstructions";
 import { Modal } from "~/components/Modal";
-import { useAuth } from "~/external-library-wrappers/oidc";
+import { type AuthContextProps } from "~/external-library-wrappers/oidc";
 import ConnectionIcon from "~/svg/ConnectionIcon";
 import { MaterializeTheme } from "~/theme";
 import { obfuscateSecret } from "~/utils/format";
@@ -36,12 +36,13 @@ const OIDC_USERNAME_PLACEHOLDER = "<your_oidc_username>";
 const OidcConnectModal = ({
   onClose,
   isOpen,
+  auth,
 }: {
   onClose: () => void;
   isOpen: boolean;
+  auth: AuthContextProps;
 }) => {
   const { colors } = useTheme<MaterializeTheme>();
-  const auth = useAuth();
   const idToken = auth.user?.id_token;
 
   const obfuscated = idToken ? obfuscateSecret(idToken) : "";

--- a/console/src/components/OidcProviderWrapper.tsx
+++ b/console/src/components/OidcProviderWrapper.tsx
@@ -7,14 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { useQuery } from "@tanstack/react-query";
 import React, { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { apiClient } from "~/api/apiClient";
 import LoadingScreen from "~/components/LoadingScreen";
 import { useAppConfig } from "~/config/useAppConfig";
-import { AuthProvider } from "~/external-library-wrappers/oidc";
+import {
+  AuthProvider,
+  useOidcManagerQuery,
+} from "~/external-library-wrappers/oidc";
 
 export const OidcProviderWrapper = ({ children }: React.PropsWithChildren) => {
   const navigate = useNavigate();
@@ -23,27 +24,7 @@ export const OidcProviderWrapper = ({ children }: React.PropsWithChildren) => {
   const isOidc =
     appConfig.mode === "self-managed" && appConfig.authMode === "Oidc";
 
-  // Not a typical data fetch — using React Query to get loading/error
-  // state without wiring up useState + useEffect manually.
-  const {
-    data: oidcManager,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["oidc-manager"],
-    queryFn: () => {
-      if (
-        apiClient.type !== "self-managed" ||
-        !apiClient.oidcManagerInitializationPromise
-      ) {
-        return null;
-      }
-      return apiClient.oidcManagerInitializationPromise;
-    },
-    enabled: isOidc,
-    staleTime: Infinity,
-    retry: false,
-  });
+  const { data: oidcManager, isLoading, error } = useOidcManagerQuery();
 
   const onSigninCallback = useCallback(() => {
     navigate("/", { replace: true });

--- a/console/src/config/AppConfigSwitch.tsx
+++ b/console/src/config/AppConfigSwitch.tsx
@@ -17,6 +17,10 @@ import {
   useAuthUser,
   type User,
 } from "~/external-library-wrappers/frontegg";
+import {
+  useAuth as useOidcAuth,
+  useOidcManagerQuery,
+} from "~/external-library-wrappers/oidc";
 
 import { CloudAppConfig, SelfManagedAppConfig } from "./AppConfig";
 import { useAppConfig } from "./useAppConfig";
@@ -36,6 +40,19 @@ export type CloudRuntimeConfig =
   | CloudFronteggRuntimeConfig
   | CloudImpersonationRuntimeConfig;
 
+type SelfManagedOidcAvailableRuntimeConfig = {
+  isOidcAvailable: true;
+  auth: NonNullable<ReturnType<typeof useOidcAuth>>;
+};
+
+type SelfManagedOidcUnavailableRuntimeConfig = {
+  isOidcAvailable: false;
+};
+
+export type SelfManagedRuntimeConfig =
+  | SelfManagedOidcAvailableRuntimeConfig
+  | SelfManagedOidcUnavailableRuntimeConfig;
+
 type CloudConfigElementRenderProps = {
   appConfig: Readonly<CloudAppConfig>;
   runtimeConfig: CloudRuntimeConfig;
@@ -43,6 +60,7 @@ type CloudConfigElementRenderProps = {
 
 type SelfManagedConfigElementRenderProps = {
   appConfig: Readonly<SelfManagedAppConfig>;
+  runtimeConfig: SelfManagedRuntimeConfig;
 };
 
 type CloudConfigElementFunction = (
@@ -97,6 +115,47 @@ const CloudImpersonationConfigElementWrapper = ({
   });
 };
 
+// Only mounted when the OIDC manager has initialized, which implies
+// OidcProviderWrapper has mounted an AuthProvider in scope.
+const SelfManagedOidcAvailableConfigElementWrapper = ({
+  selfManagedAppConfig,
+  selfManagedConfigElement,
+}: {
+  selfManagedAppConfig: Readonly<SelfManagedAppConfig>;
+  selfManagedConfigElement: SelfManagedConfigElementFunction;
+}) => {
+  const auth = useOidcAuth();
+
+  return selfManagedConfigElement({
+    appConfig: selfManagedAppConfig,
+    runtimeConfig: { isOidcAvailable: true, auth },
+  });
+};
+
+const SelfManagedConfigElementWrapper = ({
+  selfManagedAppConfig,
+  selfManagedConfigElement,
+}: {
+  selfManagedAppConfig: Readonly<SelfManagedAppConfig>;
+  selfManagedConfigElement: SelfManagedConfigElementFunction;
+}) => {
+  const { data: oidcManager } = useOidcManagerQuery();
+
+  if (!oidcManager) {
+    return selfManagedConfigElement({
+      appConfig: selfManagedAppConfig,
+      runtimeConfig: { isOidcAvailable: false },
+    });
+  }
+
+  return (
+    <SelfManagedOidcAvailableConfigElementWrapper
+      selfManagedAppConfig={selfManagedAppConfig}
+      selfManagedConfigElement={selfManagedConfigElement}
+    />
+  );
+};
+
 // A component that controls which component to render based on the deployment mode.
 // This is used to avoid having to do a discriminant check throughout the application.
 //
@@ -136,7 +195,12 @@ export const AppConfigSwitch = ({
   }
 
   if (typeof selfManagedConfigElement === "function") {
-    return selfManagedConfigElement({ appConfig });
+    return (
+      <SelfManagedConfigElementWrapper
+        selfManagedAppConfig={appConfig}
+        selfManagedConfigElement={selfManagedConfigElement}
+      />
+    );
   }
 
   return selfManagedConfigElement;

--- a/console/src/external-library-wrappers/oidc.ts
+++ b/console/src/external-library-wrappers/oidc.ts
@@ -11,9 +11,20 @@
 /**
  * This file is a facade for the react-oidc-context / oidc-client-ts libraries.
  */
-export { AuthProvider, hasAuthParams, useAuth } from "react-oidc-context";
+export {
+  type AuthContextProps,
+  AuthProvider,
+  hasAuthParams,
+  // We should not use this hook directly because it requires AuthProvider to be mounted,
+  // which it only is when OIDC is available. Instead, use AppConfigSwitch.
+  useAuth,
+} from "react-oidc-context";
 
+import { useQuery } from "@tanstack/react-query";
 import { UserManager, WebStorageStateStore } from "oidc-client-ts";
+
+import { apiClient } from "~/api/apiClient";
+import { useAppConfig } from "~/config/useAppConfig";
 
 export interface OidcConfig {
   issuer: string;
@@ -36,7 +47,7 @@ async function fetchOidcConfig(): Promise<OidcConfig> {
 
   if (!data.console_oidc_client_id) {
     throw new Error(
-      "OIDC client ID is required but was empty. Configure the console_oidc_client_id system parameter: https://materialize.com/docs/self-managed-deployments/configuration-system-parameters/",
+      "To use SSO, OIDC client ID must be set. Configure the console_oidc_client_id system parameter: https://materialize.com/docs/self-managed-deployments/configuration-system-parameters/",
     );
   }
   if (
@@ -44,7 +55,7 @@ async function fetchOidcConfig(): Promise<OidcConfig> {
     !data.console_oidc_scopes.includes("openid")
   ) {
     throw new Error(
-      "OIDC scopes must include at least 'openid'. Configure the console_oidc_scopes system parameter: https://materialize.com/docs/self-managed-deployments/configuration-system-parameters/",
+      "To use SSO, OIDC scopes must include at least 'openid'. Configure the console_oidc_scopes system parameter: https://materialize.com/docs/self-managed-deployments/configuration-system-parameters/",
     );
   }
 
@@ -119,3 +130,31 @@ export class MzOidcUserManager {
     return new MzOidcUserManager(config);
   }
 }
+
+/**
+ * Resolves the OIDC manager once initialization completes. Returns `null`
+ * when not in OIDC mode or when init fails — callers should treat the
+ * absence of a manager as "OIDC unavailable, fall back to password sign-in"
+ */
+export const useOidcManagerQuery = () => {
+  const appConfig = useAppConfig();
+  const isOidc =
+    appConfig.mode === "self-managed" && appConfig.authMode === "Oidc";
+
+  return useQuery({
+    queryKey: ["oidc-manager"],
+    queryFn: () => {
+      if (
+        apiClient.type !== "self-managed" ||
+        !apiClient.oidcManagerInitializationPromise
+      ) {
+        return null;
+      }
+      return apiClient.oidcManagerInitializationPromise;
+    },
+    enabled: isOidc,
+    staleTime: Infinity,
+    retry: false,
+    retryOnMount: false, // Do not retry on mount, otherwise we will retry indefinitely
+  });
+};

--- a/console/src/hooks/useSelfManagedProfile.ts
+++ b/console/src/hooks/useSelfManagedProfile.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import useCurrentUser from "~/api/materialize/useCurrentUser";
-import { useAuth } from "~/external-library-wrappers/oidc";
+import { type AuthContextProps } from "~/external-library-wrappers/oidc";
 
 export interface SelfManagedProfile {
   name: string | undefined;
@@ -21,8 +21,9 @@ export interface SelfManagedProfile {
 
 /** Unified identity for self-managed UI: OIDC claims when present, with the
  * SQL role as the authoritative fallback. */
-export const useSelfManagedProfile = (): SelfManagedProfile => {
-  const auth = useAuth();
+export const useSelfManagedProfile = (
+  auth: AuthContextProps | undefined,
+): SelfManagedProfile => {
   const profile = auth?.user?.profile;
   const { results: sqlRole, isLoading } = useCurrentUser();
 

--- a/console/src/layouts/NavBar.tsx
+++ b/console/src/layouts/NavBar.tsx
@@ -279,7 +279,7 @@ export const NavBar = ({ isCollapsed }: NavBarProps) => {
                 </HideIfEnvironmentDisabled>
               )
             }
-            selfManagedConfigElement={({ appConfig }) =>
+            selfManagedConfigElement={({ appConfig, runtimeConfig }) =>
               appConfig.authMode === "None" ? null : (
                 <HideIfEnvironmentDisabled>
                   <ConnectMenuItem
@@ -287,10 +287,11 @@ export const NavBar = ({ isCollapsed }: NavBarProps) => {
                     width="100%"
                     onClick={onOpenConnectModal}
                   />
-                  {appConfig.authMode === "Oidc" ? (
+                  {runtimeConfig.isOidcAvailable ? (
                     <OidcConnectModal
                       onClose={onCloseConnectModal}
                       isOpen={isConnectModalOpen}
+                      auth={runtimeConfig.auth}
                     />
                   ) : (
                     <PasswordConnectModal

--- a/console/src/layouts/NavBar/NavMenu.tsx
+++ b/console/src/layouts/NavBar/NavMenu.tsx
@@ -315,7 +315,7 @@ const NavMenuMobile = (props: {
                 </HideIfEnvironmentDisabled>
               )
             }
-            selfManagedConfigElement={({ appConfig }) =>
+            selfManagedConfigElement={({ appConfig, runtimeConfig }) =>
               appConfig.authMode === "None" ? null : (
                 <HideIfEnvironmentDisabled>
                   <ConnectMenuItem
@@ -323,10 +323,11 @@ const NavMenuMobile = (props: {
                     onClick={onOpenConnectModal}
                     mb={{ base: 0, lg: 6 }}
                   />
-                  {appConfig.authMode === "Oidc" ? (
+                  {runtimeConfig.isOidcAvailable ? (
                     <OidcConnectModal
                       onClose={onCloseConnectModal}
                       isOpen={isConnectModalOpen}
+                      auth={runtimeConfig.auth}
                     />
                   ) : (
                     <PasswordConnectModal

--- a/console/src/layouts/ProfileDropdown.tsx
+++ b/console/src/layouts/ProfileDropdown.tsx
@@ -39,7 +39,7 @@ import {
   AuthState,
   type User,
 } from "~/external-library-wrappers/frontegg";
-import { useAuth } from "~/external-library-wrappers/oidc";
+import { type AuthContextProps } from "~/external-library-wrappers/oidc";
 import { AUTH_ROUTES } from "~/fronteggRoutes";
 import { useSelfManagedProfile } from "~/hooks/useSelfManagedProfile";
 import { NAV_HORIZONTAL_SPACING, NAV_HOVER_STYLES } from "~/layouts/constants";
@@ -74,8 +74,8 @@ const UserInfoHeaderBlock = ({
   );
 };
 
-const SelfManagedUserInfoMenuItem = () => {
-  const { name, email, sqlRole, isLoading } = useSelfManagedProfile();
+const SelfManagedUserInfoMenuItem = ({ auth }: { auth?: AuthContextProps }) => {
+  const { name, email, sqlRole, isLoading } = useSelfManagedProfile(auth);
   if (isLoading && !name && !email && !sqlRole) {
     return (
       <>
@@ -114,9 +114,15 @@ const UserInfoMenuItem = () => {
           </>
         );
       }}
-      selfManagedConfigElement={({ appConfig }) => {
+      selfManagedConfigElement={({ appConfig, runtimeConfig }) => {
         if (appConfig.authMode === "None") return null;
-        return <SelfManagedUserInfoMenuItem />;
+        return (
+          <SelfManagedUserInfoMenuItem
+            auth={
+              runtimeConfig.isOidcAvailable ? runtimeConfig.auth : undefined
+            }
+          />
+        );
       }}
     />
   );
@@ -134,9 +140,9 @@ const PricingMenuItem = () => (
   </MenuItem>
 );
 
-const SelfManagedMenuButtonLabel = () => {
+const SelfManagedMenuButtonLabel = ({ auth }: { auth?: AuthContextProps }) => {
   const { colors } = useTheme<MaterializeTheme>();
-  const { name } = useSelfManagedProfile();
+  const { name } = useSelfManagedProfile(auth);
   return (
     <Text textStyle="text-ui-med" color={colors.foreground.primary}>
       {name ?? "Settings"}
@@ -144,9 +150,7 @@ const SelfManagedMenuButtonLabel = () => {
   );
 };
 
-const OidcSignOutMenuItem = () => {
-  const auth = useAuth();
-
+const OidcSignOutMenuItem = ({ auth }: { auth: AuthContextProps }) => {
   const handleLogout = async () => {
     // Clear both the session cookie and OIDC state so that
     // logout works regardless of which method the user used.
@@ -188,9 +192,11 @@ const SignOutMenuItem = () => {
           </>
         );
       }}
-      selfManagedConfigElement={({ appConfig }) => {
+      selfManagedConfigElement={({ appConfig, runtimeConfig }) => {
         if (appConfig.authMode === "None") return null;
-        if (appConfig.authMode === "Oidc") return <OidcSignOutMenuItem />;
+        if (runtimeConfig.isOidcAvailable) {
+          return <OidcSignOutMenuItem auth={runtimeConfig.auth} />;
+        }
         return (
           <>
             <MenuDivider />
@@ -208,8 +214,8 @@ const DefaultAvatar = () => {
   return <ChakraAvatar size="xs" />;
 };
 
-const SelfManagedAvatar = () => {
-  const { name, picture } = useSelfManagedProfile();
+const SelfManagedAvatar = ({ auth }: { auth?: AuthContextProps }) => {
+  const { name, picture } = useSelfManagedProfile(auth);
   return <ChakraAvatar size="xs" src={picture} name={name} />;
 };
 
@@ -229,9 +235,15 @@ const Avatar = () => {
           />
         );
       }}
-      selfManagedConfigElement={({ appConfig }) => {
+      selfManagedConfigElement={({ appConfig, runtimeConfig }) => {
         if (appConfig.authMode === "None") return <DefaultAvatar />;
-        return <SelfManagedAvatar />;
+        return (
+          <SelfManagedAvatar
+            auth={
+              runtimeConfig.isOidcAvailable ? runtimeConfig.auth : undefined
+            }
+          />
+        );
       }}
     />
   );
@@ -312,7 +324,7 @@ const ProfileDropdown = ({
                     </>
                   );
                 }}
-                selfManagedConfigElement={({ appConfig }) => {
+                selfManagedConfigElement={({ appConfig, runtimeConfig }) => {
                   if (appConfig.authMode === "None") {
                     return (
                       <Text
@@ -323,7 +335,15 @@ const ProfileDropdown = ({
                       </Text>
                     );
                   }
-                  return <SelfManagedMenuButtonLabel />;
+                  return (
+                    <SelfManagedMenuButtonLabel
+                      auth={
+                        runtimeConfig.isOidcAvailable
+                          ? runtimeConfig.auth
+                          : undefined
+                      }
+                    />
+                  );
                 }}
               />
             </VStack>

--- a/console/src/platform/UnauthenticatedRoutes.tsx
+++ b/console/src/platform/UnauthenticatedRoutes.tsx
@@ -16,7 +16,10 @@ import LoadingScreen from "~/components/LoadingScreen";
 import { type SelfManagedAppConfig } from "~/config/AppConfig";
 import { useAppConfig } from "~/config/useAppConfig";
 import { useIsAuthenticated } from "~/external-library-wrappers/frontegg";
-import { hasAuthParams, useAuth } from "~/external-library-wrappers/oidc";
+import {
+  hasAuthParams,
+  useOidcManagerQuery,
+} from "~/external-library-wrappers/oidc";
 import { AUTH_ROUTES } from "~/fronteggRoutes";
 import { AuthenticatedRoutes } from "~/platform/AuthenticatedRoutes";
 import { SentryRoutes } from "~/sentry";
@@ -25,14 +28,14 @@ import { Login } from "./auth/Login";
 import { OidcCallback } from "./auth/OidcCallback";
 
 const OidcAuthGuard = ({ children }: React.PropsWithChildren) => {
-  const auth = useAuth();
+  const { isLoading, data: auth } = useOidcManagerQuery();
 
   // OIDC initialization failed — `OidcProviderWrapper` rendered us without
   // an `AuthProvider` so password sign-in still works. Skip the OIDC checks
   // and let the user reach the app via their password session cookie.
   if (!auth) return <>{children}</>;
 
-  if (auth.isLoading || hasAuthParams()) {
+  if (isLoading || hasAuthParams()) {
     return <LoadingScreen />;
   }
 

--- a/console/src/platform/auth/Login.tsx
+++ b/console/src/platform/auth/Login.tsx
@@ -29,8 +29,7 @@ import { LOGIN_ERROR_PARAM, loginOrThrow } from "~/api/materialize/auth";
 import Alert from "~/components/Alert";
 import { LabeledInput } from "~/components/formComponentsV2";
 import { MaterializeLogo } from "~/components/MaterializeLogo";
-import { useAppConfig } from "~/config/useAppConfig";
-import { useAuth } from "~/external-library-wrappers/oidc";
+import { useAuth, useOidcManagerQuery } from "~/external-library-wrappers/oidc";
 import { AuthContentContainer, AuthLayout } from "~/layouts/AuthLayout";
 import EyeClosedIcon from "~/svg/EyeClosedIcon";
 import EyeOpenIcon from "~/svg/EyeOpenIcon";
@@ -152,10 +151,12 @@ const PasswordLoginForm = () => {
 
 const SsoLoginLink = () => {
   const { colors } = useTheme<MaterializeTheme>();
-  const auth = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const auth = useAuth();
 
-  if (!auth) return null;
+  if (!auth) {
+    return null;
+  }
 
   const handleSsoLogin = () => {
     setError(null);
@@ -184,12 +185,10 @@ const SsoLoginLink = () => {
 };
 
 export const Login = () => {
-  const appConfig = useAppConfig();
   const [searchParams] = useSearchParams();
-  const isOidc =
-    appConfig.mode === "self-managed" && appConfig.authMode === "Oidc";
+  const { data: auth, error: oidcInitializationError } = useOidcManagerQuery();
 
-  const errorMessage = searchParams.get(LOGIN_ERROR_PARAM);
+  const oidcError = searchParams.get(LOGIN_ERROR_PARAM);
 
   return (
     <AuthLayout>
@@ -198,16 +197,19 @@ export const Login = () => {
           <HStack my={{ base: "8", lg: "0" }} paddingBottom="8">
             <MaterializeLogo height="12" />
           </HStack>
-          {errorMessage && (
+          {oidcError && (
+            <Alert variant="error" minWidth="100%" message={oidcError} mb="4" />
+          )}
+          {oidcInitializationError && (
             <Alert
-              variant="error"
+              variant="info"
               minWidth="100%"
-              message={errorMessage}
+              message={oidcInitializationError.message}
               mb="4"
             />
           )}
           <PasswordLoginForm />
-          {isOidc && <SsoLoginLink />}
+          {!!auth && <SsoLoginLink />}
         </VStack>
       </AuthContentContainer>
     </AuthLayout>

--- a/console/src/platform/auth/Login.tsx
+++ b/console/src/platform/auth/Login.tsx
@@ -154,9 +154,15 @@ const SsoLoginLink = () => {
   const [error, setError] = useState<string | null>(null);
   const auth = useAuth();
 
-  if (!auth) {
-    return null;
-  }
+  // For internal errors, react-oidc-context won't throw an error in auth.signinRedirect,
+  // but will save it in its error object. So we need to check the error state
+  const oidcError = auth.error?.message ?? null;
+
+  const oidcDisplayError =
+    error ||
+    (oidcError &&
+      `${oidcError}. It looks like there may be an issue with the sign-in configuration. Please review your OIDC settings or check the console logs for more information.`) ||
+    null;
 
   const handleSsoLogin = () => {
     setError(null);
@@ -167,9 +173,15 @@ const SsoLoginLink = () => {
     });
   };
 
+  if (!auth) {
+    return null;
+  }
+
   return (
     <VStack spacing="2" alignItems="center">
-      {error && <Alert variant="error" minWidth="100%" message={error} />}
+      {oidcDisplayError && (
+        <Alert variant="error" minWidth="100%" message={oidcDisplayError} />
+      )}
       <Link
         color={colors.accent.brightPurple}
         fontSize="sm"


### PR DESCRIPTION
Before we were getting throws on password login when Oidc was never initialized. This allows us to not have to check if the oidcManager is available everytime we want Oidc auth details.

### Motivation

Bug found during product review when logging in as mz_system before Oidc was configured

### Verification
Run locally against Oidc instance and login as mz_system. Before you would crash because we were trying to access properties in useAuth that didn't exist. Now it doesn't crash