### PR TITLE
console: add oidc username for connect modal

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc",
     "gen:api": "openapi-typescript",
     "gen:types": "bin/generate-types",
-    "gen:mz-doc-urls": "ts-node-esm sitemap-to-json/index.ts"
+    "gen:mz-doc-urls": "tsx sitemap-to-json/index.ts"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",
@@ -179,6 +179,7 @@
     "prettier": "^3.3.3",
     "react-refresh": "^0.14.2",
     "terser": "^5.46.1",
+    "tsx": "^4.22.2",
     "typescript-eslint-language-service": "^5.0.5",
     "vite": "^6.4.2",
     "vite-bundle-analyzer": "^0.12.1",

--- a/console/src/components/OidcConnectModal.tsx
+++ b/console/src/components/OidcConnectModal.tsx
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import {
+  Code,
   ModalBody,
   ModalCloseButton,
   ModalContent,
@@ -26,6 +27,7 @@ import {
 } from "~/components/copyableComponents";
 import McpConnectInstructions from "~/components/McpConnectInstructions";
 import { Modal } from "~/components/Modal";
+import TextLink from "~/components/TextLink";
 import { type AuthContextProps } from "~/external-library-wrappers/oidc";
 import { useSelfManagedProfile } from "~/hooks/useSelfManagedProfile";
 import ConnectionIcon from "~/svg/ConnectionIcon";
@@ -33,6 +35,7 @@ import { MaterializeTheme } from "~/theme";
 import { obfuscateSecret } from "~/utils/format";
 
 const OIDC_USERNAME_PLACEHOLDER = "<your_oidc_username>";
+const HOST_PLACEHOLDER = "<host>";
 
 const OidcConnectModal = ({
   onClose,
@@ -51,9 +54,7 @@ const OidcConnectModal = ({
 
   const obfuscated = idToken ? obfuscateSecret(idToken) : "";
 
-  // Default to the console's hostname, but customers may need to adjust
-  // if Materialize is exposed on a different host behind a load balancer.
-  const defaultSqlAddress = `${window.location.hostname}:6875`;
+  const sqlAddress = `${HOST_PLACEHOLDER}:6875`;
 
   return (
     <Modal size="3xl" isOpen={isOpen} onClose={onClose}>
@@ -67,15 +68,26 @@ const OidcConnectModal = ({
             whiteSpace="normal"
             color={colors.foreground.secondary}
           >
-            Use the details below to connect to Materialize. The host and port
-            shown are defaults and may need to be adjusted for your deployment.
-            When prompted for a password, paste the ID token.
+            Replace <Code fontSize="xs">{HOST_PLACEHOLDER}</Code> with your
+            Materialize SQL endpoint. For Terraform installs, run{" "}
+            <Code fontSize="xs">
+              terraform output -raw balancerd_load_balancer_ip
+            </Code>{" "}
+            to get it. See the{" "}
+            <TextLink
+              href="https://materialize.com/docs/self-managed-deployments/installation/install-on-gcp/#step-3-apply-the-terraform"
+              isExternal
+            >
+              installation docs
+            </TextLink>{" "}
+            for full setup details. When prompted for a password, paste the ID
+            token below.
           </Text>
           {idToken ? (
             <VStack alignItems="stretch" spacing={6} mt="4">
               <ConnectInstructions
                 userStr={userStr}
-                environmentdAddress={defaultSqlAddress}
+                environmentdAddress={sqlAddress}
               />
               <VStack alignItems="stretch" spacing={2}>
                 <Text textStyle="heading-xs">ID Token</Text>
@@ -92,22 +104,17 @@ const OidcConnectModal = ({
               </VStack>
             </VStack>
           ) : (
-            <VStack alignItems="stretch" spacing={4} mt="4">
-              <Text fontSize="sm">
-                No ID token available. Please sign in again to access SQL
-                connection details.
-              </Text>
-              <TabbedCodeBlock
-                tabs={[
-                  {
-                    title: "MCP Server",
-                    children: <McpConnectInstructions userStr={userStr} />,
-                    icon: <ConnectionIcon w="4" h="4" />,
-                  },
-                ]}
-                minHeight="208px"
-              />
-            </VStack>
+            <TabbedCodeBlock
+              mt="4"
+              tabs={[
+                {
+                  title: "MCP Server",
+                  children: <McpConnectInstructions userStr={userStr} />,
+                  icon: <ConnectionIcon w="4" h="4" />,
+                },
+              ]}
+              minHeight="208px"
+            />
           )}
         </ModalBody>
       </ModalContent>

--- a/console/src/components/OidcConnectModal.tsx
+++ b/console/src/components/OidcConnectModal.tsx
@@ -27,6 +27,7 @@ import {
 import McpConnectInstructions from "~/components/McpConnectInstructions";
 import { Modal } from "~/components/Modal";
 import { type AuthContextProps } from "~/external-library-wrappers/oidc";
+import { useSelfManagedProfile } from "~/hooks/useSelfManagedProfile";
 import ConnectionIcon from "~/svg/ConnectionIcon";
 import { MaterializeTheme } from "~/theme";
 import { obfuscateSecret } from "~/utils/format";
@@ -44,6 +45,9 @@ const OidcConnectModal = ({
 }) => {
   const { colors } = useTheme<MaterializeTheme>();
   const idToken = auth.user?.id_token;
+
+  const { sqlRole } = useSelfManagedProfile(auth);
+  const userStr = sqlRole ?? OIDC_USERNAME_PLACEHOLDER;
 
   const obfuscated = idToken ? obfuscateSecret(idToken) : "";
 
@@ -70,9 +74,8 @@ const OidcConnectModal = ({
           {idToken ? (
             <VStack alignItems="stretch" spacing={6} mt="4">
               <ConnectInstructions
-                userStr={OIDC_USERNAME_PLACEHOLDER}
+                userStr={userStr}
                 environmentdAddress={defaultSqlAddress}
-                psqlQueryParams="options=--oidc_auth_enabled%3Dtrue"
               />
               <VStack alignItems="stretch" spacing={2}>
                 <Text textStyle="heading-xs">ID Token</Text>
@@ -98,11 +101,7 @@ const OidcConnectModal = ({
                 tabs={[
                   {
                     title: "MCP Server",
-                    children: (
-                      <McpConnectInstructions
-                        userStr={OIDC_USERNAME_PLACEHOLDER}
-                      />
-                    ),
+                    children: <McpConnectInstructions userStr={userStr} />,
                     icon: <ConnectionIcon w="4" h="4" />,
                   },
                 ]}

--- a/console/src/layouts/ProfileDropdown.tsx
+++ b/console/src/layouts/ProfileDropdown.tsx
@@ -144,7 +144,14 @@ const SelfManagedMenuButtonLabel = ({ auth }: { auth?: AuthContextProps }) => {
   const { colors } = useTheme<MaterializeTheme>();
   const { name } = useSelfManagedProfile(auth);
   return (
-    <Text textStyle="text-ui-med" color={colors.foreground.primary}>
+    <Text
+      textStyle="text-ui-med"
+      minW="100%"
+      maxW="160px"
+      noOfLines={1}
+      textAlign="left"
+      color={colors.foreground.primary}
+    >
       {name ?? "Settings"}
     </Text>
   );

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -11073,6 +11073,7 @@ __metadata:
     style-mod: "npm:^4.1.2"
     terser: "npm:^5.46.1"
     ts-node: "npm:^10.9.2"
+    tsx: "npm:^4.22.2"
     typescript: "npm:^5.6.3"
     typescript-eslint-language-service: "npm:^5.0.5"
     use-resize-observer: "npm:^9.1.0"
@@ -14369,6 +14370,21 @@ __metadata:
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10c0/e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.22.2":
+  version: 4.22.2
+  resolution: "tsx@npm:4.22.2"
+  dependencies:
+    esbuild: "npm:~0.28.0"
+    fsevents: "npm:~2.3.3"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/5e9a9b5577642b6084bac14450379bdb72567a9bf47b3508470f3ccd530693358ab0c5eb86c57c249260f2ffa0549e2e4cedc93cbe526bbae5ef4d215e1d57a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

### Motivation

Show user name in the Connect modal for OIDC console

### Verification

- Signed in via SSO; opened the Connect modal.
- Verified the `psql` snippet shows the SQL role (URL-encoded email) in place of the `<your_oidc_username>` placeholder.
- Copied the snippet, ran `PGPASSWORD='<id-token>' psql "<url>"`, confirmed `SELECT current_user;` returns the same string shown in the modal.
- Sign-out + sign-in: role stays consistent across sessions.
