### PR TITLE
console: use "info" variant for cluster metrics warning banner

### DIFF
--- a/console/src/platform/clusters/ClusterOverview.tsx
+++ b/console/src/platform/clusters/ClusterOverview.tsx
@@ -196,7 +196,10 @@ const ClusterOverview = () => {
               <Spinner data-testid="loading-spinner" />
             </Flex>
           ) : clusterHasNoMetrics ? (
-            <ErrorBox message={CLUSTER_METRICS_UNAVAILABLE_MESSAGE} />
+            <Alert
+              variant="info"
+              message={CLUSTER_METRICS_UNAVAILABLE_MESSAGE}
+            />
           ) : data ? (
             <Grid
               gridTemplateColumns={{


### PR DESCRIPTION
Warning banner variant for customers in the emulator for cluster metrics is alarming so switched it to the "info" variant. Fixes [CNS-78](https://linear.app/materializeinc/issue/CNS-78/emulator-doesnt-have-metrics-shows-red-banner)