### PR TITLE
ci: Fix unused deps

### DIFF
--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -51,3 +51,9 @@ mz-mysql-util = { path = ".", features = ["proptest"] }
 proptest.workspace = true
 proptest-derive.workspace = true
 tokio.workspace = true
+
+[package.metadata.cargo-udeps.ignore]
+# The self-dep above activates the `proptest` feature for tests so that
+# `cfg(test)`-gated `Arbitrary` derives can find `mz-repr`'s proptest impls.
+# cargo-udeps doesn't recognize feature-activation as usage.
+development = ["mz-mysql-util"]


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/16530#019e5783-3714-4448-a887-684eeb57b1ab

Test run: https://buildkite.com/materialize/nightly/builds/16532

I fixed and then broke this in https://github.com/MaterializeInc/materialize/pull/36699, it's required for per-package compilation.