### PR TITLE
adapter: wrap statement logging in an RAII StatementLoggingGuard

### DIFF
--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -200,11 +200,7 @@ impl PeekClient {
 
         // Set up statement logging, and log the beginning of execution.
         // (But only if we're not executing in the context of another statement.)
-        // The end of execution will be logged in one of the following ways:
-        // - At the end of this function, if the execution is finished by then.
-        // - Later by the Coordinator, either due to RegisterFrontendPeek or
-        //   ExecuteSlowPathPeek.
-        let statement_logging_id = self.begin_statement_logging(
+        let logging_guard = self.begin_statement_logging(
             session,
             &params,
             &logging,
@@ -212,44 +208,52 @@ impl PeekClient {
             lifecycle_timestamps,
             outer_ctx_extra,
         );
+        let statement_logging_id = logging_guard.id();
+        // Streaming peek/subscribe/slow-path/copy-to responses hand off the
+        // end-execution event to the coordinator (via
+        // `handle_peek_notification` / `cancel_pending_peeks`), so letting
+        // the RAII guard's `Drop` also emit `Aborted` on mid-flight drop
+        // would double-end and panic at `end_statement_execution`. Defuse
+        // and manage the lifecycle explicitly below: streaming arms skip
+        // emitting; non-streaming arms emit via `log_ended_execution`.
+        logging_guard.defuse();
 
         let result = self
             .try_frontend_peek_inner(session, catalog, stmt, params, statement_logging_id)
             .await;
 
-        // Log the end of execution if we are logging this statement and execution has already
-        // ended.
+        // Log the end of execution if we are logging this statement and
+        // execution has already ended.
         if let Some(logging_id) = statement_logging_id {
             let reason = match &result {
-                // Streaming results are handled asynchronously by the coordinator
+                // Streaming results are handled asynchronously by the
+                // coordinator — it will log the end via
+                // `handle_peek_notification`, so skip emitting here.
                 Ok(Some(
                     ExecuteResponse::SendingRowsStreaming { .. }
                     | ExecuteResponse::Subscribing { .. },
                 )) => {
-                    // Don't log here - the peek or subscribe is still executing.
-                    // It will be logged when handle_peek_notification is called.
                     return result;
                 }
-                // COPY TO needs to check its inner response
+                // COPY TO wrapping a streaming response: same handoff.
                 Ok(Some(resp @ ExecuteResponse::CopyTo { resp: inner, .. })) => {
                     match inner.as_ref() {
                         ExecuteResponse::SendingRowsStreaming { .. }
                         | ExecuteResponse::Subscribing { .. } => {
-                            // Don't log here - the peek or subscribe is still executing.
-                            // It will be logged when handle_peek_notification is called.
                             return result;
                         }
-                        // For non-streaming COPY TO responses, use the outer CopyTo for conversion
+                        // For non-streaming COPY TO responses, use the outer
+                        // CopyTo for conversion.
                         _ => resp.into(),
                     }
                 }
-                // Bailout case, which should not happen
+                // Bailout case, which should not happen.
                 Ok(None) => {
                     soft_panic_or_log!(
                         "Bailed out from `try_frontend_peek_inner` after we already logged the beginning of statement execution."
                     );
-                    // This statement will be handled by the old peek sequencing, which will do its
-                    // own statement logging from the beginning. So, let's close out this one.
+                    // The old peek sequencing would start its own statement
+                    // logging from scratch; close out this one as errored.
                     self.log_ended_execution(
                         logging_id,
                         StatementEndedExecutionReason::Errored {
@@ -259,10 +263,10 @@ impl PeekClient {
                     );
                     return result;
                 }
-                // All other success responses - use the From implementation
-                // TODO(peek-seq): After we delete the old peek sequencing, we'll be able to adjust
-                // the From implementation to do exactly what we need in the frontend peek
-                // sequencing, so that the above special cases won't be needed.
+                // All other success responses — use the `From` implementation.
+                // TODO(peek-seq): After we delete the old peek sequencing, we
+                // can adjust the `From` impl to do exactly what we need here,
+                // so the special cases above won't be needed.
                 Ok(Some(resp)) => resp.into(),
                 Err(e) => StatementEndedExecutionReason::Errored {
                     error: e.to_string(),

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -421,12 +421,14 @@ impl PeekClient {
     /// Set up statement logging for a frontend-sequenced operation.
     ///
     /// If `outer_ctx_extra` is `None`, begins a new statement execution log
-    /// entry. If `outer_ctx_extra` is `Some` (e.g. EXECUTE/FETCH), reuses the
-    /// existing logging id and retires the outer context.
+    /// entry. If `outer_ctx_extra` is `Some` (e.g. EXECUTE/FETCH), reuses and
+    /// retires the existing logging context.
     ///
-    /// The end of execution must be logged separately by the caller (via
-    /// [`Self::log_ended_execution`]) once the terminal outcome is known, or
-    /// handed off to the coordinator for streaming responses.
+    /// Returns a [`StatementLoggingGuard`]. Callers must
+    /// [`defuse`](StatementLoggingGuard::defuse) the guard when handing off
+    /// logging responsibility (or, in future, retire it explicitly on a
+    /// terminal outcome). Dropping the guard without retiring it emits an
+    /// `Aborted` end-execution event.
     pub(crate) fn begin_statement_logging(
         &self,
         session: &mut Session,
@@ -435,8 +437,8 @@ impl PeekClient {
         catalog: &Catalog,
         lifecycle_timestamps: Option<LifecycleTimestamps>,
         outer_ctx_extra: &mut Option<ExecuteContextGuard>,
-    ) -> Option<StatementLoggingId> {
-        if outer_ctx_extra.is_none() {
+    ) -> StatementLoggingGuard {
+        let id = if outer_ctx_extra.is_none() {
             // This is a new statement, so begin statement logging.
             let result = self.statement_logging_frontend.begin_statement_execution(
                 session,
@@ -459,6 +461,12 @@ impl PeekClient {
             outer_ctx_extra
                 .take()
                 .and_then(|guard| guard.defuse().retire())
+        };
+
+        StatementLoggingGuard {
+            id,
+            coordinator_client: self.coordinator_client.clone(),
+            now: self.statement_logging_frontend.now.clone(),
         }
     }
 
@@ -527,7 +535,10 @@ impl PeekClient {
             ));
     }
 
-    /// Log the end of statement execution.
+    /// Emit a `FrontendStatementLoggingEvent::EndedExecution` for the given
+    /// logging id. Used by callers that manage the statement-logging
+    /// lifecycle explicitly (see `try_frontend_peek`), rather than via the
+    /// RAII [`StatementLoggingGuard`].
     pub(crate) fn log_ended_execution(
         &self,
         id: StatementLoggingId,
@@ -543,6 +554,68 @@ impl PeekClient {
             .send(Command::FrontendStatementLogging(
                 FrontendStatementLoggingEvent::EndedExecution(record),
             ));
+    }
+}
+
+/// RAII guard owning a frontend statement-logging lifecycle.
+///
+/// Created by [`PeekClient::begin_statement_logging`]. Unless logging
+/// responsibility is handed off via [`defuse`](StatementLoggingGuard::defuse),
+/// the guard ensures that every statement for which `BeganExecution` was logged
+/// also receives a corresponding `EndedExecution`, even on early-return, panic,
+/// or mid-flight drop of the enclosing future: if the guard is dropped without
+/// being defused, it emits `StatementEndedExecutionReason::Aborted`.
+///
+/// When the guard is `defuse`d, some other component (e.g. the coordinator, for
+/// streaming peek / subscribe responses) takes over and logs `EndedExecution`
+/// itself.
+///
+/// For non-sampled statements the guard still exists but carries no id, and
+/// retirement / drop are no-ops.
+#[must_use = "StatementLoggingGuard must be explicitly retired or handed off; \
+              otherwise `Drop` will log the statement as Aborted"]
+pub(crate) struct StatementLoggingGuard {
+    /// `None` if the statement was not sampled for logging.
+    id: Option<StatementLoggingId>,
+    coordinator_client: Client,
+    now: mz_ore::now::NowFn,
+}
+
+impl StatementLoggingGuard {
+    /// Returns the logging id, if this statement is being logged.
+    pub(crate) fn id(&self) -> Option<StatementLoggingId> {
+        self.id
+    }
+
+    /// Hands off logging responsibility without emitting an end-execution
+    /// event. Use when another component (e.g. the coordinator, for streaming
+    /// peek / subscribe responses) will log the end asynchronously.
+    pub(crate) fn defuse(mut self) {
+        self.id = None;
+    }
+
+    fn emit(&mut self, reason: statement_logging::StatementEndedExecutionReason) {
+        let Some(id) = self.id.take() else {
+            return;
+        };
+        let ended_at = (self.now)();
+        let record = statement_logging::StatementEndedExecutionRecord {
+            id: id.0,
+            reason,
+            ended_at,
+        };
+        self.coordinator_client
+            .send(Command::FrontendStatementLogging(
+                FrontendStatementLoggingEvent::EndedExecution(record),
+            ));
+    }
+}
+
+impl Drop for StatementLoggingGuard {
+    fn drop(&mut self) {
+        // `emit` is a no-op if the guard was already retired or defused (i.e.
+        // `id` is `None`).
+        self.emit(statement_logging::StatementEndedExecutionReason::Aborted);
     }
 }
 


### PR DESCRIPTION
Convert `PeekClient::begin_statement_logging` (extracted in the previous change) from returning a raw `Option<StatementLoggingId>` to returning a `StatementLoggingGuard` whose `Drop` impl emits
`StatementEndedExecutionReason::Aborted` if the statement was begun but no terminal outcome was logged.

The guard exposes:
- `id()` to get the underlying `StatementLoggingId` for callers that manage the lifecycle manually (existing peek sequencing).
- `defuse()` to hand off responsibility (e.g. for streaming responses whose end is logged later by the coordinator).

`try_frontend_peek` keeps its existing manual `log_ended_execution` shape: it `defuse()`s the guard immediately and continues to drive the streaming/non-streaming branches itself. Otherwise the guard's `Drop` would race the coordinator's eventual `end_statement_execution` and panic.

This is preparation: the upcoming OCC read-then-write path will rely on the guard so that early-returns and panics during the SUBSCRIBE+retry loop don't strand a `BeganExecution` event without an `EndedExecution`.

Work towards https://github.com/MaterializeInc/database-issues/issues/6686