### PR TITLE
expr-derive-impl: support stateful unary/binary in sqlfunc macro

### DIFF
--- a/src/expr-derive-impl/src/lib.rs
+++ b/src/expr-derive-impl/src/lib.rs
@@ -141,6 +141,28 @@ mod test {
 
     #[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
     #[mz_ore::test]
+    fn insta_test_unary_self_arena() {
+        let attr = quote! {
+            CastArrayToString,
+            sqlname = "arraytostr",
+            preserves_uniqueness = true,
+            introduces_nulls = false,
+        };
+        let item = quote! {
+            fn cast_array_to_string<'a>(
+                &self,
+                a: Array<'a>,
+                temp_storage: &'a RowArena,
+            ) -> Result<&'a str, EvalError> {
+                unimplemented!()
+            }
+        };
+        let (output, input) = super::test_sqlfunc(attr, item);
+        insta::assert_snapshot!("unary_self_arena", output, &input);
+    }
+
+    #[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+    #[mz_ore::test]
     fn insta_test_binary_arena() {
         let attr = quote! {test = true};
         let item = quote! {

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_arena_fn.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_arena_fn.snap
@@ -2,6 +2,46 @@
 source: src/expr-derive-impl/src/lib.rs
 expression: "#[sqlfunc(test = true)]\nfn unary_fn<'a>(a: Datum<'a>, temp_storage: &RowArena) -> bool {\n    unimplemented!()\n}\n"
 ---
-::core::compile_error! {
-    "Unary functions do not yet support RowArena."
+#[derive(
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect,
+)]
+#[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
+pub struct UnaryFn;
+impl crate::func::EagerUnaryFunc for UnaryFn {
+    type Input<'a> = Datum<'a>;
+    type Output<'a> = bool;
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        unary_fn(a, temp_storage)
+    }
+    fn output_sql_type(
+        &self,
+        input_type: mz_repr::SqlColumnType,
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+}
+impl std::fmt::Display for UnaryFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(unary_fn))
+    }
+}
+fn unary_fn<'a>(a: Datum<'a>, temp_storage: &RowArena) -> bool {
+    unimplemented!()
 }

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_fn.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_fn.snap
@@ -19,7 +19,11 @@ pub struct UnaryFn;
 impl crate::func::EagerUnaryFunc for UnaryFn {
     type Input<'a> = Datum<'a>;
     type Output<'a> = bool;
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         unary_fn(a)
     }
     fn output_sql_type(

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_generic_range.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_generic_range.snap
@@ -19,7 +19,11 @@ pub struct RangeLower;
 impl crate::func::EagerUnaryFunc for RangeLower {
     type Input<'a> = Range<Datum<'a>>;
     type Output<'a> = Option<Datum<'a>>;
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         range_lower(a)
     }
     fn output_sql_type(

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_ref.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_ref.snap
@@ -19,7 +19,11 @@ pub struct UnaryFn;
 impl crate::func::EagerUnaryFunc for UnaryFn {
     type Input<'a> = &'a i16;
     type Output<'a> = bool;
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         unary_fn(a)
     }
     fn output_sql_type(

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_self_arena.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_self_arena.snap
@@ -1,0 +1,45 @@
+---
+source: src/expr-derive-impl/src/lib.rs
+expression: "#[sqlfunc(\n    CastArrayToString,\n    sqlname = \"arraytostr\",\n    preserves_uniqueness = true,\n    introduces_nulls = false,\n)]\nfn cast_array_to_string<'a>(\n    &self,\n    a: Array<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<&'a str, EvalError> {\n    unimplemented!()\n}\n"
+---
+impl CastArrayToString {
+    fn cast_array_to_string<'a>(
+        &self,
+        a: Array<'a>,
+        temp_storage: &'a RowArena,
+    ) -> Result<&'a str, EvalError> {
+        unimplemented!()
+    }
+}
+impl crate::func::EagerUnaryFunc for CastArrayToString {
+    type Input<'a> = Array<'a>;
+    type Output<'a> = Result<&'a str, EvalError>;
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        self.cast_array_to_string(a, temp_storage)
+    }
+    fn output_sql_type(
+        &self,
+        input_type: mz_repr::SqlColumnType,
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastArrayToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("arraytostr")
+    }
+}

--- a/src/expr-derive-impl/src/sqlfunc.rs
+++ b/src/expr-derive-impl/src/sqlfunc.rs
@@ -47,6 +47,9 @@ pub(crate) struct Modifiers {
     is_eliminable_cast: Option<Expr>,
     /// Whether to generate a snapshot test for the function. Defaults to false.
     test: Option<bool>,
+    /// If true, the macro does not emit a `fmt::Display` implementation. Use this when the
+    /// struct needs a non-trivial `Display` impl that the user supplies manually.
+    skip_display: Option<bool>,
 }
 
 /// A name for the SQL function. It can be either a literal or a macro, thus we
@@ -114,11 +117,12 @@ pub fn sqlfunc(
 
     let tokens = match determine_arity(&func) {
         Arity::Nullary => Err(darling::Error::custom("Nullary functions not supported")),
-        Arity::Unary { arena: false } => unary_func(&func, modifiers),
-        Arity::Unary { arena: true } => Err(darling::Error::custom(
-            "Unary functions do not yet support RowArena.",
-        )),
-        Arity::Binary { arena } => binary_func(&func, modifiers, arena),
+        Arity::Unary { arena, has_self } => {
+            unary_func(&func, modifiers, struct_ty, arena, has_self)
+        }
+        Arity::Binary { arena, has_self } => {
+            binary_func(&func, modifiers, struct_ty, arena, has_self)
+        }
         Arity::Variadic { arena, has_self } => {
             variadic_func(&func, modifiers, struct_ty, arena, has_self)
         }
@@ -172,8 +176,8 @@ fn last_is_arena(func: &syn::ItemFn) -> bool {
 /// Arity classification for a function annotated with `#[sqlfunc]`.
 enum Arity {
     Nullary,
-    Unary { arena: bool },
-    Binary { arena: bool },
+    Unary { arena: bool, has_self: bool },
+    Binary { arena: bool, has_self: bool },
     Variadic { arena: bool, has_self: bool },
 }
 
@@ -229,8 +233,8 @@ fn determine_arity(func: &syn::ItemFn) -> Arity {
     } else {
         match effective_count {
             0 => Arity::Nullary,
-            1 => Arity::Unary { arena },
-            2 => Arity::Binary { arena },
+            1 => Arity::Unary { arena, has_self },
+            2 => Arity::Binary { arena, has_self },
             _ => unreachable!(),
         }
     }
@@ -851,10 +855,29 @@ fn output_type(arg: &syn::ItemFn) -> Result<&syn::Type, syn::Error> {
 }
 
 /// Produce a `EagerUnaryFunc` implementation.
-fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<TokenStream> {
+fn unary_func(
+    func: &syn::ItemFn,
+    modifiers: Modifiers,
+    struct_ty: Option<syn::Path>,
+    arena: bool,
+    has_self: bool,
+) -> darling::Result<TokenStream> {
     let fn_name = &func.sig.ident;
-    let struct_name = camel_case(&func.sig.ident);
-    let input_ty_raw = arg_type(func, 0)?;
+    let struct_name = struct_ty
+        .as_ref()
+        .and_then(|ty| ty.segments.last())
+        .map_or_else(|| camel_case(&func.sig.ident), |seg| seg.ident.clone());
+    let input_ty_raw = arg_type(func, if has_self { 1 } else { 0 })?;
+    let (arena_param, arena_arg) = if arena {
+        (quote! { temp_storage }, quote! { , temp_storage })
+    } else {
+        (quote! { _temp_storage }, quote! {})
+    };
+    let call_expr = if has_self {
+        quote! { self.#fn_name(a #arena_arg) }
+    } else {
+        quote! { #fn_name(a #arena_arg) }
+    };
     let output_ty_raw = output_type(func)?;
     let generic_params = find_generic_type_params(func);
     // Erase generic type params → Datum<'a> for use in the trait impl's associated types.
@@ -875,7 +898,9 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
         is_associative,
         is_eliminable_cast,
         test: _,
+        skip_display,
     } = modifiers;
+    let skip_display = skip_display.unwrap_or(false);
 
     // If generic type parameters are present and no explicit output_type_expr,
     // auto-derive one from the structural relationship between input and output types.
@@ -996,21 +1021,17 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
         }
     });
 
-    let result = quote! {
-        #[derive(
-            Ord, PartialOrd, Clone,
-            Debug, Eq, PartialEq, serde::Serialize,
-            serde::Deserialize, Hash, mz_lowertest::MzReflect,
-        )]
-        #[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
-        pub struct #struct_name;
-
+    let trait_impl = quote! {
         impl crate::func::EagerUnaryFunc for #struct_name {
             type Input<'a> = #input_ty;
             type Output<'a> = #output_ty;
 
-            fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
-                #fn_name(a)
+            fn call<'a>(
+                &'a self,
+                a: Self::Input<'a>,
+                #arena_param: &'a mz_repr::RowArena,
+            ) -> Self::Output<'a> {
+                #call_expr
             }
 
             fn output_sql_type(
@@ -1033,14 +1054,45 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
             #preserves_uniqueness_fn
             #is_eliminable_cast_fn
         }
+    };
 
-        impl std::fmt::Display for #struct_name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str(#name)
+    let display_impl = if skip_display {
+        quote! {}
+    } else {
+        quote! {
+            impl std::fmt::Display for #struct_name {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    f.write_str(#name)
+                }
             }
         }
+    };
 
-        #func
+    let result = if has_self {
+        // External struct: generate method impl + trait impl + Display.
+        quote! {
+            impl #struct_name {
+                #func
+            }
+            #trait_impl
+            #display_impl
+        }
+    } else {
+        // Unit struct: generate struct + trait impl + Display + original function.
+        quote! {
+            #[derive(
+                Ord, PartialOrd, Clone,
+                Debug, Eq, PartialEq, serde::Serialize,
+                serde::Deserialize, Hash, mz_lowertest::MzReflect,
+            )]
+            #[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
+            pub struct #struct_name;
+
+            #trait_impl
+            #display_impl
+
+            #func
+        }
     };
     Ok(result)
 }
@@ -1049,12 +1101,18 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
 fn binary_func(
     func: &syn::ItemFn,
     modifiers: Modifiers,
+    struct_ty: Option<syn::Path>,
     arena: bool,
+    has_self: bool,
 ) -> darling::Result<TokenStream> {
     let fn_name = &func.sig.ident;
-    let struct_name = camel_case(&func.sig.ident);
-    let input1_ty_raw = arg_type(func, 0)?;
-    let input2_ty_raw = arg_type(func, 1)?;
+    let struct_name = struct_ty
+        .as_ref()
+        .and_then(|ty| ty.segments.last())
+        .map_or_else(|| camel_case(&func.sig.ident), |seg| seg.ident.clone());
+    let arg_offset = if has_self { 1 } else { 0 };
+    let input1_ty_raw = arg_type(func, arg_offset)?;
+    let input2_ty_raw = arg_type(func, arg_offset + 1)?;
     let output_ty_raw = output_type(func)?;
     let generic_params = find_generic_type_params(func);
     // Erase generic type params → Datum<'a> for use in the trait impl's associated types.
@@ -1077,7 +1135,9 @@ fn binary_func(
         is_associative,
         is_eliminable_cast,
         test: _,
+        skip_display,
     } = modifiers;
+    let skip_display = skip_display.unwrap_or(false);
 
     // Auto-derive output_type_expr from generic parameters, if applicable.
     // Use raw (pre-erasure) types so we can see the generic parameters.
@@ -1179,6 +1239,12 @@ fn binary_func(
         quote! {}
     };
 
+    let call_expr = if has_self {
+        quote! { self.#fn_name(a, b #arena) }
+    } else {
+        quote! { #fn_name(a, b #arena) }
+    };
+
     let could_error_fn = could_error.map(|could_error| {
         quote! {
             fn could_error(&self) -> bool {
@@ -1208,15 +1274,7 @@ fn binary_func(
     let binary_non_nullable_checks =
         non_nullable_position_checks(&[input1_ty.clone(), input2_ty.clone()]);
 
-    let result = quote! {
-        #[derive(
-            Ord, PartialOrd, Clone,
-            Debug, Eq, PartialEq, serde::Serialize,
-            serde::Deserialize, Hash, mz_lowertest::MzReflect,
-        )]
-        #[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
-        pub struct #struct_name;
-
+    let trait_impl = quote! {
         impl crate::func::binary::EagerBinaryFunc for #struct_name {
             type Input<'a> = (#input1_ty, #input2_ty);
             type Output<'a> = #output_ty;
@@ -1226,7 +1284,7 @@ fn binary_func(
                 (a, b): Self::Input<'a>,
                 temp_storage: &'a mz_repr::RowArena
             ) -> Self::Output<'a> {
-                #fn_name(a, b #arena)
+                #call_expr
             }
 
             fn output_sql_type(
@@ -1260,15 +1318,45 @@ fn binary_func(
             #negate_fn
             #propagates_nulls_fn
         }
+    };
 
-        impl std::fmt::Display for #struct_name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str(#name)
+    let display_impl = if skip_display {
+        quote! {}
+    } else {
+        quote! {
+            impl std::fmt::Display for #struct_name {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    f.write_str(#name)
+                }
             }
         }
+    };
 
-        #func
+    let result = if has_self {
+        // External struct: generate method impl + trait impl + Display.
+        quote! {
+            impl #struct_name {
+                #func
+            }
+            #trait_impl
+            #display_impl
+        }
+    } else {
+        // Unit struct: generate struct + trait impl + Display + original function.
+        quote! {
+            #[derive(
+                Ord, PartialOrd, Clone,
+                Debug, Eq, PartialEq, serde::Serialize,
+                serde::Deserialize, Hash, mz_lowertest::MzReflect,
+            )]
+            #[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
+            pub struct #struct_name;
 
+            #trait_impl
+            #display_impl
+
+            #func
+        }
     };
     Ok(result)
 }
@@ -1309,7 +1397,9 @@ fn variadic_func(
         is_associative,
         is_eliminable_cast,
         test: _,
+        skip_display,
     } = modifiers;
+    let skip_display = skip_display.unwrap_or(false);
 
     // Reject modifiers that don't apply to variadic functions.
     if preserves_uniqueness.is_some() {
@@ -1556,10 +1646,14 @@ fn variadic_func(
         }
     };
 
-    let display_impl = quote! {
-        impl std::fmt::Display for #struct_name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str(#name)
+    let display_impl = if skip_display {
+        quote! {}
+    } else {
+        quote! {
+            impl std::fmt::Display for #struct_name {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    f.write_str(#name)
+                }
             }
         }
     };

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -168,12 +168,12 @@ fn cast_array_to_array<'a>(
     &'a self,
     a: Array<'a>,
     temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
+) -> Result<Array<'a>, EvalError> {
     let dims = a.dims().into_iter().collect::<Vec<ArrayDimension>>();
     let casted_datums = a
         .elements()
         .iter()
         .map(|datum| self.cast_expr.eval(&[datum], temp_storage))
         .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
-    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, casted_datums))?)
+    Ok(temp_storage.make_datum_array(&dims, casted_datums)?)
 }

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -7,15 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-
 use mz_expr_derive::sqlfunc;
 use mz_lowertest::MzReflect;
 use mz_repr::adt::array::{Array, ArrayDimension};
-use mz_repr::{Datum, DatumList, Row, RowArena, RowPacker, SqlColumnType, SqlScalarType};
+use mz_repr::{Datum, DatumList, Row, RowArena, RowPacker, SqlScalarType};
 use serde::{Deserialize, Serialize};
 
-use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
+use crate::scalar::func::stringify_datum;
 use crate::{EvalError, MirScalarExpr};
 
 #[sqlfunc(
@@ -54,57 +52,20 @@ pub struct CastArrayToString {
     pub ty: SqlScalarType,
 }
 
-impl LazyUnaryFunc for CastArrayToString {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut buf = String::new();
-        stringify_datum(&mut buf, a, &self.ty)?;
-        Ok(Datum::String(temp_storage.push_string(buf)))
-    }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::String.nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        true
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO? If we moved typeconv into `expr` we could determine the right
-        // inverse of this.
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastArrayToString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("arraytostr")
-    }
+#[sqlfunc(
+    CastArrayToString,
+    sqlname = "arraytostr",
+    preserves_uniqueness = true,
+    introduces_nulls = false
+)]
+fn cast_array_to_string<'a>(
+    &self,
+    a: Array<'a>,
+    _temp_storage: &'a RowArena,
+) -> Result<String, EvalError> {
+    let mut buf = String::new();
+    stringify_datum(&mut buf, Datum::Array(a), &self.ty)?;
+    Ok(buf)
 }
 
 #[derive(
@@ -123,95 +84,58 @@ pub struct CastArrayToJsonb {
     pub cast_element: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastArrayToJsonb {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        fn pack<'a>(
-            temp_storage: &RowArena,
-            elems: &mut impl Iterator<Item = Datum<'a>>,
-            dims: &[ArrayDimension],
-            cast_element: &MirScalarExpr,
-            packer: &mut RowPacker,
-        ) -> Result<(), EvalError> {
-            packer.push_list_with(|packer| match dims {
-                [] => Ok(()),
-                [dim] => {
-                    for _ in 0..dim.length {
-                        let elem = elems.next().unwrap();
-                        let elem = match cast_element.eval(&[elem], temp_storage)? {
-                            Datum::Null => Datum::JsonNull,
-                            d => d,
-                        };
-                        packer.push(elem);
-                    }
-                    Ok(())
+#[sqlfunc(
+    CastArrayToJsonb,
+    sqlname = "arraytojsonb",
+    output_type_expr = "SqlScalarType::Jsonb.nullable(false)",
+    preserves_uniqueness = true,
+    introduces_nulls = false
+)]
+fn cast_array_to_jsonb<'a>(
+    &'a self,
+    a: Array<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    fn pack<'a>(
+        temp_storage: &RowArena,
+        elems: &mut impl Iterator<Item = Datum<'a>>,
+        dims: &[ArrayDimension],
+        cast_element: &MirScalarExpr,
+        packer: &mut RowPacker,
+    ) -> Result<(), EvalError> {
+        packer.push_list_with(|packer| match dims {
+            [] => Ok(()),
+            [dim] => {
+                for _ in 0..dim.length {
+                    let elem = elems.next().unwrap();
+                    let elem = match cast_element.eval(&[elem], temp_storage)? {
+                        Datum::Null => Datum::JsonNull,
+                        d => d,
+                    };
+                    packer.push(elem);
                 }
-                [dim, rest @ ..] => {
-                    for _ in 0..dim.length {
-                        pack(temp_storage, elems, rest, cast_element, packer)?;
-                    }
-                    Ok(())
+                Ok(())
+            }
+            [dim, rest @ ..] => {
+                for _ in 0..dim.length {
+                    pack(temp_storage, elems, rest, cast_element, packer)?;
                 }
-            })
-        }
-
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let a = a.unwrap_array();
-        let elements = a.elements();
-        let dims = a.dims().into_iter().collect::<Vec<_>>();
-        let mut row = Row::default();
-        pack(
-            temp_storage,
-            &mut elements.into_iter(),
-            &dims,
-            &self.cast_element,
-            &mut row.packer(),
-        )?;
-        Ok(temp_storage.push_unary_row(row))
+                Ok(())
+            }
+        })
     }
 
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::Jsonb.nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        true
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO? If we moved typeconv into `expr` we could determine the right
-        // inverse of this.
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastArrayToJsonb {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("arraytojsonb")
-    }
+    let elements = a.elements();
+    let dims = a.dims().into_iter().collect::<Vec<_>>();
+    let mut row = Row::default();
+    pack(
+        temp_storage,
+        &mut elements.into_iter(),
+        &dims,
+        &self.cast_element,
+        &mut row.packer(),
+    )?;
+    Ok(temp_storage.push_unary_row(row))
 }
 
 /// Casts an array of one type to an array of another type. Does so by casting
@@ -234,61 +158,22 @@ pub struct CastArrayToArray {
     pub cast_expr: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastArrayToArray {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-
-        let arr = a.unwrap_array();
-        let dims = arr.dims().into_iter().collect::<Vec<ArrayDimension>>();
-
-        let casted_datums = arr
-            .elements()
-            .iter()
-            .map(|datum| self.cast_expr.eval(&[datum], temp_storage))
-            .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
-
-        Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, casted_datums))?)
-    }
-
-    fn output_sql_type(&self, _input_type: SqlColumnType) -> SqlColumnType {
-        self.return_ty.clone().nullable(true)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastArrayToArray {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("arraytoarray")
-    }
+#[sqlfunc(
+    CastArrayToArray,
+    sqlname = "arraytoarray",
+    output_type_expr = "self.return_ty.clone().nullable(true)",
+    introduces_nulls = false
+)]
+fn cast_array_to_array<'a>(
+    &'a self,
+    a: Array<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let dims = a.dims().into_iter().collect::<Vec<ArrayDimension>>();
+    let casted_datums = a
+        .elements()
+        .iter()
+        .map(|datum| self.cast_expr.eval(&[datum], temp_storage))
+        .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
+    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, casted_datums))?)
 }

--- a/src/expr/src/scalar/func/impls/char.rs
+++ b/src/expr/src/scalar/func/impls/char.rs
@@ -40,7 +40,11 @@ impl EagerUnaryFunc for PadChar {
     type Input<'a> = &'a str;
     type Output<'a> = Char<String>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         Char(format_str_pad(a, self.length))
     }
 

--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -52,7 +52,11 @@ impl EagerUnaryFunc for CastDateToTimestamp {
     type Input<'a> = Date;
     type Output<'a> = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let out =
             CheckedTimestamp::from_timestamplike(NaiveDate::from(a).and_hms_opt(0, 0, 0).unwrap())?;
         let updated = out.round_to_precision(self.0)?;
@@ -100,7 +104,11 @@ impl EagerUnaryFunc for CastDateToTimestampTz {
     type Input<'a> = Date;
     type Output<'a> = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let out =
             CheckedTimestamp::from_timestamplike(DateTime::<Utc>::from_naive_utc_and_offset(
                 NaiveDate::from(a).and_hms_opt(0, 0, 0).unwrap(),
@@ -183,7 +191,11 @@ impl EagerUnaryFunc for ExtractDate {
     type Input<'a> = Date;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         extract_date_inner(self.0, a.into())
     }
 

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -202,7 +202,11 @@ impl EagerUnaryFunc for CastFloat32ToNumeric {
     type Input<'a> = f32;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         if a.is_infinite() {
             return Err(EvalError::InfinityOutOfDomain(
                 "casting real to numeric".into(),

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -215,7 +215,11 @@ impl EagerUnaryFunc for CastFloat64ToNumeric {
     type Input<'a> = f64;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         if a.is_infinite() {
             return Err(EvalError::InfinityOutOfDomain(
                 "casting double precision to numeric".into(),

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -143,7 +143,11 @@ impl EagerUnaryFunc for CastInt16ToNumeric {
     type Input<'a> = i16;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let mut a = Numeric::from(i32::from(a));
         if let Some(scale) = self.0 {
             if numeric::rescale(&mut a, scale.into_u8()).is_err() {

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -158,7 +158,11 @@ impl EagerUnaryFunc for CastInt32ToNumeric {
     type Input<'a> = i32;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let mut a = Numeric::from(a);
         if let Some(scale) = self.0 {
             if numeric::rescale(&mut a, scale.into_u8()).is_err() {

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -135,7 +135,11 @@ impl EagerUnaryFunc for CastInt64ToNumeric {
     type Input<'a> = i64;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let mut a = Numeric::from(a);
         if let Some(scale) = self.0 {
             if numeric::rescale(&mut a, scale.into_u8()).is_err() {

--- a/src/expr/src/scalar/func/impls/jsonb.rs
+++ b/src/expr/src/scalar/func/impls/jsonb.rs
@@ -110,7 +110,11 @@ impl EagerUnaryFunc for CastJsonbToNumeric {
     type Input<'a> = JsonbRef<'a>;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         match a.into_datum() {
             Datum::Numeric(mut num) => match self.0 {
                 None => Ok(num.into_inner()),

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -15,7 +15,7 @@ use mz_repr::{AsColumnType, Datum, DatumList, Row, RowArena, SqlColumnType, SqlS
 use serde::{Deserialize, Serialize};
 
 use crate::func::binary::EagerBinaryFunc;
-use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
+use crate::scalar::func::stringify_datum;
 use crate::{EvalError, MirScalarExpr};
 
 #[derive(
@@ -34,56 +34,20 @@ pub struct CastListToString {
     pub ty: SqlScalarType,
 }
 
-impl LazyUnaryFunc for CastListToString {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut buf = String::new();
-        stringify_datum(&mut buf, a, &self.ty)?;
-        Ok(Datum::String(temp_storage.push_string(buf)))
-    }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::String.nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        true
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO? if typeconv was in expr, we could determine this
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastListToString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("listtostr")
-    }
+#[sqlfunc(
+    CastListToString,
+    sqlname = "listtostr",
+    preserves_uniqueness = true,
+    introduces_nulls = false
+)]
+fn cast_list_to_string<'a>(
+    &self,
+    a: DatumList<'a>,
+    _temp_storage: &'a RowArena,
+) -> Result<String, EvalError> {
+    let mut buf = String::new();
+    stringify_datum(&mut buf, Datum::List(a), &self.ty)?;
+    Ok(buf)
 }
 
 #[derive(
@@ -102,66 +66,30 @@ pub struct CastListToJsonb {
     pub cast_element: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastListToJsonb {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
+#[sqlfunc(
+    CastListToJsonb,
+    sqlname = "listtojsonb",
+    output_type_expr = "SqlScalarType::Jsonb.nullable(false)",
+    preserves_uniqueness = true,
+    introduces_nulls = false
+)]
+fn cast_list_to_jsonb<'a>(
+    &'a self,
+    a: DatumList<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut row = Row::default();
+    row.packer().push_list_with(|packer| {
+        for elem in a.iter() {
+            let elem = match self.cast_element.eval(&[elem], temp_storage)? {
+                Datum::Null => Datum::JsonNull,
+                d => d,
+            };
+            packer.push(elem);
         }
-        let mut row = Row::default();
-        row.packer().push_list_with(|packer| {
-            for elem in a.unwrap_list().iter() {
-                let elem = match self.cast_element.eval(&[elem], temp_storage)? {
-                    Datum::Null => Datum::JsonNull,
-                    d => d,
-                };
-                packer.push(elem);
-            }
-            Ok::<_, EvalError>(())
-        })?;
-        Ok(temp_storage.push_unary_row(row))
-    }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::Jsonb.nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        true
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO? If we moved typeconv into `expr` we could determine the right
-        // inverse of this.
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastListToJsonb {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("listtojsonb")
-    }
+        Ok::<_, EvalError>(())
+    })?;
+    Ok(temp_storage.push_unary_row(row))
 }
 
 /// Casts between two list types by casting each element of `a` ("list1") using
@@ -185,64 +113,22 @@ pub struct CastList1ToList2 {
     pub cast_expr: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastList1ToList2 {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut cast_datums = Vec::new();
-        for el in a.unwrap_list().iter() {
-            // `cast_expr` is evaluated as an expression that casts the
-            // first column in `datums` (i.e. `datums[0]`) from the list elements'
-            // current type to a target type.
-            cast_datums.push(self.cast_expr.eval(&[el], temp_storage)?);
-        }
-
-        Ok(temp_storage.make_datum(|packer| packer.push_list(cast_datums)))
+#[sqlfunc(
+    CastList1ToList2,
+    sqlname = "list1tolist2",
+    output_type_expr = "self.return_ty.without_modifiers().nullable(false)",
+    introduces_nulls = false
+)]
+fn cast_list1_to_list2<'a>(
+    &'a self,
+    a: DatumList<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut cast_datums = Vec::new();
+    for el in a.iter() {
+        cast_datums.push(self.cast_expr.eval(&[el], temp_storage)?);
     }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        self.return_ty
-            .without_modifiers()
-            .nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO: this could be figured out--might be easier after enum dispatch?
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastList1ToList2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("list1tolist2")
-    }
+    Ok(temp_storage.make_datum(|packer| packer.push_list(cast_datums)))
 }
 
 #[sqlfunc(sqlname = "list_length")]

--- a/src/expr/src/scalar/func/impls/map.rs
+++ b/src/expr/src/scalar/func/impls/map.rs
@@ -7,16 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-
 use itertools::Itertools;
 use mz_expr_derive::sqlfunc;
 use mz_lowertest::MzReflect;
-use mz_repr::{Datum, DatumMap, RowArena, SqlColumnType, SqlScalarType};
+use mz_repr::{Datum, DatumList, DatumMap, RowArena, SqlScalarType};
 use serde::{Deserialize, Serialize};
 
-use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
-use crate::{EvalError, MirScalarExpr};
+use crate::EvalError;
+use crate::scalar::func::stringify_datum;
 
 #[derive(
     Ord,
@@ -34,56 +32,20 @@ pub struct CastMapToString {
     pub ty: SqlScalarType,
 }
 
-impl LazyUnaryFunc for CastMapToString {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut buf = String::new();
-        stringify_datum(&mut buf, a, &self.ty)?;
-        Ok(Datum::String(temp_storage.push_string(buf)))
-    }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::String.nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        true
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO? If we moved typeconv into expr, we could evaluate this
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastMapToString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("maptostr")
-    }
+#[sqlfunc(
+    CastMapToString,
+    sqlname = "maptostr",
+    preserves_uniqueness = true,
+    introduces_nulls = false
+)]
+fn cast_map_to_string<'a>(
+    &self,
+    a: DatumMap<'a>,
+    _temp_storage: &'a RowArena,
+) -> Result<String, EvalError> {
+    let mut buf = String::new();
+    stringify_datum(&mut buf, Datum::Map(a), &self.ty)?;
+    Ok(buf)
 }
 
 #[sqlfunc(sqlname = "map_length")]
@@ -110,72 +72,28 @@ pub struct MapBuildFromRecordList {
     pub value_type: SqlScalarType,
 }
 
-impl LazyUnaryFunc for MapBuildFromRecordList {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
+#[sqlfunc(
+    MapBuildFromRecordList,
+    sqlname = "map_build",
+    output_type_expr = "SqlScalarType::Map { value_type: Box::new(self.value_type.clone()), custom_id: None }.nullable(true)",
+    introduces_nulls = true
+)]
+fn map_build_from_record_list<'a>(
+    &self,
+    a: DatumList<'a>,
+    temp_storage: &'a RowArena,
+) -> Datum<'a> {
+    let mut map = std::collections::BTreeMap::new();
+    for i in a.iter() {
+        if i.is_null() {
+            continue;
         }
-        let list = a.unwrap_list();
-        let mut map = std::collections::BTreeMap::new();
-
-        for i in list.iter() {
-            if i.is_null() {
+        for (k, v) in i.unwrap_list().iter().tuples() {
+            if k.is_null() {
                 continue;
             }
-
-            for (k, v) in i.unwrap_list().iter().tuples() {
-                if k.is_null() {
-                    continue;
-                }
-                map.insert(k.unwrap_str(), v);
-            }
+            map.insert(k.unwrap_str(), v);
         }
-
-        let map = temp_storage.make_datum(|packer| packer.push_dict(map));
-        Ok(map)
     }
-
-    fn output_sql_type(&self, _input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::Map {
-            value_type: Box::new(self.value_type.clone()),
-            custom_id: None,
-        }
-        .nullable(true)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        true
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for MapBuildFromRecordList {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("map_build")
-    }
+    temp_storage.make_datum(|packer| packer.push_dict(map))
 }

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -327,7 +327,11 @@ impl EagerUnaryFunc for AdjustNumericScale {
     type Input<'a> = Numeric;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, mut d: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        mut d: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         if numeric::rescale(&mut d, self.0.into_u8()).is_err() {
             return Err(EvalError::NumericFieldOverflow);
         };

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -7,16 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-
 use mz_expr_derive::sqlfunc;
 use mz_lowertest::MzReflect;
 use mz_repr::adt::range::Range;
-use mz_repr::{Datum, RowArena, SqlColumnType, SqlScalarType};
+use mz_repr::{Datum, RowArena, SqlScalarType};
 use serde::{Deserialize, Serialize};
 
-use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
-use crate::{EvalError, MirScalarExpr};
+use crate::EvalError;
+use crate::scalar::func::stringify_datum;
 
 #[derive(
     Ord,
@@ -34,56 +32,25 @@ pub struct CastRangeToString {
     pub ty: SqlScalarType,
 }
 
-impl LazyUnaryFunc for CastRangeToString {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut buf = String::new();
-        stringify_datum(&mut buf, a, &self.ty)?;
-        Ok(Datum::String(temp_storage.push_string(buf)))
-    }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::String.nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        true
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO? if typeconv was in expr, we could determine this
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastRangeToString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("rangetostr")
-    }
+#[sqlfunc(
+    CastRangeToString,
+    sqlname = "rangetostr",
+    preserves_uniqueness = true,
+    introduces_nulls = false
+)]
+fn cast_range_to_string<'a, T>(
+    &self,
+    a: Range<T>,
+    temp_storage: &'a RowArena,
+) -> Result<String, EvalError>
+where
+    T: Into<Datum<'a>>,
+{
+    let d =
+        a.into_bounds(|bound| temp_storage.make_datum_nested(|packer| packer.push(bound.into())));
+    let mut buf = String::new();
+    stringify_datum(&mut buf, Datum::Range(d), &self.ty)?;
+    Ok(buf)
 }
 
 #[sqlfunc(sqlname = "rangelower", is_monotone = true)]

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -107,7 +107,7 @@ pub struct RecordGet(pub usize);
     introduces_nulls = true,
     skip_display = true
 )]
-fn record_get<'a>(&self, a: DatumList<'a>, _temp_storage: &'a RowArena) -> Datum<'a> {
+fn record_get<'a>(&self, a: DatumList<'a>) -> Datum<'a> {
     a.iter().nth(self.0).unwrap()
 }
 

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -10,11 +10,12 @@
 use std::fmt;
 
 use itertools::Itertools;
+use mz_expr_derive::sqlfunc;
 use mz_lowertest::MzReflect;
-use mz_repr::{Datum, RowArena, SqlColumnType, SqlScalarType};
+use mz_repr::{Datum, DatumList, RowArena, SqlScalarType};
 use serde::{Deserialize, Serialize};
 
-use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
+use crate::scalar::func::stringify_datum;
 use crate::{EvalError, MirScalarExpr};
 
 #[derive(
@@ -33,56 +34,20 @@ pub struct CastRecordToString {
     pub ty: SqlScalarType,
 }
 
-impl LazyUnaryFunc for CastRecordToString {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut buf = String::new();
-        stringify_datum(&mut buf, a, &self.ty)?;
-        Ok(Datum::String(temp_storage.push_string(buf)))
-    }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::String.nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        true
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO? if we moved typeconv into expr, we could evaluate this
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastRecordToString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("recordtostr")
-    }
+#[sqlfunc(
+    CastRecordToString,
+    sqlname = "recordtostr",
+    preserves_uniqueness = true,
+    introduces_nulls = false
+)]
+fn cast_record_to_string<'a>(
+    &self,
+    a: DatumList<'a>,
+    _temp_storage: &'a RowArena,
+) -> Result<String, EvalError> {
+    let mut buf = String::new();
+    stringify_datum(&mut buf, Datum::List(a), &self.ty)?;
+    Ok(buf)
 }
 
 /// Casts between two record types by casting each element of `a` ("record1") using
@@ -104,63 +69,22 @@ pub struct CastRecord1ToRecord2 {
     pub cast_exprs: Box<[MirScalarExpr]>,
 }
 
-impl LazyUnaryFunc for CastRecord1ToRecord2 {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut cast_datums = Vec::new();
-        for (el, cast_expr) in a.unwrap_list().iter().zip_eq(&self.cast_exprs) {
-            cast_datums.push(cast_expr.eval(&[el], temp_storage)?);
-        }
-        Ok(temp_storage.make_datum(|packer| packer.push_list(cast_datums)))
+#[sqlfunc(
+    CastRecord1ToRecord2,
+    sqlname = "record1torecord2",
+    output_type_expr = "self.return_ty.without_modifiers().nullable(false)",
+    introduces_nulls = false
+)]
+fn cast_record1_to_record2<'a>(
+    &'a self,
+    a: DatumList<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut cast_datums = Vec::new();
+    for (el, cast_expr) in a.iter().zip_eq(&*self.cast_exprs) {
+        cast_datums.push(cast_expr.eval(&[el], temp_storage)?);
     }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        self.return_ty
-            .without_modifiers()
-            .nullable(input_type.nullable)
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        // TODO: we could determine Record1's type from `cast_exprs`
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        // In theory this could be marked as monotone if we knew that all the expressions were
-        // monotone in the same direction. (ie. all increasing or all decreasing.) We don't yet
-        // track enough information to make that call, though!
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastRecord1ToRecord2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("record1torecord2")
-    }
+    Ok(temp_storage.make_datum(|packer| packer.push_list(cast_datums)))
 }
 
 #[derive(
@@ -177,59 +101,14 @@ impl fmt::Display for CastRecord1ToRecord2 {
 )]
 pub struct RecordGet(pub usize);
 
-impl LazyUnaryFunc for RecordGet {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        Ok(a.unwrap_list().iter().nth(self.0).unwrap())
-    }
-
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        match input_type.scalar_type {
-            SqlScalarType::Record { fields, .. } => {
-                let (_name, ty) = &fields[self.0];
-                let mut ty = ty.clone();
-                ty.nullable = ty.nullable || input_type.nullable;
-                ty
-            }
-            _ => unreachable!(
-                "RecordGet on non-record input: {:?}",
-                input_type.scalar_type
-            ),
-        }
-    }
-
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    fn introduces_nulls(&self) -> bool {
-        // Return null if the inner field is null
-        true
-    }
-
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
+#[sqlfunc(
+    RecordGet,
+    output_type_expr = "match &input_type.scalar_type { SqlScalarType::Record { fields, .. } => fields[self.0].1.clone(), _ => unreachable!(\"RecordGet on non-record input: {:?}\", input_type.scalar_type) }",
+    introduces_nulls = true,
+    skip_display = true
+)]
+fn record_get<'a>(&self, a: DatumList<'a>, _temp_storage: &'a RowArena) -> Datum<'a> {
+    a.iter().nth(self.0).unwrap()
 }
 
 impl fmt::Display for RecordGet {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -32,9 +32,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::func::{binary, regexp_match_static};
-use crate::scalar::func::{
-    EagerUnaryFunc, LazyUnaryFunc, array_create_scalar, regexp_split_to_array_re,
-};
+use crate::scalar::func::{EagerUnaryFunc, array_create_scalar, regexp_split_to_array_re};
 use crate::{EvalError, MirScalarExpr, UnaryFunc, like_pattern};
 
 #[sqlfunc(
@@ -181,7 +179,11 @@ impl EagerUnaryFunc for CastStringToNumeric {
     type Input<'a> = &'a str;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let mut d = strconv::parse_numeric(a)?;
         if let Some(scale) = self.0 {
             if numeric::rescale(&mut d.0, scale.into_u8()).is_err() {
@@ -242,7 +244,11 @@ impl EagerUnaryFunc for CastStringToTimestamp {
     type Input<'a> = &'a str;
     type Output<'a> = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let out = strconv::parse_timestamp(a)?;
         let updated = out.round_to_precision(self.0)?;
         Ok(updated)
@@ -296,7 +302,11 @@ impl EagerUnaryFunc for CastStringToTimestampTz {
     type Input<'a> = &'a str;
     type Output<'a> = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let out = strconv::parse_timestamptz(a)?;
         let updated = out.round_to_precision(self.0)?;
         Ok(updated)
@@ -355,72 +365,31 @@ pub struct CastStringToArray {
     pub cast_expr: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastStringToArray {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let (datums, dims) = strconv::parse_array(
-            a.unwrap_str(),
-            || Datum::Null,
-            |elem_text| {
-                let elem_text = match elem_text {
-                    Cow::Owned(s) => temp_storage.push_string(s),
-                    Cow::Borrowed(s) => s,
-                };
-                self.cast_expr
-                    .eval(&[Datum::String(elem_text)], temp_storage)
-            },
-        )?;
-
-        Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, datums))?)
-    }
-
-    /// The output SqlColumnType of this function
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        self.return_ty.clone().nullable(input_type.nullable)
-    }
-
-    /// Whether this function will produce NULL on NULL input
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    /// Whether this function will produce NULL on non-NULL input
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    /// Whether this function preserves uniqueness
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        to_unary!(super::CastArrayToString {
-            ty: self.return_ty.clone(),
-        })
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastStringToArray {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("strtoarray")
-    }
+#[sqlfunc(
+    CastStringToArray,
+    sqlname = "strtoarray",
+    output_type_expr = "self.return_ty.clone().nullable(false)",
+    introduces_nulls = false,
+    inverse = to_unary!(super::CastArrayToString { ty: self.return_ty.clone() }),
+)]
+fn cast_string_to_array<'a>(
+    &'a self,
+    a: &'a str,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let (datums, dims) = strconv::parse_array(
+        a,
+        || Datum::Null,
+        |elem_text| {
+            let elem_text = match elem_text {
+                Cow::Owned(s) => temp_storage.push_string(s),
+                Cow::Borrowed(s) => s,
+            };
+            self.cast_expr
+                .eval(&[Datum::String(elem_text)], temp_storage)
+        },
+    )?;
+    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, datums))?)
 }
 
 #[derive(
@@ -443,78 +412,35 @@ pub struct CastStringToList {
     pub cast_expr: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastStringToList {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let parsed_datums = strconv::parse_list(
-            a.unwrap_str(),
-            matches!(
-                self.return_ty.unwrap_list_element_type(),
-                SqlScalarType::List { .. }
-            ),
-            || Datum::Null,
-            |elem_text| {
-                let elem_text = match elem_text {
-                    Cow::Owned(s) => temp_storage.push_string(s),
-                    Cow::Borrowed(s) => s,
-                };
-                self.cast_expr
-                    .eval(&[Datum::String(elem_text)], temp_storage)
-            },
-        )?;
-
-        Ok(temp_storage.make_datum(|packer| packer.push_list(parsed_datums)))
-    }
-
-    /// The output SqlColumnType of this function
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        self.return_ty
-            .without_modifiers()
-            .nullable(input_type.nullable)
-    }
-
-    /// Whether this function will produce NULL on NULL input
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    /// Whether this function will produce NULL on non-NULL input
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    /// Whether this function preserves uniqueness
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        to_unary!(super::CastListToString {
-            ty: self.return_ty.clone(),
-        })
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastStringToList {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("strtolist")
-    }
+#[sqlfunc(
+    CastStringToList,
+    sqlname = "strtolist",
+    output_type_expr = "self.return_ty.without_modifiers().nullable(false)",
+    introduces_nulls = false,
+    inverse = to_unary!(super::CastListToString { ty: self.return_ty.clone() }),
+)]
+fn cast_string_to_list<'a>(
+    &'a self,
+    a: &'a str,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let parsed_datums = strconv::parse_list(
+        a,
+        matches!(
+            self.return_ty.unwrap_list_element_type(),
+            SqlScalarType::List { .. }
+        ),
+        || Datum::Null,
+        |elem_text| {
+            let elem_text = match elem_text {
+                Cow::Owned(s) => temp_storage.push_string(s),
+                Cow::Borrowed(s) => s,
+            };
+            self.cast_expr
+                .eval(&[Datum::String(elem_text)], temp_storage)
+        },
+    )?;
+    Ok(temp_storage.make_datum(|packer| packer.push_list(parsed_datums)))
 }
 
 #[derive(
@@ -537,84 +463,44 @@ pub struct CastStringToMap {
     pub cast_expr: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastStringToMap {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let parsed_map = strconv::parse_map(
-            a.unwrap_str(),
-            matches!(
-                self.return_ty.unwrap_map_value_type(),
-                SqlScalarType::Map { .. }
-            ),
-            |value_text| -> Result<Datum, EvalError> {
-                let value_text = match value_text {
-                    Some(Cow::Owned(s)) => Datum::String(temp_storage.push_string(s)),
-                    Some(Cow::Borrowed(s)) => Datum::String(s),
-                    None => Datum::Null,
-                };
-                self.cast_expr.eval(&[value_text], temp_storage)
-            },
-        )?;
-        let mut pairs: Vec<(String, Datum)> = parsed_map.into_iter().map(|(k, v)| (k, v)).collect();
-        pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
-        pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
-        Ok(temp_storage.make_datum(|packer| {
-            packer.push_dict_with(|packer| {
-                for (k, v) in pairs {
-                    packer.push(Datum::String(&k));
-                    packer.push(v);
-                }
-            })
-        }))
-    }
-
-    /// The output SqlColumnType of this function
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        self.return_ty.clone().nullable(input_type.nullable)
-    }
-
-    /// Whether this function will produce NULL on NULL input
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    /// Whether this function will produce NULL on non-NULL input
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    /// Whether this function preserves uniqueness
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        to_unary!(super::CastMapToString {
-            ty: self.return_ty.clone(),
+#[sqlfunc(
+    CastStringToMap,
+    sqlname = "strtomap",
+    output_type_expr = "self.return_ty.clone().nullable(false)",
+    introduces_nulls = false,
+    inverse = to_unary!(super::CastMapToString { ty: self.return_ty.clone() }),
+)]
+fn cast_string_to_map<'a>(
+    &'a self,
+    a: &'a str,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let parsed_map = strconv::parse_map(
+        a,
+        matches!(
+            self.return_ty.unwrap_map_value_type(),
+            SqlScalarType::Map { .. }
+        ),
+        |value_text| -> Result<Datum, EvalError> {
+            let value_text = match value_text {
+                Some(Cow::Owned(s)) => Datum::String(temp_storage.push_string(s)),
+                Some(Cow::Borrowed(s)) => Datum::String(s),
+                None => Datum::Null,
+            };
+            self.cast_expr.eval(&[value_text], temp_storage)
+        },
+    )?;
+    let mut pairs: Vec<(String, Datum)> = parsed_map.into_iter().map(|(k, v)| (k, v)).collect();
+    pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
+    pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
+    Ok(temp_storage.make_datum(|packer| {
+        packer.push_dict_with(|packer| {
+            for (k, v) in pairs {
+                packer.push(Datum::String(&k));
+                packer.push(v);
+            }
         })
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastStringToMap {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("strtomap")
-    }
+    }))
 }
 
 #[derive(
@@ -638,7 +524,11 @@ impl EagerUnaryFunc for CastStringToChar {
     type Input<'a> = &'a str;
     type Output<'a> = Result<Char<String>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let s = format_str_trim(a, self.length, self.fail_on_len).map_err(|_| {
             assert!(self.fail_on_len);
             EvalError::StringValueTooLong {
@@ -707,76 +597,32 @@ pub struct CastStringToRange {
     pub cast_expr: Box<MirScalarExpr>,
 }
 
-impl LazyUnaryFunc for CastStringToRange {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-        let mut range = strconv::parse_range(a.unwrap_str(), |elem_text| {
-            let elem_text = match elem_text {
-                Cow::Owned(s) => temp_storage.push_string(s),
-                Cow::Borrowed(s) => s,
-            };
-            self.cast_expr
-                .eval(&[Datum::String(elem_text)], temp_storage)
-        })?;
-
-        range.canonicalize()?;
-
-        Ok(temp_storage.make_datum(|packer| {
-            packer
-                .push_range(range)
-                .expect("must have already handled errors")
-        }))
-    }
-
-    /// The output SqlColumnType of this function
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        self.return_ty
-            .without_modifiers()
-            .nullable(input_type.nullable)
-    }
-
-    /// Whether this function will produce NULL on NULL input
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    /// Whether this function will produce NULL on non-NULL input
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    /// Whether this function preserves uniqueness
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        to_unary!(super::CastRangeToString {
-            ty: self.return_ty.clone(),
-        })
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastStringToRange {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("strtorange")
-    }
+#[sqlfunc(
+    CastStringToRange,
+    sqlname = "strtorange",
+    output_type_expr = "self.return_ty.without_modifiers().nullable(false)",
+    introduces_nulls = false,
+    inverse = to_unary!(super::CastRangeToString { ty: self.return_ty.clone() }),
+)]
+fn cast_string_to_range<'a>(
+    &'a self,
+    a: &'a str,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut range = strconv::parse_range(a, |elem_text| {
+        let elem_text = match elem_text {
+            Cow::Owned(s) => temp_storage.push_string(s),
+            Cow::Borrowed(s) => s,
+        };
+        self.cast_expr
+            .eval(&[Datum::String(elem_text)], temp_storage)
+    })?;
+    range.canonicalize()?;
+    Ok(temp_storage.make_datum(|packer| {
+        packer
+            .push_range(range)
+            .expect("must have already handled errors")
+    }))
 }
 
 #[derive(
@@ -800,7 +646,11 @@ impl EagerUnaryFunc for CastStringToVarChar {
     type Input<'a> = &'a str;
     type Output<'a> = Result<VarChar<&'a str>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let s =
             mz_repr::adt::varchar::format_str(a, self.length, self.fail_on_len).map_err(|_| {
                 assert!(self.fail_on_len);
@@ -874,65 +724,26 @@ static INT2VECTOR_CAST_EXPR: LazyLock<MirScalarExpr> = LazyLock::new(|| MirScala
 )]
 pub struct CastStringToInt2Vector;
 
-impl LazyUnaryFunc for CastStringToInt2Vector {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        if a.is_null() {
-            return Ok(Datum::Null);
-        }
-
-        let datums = strconv::parse_legacy_vector(a.unwrap_str(), |elem_text| {
-            let elem_text = match elem_text {
-                Cow::Owned(s) => temp_storage.push_string(s),
-                Cow::Borrowed(s) => s,
-            };
-            INT2VECTOR_CAST_EXPR.eval(&[Datum::String(elem_text)], temp_storage)
-        })?;
-        array_create_scalar(&datums, temp_storage)
-    }
-
-    /// The output SqlColumnType of this function
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::Int2Vector.nullable(input_type.nullable)
-    }
-
-    /// Whether this function will produce NULL on NULL input
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    /// Whether this function will produce NULL on non-NULL input
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    /// Whether this function preserves uniqueness
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        to_unary!(super::CastInt2VectorToString)
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
-}
-
-impl fmt::Display for CastStringToInt2Vector {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("strtoint2vector")
-    }
+#[sqlfunc(
+    CastStringToInt2Vector,
+    sqlname = "strtoint2vector",
+    output_type_expr = "SqlScalarType::Int2Vector.nullable(false)",
+    introduces_nulls = false,
+    inverse = to_unary!(super::CastInt2VectorToString),
+)]
+fn cast_string_to_int2_vector<'a>(
+    &self,
+    a: &'a str,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let datums = strconv::parse_legacy_vector(a, |elem_text| {
+        let elem_text = match elem_text {
+            Cow::Owned(s) => temp_storage.push_string(s),
+            Cow::Borrowed(s) => s,
+        };
+        INT2VECTOR_CAST_EXPR.eval(&[Datum::String(elem_text)], temp_storage)
+    })?;
+    array_create_scalar(&datums, temp_storage)
 }
 
 #[sqlfunc(
@@ -1044,7 +855,11 @@ impl EagerUnaryFunc for IsLikeMatch {
     type Input<'a> = &'a str;
     type Output<'a> = bool;
 
-    fn call<'a>(&self, haystack: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        haystack: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         self.0.is_match(haystack)
     }
 
@@ -1082,7 +897,11 @@ impl EagerUnaryFunc for IsRegexpMatch {
     type Input<'a> = &'a str;
     type Output<'a> = bool;
 
-    fn call<'a>(&self, haystack: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        haystack: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         self.0.is_match(haystack)
     }
 
@@ -1116,52 +935,14 @@ impl fmt::Display for IsRegexpMatch {
 )]
 pub struct RegexpMatch(pub Regex);
 
-impl LazyUnaryFunc for RegexpMatch {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let haystack = a.eval(datums, temp_storage)?;
-        if haystack.is_null() {
-            return Ok(Datum::Null);
-        }
-        regexp_match_static(haystack, temp_storage, &self.0)
-    }
-
-    /// The output SqlColumnType of this function
-    fn output_sql_type(&self, _input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::Array(Box::new(SqlScalarType::String)).nullable(true)
-    }
-
-    /// Whether this function will produce NULL on NULL input
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    /// Whether this function will produce NULL on non-NULL input
-    fn introduces_nulls(&self) -> bool {
-        // Returns null if the regex did not match
-        true
-    }
-
-    /// Whether this function preserves uniqueness
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
+#[sqlfunc(
+    RegexpMatch,
+    output_type_expr = "SqlScalarType::Array(Box::new(SqlScalarType::String)).nullable(true)",
+    introduces_nulls = true,
+    skip_display = true
+)]
+fn regexp_match<'a>(&self, a: &'a str, temp_storage: &'a RowArena) -> Result<Datum<'a>, EvalError> {
+    regexp_match_static(Datum::String(a), temp_storage, &self.0)
 }
 
 impl fmt::Display for RegexpMatch {
@@ -1189,51 +970,18 @@ impl fmt::Display for RegexpMatch {
 )]
 pub struct RegexpSplitToArray(pub Regex);
 
-impl LazyUnaryFunc for RegexpSplitToArray {
-    fn eval<'a>(
-        &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-    ) -> Result<Datum<'a>, EvalError> {
-        let haystack = a.eval(datums, temp_storage)?;
-        if haystack.is_null() {
-            return Ok(Datum::Null);
-        }
-        regexp_split_to_array_re(haystack.unwrap_str(), &self.0, temp_storage)
-    }
-
-    /// The output SqlColumnType of this function
-    fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        SqlScalarType::Array(Box::new(SqlScalarType::String)).nullable(input_type.nullable)
-    }
-
-    /// Whether this function will produce NULL on NULL input
-    fn propagates_nulls(&self) -> bool {
-        true
-    }
-
-    /// Whether this function will produce NULL on non-NULL input
-    fn introduces_nulls(&self) -> bool {
-        false
-    }
-
-    /// Whether this function preserves uniqueness
-    fn preserves_uniqueness(&self) -> bool {
-        false
-    }
-
-    fn inverse(&self) -> Option<crate::UnaryFunc> {
-        None
-    }
-
-    fn is_monotone(&self) -> bool {
-        false
-    }
-
-    fn is_eliminable_cast(&self) -> bool {
-        false
-    }
+#[sqlfunc(
+    RegexpSplitToArray,
+    output_type_expr = "SqlScalarType::Array(Box::new(SqlScalarType::String)).nullable(false)",
+    introduces_nulls = false,
+    skip_display = true
+)]
+fn regexp_split_to_array<'a>(
+    &self,
+    a: &'a str,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    regexp_split_to_array_re(a, &self.0, temp_storage)
 }
 
 impl fmt::Display for RegexpSplitToArray {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -17,6 +17,7 @@ use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
 use mz_ore::result::ResultExt;
 use mz_ore::str::StrExt;
+use mz_repr::adt::array::Array;
 use mz_repr::adt::char::{Char, format_str_trim};
 use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
@@ -376,7 +377,7 @@ fn cast_string_to_array<'a>(
     &'a self,
     a: &'a str,
     temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
+) -> Result<Array<'a>, EvalError> {
     let (datums, dims) = strconv::parse_array(
         a,
         || Datum::Null,
@@ -389,7 +390,7 @@ fn cast_string_to_array<'a>(
                 .eval(&[Datum::String(elem_text)], temp_storage)
         },
     )?;
-    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, datums))?)
+    Ok(temp_storage.make_datum_array(&dims, datums)?)
 }
 
 #[derive(

--- a/src/expr/src/scalar/func/impls/time.rs
+++ b/src/expr/src/scalar/func/impls/time.rs
@@ -105,7 +105,11 @@ impl EagerUnaryFunc for ExtractTime {
     type Input<'a> = NaiveTime;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_time_inner(self.0, a)
     }
 
@@ -138,7 +142,11 @@ impl EagerUnaryFunc for DatePartTime {
     type Input<'a> = NaiveTime;
     type Output<'a> = Result<f64, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_time_inner(self.0, a)
     }
 
@@ -184,7 +192,11 @@ impl EagerUnaryFunc for TimezoneTime {
     type Input<'a> = NaiveTime;
     type Output<'a> = NaiveTime;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         timezone_time(self.tz, a, &self.wall_time)
     }
 

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -92,7 +92,11 @@ impl EagerUnaryFunc for CastTimestampToTimestampTz {
     type Input<'a> = CheckedTimestamp<NaiveDateTime>;
     type Output<'a> = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let out =
             CheckedTimestamp::try_from(DateTime::<Utc>::from_naive_utc_and_offset(a.into(), Utc))?;
         let updated = out.round_to_precision(self.to)?;
@@ -149,7 +153,11 @@ impl EagerUnaryFunc for AdjustTimestampPrecision {
     type Input<'a> = CheckedTimestamp<NaiveDateTime>;
     type Output<'a> = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         // This should never have been called if precisions are same.
         // Adding a soft-assert to flag if there are such instances.
         mz_ore::soft_assert_no_log!(self.to != self.from);
@@ -205,7 +213,11 @@ impl EagerUnaryFunc for CastTimestampTzToTimestamp {
     type Input<'a> = CheckedTimestamp<DateTime<Utc>>;
     type Output<'a> = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let out = CheckedTimestamp::try_from(a.naive_utc())?;
         let updated = out.round_to_precision(self.to)?;
         Ok(updated)
@@ -261,7 +273,11 @@ impl EagerUnaryFunc for AdjustTimestampTzPrecision {
     type Input<'a> = CheckedTimestamp<DateTime<Utc>>;
     type Output<'a> = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         // This should never have been called if precisions are same.
         // Adding a soft-assert to flag if there are such instances.
         mz_ore::soft_assert_no_log!(self.to != self.from);
@@ -359,7 +375,11 @@ impl EagerUnaryFunc for ExtractInterval {
     type Input<'a> = Interval;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_interval_inner(self.0, a)
     }
 
@@ -392,7 +412,11 @@ impl EagerUnaryFunc for DatePartInterval {
     type Input<'a> = Interval;
     type Output<'a> = Result<f64, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_interval_inner(self.0, a)
     }
 
@@ -471,7 +495,11 @@ impl EagerUnaryFunc for ExtractTimestamp {
     type Input<'a> = CheckedTimestamp<NaiveDateTime>;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_timestamp_inner(self.0, &*a)
     }
 
@@ -508,7 +536,11 @@ impl EagerUnaryFunc for ExtractTimestampTz {
     type Input<'a> = CheckedTimestamp<DateTime<Utc>>;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_timestamp_inner(self.0, &*a)
     }
 
@@ -548,7 +580,11 @@ impl EagerUnaryFunc for DatePartTimestamp {
     type Input<'a> = CheckedTimestamp<NaiveDateTime>;
     type Output<'a> = Result<f64, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_timestamp_inner(self.0, &*a)
     }
 
@@ -581,7 +617,11 @@ impl EagerUnaryFunc for DatePartTimestampTz {
     type Input<'a> = CheckedTimestamp<DateTime<Utc>>;
     type Output<'a> = Result<f64, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_part_timestamp_inner(self.0, &*a)
     }
 
@@ -643,7 +683,11 @@ impl EagerUnaryFunc for DateTruncTimestamp {
     type Input<'a> = CheckedTimestamp<NaiveDateTime>;
     type Output<'a> = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_trunc_inner(self.0, &*a)?.try_into().err_into()
     }
 
@@ -680,7 +724,11 @@ impl EagerUnaryFunc for DateTruncTimestampTz {
     type Input<'a> = CheckedTimestamp<DateTime<Utc>>;
     type Output<'a> = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         date_trunc_inner(self.0, &*a)?.try_into().err_into()
     }
 
@@ -773,7 +821,11 @@ impl EagerUnaryFunc for TimezoneTimestamp {
     type Input<'a> = CheckedTimestamp<NaiveDateTime>;
     type Output<'a> = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         timezone_timestamp(self.0, a.to_naive())
     }
 
@@ -806,7 +858,11 @@ impl EagerUnaryFunc for TimezoneTimestampTz {
     type Input<'a> = CheckedTimestamp<DateTime<Utc>>;
     type Output<'a> = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         timezone_timestamptz(self.0, a.into())?
             .try_into()
             .err_into()
@@ -844,7 +900,11 @@ impl EagerUnaryFunc for ToCharTimestamp {
     type Input<'a> = CheckedTimestamp<NaiveDateTime>;
     type Output<'a> = String;
 
-    fn call<'a>(&self, input: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        input: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         self.format.render(&*input)
     }
 
@@ -880,7 +940,11 @@ impl EagerUnaryFunc for ToCharTimestampTz {
     type Input<'a> = CheckedTimestamp<DateTime<Utc>>;
     type Output<'a> = String;
 
-    fn call<'a>(&self, input: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        input: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         self.format.render(&*input)
     }
 

--- a/src/expr/src/scalar/func/impls/uint16.rs
+++ b/src/expr/src/scalar/func/impls/uint16.rs
@@ -125,7 +125,11 @@ impl EagerUnaryFunc for CastUint16ToNumeric {
     type Input<'a> = u16;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let mut a = Numeric::from(i32::from(a));
         if let Some(scale) = self.0 {
             if numeric::rescale(&mut a, scale.into_u8()).is_err() {

--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -130,7 +130,11 @@ impl EagerUnaryFunc for CastUint32ToNumeric {
     type Input<'a> = u32;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let mut a = Numeric::from(a);
         if let Some(scale) = self.0 {
             if numeric::rescale(&mut a, scale.into_u8()).is_err() {

--- a/src/expr/src/scalar/func/impls/uint64.rs
+++ b/src/expr/src/scalar/func/impls/uint64.rs
@@ -134,7 +134,11 @@ impl EagerUnaryFunc for CastUint64ToNumeric {
     type Input<'a> = u64;
     type Output<'a> = Result<Numeric, EvalError>;
 
-    fn call<'a>(&self, a: Self::Input<'a>) -> Self::Output<'a> {
+    fn call<'a>(
+        &'a self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
         let mut a = Numeric::from(a);
         if let Some(scale) = self.0 {
             if numeric::rescale(&mut a, scale.into_u8()).is_err() {

--- a/src/expr/src/scalar/func/unary.rs
+++ b/src/expr/src/scalar/func/unary.rs
@@ -107,10 +107,14 @@ pub trait LazyUnaryFunc {
 
 /// A description of an SQL unary function that operates on eagerly evaluated expressions
 pub trait EagerUnaryFunc {
-    type Input<'a>: InputDatumType<'a, EvalError>;
-    type Output<'a>: OutputDatumType<'a, EvalError>;
+    type Input<'a>: InputDatumType<'a, EvalError>
+    where
+        Self: 'a;
+    type Output<'a>: OutputDatumType<'a, EvalError>
+    where
+        Self: 'a;
 
-    fn call<'a>(&self, input: Self::Input<'a>) -> Self::Output<'a>;
+    fn call<'a>(&'a self, input: Self::Input<'a>, temp_storage: &'a RowArena) -> Self::Output<'a>;
 
     /// The output SqlColumnType of this function
     fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType;
@@ -164,7 +168,7 @@ impl<T: EagerUnaryFunc> LazyUnaryFunc for T {
     ) -> Result<Datum<'a>, EvalError> {
         match T::Input::<'_>::try_from_result(a.eval(datums, temp_storage)) {
             // If we can convert to the input type then we call the function
-            Ok(input) => self.call(input).into_result(temp_storage),
+            Ok(input) => self.call(input, temp_storage).into_result(temp_storage),
             // If we can't and we got a non-null datum something went wrong in the planner
             Err(Ok(datum)) if !datum.is_null() => {
                 Err(EvalError::Internal("invalid input type".into()))

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -3155,6 +3155,25 @@ impl RowArena {
         DatumList::new(datum.unwrap_list().data())
     }
 
+    /// Convenience function to build an array datum from `dims` and an
+    /// iterator of typed elements, and return it as an `Array<'a>`.
+    ///
+    /// Returns an error if the iterator's length does not match the
+    /// cardinality of `dims` or `dims` exceeds [`MAX_ARRAY_DIMENSIONS`].
+    pub fn make_datum_array<'a, T: std::borrow::Borrow<Datum<'a>>>(
+        &'a self,
+        dims: &[ArrayDimension],
+        iter: impl IntoIterator<Item = T>,
+    ) -> Result<Array<'a, T>, InvalidArrayError> {
+        let mut row = Row::default();
+        row.packer().try_push_array(dims, iter)?;
+        let array = self.push_unary_row(row).unwrap_array();
+        Ok(Array {
+            dims: array.dims,
+            elements: DatumList::new(array.elements.data()),
+        })
+    }
+
     /// Convenience function identical to `make_datum` but instead returns a
     /// `DatumNested`.
     pub fn make_datum_nested<'a, F>(&'a self, f: F) -> DatumNested<'a>

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -3138,9 +3138,12 @@ impl RowArena {
     /// Convenience function to build a list datum from an iterator of typed
     /// elements and return it as a `DatumList<'a, T>`.
     ///
-    /// By accepting an iterator of `T: Borrow<Datum>` instead of a raw
-    /// `RowPacker` closure, this guarantees that only elements of type `T`
-    /// are pushed.
+    /// `T` is a phantom marker on the returned `DatumList<'a, T>`; it is
+    /// **not** verified that the borrowed `Datum`s match T's expected
+    /// variant. The caller must ensure that the pushed `Datum`s match
+    /// what T's `FromDatum` impl (or equivalent reader) expects, or
+    /// downstream reads will panic. Bytes are written via `Datum`'s
+    /// variant tag, not via T.
     pub fn make_datum_list<'a, T: std::borrow::Borrow<Datum<'a>>>(
         &'a self,
         iter: impl IntoIterator<Item = T>,
@@ -3156,10 +3159,17 @@ impl RowArena {
     }
 
     /// Convenience function to build an array datum from `dims` and an
-    /// iterator of typed elements, and return it as an `Array<'a>`.
+    /// iterator of typed elements, and return it as an `Array<'a, T>`.
     ///
     /// Returns an error if the iterator's length does not match the
     /// cardinality of `dims` or `dims` exceeds [`MAX_ARRAY_DIMENSIONS`].
+    ///
+    /// `T` is a phantom marker on the returned `Array<'a, T>`; it is
+    /// **not** verified that the borrowed `Datum`s match T's expected
+    /// variant. The caller must ensure that the pushed `Datum`s match
+    /// what T's `FromDatum` impl (or equivalent reader) expects, or
+    /// downstream reads will panic. Bytes are written via `Datum`'s
+    /// variant tag, not via T.
     pub fn make_datum_array<'a, T: std::borrow::Borrow<Datum<'a>>>(
         &'a self,
         dims: &[ArrayDimension],


### PR DESCRIPTION
Extends `#[sqlfunc(...)]` to accept stateful structs and arena access for unary and binary functions. Bumps `EagerUnaryFunc::call` to take `&'a self` and `&'a RowArena`, mirroring the variadic shape. Adds `skip_display = true` modifier for structs needing custom `Display`.

Migrates 19 hand-written `LazyUnaryFunc` impls (compound-type casts, regex match/split, record_get, etc.) in `src/expr/src/scalar/func/impls/*` to the macro form.

Remaining hand-written impls: the 6 short-circuit variadics (`And`, `Or`, `Coalesce`, `ErrorIfNull`, `Greatest`, `Least`) plus `CaseLiteral`, which require true lazy semantics over `MirScalarExpr`.

Prep work for collapsing per-sqlfunc monomorphizations into vtable dispatch ([prompt](doc/developer/prompts/sqlfunc-dyn-dispatch.md)).