### PR TITLE
console: fix cancel subscribe button for the emulator

### DIFF
--- a/console/src/api/apiClient.ts
+++ b/console/src/api/apiClient.ts
@@ -202,6 +202,20 @@ export class SelfManagedApiClient
     };
   };
 
+  // Mirrors getWsAuthConfig() so HTTP and websocket auth as the same role;
+  // otherwise HTTP falls back to anonymous_http_user and role-membership
+  // checks (e.g. pg_cancel_backend) reject it.
+  #flexibleDeploymentAuthMiddleware: Middleware = (next) => {
+    return async (...fetchArgs) => {
+      const [input, options = {}] = fetchArgs;
+      const headers = copyHeaders(fetchArgs);
+      const { user, password } = FLEXIBLE_DEPLOYMENT_USER;
+      headers.set("Authorization", `Basic ${btoa(`${user}:${password}`)}`);
+      const request = new Request(input, { ...options, headers });
+      return next(request);
+    };
+  };
+
   constructor({ appConfig }: { appConfig: Readonly<SelfManagedAppConfig> }) {
     this.#appConfig = appConfig;
     this.mzHttpUrlScheme = this.#appConfig.environmentdScheme;
@@ -225,7 +239,10 @@ export class SelfManagedApiClient
         this.#oidcAuthMiddleware,
       );
     } else if (this.authMode === "None") {
-      this.mzApiFetch = globalFetch;
+      this.mzApiFetch = withMiddleware(
+        globalFetch,
+        this.#flexibleDeploymentAuthMiddleware,
+      );
     } else {
       this.mzApiFetch = this.#mzApiWithAuthRedirect;
     }


### PR DESCRIPTION
- Fixed a bug where clicking Cancel on a running SUBSCRIBE in the SQL Shell did nothing in self-managed deployments with authMode None (e.g. the emulator). The Shell's websocket authenticated as `materialize` via WebSocketAuth::Basic, but the HTTP path used to fire pg_cancel_backend() was bare globalFetch with no auth header, so environmentd resolved it as anonymous_http_user and rejected the cancel with 42501 — anonymous_http_user isn't a member of `materialize`, which pg_cancel_backend's role-membership check requires.

- Added a #flexibleDeploymentAuthMiddleware on SelfManagedApiClient that attaches Authorization: Basic <materialize:> on HTTP fetches in authMode None, mirroring the websocket auth already set up in getWsAuthConfig(). HTTP and websocket now resolve to the same role, so cancel works and any future role-sensitive HTTP operation (DROP, ALTER, ownership checks) won't hit the same asymmetry.

Remove these sections if your commit already has a good description!

### Motivation
Fixes [CNS-64](https://linear.app/materializeinc/issue/CNS-64/cancel-button-doesnt-work-for-running-subscribe-in-the-console-shell)


### Verification




https://github.com/user-attachments/assets/0a057d1e-4ec2-4a2b-8ee7-a70c263ca47a



