### PR TITLE
adapter: extract begin_statement_logging helper from frontend_peek

### DIFF
--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -200,33 +200,18 @@ impl PeekClient {
 
         // Set up statement logging, and log the beginning of execution.
         // (But only if we're not executing in the context of another statement.)
-        let statement_logging_id = if outer_ctx_extra.is_none() {
-            // This is a new statement, so begin statement logging
-            let result = self.statement_logging_frontend.begin_statement_execution(
-                session,
-                &params,
-                &logging,
-                catalog.system_config(),
-                lifecycle_timestamps,
-            );
-
-            if let Some((logging_id, began_execution, mseh_update, prepared_statement)) = result {
-                self.log_began_execution(began_execution, mseh_update, prepared_statement);
-                Some(logging_id)
-            } else {
-                None
-            }
-        } else {
-            // We're executing in the context of another statement (e.g., FETCH),
-            // so extract the statement logging ID from the outer context if present.
-            // We take ownership and retire the outer context here. The end of execution will be
-            // logged in one of the following ways:
-            // - At the end of this function, if the execution is finished by then.
-            // - Later by the Coordinator, either due to RegisterFrontendPeek or ExecuteSlowPathPeek.
-            outer_ctx_extra
-                .take()
-                .and_then(|guard| guard.defuse().retire())
-        };
+        // The end of execution will be logged in one of the following ways:
+        // - At the end of this function, if the execution is finished by then.
+        // - Later by the Coordinator, either due to RegisterFrontendPeek or
+        //   ExecuteSlowPathPeek.
+        let statement_logging_id = self.begin_statement_logging(
+            session,
+            &params,
+            &logging,
+            &catalog,
+            lifecycle_timestamps,
+            outer_ctx_extra,
+        );
 
         let result = self
             .try_frontend_peek_inner(session, catalog, stmt, params, statement_logging_id)

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -24,9 +24,11 @@ use mz_repr::Timestamp;
 use mz_repr::global_id::TransientIdGen;
 use mz_repr::{RelationDesc, Row};
 use mz_sql::optimizer_metrics::OptimizerMetrics;
+use mz_sql::plan::Params;
 use mz_storage_types::sources::Timeline;
 use mz_timestamp_oracle::TimestampOracle;
 use prometheus::Histogram;
+use qcell::QCell;
 use thiserror::Error;
 use timely::progress::Antichain;
 use tokio::sync::oneshot;
@@ -34,12 +36,12 @@ use uuid::Uuid;
 
 use crate::catalog::Catalog;
 use crate::command::{CatalogSnapshot, Command};
-use crate::coord::Coordinator;
 use crate::coord::peek::FastPathPlan;
-use crate::statement_logging::WatchSetCreation;
+use crate::coord::{Coordinator, ExecuteContextGuard};
+use crate::session::{LifecycleTimestamps, Session};
 use crate::statement_logging::{
-    FrontendStatementLoggingEvent, PreparedStatementEvent, StatementLoggingFrontend,
-    StatementLoggingId,
+    FrontendStatementLoggingEvent, PreparedStatementEvent, PreparedStatementLoggingInfo,
+    StatementLoggingFrontend, StatementLoggingId, WatchSetCreation,
 };
 use crate::{AdapterError, Client, CollectionIdBundle, ReadHolds, statement_logging};
 
@@ -416,7 +418,49 @@ impl PeekClient {
         })
     }
 
-    // Statement logging helper methods
+    /// Set up statement logging for a frontend-sequenced operation.
+    ///
+    /// If `outer_ctx_extra` is `None`, begins a new statement execution log
+    /// entry. If `outer_ctx_extra` is `Some` (e.g. EXECUTE/FETCH), reuses the
+    /// existing logging id and retires the outer context.
+    ///
+    /// The end of execution must be logged separately by the caller (via
+    /// [`Self::log_ended_execution`]) once the terminal outcome is known, or
+    /// handed off to the coordinator for streaming responses.
+    pub(crate) fn begin_statement_logging(
+        &self,
+        session: &mut Session,
+        params: &Params,
+        logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
+        catalog: &Catalog,
+        lifecycle_timestamps: Option<LifecycleTimestamps>,
+        outer_ctx_extra: &mut Option<ExecuteContextGuard>,
+    ) -> Option<StatementLoggingId> {
+        if outer_ctx_extra.is_none() {
+            // This is a new statement, so begin statement logging.
+            let result = self.statement_logging_frontend.begin_statement_execution(
+                session,
+                params,
+                logging,
+                catalog.system_config(),
+                lifecycle_timestamps,
+            );
+
+            if let Some((logging_id, began_execution, mseh_update, prepared_statement)) = result {
+                self.log_began_execution(began_execution, mseh_update, prepared_statement);
+                Some(logging_id)
+            } else {
+                None
+            }
+        } else {
+            // We're executing in the context of another statement (e.g. FETCH),
+            // so take ownership of the outer context and inherit its logging id
+            // (if any). The end of execution will be logged by the caller.
+            outer_ctx_extra
+                .take()
+                .and_then(|guard| guard.defuse().retire())
+        }
+    }
 
     /// Log the beginning of statement execution.
     pub(crate) fn log_began_execution(


### PR DESCRIPTION
The new statement and reused-outer-context branches in `try_frontend_peek` are otherwise identical bookkeeping. Lift them into a `PeekClient::begin_statement_logging` method so that another frontend-sequenced caller (the upcoming OCC read-then-write path) can share the same logic.

Work towards https://github.com/MaterializeInc/database-issues/issues/6686
