### PR TITLE
[SS-69] Make it obvious: Iceberg sink's AWS connection isn't used.

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1550,8 +1550,11 @@ pub enum CreateSinkConnection<T: AstInfo> {
         headers: Option<Ident>,
     },
     Iceberg {
-        connection: T::ItemName,
-        aws_connection: T::ItemName,
+        catalog_connection: T::ItemName,
+
+        /// AWS creds for the storage layer.
+        aws_connection: Option<T::ItemName>,
+
         key: Option<SinkKey>,
         options: Vec<IcebergSinkConfigOption<T>>,
     },
@@ -1583,20 +1586,22 @@ impl<T: AstInfo> AstDisplay for CreateSinkConnection<T> {
                 }
             }
             CreateSinkConnection::Iceberg {
-                connection,
+                catalog_connection,
                 aws_connection,
                 key,
                 options,
             } => {
                 f.write_str("ICEBERG CATALOG CONNECTION ");
-                f.write_node(connection);
+                f.write_node(catalog_connection);
                 if !options.is_empty() {
                     f.write_str(" (");
                     f.write_node(&display::comma_separated(options));
                     f.write_str(")");
                 }
-                f.write_str(" USING AWS CONNECTION ");
-                f.write_node(aws_connection);
+                if let Some(aws_connection) = aws_connection {
+                    f.write_str(" USING AWS CONNECTION ");
+                    f.write_node(aws_connection);
+                }
                 if let Some(key) = key.as_ref() {
                     f.write_str(" ");
                     f.write_node(key);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3861,7 +3861,7 @@ impl<'a> Parser<'a> {
         &mut self,
     ) -> Result<CreateSinkConnection<Raw>, ParserError> {
         self.expect_keyword(CONNECTION)?;
-        let connection = self.parse_raw_name()?;
+        let catalog_connection = self.parse_raw_name()?;
 
         let options = if self.consume_token(&Token::LParen) {
             let options = self.parse_comma_separated(Parser::parse_iceberg_sink_config_option)?;
@@ -3871,8 +3871,11 @@ impl<'a> Parser<'a> {
             vec![]
         };
 
-        self.expect_keywords(&[USING, AWS, CONNECTION])?;
-        let aws_connection = self.parse_raw_name()?;
+        let aws_connection = if self.parse_keywords(&[USING, AWS, CONNECTION]) {
+            Some(self.parse_raw_name()?)
+        } else {
+            None
+        };
 
         let key = if self.parse_keyword(KEY) {
             let key_columns = self.parse_parenthesized_column_list(Mandatory)?;
@@ -3887,7 +3890,7 @@ impl<'a> Parser<'a> {
         };
 
         Ok(CreateSinkConnection::Iceberg {
-            connection,
+            catalog_connection,
             aws_connection,
             key,
             options,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1055,18 +1055,25 @@ CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') KEY FORMAT 
 CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(KeyValue { key: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } }), value: Json { array: false } }), envelope: None, mode: None, with_options: [] })
 
 parse-statement
+CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = 'testnamespace', TABLE = 'daily_sales') KEY (a) NOT ENFORCED MODE UPSERT;
+----
+CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = 'testnamespace', TABLE = 'daily_sales') KEY (a) NOT ENFORCED MODE UPSERT
+=>
+CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("bar")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("foo")])), connection: Iceberg { catalog_connection: Name(UnresolvedItemName([Ident("s3tables")])), aws_connection: None, key: Some(SinkKey { key_columns: [Ident("a")], not_enforced: true }), options: [IcebergSinkConfigOption { name: Namespace, value: Some(Value(String("testnamespace"))) }, IcebergSinkConfigOption { name: Table, value: Some(Value(String("daily_sales"))) }] }, format: None, envelope: None, mode: Some(Upsert), with_options: [] })
+
+parse-statement
 CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = 'testnamespace', TABLE = 'daily_sales') USING AWS CONNECTION aws_conn KEY (a) NOT ENFORCED MODE UPSERT;
 ----
 CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = 'testnamespace', TABLE = 'daily_sales') USING AWS CONNECTION aws_conn KEY (a) NOT ENFORCED MODE UPSERT
 =>
-CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("bar")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("foo")])), connection: Iceberg { connection: Name(UnresolvedItemName([Ident("s3tables")])), aws_connection: Name(UnresolvedItemName([Ident("aws_conn")])), key: Some(SinkKey { key_columns: [Ident("a")], not_enforced: true }), options: [IcebergSinkConfigOption { name: Namespace, value: Some(Value(String("testnamespace"))) }, IcebergSinkConfigOption { name: Table, value: Some(Value(String("daily_sales"))) }] }, format: None, envelope: None, mode: Some(Upsert), with_options: [] })
+CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("bar")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("foo")])), connection: Iceberg { catalog_connection: Name(UnresolvedItemName([Ident("s3tables")])), aws_connection: Some(Name(UnresolvedItemName([Ident("aws_conn")]))), key: Some(SinkKey { key_columns: [Ident("a")], not_enforced: true }), options: [IcebergSinkConfigOption { name: Namespace, value: Some(Value(String("testnamespace"))) }, IcebergSinkConfigOption { name: Table, value: Some(Value(String("daily_sales"))) }] }, format: None, envelope: None, mode: Some(Upsert), with_options: [] })
 
 parse-statement
 CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = 'testnamespace', TABLE = 'daily_sales') USING AWS CONNECTION aws_conn KEY (a) MODE UPSERT;
 ----
 CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = 'testnamespace', TABLE = 'daily_sales') USING AWS CONNECTION aws_conn KEY (a) MODE UPSERT
 =>
-CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("bar")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("foo")])), connection: Iceberg { connection: Name(UnresolvedItemName([Ident("s3tables")])), aws_connection: Name(UnresolvedItemName([Ident("aws_conn")])), key: Some(SinkKey { key_columns: [Ident("a")], not_enforced: false }), options: [IcebergSinkConfigOption { name: Namespace, value: Some(Value(String("testnamespace"))) }, IcebergSinkConfigOption { name: Table, value: Some(Value(String("daily_sales"))) }] }, format: None, envelope: None, mode: Some(Upsert), with_options: [] })
+CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("bar")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("foo")])), connection: Iceberg { catalog_connection: Name(UnresolvedItemName([Ident("s3tables")])), aws_connection: Some(Name(UnresolvedItemName([Ident("aws_conn")]))), key: Some(SinkKey { key_columns: [Ident("a")], not_enforced: false }), options: [IcebergSinkConfigOption { name: Namespace, value: Some(Value(String("testnamespace"))) }, IcebergSinkConfigOption { name: Table, value: Some(Value(String("daily_sales"))) }] }, format: None, envelope: None, mode: Some(Upsert), with_options: [] })
 
 parse-statement
 CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (BLAH = 'boo!') USING AWS CONNECTION aws_conn MODE UPSERT;
@@ -1080,7 +1087,7 @@ CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = '
 ----
 CREATE SINK bar FROM foo INTO ICEBERG CATALOG CONNECTION s3tables (NAMESPACE = 'testnamespace', TABLE = 'daily_sales') USING AWS CONNECTION aws_conn MODE APPEND
 =>
-CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("bar")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("foo")])), connection: Iceberg { connection: Name(UnresolvedItemName([Ident("s3tables")])), aws_connection: Name(UnresolvedItemName([Ident("aws_conn")])), key: None, options: [IcebergSinkConfigOption { name: Namespace, value: Some(Value(String("testnamespace"))) }, IcebergSinkConfigOption { name: Table, value: Some(Value(String("daily_sales"))) }] }, format: None, envelope: None, mode: Some(Append), with_options: [] })
+CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("bar")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("foo")])), connection: Iceberg { catalog_connection: Name(UnresolvedItemName([Ident("s3tables")])), aws_connection: Some(Name(UnresolvedItemName([Ident("aws_conn")]))), key: None, options: [IcebergSinkConfigOption { name: Namespace, value: Some(Value(String("testnamespace"))) }, IcebergSinkConfigOption { name: Table, value: Some(Value(String("daily_sales"))) }] }, format: None, envelope: None, mode: Some(Append), with_options: [] })
 
 parse-statement
 CREATE INDEX foo ON myschema.bar (a, b)

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3482,13 +3482,13 @@ fn plan_sink(
             commit_interval,
         )?,
         CreateSinkConnection::Iceberg {
-            connection,
+            catalog_connection,
             aws_connection,
             options,
             ..
         } => iceberg_sink_builder(
             scx,
-            connection,
+            catalog_connection,
             aws_connection,
             options,
             relation_key_indices,
@@ -3660,7 +3660,7 @@ impl std::convert::TryFrom<Vec<CsrConfigOption<Aug>>> for CsrConfigOptionExtract
 fn iceberg_sink_builder(
     scx: &StatementContext,
     catalog_connection: ResolvedItemName,
-    aws_connection: ResolvedItemName,
+    storage_connection: Option<ResolvedItemName>,
     options: Vec<IcebergSinkConfigOption<Aug>>,
     relation_key_indices: Option<Vec<usize>>,
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
@@ -3672,10 +3672,9 @@ fn iceberg_sink_builder(
     // (e.g. interval -> string) don't trip the check.
     ArrowBuilder::validate_desc_for_parquet(desc, iceberg_type_overrides)
         .map_err(|e| sql_err!("{}", e))?;
+
     let catalog_connection_item = scx.get_item_by_resolved_name(&catalog_connection)?;
     let catalog_connection_id = catalog_connection_item.id();
-    let aws_connection_item = scx.get_item_by_resolved_name(&aws_connection)?;
-    let aws_connection_id = aws_connection_item.id();
     if !matches!(
         catalog_connection_item.connection()?,
         Connection::IcebergCatalog(_)
@@ -3689,13 +3688,16 @@ fn iceberg_sink_builder(
         );
     };
 
-    if !matches!(aws_connection_item.connection()?, Connection::Aws(_)) {
+    let storage_connection_item = storage_connection
+        .map(|c| scx.get_item_by_resolved_name(&c))
+        .transpose()?;
+    let storage_connection_id = storage_connection_item.as_ref().map(|c| c.id());
+    if let Some(c) = &storage_connection_item
+        && !matches!(c.connection()?, Connection::Aws(_))
+    {
         sql_bail!(
             "{} is not an AWS connection",
-            scx.catalog
-                .resolve_full_name(aws_connection_item.name())
-                .to_string()
-                .quoted()
+            scx.catalog.resolve_full_name(c.name()).to_string().quoted()
         );
     }
 
@@ -3718,8 +3720,8 @@ fn iceberg_sink_builder(
     Ok(StorageSinkConnection::Iceberg(IcebergSinkConnection {
         catalog_connection_id,
         catalog_connection: catalog_connection_id,
-        aws_connection_id,
-        aws_connection: aws_connection_id,
+        storage_connection_id,
+        storage_connection: storage_connection_id,
         table,
         namespace,
         relation_key_indices,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -542,13 +542,13 @@ async fn purify_create_sink(
             }
         }
         CreateSinkConnection::Iceberg {
-            connection,
+            catalog_connection,
             aws_connection,
             ..
         } => {
             let scx = StatementContext::new(None, &catalog);
             let connection = {
-                let item = scx.get_item_by_resolved_name(connection)?;
+                let item = scx.get_item_by_resolved_name(catalog_connection)?;
                 // Get Iceberg connection
                 match item.connection()? {
                     Connection::IcebergCatalog(connection) => {
@@ -561,63 +561,72 @@ async fn purify_create_sink(
                 }
             };
 
-            let aws_conn_id = aws_connection.item_id();
+            // Validate the sink's (optional) AWS connection even though we never use it.
+            // TODO(kynan): If we do start using the sink's creds, check again that this validation
+            //   accurately reflects what we need.
+            //   Consider rolling the storage creds validation into the catalog connection's "connect" fn,
+            //   which already validates the catalog creds (currently also used for the storage layer).
+            if let Some(aws_connection) = aws_connection {
+                let aws_conn_id = aws_connection.item_id();
+                let aws_connection = {
+                    let item = scx.get_item_by_resolved_name(aws_connection)?;
+                    // Get AWS connection
+                    match item.connection()? {
+                        Connection::Aws(aws_connection) => aws_connection.clone(),
+                        _ => sql_bail!(
+                            "{} is not an aws connection",
+                            scx.catalog.resolve_full_name(item.name())
+                        ),
+                    }
+                };
 
-            let aws_connection = {
-                let item = scx.get_item_by_resolved_name(aws_connection)?;
-                // Get AWS connection
-                match item.connection()? {
-                    Connection::Aws(aws_connection) => aws_connection.clone(),
-                    _ => sql_bail!(
-                        "{} is not an aws connection",
-                        scx.catalog.resolve_full_name(item.name())
-                    ),
-                }
-            };
-
-            // For S3 Tables connections in the Materialize Cloud product, verify the
-            // AWS region matches the environment's region. This check only applies when
-            // the enable_s3_tables_region_check dyncfg is set.
-            if let Some(s3tables) = connection.s3tables_catalog() {
-                let enable_region_check =
-                    ENABLE_S3_TABLES_REGION_CHECK.get(scx.catalog.system_vars().dyncfgs());
-                if enable_region_check {
-                    let env_id = &catalog.config().environment_id;
-                    if matches!(env_id.cloud_provider(), CloudProvider::Aws) {
-                        let env_region = env_id.cloud_provider_region();
-                        // Later on we default to "us-east-1" if the region is not set on the S3 Tables
-                        // connection, so we need to do the same check here.
-                        let s3_tables_region = s3tables
-                            .aws_connection
-                            .connection
-                            .region
-                            .clone()
-                            .unwrap_or_else(|| "us-east-1".to_string());
-                        if s3_tables_region != env_region {
-                            Err(IcebergSinkPurificationError::S3TablesRegionMismatch {
-                                s3_tables_region,
-                                environment_region: env_region.to_string(),
-                            })?;
+                // For S3 Tables connections in the Materialize Cloud product, verify the
+                // AWS region matches the environment's region. This check only applies when
+                // the enable_s3_tables_region_check dyncfg is set.
+                if let Some(s3tables) = connection.s3tables_catalog() {
+                    let enable_region_check =
+                        ENABLE_S3_TABLES_REGION_CHECK.get(scx.catalog.system_vars().dyncfgs());
+                    if enable_region_check {
+                        let env_id = &catalog.config().environment_id;
+                        if matches!(env_id.cloud_provider(), CloudProvider::Aws) {
+                            let env_region = env_id.cloud_provider_region();
+                            // Later on we default to "us-east-1" if the region is not set on the S3 Tables
+                            // connection, so we need to do the same check here.
+                            let s3_tables_region = s3tables
+                                .aws_connection
+                                .connection
+                                .region
+                                .clone()
+                                .unwrap_or_else(|| "us-east-1".to_string());
+                            if s3_tables_region != env_region {
+                                Err(IcebergSinkPurificationError::S3TablesRegionMismatch {
+                                    s3_tables_region,
+                                    environment_region: env_region.to_string(),
+                                })?;
+                            }
                         }
                     }
                 }
+
+                let _sdk_config = aws_connection
+                    .load_sdk_config(
+                        &storage_configuration.connection_context,
+                        aws_conn_id.clone(),
+                        InTask::No,
+                        mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+                            .get(storage_configuration.config_set()),
+                    )
+                    .await
+                    .map_err(|e| IcebergSinkPurificationError::AwsSdkContextError(Arc::new(e)))?;
             }
 
+            // Now that we've validated the sink's storage creds (if they exist)
+            // we _could_ use them to build a complete Iceberg client (both catalog and storage).
+            // TODO(kynan): Actually use those sink-specific creds here instead of ignoring them.
             let _catalog = connection
                 .connect(storage_configuration, InTask::No)
                 .await
                 .map_err(|e| IcebergSinkPurificationError::CatalogError(Arc::new(e)))?;
-
-            let _sdk_config = aws_connection
-                .load_sdk_config(
-                    &storage_configuration.connection_context,
-                    aws_conn_id.clone(),
-                    InTask::No,
-                    mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
-                        .get(storage_configuration.config_set()),
-                )
-                .await
-                .map_err(|e| IcebergSinkPurificationError::AwsSdkContextError(Arc::new(e)))?;
         }
     }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -561,6 +561,34 @@ async fn purify_create_sink(
                 }
             };
 
+            // For S3 Tables connections in the Materialize Cloud product, verify the
+            // AWS region matches the environment's region. This check only applies when
+            // the enable_s3_tables_region_check dyncfg is set.
+            if let Some(s3tables) = connection.s3tables_catalog() {
+                let enable_region_check =
+                    ENABLE_S3_TABLES_REGION_CHECK.get(scx.catalog.system_vars().dyncfgs());
+                if enable_region_check {
+                    let env_id = &catalog.config().environment_id;
+                    if matches!(env_id.cloud_provider(), CloudProvider::Aws) {
+                        let env_region = env_id.cloud_provider_region();
+                        // Later on we default to "us-east-1" if the region is not set on the S3 Tables
+                        // connection, so we need to do the same check here.
+                        let s3_tables_region = s3tables
+                            .aws_connection
+                            .connection
+                            .region
+                            .clone()
+                            .unwrap_or_else(|| "us-east-1".to_string());
+                        if s3_tables_region != env_region {
+                            Err(IcebergSinkPurificationError::S3TablesRegionMismatch {
+                                s3_tables_region,
+                                environment_region: env_region.to_string(),
+                            })?;
+                        }
+                    }
+                }
+            }
+
             // Validate the sink's (optional) AWS connection even though we never use it.
             // TODO(kynan): If we do start using the sink's creds, check again that this validation
             //   accurately reflects what we need.
@@ -579,34 +607,6 @@ async fn purify_create_sink(
                         ),
                     }
                 };
-
-                // For S3 Tables connections in the Materialize Cloud product, verify the
-                // AWS region matches the environment's region. This check only applies when
-                // the enable_s3_tables_region_check dyncfg is set.
-                if let Some(s3tables) = connection.s3tables_catalog() {
-                    let enable_region_check =
-                        ENABLE_S3_TABLES_REGION_CHECK.get(scx.catalog.system_vars().dyncfgs());
-                    if enable_region_check {
-                        let env_id = &catalog.config().environment_id;
-                        if matches!(env_id.cloud_provider(), CloudProvider::Aws) {
-                            let env_region = env_id.cloud_provider_region();
-                            // Later on we default to "us-east-1" if the region is not set on the S3 Tables
-                            // connection, so we need to do the same check here.
-                            let s3_tables_region = s3tables
-                                .aws_connection
-                                .connection
-                                .region
-                                .clone()
-                                .unwrap_or_else(|| "us-east-1".to_string());
-                            if s3_tables_region != env_region {
-                                Err(IcebergSinkPurificationError::S3TablesRegionMismatch {
-                                    s3_tables_region,
-                                    environment_region: env_region.to_string(),
-                                })?;
-                            }
-                        }
-                    }
-                }
 
                 let _sdk_config = aws_connection
                     .load_sdk_config(

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -771,6 +771,8 @@ impl IcebergCatalogConnection<InlinedConnection> {
             signing_name: "s3tables".to_string(),
         });
 
+        // N.B. We're using the AWS credentials from the catalog connection for the storage layer
+        //   even though the sink comes with its own (unused) AWS credentials for storage.
         let customized_credential_load = if matches!(aws_auth, AwsAuth::AssumeRole(_)) {
             Some(CustomAwsCredentialLoader::new(Arc::new(
                 AwsSdkCredentialLoader::new(credentials_provider),

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -688,8 +688,18 @@ pub fn iceberg_type_overrides(
 pub struct IcebergSinkConnection<C: ConnectionAccess = InlinedConnection> {
     pub catalog_connection_id: CatalogItemId,
     pub catalog_connection: C::IcebergCatalog,
-    pub aws_connection_id: CatalogItemId,
-    pub aws_connection: C::Aws,
+
+    /// We allow users to specify a separate (from the catalog) connection
+    /// for the storage layer, but we currently ignore it.
+    /// S3 Tables uses the same AWS connection for catalog and storage.
+    /// BigLake/Lakehouse uses the same GCP connection for catalog and storage.
+    ///
+    /// TODO(kynan): Once we need separate storage creds, make this generic.
+    ///   And check that the [`IcebergSinkConnection::alter_compatible`]
+    ///   implementation still handles `storage_connection` acceptably.
+    pub storage_connection_id: Option<CatalogItemId>,
+    pub storage_connection: Option<C::Aws>,
+
     /// A natural key of the sinked relation (view or source).
     pub relation_key_indices: Option<Vec<usize>>,
     /// The user-specified key for the sink.
@@ -710,8 +720,8 @@ impl<C: ConnectionAccess> IcebergSinkConnection<C> {
         let IcebergSinkConnection {
             catalog_connection_id: connection_id,
             catalog_connection,
-            aws_connection_id,
-            aws_connection,
+            storage_connection_id,
+            storage_connection,
             relation_key_indices,
             key_desc_and_indices,
             namespace,
@@ -729,15 +739,24 @@ impl<C: ConnectionAccess> IcebergSinkConnection<C> {
                     .is_ok(),
                 "catalog_connection",
             ),
+            // We don't use `storage_connection_id` and `storage_connection`,
+            // so allow them to be removed.
             (
-                aws_connection_id == &other.aws_connection_id,
-                "aws_connection_id",
+                other.storage_connection_id.is_none()
+                    || storage_connection_id == &other.storage_connection_id,
+                "storage_connection_id",
             ),
             (
-                aws_connection
-                    .alter_compatible(id, &other.aws_connection)
-                    .is_ok(),
-                "aws_connection",
+                match &other.storage_connection {
+                    None => true, // Removing a storage connection OR not adding a storage connection.
+                    Some(after) => {
+                        match storage_connection {
+                            None => false, // Adding a storage connection where there wasn't one before.
+                            Some(before) => before.alter_compatible(id, after).is_ok(),
+                        }
+                    }
+                },
+                "storage_connection",
             ),
             (
                 relation_key_indices == &other.relation_key_indices,
@@ -773,8 +792,8 @@ impl<R: ConnectionResolver> IntoInlineConnection<IcebergSinkConnection, R>
         let IcebergSinkConnection {
             catalog_connection_id,
             catalog_connection,
-            aws_connection_id,
-            aws_connection,
+            storage_connection_id,
+            storage_connection,
             relation_key_indices,
             key_desc_and_indices,
             namespace,
@@ -785,8 +804,8 @@ impl<R: ConnectionResolver> IntoInlineConnection<IcebergSinkConnection, R>
             catalog_connection: r
                 .resolve_connection(catalog_connection)
                 .unwrap_iceberg_catalog(),
-            aws_connection_id,
-            aws_connection: r.resolve_connection(aws_connection).unwrap_aws(),
+            storage_connection_id,
+            storage_connection: storage_connection.map(|c| r.resolve_connection(c).unwrap_aws()),
             relation_key_indices,
             key_desc_and_indices,
             namespace,

--- a/test/aws/mzcompose.py
+++ b/test/aws/mzcompose.py
@@ -325,9 +325,11 @@ def test_s3tablesrest_connection(c: Composition, ctx: TestContext):
 def test_s3tablesrest_region_mismatch(c: Composition, ctx: TestContext):
     """Test that S3 Tables sinks fail when region doesn't match environment.
 
-    The environment is configured as aws-us-east-1, so attempting to create
-    an Iceberg sink using an S3 Tables connection pointing to us-west-2 should
-    fail with a region mismatch error during sink purification.
+    The environment is aws-us-east-1; an Iceberg sink whose catalog connection
+    points at us-west-2 must fail region validation during purification. This
+    holds whether or not the sink specifies the optional (and unused)
+    `USING AWS CONNECTION` clause, since the check reads the catalog
+    connection's region, not the sink's AWS connection.
     """
     bucket = None
     customer_role = None
@@ -390,26 +392,32 @@ def test_s3tablesrest_region_mismatch(c: Composition, ctx: TestContext):
         c.sql("CREATE TABLE sink_test_table (id INT, value TEXT)")
         c.sql("INSERT INTO sink_test_table VALUES (1, 'test')")
 
-        # This should fail because the AWS connection is configured for us-west-2
-        # but the environment is running in us-east-1. The region check happens
-        # during sink purification.
-        try:
-            c.sql("""CREATE SINK s3tables_sink
-                    FROM sink_test_table
-                    INTO ICEBERG CATALOG CONNECTION s3tables_wrong_region (
-                        NAMESPACE 'test_namespace',
-                        TABLE 'test_table'
-                    )
-                    USING AWS CONNECTION aws_wrong_region""")
-            raise AssertionError(
-                "Expected S3 Tables sink to fail due to region mismatch"
-            )
-        except InternalError_ as e:
-            assert e.diag.message_primary is not None
-            assert (
-                "region mismatch" in e.diag.message_primary.lower()
-            ), f"Expected 'region mismatch' error but got: {e.diag.message_primary}"
+        # The region check must fire with or without the optional AWS connection;
+        # the no-AWS case is the regression guard. MODE/COMMIT INTERVAL keep the
+        # sink otherwise valid so the region check is its only failure mode.
+        for sink_name, using_aws in [
+            ("s3tables_sink", "USING AWS CONNECTION aws_wrong_region"),
+            ("s3tables_sink_no_aws", ""),
+        ]:
+            try:
+                c.sql(f"""CREATE SINK {sink_name}
+                        FROM sink_test_table
+                        INTO ICEBERG CATALOG CONNECTION s3tables_wrong_region (
+                            NAMESPACE 'test_namespace', TABLE 'test_table'
+                        )
+                        {using_aws}
+                        MODE APPEND WITH (COMMIT INTERVAL '1s')""")
+                raise AssertionError(f"Expected {sink_name} to fail: region mismatch")
+            except InternalError_ as e:
+                msg = e.diag.message_primary or ""
+                assert "region mismatch" in msg.lower(), f"got: {msg}"
     finally:
+        # On buggy code the no-AWS sink is created rather than rejected; drop it
+        # so it stops writing and the bucket can be deleted.
+        try:
+            c.sql("DROP SINK IF EXISTS s3tables_sink_no_aws")
+        except Exception:
+            pass
         if bucket is not None:
             ctx.s3tables.delete_table_bucket(tableBucketARN=bucket["arn"])
         if customer_role is not None:

--- a/test/iceberg/catalog.td
+++ b/test/iceberg/catalog.td
@@ -28,6 +28,8 @@
 
 > insert into foo values (1, 'one'), (2, 'two'), (3, 'three');
 
+# NOTE: This sink has "USING AWS CONNECTION aws_conn", which we validate but don't use.
+#       It's included here just to make sure its presence doesn't break the sink.
 > CREATE SINK demo
     FROM foo
     INTO ICEBERG CATALOG CONNECTION polaris (
@@ -169,7 +171,6 @@ SELECT a, b FROM polaris.default_namespace.demo_table ORDER BY a
         NAMESPACE 'default_namespace',
         TABLE 'uint_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (id) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -205,7 +206,6 @@ SELECT id, name FROM iceberg_scan('s3://test-bucket/default_namespace/uint_table
         NAMESPACE 'default_namespace',
         TABLE 'interval_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (id) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -244,7 +244,6 @@ SELECT id, dur FROM iceberg_scan('s3://test-bucket/default_namespace/interval_ta
         NAMESPACE 'default_namespace',
         TABLE 'range_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (id) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');

--- a/test/iceberg/commit-conflict-setup.td
+++ b/test/iceberg/commit-conflict-setup.td
@@ -13,13 +13,6 @@
 
 > CREATE SECRET access_key_secret AS '${arg.s3-access-key}'
 
-> CREATE CONNECTION aws_conn TO AWS (
-    ACCESS KEY ID = 'tduser',
-    SECRET ACCESS KEY = SECRET access_key_secret,
-    ENDPOINT = '${arg.aws-endpoint}',
-    REGION = 'us-east-1'
-  );
-
 > CREATE CONNECTION polaris TO ICEBERG CATALOG (
     CATALOG TYPE = 'REST',
     URL = 'http://polaris:8181/api/catalog',
@@ -40,7 +33,6 @@
         NAMESPACE 'default_namespace',
         TABLE 'conflict_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (id) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '2s');

--- a/test/iceberg/key-validation.td
+++ b/test/iceberg/key-validation.td
@@ -12,13 +12,6 @@
 
 > CREATE SECRET IF NOT EXISTS access_key_secret AS '${arg.s3-access-key}'
 
-> CREATE CONNECTION IF NOT EXISTS aws_conn TO AWS (
-    ACCESS KEY ID = 'tduser',
-    SECRET ACCESS KEY = SECRET access_key_secret,
-    ENDPOINT = '${arg.aws-endpoint}',
-    REGION = 'us-east-1'
-  );
-
 > CREATE CONNECTION IF NOT EXISTS polaris TO ICEBERG CATALOG (
     CATALOG TYPE = 'REST',
     URL = 'http://polaris:8181/api/catalog',
@@ -36,7 +29,6 @@
         NAMESPACE 'default_namespace',
         TABLE 'key_float_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (k) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -51,7 +43,6 @@ contains:cannot be used as an Iceberg equality delete key
         NAMESPACE 'default_namespace',
         TABLE 'key_double_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (k) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -66,7 +57,6 @@ contains:cannot be used as an Iceberg equality delete key
         NAMESPACE 'default_namespace',
         TABLE 'key_map_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (k) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -81,7 +71,6 @@ contains:cannot be used as an Iceberg equality delete key
         NAMESPACE 'default_namespace',
         TABLE 'key_list_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (k) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -113,7 +102,6 @@ contains:cannot be used as an Iceberg equality delete key
         NAMESPACE 'default_namespace',
         TABLE 'val_float_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (k) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');

--- a/test/iceberg/large-upsert-batch.td
+++ b/test/iceberg/large-upsert-batch.td
@@ -19,13 +19,6 @@
 
 > CREATE SECRET access_key_secret AS '${arg.s3-access-key}'
 
-> CREATE CONNECTION aws_conn TO AWS (
-    ACCESS KEY ID = 'tduser',
-    SECRET ACCESS KEY = SECRET access_key_secret,
-    ENDPOINT = '${arg.aws-endpoint}',
-    REGION = 'us-east-1'
-  );
-
 > CREATE CONNECTION polaris TO ICEBERG CATALOG (
     CATALOG TYPE = 'REST',
     URL = 'http://polaris:8181/api/catalog',
@@ -42,7 +35,6 @@
         NAMESPACE 'default_namespace',
         TABLE 'large_upsert_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (key) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '120s');

--- a/test/iceberg/mode-append.td
+++ b/test/iceberg/mode-append.td
@@ -18,13 +18,6 @@
 
 > CREATE SECRET IF NOT EXISTS append_access_key_secret AS '${arg.s3-access-key}'
 
-> CREATE CONNECTION IF NOT EXISTS append_aws_conn TO AWS (
-    ACCESS KEY ID = 'tduser',
-    SECRET ACCESS KEY = SECRET append_access_key_secret,
-    ENDPOINT = '${arg.aws-endpoint}',
-    REGION = 'us-east-1'
-  );
-
 > CREATE CONNECTION append_polaris TO ICEBERG CATALOG (
     CATALOG TYPE = 'REST',
     URL = 'http://polaris:8181/api/catalog',
@@ -44,7 +37,6 @@
         NAMESPACE 'default_namespace',
         TABLE 'append_demo_table'
     )
-    USING AWS CONNECTION append_aws_conn
     MODE APPEND
     WITH (COMMIT INTERVAL '1s');
 
@@ -121,7 +113,6 @@ SELECT a, b, _mz_diff FROM polaris.default_namespace.append_demo_table ORDER BY 
         NAMESPACE 'default_namespace',
         TABLE 'append_clash_table'
     )
-    USING AWS CONNECTION append_aws_conn
     MODE APPEND
     WITH (COMMIT INTERVAL '1s');
 contains:conflicts with the system column that MODE APPEND adds to the Iceberg table
@@ -134,7 +125,6 @@ contains:conflicts with the system column that MODE APPEND adds to the Iceberg t
         NAMESPACE 'default_namespace',
         TABLE 'append_clash_table_1'
     )
-    USING AWS CONNECTION append_aws_conn
     MODE APPEND
     WITH (COMMIT INTERVAL '1s');
 contains:conflicts with the system column that MODE APPEND adds to the Iceberg table

--- a/test/iceberg/nested-records.td
+++ b/test/iceberg/nested-records.td
@@ -11,13 +11,6 @@
 
 > CREATE SECRET nested_access_key_secret AS '${arg.s3-access-key}'
 
-> CREATE CONNECTION nested_aws_conn TO AWS (
-    ACCESS KEY ID = 'tduser',
-    SECRET ACCESS KEY = SECRET nested_access_key_secret,
-    ENDPOINT = '${arg.aws-endpoint}',
-    REGION = 'us-east-1'
-  );
-
 > CREATE CONNECTION nested_polaris TO ICEBERG CATALOG (
     CATALOG TYPE = 'REST',
     URL = 'http://polaris:8181/api/catalog',
@@ -46,7 +39,6 @@
         NAMESPACE 'default_namespace',
         TABLE 'nested_record_table'
     )
-    USING AWS CONNECTION nested_aws_conn
     KEY (id) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -95,7 +87,6 @@ SELECT id, name, addr.street, addr.city, addr.zip FROM iceberg_scan('s3://test-b
         NAMESPACE 'default_namespace',
         TABLE 'deeply_nested_table'
     )
-    USING AWS CONNECTION nested_aws_conn
     KEY (id) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -127,7 +118,6 @@ SELECT id, data.inner.x, data.inner.y, data.z FROM iceberg_scan('s3://test-bucke
         NAMESPACE 'default_namespace',
         TABLE 'nullable_record_table'
     )
-    USING AWS CONNECTION nested_aws_conn
     KEY (id) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');
@@ -149,7 +139,6 @@ SELECT id, rec.required_field, rec.optional_field FROM iceberg_scan('s3://test-b
         NAMESPACE 'default_namespace',
         TABLE 'nested_record_append_table'
     )
-    USING AWS CONNECTION nested_aws_conn
     MODE APPEND
     WITH (COMMIT INTERVAL '1s');
 


### PR DESCRIPTION
For Iceberg sinks to S3 Tables, we've been reusing the Iceberg Catalog connection's AWS creds.
Users separately specify AWS creds for the Iceberg sink itself, but we (validate and then) ignore them.

We _could_ remove the AWS creds option from Iceberg sinks, but:
- Users have already defined Iceberg sinks with superfluous AWS creds (because it's required).
- We'll likely need creds on Iceberg sinks when we support Polaris + \<insert storage service here>.

**In this PR:**
- Add comments about the sink creds being ignored.
- Make sink creds optional. Iceberg sinks to Google BigLake will just reuse the catalog connection's GCP creds.

_stacked on #36692_