### PR TITLE
console: fix missing cursor when the shell starts 

### DIFF
--- a/console/src/components/CommandBlock/Editor.tsx
+++ b/console/src/components/CommandBlock/Editor.tsx
@@ -159,7 +159,12 @@ const Editor = forwardRef<FocusableElement, EditorProps>(
     useEffect(() => {
       if (!currentView) return;
       if (autoFocus) {
-        currentView.focus();
+        // Defer focus to the next frame so the editor has been laid out before
+        // drawSelection measures the cursor. Otherwise Firefox leaves the
+        // synthetic caret positioned at 0,0 and invisible until the first
+        // keystroke triggers a re-measure (CNS-73).
+        const id = requestAnimationFrame(() => currentView.focus());
+        return () => cancelAnimationFrame(id);
       }
     }, [currentView, autoFocus]);
 


### PR DESCRIPTION
Fixes [CNS-73](https://linear.app/materializeinc/issue/CNS-73/cursor-missing-in-input-field-when-the-shell-starts). Cursor is missing when shell restarts. 

<img width="780" height="493" alt="image" src="https://github.com/user-attachments/assets/a84d7b9e-adb0-4421-897c-63fbf391c663" />

