### PR TITLE
storage-types: implement AlterCompatible for SqlServerSourceExportDetails

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -884,6 +884,7 @@ impl crate::AlterCompatible for SourceExportDetails {
             (Self::Kafka(s), Self::Kafka(o)) => s.alter_compatible(id, o),
             (Self::Postgres(s), Self::Postgres(o)) => s.alter_compatible(id, o),
             (Self::MySql(s), Self::MySql(o)) => s.alter_compatible(id, o),
+            (Self::SqlServer(s), Self::SqlServer(o)) => s.alter_compatible(id, o),
             (Self::LoadGenerator(s), Self::LoadGenerator(o)) => s.alter_compatible(id, o),
             _ => Err(AlterError { id }),
         };

--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -252,6 +252,25 @@ pub struct SqlServerSourceExportDetails {
     pub initial_lsn: mz_sql_server_util::cdc::Lsn,
 }
 
+impl AlterCompatible for SqlServerSourceExportDetails {
+    fn alter_compatible(
+        &self,
+        _id: GlobalId,
+        _other: &Self,
+    ) -> Result<(), crate::controller::AlterError> {
+        // compatibility checks are performed against the upstream table in the source
+        // render operators instead
+        let Self {
+            capture_instance: _,
+            table: _,
+            text_columns: _,
+            exclude_columns: _,
+            initial_lsn: _,
+        } = self;
+        Ok(())
+    }
+}
+
 impl SourceTimestamp for Lsn {
     fn encode_row(&self) -> mz_repr::Row {
         Row::pack_slice(&[Datum::Bytes(&self.as_bytes())])


### PR DESCRIPTION
The variant was added in #32087 without updating
SourceExportDetails::alter_compatible, so any non-identical pair of SqlServer details fell through to the wildcard and returned an error, which crashes clusterd reconciliation via
.expect("only alter compatible ingestions permitted"). Mirror the MySql pattern: defer field-level checks to the source render operators.