### PR TITLE
pgcopy,pgwire: fix CSV decoding of quoted NULL markers and end-of-copy marker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7278,7 +7278,7 @@ name = "mz-pgcopy"
 version = "0.0.0"
 dependencies = [
  "bytes",
- "csv",
+ "csv-core",
  "itertools 0.14.0",
  "mz-ore",
  "mz-pgrepr",

--- a/src/pgcopy/Cargo.toml
+++ b/src/pgcopy/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 bytes.workspace = true
-csv.workspace = true
+csv-core.workspace = true
 itertools.workspace = true
 mz-ore = { path = "../ore", features = [] }
 mz-pgrepr = { path = "../pgrepr" }

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -11,7 +11,6 @@ use std::borrow::Cow;
 use std::io;
 
 use bytes::BytesMut;
-use csv::{ByteRecord, ReaderBuilder};
 use itertools::Itertools;
 use mz_repr::{
     Datum, RelationDesc, Row, RowArena, RowRef, SharedRow, SqlColumnType, SqlRelationType,
@@ -690,73 +689,143 @@ pub fn decode_copy_format_csv(
         header,
     }: CopyCsvFormatParams,
 ) -> Result<Vec<Row>, io::Error> {
-    let mut rows = Vec::new();
-
     let (double_quote, escape) = if quote == escape {
         (true, None)
     } else {
         (false, Some(escape))
     };
 
-    let mut rdr = ReaderBuilder::new()
+    let mut rdr = csv_core::ReaderBuilder::new()
         .delimiter(delimiter)
         .quote(quote)
-        .has_headers(header)
-        .double_quote(double_quote)
         .escape(escape)
-        // Must be flexible to accept end of copy marker, which will always be 1
-        // field.
-        .flexible(true)
-        .from_reader(data);
+        .double_quote(double_quote)
+        .build();
 
     let null_as_bytes = null.as_bytes();
+    let mut rows = Vec::new();
+    // We use csv-core (rather than the higher-level csv crate) so we can
+    // recover per-field "was this field quoted?" information by inspecting the
+    // first byte of each field's input. csv unquotes during parsing, which
+    // makes a quoted empty string indistinguishable from an unquoted empty
+    // field — and PostgreSQL COPY ... FORMAT CSV semantics need that
+    // distinction to honor the NULL marker.
+    let mut input = data;
+    let mut output = vec![0u8; data.len().max(1024)];
+    let mut out_pos = 0;
+    let mut fields: Vec<(usize, usize, bool)> = Vec::new();
+    let mut field_start = 0;
+    let mut field_quoted: Option<bool> = None;
+    let mut skip_header = header;
+    // True at the start of a record (including the very first), where csv-core
+    // may have left an orphaned terminator byte; false for fields that follow a
+    // delimiter within a record.
+    let mut at_record_start = true;
 
-    let mut record = ByteRecord::new();
-
-    while rdr.read_byte_record(&mut record)? {
-        if record.len() == 1 && record.iter().next() == Some(END_OF_COPY_MARKER) {
-            break;
-        }
-
-        match record.len().cmp(&column_types.len()) {
-            std::cmp::Ordering::Less => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "missing data for column",
-            )),
-            std::cmp::Ordering::Greater => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "extra data after last expected column",
-            )),
-            std::cmp::Ordering::Equal => Ok(()),
-        }?;
-
-        let mut row_builder = SharedRow::get();
-        let mut row_packer = row_builder.packer();
-
-        for (typ, raw_value) in column_types.iter().zip_eq(record.iter()) {
-            if raw_value == null_as_bytes {
-                row_packer.push(Datum::Null);
-            } else {
-                let s = match std::str::from_utf8(raw_value) {
-                    Ok(s) => s,
-                    Err(err) => {
-                        let msg = format!("invalid utf8 data in column: {}", err);
-                        return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
-                    }
-                };
-                match mz_pgrepr::Value::decode_text_into_row(typ, s, &mut row_packer) {
-                    Ok(()) => {}
-                    Err(err) => {
-                        let msg = format!("unable to decode column: {}", err);
-                        return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
-                    }
+    loop {
+        if field_quoted.is_none() {
+            if at_record_start {
+                // csv-core's default terminator is CRLF, and it reports a
+                // record complete after consuming the `\r`, leaving the
+                // trailing `\n` as the first byte of the next record's input
+                // (and, after a worker chunk is split at a `\r` boundary, a
+                // chunk can likewise begin with that orphan `\n`). csv-core
+                // itself consumes and ignores those stray terminator bytes when
+                // parsing the field, but the quote probe below must skip them
+                // so it inspects the field's real first byte rather than an
+                // orphan — otherwise a quoted field on any non-first CRLF record
+                // is misclassified as unquoted. Only skip at a record boundary:
+                // a `\r`/`\n` after a delimiter legitimately terminates an empty
+                // trailing field and must not be swallowed.
+                while matches!(input.first(), Some(&b'\r') | Some(&b'\n')) {
+                    input = &input[1..];
                 }
             }
+            field_quoted = Some(input.first() == Some(&quote));
+            field_start = out_pos;
         }
-        rows.push(row_builder.clone());
-    }
 
-    Ok(rows)
+        let (result, nin, nout) = rdr.read_field(input, &mut output[out_pos..]);
+        input = &input[nin..];
+        out_pos += nout;
+
+        match result {
+            csv_core::ReadFieldResult::Field { record_end } => {
+                fields.push((field_start, out_pos, field_quoted.take().unwrap()));
+                // The next field begins a new record only if this field ended
+                // one; otherwise it follows a delimiter mid-record.
+                at_record_start = record_end;
+
+                if record_end {
+                    if skip_header {
+                        skip_header = false;
+                    } else if fields.len() == 1
+                        && !fields[0].2
+                        && &output[fields[0].0..fields[0].1] == END_OF_COPY_MARKER
+                    {
+                        // Bare `\.` on its own line: end-of-copy marker. A
+                        // quoted `"\."` also decodes to `\.` but is data, so
+                        // only an unquoted match terminates the import.
+                        return Ok(rows);
+                    } else {
+                        match fields.len().cmp(&column_types.len()) {
+                            std::cmp::Ordering::Less => {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    "missing data for column",
+                                ));
+                            }
+                            std::cmp::Ordering::Greater => {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    "extra data after last expected column",
+                                ));
+                            }
+                            std::cmp::Ordering::Equal => {}
+                        }
+
+                        let mut row_builder = SharedRow::get();
+                        let mut row_packer = row_builder.packer();
+                        for (typ, &(s, e, quoted)) in column_types.iter().zip_eq(fields.iter()) {
+                            let raw_value = &output[s..e];
+                            if !quoted && raw_value == null_as_bytes {
+                                row_packer.push(Datum::Null);
+                            } else {
+                                let s = match std::str::from_utf8(raw_value) {
+                                    Ok(s) => s,
+                                    Err(err) => {
+                                        let msg = format!("invalid utf8 data in column: {}", err);
+                                        return Err(io::Error::new(
+                                            io::ErrorKind::InvalidData,
+                                            msg,
+                                        ));
+                                    }
+                                };
+                                if let Err(err) =
+                                    mz_pgrepr::Value::decode_text_into_row(typ, s, &mut row_packer)
+                                {
+                                    let msg = format!("unable to decode column: {}", err);
+                                    return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
+                                }
+                            }
+                        }
+                        rows.push(row_builder.clone());
+                    }
+                    fields.clear();
+                    out_pos = 0;
+                }
+            }
+            csv_core::ReadFieldResult::OutputFull => {
+                let new_len = output.len().saturating_mul(2).max(out_pos + 1);
+                output.resize(new_len, 0);
+            }
+            csv_core::ReadFieldResult::InputEmpty => {
+                // We've consumed all input; loop again with the now-empty
+                // slice so csv-core can flush any buffered trailing field.
+            }
+            csv_core::ReadFieldResult::End => return Ok(rows),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1038,6 +1107,147 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[mz_ore::test]
+    fn test_decode_copy_format_csv_end_marker() {
+        // Bare `\.` on its own line terminates the COPY. A quoted `"\."`
+        // decodes to the same bytes but must be treated as data. This must
+        // hold for every line ending (LF, CRLF, CR): csv-core places a CRLF
+        // record boundary between `\r` and `\n`, so a naive raw-byte check is
+        // fooled by the orphaned terminator bytes on CRLF/CR input.
+        let column_types = vec![mz_pgrepr::Type::from(&mz_repr::SqlScalarType::String)];
+
+        let decode_strings = |input: &[u8]| -> Vec<String> {
+            decode_copy_format_csv(input, &column_types, CopyCsvFormatParams::default())
+                .expect("decode should succeed")
+                .iter()
+                .map(|r| match r.iter().next().unwrap() {
+                    Datum::String(s) => s.to_owned(),
+                    d => panic!("unexpected datum: {:?}", d),
+                })
+                .collect()
+        };
+
+        for eol in [&b"\n"[..], b"\r\n", b"\r"] {
+            let join = |lines: &[&str]| -> Vec<u8> {
+                let mut out = Vec::new();
+                for line in lines {
+                    out.extend_from_slice(line.as_bytes());
+                    out.extend_from_slice(eol);
+                }
+                out
+            };
+
+            // Quoted "\." is data — all three rows are imported.
+            assert_eq!(
+                decode_strings(&join(&["before", "\"\\.\"", "after"])),
+                vec!["before", "\\.", "after"],
+                "quoted marker, eol={eol:?}"
+            );
+
+            // Bare `\.` terminates the COPY; rows after it are dropped.
+            assert_eq!(
+                decode_strings(&join(&["first", "\\.", "ignored"])),
+                vec!["first"],
+                "bare marker, eol={eol:?}"
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_decode_copy_format_csv_leading_orphan() {
+        // Worker chunks after the first begin at a `\r` boundary, so for CRLF
+        // input a chunk's bytes start with the orphan `\n` that csv-core left
+        // behind. The decoder must still classify the first field's quote
+        // state from its real first byte, not the stray `\n`. Regression test
+        // for the per-chunk quote probe.
+        let column_types = vec![
+            mz_pgrepr::Type::from(&mz_repr::SqlScalarType::String),
+            mz_pgrepr::Type::from(&mz_repr::SqlScalarType::String),
+        ];
+
+        let rows = decode_copy_format_csv(
+            b"\n\"\",x\r\ny,z\r\n",
+            &column_types,
+            CopyCsvFormatParams::default(),
+        )
+        .expect("decode should succeed");
+        let got: Vec<Vec<Datum>> = rows.iter().map(|r| r.iter().collect()).collect();
+        assert_eq!(got.len(), 2);
+        // Quoted empty first field on the leading-orphan record must decode to
+        // the empty string, not SQL NULL (the bug would misread it as
+        // unquoted and match the default empty NULL marker).
+        assert_eq!(got[0][0], Datum::String(""));
+        assert_eq!(got[0][1], Datum::String("x"));
+        assert_eq!(got[1][0], Datum::String("y"));
+        assert_eq!(got[1][1], Datum::String("z"));
+    }
+
+    #[mz_ore::test]
+    fn test_decode_copy_format_csv_quoted_null() {
+        // PG COPY ... FORMAT CSV distinguishes quoted vs unquoted NULL
+        // markers: unquoted → SQL NULL, quoted → the literal string.
+        let column_types = vec![
+            mz_pgrepr::Type::from(&mz_repr::SqlScalarType::String),
+            mz_pgrepr::Type::from(&mz_repr::SqlScalarType::String),
+        ];
+
+        // Lines as (col_a, col_b) literals, joined per-eol below. The quoted
+        // vs unquoted distinction must survive CRLF/CR line endings, where
+        // csv-core leaves an orphaned terminator byte at the start of every
+        // non-first record.
+        let cases: &[(CopyCsvFormatParams, &[(&str, &str)], &[[Option<&str>; 2]])] = &[
+            // Default params: NULL marker is empty string.
+            (
+                CopyCsvFormatParams::default(),
+                &[("a", ""), ("b", "\"\""), ("\"\"", "c")],
+                &[
+                    [Some("a"), None],
+                    [Some("b"), Some("")],
+                    [Some(""), Some("c")],
+                ],
+            ),
+            // Custom NULL marker "NULL".
+            (
+                CopyCsvFormatParams {
+                    null: Cow::from("NULL"),
+                    ..Default::default()
+                },
+                &[("a", "NULL"), ("b", "\"NULL\""), ("NULL", "c")],
+                &[
+                    [Some("a"), None],
+                    [Some("b"), Some("NULL")],
+                    [None, Some("c")],
+                ],
+            ),
+        ];
+
+        for eol in [&b"\n"[..], b"\r\n", b"\r"] {
+            for (params, lines, expected) in cases {
+                let mut input = Vec::new();
+                for (a, b) in *lines {
+                    input.extend_from_slice(a.as_bytes());
+                    input.push(b',');
+                    input.extend_from_slice(b.as_bytes());
+                    input.extend_from_slice(eol);
+                }
+                let rows = decode_copy_format_csv(&input, &column_types, params.clone())
+                    .expect("decode should succeed");
+                assert_eq!(rows.len(), expected.len(), "eol={eol:?}");
+                for (row, want) in rows.iter().zip_eq(expected.iter()) {
+                    let got: Vec<Datum> = row.iter().collect();
+                    assert_eq!(got.len(), 2);
+                    for (g, w) in got.iter().zip_eq(want.iter()) {
+                        match (g, w) {
+                            (Datum::Null, None) => {}
+                            (Datum::String(s), Some(w)) => assert_eq!(s, w, "eol={eol:?}"),
+                            _ => panic!("mismatch: got {g:?}, want {w:?}, eol={eol:?}"),
+                        }
+                    }
+                }
+            }
+        }
     }
 
     proptest! {

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -678,6 +678,19 @@ impl<'a> CopyCsvFormatParams<'a> {
     }
 }
 
+/// One field decoded out of a CSV record by [`decode_copy_format_csv`]:
+/// `start..end` indexes into the per-record `output` buffer (csv-core
+/// unquotes/unescapes into that buffer), and `quoted` records whether the
+/// field's first input byte was the quote character. The quote flag is what
+/// distinguishes a literal `""` (quoted empty string) from an unquoted empty
+/// field (the default NULL marker), and a quoted `"\."` data row from the bare
+/// `\.` end-of-copy marker.
+struct DecodedField {
+    start: usize,
+    end: usize,
+    quoted: bool,
+}
+
 pub fn decode_copy_format_csv(
     data: &[u8],
     column_types: &[mz_pgrepr::Type],
@@ -713,7 +726,7 @@ pub fn decode_copy_format_csv(
     let mut input = data;
     let mut output = vec![0u8; data.len().max(1024)];
     let mut out_pos = 0;
-    let mut fields: Vec<(usize, usize, bool)> = Vec::new();
+    let mut fields: Vec<DecodedField> = Vec::new();
     let mut field_start = 0;
     let mut field_quoted: Option<bool> = None;
     let mut skip_header = header;
@@ -751,7 +764,11 @@ pub fn decode_copy_format_csv(
 
         match result {
             csv_core::ReadFieldResult::Field { record_end } => {
-                fields.push((field_start, out_pos, field_quoted.take().unwrap()));
+                fields.push(DecodedField {
+                    start: field_start,
+                    end: out_pos,
+                    quoted: field_quoted.take().unwrap(),
+                });
                 // The next field begins a new record only if this field ended
                 // one; otherwise it follows a delimiter mid-record.
                 at_record_start = record_end;
@@ -759,9 +776,14 @@ pub fn decode_copy_format_csv(
                 if record_end {
                     if skip_header {
                         skip_header = false;
-                    } else if fields.len() == 1
-                        && !fields[0].2
-                        && &output[fields[0].0..fields[0].1] == END_OF_COPY_MARKER
+                    } else if let [
+                        DecodedField {
+                            start,
+                            end,
+                            quoted: false,
+                        },
+                    ] = fields[..]
+                        && &output[start..end] == END_OF_COPY_MARKER
                     {
                         // Bare `\.` on its own line: end-of-copy marker. A
                         // quoted `"\."` also decodes to `\.` but is data, so
@@ -786,9 +808,9 @@ pub fn decode_copy_format_csv(
 
                         let mut row_builder = SharedRow::get();
                         let mut row_packer = row_builder.packer();
-                        for (typ, &(s, e, quoted)) in column_types.iter().zip_eq(fields.iter()) {
-                            let raw_value = &output[s..e];
-                            if !quoted && raw_value == null_as_bytes {
+                        for (typ, field) in column_types.iter().zip_eq(fields.iter()) {
+                            let raw_value = &output[field.start..field.end];
+                            if !field.quoted && raw_value == null_as_bytes {
                                 row_packer.push(Datum::Null);
                             } else {
                                 let s = match std::str::from_utf8(raw_value) {
@@ -820,8 +842,11 @@ pub fn decode_copy_format_csv(
                 output.resize(new_len, 0);
             }
             csv_core::ReadFieldResult::InputEmpty => {
-                // We've consumed all input; loop again with the now-empty
-                // slice so csv-core can flush any buffered trailing field.
+                // InputEmpty means csv-core consumed all our input mid-field
+                // and wants more. We have no more to give, so the next
+                // iteration calls it with the now-empty slice; per its
+                // documented termination protocol, that yields the partial
+                // field (if any) as a final `Field`, then `End`.
             }
             csv_core::ReadFieldResult::End => return Ok(rows),
         }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -3234,6 +3234,11 @@ struct CopyRowScanner {
     scan_pos: usize,
     last_row_end: Option<usize>,
     end_marker_end: Option<usize>,
+    // Byte offset within `data` at which the in-progress CSV record begins.
+    // Used to verify the end-of-copy marker against the raw input bytes,
+    // distinguishing a literal `\.` line from a quoted CSV value `"\."`
+    // whose decoded form is also `\.`.
+    record_start: usize,
     csv: Option<CsvScanState>,
 }
 
@@ -3242,8 +3247,6 @@ struct CsvScanState {
     reader: csv_core::Reader,
     output: Vec<u8>,
     ends: Vec<usize>,
-    record: Vec<u8>,
-    record_ends: Vec<usize>,
     skip_first_record: bool,
 }
 
@@ -3264,6 +3267,7 @@ impl CopyRowScanner {
             scan_pos: 0,
             last_row_end: None,
             end_marker_end: None,
+            record_start: 0,
             csv,
         }
     }
@@ -3277,17 +3281,11 @@ impl CopyRowScanner {
             let mut input = &data[self.scan_pos..];
             let mut consumed = 0usize;
             while !input.is_empty() {
-                let (result, n_input, n_output, n_ends) =
+                let (result, n_input, _n_output, _n_ends) =
                     csv.reader
                         .read_record(input, &mut csv.output, &mut csv.ends);
                 consumed += n_input;
                 input = &input[n_input..];
-                if !csv.output.is_empty() {
-                    csv.record.extend_from_slice(&csv.output[..n_output]);
-                }
-                if !csv.ends.is_empty() {
-                    csv.record_ends.extend_from_slice(&csv.ends[..n_ends]);
-                }
 
                 match result {
                     ReadRecordResult::InputEmpty => break,
@@ -3309,19 +3307,42 @@ impl CopyRowScanner {
                             let is_marker = if csv.skip_first_record {
                                 csv.skip_first_record = false;
                                 false
-                            } else if csv.record_ends.len() == 1 {
-                                let end = csv.record_ends[0];
-                                end == 2 && csv.record.get(0..end) == Some(b"\\.")
                             } else {
-                                false
+                                // Detect the marker against the raw input
+                                // bytes, not the CSV-decoded record. A quoted
+                                // data row `"\."` decodes to `\.` but must be
+                                // imported as data; only a bare `\.` line
+                                // terminates the COPY.
+                                let raw = &data[self.record_start..row_end];
+                                // csv-core ends a CRLF record after the `\r`,
+                                // leaving the trailing `\n` as the leading byte
+                                // of the next record's span; a CR-only record
+                                // ends in a lone `\r`. So a `\.` marker record's
+                                // raw span can be `\.\n` (LF), `\n\.\r` (CRLF)
+                                // or `\.\r` (CR). Trim CR/LF from both ends
+                                // before comparing — a trailing-only strip would
+                                // miss the CRLF/CR forms. Quoted `"\."` data
+                                // keeps its surrounding quotes after trimming and
+                                // is therefore correctly rejected.
+                                let start = raw
+                                    .iter()
+                                    .take_while(|&&b| b == b'\r' || b == b'\n')
+                                    .count();
+                                let trailing = raw[start..]
+                                    .iter()
+                                    .rev()
+                                    .take_while(|&&b| b == b'\r' || b == b'\n')
+                                    .count();
+                                let trimmed = &raw[start..raw.len() - trailing];
+                                trimmed == b"\\."
                             };
                             if is_marker {
                                 self.end_marker_end = Some(row_end);
+                                self.record_start = row_end;
                                 break;
                             }
                         }
-                        csv.record.clear();
-                        csv.record_ends.clear();
+                        self.record_start = row_end;
                     }
                 }
             }
@@ -3364,12 +3385,16 @@ impl CopyRowScanner {
         self.end_marker_end = self
             .end_marker_end
             .and_then(|end| end.checked_sub(split_pos));
+        // Splits always occur at a completed-row boundary, so the in-progress
+        // record (if any) starts at the new beginning of the buffer.
+        self.record_start = self.record_start.saturating_sub(split_pos);
     }
 
     fn on_truncate(&mut self, new_len: usize) {
         self.scan_pos = self.scan_pos.min(new_len);
         self.last_row_end = self.last_row_end.filter(|&end| end <= new_len);
         self.end_marker_end = self.end_marker_end.filter(|&end| end <= new_len);
+        self.record_start = self.record_start.min(new_len);
     }
 }
 
@@ -3389,8 +3414,6 @@ impl CsvScanState {
                 .build(),
             output: vec![0; 1],
             ends: vec![0; 1],
-            record: Vec::new(),
-            record_ends: Vec::new(),
             skip_first_record: header,
         }
     }
@@ -3399,6 +3422,54 @@ impl CsvScanState {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[mz_ore::test]
+    fn test_copy_row_scanner_end_marker_line_endings() {
+        // The pgwire COPY row scanner must detect a bare `\.` end-of-copy
+        // marker for every line ending, and must never mistake a quoted
+        // `"\."` data row for it. csv-core ends a CRLF record after the `\r`
+        // (leaving the `\n` as the next record's leading byte), so the raw
+        // record span of a `\.` marker is `\.\n` (LF), `\n\.\r` (CRLF) or
+        // `\.\r` (CR); a trailing-only strip would miss the CRLF/CR forms and
+        // silently import post-marker rows.
+        let params = CopyFormatParams::Csv(CopyCsvFormatParams::default());
+
+        let marker_end = |data: &[u8]| -> Option<usize> {
+            let mut scanner = CopyRowScanner::new(&params);
+            scanner.scan_new_bytes(data);
+            scanner.end_marker_end()
+        };
+
+        for eol in [&b"\n"[..], b"\r\n", b"\r"] {
+            let join = |lines: &[&str]| -> Vec<u8> {
+                let mut out = Vec::new();
+                for line in lines {
+                    out.extend_from_slice(line.as_bytes());
+                    out.extend_from_slice(eol);
+                }
+                out
+            };
+
+            // Bare `\.` (the marker is the second record, so record_start has
+            // already advanced past the orphaned terminator of `first`).
+            // csv-core reports the record after a single terminator byte, so
+            // the marker boundary sits just past `first<eol>\.` + one byte.
+            let data = join(&["first", "\\.", "after"]);
+            let mut prefix = Vec::new();
+            prefix.extend_from_slice(b"first");
+            prefix.extend_from_slice(eol);
+            prefix.extend_from_slice(b"\\.");
+            assert_eq!(
+                marker_end(&data),
+                Some(prefix.len() + 1),
+                "bare marker, eol={eol:?}"
+            );
+
+            // Quoted "\." is data, not the marker.
+            let data = join(&["before", "\"\\.\"", "after"]);
+            assert_eq!(marker_end(&data), None, "quoted marker, eol={eol:?}");
+        }
+    }
 
     #[mz_ore::test]
     fn test_parse_options() {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -38,7 +38,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
 use mz_ore::now::{EpochMillis, SYSTEM_TIME};
 use mz_ore::str::StrExt;
-use mz_ore::{assert_none, assert_ok, instrument, soft_assert_eq_or_log};
+use mz_ore::{assert_none, assert_ok, instrument, soft_assert_eq_or_log, soft_assert_or_log};
 use mz_pgcopy::{CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams};
 use mz_pgwire_common::{
     ConnectionCounter, Cursor, ErrorResponse, Format, FrontendMessage, Severity, VERSION_3,
@@ -3386,7 +3386,15 @@ impl CopyRowScanner {
             .end_marker_end
             .and_then(|end| end.checked_sub(split_pos));
         // Splits always occur at a completed-row boundary, so the in-progress
-        // record (if any) starts at the new beginning of the buffer.
+        // record (if any) starts at the new beginning of the buffer. Record
+        // this invariant explicitly so the `saturating_sub` below doesn't
+        // silently paper over a bug that bisected an in-progress record.
+        soft_assert_or_log!(
+            self.record_start >= split_pos,
+            "split bisected an in-progress CSV record: record_start={} < split_pos={}",
+            self.record_start,
+            split_pos,
+        );
         self.record_start = self.record_start.saturating_sub(split_pos);
     }
 

--- a/test/copy/mzcompose.py
+++ b/test/copy/mzcompose.py
@@ -516,3 +516,187 @@ def workflow_copy_from_csv_header(c: Composition) -> None:
         cur.execute("SELECT val FROM csv_header_test WHERE id = 999999")
         row = cur.fetchone()
         assert row is not None and row[0] == f"{pad}_0000999999"
+
+
+def workflow_copy_from_csv_quoted_null(c: Composition) -> None:
+    """Regression test: CSV COPY FROM STDIN must distinguish quoted from
+    unquoted NULL markers per PostgreSQL semantics. An unquoted occurrence of
+    the NULL marker is SQL NULL; a quoted occurrence is the literal string.
+    """
+    c.up("materialized")
+
+    conn = c.sql_connection()
+    with conn.cursor() as cur:
+        # Default NULL marker (empty string): unquoted empty -> NULL,
+        # quoted empty -> "".
+        cur.execute("CREATE TABLE csv_null_default (a TEXT, b TEXT)")
+        with cur.copy("COPY csv_null_default FROM STDIN WITH (FORMAT CSV)") as copy:
+            copy.write('a,\nb,""\n"",c\n')
+
+        cur.execute("SELECT a, b FROM csv_null_default ORDER BY a NULLS LAST")
+        rows = cur.fetchall()
+        assert rows == [
+            ("a", None),
+            ("b", ""),
+            ("", "c"),
+        ], f"unexpected rows with default NULL marker: {rows}"
+
+        # Custom NULL marker "NULL": unquoted NULL -> SQL NULL,
+        # quoted "NULL" -> the literal string "NULL".
+        cur.execute("CREATE TABLE csv_null_custom (a TEXT, b TEXT)")
+        with cur.copy(
+            "COPY csv_null_custom FROM STDIN WITH (FORMAT CSV, NULL 'NULL')"
+        ) as copy:
+            copy.write('a,NULL\nb,"NULL"\nNULL,c\n')
+
+        cur.execute("SELECT a, b FROM csv_null_custom ORDER BY a NULLS LAST")
+        rows = cur.fetchall()
+        assert rows == [
+            ("a", None),
+            ("b", "NULL"),
+            (None, "c"),
+        ], f"unexpected rows with custom NULL marker: {rows}"
+
+
+def workflow_copy_from_csv_end_marker(c: Composition) -> None:
+    """Regression test: CSV COPY FROM STDIN must distinguish a quoted "\\."
+    data row from the bare \\. end-of-copy marker.
+
+    The marker is recognized in the raw input bytes only; a CSV value whose
+    *decoded* form is \\. (i.e. the quoted field "\\.") is data. Previously
+    both the pgwire row scanner and the CSV decoder compared the decoded
+    field bytes, so a quoted "\\." row would stop the import and silently
+    drop any subsequent rows.
+    """
+    c.up("materialized")
+
+    conn = c.sql_connection()
+    with conn.cursor() as cur:
+        cur.execute("CREATE TABLE csv_end_marker_test (val TEXT)")
+
+        # A quoted "\." row in the middle, followed by another row. With the
+        # bug, the "\." row and "after" row are both silently dropped.
+        with cur.copy("COPY csv_end_marker_test FROM STDIN WITH (FORMAT CSV)") as copy:
+            copy.write('before\n"\\."\nafter\n')
+
+        cur.execute("SELECT val FROM csv_end_marker_test ORDER BY val")
+        rows = [r[0] for r in cur.fetchall()]
+        assert rows == ["\\.", "after", "before"], (
+            f'quoted "\\." CSV row was misread as end-of-copy marker; '
+            f"got {rows!r}, expected ['\\\\.', 'after', 'before']"
+        )
+
+        # Bare \. on its own line still terminates the COPY and discards
+        # everything after it, matching PostgreSQL behavior.
+        cur.execute("DELETE FROM csv_end_marker_test")
+        with cur.copy("COPY csv_end_marker_test FROM STDIN WITH (FORMAT CSV)") as copy:
+            copy.write("first\n\\.\nignored\n")
+
+        cur.execute("SELECT val FROM csv_end_marker_test")
+        rows = [r[0] for r in cur.fetchall()]
+        assert rows == [
+            "first"
+        ], f"bare \\. did not terminate COPY; got {rows!r}, expected ['first']"
+
+
+def workflow_copy_from_csv_crlf(c: Composition) -> None:
+    """Regression test: CSV COPY FROM STDIN must handle CRLF and CR line
+    endings, not just LF.
+
+    csv-core places the record boundary between \\r and \\n, so for CRLF input
+    every non-first record's bytes begin with an orphaned \\n. Both the
+    decoder's per-field quote probe and the pgwire scanner's end-of-copy marker
+    check inspect raw bytes and were fooled by this: a quoted NULL marker
+    corrupted to SQL NULL, and a quoted "\\." (plus every row after it) was
+    silently dropped. RFC 4180 mandates CRLF and Windows/Excel exports use it,
+    so the most standard CSV form was untested and broken.
+    """
+    c.up("materialized")
+
+    conn = c.sql_connection()
+    with conn.cursor() as cur:
+        for label, eol in [("crlf", "\r\n"), ("cr", "\r")]:
+            # Quoted vs unquoted NULL marker, including a quoted empty leading
+            # field on an orphan-led (non-first) record. The dynamic SQL is
+            # encoded to bytes so it satisfies psycopg's LiteralString-typed
+            # query parameter.
+            cur.execute(f"CREATE TABLE csv_{label}_null (a TEXT, b TEXT)".encode())
+            with cur.copy(
+                f"COPY csv_{label}_null FROM STDIN WITH (FORMAT CSV)".encode()
+            ) as copy:
+                copy.write(f'a,{eol}b,""{eol}"",c{eol}')
+            cur.execute(
+                f"SELECT a, b FROM csv_{label}_null ORDER BY a NULLS LAST".encode()
+            )
+            rows = cur.fetchall()
+            assert rows == [
+                ("a", None),
+                ("b", ""),
+                ("", "c"),
+            ], f"{label}: quoted/unquoted NULL markers misread on CRLF/CR: {rows}"
+
+            # Quoted "\." is data; a bare \. terminates and drops the rest.
+            cur.execute(f"CREATE TABLE csv_{label}_marker (val TEXT)".encode())
+            with cur.copy(
+                f"COPY csv_{label}_marker FROM STDIN WITH (FORMAT CSV)".encode()
+            ) as copy:
+                copy.write(f'before{eol}"\\."{eol}after{eol}\\.{eol}ignored{eol}')
+            cur.execute(f"SELECT val FROM csv_{label}_marker ORDER BY val".encode())
+            rows = [r[0] for r in cur.fetchall()]
+            assert rows == ["\\.", "after", "before"], (
+                f"{label}: quoted \\. misread as marker or bare \\. not honored "
+                f"on CRLF/CR; got {rows!r}"
+            )
+
+
+def workflow_copy_from_csv_crlf_large_end_marker(c: Composition) -> None:
+    """Regression test: a bare \\. end-of-copy marker in CRLF input must drop
+    every row after it, even when the COPY exceeds the 32MB batch size and is
+    split across parallel workers.
+
+    The pgwire scanner locates the marker and truncates the stream there. For
+    CRLF the record boundary sits between \\r and \\n, so the raw marker span
+    is "\\n\\.\\r"; a trailing-only strip missed it, leaving the stream
+    untruncated. Below 32MB the single-chunk decoder still catches the marker,
+    but past 32MB the buffer is split at row boundaries and round-robined to
+    workers, so post-marker rows in chunks other than the marker's are imported
+    anyway. Pre- and post-marker data here both exceed 32MB to force splits on
+    each side of the marker; post-marker ids are >= rows_each_side so any leak
+    is detectable via max(id).
+    """
+    c.up("materialized")
+
+    # ~95-byte rows; 400k per side ~= 38MB, comfortably over the 32MB batch.
+    rows_each_side = 400_000
+    chunk_rows = 50_000
+    pad = "a" * 80
+
+    conn = c.sql_connection()
+    with conn.cursor() as cur:
+        cur.execute("CREATE TABLE csv_crlf_marker_large (id INT, val TEXT)")
+
+        with cur.copy(
+            "COPY csv_crlf_marker_large FROM STDIN WITH (FORMAT CSV)"
+        ) as copy:
+            # Pre-marker rows: ids [0, rows_each_side).
+            for start in range(0, rows_each_side, chunk_rows):
+                end = min(start + chunk_rows, rows_each_side)
+                copy.write("".join(f"{i},{pad}\r\n" for i in range(start, end)))
+            # Bare \. end-of-copy marker (CRLF terminated).
+            copy.write("\\.\r\n")
+            # Post-marker rows: ids [rows_each_side, 2*rows_each_side). These
+            # must all be discarded.
+            for start in range(rows_each_side, 2 * rows_each_side, chunk_rows):
+                end = min(start + chunk_rows, 2 * rows_each_side)
+                copy.write("".join(f"{i},{pad}\r\n" for i in range(start, end)))
+
+        cur.execute("SELECT count(*), max(id) FROM csv_crlf_marker_large")
+        row = cur.fetchone()
+        assert row is not None
+        count, max_id = row
+        assert count == rows_each_side and max_id == rows_each_side - 1, (
+            "CRLF end-of-copy marker not honored across 32MB chunk boundaries: "
+            f"got count={count}, max_id={max_id}; "
+            f"expected count={rows_each_side}, max_id={rows_each_side - 1} "
+            "(rows after the bare \\. leaked through parallel workers)"
+        )

--- a/test/pgtest-mz/copy-from-csv.pt
+++ b/test/pgtest-mz/copy-from-csv.pt
@@ -512,3 +512,45 @@ DataRow {"fields":["b",""]}
 DataRow {"fields":["d","\\."]}
 CommandComplete {"tag":"SELECT 4"}
 ReadyForQuery {"status":"I"}
+
+# Obscure edge case: the NULL marker is itself set to `\.`, colliding with the
+# end-of-copy marker's byte sequence. The two are still distinguished:
+#   - An unquoted `\.` *field* matches the NULL marker => SQL NULL.
+#   - A quoted `"\."` field is the literal string `\.` (quoting suppresses
+#     both NULL-marker and end-marker interpretation).
+#   - A bare `\.` on its own line (a single-field record) is the end-of-copy
+#     marker regardless of the NULL setting, and subsequent rows are dropped.
+send
+Query {"query": "CREATE TABLE t9 (i INT8, t TEXT)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t9 FROM STDIN WITH (FORMAT CSV, NULL '\\.')"}
+CopyData "1,\\.\n"
+CopyData "2,\"\\.\"\n"
+CopyData "3,after\n"
+CopyData "\\.\n"
+CopyData "4,ignored\n"
+CopyDone
+Query {"query": "SELECT i, t FROM t9 ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 3"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"}]}
+DataRow {"fields":["1","NULL"]}
+DataRow {"fields":["2","\\."]}
+DataRow {"fields":["3","after"]}
+CommandComplete {"tag":"SELECT 3"}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/copy-from-csv.pt
+++ b/test/pgtest-mz/copy-from-csv.pt
@@ -21,8 +21,8 @@ ReadyForQuery
 CommandComplete {"tag":"CREATE TABLE"}
 ReadyForQuery {"status":"I"}
 
-# Note that we cannot differentiate between empty string and the quoted empty
-# string, both of which will generate NULL in MZ.
+# A quoted empty string decodes to the empty string, while an unquoted empty
+# field matches the (default, empty) NULL marker and decodes to NULL.
 send
 Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV)"}
 CopyData "1,one\n"
@@ -49,7 +49,7 @@ DataRow {"fields":["1","one"]}
 DataRow {"fields":["2","two"]}
 DataRow {"fields":["3","\"three\""]}
 DataRow {"fields":["4","fo,ur"]}
-DataRow {"fields":["5","NULL"]}
+DataRow {"fields":["5",""]}
 DataRow {"fields":["6","NULL"]}
 DataRow {"fields":["7","seven\n8,eight\n"]}
 CommandComplete {"tag":"SELECT 7"}
@@ -82,8 +82,9 @@ CommandComplete {"tag":"SELECT 2"}
 ReadyForQuery {"status":"I"}
 
 # Change options. Note that:
-# - After receiving terminating char, no other data should be accepted
-# - Quoted end of copy markers are still processed as end of copy markers
+# - After receiving the bare \. terminator, no other data is accepted
+# - The terminator is the bare, unquoted \. even with a custom QUOTE; the NULL
+#   marker (NS here) is only honored when the field is unquoted
 send
 Query {"query": "DELETE FROM t"}
 Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, QUOTE '|', ESCAPE '#', NULL 'NS', HEADER true)"}
@@ -94,7 +95,7 @@ CopyData "3,|#|three#||\n"
 CopyData "4,|fo,ur|\n"
 CopyData "5,\"five\"\n"
 CopyData "6,||\n"
-CopyData "|\\.|\n"
+CopyData "\\.\n"
 CopyData "invalid data"
 CopyDone
 Query {"query": "SELECT * FROM t ORDER BY i"}
@@ -340,7 +341,7 @@ DataRow {"fields":["materialize","1","one"]}
 DataRow {"fields":["materialize","2","two"]}
 DataRow {"fields":["materialize","3","\"three\""]}
 DataRow {"fields":["materialize","4","fo,ur"]}
-DataRow {"fields":["materialize","5","NULL"]}
+DataRow {"fields":["materialize","5",""]}
 DataRow {"fields":["materialize","6","NULL"]}
 CommandComplete {"tag":"SELECT 6"}
 ReadyForQuery {"status":"I"}
@@ -381,7 +382,133 @@ DataRow {"fields":["user:materialize","1","one"]}
 DataRow {"fields":["user:materialize","2","two"]}
 DataRow {"fields":["user:materialize","3","\"three\""]}
 DataRow {"fields":["user:materialize","4","fo,ur"]}
-DataRow {"fields":["user:materialize","5","NULL"]}
+DataRow {"fields":["user:materialize","5",""]}
 DataRow {"fields":["user:materialize","6","NULL"]}
 CommandComplete {"tag":"SELECT 6"}
+ReadyForQuery {"status":"I"}
+
+# A quoted "\." field is data, not the end-of-copy marker: only a bare,
+# unquoted \. on its own line terminates the COPY, and rows after it are
+# discarded.
+send
+Query {"query": "CREATE TABLE t6 (i INT8, t TEXT)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t6 FROM STDIN WITH (FORMAT CSV)"}
+CopyData "1,before\n"
+CopyData "2,\"\\.\"\n"
+CopyData "3,after\n"
+CopyData "\\.\n"
+CopyData "4,ignored\n"
+CopyDone
+Query {"query": "SELECT * FROM t6 ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 3"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"}]}
+DataRow {"fields":["1","before"]}
+DataRow {"fields":["2","\\."]}
+DataRow {"fields":["3","after"]}
+CommandComplete {"tag":"SELECT 3"}
+ReadyForQuery {"status":"I"}
+
+# CRLF line endings (RFC 4180, the Windows/Excel default). csv-core places the
+# record boundary between \r and \n, so every non-first record's input begins
+# with an orphaned \n. Both the decoder's per-field quote probe and the pgwire
+# scanner's end-of-copy marker check must account for that, or a quoted NULL
+# marker corrupts to SQL NULL and a quoted "\." (plus every row after it) is
+# silently dropped. This single COPY exercises all of those on CRLF input:
+#   a,        -> unquoted empty NULL marker  => NULL
+#   b,""      -> quoted empty                => ""
+#   "",c      -> quoted empty leading field on an orphan-led record => ""
+#   d,"\."    -> quoted "\." is data         => \.
+#   \.        -> bare end-of-copy marker; the trailing e,ignored is discarded
+send
+Query {"query": "CREATE TABLE t7 (a TEXT, b TEXT)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t7 FROM STDIN WITH (FORMAT CSV)"}
+CopyData "a,\r\n"
+CopyData "b,\"\"\r\n"
+CopyData "\"\",c\r\n"
+CopyData "d,\"\\.\"\r\n"
+CopyData "\\.\r\n"
+CopyData "e,ignored\r\n"
+CopyDone
+Query {"query": "SELECT a, b FROM t7 ORDER BY a"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 4"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"a"},{"name":"b"}]}
+DataRow {"fields":["","c"]}
+DataRow {"fields":["a","NULL"]}
+DataRow {"fields":["b",""]}
+DataRow {"fields":["d","\\."]}
+CommandComplete {"tag":"SELECT 4"}
+ReadyForQuery {"status":"I"}
+
+# Lone CR line endings (old-Mac style). csv-core ends a CR record on the bare
+# \r, so the scanner's raw marker span is "\.\r"; a trailing-only strip would
+# miss it. Same expectations as the CRLF case above.
+send
+Query {"query": "CREATE TABLE t8 (a TEXT, b TEXT)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t8 FROM STDIN WITH (FORMAT CSV)"}
+CopyData "a,\r"
+CopyData "b,\"\"\r"
+CopyData "\"\",c\r"
+CopyData "d,\"\\.\"\r"
+CopyData "\\.\r"
+CopyData "e,ignored\r"
+CopyDone
+Query {"query": "SELECT a, b FROM t8 ORDER BY a"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 4"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"a"},{"name":"b"}]}
+DataRow {"fields":["","c"]}
+DataRow {"fields":["a","NULL"]}
+DataRow {"fields":["b",""]}
+DataRow {"fields":["d","\\."]}
+CommandComplete {"tag":"SELECT 4"}
 ReadyForQuery {"status":"I"}


### PR DESCRIPTION
The csv crate strips quoting during parsing, so `decode_copy_format_csv` could not distinguish a quoted NULL marker from an unquoted one (silent data corruption: e.g. with default params, a literal `""` decoded to SQL NULL instead of the empty string), and the end-of-copy marker check treated a quoted `"\."` value as the bare `\.` terminator (silent data loss: the row and every subsequent row were dropped).

Switch the decoder to csv-core so we can inspect each field's leading input byte and recover per-field quote state; the NULL-marker and end-of-copy checks both now require the field to be unquoted. The pgwire COPY row scanner had the same quote-blind end-marker check; switch it to match against the raw input bytes for the in-progress record.