### PR TITLE
 console: fix cluster size ordering

### DIFF
--- a/console/src/api/materialize/cluster/__snapshots__/availableClusterSizes.test.ts.snap
+++ b/console/src/api/materialize/cluster/__snapshots__/availableClusterSizes.test.ts.snap
@@ -5,6 +5,10 @@ exports[`queries > buildAvailableClusterReplicaSizesQuery produces the expected 
   "parameters": [
     "mz_%",
   ],
-  "sql": "select "size" from "mz_cluster_replica_sizes" where "size" not like $1",
+  "sql": "select "size" from "mz_cluster_replica_sizes" where "size" not like $1 order by CASE
+          WHEN size ~ '^[0-9]+([a-zA-Z]*cc[xX]?|C)$' THEN '0_legacy'
+          WHEN size LIKE '%-%' THEN '1_' || split_part(size, '-', 1)
+          ELSE '2_tshirt'
+        END, "credits_per_hour"",
 }
 `;

--- a/console/src/api/materialize/cluster/availableClusterSizes.ts
+++ b/console/src/api/materialize/cluster/availableClusterSizes.ts
@@ -25,6 +25,16 @@ export const buildAvailableClusterReplicaSizesQuery = () => {
       .select("size")
       // We don't want to show the mz_probe size in the UI
       .where("size", "not like", "mz_%")
+      // Group sizes by family (legacy cc, t-shirt, M.1, D.1, ...) so related
+      // sizes stay contiguous, then sort by cost within each family.
+      .orderBy(
+        sql<string>`CASE
+          WHEN size ~ '^[0-9]+([a-zA-Z]*cc[xX]?|C)$' THEN '0_legacy'
+          WHEN size LIKE '%-%' THEN '1_' || split_part(size, '-', 1)
+          ELSE '2_tshirt'
+        END`,
+      )
+      .orderBy("credits_per_hour")
   );
 };
 /**


### PR DESCRIPTION
Fixes [CNS-80. ](https://linear.app/materializeinc/issue/CNS-80/cluster-sizes-are-out-of-order)`ORDER BY credits_per_hour` to sort cluster replica sizes by cost ascending.


### Verification
<img width="3018" height="1558" alt="image" src="https://github.com/user-attachments/assets/a70cc06b-c293-425c-a8dd-a6c6aa93a9cd" />


