### PR TITLE
orchestratord: Add balancerd dns names to Console config

### DIFF
--- a/src/cloud-resources/src/crd/console.rs
+++ b/src/cloud-resources/src/crd/console.rs
@@ -39,6 +39,9 @@ pub mod v1alpha1 {
         pub namespace: String,
         /// Whether to use HTTP or HTTPS to communicate with Materialize.
         pub scheme: HttpConnectionScheme,
+        /// External DNS names balancerd serves traffic for
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub dns_names: Option<Vec<String>>,
     }
 
     #[derive(

--- a/src/orchestratord/src/controller/console.rs
+++ b/src/orchestratord/src/controller/console.rs
@@ -73,6 +73,8 @@ pub struct Config {
 struct AppConfig {
     version: String,
     auth: AppConfigAuth,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    balancerd_dns_names: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -221,6 +223,7 @@ impl Context {
     }
 
     fn create_console_app_configmap_object(&self, console: &Console) -> ConfigMap {
+        let balancerd_dns_names = console.spec.balancerd.dns_names.clone();
         let version: String = console
             .spec
             .console_image_ref
@@ -230,6 +233,7 @@ impl Context {
             .to_owned();
         let app_config_json = serde_json::to_string(&AppConfig {
             version,
+            balancerd_dns_names,
             auth: AppConfigAuth {
                 mode: console.spec.authenticator_kind,
             },

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -35,7 +35,7 @@ use crate::{
     matching_image_from_environmentd_image_ref,
     metrics::Metrics,
     parse_image_tag,
-    tls::{DefaultCertificateSpecs, issuer_ref_defined},
+    tls::{DefaultCertificateSpecs, issuer_ref_defined, resolved_dns_names},
 };
 use mz_cloud_provider::CloudProvider;
 use mz_cloud_resources::crd::{
@@ -793,6 +793,10 @@ impl k8s_controller::Context for Context {
                         } else {
                             HttpConnectionScheme::Http
                         },
+                        dns_names: resolved_dns_names(
+                            &self.config.default_certificate_specs.balancerd_external,
+                            &mz.spec.balancerd_external_certificate_spec,
+                        ),
                     },
                     authenticator_kind: mz.spec.authenticator_kind,
                     resource_id: Some(status.resource_id),

--- a/src/orchestratord/src/tls.rs
+++ b/src/orchestratord/src/tls.rs
@@ -131,3 +131,13 @@ pub fn issuer_ref_defined(
             .and_then(|spec| spec.issuer_ref.as_ref())
             .is_some()
 }
+
+pub fn resolved_dns_names(
+    defaults: &Option<MaterializeCertSpec>,
+    overrides: &Option<MaterializeCertSpec>,
+) -> Option<Vec<String>> {
+    overrides
+        .as_ref()
+        .and_then(|spec| spec.dns_names.clone())
+        .or_else(|| defaults.as_ref().and_then(|spec| spec.dns_names.clone()))
+}

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -191,6 +191,28 @@ def get_clusterd_data() -> dict[str, Any]:
     )
 
 
+def get_console_app_config(namespace="materialize-environment") -> dict[str, Any]:
+    """Return the parsed contents of the console's `app-config.json` configmap."""
+    data = json.loads(
+        spawn.capture(
+            [
+                "kubectl",
+                "get",
+                "configmap",
+                "-l",
+                "materialize.cloud/app=console",
+                "-n",
+                namespace,
+                "-o",
+                "json",
+            ]
+        )
+    )
+    items = data["items"]
+    assert len(items) == 1, f"Expected exactly one console configmap, but got {items}"
+    return json.loads(items[0]["data"]["app-config.json"])
+
+
 def ensure_kind_version() -> None:
     kind_version = Version.parse(spawn.capture(["kind", "version"]).split(" ")[1][1:])
     assert kind_version >= Version.parse(
@@ -1560,6 +1582,48 @@ class ConsoleResources(Modification):
             ), f"Expected console resources {expected}, but got {resources}"
 
         retry(check_pods, 360)
+
+
+class BalancerdExternalDnsNames(Modification):
+    # The operator surfaces the balancerd external certificate's DNS names to
+    # the console's `app-config.json` as `balancerd_dns_names`, so the console
+    # knows which hostnames balancerd serves.
+    DNS_NAMES = ["balancerd.example.com"]
+
+    @classmethod
+    def values(cls, version: MzVersion) -> list[Any]:
+        return [None, cls.DNS_NAMES]
+
+    @classmethod
+    def default(cls) -> Any:
+        return None
+
+    def modify(self, definition: dict[str, Any]) -> None:
+        if self.value is not None:
+            definition["materialize"]["spec"]["balancerdExternalCertificateSpec"] = {
+                "dnsNames": self.value,
+            }
+
+    def validate(self, mods: dict[type[Modification], Any]) -> None:
+        # `balancerd_dns_names` was added to the console app config in v26.27;
+        # older orchestratord builds don't surface the cert spec's DNS names.
+        if MzVersion.parse_mz(mods[EnvironmentdImageRef]) < MzVersion.parse_mz(
+            "v26.27.0-dev.0"
+        ):
+            return
+        # Without a console there's no app config to inspect.
+        if not mods[ConsoleEnabled]:
+            return
+
+        def check() -> None:
+            app_config = get_console_app_config()
+            actual = app_config.get("balancerd_dns_names")
+            assert (
+                actual == self.value
+            ), f"Expected balancerd_dns_names {self.value}, but got {actual}: {app_config}"
+
+        # The console is reconciled last and the configmap update is async.
+        retry(check, 360)
 
 
 class AuthenticatorKind(Modification):


### PR DESCRIPTION
### Motivation

We want to show the host name in the Connect modal of the Console https://materializeinc.slack.com/archives/C07PN7KSB0T/p1779305130685629 and this is the easiest way to get it

This isn't a perfect solution because it requires TLS and Console to be enabled to work. However in the long run, we can see balancerd hosting the Console in which case they'd share the same DNS name

### Description

- Adds dns names to the balancerd ref 
- Adds those dns names to Console's app config

### Verification
Ran a helm install with externalCertificateSpec and validated that it appeared in the Console's app config