### PR TITLE
storage-types: redact credentials in ContentSource Debug

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -171,7 +171,9 @@ impl Coordinator {
                             .retire(Err(AdapterError::Unstructured(anyhow::anyhow!("{err}"))));
                     }
                 }
-                mz_storage_types::oneshot_sources::ContentSource::Http { url }
+                mz_storage_types::oneshot_sources::ContentSource::Http {
+                    url: mz_ore::url::SensitiveUrl(url),
+                }
             }
             CopyFromSource::AwsS3 {
                 uri,

--- a/src/storage-operators/src/oneshot_source/http_source.rs
+++ b/src/storage-operators/src/oneshot_source/http_source.rs
@@ -16,10 +16,10 @@ use bytes::Bytes;
 use derivative::Derivative;
 use futures::TryStreamExt;
 use futures::stream::{BoxStream, StreamExt};
+use mz_ore::url::SensitiveUrl;
 use reqwest::Client;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::oneshot_source::util::IntoRangeHeaderValue;
 use crate::oneshot_source::{
@@ -87,11 +87,11 @@ fn check_not_redirect(response: &reqwest::Response) -> Result<(), StorageErrorX>
 pub struct HttpOneshotSource {
     #[derivative(Debug = "ignore")]
     client: Client,
-    origin: Url,
+    origin: SensitiveUrl,
 }
 
 impl HttpOneshotSource {
-    pub fn new(client: Client, origin: Url) -> Self {
+    pub fn new(client: Client, origin: SensitiveUrl) -> Self {
         HttpOneshotSource { client, origin }
     }
 }
@@ -99,8 +99,8 @@ impl HttpOneshotSource {
 /// Object returned from an [`HttpOneshotSource`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HttpObject {
-    /// [`Url`] to access the file.
-    url: Url,
+    /// [`SensitiveUrl`] to access the file.
+    url: SensitiveUrl,
     /// Name of the file.
     filename: String,
     /// Size of this file reported by the [`Content-Length`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length) header
@@ -209,7 +209,7 @@ impl OneshotSource for HttpOneshotSource {
         // canonically is the right thing do.
         let response = self
             .client
-            .head(self.origin.clone())
+            .head(self.origin.0.clone())
             .send()
             .await
             .context("HEAD request")?;
@@ -225,7 +225,7 @@ impl OneshotSource for HttpOneshotSource {
 
                 let response = self
                     .client
-                    .get(self.origin.clone())
+                    .get(self.origin.0.clone())
                     .send()
                     .await
                     .context("GET request")?;
@@ -296,7 +296,7 @@ impl OneshotSource for HttpOneshotSource {
         // TODO(cf1): Validate our checksum.
 
         let initial_response = async move {
-            let mut request = self.client.get(object.url);
+            let mut request = self.client.get(object.url.0);
 
             if let Some(range) = &range {
                 let value = range.into_range_header_value();

--- a/src/storage-types/src/oneshot_sources.rs
+++ b/src/storage-types/src/oneshot_sources.rs
@@ -9,14 +9,15 @@
 
 //! Types for oneshot sources.
 
+use derivative::Derivative;
 use mz_expr::SafeMfpPlan;
+use mz_ore::url::SensitiveUrl;
 use mz_pgcopy::CopyCsvFormatParams;
 use mz_repr::{CatalogItemId, RelationDesc};
 use mz_timely_util::builder_async::PressOnDropButton;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedReceiver;
-use url::Url;
 
 use crate::connections::aws::AwsConnection;
 
@@ -39,12 +40,14 @@ pub struct OneshotIngestionRequest {
     pub shape: ContentShape,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Derivative, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derivative(Debug)]
 pub enum ContentSource {
     Http {
-        url: Url,
+        url: SensitiveUrl,
     },
     AwsS3 {
+        #[derivative(Debug = "ignore")]
         connection: AwsConnection,
         connection_id: CatalogItemId,
         uri: String,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1070,7 +1070,12 @@ impl<'w> Worker<'w> {
                     }
                 }
                 StorageCommand::RunOneshotIngestion(ingestion) => {
-                    info!(%worker_id, ?ingestion, "reconcile: received RunOneshotIngestion command");
+                    info!(
+                        %worker_id,
+                        ingestion_id = %ingestion.ingestion_id,
+                        collection_id = %ingestion.collection_id,
+                        "reconcile: received RunOneshotIngestion command",
+                    );
                     create_oneshot_ingestions.insert(ingestion.ingestion_id);
                 }
                 StorageCommand::CancelOneshotIngestion(uuid) => {


### PR DESCRIPTION
Use SensitiveUrl for ContentSource::Http and skip the AwsConnection field in Debug so reconcile log lines no longer leak url passwords or inline AWS credentials. Also narrow the storage_state reconcile log to ids only.

Carry SensitiveUrl through HttpOneshotSource and HttpObject so the `tracing::info!(?object, "found objects")` line in the HTTP oneshot source also redacts. Move URL-userinfo Basic auth into a Basic auth header before handing the URL to reqwest, so reqwest::Error::Display cannot leak the password on connect/DNS failures.
