### PR TITLE
sql: Cleaner join output in default EXPLAIN, identify cross joins

### DIFF
--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -30,7 +30,7 @@ use mz_ore::soft_assert_or_log;
 use mz_ore::str::{IndentLike, StrExt, separated};
 use mz_repr::explain::text::DisplayText;
 use mz_repr::explain::{
-    CompactScalarSeq, CompactScalars, ExplainConfig, Indices, PlanRenderingContext,
+    CompactScalarSeq, CompactScalars, ExplainConfig, ExprHumanizer, Indices, PlanRenderingContext,
 };
 
 use crate::plan::join::delta_join::{DeltaPathPlan, DeltaStagePlan};
@@ -262,7 +262,9 @@ impl Plan {
                         write!(f, "{}{label} ", ctx.indent)?;
                         fmt_join_chain(
                             f,
+                            ctx.humanizer,
                             &mode,
+                            inputs,
                             plan.source_relation,
                             plan.source_key.as_ref(),
                             plan.stage_plans
@@ -283,7 +285,9 @@ impl Plan {
                             write!(f, " [")?;
                             fmt_join_chain(
                                 f,
+                                ctx.humanizer,
                                 &mode,
+                                inputs,
                                 dpp.source_relation,
                                 Some(&dpp.source_key),
                                 dpp.stage_plans
@@ -1007,13 +1011,18 @@ impl AvailableCollections {
     }
 }
 
-/// Format a join implementation chain like `%0[#0{a}] » %1[#0{c}] » %2[×]`.
+/// Format a join implementation chain like `%0:t[#0{a}] » %1:u[#0{c}] » %2[×]`.
 ///
-/// `[×]` (U+00D7) marks a cross product (empty lookup key). A `None` `source_key`
-/// renders the source position with no bracketed suffix.
+/// Each position is rendered as `%pos:name` when an underlying [`Get`] can be
+/// dug out of the corresponding input plan (see [`humanize_input_name`]),
+/// otherwise just `%pos`. `[×]` (U+00D7) marks a cross product (empty lookup
+/// key). A `None` `source_key` renders the source position with no bracketed
+/// suffix.
 fn fmt_join_chain<'a, I>(
     f: &mut fmt::Formatter<'_>,
+    humanizer: &dyn ExprHumanizer,
     mode: &HumanizedExplain,
+    inputs: &[Plan],
     source_relation: usize,
     source_key: Option<&'a Vec<MirScalarExpr>>,
     stages: I,
@@ -1021,12 +1030,20 @@ fn fmt_join_chain<'a, I>(
 where
     I: IntoIterator<Item = (usize, &'a Vec<MirScalarExpr>)>,
 {
-    write!(f, "%{source_relation}")?;
+    write!(
+        f,
+        "{}",
+        humanize_input_name(humanizer, &inputs[source_relation], source_relation)
+    )?;
     if let Some(key) = source_key {
         fmt_join_key_brackets(f, mode, key)?;
     }
     for (lookup_relation, lookup_key) in stages {
-        write!(f, " » %{lookup_relation}")?;
+        write!(
+            f,
+            " » {}",
+            humanize_input_name(humanizer, &inputs[lookup_relation], lookup_relation)
+        )?;
         fmt_join_key_brackets(f, mode, lookup_key)?;
     }
     Ok(())
@@ -1043,6 +1060,33 @@ fn fmt_join_key_brackets(
     } else {
         let key = CompactScalars(mode.seq(key, None));
         write!(f, "[{key}]")
+    }
+}
+
+/// Render a join input as `%pos:name` if we can dig a `Get` out of `plan`,
+/// otherwise just `%pos`. Mirrors `dig_name_from_expr` in
+/// `src/expr/src/explain/text.rs` for the MIR `EXPLAIN OPTIMIZED PLAN` output.
+fn humanize_input_name(humanizer: &dyn ExprHumanizer, plan: &Plan, pos: usize) -> String {
+    fn dig(humanizer: &dyn ExprHumanizer, plan: &Plan) -> Option<String> {
+        use crate::plan::PlanNode::*;
+        match &plan.node {
+            Get { id, .. } => match id {
+                Id::Local(lid) => Some(lid.to_string()),
+                Id::Global(gid) => Some(
+                    humanizer
+                        .humanize_id_unqualified(*gid)
+                        .unwrap_or_else(|| gid.to_string()),
+                ),
+            },
+            // Transparent wrappers: keep digging.
+            ArrangeBy { input, .. } => dig(humanizer, input),
+            Mfp { input, .. } => dig(humanizer, input),
+            _ => None,
+        }
+    }
+    match dig(humanizer, plan) {
+        Some(name) => format!("%{pos}:{name}"),
+        None => format!("%{pos}"),
     }
 }
 

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -1013,7 +1013,7 @@ impl AvailableCollections {
 
 /// Format a join implementation chain like `%0:t[#0{a}] » %1:u[#0{c}] » %2[×]`.
 ///
-/// Each position is rendered as `%pos:name` when an underlying [`Get`] can be
+/// Each position is rendered as `%pos:name` when an underlying [`PlanNode::Get`] can be
 /// dug out of the corresponding input plan (see [`humanize_input_name`]),
 /// otherwise just `%pos`. `[×]` (U+00D7) marks a cross product (empty lookup
 /// key). A `None` `source_key` renders the source position with no bracketed

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -254,22 +254,42 @@ impl Plan {
                 use crate::plan::join::JoinPlan;
                 match plan {
                     JoinPlan::Linear(plan) => {
-                        write!(f, "{}→Differential Join", ctx.indent)?;
-                        write!(f, " %{}", plan.source_relation)?;
-                        for dsp in &plan.stage_plans {
-                            write!(f, " » %{}", dsp.lookup_relation)?;
-                        }
+                        let label = if plan.has_cross_stage() {
+                            "→Differential Cross Join"
+                        } else {
+                            "→Differential Join"
+                        };
+                        write!(f, "{}{label} ", ctx.indent)?;
+                        fmt_join_chain(
+                            f,
+                            &mode,
+                            plan.source_relation,
+                            plan.source_key.as_ref(),
+                            plan.stage_plans
+                                .iter()
+                                .map(|s| (s.lookup_relation, &s.lookup_key)),
+                        )?;
                         writeln!(f, "{annotations}")?;
                         ctx.indented(|ctx| plan.fmt_text(f, ctx))?;
                     }
                     JoinPlan::Delta(plan) => {
-                        write!(f, "{}→Delta Join", ctx.indent)?;
+                        let label = if plan.has_cross_stage() {
+                            "→Delta Cross Join"
+                        } else {
+                            "→Delta Join"
+                        };
+                        write!(f, "{}{label}", ctx.indent)?;
                         for dpp in &plan.path_plans {
-                            write!(f, " [%{}", dpp.source_relation)?;
-
-                            for dsp in &dpp.stage_plans {
-                                write!(f, " » %{}", dsp.lookup_relation)?;
-                            }
+                            write!(f, " [")?;
+                            fmt_join_chain(
+                                f,
+                                &mode,
+                                dpp.source_relation,
+                                Some(&dpp.source_key),
+                                dpp.stage_plans
+                                    .iter()
+                                    .map(|s| (s.lookup_relation, &s.lookup_key)),
+                            )?;
                             write!(f, "]")?;
                         }
                         writeln!(f, "{annotations}")?;
@@ -987,6 +1007,45 @@ impl AvailableCollections {
     }
 }
 
+/// Format a join implementation chain like `%0[#0{a}] » %1[#0{c}] » %2[×]`.
+///
+/// `[×]` (U+00D7) marks a cross product (empty lookup key). A `None` `source_key`
+/// renders the source position with no bracketed suffix.
+fn fmt_join_chain<'a, I>(
+    f: &mut fmt::Formatter<'_>,
+    mode: &HumanizedExplain,
+    source_relation: usize,
+    source_key: Option<&'a Vec<MirScalarExpr>>,
+    stages: I,
+) -> fmt::Result
+where
+    I: IntoIterator<Item = (usize, &'a Vec<MirScalarExpr>)>,
+{
+    write!(f, "%{source_relation}")?;
+    if let Some(key) = source_key {
+        fmt_join_key_brackets(f, mode, key)?;
+    }
+    for (lookup_relation, lookup_key) in stages {
+        write!(f, " » %{lookup_relation}")?;
+        fmt_join_key_brackets(f, mode, lookup_key)?;
+    }
+    Ok(())
+}
+
+/// Render `[k1, k2, …]` for a non-empty join key, or `[×]` for a cross product.
+fn fmt_join_key_brackets(
+    f: &mut fmt::Formatter<'_>,
+    mode: &HumanizedExplain,
+    key: &Vec<MirScalarExpr>,
+) -> fmt::Result {
+    if key.is_empty() {
+        write!(f, "[×]")
+    } else {
+        let key = CompactScalars(mode.seq(key, None));
+        write!(f, "[{key}]")
+    }
+}
+
 impl DisplayText<PlanRenderingContext<'_, Plan>> for LinearJoinPlan {
     fn fmt_text(
         &self,
@@ -1001,31 +1060,30 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for LinearJoinPlan {
     }
 }
 impl LinearJoinPlan {
+    /// True iff at least one stage is a cross product (empty lookup key).
+    fn has_cross_stage(&self) -> bool {
+        self.stage_plans.iter().any(|s| s.lookup_key.is_empty())
+    }
+
     #[allow(clippy::needless_pass_by_ref_mut)]
     fn fmt_default_text(
         &self,
         f: &mut fmt::Formatter<'_>,
         ctx: &mut PlanRenderingContext<'_, Plan>,
     ) -> fmt::Result {
-        for (i, plan) in self.stage_plans.iter().enumerate().rev() {
-            let lookup_relation = &plan.lookup_relation;
-            write!(f, "{}Join stage {i} in %{lookup_relation}", ctx.indent)?;
-            if !plan.lookup_key.is_empty() {
-                let lookup_key = CompactScalarSeq(&plan.lookup_key);
-                writeln!(f, " with lookup key {lookup_key}",)?;
-            } else {
-                writeln!(f)?;
-            }
-            if plan.closure.maps_or_filters() {
-                ctx.indented(|ctx| plan.closure.fmt_default_text(f, ctx))?;
+        // Per-stage closures (natural 0..N order). The header chain already
+        // shows each stage's position + key, so we only emit a block when
+        // there's a non-identity closure to attribute to that stage.
+        for stage in self.stage_plans.iter() {
+            if stage.closure.maps_or_filters() {
+                writeln!(f, "{}after %{}:", ctx.indent, stage.lookup_relation)?;
+                ctx.indented(|ctx| stage.closure.fmt_default_text(f, ctx))?;
             }
         }
         if let Some(final_closure) = &self.final_closure {
             if final_closure.maps_or_filters() {
-                ctx.indented(|ctx| {
-                    writeln!(f, "{}Final closure:", ctx.indent)?;
-                    ctx.indented(|ctx| final_closure.fmt_default_text(f, ctx))
-                })?;
+                writeln!(f, "{}Final closure:", ctx.indent)?;
+                ctx.indented(|ctx| final_closure.fmt_default_text(f, ctx))?;
             }
         }
         Ok(())
@@ -1158,13 +1216,31 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for DeltaJoinPlan {
     }
 }
 impl DeltaJoinPlan {
+    /// True iff any stage in any path is a cross product.
+    fn has_cross_stage(&self) -> bool {
+        self.path_plans
+            .iter()
+            .any(|p| p.stage_plans.iter().any(|s| s.lookup_key.is_empty()))
+    }
+
     fn fmt_default_text(
         &self,
         f: &mut fmt::Formatter<'_>,
         ctx: &mut PlanRenderingContext<'_, Plan>,
     ) -> fmt::Result {
-        for (i, plan) in self.path_plans.iter().enumerate() {
-            writeln!(f, "{}Delta join path for input %{i}", ctx.indent)?;
+        // The header chain already shows each path's positions + keys, so we
+        // only print a `path %src:` block when at least one of its stage
+        // closures or its final closure is non-identity.
+        for plan in self.path_plans.iter() {
+            let has_stage_closure = plan.stage_plans.iter().any(|s| s.closure.maps_or_filters());
+            let has_final_closure = plan
+                .final_closure
+                .as_ref()
+                .is_some_and(|c| c.maps_or_filters());
+            if !has_stage_closure && !has_final_closure {
+                continue;
+            }
+            writeln!(f, "{}path %{}:", ctx.indent, plan.source_relation)?;
             ctx.indented(|ctx| plan.fmt_text(f, ctx))?;
         }
         Ok(())
@@ -1204,36 +1280,16 @@ impl DeltaPathPlan {
         f: &mut fmt::Formatter<'_>,
         ctx: &mut PlanRenderingContext<'_, Plan>,
     ) -> fmt::Result {
-        for (
-            i,
-            DeltaStagePlan {
-                lookup_key,
-                lookup_relation,
-                closure,
-                ..
-            },
-        ) in self.stage_plans.iter().enumerate()
-        {
-            if !lookup_key.is_empty() {
-                let lookup_key = CompactScalarSeq(lookup_key);
-                writeln!(
-                    f,
-                    "{}stage {i} for %{lookup_relation}: lookup key {lookup_key}",
-                    ctx.indent
-                )?;
-            } else {
-                writeln!(f, "{}stage %{i} for  %{lookup_relation}", ctx.indent)?;
-            }
-            if closure.maps_or_filters() {
-                ctx.indented(|ctx| closure.fmt_default_text(f, ctx))?;
+        for stage in self.stage_plans.iter() {
+            if stage.closure.maps_or_filters() {
+                writeln!(f, "{}after %{}:", ctx.indent, stage.lookup_relation)?;
+                ctx.indented(|ctx| stage.closure.fmt_default_text(f, ctx))?;
             }
         }
         if let Some(final_closure) = &self.final_closure {
             if final_closure.maps_or_filters() {
-                ctx.indented(|ctx| {
-                    writeln!(f, "{}Final closure:", ctx.indent)?;
-                    ctx.indented(|ctx| final_closure.fmt_default_text(f, ctx))
-                })?;
+                writeln!(f, "{}Final closure:", ctx.indent)?;
+                ctx.indented(|ctx| final_closure.fmt_default_text(f, ctx))?;
             }
         }
         Ok(())
@@ -1362,7 +1418,8 @@ impl JoinClosure {
     ) -> fmt::Result {
         let mode = HumanizedExplain::new(ctx.config.redacted);
         if !self.before.is_identity() {
-            mode.expr(self.before.deref(), None).fmt_text(f, ctx)?;
+            mode.expr(self.before.deref(), None)
+                .fmt_default_text(f, ctx)?;
         }
         if !self.ready_equivalences.is_empty() {
             let equivalences = separated(

--- a/test/sqllogictest/explain/default.slt
+++ b/test/sqllogictest/explain/default.slt
@@ -453,14 +453,13 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
 Explained Query:
   →With
     cte l0 =
-      →Differential Join %1 » %0
-        Join stage 0 in %0 with lookup key #0{a}
+      →Differential Join %1[#0] » %0[#0{a}]
         →Arranged materialize.public.t
         →Distinct GroupAggregate
-          →Differential Join %0 » %1
-            Join stage 0 in %1
-              project=(#0)
-              filter=((#0{a} < #1{a}))
+          →Differential Cross Join %0[×] » %1[×]
+            after %1:
+              Project: #0
+              Filter: (#0{a} < #1{a})
             →Arrange (empty key)
               →Distinct GroupAggregate
                 →Fused with Child Map/Filter/Project
@@ -472,15 +471,14 @@ Explained Query:
                 Project: #0
                   →Read materialize.public.mv
   →Return
-    →Differential Join %1 » %0
-      Join stage 0 in %0 with lookup key #1
+    →Differential Join %1[#0] » %0[#1]
       →Arrange (#1)
         →Stream l0
       →Distinct GroupAggregate
-        →Differential Join %0 » %1
-          Join stage 0 in %1
-            project=(#0)
-            filter=((#0{b} > #1{b}))
+        →Differential Cross Join %0[×] » %1[×]
+          after %1:
+            Project: #0
+            Filter: (#0{b} > #1{b})
           →Arrange (empty key)
             →Distinct GroupAggregate
               →Fused with Child Map/Filter/Project
@@ -518,30 +516,20 @@ Explained Query:
     cte l3 =
       →Consolidating Monotonic Top1
         Group By #0
-        →Differential Join %0 » %1
-          Join stage 0 in %1 with lookup key #1{b}
-            filter=((#0{b}) IS NOT NULL)
+        →Differential Join %0[#0] » %1[#1{b}]
+          after %1:
+            Filter: (#0{b}) IS NOT NULL
           →Arranged l2
           →Arranged materialize.public.iv
     cte l4 =
       →Consolidating Monotonic Top1
         Group By #0
-        →Differential Join %0 » %1
-          Join stage 0 in %1 with lookup key #1{b}
+        →Differential Join %0[#0] » %1[#1{b}]
           →Arranged l2
           →Arrange (#1{b})
             →Read materialize.public.mv
   →Return
-    →Delta Join [%0 » %1 » %2] [%1 » %2 » %0] [%2 » %1 » %0]
-      Delta join path for input %0
-        stage 0 for %1: lookup key #0
-        stage 1 for %2: lookup key #0
-      Delta join path for input %1
-        stage 0 for %2: lookup key #0
-        stage 1 for %0: lookup key #0
-      Delta join path for input %2
-        stage 0 for %1: lookup key #0
-        stage 1 for %0: lookup key #0
+    →Delta Join [%0[#0] » %1[#0] » %2[#0]] [%1[#0] » %2[#0] » %0[#0]] [%2[#0] » %1[#0] » %0[#0]]
       →Arrange (#0)
         →Stream l0
       →Arrange (#0)
@@ -606,16 +594,7 @@ Explained Query:
           Project: #1
             →Read l0
     cte l3 =
-      →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %0 » %1]
-        Delta join path for input %0
-          stage 0 for %1: lookup key #1{b}
-          stage 1 for %2: lookup key #0{b}
-        Delta join path for input %1
-          stage 0 for %0: lookup key #1{b}
-          stage 1 for %2: lookup key #0{b}
-        Delta join path for input %2
-          stage 0 for %0: lookup key #1{b}
-          stage 1 for %1: lookup key #1{b}
+      →Delta Join [%0[#1{b}] » %1[#1{b}] » %2[#0{b}]] [%1[#1{b}] » %0[#1{b}] » %2[#0{b}]] [%2[#0{b}] » %0[#1{b}] » %1[#1{b}]]
         →Arranged l1
         →Arranged l1
         →Arranged l2
@@ -626,8 +605,7 @@ Explained Query:
         Map: null, null
           →Consolidating Union
             →Negate Diffs
-              →Differential Join %1 » %0
-                Join stage 0 in %0 with lookup key #0{b}
+              →Differential Join %1[#0] » %0[#0{b}]
                 →Arranged l2
                 →Distinct GroupAggregate
                   →Fused with Child Map/Filter/Project
@@ -663,10 +641,10 @@ Explained Query:
             →Arranged materialize.public.t
               Key: (#0{a})
   →Return
-    →Differential Join %0 » %1
-      Join stage 0 in %1
-        project=(#2)
-        map=((#0{v} + #1{v}))
+    →Differential Cross Join %0[×] » %1[×]
+      after %1:
+        Project: #2
+        Map: (#0{v} + #1{v})
       →Arranged l0
       →Arranged l0
 
@@ -783,34 +761,32 @@ Explained Query:
       →Arrange (empty key)
         →Stream l0
     cte l2 =
-      →Differential Join %1 » %0
-        Join stage 0 in %0 with lookup key #0{a}
-          project=(#0, #2, #1)
-          filter=((#0 != #1{m}))
+      →Differential Join %1[#0] » %0[#0{a}]
+        after %0:
+          Project: #0, #2, #1
+          Filter: (#0 != #1{m})
         →Arranged materialize.public.t
         →Consolidating Monotonic GroupAggregate
           Aggregations: max
           Key:
             Project: #0
-          →Differential Join %0 » %1
-            Join stage 0 in %1
+          →Differential Cross Join %0[×] » %1[×]
             →Arrange (empty key)
               →Distinct GroupAggregate
                 →Stream l0
             →Arranged l1
   →Return
-    →Differential Join %1 » %0
-      Join stage 0 in %0 with lookup key #0
-        project=(#0, #2, #3, #1)
-        filter=((#0 != #1{m}))
+    →Differential Join %1[#0] » %0[#0]
+      after %0:
+        Project: #0, #2, #3, #1
+        Filter: (#0 != #1{m})
       →Arrange (#0)
         →Stream l2
       →Consolidating Monotonic GroupAggregate
         Aggregations: max
         Key:
           Project: #0
-        →Differential Join %0 » %1
-          Join stage 0 in %1
+        →Differential Cross Join %0[×] » %1[×]
           →Arrange (empty key)
             →Distinct GroupAggregate
               →Fused with Child Map/Filter/Project
@@ -839,8 +815,7 @@ Explained Query:
             →Arranged materialize.public.t
               Key: (#0{a})
   →Return
-    →Differential Join %0 » %1
-      Join stage 0 in %1
+    →Differential Cross Join %0[×] » %1[×]
       →Arranged l0
       →Arranged l0
 
@@ -872,16 +847,7 @@ Explained Query:
       →Arrange (#1{b})
         →Stream l0
   →Return
-    →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %0 » %1]
-      Delta join path for input %0
-        stage 0 for %1: lookup key #1{b}
-        stage 1 for %2: lookup key #0{b}
-      Delta join path for input %1
-        stage 0 for %0: lookup key #1{b}
-        stage 1 for %2: lookup key #0{b}
-      Delta join path for input %2
-        stage 0 for %0: lookup key #1{b}
-        stage 1 for %1: lookup key #1{b}
+    →Delta Join [%0[#1{b}] » %1[#1{b}] » %2[#0{b}]] [%1[#1{b}] » %0[#1{b}] » %2[#0{b}]] [%2[#0{b}] » %0[#1{b}] » %1[#1{b}]]
       →Arranged l1
       →Arranged l1
       →Arrange (#0{b})
@@ -921,10 +887,9 @@ FROM t, u, v
 WHERE a = c and d = e and b = f
 ----
 Explained Query:
-  →Differential Join %0 » %1 » %2
-    Join stage 1 in %2 with lookup key #0{e}, #1{f}
-    Join stage 0 in %1 with lookup key #0{c}
-      filter=((#0{a}) IS NOT NULL)
+  →Differential Join %0[#0{a}] » %1[#0{c}] » %2[#0{e}, #1{f}]
+    after %1:
+      Filter: (#0{a}) IS NOT NULL
     →Arranged materialize.public.t
     →Arranged materialize.public.u
     →Arrange (#0{e}, #1{f})
@@ -950,10 +915,9 @@ FROM t, u, v
 WHERE a = c and d = e and b = f
 ----
 Explained Query:
-  →Differential Join %0 » %1 » %2
-    Join stage 1 in %2 with lookup key #0{e}, #1{f}
-    Join stage 0 in %1 with lookup key #0{c}
-      filter=((#0{a}) IS NOT NULL)
+  →Differential Join %0[#0{a}] » %1[#0{c}] » %2[#0{e}, #1{f}]
+    after %1:
+      Filter: (#0{a}) IS NOT NULL
     →Arranged materialize.public.t
     →Arranged materialize.public.u
     →Arrange (#0{e}, #1{f})
@@ -961,6 +925,49 @@ Explained Query:
         Filter: (#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL
           →Arranged materialize.public.v
             Key: (#0{e})
+
+Used Indexes:
+  - materialize.public.t_a_idx (differential join)
+  - materialize.public.u_c_idx (differential join)
+  - materialize.public.v_e_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# Test a pure differential cross join (no equi-condition).
+query T multiline
+EXPLAIN WITH(humanized expressions)
+SELECT a, b, c, d FROM t, u
+----
+Explained Query:
+  →Differential Cross Join %0[×] » %1[×]
+    →Arrange (empty key)
+      →Arranged materialize.public.t
+    →Arrange (empty key)
+      →Arranged materialize.public.u
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+  - materialize.public.u_c_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# Test a mixed differential join (some equi-stages, some cross-stages).
+query T multiline
+EXPLAIN WITH(humanized expressions)
+SELECT a, b, c, d, e, f FROM t, u, v WHERE a = c
+----
+Explained Query:
+  →Differential Cross Join %0[#0{a}] » %1[#0{c}] » %2[×]
+    after %1:
+      Filter: (#0{a}) IS NOT NULL
+    →Arranged materialize.public.t
+    →Arranged materialize.public.u
+    →Arrange (empty key)
+      →Arranged materialize.public.v
 
 Used Indexes:
   - materialize.public.t_a_idx (differential join)
@@ -989,24 +996,22 @@ FROM t, u, v
 WHERE b = c and d = e
 ----
 Explained Query:
-  →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %1 » %0]
-    Delta join path for input %0
-      stage 0 for %1: lookup key #0{c}
-        project=(#1, #0, #2)
-        filter=((#2{d}) IS NOT NULL)
-      stage 1 for %2: lookup key #0{e}
-    Delta join path for input %1
-      stage 0 for %0: lookup key #1{b}
-        project=(#2, #0, #1)
-        filter=((#0{b}) IS NOT NULL)
-      stage 1 for %2: lookup key #0{e}
-    Delta join path for input %2
-      stage 0 for %1: lookup key #1{d}
-        project=(#2, #0, #1)
-        filter=((#0{d}) IS NOT NULL)
-      stage 1 for %0: lookup key #1{b}
-        project=(#3, #0..=#2)
-        filter=((#0{b}) IS NOT NULL)
+  →Delta Join [%0[#1{b}] » %1[#0{c}] » %2[#0{e}]] [%1[#0{c}] » %0[#1{b}] » %2[#0{e}]] [%2[#0{e}] » %1[#1{d}] » %0[#1{b}]]
+    path %0:
+      after %1:
+        Project: #1, #0, #2
+        Filter: (#2{d}) IS NOT NULL
+    path %1:
+      after %0:
+        Project: #2, #0, #1
+        Filter: (#0{b}) IS NOT NULL
+    path %2:
+      after %1:
+        Project: #2, #0, #1
+        Filter: (#0{d}) IS NOT NULL
+      after %0:
+        Project: #3, #0..=#2
+        Filter: (#0{b}) IS NOT NULL
     →Arranged materialize.public.t
     →Arranged materialize.public.u
     →Arranged materialize.public.v
@@ -1029,24 +1034,22 @@ FROM t, u, v
 WHERE b = c and d = e
 ----
 Explained Query:
-  →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %1 » %0]
-    Delta join path for input %0
-      stage 0 for %1: lookup key #0{c}
-        project=(#1, #0, #2)
-        filter=((#2{d}) IS NOT NULL)
-      stage 1 for %2: lookup key #0{e}
-    Delta join path for input %1
-      stage 0 for %0: lookup key #1{b}
-        project=(#2, #0, #1)
-        filter=((#0{b}) IS NOT NULL)
-      stage 1 for %2: lookup key #0{e}
-    Delta join path for input %2
-      stage 0 for %1: lookup key #1{d}
-        project=(#2, #0, #1)
-        filter=((#0{d}) IS NOT NULL)
-      stage 1 for %0: lookup key #1{b}
-        project=(#3, #0..=#2)
-        filter=((#0{b}) IS NOT NULL)
+  →Delta Join [%0[#1{b}] » %1[#0{c}] » %2[#0{e}]] [%1[#0{c}] » %0[#1{b}] » %2[#0{e}]] [%2[#0{e}] » %1[#1{d}] » %0[#1{b}]]
+    path %0:
+      after %1:
+        Project: #1, #0, #2
+        Filter: (#2{d}) IS NOT NULL
+    path %1:
+      after %0:
+        Project: #2, #0, #1
+        Filter: (#0{b}) IS NOT NULL
+    path %2:
+      after %1:
+        Project: #2, #0, #1
+        Filter: (#0{d}) IS NOT NULL
+      after %0:
+        Project: #3, #0..=#2
+        Filter: (#0{b}) IS NOT NULL
     →Arranged materialize.public.t
     →Arranged materialize.public.u
     →Arranged materialize.public.v
@@ -1069,20 +1072,15 @@ FROM t, u, v
 WHERE a = c and b = e
 ----
 Explained Query:
-  →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %0 » %1]
-    Delta join path for input %0
-      stage 0 for %1: lookup key #0{c}
-      stage 1 for %2: lookup key #0{e}
-    Delta join path for input %1
-      stage 0 for %0: lookup key #0{a}
-        project=(#0, #2, #1)
-        filter=((#0{a}) IS NOT NULL AND (#2{b}) IS NOT NULL)
-      stage 1 for %2: lookup key #0{e}
-    Delta join path for input %2
-      stage 0 for %0: lookup key #1{b}
-        project=(#2, #0, #1)
-        filter=((#0{b}) IS NOT NULL AND (#2{a}) IS NOT NULL)
-      stage 1 for %1: lookup key #0{c}
+  →Delta Join [%0[#0{a}] » %1[#0{c}] » %2[#0{e}]] [%1[#0{c}] » %0[#0{a}] » %2[#0{e}]] [%2[#0{e}] » %0[#1{b}] » %1[#0{c}]]
+    path %1:
+      after %0:
+        Project: #0, #2, #1
+        Filter: (#0{a}) IS NOT NULL AND (#2{b}) IS NOT NULL
+    path %2:
+      after %0:
+        Project: #2, #0, #1
+        Filter: (#0{b}) IS NOT NULL AND (#2{a}) IS NOT NULL
     →Arranged materialize.public.t
     →Arranged materialize.public.u
     →Arranged materialize.public.v
@@ -1113,8 +1111,7 @@ Explained Query:
         Aggregations: max
         Key:
           Project: ()
-        →Differential Join %1 » %0
-          Join stage 0 in %0 with lookup key #0{a}
+        →Differential Join %1[#0] » %0[#0{a}]
           →Arranged materialize.public.t
           →Arrange (#0)
             →Constant (1 row)
@@ -1144,8 +1141,7 @@ Explained Query:
     Aggregations: max
     Key:
       Project: #0
-    →Differential Join %1 » %0
-      Join stage 0 in %0 with lookup key #0{a}, #1{b}
+    →Differential Join %1[#0, #1] » %0[#0{a}, #1{b}]
       →Arranged materialize.public.t
       →Arrange (#0, #1)
         →Constant (3 rows)
@@ -1206,8 +1202,7 @@ Explained Query:
       →Arrange (#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16})
         →Read materialize.public.r
   →Return
-    →Differential Join %0 » %1
-      Join stage 0 in %1 with lookup key #0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}
+    →Differential Join %0[#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}] » %1[#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}]
       →Arranged l0
       →Arranged l0
 
@@ -1358,8 +1353,7 @@ FROM t, u
 WHERE t.b = u.c;
 ----
 Explained Query:
-  →Differential Join %1 » %0
-    Join stage 0 in %0 with lookup key #1{b}
+  →Differential Join %1[#0{c}] » %0[#1{b}]
     →Arrange (#1{b})
       →Read materialize.public.t
     →Arranged materialize.public.u
@@ -1381,8 +1375,7 @@ FROM t, u
 WHERE t.b = u.d;
 ----
 Explained Query:
-  →Differential Join %1 » %0
-    Join stage 0 in %0 with lookup key #1{b}
+  →Differential Join %1[#1{d}] » %0[#1{b}]
     →Arrange (#1{b})
       →Read materialize.public.t
     →Arranged materialize.public.u
@@ -1415,8 +1408,7 @@ FROM t, u
 WHERE t.a = u.c
 ----
 Explained Query:
-  →Differential Join %0 » %1
-    Join stage 0 in %1 with lookup key #0{c}
+  →Differential Join %0[#0{a}] » %1[#0{c}]
     →Arranged materialize.public.t
     →Arrange (#0{c})
       →Fused with Child Map/Filter/Project
@@ -1445,20 +1437,15 @@ Explained Query:
     cte l0 =
       →Arranged materialize.public.t
   →Return
-    →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %0 » %1]
-      Delta join path for input %0
-        stage 0 for %1: lookup key #0{a}
-        stage 1 for %2: lookup key #0{a}
-      Delta join path for input %1
-        stage 0 for %0: lookup key #0{a}
-          project=(#0, #2, #0, #1)
-          filter=((#0{a}) IS NOT NULL)
-        stage 1 for %2: lookup key #0{a}
-      Delta join path for input %2
-        stage 0 for %0: lookup key #0{a}
-          project=(#0, #2, #0, #1)
-          filter=((#0{a}) IS NOT NULL)
-        stage 1 for %1: lookup key #0{a}
+    →Delta Join [%0[#0{a}] » %1[#0{a}] » %2[#0{a}]] [%1[#0{a}] » %0[#0{a}] » %2[#0{a}]] [%2[#0{a}] » %0[#0{a}] » %1[#0{a}]]
+      path %1:
+        after %0:
+          Project: #0, #2, #0, #1
+          Filter: (#0{a}) IS NOT NULL
+      path %2:
+        after %0:
+          Project: #0, #2, #0, #1
+          Filter: (#0{a}) IS NOT NULL
       →Arranged l0
       →Arranged l0
       →Arranged l0
@@ -1488,11 +1475,11 @@ Explained Query:
   →Return
     →Distinct GroupAggregate
       →Union
-        →Differential Join %0 » %1
-          Join stage 0 in %1 with lookup key #0{a}
-            project=(#3, #4)
-            filter=((#0{a}) IS NOT NULL)
-            map=((#0{a} + #0{a}), (#1{b} + #2{b}))
+        →Differential Join %0[#0{a}] » %1[#0{a}]
+          after %1:
+            Project: #3, #4
+            Filter: (#0{a}) IS NOT NULL
+            Map: (#0{a} + #0{a}), (#1{b} + #2{b})
           →Arranged l0
           →Arranged l0
         →Fused with Child Map/Filter/Project
@@ -1529,10 +1516,10 @@ Explained Query:
   →Return
     →Distinct GroupAggregate
       →Union
-        →Differential Join %0 » %1
-          Join stage 0 in %1 with lookup key #1{b}
-            project=(#3, #4)
-            map=((#1{a} + #2{a}), (#0{b} + #0{b}))
+        →Differential Join %0[#1{b}] » %1[#1{b}]
+          after %1:
+            Project: #3, #4
+            Map: (#1{a} + #2{a}), (#0{b} + #0{b})
           →Arranged l0
           →Arranged l0
         →Fused with Child Map/Filter/Project
@@ -1577,10 +1564,10 @@ Explained Query:
   →Return
     →Distinct GroupAggregate
       →Union
-        →Differential Join %0 » %1
-          Join stage 0 in %1 with lookup key #1{b}
-            project=(#3, #4)
-            map=((#1{a} + #2{a}), (#0{b} + #0{b}))
+        →Differential Join %0[#1{b}] » %1[#1{b}]
+          after %1:
+            Project: #3, #4
+            Map: (#1{a} + #2{a}), (#0{b} + #0{b})
           →Arranged l0
           →Arranged l0
         →Fused with Child Map/Filter/Project
@@ -1610,10 +1597,10 @@ UNION
 Explained Query:
   →Distinct GroupAggregate
     →Union
-      →Differential Join %0 » %1
-        Join stage 0 in %1 with lookup key (#1{b} + 1)
-          project=(#4, #5)
-          map=((#1{a} + #2{a}), (#0{b} + #3{b}))
+      →Differential Join %0[#1{b}] » %1[(#1{b} + 1)]
+        after %1:
+          Project: #4, #5
+          Map: (#1{a} + #2{a}), (#0{b} + #3{b})
         →Arrange (#1{b})
           →Arranged materialize.public.t_non_null
         →Arrange ((#1{b} + 1))
@@ -1642,8 +1629,7 @@ Explained Query:
     →Union
       →Unarranged Raw Stream
         →Arranged materialize.public.t
-      →Differential Join %1 » %0
-        Join stage 0 in %0 with lookup key #0{a}
+      →Differential Join %1[#0] » %0[#0{a}]
         →Arranged materialize.public.t
         →Arrange (#0)
           →Constant (1 row)
@@ -1676,13 +1662,11 @@ Explained Query:
   →Union
     →Unarranged Raw Stream
       →Arranged materialize.public.t
-    →Differential Join %1 » %0
-      Join stage 0 in %0 with lookup key #1{b}
+    →Differential Join %1[#0] » %0[#1{b}]
       →Arranged materialize.public.t
       →Arrange (#0)
         →Constant (1 row)
-    →Differential Join %1 » %0
-      Join stage 0 in %0 with lookup key #0{a}
+    →Differential Join %1[#0] » %0[#0{a}]
       →Arranged materialize.public.t
       →Arrange (#0)
         →Constant (1 row)
@@ -1691,8 +1675,7 @@ Explained Query:
       Filter: (#1{c} = 3)
         →Arranged materialize.public.u
           Key: (#1{d})
-    →Differential Join %1 » %0
-      Join stage 0 in %0 with lookup key #1{d}
+    →Differential Join %1[#0] » %0[#1{d}]
       →Arranged materialize.public.u
       →Arrange (#0)
         →Constant (1 row)
@@ -1848,8 +1831,7 @@ FROM t5, t6
 WHERE x = a AND b IN (8,9);
 ----
 Explained Query:
-  →Differential Join %1 » %0
-    Join stage 0 in %0 with lookup key #0{x}
+  →Differential Join %1[#0{a}] » %0[#0{x}]
     →Arrange (#0{x})
       →Read materialize.public.t5
     →Arrange (#0{a})
@@ -1871,8 +1853,7 @@ FROM t5, t6
 WHERE x = a AND b IN (8,9);
 ----
 Explained Query:
-  →Differential Join %1 » %0
-    Join stage 0 in %0 with lookup key #0{x}
+  →Differential Join %1[#0{a}] » %0[#0{x}]
     →Arrange (#0{x})
       →Read materialize.public.t5
     →Arrange (#0{a})
@@ -2039,10 +2020,10 @@ Explained Query:
               Project: ()
                 →Read l0
   →Return
-    →Differential Join %0 » %1
-      Join stage 0 in %1
-        project=(#3, #2)
-        map=((#0{a} + #1{b}))
+    →Differential Cross Join %0[×] » %1[×]
+      after %1:
+        Project: #3, #2
+        Map: (#0{a} + #1{b})
       →Arrange (empty key)
         →Read materialize.public.t4
       →Arrange (empty key)
@@ -2085,8 +2066,7 @@ EXPLAIN
 SELECT * FROM tnn JOIN unn USING (x, y);
 ----
 Explained Query:
-  →Differential Join %0 » %1
-    Join stage 0 in %1 with lookup key #0{y}, #1{x}
+  →Differential Join %0[#2{y}, #1{x}] » %1[#0{y}, #1{x}]
     →Arrange (#2{y}, #1{x})
       →Fused with Parent Map/Filter/Project
         Project: #2, #0, #1
@@ -2110,10 +2090,10 @@ WITH
 SELECT a, b, a = b FROM t_as, t_bs
 ----
 Explained Query:
-  →Differential Join %0 » %1
-    Join stage 0 in %1
-      project=(#0..=#2)
-      map=((#0{a} = #1{b}))
+  →Differential Cross Join %0[×] » %1[×]
+    after %1:
+      Project: #0..=#2
+      Map: (#0{a} = #1{b})
     →Arrange (empty key)
       →Distinct GroupAggregate
         →Fused with Child Map/Filter/Project

--- a/test/sqllogictest/explain/default.slt
+++ b/test/sqllogictest/explain/default.slt
@@ -453,10 +453,10 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
 Explained Query:
   →With
     cte l0 =
-      →Differential Join %1[#0] » %0[#0{a}]
+      →Differential Join %1[#0] » %0:t[#0{a}]
         →Arranged materialize.public.t
         →Distinct GroupAggregate
-          →Differential Cross Join %0[×] » %1[×]
+          →Differential Cross Join %0[×] » %1:mv[×]
             after %1:
               Project: #0
               Filter: (#0{a} < #1{a})
@@ -471,11 +471,11 @@ Explained Query:
                 Project: #0
                   →Read materialize.public.mv
   →Return
-    →Differential Join %1[#0] » %0[#1]
+    →Differential Join %1[#0] » %0:l0[#1]
       →Arrange (#1)
         →Stream l0
       →Distinct GroupAggregate
-        →Differential Cross Join %0[×] » %1[×]
+        →Differential Cross Join %0[×] » %1:mv[×]
           after %1:
             Project: #0
             Filter: (#0{b} > #1{b})
@@ -516,7 +516,7 @@ Explained Query:
     cte l3 =
       →Consolidating Monotonic Top1
         Group By #0
-        →Differential Join %0[#0] » %1[#1{b}]
+        →Differential Join %0:l2[#0] » %1:iv[#1{b}]
           after %1:
             Filter: (#0{b}) IS NOT NULL
           →Arranged l2
@@ -524,12 +524,12 @@ Explained Query:
     cte l4 =
       →Consolidating Monotonic Top1
         Group By #0
-        →Differential Join %0[#0] » %1[#1{b}]
+        →Differential Join %0:l2[#0] » %1:mv[#1{b}]
           →Arranged l2
           →Arrange (#1{b})
             →Read materialize.public.mv
   →Return
-    →Delta Join [%0[#0] » %1[#0] » %2[#0]] [%1[#0] » %2[#0] » %0[#0]] [%2[#0] » %1[#0] » %0[#0]]
+    →Delta Join [%0:l0[#0] » %1[#0] » %2[#0]] [%1[#0] » %2[#0] » %0:l0[#0]] [%2[#0] » %1[#0] » %0:l0[#0]]
       →Arrange (#0)
         →Stream l0
       →Arrange (#0)
@@ -594,7 +594,7 @@ Explained Query:
           Project: #1
             →Read l0
     cte l3 =
-      →Delta Join [%0[#1{b}] » %1[#1{b}] » %2[#0{b}]] [%1[#1{b}] » %0[#1{b}] » %2[#0{b}]] [%2[#0{b}] » %0[#1{b}] » %1[#1{b}]]
+      →Delta Join [%0:l1[#1{b}] » %1:l1[#1{b}] » %2:l2[#0{b}]] [%1:l1[#1{b}] » %0:l1[#1{b}] » %2:l2[#0{b}]] [%2:l2[#0{b}] » %0:l1[#1{b}] » %1:l1[#1{b}]]
         →Arranged l1
         →Arranged l1
         →Arranged l2
@@ -605,7 +605,7 @@ Explained Query:
         Map: null, null
           →Consolidating Union
             →Negate Diffs
-              →Differential Join %1[#0] » %0[#0{b}]
+              →Differential Join %1[#0] » %0:l2[#0{b}]
                 →Arranged l2
                 →Distinct GroupAggregate
                   →Fused with Child Map/Filter/Project
@@ -641,7 +641,7 @@ Explained Query:
             →Arranged materialize.public.t
               Key: (#0{a})
   →Return
-    →Differential Cross Join %0[×] » %1[×]
+    →Differential Cross Join %0:l0[×] » %1:l0[×]
       after %1:
         Project: #2
         Map: (#0{v} + #1{v})
@@ -761,7 +761,7 @@ Explained Query:
       →Arrange (empty key)
         →Stream l0
     cte l2 =
-      →Differential Join %1[#0] » %0[#0{a}]
+      →Differential Join %1[#0] » %0:t[#0{a}]
         after %0:
           Project: #0, #2, #1
           Filter: (#0 != #1{m})
@@ -770,13 +770,13 @@ Explained Query:
           Aggregations: max
           Key:
             Project: #0
-          →Differential Cross Join %0[×] » %1[×]
+          →Differential Cross Join %0[×] » %1:l1[×]
             →Arrange (empty key)
               →Distinct GroupAggregate
                 →Stream l0
             →Arranged l1
   →Return
-    →Differential Join %1[#0] » %0[#0]
+    →Differential Join %1[#0] » %0:l2[#0]
       after %0:
         Project: #0, #2, #3, #1
         Filter: (#0 != #1{m})
@@ -786,7 +786,7 @@ Explained Query:
         Aggregations: max
         Key:
           Project: #0
-        →Differential Cross Join %0[×] » %1[×]
+        →Differential Cross Join %0[×] » %1:l1[×]
           →Arrange (empty key)
             →Distinct GroupAggregate
               →Fused with Child Map/Filter/Project
@@ -815,7 +815,7 @@ Explained Query:
             →Arranged materialize.public.t
               Key: (#0{a})
   →Return
-    →Differential Cross Join %0[×] » %1[×]
+    →Differential Cross Join %0:l0[×] » %1:l0[×]
       →Arranged l0
       →Arranged l0
 
@@ -847,7 +847,7 @@ Explained Query:
       →Arrange (#1{b})
         →Stream l0
   →Return
-    →Delta Join [%0[#1{b}] » %1[#1{b}] » %2[#0{b}]] [%1[#1{b}] » %0[#1{b}] » %2[#0{b}]] [%2[#0{b}] » %0[#1{b}] » %1[#1{b}]]
+    →Delta Join [%0:l1[#1{b}] » %1:l1[#1{b}] » %2:l0[#0{b}]] [%1:l1[#1{b}] » %0:l1[#1{b}] » %2:l0[#0{b}]] [%2:l0[#0{b}] » %0:l1[#1{b}] » %1:l1[#1{b}]]
       →Arranged l1
       →Arranged l1
       →Arrange (#0{b})
@@ -887,7 +887,7 @@ FROM t, u, v
 WHERE a = c and d = e and b = f
 ----
 Explained Query:
-  →Differential Join %0[#0{a}] » %1[#0{c}] » %2[#0{e}, #1{f}]
+  →Differential Join %0:t[#0{a}] » %1:u[#0{c}] » %2:v[#0{e}, #1{f}]
     after %1:
       Filter: (#0{a}) IS NOT NULL
     →Arranged materialize.public.t
@@ -915,7 +915,7 @@ FROM t, u, v
 WHERE a = c and d = e and b = f
 ----
 Explained Query:
-  →Differential Join %0[#0{a}] » %1[#0{c}] » %2[#0{e}, #1{f}]
+  →Differential Join %0:t[#0{a}] » %1:u[#0{c}] » %2:v[#0{e}, #1{f}]
     after %1:
       Filter: (#0{a}) IS NOT NULL
     →Arranged materialize.public.t
@@ -941,7 +941,7 @@ EXPLAIN WITH(humanized expressions)
 SELECT a, b, c, d FROM t, u
 ----
 Explained Query:
-  →Differential Cross Join %0[×] » %1[×]
+  →Differential Cross Join %0:t[×] » %1:u[×]
     →Arrange (empty key)
       →Arranged materialize.public.t
     →Arrange (empty key)
@@ -961,7 +961,7 @@ EXPLAIN WITH(humanized expressions)
 SELECT a, b, c, d, e, f FROM t, u, v WHERE a = c
 ----
 Explained Query:
-  →Differential Cross Join %0[#0{a}] » %1[#0{c}] » %2[×]
+  →Differential Cross Join %0:t[#0{a}] » %1:u[#0{c}] » %2:v[×]
     after %1:
       Filter: (#0{a}) IS NOT NULL
     →Arranged materialize.public.t
@@ -996,7 +996,7 @@ FROM t, u, v
 WHERE b = c and d = e
 ----
 Explained Query:
-  →Delta Join [%0[#1{b}] » %1[#0{c}] » %2[#0{e}]] [%1[#0{c}] » %0[#1{b}] » %2[#0{e}]] [%2[#0{e}] » %1[#1{d}] » %0[#1{b}]]
+  →Delta Join [%0:t[#1{b}] » %1:u[#0{c}] » %2:v[#0{e}]] [%1:u[#0{c}] » %0:t[#1{b}] » %2:v[#0{e}]] [%2:v[#0{e}] » %1:u[#1{d}] » %0:t[#1{b}]]
     path %0:
       after %1:
         Project: #1, #0, #2
@@ -1034,7 +1034,7 @@ FROM t, u, v
 WHERE b = c and d = e
 ----
 Explained Query:
-  →Delta Join [%0[#1{b}] » %1[#0{c}] » %2[#0{e}]] [%1[#0{c}] » %0[#1{b}] » %2[#0{e}]] [%2[#0{e}] » %1[#1{d}] » %0[#1{b}]]
+  →Delta Join [%0:t[#1{b}] » %1:u[#0{c}] » %2:v[#0{e}]] [%1:u[#0{c}] » %0:t[#1{b}] » %2:v[#0{e}]] [%2:v[#0{e}] » %1:u[#1{d}] » %0:t[#1{b}]]
     path %0:
       after %1:
         Project: #1, #0, #2
@@ -1072,7 +1072,7 @@ FROM t, u, v
 WHERE a = c and b = e
 ----
 Explained Query:
-  →Delta Join [%0[#0{a}] » %1[#0{c}] » %2[#0{e}]] [%1[#0{c}] » %0[#0{a}] » %2[#0{e}]] [%2[#0{e}] » %0[#1{b}] » %1[#0{c}]]
+  →Delta Join [%0:t[#0{a}] » %1:u[#0{c}] » %2:v[#0{e}]] [%1:u[#0{c}] » %0:t[#0{a}] » %2:v[#0{e}]] [%2:v[#0{e}] » %0:t[#1{b}] » %1:u[#0{c}]]
     path %1:
       after %0:
         Project: #0, #2, #1
@@ -1111,7 +1111,7 @@ Explained Query:
         Aggregations: max
         Key:
           Project: ()
-        →Differential Join %1[#0] » %0[#0{a}]
+        →Differential Join %1[#0] » %0:t[#0{a}]
           →Arranged materialize.public.t
           →Arrange (#0)
             →Constant (1 row)
@@ -1141,7 +1141,7 @@ Explained Query:
     Aggregations: max
     Key:
       Project: #0
-    →Differential Join %1[#0, #1] » %0[#0{a}, #1{b}]
+    →Differential Join %1[#0, #1] » %0:t[#0{a}, #1{b}]
       →Arranged materialize.public.t
       →Arrange (#0, #1)
         →Constant (3 rows)
@@ -1202,7 +1202,7 @@ Explained Query:
       →Arrange (#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16})
         →Read materialize.public.r
   →Return
-    →Differential Join %0[#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}] » %1[#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}]
+    →Differential Join %0:l0[#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}] » %1:l0[#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}]
       →Arranged l0
       →Arranged l0
 
@@ -1353,7 +1353,7 @@ FROM t, u
 WHERE t.b = u.c;
 ----
 Explained Query:
-  →Differential Join %1[#0{c}] » %0[#1{b}]
+  →Differential Join %1:u[#0{c}] » %0:t[#1{b}]
     →Arrange (#1{b})
       →Read materialize.public.t
     →Arranged materialize.public.u
@@ -1375,7 +1375,7 @@ FROM t, u
 WHERE t.b = u.d;
 ----
 Explained Query:
-  →Differential Join %1[#1{d}] » %0[#1{b}]
+  →Differential Join %1:u[#1{d}] » %0:t[#1{b}]
     →Arrange (#1{b})
       →Read materialize.public.t
     →Arranged materialize.public.u
@@ -1408,7 +1408,7 @@ FROM t, u
 WHERE t.a = u.c
 ----
 Explained Query:
-  →Differential Join %0[#0{a}] » %1[#0{c}]
+  →Differential Join %0:t[#0{a}] » %1:u[#0{c}]
     →Arranged materialize.public.t
     →Arrange (#0{c})
       →Fused with Child Map/Filter/Project
@@ -1437,7 +1437,7 @@ Explained Query:
     cte l0 =
       →Arranged materialize.public.t
   →Return
-    →Delta Join [%0[#0{a}] » %1[#0{a}] » %2[#0{a}]] [%1[#0{a}] » %0[#0{a}] » %2[#0{a}]] [%2[#0{a}] » %0[#0{a}] » %1[#0{a}]]
+    →Delta Join [%0:l0[#0{a}] » %1:l0[#0{a}] » %2:l0[#0{a}]] [%1:l0[#0{a}] » %0:l0[#0{a}] » %2:l0[#0{a}]] [%2:l0[#0{a}] » %0:l0[#0{a}] » %1:l0[#0{a}]]
       path %1:
         after %0:
           Project: #0, #2, #0, #1
@@ -1475,7 +1475,7 @@ Explained Query:
   →Return
     →Distinct GroupAggregate
       →Union
-        →Differential Join %0[#0{a}] » %1[#0{a}]
+        →Differential Join %0:l0[#0{a}] » %1:l0[#0{a}]
           after %1:
             Project: #3, #4
             Filter: (#0{a}) IS NOT NULL
@@ -1516,7 +1516,7 @@ Explained Query:
   →Return
     →Distinct GroupAggregate
       →Union
-        →Differential Join %0[#1{b}] » %1[#1{b}]
+        →Differential Join %0:l0[#1{b}] » %1:l0[#1{b}]
           after %1:
             Project: #3, #4
             Map: (#1{a} + #2{a}), (#0{b} + #0{b})
@@ -1564,7 +1564,7 @@ Explained Query:
   →Return
     →Distinct GroupAggregate
       →Union
-        →Differential Join %0[#1{b}] » %1[#1{b}]
+        →Differential Join %0:l0[#1{b}] » %1:l0[#1{b}]
           after %1:
             Project: #3, #4
             Map: (#1{a} + #2{a}), (#0{b} + #0{b})
@@ -1597,7 +1597,7 @@ UNION
 Explained Query:
   →Distinct GroupAggregate
     →Union
-      →Differential Join %0[#1{b}] » %1[(#1{b} + 1)]
+      →Differential Join %0:t_non_null[#1{b}] » %1:t_non_null[(#1{b} + 1)]
         after %1:
           Project: #4, #5
           Map: (#1{a} + #2{a}), (#0{b} + #3{b})
@@ -1629,7 +1629,7 @@ Explained Query:
     →Union
       →Unarranged Raw Stream
         →Arranged materialize.public.t
-      →Differential Join %1[#0] » %0[#0{a}]
+      →Differential Join %1[#0] » %0:t[#0{a}]
         →Arranged materialize.public.t
         →Arrange (#0)
           →Constant (1 row)
@@ -1662,11 +1662,11 @@ Explained Query:
   →Union
     →Unarranged Raw Stream
       →Arranged materialize.public.t
-    →Differential Join %1[#0] » %0[#1{b}]
+    →Differential Join %1[#0] » %0:t[#1{b}]
       →Arranged materialize.public.t
       →Arrange (#0)
         →Constant (1 row)
-    →Differential Join %1[#0] » %0[#0{a}]
+    →Differential Join %1[#0] » %0:t[#0{a}]
       →Arranged materialize.public.t
       →Arrange (#0)
         →Constant (1 row)
@@ -1675,7 +1675,7 @@ Explained Query:
       Filter: (#1{c} = 3)
         →Arranged materialize.public.u
           Key: (#1{d})
-    →Differential Join %1[#0] » %0[#1{d}]
+    →Differential Join %1[#0] » %0:u[#1{d}]
       →Arranged materialize.public.u
       →Arrange (#0)
         →Constant (1 row)
@@ -1831,7 +1831,7 @@ FROM t5, t6
 WHERE x = a AND b IN (8,9);
 ----
 Explained Query:
-  →Differential Join %1[#0{a}] » %0[#0{x}]
+  →Differential Join %1:t6[#0{a}] » %0:t5[#0{x}]
     →Arrange (#0{x})
       →Read materialize.public.t5
     →Arrange (#0{a})
@@ -1853,7 +1853,7 @@ FROM t5, t6
 WHERE x = a AND b IN (8,9);
 ----
 Explained Query:
-  →Differential Join %1[#0{a}] » %0[#0{x}]
+  →Differential Join %1:t6[#0{a}] » %0:t5[#0{x}]
     →Arrange (#0{x})
       →Read materialize.public.t5
     →Arrange (#0{a})
@@ -2020,7 +2020,7 @@ Explained Query:
               Project: ()
                 →Read l0
   →Return
-    →Differential Cross Join %0[×] » %1[×]
+    →Differential Cross Join %0:t4[×] » %1[×]
       after %1:
         Project: #3, #2
         Map: (#0{a} + #1{b})
@@ -2066,7 +2066,7 @@ EXPLAIN
 SELECT * FROM tnn JOIN unn USING (x, y);
 ----
 Explained Query:
-  →Differential Join %0[#2{y}, #1{x}] » %1[#0{y}, #1{x}]
+  →Differential Join %0:tnn[#2{y}, #1{x}] » %1:unn[#0{y}, #1{x}]
     →Arrange (#2{y}, #1{x})
       →Fused with Parent Map/Filter/Project
         Project: #2, #0, #1


### PR DESCRIPTION
### Motivation

Closes https://github.com/MaterializeInc/database-issues/issues/9376

### Description

Makes default `EXPLAIN` give substantially cleaner output, more like `EXPLAIN OPTIMIZED PLAN`, with a particular eye to identifying cross joins. 

Old janky:
```
    →Differential Join %0 » %1
      Join stage 0 in %1
        project=(#2)
        map=((#0{v} + #1{v}))
```

New hotness:
```
    →Differential Cross Join %0[×] » %1[×]
      after %1:
        Project: #2
        Map: (#0{v} + #1{v})
      →Arranged l0
      →Arranged l0
```

We call a join a cross join if _any_ part of it involves a cross join:

```
query T multiline
EXPLAIN WITH(humanized expressions)
SELECT a, b, c, d, e, f FROM t, u, v WHERE a = c
----
Explained Query:
  →Differential Cross Join %0[#0{a}] » %1[#0{c}] » %2[×]
    after %1:
      Filter: (#0{a}) IS NOT NULL
    →Arranged materialize.public.t
    →Arranged materialize.public.u
    →Arrange (empty key)
      →Arranged materialize.public.v
```

### Verification

Rewrote `default.slt` and added cross join cases.
