### PR TITLE
Handle overflow in get_bit and get_byte error messages

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1406,7 +1406,7 @@ fn power_numeric(mut a: Numeric, b: Numeric) -> Result<Numeric, EvalError> {
 fn get_bit(bytes: &[u8], index: i32) -> Result<i32, EvalError> {
     let err = EvalError::IndexOutOfRange {
         provided: index,
-        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,
+        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap_or(i32::MAX) - 1,
     };
 
     let index = usize::try_from(index).map_err(|_| err.clone())?;
@@ -1426,7 +1426,7 @@ fn get_bit(bytes: &[u8], index: i32) -> Result<i32, EvalError> {
 fn get_byte(bytes: &[u8], index: i32) -> Result<i32, EvalError> {
     let err = EvalError::IndexOutOfRange {
         provided: index,
-        valid_end: i32::try_from(bytes.len()).unwrap() - 1,
+        valid_end: i32::try_from(bytes.len()).unwrap_or(i32::MAX) - 1,
     };
     let i: &u8 = bytes
         .get(usize::try_from(index).map_err(|_| err.clone())?)


### PR DESCRIPTION
### Motivation

The `get_bit` and `get_byte` functions construct error messages that include a `valid_end` field. When the byte array is very large, computing `bytes.len().saturating_mul(8)` or `bytes.len()` and converting to `i32` could overflow. The current code uses `unwrap()` which would panic on overflow, creating a potential denial-of-service vector.

### Description

Changed two error message constructions to use `unwrap_or(i32::MAX)` instead of `unwrap()`:

1. In `get_bit`: `i32::try_from(bytes.len().saturating_mul(8)).unwrap_or(i32::MAX) - 1`
2. In `get_byte`: `i32::try_from(bytes.len()).unwrap_or(i32::MAX) - 1`

This ensures that if the conversion overflows, we gracefully use `i32::MAX` as the upper bound in the error message rather than panicking. This is a reasonable fallback since the actual error checking logic (which validates the index is within bounds) happens separately and will still correctly reject out-of-range indices.

### Verification

The change is defensive and doesn't affect the core validation logic—only the error message construction. Existing tests will continue to pass, and the code now handles edge cases with very large byte arrays without panicking.

https://claude.ai/code/session_011hMwDY2yXg7aey2s47PYF2