### PR TITLE
storage-types: use scheme default port for CSR SSH tunnel

### DIFF
--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1478,9 +1478,9 @@ impl CsrConnection {
                     .connect(
                         storage_configuration,
                         host,
-                        // Default to the default http port, but this
-                        // could default to 8081...
-                        self.url.port().unwrap_or(80),
+                        // Honor the URL scheme's default port (443 for https,
+                        // 80 for http) if no explicit port was provided.
+                        self.url.port_or_known_default().unwrap_or(80),
                         in_task,
                     )
                     .await


### PR DESCRIPTION
Previously `url::Url::port()` returned `None` for default ports, so HTTPS schema registry URLs without an explicit port forwarded SSH tunnel traffic to port 80, causing TLS handshake failures.