### PR TITLE
refactor: Use BTreeSet::last() and ::first() to compute max (logarithmic instead of linear)

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -921,7 +921,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             return self.as_specific_collection(key.as_deref(), config_set);
         }
 
-        let max_demand = mfp.demand().iter().max().map(|x| *x + 1).unwrap_or(0);
+        let max_demand = mfp.demand().last().map(|x| *x + 1).unwrap_or(0);
         mfp.permute_fn(|c| c, max_demand);
         mfp.optimize();
         let mfp_plan = mfp.into_plan().unwrap();

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -501,7 +501,7 @@ impl MapFilterProject {
                         let mut prev: BTreeSet<_> = mfps[0]
                             .expressions
                             .iter()
-                            .filter(|e| e.support().iter().max() < Some(&input_arity))
+                            .filter(|e| e.support().last() < Some(&input_arity))
                             .collect();
                         let mut next = BTreeSet::default();
                         for mfp in mfps[1..].iter() {
@@ -565,7 +565,7 @@ impl MapFilterProject {
                         .predicates
                         .iter()
                         .map(|(_, e)| e)
-                        .filter(|e| e.support().iter().max() < Some(&input_arity))
+                        .filter(|e| e.support().last() < Some(&input_arity))
                         .collect();
                     let mut next = BTreeSet::default();
                     for mfp in mfps[1..].iter() {
@@ -1184,7 +1184,7 @@ impl MapFilterProject {
 
         // Restore predicate order invariants.
         for (pos, pred) in self.predicates.iter_mut() {
-            *pos = pred.support().into_iter().max().map(|x| x + 1).unwrap_or(0);
+            *pos = pred.support().last().map(|x| *x + 1).unwrap_or(0);
         }
     }
 

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -856,6 +856,8 @@ impl MapFilterProject {
 
     /// Lists input columns whose values are used in outputs.
     ///
+    /// You can use `BTreeSet::last()` to extract the maximum demanded column from the set.
+    ///
     /// It is entirely appropriate to determine the demand of an instance
     /// and then both apply a projection to the subject of the instance and
     /// `self.permute` this instance.

--- a/src/expr/src/scalar/columns.rs
+++ b/src/expr/src/scalar/columns.rs
@@ -18,12 +18,17 @@ pub trait Columns: Sized {
     /// If self is a column, return the column index, otherwise `None`.
     fn as_column(&self) -> Option<usize>;
 
+    /// The support of the given set, i.e., the columns that are actually used.
+    ///
+    /// You can use `BTreeSet::last()` to extract the maximum column.
     fn support(&self) -> BTreeSet<usize> {
         let mut support = BTreeSet::new();
         self.support_into(&mut support);
         support
     }
 
+    /// Adds the support of the given set, i.e., the columns that are actually used,
+    /// to the given set.
     fn support_into(&self, support: &mut BTreeSet<usize>);
 
     /// Rewrites column indices with their value in `permutation`.

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1147,11 +1147,12 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
             return ApplyMergeResult::NotAppliedNoMatch;
         }
 
-        let range: BTreeSet<_> = range.iter().map(|(i, _)| *i).collect();
-
         // This is the range of hollow batches that we will replace.
-        let min = *range.first().unwrap();
-        let max = *range.last().unwrap();
+        let (min, max) = match range.iter().map(|(i, _)| *i).minmax() {
+            itertools::MinMaxResult::NoElements => return ApplyMergeResult::NotAppliedNoMatch,
+            itertools::MinMaxResult::OneElement(elt) => (elt, elt),
+            itertools::MinMaxResult::MinMax(min, max) => (min, max),
+        };
         let replacement_range = min..max + 1;
 
         // We need to replace a range of parts. Here we don't care about the run_indices

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1150,8 +1150,8 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
         let range: BTreeSet<_> = range.iter().map(|(i, _)| *i).collect();
 
         // This is the range of hollow batches that we will replace.
-        let min = *range.iter().min().unwrap();
-        let max = *range.iter().max().unwrap();
+        let min = *range.first().unwrap();
+        let max = *range.last().unwrap();
         let replacement_range = min..max + 1;
 
         // We need to replace a range of parts. Here we don't care about the run_indices


### PR DESCRIPTION
### Motivation

Noticed a few places in the code that call `.iter().max()` and `.iter().min()` on a `BTreeSet`---this is linear. `BTreeSet`s are already neatly ordered, with `.first()` returning the minimum element and `last()` returning the maximum.

### Description

Refactored several calls.

One of the calls, on closer inspection, could entirely be replaced by a call to `itertools`'s `.minmax()`, which should save us the allocation of a `BTreeSet` entirely.

### Verification

CI should be green. I can't imagine this actually moves the needle (the sets are typically <100 elements), so not doing further measurement.