### PR TITLE
Prevent zombie Kafka source on low watermark failures

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -558,7 +558,7 @@ fn render_reader<'scope>(
                                     adjusting your retention policies to prevent this.",
                                 );
 
-                                let update = HealthStatusUpdate::halting(
+                                let update = HealthStatusUpdate::stalled(
                                     err_str.clone(),
                                     None,
                                 );

--- a/test/kafka-low-watermark/mzcompose.py
+++ b/test/kafka-low-watermark/mzcompose.py
@@ -96,6 +96,14 @@ def workflow_low_watermark(c: Composition) -> None:
 > COMMIT
 {select_cmd} SELECT count(*) FROM lwm_{suffix}_tbl
 {expected}
+$ skip-if
+SELECT {"true" if not start_offset_clause else "false"}
+# Sleep for 20s to make sure that the source has not restarted (would happen after 5s)
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=20s
+{select_cmd} SELECT count(*) FROM lwm_{suffix}_tbl
+{expected}
+> SELECT count(*) FROM mz_internal.mz_source_status_history hx JOIN mz_catalog.mz_sources s ON hx.source_id = s.id WHERE s.name = 'lwm_{suffix}' AND hx.status = 'starting'
+1
 """)
         print(f"PASSED: {suffix} START OFFSET with low watermark > 0")
 


### PR DESCRIPTION
We saw an issue where a source failed because the kafka low watermarks were beyond the `resume_upper` for that source, indicating there was data compacted away that we would never get back. However, because the source emitted an error at the timestamp of the snapshot, and then exited, implicitly dropping its capabilities, the remap operator believed that all messages up until the input upper (high watermarks of the kafka partitions) had been completed, and advanced the `resume_uppers` to the high watermarks. This is normal procedure when emitting definite errors that indicate the source is irreparably broken.

However, at this point the kafka replication operator emitted a `HealthStatusUpdate` with `halting = true`. This meant that the healthcheck operator would then issue a suspend and restart command to the storage controller. When restarting, because the resume uppers had advanced, the source was able to continue reading from the previous frontier, and the status appeared healthy until querying the source table, when you would get the low watermark error. 

Instead, we should emit a `HealthStatusUpdate::stalled` which will tell the healthcheck operator not to issue a restart command, and the source will stay visibly stalled rather than appear healthy.