### PR TITLE
[SS-69] Iceberg catalog/sink can use a GCP connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +1819,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -4573,6 +4602,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -4788,6 +4818,21 @@ checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -5733,7 +5778,7 @@ dependencies = [
 name = "mz-authenticator"
 version = "0.1.0"
 dependencies = [
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "mz-adapter",
  "mz-adapter-types",
  "mz-auth",
@@ -5831,7 +5876,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-openssl",
  "hyper-util",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "launchdarkly-server-sdk",
  "mz-alloc",
  "mz-alloc-default",
@@ -6438,7 +6483,7 @@ dependencies = [
  "insta",
  "ipnet",
  "itertools 0.14.0",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "maplit",
  "mime",
  "mz-adapter",
@@ -6668,7 +6713,7 @@ dependencies = [
  "clap",
  "derivative",
  "futures",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "lru",
  "mz-auth",
  "mz-ore",
@@ -6689,7 +6734,7 @@ dependencies = [
 name = "mz-frontegg-client"
 version = "0.0.0"
 dependencies = [
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "mz-frontegg-auth",
  "mz-ore",
  "reqwest 0.12.28",
@@ -6712,7 +6757,7 @@ dependencies = [
  "chrono",
  "clap",
  "hyper 1.9.0",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "mz-frontegg-auth",
  "mz-ore",
  "openssl",
@@ -6826,7 +6871,7 @@ dependencies = [
  "aws-sdk-kms",
  "base64 0.22.1",
  "clap",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "mz-aws-util",
  "mz-ore",
  "pem",
@@ -6964,7 +7009,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "mz-ore",
  "openssl",
  "reqwest 0.12.28",
@@ -7418,7 +7463,7 @@ dependencies = [
  "enum-kinds",
  "futures",
  "itertools 0.14.0",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "mz-adapter",
  "mz-adapter-types",
  "mz-auth",
@@ -9317,6 +9362,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9579,12 +9634,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -10531,11 +10603,13 @@ dependencies = [
  "hmac",
  "home",
  "http 1.4.0",
+ "jsonwebtoken 9.3.1",
  "log",
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "rsa",
  "rust-ini",
  "serde",
  "serde_json",
@@ -10946,6 +11020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11012,6 +11095,17 @@ name = "scratch"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "seahash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,7 +370,7 @@ hyper-util = "0.1.20"
 tower-service = "0.3.3"
 iceberg = "0.9.0"
 iceberg-catalog-rest = "0.9.0"
-iceberg-storage-opendal = { version = "0.9.0", default-features = false, features = ["opendal-s3"] }
+iceberg-storage-opendal = { version = "0.9.0", default-features = false, features = ["opendal-s3", "opendal-gcs"] }
 imbl = { version = "7.0.0", features = ["serde"] }
 include_dir = "0.7.4"
 indexmap = { version = "2.10.0", default-features = false, features = ["std"] }

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -274,6 +274,10 @@ case "$cmd" in
                 --env AZURE_SERVICE_ACCOUNT_PASSWORD
                 --env AZURE_SERVICE_ACCOUNT_TENANT
                 --env GCP_SERVICE_ACCOUNT_JSON
+                # For test/gcp Iceberg E2E
+                --env ICEBERG_GCS_BUCKET
+                --env ICEBERG_GCP_PROJECT
+                --env ICEBERG_GCP_SA_JSON_B64
                 --env GITHUB_TOKEN
                 --env GITHUB_GHCR_TOKEN
                 --env GPG_KEY

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -959,6 +959,20 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: secrets-local-file
 
+  - group: GCP
+    key: gcp
+    steps:
+      - id: gcp-real
+        label: GCP (Real)
+        depends_on: build-aarch64
+        timeout_in_minutes: 30
+        agents:
+          # because of GCP access
+          queue: linux-aarch64-small
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: gcp
+
   - group: "Platform checks"
     key: platform-checks
     steps:

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -777,6 +777,7 @@ pub enum ConnectionOptionName {
     Credential,
     Database,
     Endpoint,
+    GcpConnection,
     Host,
     Password,
     Port,
@@ -818,6 +819,7 @@ impl AstDisplay for ConnectionOptionName {
             ConnectionOptionName::Credential => "CREDENTIAL",
             ConnectionOptionName::Database => "DATABASE",
             ConnectionOptionName::Endpoint => "ENDPOINT",
+            ConnectionOptionName::GcpConnection => "GCP CONNECTION",
             ConnectionOptionName::Host => "HOST",
             ConnectionOptionName::Password => "PASSWORD",
             ConnectionOptionName::Port => "PORT",
@@ -871,6 +873,7 @@ impl WithOptionName for ConnectionOptionName {
             | ConnectionOptionName::Credential
             | ConnectionOptionName::Database
             | ConnectionOptionName::Endpoint
+            | ConnectionOptionName::GcpConnection
             | ConnectionOptionName::Host
             | ConnectionOptionName::Password
             | ConnectionOptionName::Port

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2790,6 +2790,7 @@ impl<'a> Parser<'a> {
                 CREDENTIAL,
                 DATABASE,
                 ENDPOINT,
+                GCP,
                 HOST,
                 PASSWORD,
                 PORT,
@@ -2844,6 +2845,10 @@ impl<'a> Parser<'a> {
                 CREDENTIAL => ConnectionOptionName::Credential,
                 DATABASE => ConnectionOptionName::Database,
                 ENDPOINT => ConnectionOptionName::Endpoint,
+                GCP => {
+                    self.expect_keyword(CONNECTION)?;
+                    ConnectionOptionName::GcpConnection
+                }
                 HOST => ConnectionOptionName::Host,
                 PASSWORD => ConnectionOptionName::Password,
                 PORT => ConnectionOptionName::Port,
@@ -2925,6 +2930,7 @@ impl<'a> Parser<'a> {
             ConnectionOptionName::Brokers => Some(WithOptionValue::Sequence(
                 self.parse_list_value(Parser::parse_kafka_broker_or_matching_rule)?,
             )),
+            ConnectionOptionName::GcpConnection => Some(self.parse_object_option_value()?),
             ConnectionOptionName::SshTunnel => Some(self.parse_object_option_value()?),
             _ => self.parse_optional_option_value()?,
         };

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -642,6 +642,13 @@ CREATE CONNECTION glueconn TO AWS GLUE SCHEMA REGISTRY (AWS CONNECTION = awsconn
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("glueconn")]), connection_type: GlueSchemaRegistry, if_not_exists: false, values: [ConnectionOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("awsconn")])))) }, ConnectionOption { name: Registry, value: Some(Value(String("my-registry"))) }], with_options: [CreateConnectionOption { name: Validate, value: Some(Value(Boolean(false))) }] })
 
 parse-statement
+CREATE CONNECTION biglake TO ICEBERG CATALOG (CATALOG TYPE = 'rest', URL = 'https://biglake.googleapis.com/iceberg/v1/restcatalog', GCP CONNECTION = gcpconn, WAREHOUSE = 'gs://iceberg-test')
+----
+CREATE CONNECTION biglake TO ICEBERG CATALOG (CATALOG TYPE = 'rest', URL = 'https://biglake.googleapis.com/iceberg/v1/restcatalog', GCP CONNECTION = gcpconn, WAREHOUSE = 'gs://iceberg-test')
+=>
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("biglake")]), connection_type: IcebergCatalog, if_not_exists: false, values: [ConnectionOption { name: CatalogType, value: Some(Value(String("rest"))) }, ConnectionOption { name: Url, value: Some(Value(String("https://biglake.googleapis.com/iceberg/v1/restcatalog"))) }, ConnectionOption { name: GcpConnection, value: Some(Item(Name(UnresolvedItemName([Ident("gcpconn")])))) }, ConnectionOption { name: Warehouse, value: Some(Value(String("gs://iceberg-test"))) }], with_options: [] })
+
+parse-statement
 CREATE CONNECTION pgconn FOR postgres HOST foo, PORT 1234, SSL CERTIFICATE AUTHORITY 'foo', SSH TUNNEL tun, DATABASE 'db', PASSWORD 'pw', SSL CERTIFICATE 'cert', SSL KEY 'key', SSL MODE 'mode', USER 'postgres'
 ----
 CREATE CONNECTION pgconn TO POSTGRES (HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun, DATABASE = 'db', PASSWORD = 'pw', SSL CERTIFICATE = 'cert', SSL KEY = 'key', SSL MODE = 'mode', USER = 'postgres')
@@ -2879,7 +2886,7 @@ CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("my
 parse-statement
 CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL (PUBLIC KEY 3 = nope)
 ----
-error: Expected one of ACCESS or ASSUME or AVAILABILITY or AWS or BROKER or BROKERS or CATALOG or CREDENTIAL or DATABASE or ENDPOINT or HOST or PASSWORD or PORT or PUBLIC or PROGRESS or REGION or REGISTRY or ROLE or SASL or SCOPE or SECRET or SECURITY or SERVICE or SESSION or SSH or SSL or URL or USER or USERNAME or WAREHOUSE, found left parenthesis
+error: Expected one of ACCESS or ASSUME or AVAILABILITY or AWS or BROKER or BROKERS or CATALOG or CREDENTIAL or DATABASE or ENDPOINT or GCP or HOST or PASSWORD or PORT or PUBLIC or PROGRESS or REGION or REGISTRY or ROLE or SASL or SCOPE or SECRET or SECURITY or SERVICE or SESSION or SSH or SSL or URL or USER or USERNAME or WAREHOUSE, found left parenthesis
 CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL (PUBLIC KEY 3 = nope)
                                                ^
 

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -729,7 +729,18 @@ impl ConnectionOptionExtracted {
                                 credential,
                                 scope: self.scope.clone(),
                             },
-                            (None, Some(gcp_connection)) => IcebergCatalogAuth::Gcp(gcp_connection),
+                            (None, Some(gcp_connection)) => {
+                                /// All BigLake Iceberg REST Catalogs use the same catalog URI.
+                                const BIGLAKE_CATALOG_URI: &str =
+                                    "https://biglake.googleapis.com/iceberg/v1/restcatalog";
+                                if uri.to_string() != BIGLAKE_CATALOG_URI {
+                                    sql_bail!(
+                                        "GCP connection can only be used with '{}'",
+                                        BIGLAKE_CATALOG_URI
+                                    );
+                                }
+                                IcebergCatalogAuth::Gcp(gcp_connection)
+                            }
                             (None, None) => sql_bail!(
                                 "invalid CONNECTION: ICEBERG rest connections require a CREDENTIAL or GCP CONNECTION"
                             ),

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -29,16 +29,16 @@ use mz_ssh_util::keys::SshKeyPair;
 use mz_storage_types::connections::aws::{
     AwsAssumeRole, AwsAuth, AwsConnection, AwsConnectionReference, AwsCredentials,
 };
-use mz_storage_types::connections::gcp::GcpConnection;
+use mz_storage_types::connections::gcp::{GcpConnection, GcpConnectionReference};
 use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::connections::string_or_secret::StringOrSecret;
 use mz_storage_types::connections::{
     AwsPrivatelink, AwsPrivatelinkConnection, AwsPrivatelinkRule, CsrConnection,
-    CsrConnectionHttpAuth, GlueSchemaRegistryConnection, IcebergCatalogConnection,
-    IcebergCatalogImpl, IcebergCatalogType, KafkaConnection, KafkaSaslConfig, KafkaTlsConfig,
-    KafkaTopicOptions, MySqlConnection, MySqlSslMode, PostgresConnection, RestIcebergCatalog,
-    S3TablesRestIcebergCatalog, SqlServerConnectionDetails, SshConnection, SshTunnel, TlsIdentity,
-    Tunnel,
+    CsrConnectionHttpAuth, GlueSchemaRegistryConnection, IcebergCatalogAuth,
+    IcebergCatalogConnection, IcebergCatalogImpl, IcebergCatalogType, KafkaConnection,
+    KafkaSaslConfig, KafkaTlsConfig, KafkaTopicOptions, MySqlConnection, MySqlSslMode,
+    PostgresConnection, RestIcebergCatalog, S3TablesRestIcebergCatalog, SqlServerConnectionDetails,
+    SshConnection, SshTunnel, TlsIdentity, Tunnel,
 };
 
 use crate::names::Aug;
@@ -60,6 +60,7 @@ generate_extracted_config!(
     (Credential, StringOrSecret),
     (Database, String),
     (Endpoint, String),
+    (GcpConnection, with_options::Object),
     (Host, String),
     (Password, with_options::Secret),
     (Port, u16),
@@ -192,6 +193,7 @@ pub(super) fn validate_options_per_connection_type(
             AwsConnection,
             CatalogType,
             Credential,
+            GcpConnection,
             Scope,
             Url,
             Warehouse,
@@ -688,9 +690,15 @@ impl ConnectionOptionExtracted {
                 let warehouse = self.warehouse.clone();
                 let credential = self.credential.clone();
                 let aws_connection = get_aws_connection_reference(scx, &self)?;
+                let gcp_connection = get_gcp_connection_reference(scx, &self)?;
 
                 let catalog = match catalog_type {
                     IcebergCatalogType::S3TablesRest => {
+                        if gcp_connection.is_some() {
+                            sql_bail!(
+                                "invalid CONNECTION: ICEBERG s3tablesrest connections do not support GCP CONNECTION"
+                            );
+                        }
                         let Some(warehouse) = warehouse else {
                             sql_bail!(
                                 "invalid CONNECTION: ICEBERG s3tablesrest connections must specify WAREHOUSE"
@@ -708,17 +716,26 @@ impl ConnectionOptionExtracted {
                         })
                     }
                     IcebergCatalogType::Rest => {
-                        let Some(credential) = credential else {
+                        if aws_connection.is_some() {
                             sql_bail!(
-                                "invalid CONNECTION: ICEBERG rest connections require a CREDENTIAL"
+                                "invalid CONNECTION: ICEBERG rest connections do not support AWS CONNECTION.\n\nTry s3tablesrest instead."
                             );
+                        }
+                        let auth = match (credential, gcp_connection) {
+                            (Some(_), Some(_)) => sql_bail!(
+                                "invalid CONNECTION: ICEBERG rest connections may set CREDENTIAL or GCP CONNECTION, not both"
+                            ),
+                            (Some(credential), None) => IcebergCatalogAuth::OAuth {
+                                credential,
+                                scope: self.scope.clone(),
+                            },
+                            (None, Some(gcp_connection)) => IcebergCatalogAuth::Gcp(gcp_connection),
+                            (None, None) => sql_bail!(
+                                "invalid CONNECTION: ICEBERG rest connections require a CREDENTIAL or GCP CONNECTION"
+                            ),
                         };
 
-                        IcebergCatalogImpl::Rest(RestIcebergCatalog {
-                            credential,
-                            scope: self.scope.clone(),
-                            warehouse,
-                        })
+                        IcebergCatalogImpl::Rest(RestIcebergCatalog { auth, warehouse })
                     }
                 };
 
@@ -834,6 +851,24 @@ fn get_aws_connection_reference(
             connection: id,
         }),
         _ => sql_bail!("{} is not an AWS connection", item.name().item),
+    })
+}
+fn get_gcp_connection_reference(
+    scx: &StatementContext,
+    conn_options: &ConnectionOptionExtracted,
+) -> Result<Option<GcpConnectionReference<ReferencedConnection>>, PlanError> {
+    let Some(gcp_connection_id) = conn_options.gcp_connection else {
+        return Ok(None);
+    };
+
+    let id = CatalogItemId::from(gcp_connection_id);
+    let item = scx.catalog.get_item(&id);
+    Ok(match item.connection()? {
+        Connection::Gcp(_) => Some(GcpConnectionReference {
+            connection_id: id,
+            connection: id,
+        }),
+        _ => sql_bail!("{} is not a GCP connection", item.name().item),
     })
 }
 

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -915,6 +915,7 @@ impl IcebergCatalogConnection<InlinedConnection> {
                     GCS_CREDENTIALS_JSON.to_owned(),
                     base64::engine::general_purpose::STANDARD.encode(creds_json),
                 );
+                // We supplied a service account key. Don't look elsewhere for GCP credentials.
                 props.insert(GCS_DISABLE_VM_METADATA.to_owned(), "true".to_owned());
                 props.insert(GCS_DISABLE_CONFIG_LOAD.to_owned(), "true".to_owned());
                 if let Some(project_id) = service_account.project_id() {

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -22,10 +22,14 @@ use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, si
 use aws_sigv4::sign::v4;
 // Aliased to avoid colliding with `mz_ccsr::tls::Identity`.
 use aws_smithy_runtime_api::client::identity::Identity as AwsIdentity;
+use base64::Engine;
 use http::{HeaderName, HeaderValue};
 use iceberg::Catalog;
 use iceberg::CatalogBuilder;
-use iceberg::io::{S3_ACCESS_KEY_ID, S3_DISABLE_EC2_METADATA, S3_REGION, S3_SECRET_ACCESS_KEY};
+use iceberg::io::{
+    GCS_CREDENTIALS_JSON, GCS_DISABLE_CONFIG_LOAD, GCS_DISABLE_VM_METADATA, GCS_USER_PROJECT,
+    S3_ACCESS_KEY_ID, S3_DISABLE_EC2_METADATA, S3_REGION, S3_SECRET_ACCESS_KEY,
+};
 use iceberg_catalog_rest::{
     REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE, RequestAuthenticator, RestCatalogBuilder,
 };
@@ -70,6 +74,7 @@ use crate::configuration::StorageConfiguration;
 use crate::connections::aws::{
     AwsAuth, AwsConnection, AwsConnectionReference, AwsConnectionValidationError,
 };
+use crate::connections::gcp::{GcpConnectionReference, GcpTokenProvider};
 use crate::connections::string_or_secret::StringOrSecret;
 use crate::controller::AlterError;
 use crate::dyncfgs::{
@@ -487,6 +492,13 @@ impl Connection<InlinedConnection> {
         }
     }
 
+    pub fn unwrap_gcp(self) -> <InlinedConnection as ConnectionAccess>::Gcp {
+        match self {
+            Self::Gcp(conn) => conn,
+            o => unreachable!("{o:?} is not a GCP connection"),
+        }
+    }
+
     pub fn unwrap_ssh(self) -> <InlinedConnection as ConnectionAccess>::Ssh {
         match self {
             Self::Ssh(conn) => conn,
@@ -584,12 +596,22 @@ impl<C: ConnectionAccess> AlterCompatible for Connection<C> {
     }
 }
 
+/// Auth mechanism for Iceberg REST catalogs.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct RestIcebergCatalog {
-    /// For REST catalogs, the oauth2 credential in a `CLIENT_ID:CLIENT_SECRET` format
-    pub credential: StringOrSecret,
-    /// The oauth2 scope for REST catalogs
-    pub scope: Option<String>,
+pub enum IcebergCatalogAuth<C: ConnectionAccess = InlinedConnection> {
+    /// Use Iceberg catalog REST API's standard OAuth flow.
+    OAuth {
+        /// client_id:client_secret
+        credential: StringOrSecret,
+        /// OAuth2 scope
+        scope: Option<String>,
+    },
+    Gcp(GcpConnectionReference<C>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct RestIcebergCatalog<C: ConnectionAccess = InlinedConnection> {
+    pub auth: IcebergCatalogAuth<C>,
     /// The warehouse for REST catalogs
     pub warehouse: Option<String>,
 }
@@ -600,6 +622,30 @@ pub struct S3TablesRestIcebergCatalog<C: ConnectionAccess = InlinedConnection> {
     pub aws_connection: AwsConnectionReference<C>,
     /// The warehouse for s3tables
     pub warehouse: String,
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<IcebergCatalogAuth, R>
+    for IcebergCatalogAuth<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> IcebergCatalogAuth {
+        match self {
+            IcebergCatalogAuth::Gcp(x) => IcebergCatalogAuth::Gcp(x.into_inline_connection(&r)),
+            IcebergCatalogAuth::OAuth { credential, scope } => {
+                IcebergCatalogAuth::OAuth { credential, scope }
+            }
+        }
+    }
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<RestIcebergCatalog, R>
+    for RestIcebergCatalog<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> RestIcebergCatalog {
+        RestIcebergCatalog {
+            auth: self.auth.into_inline_connection(&r),
+            warehouse: self.warehouse,
+        }
+    }
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<S3TablesRestIcebergCatalog, R>
@@ -621,7 +667,7 @@ pub enum IcebergCatalogType {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum IcebergCatalogImpl<C: ConnectionAccess = InlinedConnection> {
-    Rest(RestIcebergCatalog),
+    Rest(RestIcebergCatalog<C>),
     S3TablesRest(S3TablesRestIcebergCatalog<C>),
 }
 
@@ -630,7 +676,9 @@ impl<R: ConnectionResolver> IntoInlineConnection<IcebergCatalogImpl, R>
 {
     fn into_inline_connection(self, r: R) -> IcebergCatalogImpl {
         match self {
-            IcebergCatalogImpl::Rest(rest) => IcebergCatalogImpl::Rest(rest),
+            IcebergCatalogImpl::Rest(rest) => {
+                IcebergCatalogImpl::Rest(rest.into_inline_connection(r))
+            }
             IcebergCatalogImpl::S3TablesRest(s3tables) => {
                 IcebergCatalogImpl::S3TablesRest(s3tables.into_inline_connection(r))
             }
@@ -827,29 +875,71 @@ impl IcebergCatalogConnection<InlinedConnection> {
             props.insert(REST_CATALOG_PROP_WAREHOUSE.to_string(), warehouse.clone());
         }
 
-        let credential = rest
-            .credential
-            .get_string(
-                in_task,
-                &storage_configuration.connection_context.secrets_reader,
-            )
-            .await
-            .map_err(|e| anyhow!("failed to read Iceberg catalog credential: {e}"))?;
-        props.insert(REST_CATALOG_PROP_CREDENTIAL.to_string(), credential);
+        // Catalog auth is configured through a combination of `props` and `.with_authenticator(...)`,
+        // which happen at different stages of the [`RestCatalogBuilder`] -> [`RestCatalog`]
+        // construction pipeline.
+        let (storage_factory, custom_authenticator) = match &rest.auth {
+            IcebergCatalogAuth::OAuth { credential, scope } => {
+                let credential = credential
+                    .get_string(
+                        in_task,
+                        &storage_configuration.connection_context.secrets_reader,
+                    )
+                    .await
+                    .map_err(|e| anyhow!("failed to read Iceberg catalog credential: {e}"))?;
+                props.insert(REST_CATALOG_PROP_CREDENTIAL.to_string(), credential);
 
-        if let Some(scope) = &rest.scope {
-            props.insert(REST_CATALOG_PROP_SCOPE.to_string(), scope.clone());
+                if let Some(scope) = scope {
+                    props.insert(REST_CATALOG_PROP_SCOPE.to_string(), scope.clone());
+                }
+                (
+                    OpenDalStorageFactory::S3 {
+                        configured_scheme: "s3".to_string(),
+                        // When used with MinIO, Polaris returns a config with:
+                        //   s3.access-key-id, s3.secret-access-key, s3.endpoint, ...
+                        // `iceberg-rust` forwards these props to `opendal`.
+                        // N.B. This is not confirmed to work with other catalog & storage implementations.
+                        customized_credential_load: None,
+                    },
+                    None,
+                )
+            }
+            IcebergCatalogAuth::Gcp(gcp_connection_reference) => {
+                let (creds_json, service_account) = gcp_connection_reference
+                    .connection
+                    .read_credentials(storage_configuration)
+                    .await
+                    .map_err(|e| anyhow!("failed to parse GCP service account JSON: {e}"))?;
+
+                props.insert(
+                    GCS_CREDENTIALS_JSON.to_owned(),
+                    base64::engine::general_purpose::STANDARD.encode(creds_json),
+                );
+                props.insert(GCS_DISABLE_VM_METADATA.to_owned(), "true".to_owned());
+                props.insert(GCS_DISABLE_CONFIG_LOAD.to_owned(), "true".to_owned());
+                if let Some(project_id) = service_account.project_id() {
+                    props.insert(GCS_USER_PROJECT.to_owned(), project_id.to_owned());
+                    props.insert(
+                        "header.x-goog-user-project".to_owned(),
+                        project_id.to_owned(),
+                    );
+                }
+
+                (
+                    OpenDalStorageFactory::Gcs,
+                    Some(iceberg_catalog_rest::BearerTokenAuthenticator::new(
+                        Arc::new(GcpTokenProvider { service_account }),
+                    )),
+                )
+            }
+        };
+
+        let mut catalog =
+            RestCatalogBuilder::default().with_storage_factory(Arc::new(storage_factory));
+        if let Some(auth) = custom_authenticator {
+            catalog = catalog.with_authenticator(Arc::new(auth));
         }
-
-        let catalog = RestCatalogBuilder::default()
-            .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
-                configured_scheme: "s3".to_string(),
-                // Polaris returns a config with:
-                //   s3.access-key-id, s3.secret-access-key, s3.endpoint, ...
-                // `iceberg-rust` forwards these props to `opendal`.
-                // N.B. This is not confirmed to work with other catalog & storage implementations.
-                customized_credential_load: None,
-            }))
+        let catalog = catalog
             .load("IcebergCatalog", props.into_iter().collect())
             .await
             .map_err(|e| anyhow!("failed to create Iceberg catalog: {e}"))?;

--- a/src/storage-types/src/connections/gcp.rs
+++ b/src/storage-types/src/connections/gcp.rs
@@ -9,20 +9,24 @@
 
 //! GCP configuration for sources and sinks.
 
-use gcp_auth::{CustomServiceAccount, TokenProvider};
+use async_trait::async_trait;
+use gcp_auth::{CustomServiceAccount, TokenProvider as _};
+use iceberg_catalog_rest::TokenProvider;
 use mz_ore::error::ErrorExt;
 use mz_repr::{CatalogItemId, GlobalId};
 use serde::{Deserialize, Serialize};
 
 use crate::AlterCompatible;
 use crate::configuration::StorageConfiguration;
+use crate::connections::inline::{
+    ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
+    ReferencedConnection,
+};
 use crate::controller::AlterError;
 
-/// Scope used when probing the credentials during validation. Picked because
-/// every service-account key is allowed to mint tokens for it, so a successful
-/// response confirms the key is well-formed and accepted by Google's token
-/// endpoint without requiring any specific IAM grants on the service account.
-const VALIDATION_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+/// Every service-account key is allowed to mint tokens for this scope,
+/// and it's a blanket scope that covers both BigLake (Iceberg catalog) and GCS.
+const GCP_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
 
 /// Modern GCP Service Account keys always use the same token URI.
 const OAUTH_TOKEN_URI: &str = "https://oauth2.googleapis.com/token";
@@ -65,14 +69,11 @@ impl GcpServiceAccountKeyTokenUri {
 }
 
 impl GcpConnection {
-    /// Validates this connection by reading the service-account key out of the
-    /// secrets store, parsing it, and exchanging it for an OAuth2 access token
-    /// at Google's token endpoint.
-    pub(crate) async fn validate(
+    /// Returns (credentials JSON, parsed service account) because both forms are useful.
+    pub(crate) async fn read_credentials(
         &self,
-        _id: CatalogItemId,
         storage_configuration: &StorageConfiguration,
-    ) -> Result<(), GcpConnectionValidationError> {
+    ) -> Result<(String, CustomServiceAccount), GcpConnectionValidationError> {
         let json = storage_configuration
             .connection_context
             .secrets_reader
@@ -81,10 +82,20 @@ impl GcpConnection {
             .map_err(GcpConnectionValidationError::SecretRead)?;
         GcpServiceAccountKeyTokenUri::validate_json(&json)
             .map_err(GcpConnectionValidationError::ParseKey)?;
-        let service_account = CustomServiceAccount::from_json(&json)
+        let account = CustomServiceAccount::from_json(&json)
             .map_err(|e| GcpConnectionValidationError::ParseKey(anyhow::Error::from(e)))?;
+        Ok((json, account))
+    }
+
+    /// Pull the service account key and check that we can retrieve an access token.
+    pub(crate) async fn validate(
+        &self,
+        _id: CatalogItemId,
+        storage_configuration: &StorageConfiguration,
+    ) -> Result<(), GcpConnectionValidationError> {
+        let (_, service_account) = self.read_credentials(storage_configuration).await?;
         service_account
-            .token(&[VALIDATION_SCOPE])
+            .token(&[GCP_SCOPE])
             .await
             .map_err(GcpConnectionValidationError::FetchToken)?;
         Ok(())
@@ -119,5 +130,61 @@ impl GcpConnectionValidationError {
             ),
             _ => None,
         }
+    }
+}
+
+/// References a GCP connection.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct GcpConnectionReference<C: ConnectionAccess = InlinedConnection> {
+    /// ID of the GCP connection.
+    pub connection_id: CatalogItemId,
+    /// GCP connection object.
+    pub connection: C::Gcp,
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<GcpConnectionReference, R>
+    for GcpConnectionReference<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> GcpConnectionReference {
+        let GcpConnectionReference {
+            connection,
+            connection_id,
+        } = self;
+
+        GcpConnectionReference {
+            connection: r.resolve_connection(connection).unwrap_gcp(),
+            connection_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GcpTokenProvider {
+    pub(crate) service_account: CustomServiceAccount,
+}
+
+#[async_trait]
+impl TokenProvider for GcpTokenProvider {
+    async fn token(&self) -> iceberg::Result<String> {
+        let token = self
+            .service_account
+            .token(&[GCP_SCOPE])
+            .await
+            .map_err(|e| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::Unexpected,
+                    format!("gcp_auth: {}", e.display_with_causes()),
+                )
+            })?;
+        Ok(token.as_str().to_string())
+    }
+
+    async fn invalidate(&self) -> iceberg::Result<()> {
+        // gcp_auth caches+refreshes internally based on Token::has_expired.
+        Ok(())
+    }
+
+    async fn regenerate(&self) -> iceberg::Result<()> {
+        Ok(())
     }
 }

--- a/src/storage-types/src/connections/inline.rs
+++ b/src/storage-types/src/connections/inline.rs
@@ -77,6 +77,14 @@ pub trait ConnectionAccess: Clone + Debug + Eq + PartialEq + Serialize + 'static
         + Serialize
         + for<'a> Deserialize<'a>
         + AlterCompatible;
+    type Gcp: Clone
+        + Debug
+        + Eq
+        + PartialEq
+        + Hash
+        + Serialize
+        + for<'a> Deserialize<'a>
+        + AlterCompatible;
     type Ssh: Clone
         + Debug
         + Eq
@@ -137,6 +145,7 @@ impl ConnectionAccess for ReferencedConnection {
     type Kafka = CatalogItemId;
     type Pg = CatalogItemId;
     type Aws = CatalogItemId;
+    type Gcp = CatalogItemId;
     type Ssh = CatalogItemId;
     type Csr = CatalogItemId;
     type GlueSchemaRegistry = CatalogItemId;
@@ -153,6 +162,7 @@ impl ConnectionAccess for InlinedConnection {
     type Kafka = super::KafkaConnection;
     type Pg = super::PostgresConnection;
     type Aws = super::aws::AwsConnection;
+    type Gcp = super::gcp::GcpConnection;
     type Ssh = super::SshConnection;
     type Csr = super::CsrConnection;
     type GlueSchemaRegistry = super::GlueSchemaRegistryConnection;

--- a/test/gcp/gcp-iceberg-e2e.td
+++ b/test/gcp/gcp-iceberg-e2e.td
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SECRET gcpsa AS decode('${arg.gcp-sa-json-b64}', 'base64');
+
+> CREATE CONNECTION gcpconn TO GCP (SERVICE ACCOUNT KEY = SECRET gcpsa);
+
+> CREATE CONNECTION biglake TO ICEBERG CATALOG (
+    CATALOG TYPE = 'rest',
+    URL = 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
+    GCP CONNECTION = gcpconn,
+    WAREHOUSE = 'gs://${arg.gcs-bucket}'
+  );
+
+> create table foo(a int, b text);
+
+> insert into foo values (1, 'one'), (2, 'two'), (3, 'three');
+
+> CREATE SINK demo
+    FROM foo
+    INTO ICEBERG CATALOG CONNECTION biglake (
+        NAMESPACE '${arg.namespace}',
+        TABLE '${arg.table}'
+    )
+    KEY (a) NOT ENFORCED
+    MODE UPSERT
+    WITH (COMMIT INTERVAL '1s');
+
+# Iceberg sinks commit data asynchronously. We leave the sink running and let
+# mzcompose.py poll BigLake until the commit lands or times out.

--- a/test/gcp/mzcompose
+++ b/test/gcp/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/gcp/mzcompose.py
+++ b/test/gcp/mzcompose.py
@@ -1,0 +1,433 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Tests of GCP functionality that run against GCP.
+
+To run these tests locally:
+
+  $ cd test/gcp
+  $ ICEBERG_GCS_BUCKET=... \
+    ICEBERG_GCP_PROJECT=... \
+    ICEBERG_GCP_SA_JSON_B64=... \
+    ./mzcompose --dev run default
+"""
+
+import base64
+import json
+import os
+import random
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+import jwt
+
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.testdrive import Testdrive
+
+# Blanket scope used to mint tokens for both GCS and BigLake. Matches GCP_SCOPE
+# in src/storage-types/src/connections/gcp.rs.
+GCP_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+BIGLAKE_REST_BASE = "https://biglake.googleapis.com/iceberg/v1/restcatalog"
+
+# Per-run namespace name format: e2e_<UTC date>_<random hex>. The date lets the
+# pre-test sweep age out namespaces left behind by killed runs without extra API
+# calls.
+NAMESPACE_PREFIX = "e2e"
+NAMESPACE_DATE_FORMAT = "%Y%m%d"
+NAMESPACE_RE = re.compile(rf"^{NAMESPACE_PREFIX}_(\d{{8}})_[0-9a-f]+$")
+# Sweep anything strictly older than this. One day is long enough that any
+# in-flight concurrent run (which finishes in minutes) is never targeted.
+STALE_NAMESPACE_AGE = timedelta(days=1)
+
+SERVICES = [
+    Materialized(),
+    Testdrive(),
+]
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(
+            f"{name} is not set. This test requires real GCP credentials; "
+            "see the docstring at the top of mzcompose.py."
+        )
+    return value
+
+
+def _mint_gcp_access_token(service_account: dict) -> str:
+    """Mint an OAuth2 access token from a GCP service-account key (JWT bearer flow)."""
+    now = int(time.time())
+    assertion = jwt.encode(
+        {
+            "iss": service_account["client_email"],
+            "scope": GCP_SCOPE,
+            "aud": "https://oauth2.googleapis.com/token",
+            "iat": now,
+            "exp": now + 3600,
+        },
+        service_account["private_key"],
+        algorithm="RS256",
+    )
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": assertion,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        "https://oauth2.googleapis.com/token",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())["access_token"]
+
+
+def _biglake_request(
+    method: str, url: str, token: str, project: str
+) -> urllib.request.Request:
+    return urllib.request.Request(
+        url,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "x-goog-user-project": project,
+        },
+    )
+
+
+def _ensure_biglake_catalog(token: str, project: str, bucket: str) -> None:
+    """Create the BigLake Iceberg REST catalog for this bucket if it's missing.
+
+    The Iceberg REST `/v1/config?warehouse=gs://<bucket>` lookup resolves the catalog
+    whose id equals the bucket name; it does not provision one on demand. Without it,
+    every REST call returns a sanitized 403. Creating it here lets the test bootstrap
+    its own catalog instead of depending on out-of-band (Pulumi/console) setup.
+
+    Credential mode is END_USER: the Materialize sink writes to GCS with the service
+    account's own credentials (see `connect_rest` for the GCP branch in
+    mz_storage_types::connections), not credentials vended by the catalog.
+    """
+    base = f"{BIGLAKE_REST_BASE}/extensions/projects/{project}/catalogs"
+
+    # GET returns the catalog if it exists, 404 if not.
+    try:
+        urllib.request.urlopen(
+            _biglake_request("GET", f"{base}/{bucket}", token, project)
+        )
+        return
+    except urllib.error.HTTPError as e:
+        if e.code != 404:
+            raise
+
+    create_url = f"{base}?iceberg-catalog-id={urllib.parse.quote(bucket, safe='')}"
+    req = _biglake_request("POST", create_url, token, project)
+    req.add_header("Content-Type", "application/json")
+    req.data = json.dumps(
+        {
+            "catalog-type": "CATALOG_TYPE_GCS_BUCKET",
+            "credential-mode": "CREDENTIAL_MODE_END_USER",
+        }
+    ).encode()
+    try:
+        urllib.request.urlopen(req)
+        print(f"created BigLake catalog for gs://{bucket}")
+    except urllib.error.HTTPError as e:
+        # A concurrent run can create the catalog between our GET and POST.
+        if e.code == 409:
+            return
+        body = e.read().decode("utf-8", errors="replace")
+        print(f"BigLake catalog create failed: HTTP {e.code}\n{body}")
+        raise
+
+
+def _resolve_warehouse_prefix(token: str, project: str, bucket: str) -> str:
+    """Return the catalog prefix BigLake assigns to this warehouse.
+
+    Iceberg REST clients call GET /v1/config?warehouse=... before any other
+    operation. The catalog's response includes an `overrides.prefix` that the
+    client splices in between `/v1/` and resource paths for every later call:
+
+        {uri}/v1/{prefix}/namespaces/{ns}/tables/{tbl}
+
+    See `RestCatalogConfig::url_prefixed` in iceberg-catalog-rest.
+    """
+    warehouse = f"gs://{bucket}"
+    url = (
+        f"{BIGLAKE_REST_BASE}/v1/config"
+        f"?warehouse={urllib.parse.quote(warehouse, safe='')}"
+    )
+    with urllib.request.urlopen(_biglake_request("GET", url, token, project)) as resp:
+        config = json.loads(resp.read())
+    print(f"BigLake /v1/config response: {json.dumps(config)}")
+    return config.get("overrides", {}).get("prefix", "")
+
+
+def _catalog_url(prefix: str, suffix: str) -> str:
+    middle = f"{prefix}/" if prefix else ""
+    return f"{BIGLAKE_REST_BASE}/v1/{middle}{suffix}"
+
+
+def _table_url(prefix: str, namespace: str, table: str) -> str:
+    ns = urllib.parse.quote(namespace, safe="")
+    tbl = urllib.parse.quote(table, safe="")
+    return _catalog_url(prefix, f"namespaces/{ns}/tables/{tbl}")
+
+
+def _namespace_url(prefix: str, namespace: str) -> str:
+    ns = urllib.parse.quote(namespace, safe="")
+    return _catalog_url(prefix, f"namespaces/{ns}")
+
+
+def _verify_sink_committed(
+    token: str,
+    project: str,
+    prefix: str,
+    namespace: str,
+    table: str,
+    expected_rows: int,
+) -> None:
+    """Poll BigLake until the table's current snapshot has expected_rows.
+
+    Iceberg sinks commit asynchronously. Iceberg uses -1 to mean "no snapshot yet";
+    we poll until the snapshot lands or we time out.
+
+    Unlike the AWS test, we verify only the row count, not the row values. DuckDB
+    is how the AWS test reads the iceberg table back, but DuckDB's iceberg
+    extension didn't gain custom-HTTP-header support (needed for BigLake's
+    `x-goog-user-project`) until duckdb-iceberg PR #687, which only landed on
+    `main` / `v1.5-variegata`. Our workspace duckdb is pinned to 1.4.x, whose
+    iceberg extension branch (`v1.4-andium`) does not have the backport.
+    """
+    url = _table_url(prefix, namespace, table)
+    print(f"BigLake GET table URL: {url}")
+
+    deadline = time.time() + 60
+    last_state = "no response yet"
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(
+                _biglake_request("GET", url, token, project)
+            ) as resp:
+                body = json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            last_state = f"HTTP {e.code}"
+            if e.code != 404:
+                raise
+            time.sleep(2)
+            continue
+
+        metadata = body["metadata"]
+        snapshot_id = metadata.get("current-snapshot-id")
+        if snapshot_id is None or snapshot_id == -1:
+            last_state = "current-snapshot-id is null/-1 (table created, no commit yet)"
+            time.sleep(2)
+            continue
+
+        snapshot = next(
+            (
+                s
+                for s in metadata.get("snapshots", [])
+                if s["snapshot-id"] == snapshot_id
+            ),
+            None,
+        )
+        if snapshot is None:
+            last_state = f"current-snapshot-id={snapshot_id} but not in snapshots list"
+            time.sleep(2)
+            continue
+
+        # Iceberg summary values are strings per the REST spec.
+        total_records = int(snapshot["summary"]["total-records"])
+        if total_records != expected_rows:
+            last_state = f"snapshot has {total_records} rows, want {expected_rows}"
+            time.sleep(2)
+            continue
+
+        return
+
+    raise AssertionError(
+        f"BigLake table {namespace}.{table} did not converge to {expected_rows} "
+        f"rows within timeout; last state: {last_state}"
+    )
+
+
+def _create_biglake_namespace(
+    token: str, project: str, prefix: str, namespace: str
+) -> None:
+    """Create the namespace. BigLake doesn't auto-create on first commit."""
+    req = _biglake_request("POST", _catalog_url(prefix, "namespaces"), token, project)
+    req.add_header("Content-Type", "application/json")
+    req.data = json.dumps({"namespace": [namespace]}).encode()
+    urllib.request.urlopen(req)
+
+
+def _delete_biglake(method_url: str, token: str, project: str) -> None:
+    """DELETE a BigLake resource, tolerating 404 so cleanup is idempotent."""
+    try:
+        urllib.request.urlopen(_biglake_request("DELETE", method_url, token, project))
+    except urllib.error.HTTPError as e:
+        if e.code != 404:
+            raise
+
+
+def _paginated_get(url: str, token: str, project: str, items_key: str):
+    """Yield items from a paginated Iceberg REST list endpoint."""
+    page_token = None
+    while True:
+        page_url = url
+        if page_token:
+            sep = "&" if "?" in page_url else "?"
+            page_url = f"{page_url}{sep}pageToken={urllib.parse.quote(page_token)}"
+        with urllib.request.urlopen(
+            _biglake_request("GET", page_url, token, project)
+        ) as resp:
+            body = json.loads(resp.read())
+        yield from body.get(items_key, [])
+        page_token = body.get("next-page-token")
+        if not page_token:
+            return
+
+
+def _list_biglake_namespaces(token: str, project: str, prefix: str) -> list[str]:
+    """Return single-segment namespace names under this catalog prefix."""
+    return [
+        ns[0]
+        for ns in _paginated_get(
+            _catalog_url(prefix, "namespaces"), token, project, "namespaces"
+        )
+        if len(ns) == 1
+    ]
+
+
+def _list_biglake_tables(
+    token: str, project: str, prefix: str, namespace: str
+) -> list[str]:
+    return [
+        ident["name"]
+        for ident in _paginated_get(
+            _catalog_url(
+                prefix, f"namespaces/{urllib.parse.quote(namespace, safe='')}/tables"
+            ),
+            token,
+            project,
+            "identifiers",
+        )
+    ]
+
+
+def _sweep_stale_biglake_namespaces(token: str, project: str, prefix: str) -> None:
+    """Delete e2e_* namespaces left behind by killed/timed-out previous runs.
+
+    Iceberg sinks normally clean themselves up in mzcompose.py's `finally`, but
+    SIGKILL (oomkill, agent reboot) skips that path. We parse the date embedded
+    in the namespace name to age out anything older than STALE_NAMESPACE_AGE
+    without an extra metadata round-trip per namespace.
+    """
+    today = datetime.now(timezone.utc).date()
+    for ns in _list_biglake_namespaces(token, project, prefix):
+        match = NAMESPACE_RE.match(ns)
+        if not match:
+            continue
+        ns_date = datetime.strptime(match.group(1), NAMESPACE_DATE_FORMAT).date()
+        age = today - ns_date
+        if age <= STALE_NAMESPACE_AGE:
+            continue
+        print(f"sweeping stale BigLake namespace: {ns} (age {age})")
+        try:
+            for tbl in _list_biglake_tables(token, project, prefix, ns):
+                _delete_biglake(_table_url(prefix, ns, tbl), token, project)
+            _delete_biglake(_namespace_url(prefix, ns), token, project)
+        except Exception as e:
+            # Keep sweeping; a single bad namespace shouldn't block the test.
+            print(f"warning: failed to sweep namespace {ns}: {e}")
+
+
+def workflow_default(c: Composition) -> None:
+    bucket = _require_env("ICEBERG_GCS_BUCKET")
+    project = _require_env("ICEBERG_GCP_PROJECT")
+    sa_json_b64 = _require_env("ICEBERG_GCP_SA_JSON_B64")
+
+    service_account = json.loads(base64.b64decode(sa_json_b64))
+
+    # Per-run namespace so concurrent / repeated runs against the shared
+    # bucket don't collide on table state. The embedded date lets the pre-test
+    # sweep age out namespaces left behind by killed runs.
+    seed = random.getrandbits(32)
+    today = datetime.now(timezone.utc).strftime(NAMESPACE_DATE_FORMAT)
+    namespace = f"{NAMESPACE_PREFIX}_{today}_{seed:08x}"
+    table = "demo_table"
+    # The .td inserts these three rows; verification asserts the snapshot
+    # summary matches.
+    expected_rows = 3
+
+    materialized = Materialized()
+    with c.override(materialized):
+        c.down()
+        c.up("materialized")
+        c.sql(
+            port=6877,
+            user="mz_system",
+            sql="""
+            ALTER SYSTEM SET enable_connection_validation_syntax = true;
+            """,
+        )
+
+        # Mint once and reuse for verification + cleanup. Tokens last an hour;
+        # minting up front also fails fast if the service-account key is broken.
+        token = _mint_gcp_access_token(service_account)
+        # Bootstrap the catalog if absent; /v1/config 403s otherwise.
+        _ensure_biglake_catalog(token, project, bucket)
+        # Discover the per-warehouse catalog prefix once; it's identical for
+        # the verify and cleanup paths.
+        prefix = _resolve_warehouse_prefix(token, project, bucket)
+        # Garbage-collect namespaces from previous runs that were killed before
+        # their `finally` could run. Best-effort; logged failures don't block.
+        _sweep_stale_biglake_namespaces(token, project, prefix)
+        # BigLake doesn't auto-create namespaces on first commit, so we have to
+        # pre-create (matching how the AWS test pre-creates the S3 Tables namespace).
+        _create_biglake_namespace(token, project, prefix, namespace)
+
+        try:
+            c.run_testdrive_files(
+                "--no-reset",
+                f"--var=gcp-sa-json-b64={sa_json_b64}",
+                f"--var=gcs-bucket={bucket}",
+                f"--var=namespace={namespace}",
+                f"--var=table={table}",
+                "gcp-iceberg-e2e.td",
+            )
+
+            try:
+                _verify_sink_committed(
+                    token, project, prefix, namespace, table, expected_rows
+                )
+            except Exception:
+                # Dump Materialize logs to make sink errors visible.
+                logs = c.invoke("logs", "materialized", capture=True)
+                print("--- materialized logs (tail) ---")
+                print("\n".join(logs.stdout.splitlines()[-200:]))
+                print("--- end materialized logs ---")
+                raise
+
+            c.sql("DROP SINK demo;")
+        finally:
+            try:
+                _delete_biglake(_table_url(prefix, namespace, table), token, project)
+                _delete_biglake(_namespace_url(prefix, namespace), token, project)
+            except Exception as cleanup_error:
+                # Don't mask the real failure if there was one.
+                print(f"warning: BigLake cleanup failed: {cleanup_error}")

--- a/test/iceberg/gcp-connection-validation.td
+++ b/test/iceberg/gcp-connection-validation.td
@@ -37,7 +37,7 @@ $ set gcp-ssrf-key="-----BEGIN PRIVATE KEY-----\\nMIIEvAIBADANBgkqhkiG9w0BAQEFAA
     GCP CONNECTION = gcpconn,
     WAREHOUSE = 'gs://anything'
   )
-contains:must point URL at a *.googleapis.com host
+contains:GCP connection can only be used with 'https://biglake.googleapis.com/iceberg/v1/restcatalog'
 
 # Positive control: a real BigLake host is accepted, so the allowlist doesn't
 # break the feature.

--- a/test/iceberg/gcp-connection-validation.td
+++ b/test/iceberg/gcp-connection-validation.td
@@ -1,0 +1,49 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for SS-69: an Iceberg REST catalog connection that
+# authenticates with a GCP connection must only send its reusable, broadly-
+# scoped bearer token to a Google-operated host. Without a plan-time host check,
+# a principal with only USAGE on the GCP connection can aim the catalog URL at a
+# host they control and exfiltrate the service-account token.
+
+# Disable default validation so the accepted case below doesn't try to connect to the catalog
+# (and fail because it's using a dummy private key).
+# The catalog host check is enforced at plan time, independent of validation.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_default_connection_validation = false
+
+# The private_key is a throwaway RSA key reused from the repo (src/ccsr/tests and
+# the trufflehog allowlist) -- never a real credential. It must parse so gcp_auth
+# reaches the token-fetch step that consumes token_uri. Backslashes are doubled:
+# standard_conforming_strings is on, so the text->bytea cast turns each "\\n"
+# into the literal "\n" the JSON needs.
+$ set gcp-ssrf-key="-----BEGIN PRIVATE KEY-----\\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDC5MP3v1BHOgI\\n5SsmrW8mjxzQGOz0IlC5jp1muW/kpEoE9TG317TEnO5Uye6zZudkFCP8YGEiN3Mc\\nFbTM7eX6PjAPdnGU7khuUt/20ZM+NX5kWZPrmPTh4WQaDCL7ah1LqzBaUAMaSXq8\\niuy7LGJNF8wdx8L5BjDiGTTxZXOg0Haxknc7Mbiwc9z8eb7omvzQzsOwyqocrF2u\\nz86TzX1jtHP48i5CxoRHKxE94De3tNxjT/Y3OZlS4QS7iekAOQ04DVV3GIHvRUXN\\n2H8ayy4+yOdhHn6ER5Jn3lti1Q5XSrxkrYn7L1Vcj6IwZQhhF5vc+ovxOYb+8ert\\nEo97tIkLAgMBAAECggEAQteHHRPKz9Mzs8Sxvo4GPv0hnzFDl0DhUE4PJCKdtYoV\\n8dADq2DJiu3LAZS4cJPt7Y63bGitMRg2oyPPM8G9pD5Goy3wq9zjRqexKDlXUCTt\\n/T7zofRny7c94m1RWb7ablGq/vBXt90BqnajvVtvDsN+iKAqccQM4ZdI3QdrEmt1\\ncHex924itzG/mqbFTAfAmVj1ZsRnJp55Txy2gqq7jX00xDM8+H49SRvUu49N64LQ\\n6BUWCgWCJePRtgjSHjboAzPqSkMdaTE/WDY2zgGF3Qfq4f6JCHKfm4QylCH4gYUU\\n1Kf7ttmhu9NoZO+hczobKkxP9RtXfyTRH2bsJXy2HQKBgQDhHgavxk/ln5mdMGGw\\nrQud2vF9n7UwFiysYxocIC5/CWD0GAhnawchjPypbW/7vKM5Z9zhW3eH1U9P13sa\\n2xHfrU5BZ16rxoBbKNpcr7VeEbUBAsDoGV24xjoecp7rB2hZ+mGik5/5Ig1Rk1KH\\ndcvYy2KSi1h4Sm+mXwimmA4VDQKBgQDdzW+5FPbdM2sUB2gLMQtn3ICjDSu6IQ+k\\nd0p3WlTIT51RUsPXXKkk96O5anUbeB3syY8tSKPGggsaXaeL3o09yIamtERgCnn3\\nd9IS+4VKPWQlFUICU1KrD+TO7IYIX04iXBuVE5ihv0q3mslhDotmX4kS38NtKEFF\\njLjA2RvAdwKBgAFkIxxw+Ett+hALnX7vAtRd5wIku4TpjisejanA1Si50RyRDXQ+\\nKBQf/+u4HmoK12Nibe4Cl7GCMvRGW59l3S1pr8MdtWsQVfi6Puc1usQzDdBMyQ5m\\nIbsjlnZbtPm02QM9Vd8gVGvAtx5a77aglrrnPtuy+r/7jccUbURCSkv9AoGAH9m3\\nWGmVRZBzqO2jWDATxjdY1ZE3nUPQHjrvG5KCKD2ehqYO72cj9uYEwcRyyp4GFhGf\\nmM4cjo3wEDowrBoqSBv6kgfC5dO7TfkL1qP9sPp93gFeeD0E2wGuRrSaTqt46eA2\\nKcMloNx6W0FD98cB55KCeY5eXtdwAA/EHBVRMeMCgYAd3n6PcL6rVXyE3+wRTKK4\\n+zvx5sjTAnljr5ttbEnpZafzrYIfDpB8NNjexy83AeC0O13LvSHIFoTwP8sywJRO\\nRxbPMjhEBdVZ5NxlxYer7yKN+h5OBJfrLswPku7y4vdFYK3x/lMuNQO61hb1VFHc\\nT2BDTbF0QSlPxFsv18B9zg==\\n-----END PRIVATE KEY-----\\n"
+
+> CREATE SECRET gcpsa AS '{"type":"service_account","project_id":"x","client_email":"a@b.com","private_key":"${gcp-ssrf-key}","token_uri":"https://oauth2.googleapis.com/token"}'
+
+> CREATE CONNECTION gcpconn TO GCP (SERVICE ACCOUNT KEY = SECRET gcpsa)
+
+# Exploit: a non-Google catalog host must be rejected before any token is sent.
+! CREATE CONNECTION evil TO ICEBERG CATALOG (
+    CATALOG TYPE = 'rest',
+    URL = 'https://attacker.example.com/iceberg/v1/restcatalog',
+    GCP CONNECTION = gcpconn,
+    WAREHOUSE = 'gs://anything'
+  )
+contains:must point URL at a *.googleapis.com host
+
+# Positive control: a real BigLake host is accepted, so the allowlist doesn't
+# break the feature.
+> CREATE CONNECTION biglake TO ICEBERG CATALOG (
+    CATALOG TYPE = 'rest',
+    URL = 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
+    GCP CONNECTION = gcpconn,
+    WAREHOUSE = 'gs://anything'
+  )

--- a/test/iceberg/key-validation.td
+++ b/test/iceberg/key-validation.td
@@ -86,7 +86,6 @@ contains:cannot be used as an Iceberg equality delete key
         NAMESPACE 'default_namespace',
         TABLE 'key_range_table'
     )
-    USING AWS CONNECTION aws_conn
     KEY (k) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL '1s');

--- a/test/iceberg/mzcompose.py
+++ b/test/iceberg/mzcompose.py
@@ -79,6 +79,22 @@ def workflow_smoke(c: Composition) -> None:
     )
 
 
+def workflow_gcp_connection_validation(c: Composition) -> None:
+    """Regression test for SS-69: an Iceberg REST catalog connection that
+    authenticates with a GCP connection must only target Google-operated catalog
+    hosts. A GCP access token is a reusable, broadly-scoped bearer credential
+    with no audience binding, so before this validation a principal with only
+    USAGE on a GCP connection could point the catalog URL at an attacker host and
+    exfiltrate the connection's service-account token. This exercises connection
+    planning only and needs no Iceberg backend."""
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+
+    c.run_testdrive_files(
+        "gcp-connection-validation.td",
+    )
+
+
 def workflow_mode_append(c: Composition) -> None:
     key = _setup(c)
 


### PR DESCRIPTION
**In this PR:**
- `iceberg-rust` `RequestAuthenticator` using `gcp_auth`
- Iceberg catalog connection can use a GCP connection now.
  - Iceberg sink _just works_.
- new Nightly CI group "GCP" with a GCP test
  - uses https://github.com/MaterializeInc/i2/pull/3279

N.B. GCP BigLake doesn't perform Iceberg maintenance yet, so long-running Iceberg sinks will fail when the table metadata grows too large.
(ref: https://cloud.google.com/blog/products/data-analytics/improved-interoperability-for-your-apache-iceberg-lakehouse)

_stacked on #36694_