### PR TITLE
mcp: skip auto-route when role lacks USAGE on the data product's cluster

### DIFF
--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -84,6 +84,8 @@ enum McpRequestError {
     ToolNotFound(String),
     #[error("Data product not found: {0}")]
     DataProductNotFound(String),
+    #[error("{0}")]
+    ClusterPrivilegeMissing(String),
     #[error("Query validation failed: {0}")]
     QueryValidationFailed(String),
     #[error("Query execution failed: {0}")]
@@ -99,6 +101,7 @@ impl McpRequestError {
             Self::MethodNotFound(_) => error_codes::METHOD_NOT_FOUND,
             Self::ToolNotFound(_) => error_codes::INVALID_PARAMS,
             Self::DataProductNotFound(_) => error_codes::INVALID_PARAMS,
+            Self::ClusterPrivilegeMissing(_) => error_codes::INVALID_PARAMS,
             Self::QueryValidationFailed(_) => error_codes::INVALID_PARAMS,
             Self::QueryExecutionFailed(_) | Self::Internal(_) => error_codes::INTERNAL_ERROR,
         }
@@ -110,6 +113,7 @@ impl McpRequestError {
             Self::MethodNotFound(_) => "MethodNotFound",
             Self::ToolNotFound(_) => "ToolNotFound",
             Self::DataProductNotFound(_) => "DataProductNotFound",
+            Self::ClusterPrivilegeMissing(_) => "ClusterPrivilegeMissing",
             Self::QueryValidationFailed(_) => "ValidationError",
             Self::QueryExecutionFailed(_) => "ExecutionError",
             Self::Internal(_) => "InternalError",
@@ -1042,22 +1046,32 @@ async fn read_data_product(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Override > catalog (when usable) > session default. Skipping
-    // auto-route on missing USAGE keeps the read on a cluster the role
-    // can actually use; SET CLUSTER itself would succeed but the SELECT
-    // would then fail with `permission denied for CLUSTER`.
-    let target_cluster = cluster_override.or_else(|| {
-        if has_cluster_usage {
-            catalog_cluster
-        } else {
-            debug!(
-                name = %name,
-                cluster = ?catalog_cluster,
-                "skipping auto-route: role lacks USAGE on the data product's cluster",
-            );
-            None
-        }
-    });
+    // Override beats everything. Otherwise the read auto-routes to the
+    // catalog cluster, but only if the role has USAGE on it: silently
+    // falling back to the session default would mask a missing privilege
+    // as "slow reads forever", so we fail loud with an actionable error
+    // instead.
+    let target_cluster = match cluster_override {
+        Some(c) => c,
+        None => match catalog_cluster {
+            Some(c) if has_cluster_usage => c,
+            Some(c) => {
+                return Err(McpRequestError::ClusterPrivilegeMissing(format!(
+                    "Data product {name} is hosted on cluster {c:?}, which your role \
+                     does not have USAGE on. Pass `cluster: \"<a-cluster-you-have-USAGE-on>\"` \
+                     to read it from a different cluster (slower, no index), or have USAGE \
+                     granted on {c:?}.",
+                )));
+            }
+            None => {
+                // Defensive: every legitimate row in `mz_mcp_data_products`
+                // has a non-NULL cluster, so this is an internal error.
+                return Err(McpRequestError::Internal(anyhow!(
+                    "data product {name} has no cluster in the catalog"
+                )));
+            }
+        },
+    };
 
     // No row cap is applied here: the response is bounded by the size cap
     // enforced in format_rows_response (MCP_MAX_RESPONSE_SIZE), and by
@@ -1073,24 +1087,17 @@ async fn read_data_product(
 /// Builds the SQL the agent runs for `read_data_product`.
 ///
 /// `safe_name` must already be the validated, quoted form produced by
-/// [`safe_data_product_name`]. `target_cluster`, when provided, is escaped
-/// as a SQL string literal and wrapped in `SET CLUSTER` inside a `BEGIN
-/// READ ONLY` transaction so the cluster choice is scoped to this read
-/// and does not leak into the session.
-///
-/// `target_cluster: None` emits a bare `SELECT` on the session default —
-/// the fallback when the role lacks `USAGE` on the data product's home
-/// cluster (see [`read_data_product`]).
-fn build_read_query(safe_name: &str, limit: u32, target_cluster: Option<&str>) -> String {
-    match target_cluster {
-        Some(cluster) => format!(
-            "BEGIN READ ONLY; SET CLUSTER = {}; SELECT * FROM {} LIMIT {}\n; COMMIT;",
-            escaped_string_literal(cluster),
-            safe_name,
-            limit,
-        ),
-        None => format!("SELECT * FROM {} LIMIT {}", safe_name, limit),
-    }
+/// [`safe_data_product_name`]. `target_cluster` is escaped as a SQL
+/// string literal and wrapped in `SET CLUSTER` inside a `BEGIN READ
+/// ONLY` transaction so the cluster choice is scoped to this read and
+/// does not leak into the session.
+fn build_read_query(safe_name: &str, limit: u32, target_cluster: &str) -> String {
+    format!(
+        "BEGIN READ ONLY; SET CLUSTER = {}; SELECT * FROM {} LIMIT {}\n; COMMIT;",
+        escaped_string_literal(target_cluster),
+        safe_name,
+        limit,
+    )
 }
 
 /// Validates query is a single SELECT, SHOW, or EXPLAIN statement.
@@ -1858,29 +1865,12 @@ mod tests {
 
     // ── build_read_query tests (DEX-27) ────────────────────────────────
 
-    /// Without a target cluster, the read is a single bare `SELECT` so
-    /// session-default reads avoid the three extra round trips that
-    /// `BEGIN READ ONLY; SET CLUSTER; ...; COMMIT;` would cost.
-    #[mz_ore::test]
-    fn test_build_read_query_no_cluster() {
-        let sql = build_read_query("\"db\".\"sch\".\"v\"", 100, None);
-        assert_eq!(sql, "SELECT * FROM \"db\".\"sch\".\"v\" LIMIT 100");
-        assert!(
-            !sql.contains("SET CLUSTER"),
-            "session-default reads should not emit SET CLUSTER: {sql}",
-        );
-        assert!(
-            !sql.contains("BEGIN"),
-            "session-default reads should not open a transaction: {sql}",
-        );
-    }
-
-    /// With a target cluster, the read is wrapped in a `BEGIN READ ONLY`
-    /// transaction so the `SET CLUSTER` scope is bounded to this read and
-    /// does not leak into the rest of the session.
+    /// The read is wrapped in a `BEGIN READ ONLY` transaction so the
+    /// `SET CLUSTER` scope is bounded to this read and does not leak
+    /// into the rest of the session.
     #[mz_ore::test]
     fn test_build_read_query_with_cluster() {
-        let sql = build_read_query("\"db\".\"sch\".\"v\"", 50, Some("prod_cluster"));
+        let sql = build_read_query("\"db\".\"sch\".\"v\"", 50, "prod_cluster");
         assert!(sql.contains("BEGIN READ ONLY"), "{sql}");
         assert!(sql.contains("SET CLUSTER = 'prod_cluster'"), "{sql}");
         assert!(
@@ -1896,11 +1886,7 @@ mod tests {
     /// adversarial cluster names.
     #[mz_ore::test]
     fn test_build_read_query_escapes_cluster_name() {
-        let sql = build_read_query(
-            "\"db\".\"sch\".\"v\"",
-            10,
-            Some("evil'; DROP TABLE secrets; --"),
-        );
+        let sql = build_read_query("\"db\".\"sch\".\"v\"", 10, "evil'; DROP TABLE secrets; --");
         // The single quote in `evil'` must be doubled inside the literal.
         assert!(
             sql.contains("SET CLUSTER = 'evil''; DROP TABLE secrets; --'"),

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -994,9 +994,10 @@ fn safe_data_product_name(name: &str) -> Result<String, McpRequestError> {
 /// same read on a named cluster instead — useful for running the read on a
 /// differently-sized or differently-replicated cluster.
 ///
-/// If both the override and the catalog cluster are absent (the catalog
-/// cluster column is unexpectedly null), the query falls back to the
-/// session's default cluster.
+/// Without an override, the role must have `USAGE` on the catalog cluster
+/// — otherwise the call fails with [`McpRequestError::ClusterPrivilegeMissing`]
+/// rather than silently degrading to a slower path that would mask the
+/// missing privilege.
 ///
 /// The name is expected to come from `get_data_products()` /
 /// `get_data_product_details()`. The query runs inside a READ ONLY

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -1011,14 +1011,28 @@ async fn read_data_product(
 
     // Lookup query: serves as the existence check (we still error
     // `DataProductNotFound` on an empty result) and at the same time
-    // recovers the catalog cluster for auto-routing. `mz_mcp_data_products`
-    // can hold multiple rows per object_name when a product is indexed on
-    // multiple clusters; `ORDER BY cluster NULLS LAST LIMIT 1` picks one
-    // deterministically. Callers can disambiguate via `cluster_override`.
+    // recovers the catalog cluster for auto-routing along with whether the
+    // calling role has `USAGE` on it. `mz_mcp_data_products` filters by
+    // `SELECT` on the object but not by cluster privileges, so a role may
+    // legitimately see a data product whose home cluster it cannot use;
+    // when that happens we fall back to the session default rather than
+    // emit `SET CLUSTER` followed by a hard `permission denied` failure.
+    //
+    // `mz_mcp_data_products` can hold multiple rows per object_name when a
+    // product is indexed on multiple clusters. The `ORDER BY` picks the
+    // best candidate deterministically: prefer a cluster the role can
+    // actually use, then break ties alphabetically. Callers can override
+    // the choice via `cluster_override`.
     let lookup_query = format!(
-        "SELECT cluster FROM mz_internal.mz_mcp_data_products \
+        "SELECT \
+             cluster, \
+             cluster IS NULL OR has_cluster_privilege(cluster, 'USAGE') \
+                 AS has_cluster_usage \
+         FROM mz_internal.mz_mcp_data_products \
          WHERE object_name = {} \
-         ORDER BY cluster NULLS LAST \
+         ORDER BY \
+             (cluster IS NOT NULL AND has_cluster_usage) DESC, \
+             cluster NULLS LAST \
          LIMIT 1",
         escaped_string_literal(name)
     );
@@ -1026,13 +1040,34 @@ async fn read_data_product(
     if lookup_rows.is_empty() {
         return Err(McpRequestError::DataProductNotFound(name.to_string()));
     }
-    let catalog_cluster: Option<&str> = lookup_rows
-        .first()
+    let lookup_row = lookup_rows.first();
+    let catalog_cluster: Option<&str> = lookup_row
         .and_then(|row| row.first())
         .and_then(|v| v.as_str());
+    // Treat anything other than an explicit `true` as a missing privilege,
+    // including the unexpected `NULL` case.
+    let has_cluster_usage: bool = lookup_row
+        .and_then(|row| row.get(1))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
-    // Override beats catalog; catalog beats session default.
-    let target_cluster = cluster_override.or(catalog_cluster);
+    // Override beats everything. Otherwise auto-route to the catalog
+    // cluster only when the role has `USAGE` on it; without `USAGE` the
+    // `SET CLUSTER` would succeed but the subsequent `SELECT` would fail
+    // with a `permission denied`, so we leave the read on the session
+    // default — slower (no index) but correct.
+    let target_cluster = cluster_override.or_else(|| {
+        if has_cluster_usage {
+            catalog_cluster
+        } else {
+            debug!(
+                name = %name,
+                cluster = ?catalog_cluster,
+                "skipping auto-route: role lacks USAGE on the data product's cluster",
+            );
+            None
+        }
+    });
 
     // No row cap is applied here: the response is bounded by the size cap
     // enforced in format_rows_response (MCP_MAX_RESPONSE_SIZE), and by
@@ -1050,12 +1085,15 @@ async fn read_data_product(
 /// `safe_name` must already be the validated, quoted form produced by
 /// [`safe_data_product_name`]. `target_cluster`, when provided, is escaped
 /// as a SQL string literal and wrapped in `SET CLUSTER` inside a `BEGIN
-/// READ ONLY` transaction so the cluster choice is scoped to this read and
-/// does not leak into the session.
+/// READ ONLY` transaction so the cluster choice is scoped to this read
+/// and does not leak into the session.
 ///
 /// When `target_cluster` is `None` we emit a single bare `SELECT` instead
-/// of opening a transaction, which avoids three extra round trips on the
-/// hot path of session-default reads.
+/// of opening a transaction. This case is reached for restricted roles
+/// that have `SELECT` on the data product but not `USAGE` on its home
+/// cluster: rather than `SET CLUSTER` to a cluster the role cannot use
+/// (which would hard-fail), [`read_data_product`] falls back to the
+/// session default and accepts the suboptimal-but-correct read.
 fn build_read_query(safe_name: &str, limit: u32, target_cluster: Option<&str>) -> String {
     match target_cluster {
         Some(cluster) => format!(

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -1031,7 +1031,8 @@ async fn read_data_product(
          FROM mz_internal.mz_mcp_data_products \
          WHERE object_name = {} \
          ORDER BY \
-             (cluster IS NOT NULL AND has_cluster_usage) DESC, \
+             (cluster IS NOT NULL \
+                 AND has_cluster_privilege(cluster, 'USAGE')) DESC, \
              cluster NULLS LAST \
          LIMIT 1",
         escaped_string_literal(name)

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -1009,20 +1009,10 @@ async fn read_data_product(
     // Parse and safely quote the name for SQL interpolation.
     let safe_name = safe_data_product_name(name)?;
 
-    // Lookup query: serves as the existence check (we still error
-    // `DataProductNotFound` on an empty result) and at the same time
-    // recovers the catalog cluster for auto-routing along with whether the
-    // calling role has `USAGE` on it. `mz_mcp_data_products` filters by
-    // `SELECT` on the object but not by cluster privileges, so a role may
-    // legitimately see a data product whose home cluster it cannot use;
-    // when that happens we fall back to the session default rather than
-    // emit `SET CLUSTER` followed by a hard `permission denied` failure.
-    //
-    // `mz_mcp_data_products` can hold multiple rows per object_name when a
-    // product is indexed on multiple clusters. The `ORDER BY` picks the
-    // best candidate deterministically: prefer a cluster the role can
-    // actually use, then break ties alphabetically. Callers can override
-    // the choice via `cluster_override`.
+    // Existence check + recover the cluster for auto-routing. The view
+    // filters by SELECT on the object but not by cluster privileges, so we
+    // also fetch USAGE on the cluster and prefer a usable one in ORDER BY
+    // (an MV indexed on multiple clusters can appear more than once).
     let lookup_query = format!(
         "SELECT \
              cluster, \
@@ -1052,11 +1042,10 @@ async fn read_data_product(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Override beats everything. Otherwise auto-route to the catalog
-    // cluster only when the role has `USAGE` on it; without `USAGE` the
-    // `SET CLUSTER` would succeed but the subsequent `SELECT` would fail
-    // with a `permission denied`, so we leave the read on the session
-    // default — slower (no index) but correct.
+    // Override > catalog (when usable) > session default. Skipping
+    // auto-route on missing USAGE keeps the read on a cluster the role
+    // can actually use; SET CLUSTER itself would succeed but the SELECT
+    // would then fail with `permission denied for CLUSTER`.
     let target_cluster = cluster_override.or_else(|| {
         if has_cluster_usage {
             catalog_cluster
@@ -1089,12 +1078,9 @@ async fn read_data_product(
 /// READ ONLY` transaction so the cluster choice is scoped to this read
 /// and does not leak into the session.
 ///
-/// When `target_cluster` is `None` we emit a single bare `SELECT` instead
-/// of opening a transaction. This case is reached for restricted roles
-/// that have `SELECT` on the data product but not `USAGE` on its home
-/// cluster: rather than `SET CLUSTER` to a cluster the role cannot use
-/// (which would hard-fail), [`read_data_product`] falls back to the
-/// session default and accepts the suboptimal-but-correct read.
+/// `target_cluster: None` emits a bare `SELECT` on the session default —
+/// the fallback when the role lacks `USAGE` on the data product's home
+/// cluster (see [`read_data_product`]).
 fn build_read_query(safe_name: &str, limit: u32, target_cluster: Option<&str>) -> String {
     match target_cluster {
         Some(cluster) => format!(

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -451,20 +451,22 @@ def workflow_default(c: Composition) -> None:
             f"(dex27_other), but activity log shows cluster_name = {observed_cluster!r}"
         )
 
-    # -- read_data_product fallback when role lacks USAGE on the home cluster -
+    # -- read_data_product fails loud when role lacks USAGE on home cluster ---
     #
-    # The catalog view `mz_mcp_data_products` filters by SELECT on the
-    # object but not by cluster privileges, so a role may legitimately see
-    # a data product whose home cluster it cannot use. Before the USAGE
-    # check, the no-override path emitted `SET CLUSTER = <home>; SELECT`
-    # and the SELECT hard-failed on `permission denied for CLUSTER`. We
-    # now skip the `SET CLUSTER` in that case and run the read on the
-    # session default — slower (no index access) but correct.
+    # `mz_mcp_data_products` filters by SELECT on the object but not by
+    # cluster privileges, so a role may see a data product hosted on a
+    # cluster it can't use. Auto-routing without a USAGE check would
+    # emit `SET CLUSTER = <home>; SELECT ...` and the SELECT would fail
+    # with `permission denied for CLUSTER`. Silently falling back to the
+    # session default would hide the missing privilege as "slow reads
+    # forever," so we instead surface a clear `ClusterPrivilegeMissing`
+    # error and let the caller decide: grant USAGE, or pass an explicit
+    # `cluster` override to read from a cluster they can use.
 
-    with c.test_case("agent_read_data_product_falls_back_without_cluster_usage"):
+    with c.test_case("agent_read_data_product_fails_when_lacking_cluster_usage"):
         # Provision a "compute" cluster that hosts the MV's dataflow, and
-        # a "serving" cluster that the HTTP user has USAGE on. Grant
-        # SELECT on the MV but withhold USAGE on the compute cluster.
+        # a "serving" cluster the HTTP user has USAGE on. Grant SELECT on
+        # the MV but withhold USAGE on the compute cluster.
         c.sql(
             """
             DROP MATERIALIZED VIEW IF EXISTS public.restricted_mv;
@@ -473,9 +475,7 @@ def workflow_default(c: Composition) -> None:
             CREATE CLUSTER restricted_compute REPLICAS (r1 (SIZE 'scale=1,workers=1'));
             CREATE CLUSTER restricted_serving REPLICAS (r1 (SIZE 'scale=1,workers=1'));
             CREATE MATERIALIZED VIEW public.restricted_mv IN CLUSTER restricted_compute
-                AS SELECT 9::int AS id, 'fallback'::text AS name;
-            -- Agent gets SELECT on the MV and USAGE on the serving cluster
-            -- only; nothing on `restricted_compute`.
+                AS SELECT 9::int AS id, 'override'::text AS name;
             GRANT SELECT ON public.restricted_mv TO anonymous_http_user;
             GRANT USAGE ON CLUSTER restricted_serving TO anonymous_http_user;
             REVOKE USAGE ON CLUSTER restricted_compute FROM anonymous_http_user;
@@ -486,10 +486,7 @@ def workflow_default(c: Composition) -> None:
             print_statement=False,
         )
 
-        # Touch the agent endpoint so `anonymous_http_user` exists, then
-        # call `read_data_product` with no override. The server must
-        # detect that the role lacks USAGE on `restricted_compute` and
-        # run the read on the session default (`restricted_serving`).
+        # Touch the agent endpoint so `anonymous_http_user` exists.
         post_mcp(
             c,
             "agent",
@@ -503,6 +500,9 @@ def workflow_default(c: Composition) -> None:
                 req_id=2800,
             ),
         )
+
+        # No-override read: must fail with ClusterPrivilegeMissing and an
+        # actionable message naming the missing cluster.
         r = post_mcp(
             c,
             "agent",
@@ -520,44 +520,45 @@ def workflow_default(c: Composition) -> None:
         )
         assert r.status_code == 200, f"unexpected status: {r.status_code} {r.text}"
         body = r.json()
-        assert "error" not in body, (
-            "no-override read should fall back to the session default when the "
-            f"role lacks USAGE on the home cluster, but got error: {body}"
+        err = body.get("error")
+        assert err is not None, (
+            "no-override read should fail loud when the role lacks USAGE on "
+            f"the home cluster, but got: {body}"
         )
+        assert (
+            err["data"]["error_type"] == "ClusterPrivilegeMissing"
+        ), f"unexpected error_type: {err}"
+        assert (
+            "restricted_compute" in err["message"]
+        ), f"error message should name the missing cluster: {err['message']!r}"
+
+        # With an explicit `cluster` override to a usable cluster, the
+        # read succeeds. Confirms the documented recovery path.
+        r = post_mcp(
+            c,
+            "agent",
+            jsonrpc(
+                "tools/call",
+                {
+                    "name": "read_data_product",
+                    "arguments": {
+                        "name": '"materialize"."public"."restricted_mv"',
+                        "cluster": "restricted_serving",
+                        "limit": 5,
+                    },
+                },
+                req_id=2802,
+            ),
+        )
+        body = r.json()
+        assert (
+            "error" not in body
+        ), f"override to a usable cluster should succeed, got: {body}"
         rows = json.loads(body["result"]["content"][0]["text"])
-        assert rows == [["9", "fallback"]], f"unexpected rows: {rows}"
+        assert rows == [["9", "override"]], f"unexpected rows: {rows}"
 
-        # Confirm via the activity log that the SELECT ran on
-        # `restricted_serving` (the session default), not the home
-        # cluster the role can't use.
-        deadline = time.monotonic() + 30
-        observed_cluster: str | None = None
-        while time.monotonic() < deadline:
-            log_rows = c.sql_query(
-                """
-                SELECT cluster_name
-                FROM mz_internal.mz_recent_activity_log
-                WHERE application_name = 'mz_mcp_agents'
-                  AND sql ILIKE '%restricted_mv%'
-                  AND finished_status = 'success'
-                ORDER BY began_at DESC
-                LIMIT 1
-                """,
-                user="mz_system",
-                port=6877,
-            )
-            if log_rows:
-                observed_cluster = log_rows[0][0]
-                break
-            time.sleep(0.5)
-        assert observed_cluster == "restricted_serving", (
-            "read should have fallen back to the session default, but activity "
-            f"log shows cluster_name = {observed_cluster!r}"
-        )
-
-        # Sanity check: an explicit override still wins over auto-routing
-        # and over the fallback. Passing the home cluster fails as before
-        # because the role lacks USAGE — explicit caller intent is honored.
+        # Sanity: explicit override to the un-usable home cluster still
+        # fails (now at SQL execution time, not in the auto-route check).
         r = post_mcp(
             c,
             "agent",
@@ -571,7 +572,7 @@ def workflow_default(c: Composition) -> None:
                         "limit": 5,
                     },
                 },
-                req_id=2802,
+                req_id=2803,
             ),
         )
         body = r.json()

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -451,6 +451,142 @@ def workflow_default(c: Composition) -> None:
             f"(dex27_other), but activity log shows cluster_name = {observed_cluster!r}"
         )
 
+    # -- read_data_product fallback when role lacks USAGE on the home cluster -
+    #
+    # The catalog view `mz_mcp_data_products` filters by SELECT on the
+    # object but not by cluster privileges, so a role may legitimately see
+    # a data product whose home cluster it cannot use. Before the USAGE
+    # check, the no-override path emitted `SET CLUSTER = <home>; SELECT`
+    # and the SELECT hard-failed on `permission denied for CLUSTER`. We
+    # now skip the `SET CLUSTER` in that case and run the read on the
+    # session default — slower (no index access) but correct.
+
+    with c.test_case("agent_read_data_product_falls_back_without_cluster_usage"):
+        # Provision a "compute" cluster that hosts the MV's dataflow, and
+        # a "serving" cluster that the HTTP user has USAGE on. Grant
+        # SELECT on the MV but withhold USAGE on the compute cluster.
+        c.sql(
+            """
+            DROP MATERIALIZED VIEW IF EXISTS public.restricted_mv;
+            DROP CLUSTER IF EXISTS restricted_compute CASCADE;
+            DROP CLUSTER IF EXISTS restricted_serving CASCADE;
+            CREATE CLUSTER restricted_compute REPLICAS (r1 (SIZE 'scale=1,workers=1'));
+            CREATE CLUSTER restricted_serving REPLICAS (r1 (SIZE 'scale=1,workers=1'));
+            CREATE MATERIALIZED VIEW public.restricted_mv IN CLUSTER restricted_compute
+                AS SELECT 9::int AS id, 'fallback'::text AS name;
+            -- Agent gets SELECT on the MV and USAGE on the serving cluster
+            -- only; nothing on `restricted_compute`.
+            GRANT SELECT ON public.restricted_mv TO anonymous_http_user;
+            GRANT USAGE ON CLUSTER restricted_serving TO anonymous_http_user;
+            REVOKE USAGE ON CLUSTER restricted_compute FROM anonymous_http_user;
+            ALTER ROLE anonymous_http_user SET cluster = 'restricted_serving';
+            """,
+            user="mz_system",
+            port=6877,
+            print_statement=False,
+        )
+
+        # Touch the agent endpoint so `anonymous_http_user` exists, then
+        # call `read_data_product` with no override. The server must
+        # detect that the role lacks USAGE on `restricted_compute` and
+        # run the read on the session default (`restricted_serving`).
+        post_mcp(
+            c,
+            "agent",
+            jsonrpc(
+                "initialize",
+                {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "restricted", "version": "0.1.0"},
+                },
+                req_id=2800,
+            ),
+        )
+        r = post_mcp(
+            c,
+            "agent",
+            jsonrpc(
+                "tools/call",
+                {
+                    "name": "read_data_product",
+                    "arguments": {
+                        "name": '"materialize"."public"."restricted_mv"',
+                        "limit": 5,
+                    },
+                },
+                req_id=2801,
+            ),
+        )
+        assert r.status_code == 200, f"unexpected status: {r.status_code} {r.text}"
+        body = r.json()
+        assert "error" not in body, (
+            "no-override read should fall back to the session default when the "
+            f"role lacks USAGE on the home cluster, but got error: {body}"
+        )
+        rows = json.loads(body["result"]["content"][0]["text"])
+        assert rows == [["9", "fallback"]], f"unexpected rows: {rows}"
+
+        # Confirm via the activity log that the SELECT ran on
+        # `restricted_serving` (the session default), not the home
+        # cluster the role can't use.
+        deadline = time.monotonic() + 30
+        observed_cluster: str | None = None
+        while time.monotonic() < deadline:
+            log_rows = c.sql_query(
+                """
+                SELECT cluster_name
+                FROM mz_internal.mz_recent_activity_log
+                WHERE application_name = 'mz_mcp_agents'
+                  AND sql ILIKE '%restricted_mv%'
+                  AND finished_status = 'success'
+                ORDER BY began_at DESC
+                LIMIT 1
+                """,
+                user="mz_system",
+                port=6877,
+            )
+            if log_rows:
+                observed_cluster = log_rows[0][0]
+                break
+            time.sleep(0.5)
+        assert observed_cluster == "restricted_serving", (
+            "read should have fallen back to the session default, but activity "
+            f"log shows cluster_name = {observed_cluster!r}"
+        )
+
+        # Sanity check: an explicit override still wins over auto-routing
+        # and over the fallback. Passing the home cluster fails as before
+        # because the role lacks USAGE — explicit caller intent is honored.
+        r = post_mcp(
+            c,
+            "agent",
+            jsonrpc(
+                "tools/call",
+                {
+                    "name": "read_data_product",
+                    "arguments": {
+                        "name": '"materialize"."public"."restricted_mv"',
+                        "cluster": "restricted_compute",
+                        "limit": 5,
+                    },
+                },
+                req_id=2802,
+            ),
+        )
+        body = r.json()
+        assert (
+            "error" in body
+        ), "explicit override to a cluster without USAGE should still fail loudly"
+
+        # Tidy up the role default so it does not leak into later cases.
+        c.sql(
+            "ALTER ROLE anonymous_http_user RESET cluster",
+            user="mz_system",
+            port=6877,
+            print_statement=False,
+        )
+
     # -- agent: disable/enable via flag ----------------------------------------
 
     with c.test_case("agent_disable_via_flag"):


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/36619#issuecomment-4540116380