### PR TITLE
build(deps): Bump native-tls in misc/wasm

### DIFF
--- a/misc/wasm/Cargo.lock
+++ b/misc/wasm/Cargo.lock
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "6cdede44f9a69cab2899a2049e2c3bd49bf911a157f6a3353d4a91c61abbce44"
 dependencies = [
  "libc",
  "log",


### PR DESCRIPTION
Noticed in https://buildkite.com/materialize/test/builds/123735#019e5d84-c359-49cd-8955-c3c4651ba872