### PR TITLE
catalog-protos: gate Arbitrary derives behind feature/cfg(test)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,6 +5874,7 @@ dependencies = [
  "anyhow",
  "md-5",
  "mz-audit-log",
+ "mz-catalog-protos",
  "mz-compute-types",
  "mz-controller-types",
  "mz-expr",

--- a/src/catalog-protos/Cargo.toml
+++ b/src/catalog-protos/Cargo.toml
@@ -17,14 +17,17 @@ mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
 mz-storage-types = { path = "../storage-types" }
 num_enum.workspace = true
-proptest.workspace = true
-proptest-derive.workspace = true
+proptest = { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
 serde.workspace = true
 serde_repr.workspace = true
 
 [dev-dependencies]
+mz-catalog-protos = { path = ".", features = ["proptest"] }
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore", features = ["test"] }
+proptest.workspace = true
+proptest-derive.workspace = true
 serde_json.workspace = true
 similar-asserts.workspace = true
 
@@ -36,3 +39,4 @@ serde_json.workspace = true
 
 [features]
 default = []
+proptest = ["dep:proptest", "dep:proptest-derive"]

--- a/src/catalog-protos/objects_hashes.json
+++ b/src/catalog-protos/objects_hashes.json
@@ -1,54 +1,54 @@
 [
   {
     "name": "objects.rs",
-    "md5": "8f899255990eec45ad8f1380d6f80bce"
+    "md5": "e80f862e380a58535975f052a9ace35f"
   },
   {
     "name": "objects_v74.rs",
-    "md5": "e7b522bf1c6d86e6045bbe3e9a3d4726"
+    "md5": "ba4536a45674638817f739fe6e5683c0"
   },
   {
     "name": "objects_v75.rs",
-    "md5": "074a588438056bfe5610f46cb027978c"
+    "md5": "fa305f492f183ba2883fc15e3bc32297"
   },
   {
     "name": "objects_v76.rs",
-    "md5": "854637ccdb7fd13309f79d06e11eb31b"
+    "md5": "17cc855db0cea044b709db4ea0b9fb41"
   },
   {
     "name": "objects_v77.rs",
-    "md5": "854637ccdb7fd13309f79d06e11eb31b"
+    "md5": "17cc855db0cea044b709db4ea0b9fb41"
   },
   {
     "name": "objects_v78.rs",
-    "md5": "252dc6bb74f16c3b8d84af66e1f81ef7"
+    "md5": "3b34e160733bc6d26274d163229d107d"
   },
   {
     "name": "objects_v79.rs",
-    "md5": "1dcb67982b9a9d775ade5820f50c736b"
+    "md5": "20913dc612bd85439274022c72aa5016"
   },
   {
     "name": "objects_v80.rs",
-    "md5": "4a133ca169b83cd4fd762aba9b556dc4"
+    "md5": "81bfe01e9891a4325cf50eebed093f0a"
   },
   {
     "name": "objects_v81.rs",
-    "md5": "42585baa1b4b5e1b6da4e361a35ec546"
+    "md5": "6ee8eb215409de2102166461f28a74a0"
   },
   {
     "name": "objects_v82.rs",
-    "md5": "dfd89e1c62b7f1663d6429846a76159f"
+    "md5": "d7675550f85716224499575ce3811e97"
   },
   {
     "name": "objects_v83.rs",
-    "md5": "dfd89e1c62b7f1663d6429846a76159f"
+    "md5": "d7675550f85716224499575ce3811e97"
   },
   {
     "name": "objects_v84.rs",
-    "md5": "dfd89e1c62b7f1663d6429846a76159f"
+    "md5": "d7675550f85716224499575ce3811e97"
   },
   {
     "name": "objects_v85.rs",
-    "md5": "8f899255990eec45ad8f1380d6f80bce"
+    "md5": "e80f862e380a58535975f052a9ace35f"
   }
 ]

--- a/src/catalog-protos/src/objects.rs
+++ b/src/catalog-protos/src/objects.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -582,24 +412,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -613,40 +434,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -662,54 +465,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -723,22 +499,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -752,9 +519,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -769,9 +536,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -785,39 +552,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -831,9 +580,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -850,9 +599,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -864,9 +613,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -878,9 +627,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -898,9 +647,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -912,9 +661,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -926,9 +675,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -943,9 +692,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -960,9 +709,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -977,9 +726,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -994,9 +743,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1011,9 +760,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1028,9 +777,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1045,9 +794,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1062,9 +811,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1079,25 +828,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1112,9 +852,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1128,57 +868,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1188,49 +901,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1239,17 +925,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1264,9 +941,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1283,9 +960,9 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AutoProvisionSource {
     Oidc = 0,
     Frontegg = 1,
@@ -1301,9 +978,9 @@ pub enum AutoProvisionSource {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1311,17 +988,8 @@ pub struct RoleAttributes {
     pub auto_provision_source: Option<AutoProvisionSource>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1335,72 +1003,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1417,9 +1049,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1433,9 +1065,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1449,9 +1081,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1465,9 +1097,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1483,9 +1115,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1503,9 +1135,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1519,9 +1151,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1536,24 +1168,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1566,83 +1189,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1650,34 +1228,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1689,17 +1249,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1713,17 +1264,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1737,17 +1279,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1760,17 +1293,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1778,17 +1302,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1798,17 +1313,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1827,9 +1333,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1843,89 +1349,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1933,34 +1394,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1968,34 +1411,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2003,34 +1428,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2038,33 +1445,15 @@ pub mod audit_log_event_v1 {
         pub replacement_target_id: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterApplyReplacementV1 {
         pub target: IdFullNameV1,
         pub replacement: IdFullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2072,17 +1461,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2090,34 +1470,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2125,33 +1487,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2159,17 +1503,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2177,17 +1512,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2196,68 +1522,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2265,50 +1555,23 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterAddColumnV1 {
         pub id: String,
         pub column: String,
@@ -2316,98 +1579,44 @@ pub mod audit_log_event_v1 {
         pub nullable: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceTimestampIntervalV1 {
         pub id: String,
         pub old_interval: Option<String>,
         pub new_interval: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateRoleV1 {
         pub id: String,
         pub name: String,
@@ -2424,9 +1633,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2448,9 +1657,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2474,17 +1683,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2531,17 +1731,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2571,96 +1762,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2675,9 +1812,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2692,185 +1829,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2885,56 +1923,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2949,9 +1960,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2977,9 +1988,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v74.rs
+++ b/src/catalog-protos/src/objects_v74.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,9 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -37,9 +38,9 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
@@ -53,9 +54,9 @@ pub struct ConfigValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
@@ -69,9 +70,9 @@ pub struct SettingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
@@ -85,9 +86,9 @@ pub struct SettingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -102,9 +103,9 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
@@ -118,9 +119,9 @@ pub struct IdAllocValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: i32,
@@ -136,9 +137,9 @@ pub struct GidMappingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub id: u64,
     pub fingerprint: String,
@@ -155,9 +156,9 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: Option<ClusterId>,
 }
@@ -171,9 +172,9 @@ pub struct ClusterKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -190,9 +191,9 @@ pub struct ClusterValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -208,9 +209,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub index_id: u64,
     pub oid: u32,
@@ -227,9 +228,9 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: Option<ReplicaId>,
 }
@@ -243,9 +244,9 @@ pub struct ClusterReplicaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -263,9 +264,9 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: Option<DatabaseId>,
 }
@@ -279,9 +280,9 @@ pub struct DatabaseKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -299,9 +300,9 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: Option<SchemaId>,
 }
@@ -315,9 +316,9 @@ pub struct SchemaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -336,9 +337,9 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: Option<CatalogItemId>,
 }
@@ -352,9 +353,9 @@ pub struct ItemKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: Option<SchemaId>,
     pub name: String,
@@ -376,9 +377,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: Option<GlobalId>,
     pub version: Option<Version>,
@@ -394,9 +395,9 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: Option<RoleId>,
 }
@@ -410,9 +411,9 @@ pub struct RoleKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: Option<RoleAttributes>,
@@ -431,9 +432,9 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: Option<RoleId>,
 }
@@ -447,9 +448,9 @@ pub struct RoleAuthKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: Option<EpochMillis>,
@@ -465,9 +466,9 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: Option<NetworkPolicyId>,
 }
@@ -481,9 +482,9 @@ pub struct NetworkPolicyKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -501,9 +502,9 @@ pub struct NetworkPolicyValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
@@ -517,9 +518,9 @@ pub struct ServerConfigurationKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
@@ -533,9 +534,9 @@ pub struct ServerConfigurationValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: Option<audit_log_key::Event>,
 }
@@ -543,17 +544,8 @@ pub struct AuditLogKey {
 pub mod audit_log_key {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Event {
         V1(AuditLogEventV1),
     }
@@ -569,9 +561,9 @@ pub mod audit_log_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: Option<comment_key::Object>,
     pub sub_component: Option<comment_key::SubComponent>,
@@ -589,9 +581,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Object {
         Table(CatalogItemId),
         View(CatalogItemId),
@@ -621,9 +613,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum SubComponent {
         ColumnPos(u64),
     }
@@ -638,9 +630,9 @@ pub mod comment_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -655,9 +647,9 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: Option<CatalogItemId>,
 }
@@ -671,9 +663,9 @@ pub struct SourceReferencesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: Option<EpochMillis>,
@@ -688,9 +680,9 @@ pub struct SourceReferencesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -707,9 +699,9 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: Option<GlobalId>,
 }
@@ -723,9 +715,9 @@ pub struct StorageCollectionMetadataKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
@@ -739,9 +731,9 @@ pub struct StorageCollectionMetadataValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
@@ -755,9 +747,9 @@ pub struct UnfinalizedShardKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -772,9 +764,9 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
 #[derive(
@@ -786,9 +778,9 @@ pub struct Empty {}
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -803,9 +795,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -821,9 +813,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -838,9 +830,9 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Timestamp {
     pub internal: u64,
 }
@@ -855,9 +847,9 @@ pub struct Timestamp {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
@@ -871,9 +863,9 @@ pub struct Version {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItem {
     pub value: Option<catalog_item::Value>,
 }
@@ -890,24 +882,15 @@ pub mod catalog_item {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct V1 {
         pub create_sql: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         V1(V1),
     }
@@ -923,9 +906,9 @@ pub mod catalog_item {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemId {
     pub value: Option<catalog_item_id::Value>,
 }
@@ -942,9 +925,9 @@ pub mod catalog_item_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -963,9 +946,9 @@ pub mod catalog_item_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId {
     pub value: u64,
 }
@@ -980,9 +963,9 @@ pub struct SystemCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId {
     pub value: u64,
 }
@@ -997,9 +980,9 @@ pub struct IntrospectionSourceIndexCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GlobalId {
     pub value: Option<global_id::Value>,
 }
@@ -1016,9 +999,9 @@ pub mod global_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1038,9 +1021,9 @@ pub mod global_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId {
     pub value: u64,
 }
@@ -1055,9 +1038,9 @@ pub struct SystemGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId {
     pub value: u64,
 }
@@ -1072,9 +1055,9 @@ pub struct IntrospectionSourceIndexGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterId {
     pub value: Option<cluster_id::Value>,
 }
@@ -1091,9 +1074,9 @@ pub mod cluster_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1110,9 +1093,9 @@ pub mod cluster_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseId {
     pub value: Option<database_id::Value>,
 }
@@ -1129,9 +1112,9 @@ pub mod database_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1148,9 +1131,9 @@ pub mod database_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedDatabaseSpecifier {
     pub spec: Option<resolved_database_specifier::Spec>,
 }
@@ -1167,9 +1150,9 @@ pub mod resolved_database_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Ambient(Empty),
         Id(DatabaseId),
@@ -1186,9 +1169,9 @@ pub mod resolved_database_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaId {
     pub value: Option<schema_id::Value>,
 }
@@ -1205,9 +1188,9 @@ pub mod schema_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1224,9 +1207,9 @@ pub mod schema_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaSpecifier {
     pub spec: Option<schema_specifier::Spec>,
 }
@@ -1243,9 +1226,9 @@ pub mod schema_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Temporary(Empty),
         Id(SchemaId),
@@ -1262,9 +1245,9 @@ pub mod schema_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: Option<ResolvedDatabaseSpecifier>,
     pub schema: Option<SchemaSpecifier>,
@@ -1280,9 +1263,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaId {
     pub value: Option<replica_id::Value>,
 }
@@ -1299,9 +1282,9 @@ pub mod replica_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1318,9 +1301,9 @@ pub mod replica_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: Option<ClusterId>,
     pub replica_id: Option<ReplicaId>,
@@ -1336,9 +1319,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyId {
     pub value: Option<network_policy_id::Value>,
 }
@@ -1355,9 +1338,9 @@ pub mod network_policy_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1374,9 +1357,9 @@ pub mod network_policy_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
@@ -1391,9 +1374,9 @@ pub struct ReplicaLogging {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1409,9 +1392,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Option<Duration>,
 }
@@ -1426,9 +1409,9 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterSchedule {
     pub value: Option<cluster_schedule::Value>,
 }
@@ -1445,9 +1428,9 @@ pub mod cluster_schedule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         Manual(Empty),
         Refresh(ClusterScheduleRefreshOptions),
@@ -1463,9 +1446,9 @@ pub mod cluster_schedule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: Option<cluster_config::Variant>,
@@ -1483,9 +1466,9 @@ pub mod cluster_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedCluster {
         pub size: String,
         pub replication_factor: u32,
@@ -1496,17 +1479,8 @@ pub mod cluster_config {
         pub schedule: Option<ClusterSchedule>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Variant {
         Unmanaged(Empty),
         Managed(ManagedCluster),
@@ -1522,9 +1496,9 @@ pub mod cluster_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: Option<ReplicaLogging>,
     pub location: Option<replica_config::Location>,
@@ -1542,9 +1516,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnmanagedLocation {
         pub storagectl_addrs: Vec<String>,
         pub storage_addrs: Vec<String>,
@@ -1562,9 +1536,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedLocation {
         pub size: String,
         pub availability_zone: Option<String>,
@@ -1574,17 +1548,8 @@ pub mod replica_config {
         pub pending: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Location {
         Unmanaged(UnmanagedLocation),
         Managed(ManagedLocation),
@@ -1601,9 +1566,9 @@ pub mod replica_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleId {
     pub value: Option<role_id::Value>,
 }
@@ -1620,9 +1585,9 @@ pub mod role_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1641,9 +1606,9 @@ pub mod role_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1659,9 +1624,9 @@ pub struct RoleAttributes {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<role_membership::Entry>,
 }
@@ -1679,9 +1644,9 @@ pub mod role_membership {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: Option<RoleId>,
         pub value: Option<RoleId>,
@@ -1697,9 +1662,9 @@ pub mod role_membership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<role_vars::Entry>,
 }
@@ -1716,9 +1681,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SqlSet {
         pub entries: Vec<String>,
     }
@@ -1732,9 +1697,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: String,
         pub val: Option<entry::Val>,
@@ -1743,17 +1708,8 @@ pub mod role_vars {
     pub mod entry {
         use super::*;
 
-        #[derive(
-            Clone,
-            Debug,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Serialize,
-            Deserialize,
-            Arbitrary
-        )]
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Val {
             Flat(String),
             SqlSet(SqlSet),
@@ -1770,9 +1726,9 @@ pub mod role_vars {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1792,9 +1748,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Action {
         Allow(Empty),
     }
@@ -1808,9 +1764,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Direction {
         Ingress(Empty),
     }
@@ -1826,9 +1782,9 @@ pub mod network_policy_rule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1843,9 +1799,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1862,9 +1818,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: Option<RoleId>,
     pub database_id: Option<DatabaseId>,
@@ -1883,9 +1839,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: Option<AclMode>,
 }
@@ -1900,9 +1856,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1918,9 +1874,9 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: Option<AclMode>,
 }
@@ -1934,9 +1890,9 @@ pub struct SystemPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: i32,
@@ -1958,9 +1914,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -1975,9 +1931,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
@@ -1993,9 +1949,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
@@ -2010,9 +1966,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
@@ -2028,9 +1984,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -2047,9 +2003,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: Option<FullNameV1>,
@@ -2065,9 +2021,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2088,9 +2044,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2113,9 +2069,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2138,9 +2094,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2157,9 +2113,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2178,9 +2134,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2200,9 +2156,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: Option<create_or_drop_cluster_replica_reason_v1::Reason>,
     }
@@ -2219,9 +2175,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Reason {
             Manual(Empty),
             Schedule(Empty),
@@ -2238,9 +2194,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: Option<RefreshDecisionWithReasonV1>,
     }
@@ -2254,9 +2210,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: Option<RefreshDecisionWithReasonV2>,
     }
@@ -2270,9 +2226,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
@@ -2291,9 +2247,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2309,9 +2265,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -2331,9 +2287,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2349,9 +2305,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2367,9 +2323,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2386,9 +2342,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2404,9 +2360,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2423,9 +2379,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2441,9 +2397,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2459,9 +2415,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2478,9 +2434,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2497,9 +2453,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2515,9 +2471,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2534,9 +2490,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2551,9 +2507,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2570,9 +2526,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2589,9 +2545,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2609,9 +2565,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
@@ -2627,9 +2583,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
@@ -2645,9 +2601,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
@@ -2663,9 +2619,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2682,9 +2638,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2699,9 +2655,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
@@ -2717,9 +2673,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
@@ -2734,9 +2690,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
@@ -2751,9 +2707,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
@@ -2768,9 +2724,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
@@ -2785,10 +2741,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum EventType {
         Unknown = 0,
@@ -2809,10 +2765,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2835,17 +2791,8 @@ pub mod audit_log_event_v1 {
         ContinualTask = 17,
         NetworkPolicy = 18,
     }
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2895,9 +2842,9 @@ pub mod audit_log_event_v1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StateUpdateKind {
     pub kind: Option<state_update_kind::Kind>,
 }
@@ -2914,9 +2861,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AuditLog {
         pub key: Option<AuditLogKey>,
     }
@@ -2930,9 +2877,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Cluster {
         pub key: Option<ClusterKey>,
         pub value: Option<ClusterValue>,
@@ -2947,9 +2894,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterReplica {
         pub key: Option<ClusterReplicaKey>,
         pub value: Option<ClusterReplicaValue>,
@@ -2964,9 +2911,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Comment {
         pub key: Option<CommentKey>,
         pub value: Option<CommentValue>,
@@ -2981,9 +2928,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Config {
         pub key: Option<ConfigKey>,
         pub value: Option<ConfigValue>,
@@ -2998,9 +2945,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Database {
         pub key: Option<DatabaseKey>,
         pub value: Option<DatabaseValue>,
@@ -3016,9 +2963,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DefaultPrivileges {
         pub key: Option<DefaultPrivilegesKey>,
         pub value: Option<DefaultPrivilegesValue>,
@@ -3034,9 +2981,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FenceToken {
         pub deploy_generation: u64,
         pub epoch: i64,
@@ -3051,9 +2998,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdAlloc {
         pub key: Option<IdAllocKey>,
         pub value: Option<IdAllocValue>,
@@ -3068,9 +3015,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterIntrospectionSourceIndex {
         pub key: Option<ClusterIntrospectionSourceIndexKey>,
         pub value: Option<ClusterIntrospectionSourceIndexValue>,
@@ -3085,9 +3032,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Item {
         pub key: Option<ItemKey>,
         pub value: Option<ItemValue>,
@@ -3102,9 +3049,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Role {
         pub key: Option<RoleKey>,
         pub value: Option<RoleValue>,
@@ -3119,9 +3066,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RoleAuth {
         pub key: Option<RoleAuthKey>,
         pub value: Option<RoleAuthValue>,
@@ -3136,9 +3083,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct NetworkPolicy {
         pub key: Option<NetworkPolicyKey>,
         pub value: Option<NetworkPolicyValue>,
@@ -3153,9 +3100,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Schema {
         pub key: Option<SchemaKey>,
         pub value: Option<SchemaValue>,
@@ -3170,9 +3117,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Setting {
         pub key: Option<SettingKey>,
         pub value: Option<SettingValue>,
@@ -3187,9 +3134,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ServerConfiguration {
         pub key: Option<ServerConfigurationKey>,
         pub value: Option<ServerConfigurationValue>,
@@ -3204,9 +3151,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SourceReferences {
         pub key: Option<SourceReferencesKey>,
         pub value: Option<SourceReferencesValue>,
@@ -3221,9 +3168,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GidMapping {
         pub key: Option<GidMappingKey>,
         pub value: Option<GidMappingValue>,
@@ -3239,9 +3186,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SystemPrivileges {
         pub key: Option<SystemPrivilegesKey>,
         pub value: Option<SystemPrivilegesValue>,
@@ -3256,9 +3203,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct StorageCollectionMetadata {
         pub key: Option<StorageCollectionMetadataKey>,
         pub value: Option<StorageCollectionMetadataValue>,
@@ -3273,9 +3220,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnfinalizedShard {
         pub key: Option<UnfinalizedShardKey>,
     }
@@ -3289,24 +3236,15 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct TxnWalShard {
         pub value: Option<TxnWalShardValue>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
     // persist pushdown statistics for success.
     #[serde(tag = "kind")]
@@ -3346,10 +3284,10 @@ pub mod state_update_kind {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -3375,10 +3313,10 @@ pub enum CatalogItemType {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v75.rs
+++ b/src/catalog-protos/src/objects_v75.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,9 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -37,9 +38,9 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
@@ -53,9 +54,9 @@ pub struct ConfigValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
@@ -69,9 +70,9 @@ pub struct SettingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
@@ -85,9 +86,9 @@ pub struct SettingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -102,9 +103,9 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
@@ -118,9 +119,9 @@ pub struct IdAllocValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: i32,
@@ -136,9 +137,9 @@ pub struct GidMappingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub id: u64,
     pub fingerprint: String,
@@ -155,9 +156,9 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: Option<ClusterId>,
 }
@@ -171,9 +172,9 @@ pub struct ClusterKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -190,9 +191,9 @@ pub struct ClusterValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -208,9 +209,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub index_id: u64,
     pub oid: u32,
@@ -227,9 +228,9 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: Option<ReplicaId>,
 }
@@ -243,9 +244,9 @@ pub struct ClusterReplicaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -263,9 +264,9 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: Option<DatabaseId>,
 }
@@ -279,9 +280,9 @@ pub struct DatabaseKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -299,9 +300,9 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: Option<SchemaId>,
 }
@@ -315,9 +316,9 @@ pub struct SchemaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -336,9 +337,9 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: Option<CatalogItemId>,
 }
@@ -352,9 +353,9 @@ pub struct ItemKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: Option<SchemaId>,
     pub name: String,
@@ -376,9 +377,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: Option<GlobalId>,
     pub version: Option<Version>,
@@ -394,9 +395,9 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: Option<RoleId>,
 }
@@ -410,9 +411,9 @@ pub struct RoleKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: Option<RoleAttributes>,
@@ -431,9 +432,9 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: Option<RoleId>,
 }
@@ -447,9 +448,9 @@ pub struct RoleAuthKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: Option<EpochMillis>,
@@ -465,9 +466,9 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: Option<NetworkPolicyId>,
 }
@@ -481,9 +482,9 @@ pub struct NetworkPolicyKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -501,9 +502,9 @@ pub struct NetworkPolicyValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
@@ -517,9 +518,9 @@ pub struct ServerConfigurationKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
@@ -533,9 +534,9 @@ pub struct ServerConfigurationValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: Option<audit_log_key::Event>,
 }
@@ -543,17 +544,8 @@ pub struct AuditLogKey {
 pub mod audit_log_key {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Event {
         V1(AuditLogEventV1),
     }
@@ -569,9 +561,9 @@ pub mod audit_log_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: Option<comment_key::Object>,
     pub sub_component: Option<comment_key::SubComponent>,
@@ -589,9 +581,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Object {
         Table(CatalogItemId),
         View(CatalogItemId),
@@ -621,9 +613,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum SubComponent {
         ColumnPos(u64),
     }
@@ -638,9 +630,9 @@ pub mod comment_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -655,9 +647,9 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: Option<CatalogItemId>,
 }
@@ -671,9 +663,9 @@ pub struct SourceReferencesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: Option<EpochMillis>,
@@ -688,9 +680,9 @@ pub struct SourceReferencesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -707,9 +699,9 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: Option<GlobalId>,
 }
@@ -723,9 +715,9 @@ pub struct StorageCollectionMetadataKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
@@ -739,9 +731,9 @@ pub struct StorageCollectionMetadataValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
@@ -755,9 +747,9 @@ pub struct UnfinalizedShardKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -772,9 +764,9 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
 #[derive(
@@ -786,9 +778,9 @@ pub struct Empty {}
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -803,9 +795,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -821,9 +813,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -838,9 +830,9 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Timestamp {
     pub internal: u64,
 }
@@ -855,9 +847,9 @@ pub struct Timestamp {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
@@ -871,9 +863,9 @@ pub struct Version {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItem {
     pub value: Option<catalog_item::Value>,
 }
@@ -890,24 +882,15 @@ pub mod catalog_item {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct V1 {
         pub create_sql: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         V1(V1),
     }
@@ -923,9 +906,9 @@ pub mod catalog_item {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemId {
     pub value: Option<catalog_item_id::Value>,
 }
@@ -942,9 +925,9 @@ pub mod catalog_item_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -963,9 +946,9 @@ pub mod catalog_item_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId {
     pub value: u64,
 }
@@ -980,9 +963,9 @@ pub struct SystemCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId {
     pub value: u64,
 }
@@ -997,9 +980,9 @@ pub struct IntrospectionSourceIndexCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GlobalId {
     pub value: Option<global_id::Value>,
 }
@@ -1016,9 +999,9 @@ pub mod global_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1038,9 +1021,9 @@ pub mod global_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId {
     pub value: u64,
 }
@@ -1055,9 +1038,9 @@ pub struct SystemGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId {
     pub value: u64,
 }
@@ -1072,9 +1055,9 @@ pub struct IntrospectionSourceIndexGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterId {
     pub value: Option<cluster_id::Value>,
 }
@@ -1091,9 +1074,9 @@ pub mod cluster_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1110,9 +1093,9 @@ pub mod cluster_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseId {
     pub value: Option<database_id::Value>,
 }
@@ -1129,9 +1112,9 @@ pub mod database_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1148,9 +1131,9 @@ pub mod database_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedDatabaseSpecifier {
     pub spec: Option<resolved_database_specifier::Spec>,
 }
@@ -1167,9 +1150,9 @@ pub mod resolved_database_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Ambient(Empty),
         Id(DatabaseId),
@@ -1186,9 +1169,9 @@ pub mod resolved_database_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaId {
     pub value: Option<schema_id::Value>,
 }
@@ -1205,9 +1188,9 @@ pub mod schema_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1224,9 +1207,9 @@ pub mod schema_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaSpecifier {
     pub spec: Option<schema_specifier::Spec>,
 }
@@ -1243,9 +1226,9 @@ pub mod schema_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Temporary(Empty),
         Id(SchemaId),
@@ -1262,9 +1245,9 @@ pub mod schema_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: Option<ResolvedDatabaseSpecifier>,
     pub schema: Option<SchemaSpecifier>,
@@ -1280,9 +1263,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaId {
     pub value: Option<replica_id::Value>,
 }
@@ -1299,9 +1282,9 @@ pub mod replica_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1318,9 +1301,9 @@ pub mod replica_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: Option<ClusterId>,
     pub replica_id: Option<ReplicaId>,
@@ -1336,9 +1319,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyId {
     pub value: Option<network_policy_id::Value>,
 }
@@ -1355,9 +1338,9 @@ pub mod network_policy_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1374,9 +1357,9 @@ pub mod network_policy_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
@@ -1391,9 +1374,9 @@ pub struct ReplicaLogging {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1409,9 +1392,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Option<Duration>,
 }
@@ -1426,9 +1409,9 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterSchedule {
     pub value: Option<cluster_schedule::Value>,
 }
@@ -1445,9 +1428,9 @@ pub mod cluster_schedule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         Manual(Empty),
         Refresh(ClusterScheduleRefreshOptions),
@@ -1463,9 +1446,9 @@ pub mod cluster_schedule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: Option<cluster_config::Variant>,
@@ -1483,9 +1466,9 @@ pub mod cluster_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedCluster {
         pub size: String,
         pub replication_factor: u32,
@@ -1496,17 +1479,8 @@ pub mod cluster_config {
         pub schedule: Option<ClusterSchedule>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Variant {
         Unmanaged(Empty),
         Managed(ManagedCluster),
@@ -1522,9 +1496,9 @@ pub mod cluster_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: Option<ReplicaLogging>,
     pub location: Option<replica_config::Location>,
@@ -1542,9 +1516,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnmanagedLocation {
         pub storagectl_addrs: Vec<String>,
         pub computectl_addrs: Vec<String>,
@@ -1559,9 +1533,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedLocation {
         pub size: String,
         pub availability_zone: Option<String>,
@@ -1571,17 +1545,8 @@ pub mod replica_config {
         pub pending: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Location {
         Unmanaged(UnmanagedLocation),
         Managed(ManagedLocation),
@@ -1598,9 +1563,9 @@ pub mod replica_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleId {
     pub value: Option<role_id::Value>,
 }
@@ -1617,9 +1582,9 @@ pub mod role_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1638,9 +1603,9 @@ pub mod role_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1656,9 +1621,9 @@ pub struct RoleAttributes {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<role_membership::Entry>,
 }
@@ -1676,9 +1641,9 @@ pub mod role_membership {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: Option<RoleId>,
         pub value: Option<RoleId>,
@@ -1694,9 +1659,9 @@ pub mod role_membership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<role_vars::Entry>,
 }
@@ -1713,9 +1678,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SqlSet {
         pub entries: Vec<String>,
     }
@@ -1729,9 +1694,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: String,
         pub val: Option<entry::Val>,
@@ -1740,17 +1705,8 @@ pub mod role_vars {
     pub mod entry {
         use super::*;
 
-        #[derive(
-            Clone,
-            Debug,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Serialize,
-            Deserialize,
-            Arbitrary
-        )]
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Val {
             Flat(String),
             SqlSet(SqlSet),
@@ -1767,9 +1723,9 @@ pub mod role_vars {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1789,9 +1745,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Action {
         Allow(Empty),
     }
@@ -1805,9 +1761,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Direction {
         Ingress(Empty),
     }
@@ -1823,9 +1779,9 @@ pub mod network_policy_rule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1840,9 +1796,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1859,9 +1815,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: Option<RoleId>,
     pub database_id: Option<DatabaseId>,
@@ -1880,9 +1836,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: Option<AclMode>,
 }
@@ -1897,9 +1853,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1915,9 +1871,9 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: Option<AclMode>,
 }
@@ -1931,9 +1887,9 @@ pub struct SystemPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: i32,
@@ -1955,9 +1911,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -1972,9 +1928,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
@@ -1990,9 +1946,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
@@ -2007,9 +1963,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
@@ -2025,9 +1981,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -2044,9 +2000,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: Option<FullNameV1>,
@@ -2062,9 +2018,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2085,9 +2041,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2110,9 +2066,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2135,9 +2091,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2154,9 +2110,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2175,9 +2131,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2197,9 +2153,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: Option<create_or_drop_cluster_replica_reason_v1::Reason>,
     }
@@ -2216,9 +2172,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Reason {
             Manual(Empty),
             Schedule(Empty),
@@ -2235,9 +2191,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: Option<RefreshDecisionWithReasonV1>,
     }
@@ -2251,9 +2207,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: Option<RefreshDecisionWithReasonV2>,
     }
@@ -2267,9 +2223,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
@@ -2288,9 +2244,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2306,9 +2262,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -2328,9 +2284,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2346,9 +2302,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2364,9 +2320,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2383,9 +2339,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2401,9 +2357,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2420,9 +2376,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2438,9 +2394,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2456,9 +2412,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2475,9 +2431,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2494,9 +2450,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2512,9 +2468,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2531,9 +2487,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2548,9 +2504,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2567,9 +2523,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2586,9 +2542,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2606,9 +2562,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
@@ -2624,9 +2580,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
@@ -2642,9 +2598,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
@@ -2660,9 +2616,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2679,9 +2635,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2696,9 +2652,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
@@ -2714,9 +2670,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
@@ -2731,9 +2687,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
@@ -2748,9 +2704,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
@@ -2765,9 +2721,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
@@ -2782,10 +2738,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum EventType {
         Unknown = 0,
@@ -2806,10 +2762,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2832,17 +2788,8 @@ pub mod audit_log_event_v1 {
         ContinualTask = 17,
         NetworkPolicy = 18,
     }
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2892,9 +2839,9 @@ pub mod audit_log_event_v1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StateUpdateKind {
     pub kind: Option<state_update_kind::Kind>,
 }
@@ -2911,9 +2858,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AuditLog {
         pub key: Option<AuditLogKey>,
     }
@@ -2927,9 +2874,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Cluster {
         pub key: Option<ClusterKey>,
         pub value: Option<ClusterValue>,
@@ -2944,9 +2891,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterReplica {
         pub key: Option<ClusterReplicaKey>,
         pub value: Option<ClusterReplicaValue>,
@@ -2961,9 +2908,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Comment {
         pub key: Option<CommentKey>,
         pub value: Option<CommentValue>,
@@ -2978,9 +2925,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Config {
         pub key: Option<ConfigKey>,
         pub value: Option<ConfigValue>,
@@ -2995,9 +2942,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Database {
         pub key: Option<DatabaseKey>,
         pub value: Option<DatabaseValue>,
@@ -3013,9 +2960,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DefaultPrivileges {
         pub key: Option<DefaultPrivilegesKey>,
         pub value: Option<DefaultPrivilegesValue>,
@@ -3031,9 +2978,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FenceToken {
         pub deploy_generation: u64,
         pub epoch: i64,
@@ -3048,9 +2995,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdAlloc {
         pub key: Option<IdAllocKey>,
         pub value: Option<IdAllocValue>,
@@ -3065,9 +3012,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterIntrospectionSourceIndex {
         pub key: Option<ClusterIntrospectionSourceIndexKey>,
         pub value: Option<ClusterIntrospectionSourceIndexValue>,
@@ -3082,9 +3029,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Item {
         pub key: Option<ItemKey>,
         pub value: Option<ItemValue>,
@@ -3099,9 +3046,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Role {
         pub key: Option<RoleKey>,
         pub value: Option<RoleValue>,
@@ -3116,9 +3063,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RoleAuth {
         pub key: Option<RoleAuthKey>,
         pub value: Option<RoleAuthValue>,
@@ -3133,9 +3080,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct NetworkPolicy {
         pub key: Option<NetworkPolicyKey>,
         pub value: Option<NetworkPolicyValue>,
@@ -3150,9 +3097,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Schema {
         pub key: Option<SchemaKey>,
         pub value: Option<SchemaValue>,
@@ -3167,9 +3114,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Setting {
         pub key: Option<SettingKey>,
         pub value: Option<SettingValue>,
@@ -3184,9 +3131,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ServerConfiguration {
         pub key: Option<ServerConfigurationKey>,
         pub value: Option<ServerConfigurationValue>,
@@ -3201,9 +3148,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SourceReferences {
         pub key: Option<SourceReferencesKey>,
         pub value: Option<SourceReferencesValue>,
@@ -3218,9 +3165,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GidMapping {
         pub key: Option<GidMappingKey>,
         pub value: Option<GidMappingValue>,
@@ -3236,9 +3183,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SystemPrivileges {
         pub key: Option<SystemPrivilegesKey>,
         pub value: Option<SystemPrivilegesValue>,
@@ -3253,9 +3200,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct StorageCollectionMetadata {
         pub key: Option<StorageCollectionMetadataKey>,
         pub value: Option<StorageCollectionMetadataValue>,
@@ -3270,9 +3217,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnfinalizedShard {
         pub key: Option<UnfinalizedShardKey>,
     }
@@ -3286,24 +3233,15 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct TxnWalShard {
         pub value: Option<TxnWalShardValue>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
     // persist pushdown statistics for success.
     #[serde(tag = "kind")]
@@ -3343,10 +3281,10 @@ pub mod state_update_kind {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -3372,10 +3310,10 @@ pub enum CatalogItemType {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v76.rs
+++ b/src/catalog-protos/src/objects_v76.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,9 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -37,9 +38,9 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
@@ -53,9 +54,9 @@ pub struct ConfigValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
@@ -69,9 +70,9 @@ pub struct SettingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
@@ -85,9 +86,9 @@ pub struct SettingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -102,9 +103,9 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
@@ -118,9 +119,9 @@ pub struct IdAllocValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: i32,
@@ -136,9 +137,9 @@ pub struct GidMappingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub id: u64,
     pub fingerprint: String,
@@ -155,9 +156,9 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: Option<ClusterId>,
 }
@@ -171,9 +172,9 @@ pub struct ClusterKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -190,9 +191,9 @@ pub struct ClusterValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -208,9 +209,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub index_id: u64,
     pub oid: u32,
@@ -227,9 +228,9 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: Option<ReplicaId>,
 }
@@ -243,9 +244,9 @@ pub struct ClusterReplicaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -263,9 +264,9 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: Option<DatabaseId>,
 }
@@ -279,9 +280,9 @@ pub struct DatabaseKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -299,9 +300,9 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: Option<SchemaId>,
 }
@@ -315,9 +316,9 @@ pub struct SchemaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -336,9 +337,9 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: Option<CatalogItemId>,
 }
@@ -352,9 +353,9 @@ pub struct ItemKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: Option<SchemaId>,
     pub name: String,
@@ -376,9 +377,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: Option<GlobalId>,
     pub version: Option<Version>,
@@ -394,9 +395,9 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: Option<RoleId>,
 }
@@ -410,9 +411,9 @@ pub struct RoleKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: Option<RoleAttributes>,
@@ -431,9 +432,9 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: Option<RoleId>,
 }
@@ -447,9 +448,9 @@ pub struct RoleAuthKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: Option<EpochMillis>,
@@ -465,9 +466,9 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: Option<NetworkPolicyId>,
 }
@@ -481,9 +482,9 @@ pub struct NetworkPolicyKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -501,9 +502,9 @@ pub struct NetworkPolicyValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
@@ -517,9 +518,9 @@ pub struct ServerConfigurationKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
@@ -533,9 +534,9 @@ pub struct ServerConfigurationValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: Option<audit_log_key::Event>,
 }
@@ -543,17 +544,8 @@ pub struct AuditLogKey {
 pub mod audit_log_key {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Event {
         V1(AuditLogEventV1),
     }
@@ -569,9 +561,9 @@ pub mod audit_log_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: Option<comment_key::Object>,
     pub sub_component: Option<comment_key::SubComponent>,
@@ -589,9 +581,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Object {
         Table(CatalogItemId),
         View(CatalogItemId),
@@ -621,9 +613,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum SubComponent {
         ColumnPos(u64),
     }
@@ -638,9 +630,9 @@ pub mod comment_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -655,9 +647,9 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: Option<CatalogItemId>,
 }
@@ -671,9 +663,9 @@ pub struct SourceReferencesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: Option<EpochMillis>,
@@ -688,9 +680,9 @@ pub struct SourceReferencesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -707,9 +699,9 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: Option<GlobalId>,
 }
@@ -723,9 +715,9 @@ pub struct StorageCollectionMetadataKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
@@ -739,9 +731,9 @@ pub struct StorageCollectionMetadataValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
@@ -755,9 +747,9 @@ pub struct UnfinalizedShardKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -772,9 +764,9 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
 #[derive(
@@ -786,9 +778,9 @@ pub struct Empty {}
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -803,9 +795,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -821,9 +813,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -838,9 +830,9 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Timestamp {
     pub internal: u64,
 }
@@ -855,9 +847,9 @@ pub struct Timestamp {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
@@ -871,9 +863,9 @@ pub struct Version {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItem {
     pub value: Option<catalog_item::Value>,
 }
@@ -890,24 +882,15 @@ pub mod catalog_item {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct V1 {
         pub create_sql: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         V1(V1),
     }
@@ -923,9 +906,9 @@ pub mod catalog_item {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemId {
     pub value: Option<catalog_item_id::Value>,
 }
@@ -942,9 +925,9 @@ pub mod catalog_item_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -963,9 +946,9 @@ pub mod catalog_item_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId {
     pub value: u64,
 }
@@ -980,9 +963,9 @@ pub struct SystemCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId {
     pub value: u64,
 }
@@ -997,9 +980,9 @@ pub struct IntrospectionSourceIndexCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GlobalId {
     pub value: Option<global_id::Value>,
 }
@@ -1016,9 +999,9 @@ pub mod global_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1038,9 +1021,9 @@ pub mod global_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId {
     pub value: u64,
 }
@@ -1055,9 +1038,9 @@ pub struct SystemGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId {
     pub value: u64,
 }
@@ -1072,9 +1055,9 @@ pub struct IntrospectionSourceIndexGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterId {
     pub value: Option<cluster_id::Value>,
 }
@@ -1091,9 +1074,9 @@ pub mod cluster_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1110,9 +1093,9 @@ pub mod cluster_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseId {
     pub value: Option<database_id::Value>,
 }
@@ -1129,9 +1112,9 @@ pub mod database_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1148,9 +1131,9 @@ pub mod database_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedDatabaseSpecifier {
     pub spec: Option<resolved_database_specifier::Spec>,
 }
@@ -1167,9 +1150,9 @@ pub mod resolved_database_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Ambient(Empty),
         Id(DatabaseId),
@@ -1186,9 +1169,9 @@ pub mod resolved_database_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaId {
     pub value: Option<schema_id::Value>,
 }
@@ -1205,9 +1188,9 @@ pub mod schema_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1224,9 +1207,9 @@ pub mod schema_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaSpecifier {
     pub spec: Option<schema_specifier::Spec>,
 }
@@ -1243,9 +1226,9 @@ pub mod schema_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Temporary(Empty),
         Id(SchemaId),
@@ -1262,9 +1245,9 @@ pub mod schema_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: Option<ResolvedDatabaseSpecifier>,
     pub schema: Option<SchemaSpecifier>,
@@ -1280,9 +1263,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaId {
     pub value: Option<replica_id::Value>,
 }
@@ -1299,9 +1282,9 @@ pub mod replica_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1318,9 +1301,9 @@ pub mod replica_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: Option<ClusterId>,
     pub replica_id: Option<ReplicaId>,
@@ -1336,9 +1319,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyId {
     pub value: Option<network_policy_id::Value>,
 }
@@ -1355,9 +1338,9 @@ pub mod network_policy_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1374,9 +1357,9 @@ pub mod network_policy_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
@@ -1391,9 +1374,9 @@ pub struct ReplicaLogging {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1409,9 +1392,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Option<Duration>,
 }
@@ -1426,9 +1409,9 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterSchedule {
     pub value: Option<cluster_schedule::Value>,
 }
@@ -1445,9 +1428,9 @@ pub mod cluster_schedule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         Manual(Empty),
         Refresh(ClusterScheduleRefreshOptions),
@@ -1463,9 +1446,9 @@ pub mod cluster_schedule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: Option<cluster_config::Variant>,
@@ -1483,9 +1466,9 @@ pub mod cluster_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedCluster {
         pub size: String,
         pub replication_factor: u32,
@@ -1495,17 +1478,8 @@ pub mod cluster_config {
         pub schedule: Option<ClusterSchedule>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Variant {
         Unmanaged(Empty),
         Managed(ManagedCluster),
@@ -1521,9 +1495,9 @@ pub mod cluster_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: Option<ReplicaLogging>,
     pub location: Option<replica_config::Location>,
@@ -1541,9 +1515,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnmanagedLocation {
         pub storagectl_addrs: Vec<String>,
         pub computectl_addrs: Vec<String>,
@@ -1558,9 +1532,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedLocation {
         pub size: String,
         pub availability_zone: Option<String>,
@@ -1569,17 +1543,8 @@ pub mod replica_config {
         pub pending: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Location {
         Unmanaged(UnmanagedLocation),
         Managed(ManagedLocation),
@@ -1596,9 +1561,9 @@ pub mod replica_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleId {
     pub value: Option<role_id::Value>,
 }
@@ -1615,9 +1580,9 @@ pub mod role_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1636,9 +1601,9 @@ pub mod role_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1654,9 +1619,9 @@ pub struct RoleAttributes {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<role_membership::Entry>,
 }
@@ -1674,9 +1639,9 @@ pub mod role_membership {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: Option<RoleId>,
         pub value: Option<RoleId>,
@@ -1692,9 +1657,9 @@ pub mod role_membership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<role_vars::Entry>,
 }
@@ -1711,9 +1676,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SqlSet {
         pub entries: Vec<String>,
     }
@@ -1727,9 +1692,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: String,
         pub val: Option<entry::Val>,
@@ -1738,17 +1703,8 @@ pub mod role_vars {
     pub mod entry {
         use super::*;
 
-        #[derive(
-            Clone,
-            Debug,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Serialize,
-            Deserialize,
-            Arbitrary
-        )]
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Val {
             Flat(String),
             SqlSet(SqlSet),
@@ -1765,9 +1721,9 @@ pub mod role_vars {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1787,9 +1743,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Action {
         Allow(Empty),
     }
@@ -1803,9 +1759,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Direction {
         Ingress(Empty),
     }
@@ -1821,9 +1777,9 @@ pub mod network_policy_rule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1838,9 +1794,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1857,9 +1813,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: Option<RoleId>,
     pub database_id: Option<DatabaseId>,
@@ -1878,9 +1834,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: Option<AclMode>,
 }
@@ -1895,9 +1851,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1913,9 +1869,9 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: Option<AclMode>,
 }
@@ -1929,9 +1885,9 @@ pub struct SystemPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: i32,
@@ -1953,9 +1909,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -1970,9 +1926,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
@@ -1988,9 +1944,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
@@ -2005,9 +1961,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
@@ -2023,9 +1979,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -2042,9 +1998,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: Option<FullNameV1>,
@@ -2060,9 +2016,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2083,9 +2039,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2108,9 +2064,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2133,9 +2089,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2157,9 +2113,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2176,9 +2132,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2197,9 +2153,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2219,9 +2175,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: Option<create_or_drop_cluster_replica_reason_v1::Reason>,
     }
@@ -2238,9 +2194,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Reason {
             Manual(Empty),
             Schedule(Empty),
@@ -2257,9 +2213,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: Option<RefreshDecisionWithReasonV1>,
     }
@@ -2273,9 +2229,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: Option<RefreshDecisionWithReasonV2>,
     }
@@ -2289,9 +2245,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
@@ -2310,9 +2266,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2328,9 +2284,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -2350,9 +2306,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2368,9 +2324,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2386,9 +2342,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2405,9 +2361,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2423,9 +2379,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2442,9 +2398,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2460,9 +2416,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2478,9 +2434,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2497,9 +2453,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2516,9 +2472,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2534,9 +2490,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2553,9 +2509,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2570,9 +2526,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2589,9 +2545,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2608,9 +2564,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2628,9 +2584,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
@@ -2646,9 +2602,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
@@ -2664,9 +2620,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
@@ -2682,9 +2638,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2701,9 +2657,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2718,9 +2674,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
@@ -2736,9 +2692,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
@@ -2753,9 +2709,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
@@ -2770,9 +2726,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
@@ -2787,9 +2743,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
@@ -2804,10 +2760,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum EventType {
         Unknown = 0,
@@ -2828,10 +2784,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2855,17 +2811,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2916,9 +2863,9 @@ pub mod audit_log_event_v1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StateUpdateKind {
     pub kind: Option<state_update_kind::Kind>,
 }
@@ -2935,9 +2882,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AuditLog {
         pub key: Option<AuditLogKey>,
     }
@@ -2951,9 +2898,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Cluster {
         pub key: Option<ClusterKey>,
         pub value: Option<ClusterValue>,
@@ -2968,9 +2915,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterReplica {
         pub key: Option<ClusterReplicaKey>,
         pub value: Option<ClusterReplicaValue>,
@@ -2985,9 +2932,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Comment {
         pub key: Option<CommentKey>,
         pub value: Option<CommentValue>,
@@ -3002,9 +2949,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Config {
         pub key: Option<ConfigKey>,
         pub value: Option<ConfigValue>,
@@ -3019,9 +2966,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Database {
         pub key: Option<DatabaseKey>,
         pub value: Option<DatabaseValue>,
@@ -3037,9 +2984,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DefaultPrivileges {
         pub key: Option<DefaultPrivilegesKey>,
         pub value: Option<DefaultPrivilegesValue>,
@@ -3055,9 +3002,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FenceToken {
         pub deploy_generation: u64,
         pub epoch: i64,
@@ -3072,9 +3019,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdAlloc {
         pub key: Option<IdAllocKey>,
         pub value: Option<IdAllocValue>,
@@ -3089,9 +3036,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterIntrospectionSourceIndex {
         pub key: Option<ClusterIntrospectionSourceIndexKey>,
         pub value: Option<ClusterIntrospectionSourceIndexValue>,
@@ -3106,9 +3053,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Item {
         pub key: Option<ItemKey>,
         pub value: Option<ItemValue>,
@@ -3123,9 +3070,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Role {
         pub key: Option<RoleKey>,
         pub value: Option<RoleValue>,
@@ -3140,9 +3087,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RoleAuth {
         pub key: Option<RoleAuthKey>,
         pub value: Option<RoleAuthValue>,
@@ -3157,9 +3104,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct NetworkPolicy {
         pub key: Option<NetworkPolicyKey>,
         pub value: Option<NetworkPolicyValue>,
@@ -3174,9 +3121,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Schema {
         pub key: Option<SchemaKey>,
         pub value: Option<SchemaValue>,
@@ -3191,9 +3138,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Setting {
         pub key: Option<SettingKey>,
         pub value: Option<SettingValue>,
@@ -3208,9 +3155,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ServerConfiguration {
         pub key: Option<ServerConfigurationKey>,
         pub value: Option<ServerConfigurationValue>,
@@ -3225,9 +3172,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SourceReferences {
         pub key: Option<SourceReferencesKey>,
         pub value: Option<SourceReferencesValue>,
@@ -3242,9 +3189,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GidMapping {
         pub key: Option<GidMappingKey>,
         pub value: Option<GidMappingValue>,
@@ -3260,9 +3207,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SystemPrivileges {
         pub key: Option<SystemPrivilegesKey>,
         pub value: Option<SystemPrivilegesValue>,
@@ -3277,9 +3224,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct StorageCollectionMetadata {
         pub key: Option<StorageCollectionMetadataKey>,
         pub value: Option<StorageCollectionMetadataValue>,
@@ -3294,9 +3241,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnfinalizedShard {
         pub key: Option<UnfinalizedShardKey>,
     }
@@ -3310,24 +3257,15 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct TxnWalShard {
         pub value: Option<TxnWalShardValue>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
     // persist pushdown statistics for success.
     #[serde(tag = "kind")]
@@ -3367,10 +3305,10 @@ pub mod state_update_kind {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -3396,10 +3334,10 @@ pub enum CatalogItemType {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v77.rs
+++ b/src/catalog-protos/src/objects_v77.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,9 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -37,9 +38,9 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
@@ -53,9 +54,9 @@ pub struct ConfigValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
@@ -69,9 +70,9 @@ pub struct SettingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
@@ -85,9 +86,9 @@ pub struct SettingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -102,9 +103,9 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
@@ -118,9 +119,9 @@ pub struct IdAllocValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: i32,
@@ -136,9 +137,9 @@ pub struct GidMappingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub id: u64,
     pub fingerprint: String,
@@ -155,9 +156,9 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: Option<ClusterId>,
 }
@@ -171,9 +172,9 @@ pub struct ClusterKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -190,9 +191,9 @@ pub struct ClusterValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -208,9 +209,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub index_id: u64,
     pub oid: u32,
@@ -227,9 +228,9 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: Option<ReplicaId>,
 }
@@ -243,9 +244,9 @@ pub struct ClusterReplicaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -263,9 +264,9 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: Option<DatabaseId>,
 }
@@ -279,9 +280,9 @@ pub struct DatabaseKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -299,9 +300,9 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: Option<SchemaId>,
 }
@@ -315,9 +316,9 @@ pub struct SchemaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -336,9 +337,9 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: Option<CatalogItemId>,
 }
@@ -352,9 +353,9 @@ pub struct ItemKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: Option<SchemaId>,
     pub name: String,
@@ -376,9 +377,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: Option<GlobalId>,
     pub version: Option<Version>,
@@ -394,9 +395,9 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: Option<RoleId>,
 }
@@ -410,9 +411,9 @@ pub struct RoleKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: Option<RoleAttributes>,
@@ -431,9 +432,9 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: Option<RoleId>,
 }
@@ -447,9 +448,9 @@ pub struct RoleAuthKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: Option<EpochMillis>,
@@ -465,9 +466,9 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: Option<NetworkPolicyId>,
 }
@@ -481,9 +482,9 @@ pub struct NetworkPolicyKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -501,9 +502,9 @@ pub struct NetworkPolicyValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
@@ -517,9 +518,9 @@ pub struct ServerConfigurationKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
@@ -533,9 +534,9 @@ pub struct ServerConfigurationValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: Option<audit_log_key::Event>,
 }
@@ -543,17 +544,8 @@ pub struct AuditLogKey {
 pub mod audit_log_key {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Event {
         V1(AuditLogEventV1),
     }
@@ -569,9 +561,9 @@ pub mod audit_log_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: Option<comment_key::Object>,
     pub sub_component: Option<comment_key::SubComponent>,
@@ -589,9 +581,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Object {
         Table(CatalogItemId),
         View(CatalogItemId),
@@ -621,9 +613,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum SubComponent {
         ColumnPos(u64),
     }
@@ -638,9 +630,9 @@ pub mod comment_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -655,9 +647,9 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: Option<CatalogItemId>,
 }
@@ -671,9 +663,9 @@ pub struct SourceReferencesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: Option<EpochMillis>,
@@ -688,9 +680,9 @@ pub struct SourceReferencesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -707,9 +699,9 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: Option<GlobalId>,
 }
@@ -723,9 +715,9 @@ pub struct StorageCollectionMetadataKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
@@ -739,9 +731,9 @@ pub struct StorageCollectionMetadataValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
@@ -755,9 +747,9 @@ pub struct UnfinalizedShardKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -772,9 +764,9 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
 #[derive(
@@ -786,9 +778,9 @@ pub struct Empty {}
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -803,9 +795,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -821,9 +813,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -838,9 +830,9 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Timestamp {
     pub internal: u64,
 }
@@ -855,9 +847,9 @@ pub struct Timestamp {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
@@ -871,9 +863,9 @@ pub struct Version {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItem {
     pub value: Option<catalog_item::Value>,
 }
@@ -890,24 +882,15 @@ pub mod catalog_item {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct V1 {
         pub create_sql: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         V1(V1),
     }
@@ -923,9 +906,9 @@ pub mod catalog_item {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemId {
     pub value: Option<catalog_item_id::Value>,
 }
@@ -942,9 +925,9 @@ pub mod catalog_item_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -963,9 +946,9 @@ pub mod catalog_item_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId {
     pub value: u64,
 }
@@ -980,9 +963,9 @@ pub struct SystemCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId {
     pub value: u64,
 }
@@ -997,9 +980,9 @@ pub struct IntrospectionSourceIndexCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GlobalId {
     pub value: Option<global_id::Value>,
 }
@@ -1016,9 +999,9 @@ pub mod global_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1038,9 +1021,9 @@ pub mod global_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId {
     pub value: u64,
 }
@@ -1055,9 +1038,9 @@ pub struct SystemGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId {
     pub value: u64,
 }
@@ -1072,9 +1055,9 @@ pub struct IntrospectionSourceIndexGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterId {
     pub value: Option<cluster_id::Value>,
 }
@@ -1091,9 +1074,9 @@ pub mod cluster_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1110,9 +1093,9 @@ pub mod cluster_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseId {
     pub value: Option<database_id::Value>,
 }
@@ -1129,9 +1112,9 @@ pub mod database_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1148,9 +1131,9 @@ pub mod database_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedDatabaseSpecifier {
     pub spec: Option<resolved_database_specifier::Spec>,
 }
@@ -1167,9 +1150,9 @@ pub mod resolved_database_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Ambient(Empty),
         Id(DatabaseId),
@@ -1186,9 +1169,9 @@ pub mod resolved_database_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaId {
     pub value: Option<schema_id::Value>,
 }
@@ -1205,9 +1188,9 @@ pub mod schema_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1224,9 +1207,9 @@ pub mod schema_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaSpecifier {
     pub spec: Option<schema_specifier::Spec>,
 }
@@ -1243,9 +1226,9 @@ pub mod schema_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Temporary(Empty),
         Id(SchemaId),
@@ -1262,9 +1245,9 @@ pub mod schema_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: Option<ResolvedDatabaseSpecifier>,
     pub schema: Option<SchemaSpecifier>,
@@ -1280,9 +1263,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaId {
     pub value: Option<replica_id::Value>,
 }
@@ -1299,9 +1282,9 @@ pub mod replica_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1318,9 +1301,9 @@ pub mod replica_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: Option<ClusterId>,
     pub replica_id: Option<ReplicaId>,
@@ -1336,9 +1319,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyId {
     pub value: Option<network_policy_id::Value>,
 }
@@ -1355,9 +1338,9 @@ pub mod network_policy_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1374,9 +1357,9 @@ pub mod network_policy_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
@@ -1391,9 +1374,9 @@ pub struct ReplicaLogging {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1409,9 +1392,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Option<Duration>,
 }
@@ -1426,9 +1409,9 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterSchedule {
     pub value: Option<cluster_schedule::Value>,
 }
@@ -1445,9 +1428,9 @@ pub mod cluster_schedule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         Manual(Empty),
         Refresh(ClusterScheduleRefreshOptions),
@@ -1463,9 +1446,9 @@ pub mod cluster_schedule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: Option<cluster_config::Variant>,
@@ -1483,9 +1466,9 @@ pub mod cluster_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedCluster {
         pub size: String,
         pub replication_factor: u32,
@@ -1495,17 +1478,8 @@ pub mod cluster_config {
         pub schedule: Option<ClusterSchedule>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Variant {
         Unmanaged(Empty),
         Managed(ManagedCluster),
@@ -1521,9 +1495,9 @@ pub mod cluster_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: Option<ReplicaLogging>,
     pub location: Option<replica_config::Location>,
@@ -1541,9 +1515,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnmanagedLocation {
         pub storagectl_addrs: Vec<String>,
         pub computectl_addrs: Vec<String>,
@@ -1558,9 +1532,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedLocation {
         pub size: String,
         pub availability_zone: Option<String>,
@@ -1569,17 +1543,8 @@ pub mod replica_config {
         pub pending: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Location {
         Unmanaged(UnmanagedLocation),
         Managed(ManagedLocation),
@@ -1596,9 +1561,9 @@ pub mod replica_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleId {
     pub value: Option<role_id::Value>,
 }
@@ -1615,9 +1580,9 @@ pub mod role_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1636,9 +1601,9 @@ pub mod role_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1654,9 +1619,9 @@ pub struct RoleAttributes {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<role_membership::Entry>,
 }
@@ -1674,9 +1639,9 @@ pub mod role_membership {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: Option<RoleId>,
         pub value: Option<RoleId>,
@@ -1692,9 +1657,9 @@ pub mod role_membership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<role_vars::Entry>,
 }
@@ -1711,9 +1676,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SqlSet {
         pub entries: Vec<String>,
     }
@@ -1727,9 +1692,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: String,
         pub val: Option<entry::Val>,
@@ -1738,17 +1703,8 @@ pub mod role_vars {
     pub mod entry {
         use super::*;
 
-        #[derive(
-            Clone,
-            Debug,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Serialize,
-            Deserialize,
-            Arbitrary
-        )]
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Val {
             Flat(String),
             SqlSet(SqlSet),
@@ -1765,9 +1721,9 @@ pub mod role_vars {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1787,9 +1743,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Action {
         Allow(Empty),
     }
@@ -1803,9 +1759,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Direction {
         Ingress(Empty),
     }
@@ -1821,9 +1777,9 @@ pub mod network_policy_rule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1838,9 +1794,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1857,9 +1813,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: Option<RoleId>,
     pub database_id: Option<DatabaseId>,
@@ -1878,9 +1834,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: Option<AclMode>,
 }
@@ -1895,9 +1851,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1913,9 +1869,9 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: Option<AclMode>,
 }
@@ -1929,9 +1885,9 @@ pub struct SystemPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: i32,
@@ -1953,9 +1909,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -1970,9 +1926,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
@@ -1988,9 +1944,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
@@ -2005,9 +1961,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
@@ -2023,9 +1979,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -2042,9 +1998,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: Option<FullNameV1>,
@@ -2060,9 +2016,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2083,9 +2039,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2108,9 +2064,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2133,9 +2089,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2157,9 +2113,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2176,9 +2132,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2197,9 +2153,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2219,9 +2175,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: Option<create_or_drop_cluster_replica_reason_v1::Reason>,
     }
@@ -2238,9 +2194,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Reason {
             Manual(Empty),
             Schedule(Empty),
@@ -2257,9 +2213,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: Option<RefreshDecisionWithReasonV1>,
     }
@@ -2273,9 +2229,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: Option<RefreshDecisionWithReasonV2>,
     }
@@ -2289,9 +2245,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
@@ -2310,9 +2266,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2328,9 +2284,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -2350,9 +2306,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2368,9 +2324,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2386,9 +2342,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2405,9 +2361,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2423,9 +2379,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2442,9 +2398,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2460,9 +2416,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2478,9 +2434,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2497,9 +2453,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2516,9 +2472,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2534,9 +2490,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2553,9 +2509,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2570,9 +2526,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2589,9 +2545,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2608,9 +2564,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2628,9 +2584,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
@@ -2646,9 +2602,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
@@ -2664,9 +2620,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
@@ -2682,9 +2638,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2701,9 +2657,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: Option<FullNameV1>,
@@ -2718,9 +2674,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
@@ -2736,9 +2692,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
@@ -2753,9 +2709,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
@@ -2770,9 +2726,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
@@ -2787,9 +2743,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
@@ -2804,10 +2760,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum EventType {
         Unknown = 0,
@@ -2828,10 +2784,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2855,17 +2811,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2916,9 +2863,9 @@ pub mod audit_log_event_v1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StateUpdateKind {
     pub kind: Option<state_update_kind::Kind>,
 }
@@ -2935,9 +2882,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AuditLog {
         pub key: Option<AuditLogKey>,
     }
@@ -2951,9 +2898,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Cluster {
         pub key: Option<ClusterKey>,
         pub value: Option<ClusterValue>,
@@ -2968,9 +2915,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterReplica {
         pub key: Option<ClusterReplicaKey>,
         pub value: Option<ClusterReplicaValue>,
@@ -2985,9 +2932,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Comment {
         pub key: Option<CommentKey>,
         pub value: Option<CommentValue>,
@@ -3002,9 +2949,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Config {
         pub key: Option<ConfigKey>,
         pub value: Option<ConfigValue>,
@@ -3019,9 +2966,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Database {
         pub key: Option<DatabaseKey>,
         pub value: Option<DatabaseValue>,
@@ -3037,9 +2984,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DefaultPrivileges {
         pub key: Option<DefaultPrivilegesKey>,
         pub value: Option<DefaultPrivilegesValue>,
@@ -3055,9 +3002,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FenceToken {
         pub deploy_generation: u64,
         pub epoch: i64,
@@ -3072,9 +3019,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdAlloc {
         pub key: Option<IdAllocKey>,
         pub value: Option<IdAllocValue>,
@@ -3089,9 +3036,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterIntrospectionSourceIndex {
         pub key: Option<ClusterIntrospectionSourceIndexKey>,
         pub value: Option<ClusterIntrospectionSourceIndexValue>,
@@ -3106,9 +3053,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Item {
         pub key: Option<ItemKey>,
         pub value: Option<ItemValue>,
@@ -3123,9 +3070,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Role {
         pub key: Option<RoleKey>,
         pub value: Option<RoleValue>,
@@ -3140,9 +3087,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RoleAuth {
         pub key: Option<RoleAuthKey>,
         pub value: Option<RoleAuthValue>,
@@ -3157,9 +3104,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct NetworkPolicy {
         pub key: Option<NetworkPolicyKey>,
         pub value: Option<NetworkPolicyValue>,
@@ -3174,9 +3121,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Schema {
         pub key: Option<SchemaKey>,
         pub value: Option<SchemaValue>,
@@ -3191,9 +3138,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Setting {
         pub key: Option<SettingKey>,
         pub value: Option<SettingValue>,
@@ -3208,9 +3155,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ServerConfiguration {
         pub key: Option<ServerConfigurationKey>,
         pub value: Option<ServerConfigurationValue>,
@@ -3225,9 +3172,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SourceReferences {
         pub key: Option<SourceReferencesKey>,
         pub value: Option<SourceReferencesValue>,
@@ -3242,9 +3189,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GidMapping {
         pub key: Option<GidMappingKey>,
         pub value: Option<GidMappingValue>,
@@ -3260,9 +3207,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SystemPrivileges {
         pub key: Option<SystemPrivilegesKey>,
         pub value: Option<SystemPrivilegesValue>,
@@ -3277,9 +3224,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct StorageCollectionMetadata {
         pub key: Option<StorageCollectionMetadataKey>,
         pub value: Option<StorageCollectionMetadataValue>,
@@ -3294,9 +3241,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnfinalizedShard {
         pub key: Option<UnfinalizedShardKey>,
     }
@@ -3310,24 +3257,15 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct TxnWalShard {
         pub value: Option<TxnWalShardValue>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
     // persist pushdown statistics for success.
     #[serde(tag = "kind")]
@@ -3367,10 +3305,10 @@ pub mod state_update_kind {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -3396,10 +3334,10 @@ pub enum CatalogItemType {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v78.rs
+++ b/src/catalog-protos/src/objects_v78.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,9 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -37,9 +38,9 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
@@ -53,9 +54,9 @@ pub struct ConfigValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
@@ -69,9 +70,9 @@ pub struct SettingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
@@ -85,9 +86,9 @@ pub struct SettingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -102,9 +103,9 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
@@ -118,9 +119,9 @@ pub struct IdAllocValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: i32,
@@ -136,9 +137,9 @@ pub struct GidMappingKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub id: u64,
     pub fingerprint: String,
@@ -155,9 +156,9 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: Option<ClusterId>,
 }
@@ -171,9 +172,9 @@ pub struct ClusterKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -190,9 +191,9 @@ pub struct ClusterValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -208,9 +209,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub index_id: u64,
     pub oid: u32,
@@ -227,9 +228,9 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: Option<ReplicaId>,
 }
@@ -243,9 +244,9 @@ pub struct ClusterReplicaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: Option<ClusterId>,
     pub name: String,
@@ -263,9 +264,9 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: Option<DatabaseId>,
 }
@@ -279,9 +280,9 @@ pub struct DatabaseKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: Option<RoleId>,
@@ -299,9 +300,9 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: Option<SchemaId>,
 }
@@ -315,9 +316,9 @@ pub struct SchemaKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -336,9 +337,9 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: Option<CatalogItemId>,
 }
@@ -352,9 +353,9 @@ pub struct ItemKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: Option<SchemaId>,
     pub name: String,
@@ -376,9 +377,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: Option<GlobalId>,
     pub version: Option<Version>,
@@ -394,9 +395,9 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: Option<RoleId>,
 }
@@ -410,9 +411,9 @@ pub struct RoleKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: Option<RoleAttributes>,
@@ -431,9 +432,9 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: Option<RoleId>,
 }
@@ -447,12 +448,12 @@ pub struct RoleAuthKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub updated_at: Option<EpochMillis>,
 }
 
@@ -466,9 +467,9 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: Option<NetworkPolicyId>,
 }
@@ -482,9 +483,9 @@ pub struct NetworkPolicyKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -502,9 +503,9 @@ pub struct NetworkPolicyValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
@@ -518,9 +519,9 @@ pub struct ServerConfigurationKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
@@ -534,28 +535,19 @@ pub struct ServerConfigurationValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub event: Option<audit_log_key::Event>,
 }
 
 pub mod audit_log_key {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Event {
         V1(AuditLogEventV1),
     }
@@ -571,9 +563,9 @@ pub mod audit_log_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: Option<comment_key::Object>,
     pub sub_component: Option<comment_key::SubComponent>,
@@ -591,9 +583,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Object {
         Table(CatalogItemId),
         View(CatalogItemId),
@@ -623,9 +615,9 @@ pub mod comment_key {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum SubComponent {
         ColumnPos(u64),
     }
@@ -640,9 +632,9 @@ pub mod comment_key {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -657,9 +649,9 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: Option<CatalogItemId>,
 }
@@ -673,12 +665,12 @@ pub struct SourceReferencesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub updated_at: Option<EpochMillis>,
 }
 
@@ -691,9 +683,9 @@ pub struct SourceReferencesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -710,9 +702,9 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: Option<GlobalId>,
 }
@@ -726,9 +718,9 @@ pub struct StorageCollectionMetadataKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
@@ -742,9 +734,9 @@ pub struct StorageCollectionMetadataValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
@@ -758,9 +750,9 @@ pub struct UnfinalizedShardKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -775,9 +767,9 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
 #[derive(
@@ -789,9 +781,9 @@ pub struct Empty {}
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -806,9 +798,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -824,9 +816,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -841,9 +833,9 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Timestamp {
     pub internal: u64,
 }
@@ -858,9 +850,9 @@ pub struct Timestamp {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
@@ -874,9 +866,9 @@ pub struct Version {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItem {
     pub value: Option<catalog_item::Value>,
 }
@@ -893,24 +885,15 @@ pub mod catalog_item {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct V1 {
         pub create_sql: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         V1(V1),
     }
@@ -926,9 +909,9 @@ pub mod catalog_item {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemId {
     pub value: Option<catalog_item_id::Value>,
 }
@@ -945,9 +928,9 @@ pub mod catalog_item_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -966,9 +949,9 @@ pub mod catalog_item_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId {
     pub value: u64,
 }
@@ -983,9 +966,9 @@ pub struct SystemCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId {
     pub value: u64,
 }
@@ -1000,9 +983,9 @@ pub struct IntrospectionSourceIndexCatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GlobalId {
     pub value: Option<global_id::Value>,
 }
@@ -1019,9 +1002,9 @@ pub mod global_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1041,9 +1024,9 @@ pub mod global_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId {
     pub value: u64,
 }
@@ -1058,9 +1041,9 @@ pub struct SystemGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId {
     pub value: u64,
 }
@@ -1075,9 +1058,9 @@ pub struct IntrospectionSourceIndexGlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterId {
     pub value: Option<cluster_id::Value>,
 }
@@ -1094,9 +1077,9 @@ pub mod cluster_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1113,9 +1096,9 @@ pub mod cluster_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseId {
     pub value: Option<database_id::Value>,
 }
@@ -1132,9 +1115,9 @@ pub mod database_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1151,9 +1134,9 @@ pub mod database_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedDatabaseSpecifier {
     pub spec: Option<resolved_database_specifier::Spec>,
 }
@@ -1170,9 +1153,9 @@ pub mod resolved_database_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Ambient(Empty),
         Id(DatabaseId),
@@ -1189,9 +1172,9 @@ pub mod resolved_database_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaId {
     pub value: Option<schema_id::Value>,
 }
@@ -1208,9 +1191,9 @@ pub mod schema_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1227,9 +1210,9 @@ pub mod schema_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaSpecifier {
     pub spec: Option<schema_specifier::Spec>,
 }
@@ -1246,9 +1229,9 @@ pub mod schema_specifier {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Spec {
         Temporary(Empty),
         Id(SchemaId),
@@ -1265,9 +1248,9 @@ pub mod schema_specifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: Option<ResolvedDatabaseSpecifier>,
     pub schema: Option<SchemaSpecifier>,
@@ -1283,9 +1266,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaId {
     pub value: Option<replica_id::Value>,
 }
@@ -1302,9 +1285,9 @@ pub mod replica_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1321,9 +1304,9 @@ pub mod replica_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: Option<ClusterId>,
     pub replica_id: Option<ReplicaId>,
@@ -1339,9 +1322,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyId {
     pub value: Option<network_policy_id::Value>,
 }
@@ -1358,9 +1341,9 @@ pub mod network_policy_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1377,9 +1360,9 @@ pub mod network_policy_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
@@ -1394,9 +1377,9 @@ pub struct ReplicaLogging {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1412,11 +1395,11 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub rehydration_time_estimate: Option<Duration>,
 }
 
@@ -1430,9 +1413,9 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterSchedule {
     pub value: Option<cluster_schedule::Value>,
 }
@@ -1449,9 +1432,9 @@ pub mod cluster_schedule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         Manual(Empty),
         Refresh(ClusterScheduleRefreshOptions),
@@ -1467,9 +1450,9 @@ pub mod cluster_schedule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: Option<cluster_config::Variant>,
@@ -1487,9 +1470,9 @@ pub mod cluster_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedCluster {
         pub size: String,
         pub replication_factor: u32,
@@ -1499,17 +1482,8 @@ pub mod cluster_config {
         pub schedule: Option<ClusterSchedule>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Variant {
         Unmanaged(Empty),
         Managed(ManagedCluster),
@@ -1525,13 +1499,13 @@ pub mod cluster_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub logging: Option<ReplicaLogging>,
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub location: Option<replica_config::Location>,
 }
 
@@ -1547,9 +1521,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnmanagedLocation {
         pub storagectl_addrs: Vec<String>,
         pub computectl_addrs: Vec<String>,
@@ -1564,9 +1538,9 @@ pub mod replica_config {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ManagedLocation {
         pub size: String,
         pub availability_zone: Option<String>,
@@ -1575,17 +1549,8 @@ pub mod replica_config {
         pub pending: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Location {
         Unmanaged(UnmanagedLocation),
         Managed(ManagedLocation),
@@ -1602,9 +1567,9 @@ pub mod replica_config {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleId {
     pub value: Option<role_id::Value>,
 }
@@ -1621,9 +1586,9 @@ pub mod role_id {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Value {
         System(u64),
         User(u64),
@@ -1642,9 +1607,9 @@ pub mod role_id {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1660,9 +1625,9 @@ pub struct RoleAttributes {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<role_membership::Entry>,
 }
@@ -1680,9 +1645,9 @@ pub mod role_membership {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: Option<RoleId>,
         pub value: Option<RoleId>,
@@ -1698,9 +1663,9 @@ pub mod role_membership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<role_vars::Entry>,
 }
@@ -1717,9 +1682,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SqlSet {
         pub entries: Vec<String>,
     }
@@ -1733,9 +1698,9 @@ pub mod role_vars {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Entry {
         pub key: String,
         pub val: Option<entry::Val>,
@@ -1744,17 +1709,8 @@ pub mod role_vars {
     pub mod entry {
         use super::*;
 
-        #[derive(
-            Clone,
-            Debug,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Serialize,
-            Deserialize,
-            Arbitrary
-        )]
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Val {
             Flat(String),
             SqlSet(SqlSet),
@@ -1771,9 +1727,9 @@ pub mod role_vars {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1793,9 +1749,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Action {
         Allow(Empty),
     }
@@ -1809,9 +1765,9 @@ pub mod network_policy_rule {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Direction {
         Ingress(Empty),
     }
@@ -1827,9 +1783,9 @@ pub mod network_policy_rule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1844,9 +1800,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1863,9 +1819,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: Option<RoleId>,
     pub database_id: Option<DatabaseId>,
@@ -1884,11 +1840,11 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub privileges: Option<AclMode>,
 }
 
@@ -1902,9 +1858,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: Option<RoleId>,
     pub grantor: Option<RoleId>,
@@ -1920,11 +1876,11 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub acl_mode: Option<AclMode>,
 }
 
@@ -1937,19 +1893,19 @@ pub struct SystemPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
-    #[proptest(strategy = "0..=6")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(strategy = "0..=6"))]
     pub event_type: i32,
-    #[proptest(strategy = "0..=18")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(strategy = "0..=18"))]
     pub object_type: i32,
     pub user: Option<StringWrapper>,
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub occurred_at: Option<EpochMillis>,
-    #[proptest(filter = "Option::is_some")]
+    #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
     pub details: Option<audit_log_event_v1::Details>,
 }
 
@@ -1965,12 +1921,12 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
     }
 
@@ -1983,9 +1939,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
@@ -2001,9 +1957,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
@@ -2018,9 +1974,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
@@ -2036,9 +1992,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -2055,14 +2011,14 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub old_name: Option<FullNameV1>,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub new_name: Option<FullNameV1>,
     }
 
@@ -2075,9 +2031,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2098,9 +2054,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2110,7 +2066,7 @@ pub mod audit_log_event_v1 {
         pub disk: bool,
         pub billed_as: Option<String>,
         pub internal: bool,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub reason: Option<CreateOrDropClusterReplicaReasonV1>,
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
@@ -2124,9 +2080,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2136,7 +2092,7 @@ pub mod audit_log_event_v1 {
         pub disk: bool,
         pub billed_as: Option<String>,
         pub internal: bool,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub reason: Option<CreateOrDropClusterReplicaReasonV1>,
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
@@ -2150,9 +2106,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2161,7 +2117,7 @@ pub mod audit_log_event_v1 {
         pub logical_size: String,
         pub billed_as: Option<String>,
         pub internal: bool,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub reason: Option<CreateOrDropClusterReplicaReasonV1>,
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
@@ -2175,9 +2131,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -2194,15 +2150,15 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
         pub replica_id: Option<StringWrapper>,
         pub replica_name: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub reason: Option<CreateOrDropClusterReplicaReasonV1>,
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
@@ -2216,15 +2172,15 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
         pub replica_id: Option<StringWrapper>,
         pub replica_name: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub reason: Option<CreateOrDropClusterReplicaReasonV1>,
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
@@ -2239,11 +2195,11 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub reason: Option<create_or_drop_cluster_replica_reason_v1::Reason>,
     }
 
@@ -2259,9 +2215,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Reason {
             Manual(Empty),
             Schedule(Empty),
@@ -2278,11 +2234,11 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub on_refresh: Option<RefreshDecisionWithReasonV1>,
     }
 
@@ -2295,11 +2251,11 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub on_refresh: Option<RefreshDecisionWithReasonV2>,
     }
 
@@ -2312,13 +2268,13 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub decision: Option<refresh_decision_with_reason_v1::Decision>,
     }
 
@@ -2334,9 +2290,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2352,14 +2308,14 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
         pub rehydration_time_estimate: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub decision: Option<refresh_decision_with_reason_v2::Decision>,
     }
 
@@ -2375,9 +2331,9 @@ pub mod audit_log_event_v1 {
             PartialOrd,
             Ord,
             Serialize,
-            Deserialize,
-            Arbitrary
+            Deserialize
         )]
+        #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
         pub enum Decision {
             On(Empty),
             Off(Empty),
@@ -2393,12 +2349,12 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
         pub size: Option<StringWrapper>,
     }
@@ -2412,12 +2368,12 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
         pub size: Option<StringWrapper>,
         pub external_type: String,
@@ -2432,12 +2388,12 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
         pub external_type: String,
     }
@@ -2451,13 +2407,13 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
         pub external_type: String,
     }
@@ -2471,13 +2427,13 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
     }
 
@@ -2490,13 +2446,13 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
     }
 
@@ -2509,12 +2465,12 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
         pub old_size: Option<StringWrapper>,
         pub new_size: Option<StringWrapper>,
@@ -2529,12 +2485,12 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
         pub old_cluster: Option<StringWrapper>,
         pub new_cluster: Option<StringWrapper>,
@@ -2549,9 +2505,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2567,9 +2523,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2586,9 +2542,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
@@ -2603,9 +2559,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2622,9 +2578,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2641,9 +2597,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2661,9 +2617,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
@@ -2679,9 +2635,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
@@ -2697,9 +2653,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
@@ -2715,9 +2671,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2734,12 +2690,12 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub name: Option<FullNameV1>,
     }
 
@@ -2752,14 +2708,14 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub old_history: Option<String>,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub new_history: Option<String>,
     }
 
@@ -2772,9 +2728,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
@@ -2789,9 +2745,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
@@ -2806,9 +2762,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
@@ -2823,9 +2779,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
@@ -2840,10 +2796,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum EventType {
         Unknown = 0,
@@ -2864,10 +2820,10 @@ pub mod audit_log_event_v1 {
         Hash,
         PartialOrd,
         Ord,
-        Arbitrary,
         IntoPrimitive,
         TryFromPrimitive
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(i32)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2891,17 +2847,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2952,9 +2899,9 @@ pub mod audit_log_event_v1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StateUpdateKind {
     pub kind: Option<state_update_kind::Kind>,
 }
@@ -2971,11 +2918,11 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AuditLog {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub key: Option<AuditLogKey>,
     }
 
@@ -2988,9 +2935,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Cluster {
         pub key: Option<ClusterKey>,
         pub value: Option<ClusterValue>,
@@ -3005,9 +2952,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterReplica {
         pub key: Option<ClusterReplicaKey>,
         pub value: Option<ClusterReplicaValue>,
@@ -3022,9 +2969,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Comment {
         pub key: Option<CommentKey>,
         pub value: Option<CommentValue>,
@@ -3039,13 +2986,13 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Config {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub key: Option<ConfigKey>,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub value: Option<ConfigValue>,
     }
 
@@ -3058,9 +3005,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Database {
         pub key: Option<DatabaseKey>,
         pub value: Option<DatabaseValue>,
@@ -3076,9 +3023,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DefaultPrivileges {
         pub key: Option<DefaultPrivilegesKey>,
         pub value: Option<DefaultPrivilegesValue>,
@@ -3094,9 +3041,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FenceToken {
         pub deploy_generation: u64,
         pub epoch: i64,
@@ -3111,13 +3058,13 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdAlloc {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub key: Option<IdAllocKey>,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub value: Option<IdAllocValue>,
     }
 
@@ -3130,9 +3077,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ClusterIntrospectionSourceIndex {
         pub key: Option<ClusterIntrospectionSourceIndexKey>,
         pub value: Option<ClusterIntrospectionSourceIndexValue>,
@@ -3147,9 +3094,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Item {
         pub key: Option<ItemKey>,
         pub value: Option<ItemValue>,
@@ -3164,9 +3111,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Role {
         pub key: Option<RoleKey>,
         pub value: Option<RoleValue>,
@@ -3181,9 +3128,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RoleAuth {
         pub key: Option<RoleAuthKey>,
         pub value: Option<RoleAuthValue>,
@@ -3198,9 +3145,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct NetworkPolicy {
         pub key: Option<NetworkPolicyKey>,
         pub value: Option<NetworkPolicyValue>,
@@ -3215,9 +3162,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Schema {
         pub key: Option<SchemaKey>,
         pub value: Option<SchemaValue>,
@@ -3232,13 +3179,13 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct Setting {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub key: Option<SettingKey>,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub value: Option<SettingValue>,
     }
 
@@ -3251,13 +3198,13 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ServerConfiguration {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub key: Option<ServerConfigurationKey>,
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub value: Option<ServerConfigurationValue>,
     }
 
@@ -3270,9 +3217,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SourceReferences {
         pub key: Option<SourceReferencesKey>,
         pub value: Option<SourceReferencesValue>,
@@ -3287,9 +3234,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GidMapping {
         pub key: Option<GidMappingKey>,
         pub value: Option<GidMappingValue>,
@@ -3305,9 +3252,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SystemPrivileges {
         pub key: Option<SystemPrivilegesKey>,
         pub value: Option<SystemPrivilegesValue>,
@@ -3322,9 +3269,9 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct StorageCollectionMetadata {
         pub key: Option<StorageCollectionMetadataKey>,
         pub value: Option<StorageCollectionMetadataValue>,
@@ -3339,11 +3286,11 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UnfinalizedShard {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub key: Option<UnfinalizedShardKey>,
     }
 
@@ -3356,25 +3303,16 @@ pub mod state_update_kind {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct TxnWalShard {
-        #[proptest(filter = "Option::is_some")]
+        #[cfg_attr(any(test, feature = "proptest"), proptest(filter = "Option::is_some"))]
         pub value: Option<TxnWalShardValue>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
     // persist pushdown statistics for success.
     #[serde(tag = "kind")]
@@ -3414,10 +3352,10 @@ pub mod state_update_kind {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -3443,10 +3381,10 @@ pub enum CatalogItemType {
     Hash,
     PartialOrd,
     Ord,
-    Arbitrary,
     IntoPrimitive,
     TryFromPrimitive
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(i32)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v79.rs
+++ b/src/catalog-protos/src/objects_v79.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -583,24 +413,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -614,40 +435,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -663,54 +466,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -724,22 +500,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -753,9 +520,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -770,9 +537,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -786,39 +553,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -832,9 +581,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -851,9 +600,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -865,9 +614,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -879,9 +628,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -899,9 +648,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -913,9 +662,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -927,9 +676,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -944,9 +693,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -961,9 +710,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -978,9 +727,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -995,9 +744,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1012,9 +761,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1029,9 +778,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1046,9 +795,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1063,9 +812,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1080,25 +829,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1113,9 +853,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1129,57 +869,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1189,49 +902,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1240,17 +926,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1265,9 +942,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1284,26 +961,17 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
     pub login: Option<bool>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1317,72 +985,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1399,9 +1031,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1415,9 +1047,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1431,9 +1063,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1447,9 +1079,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1465,9 +1097,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1485,9 +1117,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1501,9 +1133,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1518,24 +1150,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1548,83 +1171,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1632,34 +1210,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1671,17 +1231,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1695,17 +1246,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1719,17 +1261,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1742,17 +1275,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1760,17 +1284,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1780,17 +1295,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1809,9 +1315,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1825,89 +1331,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1915,34 +1376,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1950,34 +1393,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -1985,51 +1410,24 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2037,17 +1435,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2055,34 +1444,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2090,33 +1461,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2124,17 +1477,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2142,17 +1486,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2161,68 +1496,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2230,98 +1529,44 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
@@ -2337,9 +1582,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2361,9 +1606,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2387,17 +1632,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2440,17 +1676,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2480,96 +1707,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2584,9 +1757,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2601,185 +1774,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2794,56 +1868,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2858,9 +1905,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2887,9 +1934,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v80.rs
+++ b/src/catalog-protos/src/objects_v80.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -583,24 +413,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -614,40 +435,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -663,54 +466,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -724,22 +500,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -753,9 +520,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -770,9 +537,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -786,39 +553,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -832,9 +581,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -851,9 +600,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -865,9 +614,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -879,9 +628,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -899,9 +648,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -913,9 +662,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -927,9 +676,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -944,9 +693,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -961,9 +710,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -978,9 +727,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -995,9 +744,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1012,9 +761,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1029,9 +778,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1046,9 +795,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1063,9 +812,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1080,25 +829,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1113,9 +853,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1129,57 +869,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1189,49 +902,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1240,17 +926,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1265,9 +942,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1284,26 +961,17 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
     pub login: Option<bool>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1317,72 +985,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1399,9 +1031,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1415,9 +1047,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1431,9 +1063,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1447,9 +1079,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1465,9 +1097,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1485,9 +1117,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1501,9 +1133,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1518,24 +1150,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1548,83 +1171,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1632,34 +1210,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1671,17 +1231,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1695,17 +1246,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1719,17 +1261,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1742,17 +1275,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1760,17 +1284,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1780,17 +1295,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1809,9 +1315,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1825,89 +1331,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1915,34 +1376,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1950,34 +1393,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -1985,34 +1410,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2020,33 +1427,15 @@ pub mod audit_log_event_v1 {
         pub replacement_target_id: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterApplyReplacementV1 {
         pub target: IdFullNameV1,
         pub replacement: IdFullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2054,17 +1443,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2072,34 +1452,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2107,33 +1469,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2141,17 +1485,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2159,17 +1494,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2178,68 +1504,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2247,98 +1537,44 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
@@ -2354,9 +1590,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2378,9 +1614,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2404,17 +1640,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2458,17 +1685,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2498,96 +1716,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2602,9 +1766,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2619,185 +1783,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2812,56 +1877,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2876,9 +1914,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2905,9 +1943,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v81.rs
+++ b/src/catalog-protos/src/objects_v81.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -583,24 +413,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -614,40 +435,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -663,54 +466,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -724,22 +500,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -753,9 +520,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -770,9 +537,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -786,39 +553,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -832,9 +581,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -851,9 +600,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -865,9 +614,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -879,9 +628,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -899,9 +648,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -913,9 +662,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -927,9 +676,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -944,9 +693,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -961,9 +710,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -978,9 +727,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -995,9 +744,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1012,9 +761,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1029,9 +778,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1046,9 +795,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1063,9 +812,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1080,25 +829,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1113,9 +853,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1129,57 +869,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1189,49 +902,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1240,17 +926,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1265,9 +942,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1284,9 +961,9 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AutoProvisionSource {
     Oidc = 0,
     Frontegg = 1,
@@ -1302,9 +979,9 @@ pub enum AutoProvisionSource {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1312,17 +989,8 @@ pub struct RoleAttributes {
     pub auto_provision_source: Option<AutoProvisionSource>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1336,72 +1004,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1418,9 +1050,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1434,9 +1066,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1450,9 +1082,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1466,9 +1098,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1484,9 +1116,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1504,9 +1136,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1520,9 +1152,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1537,24 +1169,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1567,83 +1190,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1651,34 +1229,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1690,17 +1250,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1714,17 +1265,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1738,17 +1280,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1761,17 +1294,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1779,17 +1303,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1799,17 +1314,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1828,9 +1334,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1844,89 +1350,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1934,34 +1395,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1969,34 +1412,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2004,34 +1429,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2039,33 +1446,15 @@ pub mod audit_log_event_v1 {
         pub replacement_target_id: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterApplyReplacementV1 {
         pub target: IdFullNameV1,
         pub replacement: IdFullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2073,17 +1462,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2091,34 +1471,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2126,33 +1488,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2160,17 +1504,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2178,17 +1513,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2197,68 +1523,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2266,114 +1556,51 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateRoleV1 {
         pub id: String,
         pub name: String,
@@ -2390,9 +1617,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2414,9 +1641,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2440,17 +1667,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2495,17 +1713,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2535,96 +1744,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2639,9 +1794,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2656,185 +1811,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2849,56 +1905,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2913,9 +1942,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2942,9 +1971,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v82.rs
+++ b/src/catalog-protos/src/objects_v82.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -582,24 +412,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -613,40 +434,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -662,54 +465,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -723,22 +499,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -752,9 +519,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -769,9 +536,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -785,39 +552,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -831,9 +580,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -850,9 +599,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -864,9 +613,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -878,9 +627,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -898,9 +647,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -912,9 +661,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -926,9 +675,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -943,9 +692,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -960,9 +709,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -977,9 +726,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -994,9 +743,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1011,9 +760,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1028,9 +777,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1045,9 +794,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1062,9 +811,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1079,25 +828,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1112,9 +852,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1128,57 +868,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1188,49 +901,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1239,17 +925,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1264,9 +941,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1283,9 +960,9 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AutoProvisionSource {
     Oidc = 0,
     Frontegg = 1,
@@ -1301,9 +978,9 @@ pub enum AutoProvisionSource {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1311,17 +988,8 @@ pub struct RoleAttributes {
     pub auto_provision_source: Option<AutoProvisionSource>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1335,72 +1003,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1417,9 +1049,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1433,9 +1065,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1449,9 +1081,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1465,9 +1097,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1483,9 +1115,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1503,9 +1135,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1519,9 +1151,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1536,24 +1168,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1566,83 +1189,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1650,34 +1228,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1689,17 +1249,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1713,17 +1264,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1737,17 +1279,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1760,17 +1293,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1778,17 +1302,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1798,17 +1313,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1827,9 +1333,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1843,89 +1349,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1933,34 +1394,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1968,34 +1411,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2003,34 +1428,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2038,33 +1445,15 @@ pub mod audit_log_event_v1 {
         pub replacement_target_id: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterApplyReplacementV1 {
         pub target: IdFullNameV1,
         pub replacement: IdFullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2072,17 +1461,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2090,34 +1470,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2125,33 +1487,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2159,17 +1503,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2177,17 +1512,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2196,68 +1522,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2265,114 +1555,51 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateRoleV1 {
         pub id: String,
         pub name: String,
@@ -2389,9 +1616,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2413,9 +1640,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2439,17 +1666,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2494,17 +1712,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2534,96 +1743,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2638,9 +1793,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2655,185 +1810,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2848,56 +1904,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2912,9 +1941,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2940,9 +1969,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v83.rs
+++ b/src/catalog-protos/src/objects_v83.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -582,24 +412,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -613,40 +434,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -662,54 +465,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -723,22 +499,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -752,9 +519,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -769,9 +536,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -785,39 +552,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -831,9 +580,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -850,9 +599,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -864,9 +613,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -878,9 +627,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -898,9 +647,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -912,9 +661,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -926,9 +675,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -943,9 +692,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -960,9 +709,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -977,9 +726,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -994,9 +743,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1011,9 +760,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1028,9 +777,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1045,9 +794,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1062,9 +811,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1079,25 +828,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1112,9 +852,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1128,57 +868,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1188,49 +901,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1239,17 +925,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1264,9 +941,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1283,9 +960,9 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AutoProvisionSource {
     Oidc = 0,
     Frontegg = 1,
@@ -1301,9 +978,9 @@ pub enum AutoProvisionSource {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1311,17 +988,8 @@ pub struct RoleAttributes {
     pub auto_provision_source: Option<AutoProvisionSource>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1335,72 +1003,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1417,9 +1049,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1433,9 +1065,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1449,9 +1081,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1465,9 +1097,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1483,9 +1115,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1503,9 +1135,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1519,9 +1151,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1536,24 +1168,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1566,83 +1189,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1650,34 +1228,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1689,17 +1249,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1713,17 +1264,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1737,17 +1279,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1760,17 +1293,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1778,17 +1302,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1798,17 +1313,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1827,9 +1333,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1843,89 +1349,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1933,34 +1394,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1968,34 +1411,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2003,34 +1428,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2038,33 +1445,15 @@ pub mod audit_log_event_v1 {
         pub replacement_target_id: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterApplyReplacementV1 {
         pub target: IdFullNameV1,
         pub replacement: IdFullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2072,17 +1461,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2090,34 +1470,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2125,33 +1487,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2159,17 +1503,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2177,17 +1512,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2196,68 +1522,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2265,114 +1555,51 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateRoleV1 {
         pub id: String,
         pub name: String,
@@ -2389,9 +1616,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2413,9 +1640,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2439,17 +1666,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2494,17 +1712,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2534,96 +1743,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2638,9 +1793,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2655,185 +1810,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2848,56 +1904,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2912,9 +1941,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2940,9 +1969,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v84.rs
+++ b/src/catalog-protos/src/objects_v84.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -582,24 +412,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -613,40 +434,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -662,54 +465,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -723,22 +499,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -752,9 +519,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -769,9 +536,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -785,39 +552,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -831,9 +580,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -850,9 +599,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -864,9 +613,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -878,9 +627,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -898,9 +647,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -912,9 +661,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -926,9 +675,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -943,9 +692,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -960,9 +709,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -977,9 +726,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -994,9 +743,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1011,9 +760,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1028,9 +777,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1045,9 +794,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1062,9 +811,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1079,25 +828,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1112,9 +852,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1128,57 +868,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1188,49 +901,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1239,17 +925,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1264,9 +941,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1283,9 +960,9 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AutoProvisionSource {
     Oidc = 0,
     Frontegg = 1,
@@ -1301,9 +978,9 @@ pub enum AutoProvisionSource {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1311,17 +988,8 @@ pub struct RoleAttributes {
     pub auto_provision_source: Option<AutoProvisionSource>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1335,72 +1003,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1417,9 +1049,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1433,9 +1065,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1449,9 +1081,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1465,9 +1097,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1483,9 +1115,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1503,9 +1135,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1519,9 +1151,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1536,24 +1168,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1566,83 +1189,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1650,34 +1228,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1689,17 +1249,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1713,17 +1264,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1737,17 +1279,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1760,17 +1293,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1778,17 +1302,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1798,17 +1313,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1827,9 +1333,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1843,89 +1349,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1933,34 +1394,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1968,34 +1411,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2003,34 +1428,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2038,33 +1445,15 @@ pub mod audit_log_event_v1 {
         pub replacement_target_id: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterApplyReplacementV1 {
         pub target: IdFullNameV1,
         pub replacement: IdFullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2072,17 +1461,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2090,34 +1470,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2125,33 +1487,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2159,17 +1503,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2177,17 +1512,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2196,68 +1522,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2265,114 +1555,51 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateRoleV1 {
         pub id: String,
         pub name: String,
@@ -2389,9 +1616,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2413,9 +1640,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2439,17 +1666,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2494,17 +1712,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2534,96 +1743,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2638,9 +1793,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2655,185 +1810,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2848,56 +1904,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2912,9 +1941,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2940,9 +1969,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog-protos/src/objects_v85.rs
+++ b/src/catalog-protos/src/objects_v85.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(any(test, feature = "proptest"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigKey {
     pub key: String,
 }
@@ -35,54 +27,27 @@ pub struct ConfigKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ConfigValue {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SettingValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocKey {
     pub name: String,
 }
@@ -96,41 +61,23 @@ pub struct IdAllocKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAllocValue {
     pub next_id: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingKey {
     pub schema_name: String,
     pub object_type: CatalogItemType,
     pub object_name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMappingValue {
     pub catalog_id: SystemCatalogItemId,
     pub global_id: SystemGlobalId,
@@ -146,24 +93,15 @@ pub struct GidMappingValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterKey {
     pub id: ClusterId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -171,17 +109,8 @@ pub struct ClusterValue {
     pub config: ClusterConfig,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexKey {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -196,9 +125,9 @@ pub struct ClusterIntrospectionSourceIndexKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndexValue {
     pub catalog_id: IntrospectionSourceIndexCatalogItemId,
     pub global_id: IntrospectionSourceIndexGlobalId,
@@ -214,24 +143,15 @@ pub struct ClusterIntrospectionSourceIndexValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaKey {
     pub id: ReplicaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaValue {
     pub cluster_id: ClusterId,
     pub name: String,
@@ -248,24 +168,15 @@ pub struct ClusterReplicaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseKey {
     pub id: DatabaseId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DatabaseValue {
     pub name: String,
     pub owner_id: RoleId,
@@ -282,24 +193,15 @@ pub struct DatabaseValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaKey {
     pub id: SchemaId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SchemaValue {
     pub database_id: Option<DatabaseId>,
     pub name: String,
@@ -317,24 +219,15 @@ pub struct SchemaValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemKey {
     pub gid: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemValue {
     pub schema_id: SchemaId,
     pub name: String,
@@ -355,9 +248,9 @@ pub struct ItemValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ItemVersion {
     pub global_id: GlobalId,
     pub version: Version,
@@ -372,24 +265,15 @@ pub struct ItemVersion {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleValue {
     pub name: String,
     pub attributes: RoleAttributes,
@@ -407,24 +291,15 @@ pub struct RoleValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthKey {
     pub id: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuthValue {
     pub password_hash: Option<String>,
     pub updated_at: EpochMillis,
@@ -439,24 +314,15 @@ pub struct RoleAuthValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyKey {
     pub id: NetworkPolicyId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyValue {
     pub name: String,
     pub rules: Vec<NetworkPolicyRule>,
@@ -465,62 +331,26 @@ pub struct NetworkPolicyValue {
     pub oid: u32,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationKey {
     pub name: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfigurationValue {
     pub value: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogKey {
     pub event: AuditLogEvent,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AuditLogEvent {
     V1(AuditLogEventV1),
 }
@@ -534,9 +364,9 @@ pub enum AuditLogEvent {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentKey {
     pub object: CommentObject,
     pub sub_component: Option<CommentSubComponent>,
@@ -551,9 +381,9 @@ pub struct CommentKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentObject {
     Table(CatalogItemId),
     View(CatalogItemId),
@@ -582,24 +412,15 @@ pub enum CommentObject {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CommentSubComponent {
     ColumnPos(u64),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CommentValue {
     pub comment: String,
 }
@@ -613,40 +434,22 @@ pub struct CommentValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub source: CatalogItemId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub references: Vec<SourceReference>,
     pub updated_at: EpochMillis,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -662,54 +465,27 @@ pub struct SourceReference {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataKey {
     pub id: GlobalId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadataValue {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShardKey {
     pub shard: String,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShardValue {
     pub shard: String,
 }
@@ -723,22 +499,13 @@ pub struct TxnWalShardValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Empty {}
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StringWrapper {
     pub inner: String,
 }
@@ -752,9 +519,9 @@ pub struct StringWrapper {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
@@ -769,9 +536,9 @@ pub struct Duration {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct EpochMillis {
     pub millis: u64,
 }
@@ -785,39 +552,21 @@ pub struct EpochMillis {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Version {
     pub value: u64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItem {
     V1(CatalogItemV1),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct CatalogItemV1 {
     pub create_sql: String,
 }
@@ -831,9 +580,9 @@ pub struct CatalogItemV1 {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum CatalogItemId {
     System(u64),
     User(u64),
@@ -850,9 +599,9 @@ pub enum CatalogItemId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemCatalogItemId(pub u64);
 
 #[derive(
@@ -864,9 +613,9 @@ pub struct SystemCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
 
 #[derive(
@@ -878,9 +627,9 @@ pub struct IntrospectionSourceIndexCatalogItemId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum GlobalId {
     System(u64),
     User(u64),
@@ -898,9 +647,9 @@ pub enum GlobalId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemGlobalId(pub u64);
 
 #[derive(
@@ -912,9 +661,9 @@ pub struct SystemGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IntrospectionSourceIndexGlobalId(pub u64);
 
 #[derive(
@@ -926,9 +675,9 @@ pub struct IntrospectionSourceIndexGlobalId(pub u64);
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterId {
     System(u64),
     User(u64),
@@ -943,9 +692,9 @@ pub enum ClusterId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum DatabaseId {
     System(u64),
     User(u64),
@@ -960,9 +709,9 @@ pub enum DatabaseId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ResolvedDatabaseSpecifier {
     Ambient,
     Id(DatabaseId),
@@ -977,9 +726,9 @@ pub enum ResolvedDatabaseSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaId {
     System(u64),
     User(u64),
@@ -994,9 +743,9 @@ pub enum SchemaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum SchemaSpecifier {
     Temporary,
     Id(SchemaId),
@@ -1011,9 +760,9 @@ pub enum SchemaSpecifier {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ResolvedSchema {
     pub database: ResolvedDatabaseSpecifier,
     pub schema: SchemaSpecifier,
@@ -1028,9 +777,9 @@ pub struct ResolvedSchema {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaId {
     System(u64),
     User(u64),
@@ -1045,9 +794,9 @@ pub enum ReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplicaId {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
@@ -1062,9 +811,9 @@ pub struct ClusterReplicaId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyId {
     System(u64),
     User(u64),
@@ -1079,25 +828,16 @@ pub enum NetworkPolicyId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaLogging {
     pub log_logging: bool,
     pub interval: Option<Duration>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct OptimizerFeatureOverride {
     pub name: String,
     pub value: String,
@@ -1112,9 +852,9 @@ pub struct OptimizerFeatureOverride {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterScheduleRefreshOptions {
     pub rehydration_time_estimate: Duration,
 }
@@ -1128,57 +868,30 @@ pub struct ClusterScheduleRefreshOptions {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterSchedule {
     Manual,
     Refresh(ClusterScheduleRefreshOptions),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterConfig {
     pub workload_class: Option<String>,
     pub variant: ClusterVariant,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ClusterVariant {
     Unmanaged,
     Managed(ManagedCluster),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedCluster {
     pub size: String,
     pub replication_factor: u32,
@@ -1188,49 +901,22 @@ pub struct ManagedCluster {
     pub schedule: ClusterSchedule,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ReplicaConfig {
     pub logging: ReplicaLogging,
     pub location: ReplicaLocation,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnmanagedLocation {
     pub storagectl_addrs: Vec<String>,
     pub computectl_addrs: Vec<String>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ManagedLocation {
     pub size: String,
     pub availability_zone: Option<String>,
@@ -1239,17 +925,8 @@ pub struct ManagedLocation {
     pub pending: bool,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum ReplicaLocation {
     Unmanaged(UnmanagedLocation),
     Managed(ManagedLocation),
@@ -1264,9 +941,9 @@ pub enum ReplicaLocation {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleId {
     System(u64),
     User(u64),
@@ -1283,9 +960,9 @@ pub enum RoleId {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum AutoProvisionSource {
     Oidc = 0,
     Frontegg = 1,
@@ -1301,9 +978,9 @@ pub enum AutoProvisionSource {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAttributes {
     pub inherit: bool,
     pub superuser: Option<bool>,
@@ -1311,17 +988,8 @@ pub struct RoleAttributes {
     pub auto_provision_source: Option<AutoProvisionSource>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembership {
     pub map: Vec<RoleMembershipEntry>,
 }
@@ -1335,72 +1003,36 @@ pub struct RoleMembership {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleMembershipEntry {
     pub key: RoleId,
     pub value: RoleId,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVars {
     pub entries: Vec<RoleVarsEntry>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleVarsEntry {
     pub key: String,
     pub val: RoleVar,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum RoleVar {
     Flat(String),
     SqlSet(Vec<String>),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicyRule {
     pub name: String,
     pub address: String,
@@ -1417,9 +1049,9 @@ pub struct NetworkPolicyRule {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleAction {
     Allow,
 }
@@ -1433,9 +1065,9 @@ pub enum NetworkPolicyRuleAction {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub enum NetworkPolicyRuleDirection {
     Ingress,
 }
@@ -1449,9 +1081,9 @@ pub enum NetworkPolicyRuleDirection {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AclMode {
     pub bitflags: u64,
 }
@@ -1465,9 +1097,9 @@ pub struct AclMode {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct MzAclItem {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1483,9 +1115,9 @@ pub struct MzAclItem {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesKey {
     pub role_id: RoleId,
     pub database_id: Option<DatabaseId>,
@@ -1503,9 +1135,9 @@ pub struct DefaultPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivilegesValue {
     pub privileges: AclMode,
 }
@@ -1519,9 +1151,9 @@ pub struct DefaultPrivilegesValue {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesKey {
     pub grantee: RoleId,
     pub grantor: RoleId,
@@ -1536,24 +1168,15 @@ pub struct SystemPrivilegesKey {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivilegesValue {
     pub acl_mode: AclMode,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLogEventV1 {
     pub id: u64,
     pub event_type: audit_log_event_v1::EventType,
@@ -1566,83 +1189,38 @@ pub struct AuditLogEventV1 {
 pub mod audit_log_event_v1 {
     use super::*;
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdFullNameV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FullNameV1 {
         pub database: String,
         pub schema: String,
         pub item: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct IdNameV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterV1 {
         pub id: String,
         pub old_name: String,
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameClusterReplicaV1 {
         pub cluster_id: String,
         pub replica_id: String,
@@ -1650,34 +1228,16 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameItemV1 {
         pub id: String,
         pub old_name: FullNameV1,
         pub new_name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1689,17 +1249,8 @@ pub mod audit_log_event_v1 {
         pub internal: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1713,17 +1264,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1737,17 +1279,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateClusterReplicaV4 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1760,17 +1293,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV2>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV1 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1778,17 +1302,8 @@ pub mod audit_log_event_v1 {
         pub replica_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV2 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1798,17 +1313,8 @@ pub mod audit_log_event_v1 {
         pub scheduling_policies: Option<SchedulingDecisionsWithReasonsV1>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct DropClusterReplicaV3 {
         pub cluster_id: String,
         pub cluster_name: String,
@@ -1827,9 +1333,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateOrDropClusterReplicaReasonV1 {
         pub reason: CreateOrDropClusterReplicaReasonV1Reason,
     }
@@ -1843,89 +1349,44 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize,
-        Deserialize,
-        Arbitrary
+        Deserialize
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum CreateOrDropClusterReplicaReasonV1Reason {
         Manual(Empty),
         Schedule(Empty),
         System(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV1 {
         pub on_refresh: RefreshDecisionWithReasonV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchedulingDecisionsWithReasonsV2 {
         pub on_refresh: RefreshDecisionWithReasonV2,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum RefreshDecision {
         On(Empty),
         Off(Empty),
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV1 {
         pub objects_needing_refresh: Vec<String>,
         pub rehydration_time_estimate: String,
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RefreshDecisionWithReasonV2 {
         pub objects_needing_refresh: Vec<String>,
         pub objects_needing_compaction: Vec<String>,
@@ -1933,34 +1394,16 @@ pub mod audit_log_event_v1 {
         pub decision: RefreshDecision,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
         pub size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV2 {
         pub id: String,
         pub name: FullNameV1,
@@ -1968,34 +1411,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV3 {
         pub id: String,
         pub name: FullNameV1,
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateSourceSinkV4 {
         pub id: String,
         pub cluster_id: Option<StringWrapper>,
@@ -2003,34 +1428,16 @@ pub mod audit_log_event_v1 {
         pub external_type: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateIndexV1 {
         pub id: String,
         pub cluster_id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateMaterializedViewV1 {
         pub id: String,
         pub cluster_id: String,
@@ -2038,33 +1445,15 @@ pub mod audit_log_event_v1 {
         pub replacement_target_id: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterApplyReplacementV1 {
         pub target: IdFullNameV1,
         pub replacement: IdFullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceSinkV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2072,17 +1461,8 @@ pub mod audit_log_event_v1 {
         pub new_size: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSetClusterV1 {
         pub id: String,
         pub name: FullNameV1,
@@ -2090,34 +1470,16 @@ pub mod audit_log_event_v1 {
         pub new_cluster_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV1 {
         pub role_id: String,
         pub member_id: String,
         pub grantor_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct GrantRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2125,33 +1487,15 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV1 {
         pub role_id: String,
         pub member_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RevokeRoleV2 {
         pub role_id: String,
         pub member_id: String,
@@ -2159,17 +1503,8 @@ pub mod audit_log_event_v1 {
         pub executed_by: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdatePrivilegeV1 {
         pub object_id: String,
         pub grantee_id: String,
@@ -2177,17 +1512,8 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterDefaultPrivilegeV1 {
         pub role_id: String,
         pub database_id: Option<StringWrapper>,
@@ -2196,68 +1522,32 @@ pub mod audit_log_event_v1 {
         pub privileges: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateOwnerV1 {
         pub object_id: String,
         pub old_owner_id: String,
         pub new_owner_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV1 {
         pub id: String,
         pub name: String,
         pub database_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SchemaV2 {
         pub id: String,
         pub name: String,
         pub database_name: Option<StringWrapper>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RenameSchemaV1 {
         pub id: String,
         pub database_name: Option<String>,
@@ -2265,50 +1555,23 @@ pub mod audit_log_event_v1 {
         pub new_name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct UpdateItemV1 {
         pub id: String,
         pub name: FullNameV1,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterRetainHistoryV1 {
         pub id: String,
         pub old_history: Option<String>,
         pub new_history: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterAddColumnV1 {
         pub id: String,
         pub column: String,
@@ -2316,98 +1579,44 @@ pub mod audit_log_event_v1 {
         pub nullable: bool,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct AlterSourceTimestampIntervalV1 {
         pub id: String,
         pub old_interval: Option<String>,
         pub new_interval: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct ToNewIdV1 {
         pub id: String,
         pub new_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct FromPreviousIdV1 {
         pub id: String,
         pub previous_id: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct SetV1 {
         pub name: String,
         pub value: Option<String>,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct RotateKeysV1 {
         pub id: String,
         pub name: String,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub struct CreateRoleV1 {
         pub id: String,
         pub name: String,
@@ -2424,9 +1633,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum EventType {
         Unknown = 0,
@@ -2448,9 +1657,9 @@ pub mod audit_log_event_v1 {
         PartialOrd,
         Ord,
         Serialize_repr,
-        Deserialize_repr,
-        Arbitrary
+        Deserialize_repr
     )]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     #[repr(u8)]
     pub enum ObjectType {
         Unknown = 0,
@@ -2474,17 +1683,8 @@ pub mod audit_log_event_v1 {
         NetworkPolicy = 18,
     }
 
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Serialize,
-        Deserialize,
-        Arbitrary
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
     pub enum Details {
         CreateClusterReplicaV1(CreateClusterReplicaV1),
         CreateClusterReplicaV2(CreateClusterReplicaV2),
@@ -2531,17 +1731,8 @@ pub mod audit_log_event_v1 {
 }
 
 /// The contents of a single state update.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 // Serialize the top-level enum in the persist-backed catalog as internally tagged to set up
 // persist pushdown statistics for success.
 #[serde(tag = "kind")]
@@ -2571,96 +1762,42 @@ pub enum StateUpdateKind {
     UnfinalizedShard(UnfinalizedShard),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct AuditLog {
     pub key: AuditLogKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Cluster {
     pub key: ClusterKey,
     pub value: ClusterValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterReplica {
     pub key: ClusterReplicaKey,
     pub value: ClusterReplicaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Comment {
     pub key: CommentKey,
     pub value: CommentValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Config {
     pub key: ConfigKey,
     pub value: ConfigValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Database {
     pub key: DatabaseKey,
     pub value: DatabaseValue,
@@ -2675,9 +1812,9 @@ pub struct Database {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct DefaultPrivileges {
     pub key: DefaultPrivilegesKey,
     pub value: DefaultPrivilegesValue,
@@ -2692,185 +1829,86 @@ pub struct DefaultPrivileges {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct FenceToken {
     pub deploy_generation: u64,
     pub epoch: i64,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct IdAlloc {
     pub key: IdAllocKey,
     pub value: IdAllocValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ClusterIntrospectionSourceIndex {
     pub key: ClusterIntrospectionSourceIndexKey,
     pub value: ClusterIntrospectionSourceIndexValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Item {
     pub key: ItemKey,
     pub value: ItemValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Role {
     pub key: RoleKey,
     pub value: RoleValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct RoleAuth {
     pub key: RoleAuthKey,
     pub value: RoleAuthValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct NetworkPolicy {
     pub key: NetworkPolicyKey,
     pub value: NetworkPolicyValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Schema {
     pub key: SchemaKey,
     pub value: SchemaValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct Setting {
     pub key: SettingKey,
     pub value: SettingValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct ServerConfiguration {
     pub key: ServerConfigurationKey,
     pub value: ServerConfigurationValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SourceReferences {
     pub key: SourceReferencesKey,
     pub value: SourceReferencesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct GidMapping {
     pub key: GidMappingKey,
     pub value: GidMappingValue,
@@ -2885,56 +1923,29 @@ pub struct GidMapping {
     PartialOrd,
     Ord,
     Serialize,
-    Deserialize,
-    Arbitrary
+    Deserialize
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct SystemPrivileges {
     pub key: SystemPrivilegesKey,
     pub value: SystemPrivilegesValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct StorageCollectionMetadata {
     pub key: StorageCollectionMetadataKey,
     pub value: StorageCollectionMetadataValue,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct UnfinalizedShard {
     pub key: UnfinalizedShardKey,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    Arbitrary
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 pub struct TxnWalShard {
     pub value: TxnWalShardValue,
 }
@@ -2949,9 +1960,9 @@ pub struct TxnWalShard {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum CatalogItemType {
     Unknown = 0,
@@ -2977,9 +1988,9 @@ pub enum CatalogItemType {
     PartialOrd,
     Ord,
     Serialize_repr,
-    Deserialize_repr,
-    Arbitrary
+    Deserialize_repr
 )]
+#[cfg_attr(any(test, feature = "proptest"), derive(Arbitrary))]
 #[repr(u8)]
 pub enum ObjectType {
     Unknown = 0,

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -53,8 +53,6 @@ mz-transform = { path = "../transform" }
 openssl.workspace = true
 paste.workspace = true
 prometheus.workspace = true
-proptest.workspace = true
-proptest-derive.workspace = true
 prost.workspace = true
 rand.workspace = true
 semver.workspace = true
@@ -72,6 +70,9 @@ uuid.workspace = true
 [dev-dependencies]
 base64.workspace = true
 insta.workspace = true
+mz-catalog-protos = { path = "../catalog-protos", features = ["proptest"] }
+proptest.workspace = true
+proptest-derive.workspace = true
 
 [features]
 default = []

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -45,6 +45,7 @@ use mz_sql::catalog::{
 };
 use mz_sql::names::{CommentObjectId, DatabaseId, SchemaId};
 use mz_sql::plan::{ClusterSchedule, NetworkPolicyRule};
+#[cfg(test)]
 use proptest_derive::Arbitrary;
 
 use crate::builtin::RUNTIME_ALTERABLE_FINGERPRINT_SENTINEL;
@@ -586,7 +587,8 @@ pub struct SourceReferences {
     pub references: Vec<SourceReference>,
 }
 
-#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Arbitrary)]
+#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,
@@ -1172,7 +1174,8 @@ impl Snapshot {
 ///
 /// Every time a new process takes over, the `epoch` should be incremented.
 /// Every time a new version is deployed, the `deploy` generation should be incremented.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct FenceToken {
     pub(crate) deploy_generation: u64,
     pub(crate) epoch: Epoch,
@@ -1265,12 +1268,14 @@ pub struct ClusterReplicaValue {
     pub(crate) owner_id: RoleId,
 }
 
-#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
+#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Ord, Hash)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct DatabaseKey {
     pub(crate) id: DatabaseId,
 }
 
-#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord, Arbitrary)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct DatabaseValue {
     pub(crate) name: String,
     pub(crate) owner_id: RoleId,
@@ -1278,23 +1283,27 @@ pub struct DatabaseValue {
     pub(crate) oid: u32,
 }
 
-#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
+#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Ord, Hash)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct SourceReferencesKey {
     pub(crate) source_id: CatalogItemId,
 }
 
-#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord, Arbitrary)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct SourceReferencesValue {
     pub(crate) references: Vec<SourceReference>,
     pub(crate) updated_at: u64,
 }
 
-#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
+#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Ord, Hash)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct SchemaKey {
     pub(crate) id: SchemaId,
 }
 
-#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord, Arbitrary)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct SchemaValue {
     pub(crate) database_id: Option<DatabaseId>,
     pub(crate) name: String,
@@ -1303,12 +1312,14 @@ pub struct SchemaValue {
     pub(crate) oid: u32,
 }
 
-#[derive(Clone, PartialOrd, PartialEq, Eq, Ord, Hash, Debug, Arbitrary)]
+#[derive(Clone, PartialOrd, PartialEq, Eq, Ord, Hash, Debug)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct ItemKey {
     pub(crate) id: CatalogItemId,
 }
 
-#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord, Arbitrary)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct ItemValue {
     pub(crate) schema_id: SchemaId,
     pub(crate) name: String,
@@ -1363,7 +1374,8 @@ pub struct CommentKey {
     pub(crate) sub_component: Option<usize>,
 }
 
-#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord, Arbitrary)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct CommentValue {
     pub(crate) comment: String,
 }

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -43,6 +43,7 @@ use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::adt::numeric::{Dec, Numeric};
 use mz_storage_types::StorageDiff;
 use mz_storage_types::sources::SourceData;
+#[cfg(test)]
 use proptest_derive::Arbitrary;
 use tracing::error;
 
@@ -216,7 +217,8 @@ impl StateUpdate {
 ///
 /// The entire catalog is serialized as bytes and saved in a single persist shard. We use this
 /// enum to determine what collection something in the catalog belongs to.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum StateUpdateKind {
     AuditLog(proto::AuditLogKey, ()),
     Cluster(proto::ClusterKey, proto::ClusterValue),

--- a/src/catalog/src/durable/upgrade/json_compatible.rs
+++ b/src/catalog/src/durable/upgrade/json_compatible.rs
@@ -46,13 +46,11 @@ macro_rules! json_compatible {
     ($a:ident $(:: $a_sub:ident)* with $b:ident $(:: $b_sub:ident)*) => {
         ::static_assertions::assert_impl_all!(
             $a $(::$a_sub)* :
-                ::proptest::arbitrary::Arbitrary,
                 ::serde::Serialize,
                 ::serde::de::DeserializeOwned,
         );
         ::static_assertions::assert_impl_all!(
             $b $(::$b_sub)* :
-                ::proptest::arbitrary::Arbitrary,
                 ::serde::Serialize,
                 ::serde::de::DeserializeOwned,
         );
@@ -67,6 +65,18 @@ macro_rules! json_compatible {
             ::JsonCompatible< $a $(::$a_sub)* >
             for $b $(::$b_sub)* {}
 
+        #[cfg(test)]
+        ::static_assertions::assert_impl_all!(
+            $a $(::$a_sub)* :
+                ::proptest::arbitrary::Arbitrary,
+        );
+        #[cfg(test)]
+        ::static_assertions::assert_impl_all!(
+            $b $(::$b_sub)* :
+                ::proptest::arbitrary::Arbitrary,
+        );
+
+        #[cfg(test)]
         ::paste::paste! {
             ::proptest::proptest! {
                 #![proptest_config(::proptest::test_runner::Config {


### PR DESCRIPTION
### Motivation

`proptest-derive` was expanding `Arbitrary` on ~2200 types in `src/catalog-protos/` on every build, even though the impls are only needed by tests in `mz-catalog`.

### Description

`mz-catalog-protos` gains a `proptest` feature. Each `derive(Arbitrary)` and `#[proptest(...)]` field attribute is wrapped in `#[cfg_attr(any(test, feature = "proptest"), ...)]`. A self-dep in `[dev-dependencies]` enables the feature when building the crate's own tests.

`mz-catalog` moves `proptest`/`proptest-derive` to dev-dependencies, gates its own `derive(Arbitrary)` on durable objects behind `cfg(test)`, and restructures the `json_compatible!` macro so the `unsafe impl JsonCompatible` stays unconditional (production migrations rely on it) while `assert_impl_all` and `proptest!` blocks are `cfg(test)`-only.

### Compile-time impact

Measured `mz-catalog-protos` self-time via `cargo --timings`, deps pre-warmed, 3 iterations each, median reported.

| Profile | Before | After | Reduction |
| --- | --- | --- | --- |
| `cargo check -p mz-catalog-protos` | 16.5s | 13.3s | 19% |
| `cargo build -p mz-catalog-protos --profile=optimized` | 41.6s | 16.6s | 60% |

Optimized win dominated by skipped codegen on the ~2200 `Arbitrary` impls. Numbers cover catalog-protos lib only; downstream consumers of these types likely see further savings not measured here.
