### PR TITLE
Docs: `CREATE/DROP API`, `CREATE/DROP METRIC`, and the metrics endpoint (3/3)

### DIFF
--- a/doc/user/content/headless/sql-command-privileges/create-api.md
+++ b/doc/user/content/headless/sql-command-privileges/create-api.md
@@ -1,0 +1,5 @@
+---
+headless: true
+---
+- `CREATE` privileges on the containing schema.
+- `USAGE` privileges on the cluster the API runs on.

--- a/doc/user/content/headless/sql-command-privileges/create-metric.md
+++ b/doc/user/content/headless/sql-command-privileges/create-metric.md
@@ -3,6 +3,6 @@ headless: true
 ---
 - `CREATE` privileges on the containing schema.
 - `USAGE` privileges on the API the metric is bound to.
-- `SELECT` privileges on the relation named in `VALUES FROM`.
+- `SELECT` privileges on the relation named in `SERIES FROM`.
   - NOTE: if the relation is a materialized view, then the view owner must
     also have the necessary privileges to execute the view definition.

--- a/doc/user/content/headless/sql-command-privileges/create-metric.md
+++ b/doc/user/content/headless/sql-command-privileges/create-metric.md
@@ -1,0 +1,8 @@
+---
+headless: true
+---
+- `CREATE` privileges on the containing schema.
+- `USAGE` privileges on the API the metric is bound to.
+- `SELECT` privileges on the relation named in `VALUES FROM`.
+  - NOTE: if the relation is a materialized view, then the view owner must
+    also have the necessary privileges to execute the view definition.

--- a/doc/user/content/headless/sql-command-privileges/drop-api.md
+++ b/doc/user/content/headless/sql-command-privileges/drop-api.md
@@ -1,0 +1,5 @@
+---
+headless: true
+---
+- Ownership of the dropped API.
+- `USAGE` privileges on the containing schema.

--- a/doc/user/content/headless/sql-command-privileges/drop-metric.md
+++ b/doc/user/content/headless/sql-command-privileges/drop-metric.md
@@ -1,0 +1,5 @@
+---
+headless: true
+---
+- Ownership of the dropped metric.
+- `USAGE` privileges on the containing schema.

--- a/doc/user/content/headless/sql-command-privileges/scrape-api.md
+++ b/doc/user/content/headless/sql-command-privileges/scrape-api.md
@@ -7,9 +7,9 @@ The privileges required by the role that authenticates the scrape request are:
   receives `404 Not Found`; the response does not distinguish "API exists
   but you cannot see it" from "no such API".
 - `USAGE` privileges on the database and schema containing the API, and on
-  the database and schema containing each metric's `VALUES FROM` relation.
+  the database and schema containing each metric's `SERIES FROM` relation.
 - `USAGE` privileges on the cluster the API runs on.
-- `SELECT` privileges on every relation named in `VALUES FROM` across the
+- `SELECT` privileges on every relation named in `SERIES FROM` across the
   API's metrics. A scrape that hits a metric whose relation the role cannot
   read fails with `403 Forbidden`; other metrics on the same API are not
   exposed for that request.

--- a/doc/user/content/headless/sql-command-privileges/scrape-api.md
+++ b/doc/user/content/headless/sql-command-privileges/scrape-api.md
@@ -1,0 +1,15 @@
+---
+headless: true
+---
+The privileges required by the role that authenticates the scrape request are:
+
+- `USAGE` privileges on the API. A role that lacks `USAGE` on the API
+  receives `404 Not Found`; the response does not distinguish "API exists
+  but you cannot see it" from "no such API".
+- `USAGE` privileges on the database and schema containing the API, and on
+  the database and schema containing each metric's `VALUES FROM` relation.
+- `USAGE` privileges on the cluster the API runs on.
+- `SELECT` privileges on every relation named in `VALUES FROM` across the
+  API's metrics. A scrape that hits a metric whose relation the role cannot
+  read fails with `403 Forbidden`; other metrics on the same API are not
+  exposed for that request.

--- a/doc/user/content/sql/create-api.md
+++ b/doc/user/content/sql/create-api.md
@@ -11,7 +11,7 @@ menu:
 `CREATE API` defines a Prometheus scrape endpoint backed by views in
 Materialize. After creating the API, any [`CREATE METRIC`](../create-metric)
 in the same API is exposed at
-`GET /metrics/custom/<database>/<schema>/<api_name>` on every HTTP listener
+`GET /api/metrics/custom/<database>/<schema>/<api_name>` on every HTTP listener
 whose configuration enables the custom-metrics route.
 
 ## Syntax
@@ -22,7 +22,7 @@ whose configuration enables the custom-metrics route.
 
 ### Endpoint exposure
 
-Whether `/metrics/custom/...` is reachable on a given HTTP listener is a
+Whether `/api/metrics/custom/...` is reachable on a given HTTP listener is a
 deployment-time decision controlled by the listener's configuration, not by
 the `CREATE API` statement. APIs are not bound to a specific listener; on
 listeners where the route is enabled, every API the requesting role can see
@@ -30,7 +30,7 @@ is reachable.
 
 ### Scraping
 
-Each request to `/metrics/custom/<database>/<schema>/<api_name>` re-evaluates
+Each request to `/api/metrics/custom/<database>/<schema>/<api_name>` re-evaluates
 every metric in the API on the API's cluster. Empty exposures (an API with no
 metrics, or metrics whose backing relation is empty) return `200 OK` with no
 samples.
@@ -44,15 +44,17 @@ The privileges required to execute this statement are:
 ### Scrape-time privileges
 
 `CREATE API` and `CREATE METRIC` only check the privileges of the role
-creating those objects. When `/metrics/custom/<database>/<schema>/<api_name>`
+creating those objects. When `/api/metrics/custom/<database>/<schema>/<api_name>`
 is scraped, Materialize evaluates each metric's source relation as the role
 that authenticated the HTTP request. That role must hold:
 
 {{% include-headless "/headless/sql-command-privileges/scrape-api" %}}
 
-On a listener with `authenticator_kind = "None"`, unauthenticated requests
-run as `anonymous_http_user`. Grant the required privileges to that role
-(or to `PUBLIC`) if you intend to expose the API without authentication.
+On a listener with `authenticator_kind = "None"`, the role is taken from the
+basic-auth username in the request (the password is not checked); a request
+with no credentials runs as `anonymous_http_user`. Grant the required
+privileges to the role you scrape as (or to `PUBLIC`) if you intend to expose
+the API without authentication.
 
 ## Examples
 
@@ -78,7 +80,7 @@ CREATE METRIC materialize.public.orders_open
   IN API materialize.public.app_metrics AS (
     TYPE 'gauge',
     HELP 'Number of open orders by status',
-    VALUES FROM materialize.public.orders_by_status,
+    SERIES FROM materialize.public.orders_by_status,
     VALUE COLUMN 'count'
   );
 ```
@@ -86,7 +88,7 @@ CREATE METRIC materialize.public.orders_open
 Scrape it:
 
 ```
-curl https://<region-host>/metrics/custom/materialize/public/app_metrics
+curl https://<region-host>/api/metrics/custom/materialize/public/app_metrics
 ```
 
 ## Related pages

--- a/doc/user/content/sql/create-api.md
+++ b/doc/user/content/sql/create-api.md
@@ -1,0 +1,95 @@
+---
+title: "CREATE API"
+description: "`CREATE API` exposes a Prometheus scrape endpoint that serves metrics defined with `CREATE METRIC`."
+menu:
+  main:
+    parent: 'commands'
+---
+
+{{< private-preview />}}
+
+`CREATE API` defines a Prometheus scrape endpoint backed by views in
+Materialize. After creating the API, any [`CREATE METRIC`](../create-metric)
+in the same API is exposed at
+`GET /metrics/custom/<database>/<schema>/<api_name>` on every HTTP listener
+whose configuration enables the custom-metrics route.
+
+## Syntax
+
+{{% include-syntax file="examples/create_api" example="syntax" %}}
+
+## Details
+
+### Endpoint exposure
+
+Whether `/metrics/custom/...` is reachable on a given HTTP listener is a
+deployment-time decision controlled by the listener's configuration, not by
+the `CREATE API` statement. APIs are not bound to a specific listener; on
+listeners where the route is enabled, every API the requesting role can see
+is reachable.
+
+### Scraping
+
+Each request to `/metrics/custom/<database>/<schema>/<api_name>` re-evaluates
+every metric in the API on the API's cluster. Empty exposures (an API with no
+metrics, or metrics whose backing relation is empty) return `200 OK` with no
+samples.
+
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/create-api" %}}
+
+### Scrape-time privileges
+
+`CREATE API` and `CREATE METRIC` only check the privileges of the role
+creating those objects. When `/metrics/custom/<database>/<schema>/<api_name>`
+is scraped, Materialize evaluates each metric's source relation as the role
+that authenticated the HTTP request. That role must hold:
+
+{{% include-headless "/headless/sql-command-privileges/scrape-api" %}}
+
+On a listener with `authenticator_kind = "None"`, unauthenticated requests
+run as `anonymous_http_user`. Grant the required privileges to that role
+(or to `PUBLIC`) if you intend to expose the API without authentication.
+
+## Examples
+
+Create a relation to expose, an API, then a metric backed by that relation:
+
+```mzsql
+-- A table (or source) holding the raw data.
+CREATE TABLE orders (id int, status text);
+INSERT INTO orders VALUES
+  (1, 'open'), (2, 'open'), (3, 'closed');
+
+-- A view that aggregates it into one row per label value.
+CREATE MATERIALIZED VIEW orders_by_status AS
+  SELECT status, count(*) AS count
+  FROM orders
+  GROUP BY status;
+
+CREATE API materialize.public.app_metrics
+  FORMAT PROMETHEUS
+  IN CLUSTER quickstart;
+
+CREATE METRIC materialize.public.orders_open
+  IN API materialize.public.app_metrics AS (
+    TYPE 'gauge',
+    HELP 'Number of open orders by status',
+    VALUES FROM materialize.public.orders_by_status,
+    VALUE COLUMN 'count'
+  );
+```
+
+Scrape it:
+
+```
+curl https://<region-host>/metrics/custom/materialize/public/app_metrics
+```
+
+## Related pages
+
+- [`CREATE METRIC`](../create-metric)
+- [`DROP API`](../drop-api)

--- a/doc/user/content/sql/create-metric.md
+++ b/doc/user/content/sql/create-metric.md
@@ -72,14 +72,17 @@ CREATE METRIC materialize.public.orders_open
   );
 ```
 
-A scrape of the API now returns one `orders_open{status="..."}` sample per
-row of `orders_by_status`:
+A scrape of the API now returns one `mz_custom_orders_open{status="..."}`
+sample per row of `orders_by_status`. Every exposed metric name is prefixed
+with `mz_custom_` to namespace it from Materialize's built-in metrics; the
+name you give in `CREATE METRIC` (here, `orders_open`) is what appears in the
+catalog:
 
 ```nofmt
-# HELP orders_open Number of open orders by status
-# TYPE orders_open gauge
-orders_open{status="open"} 2
-orders_open{status="closed"} 1
+# HELP mz_custom_orders_open Number of open orders by status
+# TYPE mz_custom_orders_open gauge
+mz_custom_orders_open{status="open"} 2
+mz_custom_orders_open{status="closed"} 1
 ```
 
 ## Related pages

--- a/doc/user/content/sql/create-metric.md
+++ b/doc/user/content/sql/create-metric.md
@@ -67,7 +67,7 @@ CREATE METRIC materialize.public.orders_open
   IN API materialize.public.app_metrics AS (
     TYPE 'gauge',
     HELP 'Number of open orders by status',
-    VALUES FROM materialize.public.orders_by_status,
+    SERIES FROM materialize.public.orders_by_status,
     VALUE COLUMN 'count'
   );
 ```

--- a/doc/user/content/sql/create-metric.md
+++ b/doc/user/content/sql/create-metric.md
@@ -1,0 +1,88 @@
+---
+title: "CREATE METRIC"
+description: "`CREATE METRIC` exposes a relation as a Prometheus metric on an API created with `CREATE API`."
+menu:
+  main:
+    parent: 'commands'
+---
+
+{{< private-preview />}}
+
+`CREATE METRIC` binds a relation in Materialize to a Prometheus metric on an
+existing [`API`](../create-api). Each row of the relation becomes a sample;
+the value column supplies the numeric value, and the remaining columns
+supply Prometheus label values.
+
+## Syntax
+
+{{% include-syntax file="examples/create_metric" example="syntax" %}}
+
+## Details
+
+### Sampling
+
+When the API is scraped, Materialize evaluates the metric's source relation
+on the API's cluster and produces one Prometheus sample per row. The same
+metric can produce arbitrarily many samples, distinguished by their label
+values.
+
+A relation that produces no rows produces no samples. The metric's `# HELP`
+and `# TYPE` lines are still emitted.
+
+### Metric types
+
+`TYPE 'gauge'` is the only supported metric type today. Counters and
+histograms are not yet supported.
+
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/create-metric" %}}
+
+## Examples
+
+Expose a materialized view of order counts as a Prometheus gauge. The metric
+needs a relation to read and an [`API`](../create-api) to attach to, so create
+those first:
+
+```mzsql
+-- A table (or source) holding the raw data.
+CREATE TABLE orders (id int, status text);
+INSERT INTO orders VALUES
+  (1, 'open'), (2, 'open'), (3, 'closed');
+
+-- A view that aggregates it into one row per label value.
+CREATE MATERIALIZED VIEW orders_by_status AS
+  SELECT status, count(*) AS count
+  FROM orders
+  GROUP BY status;
+
+-- The API that exposes the metric.
+CREATE API materialize.public.app_metrics
+  FORMAT PROMETHEUS
+  IN CLUSTER quickstart;
+
+CREATE METRIC materialize.public.orders_open
+  IN API materialize.public.app_metrics AS (
+    TYPE 'gauge',
+    HELP 'Number of open orders by status',
+    VALUES FROM materialize.public.orders_by_status,
+    VALUE COLUMN 'count'
+  );
+```
+
+A scrape of the API now returns one `orders_open{status="..."}` sample per
+row of `orders_by_status`:
+
+```nofmt
+# HELP orders_open Number of open orders by status
+# TYPE orders_open gauge
+orders_open{status="open"} 2
+orders_open{status="closed"} 1
+```
+
+## Related pages
+
+- [`CREATE API`](../create-api)
+- [`DROP METRIC`](../drop-metric)

--- a/doc/user/content/sql/drop-api.md
+++ b/doc/user/content/sql/drop-api.md
@@ -40,7 +40,7 @@ DROP API materialize.public.app_metrics CASCADE;
 ```
 
 After a successful `DROP API`, subsequent requests to
-`/metrics/custom/<database>/<schema>/<api_name>` return `404`.
+`/api/metrics/custom/<database>/<schema>/<api_name>` return `404`.
 
 ## Privileges
 

--- a/doc/user/content/sql/drop-api.md
+++ b/doc/user/content/sql/drop-api.md
@@ -1,0 +1,55 @@
+---
+title: "DROP API"
+description: "`DROP API` removes a Prometheus scrape endpoint created with `CREATE API`."
+menu:
+  main:
+    parent: 'commands'
+---
+
+{{< private-preview />}}
+
+`DROP API` removes an API created with [`CREATE API`](../create-api). If any
+[metrics](../create-metric) depend on the API, you must drop them first or
+use the `CASCADE` option.
+
+## Syntax
+
+```mzsql
+DROP API [IF EXISTS] <api_name> [, ...] [CASCADE|RESTRICT];
+```
+
+Syntax element | Description
+---------------|------------
+**IF EXISTS** | Optional. If specified, do not return an error if the named API does not exist.
+_api&lowbar;name_ | The API to drop.
+**CASCADE** | Optional. Also drop every metric bound to the API.
+**RESTRICT** | Optional. Refuse to drop the API if any metric depends on it. _(Default)_
+
+## Examples
+
+Drop an API with no dependent metrics:
+
+```mzsql
+DROP API materialize.public.app_metrics;
+```
+
+Drop an API together with its metrics:
+
+```mzsql
+DROP API materialize.public.app_metrics CASCADE;
+```
+
+After a successful `DROP API`, subsequent requests to
+`/metrics/custom/<database>/<schema>/<api_name>` return `404`.
+
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/drop-api" %}}
+
+## Related pages
+
+- [`CREATE API`](../create-api)
+- [`DROP METRIC`](../drop-metric)
+- [`DROP OWNED`](../drop-owned)

--- a/doc/user/content/sql/drop-metric.md
+++ b/doc/user/content/sql/drop-metric.md
@@ -1,0 +1,47 @@
+---
+title: "DROP METRIC"
+description: "`DROP METRIC` removes a Prometheus metric created with `CREATE METRIC`."
+menu:
+  main:
+    parent: 'commands'
+---
+
+{{< private-preview />}}
+
+`DROP METRIC` removes a metric created with [`CREATE METRIC`](../create-metric).
+The metric's API is left in place; if the API has no other metrics, it
+continues to serve an empty exposition.
+
+## Syntax
+
+```mzsql
+DROP METRIC [IF EXISTS] <metric_name> [, ...] [CASCADE|RESTRICT];
+```
+
+Syntax element | Description
+---------------|------------
+**IF EXISTS** | Optional. If specified, do not return an error if the named metric does not exist.
+_metric&lowbar;name_ | The metric to drop.
+**CASCADE** | Optional. Permitted for symmetry with other `DROP` statements. Metrics do not have dependents today, so `CASCADE` and `RESTRICT` behave identically.
+**RESTRICT** | Optional. _(Default)_
+
+## Examples
+
+```mzsql
+DROP METRIC materialize.public.orders_open;
+```
+
+After dropping the metric, scraping its API no longer emits samples for
+`orders_open`.
+
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/drop-metric" %}}
+
+## Related pages
+
+- [`CREATE METRIC`](../create-metric)
+- [`DROP API`](../drop-api)
+- [`DROP OWNED`](../drop-owned)

--- a/doc/user/data/examples/create_api.yml
+++ b/doc/user/data/examples/create_api.yml
@@ -13,7 +13,7 @@
         The identifier for the API.
     - name: "`FORMAT PROMETHEUS`"
       description: |
-        The exposition format served at `/metrics/custom/...` for the API.
+        The exposition format served at `/api/metrics/custom/...` for the API.
         `PROMETHEUS` is the only supported format today.
     - name: "`IN CLUSTER <cluster_name>`"
       description: |

--- a/doc/user/data/examples/create_api.yml
+++ b/doc/user/data/examples/create_api.yml
@@ -1,0 +1,21 @@
+- name: "syntax"
+  code: |
+    CREATE API [IF NOT EXISTS] <name>
+      FORMAT PROMETHEUS
+      [IN CLUSTER <cluster_name>];
+  syntax_elements:
+    - name: "`IF NOT EXISTS`"
+      description: |
+        If specified, do not generate an error if an API of the same name
+        already exists.
+    - name: "`<name>`"
+      description: |
+        The identifier for the API.
+    - name: "`FORMAT PROMETHEUS`"
+      description: |
+        The exposition format served at `/metrics/custom/...` for the API.
+        `PROMETHEUS` is the only supported format today.
+    - name: "`IN CLUSTER <cluster_name>`"
+      description: |
+        The cluster that scrapes the API's metrics will run on. If omitted,
+        the session's active cluster is used.

--- a/doc/user/data/examples/create_metric.yml
+++ b/doc/user/data/examples/create_metric.yml
@@ -4,7 +4,7 @@
       IN API <api_name> AS (
         TYPE '<metric_type>',
         HELP '<help_text>',
-        VALUES FROM <relation>,
+        SERIES FROM <relation>,
         VALUE COLUMN '<column_name>'
       );
   syntax_elements:
@@ -26,7 +26,7 @@
       description: |
         A human-readable description, emitted as the `# HELP` line in the
         exposition.
-    - name: "`VALUES FROM <relation>`"
+    - name: "`SERIES FROM <relation>`"
       description: |
         The view, materialized view, source, or table whose rows are scraped
         each time the API is queried. Every row becomes one sample; columns

--- a/doc/user/data/examples/create_metric.yml
+++ b/doc/user/data/examples/create_metric.yml
@@ -1,0 +1,37 @@
+- name: "syntax"
+  code: |
+    CREATE METRIC [IF NOT EXISTS] <name>
+      IN API <api_name> AS (
+        TYPE '<metric_type>',
+        HELP '<help_text>',
+        VALUES FROM <relation>,
+        VALUE COLUMN '<column_name>'
+      );
+  syntax_elements:
+    - name: "`IF NOT EXISTS`"
+      description: |
+        If specified, do not generate an error if a metric of the same name
+        already exists.
+    - name: "`<name>`"
+      description: |
+        The identifier for the metric. This identifier is also the name
+        emitted in the Prometheus exposition.
+    - name: "`IN API <api_name>`"
+      description: |
+        The [API](../create-api) that exposes this metric.
+    - name: "`TYPE '<metric_type>'`"
+      description: |
+        The Prometheus metric type. Only `'gauge'` is supported today.
+    - name: "`HELP '<help_text>'`"
+      description: |
+        A human-readable description, emitted as the `# HELP` line in the
+        exposition.
+    - name: "`VALUES FROM <relation>`"
+      description: |
+        The view, materialized view, source, or table whose rows are scraped
+        each time the API is queried. Every row becomes one sample; columns
+        other than the value column become Prometheus label values.
+    - name: "`VALUE COLUMN '<column_name>'`"
+      description: |
+        The column of `<relation>` containing the numeric metric value. Must
+        be castable to `f64`.

--- a/doc/user/data/sql_commands_all.yml
+++ b/doc/user/data/sql_commands_all.yml
@@ -110,6 +110,10 @@ rows:
   - command: "[`COPY TO`](/sql/copy-to)"
     labels:
       - "copy"
+  - command: "[`CREATE API`](/sql/create-api)"
+    object: "API"
+    labels:
+      - "object"
   - command: "[`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica)"
     object: "Cluster Replica"
     labels:
@@ -132,6 +136,10 @@ rows:
       - "object"
   - command: "[`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view)"
     object: "Materialized View"
+    labels:
+      - "object"
+  - command: "[`CREATE METRIC`](/sql/create-metric)"
+    object: "Metric"
     labels:
       - "object"
   - command: "[`CREATE NETWORK POLICY`](/sql/create-network-policy)"
@@ -188,6 +196,10 @@ rows:
     object: "session state"
     labels:
       - "session"
+  - command: "[`DROP API`](/sql/drop-api)"
+    object: "API"
+    labels:
+      - "object"
   - command: "[`DROP CLUSTER REPLICA`](/sql/drop-cluster-replica)"
     object: "Cluster Replica"
     labels:
@@ -210,6 +222,10 @@ rows:
       - "object"
   - command: "[`DROP MATERIALIZED VIEW`](/sql/drop-materialized-view)"
     object: "Materialized View"
+    labels:
+      - "object"
+  - command: "[`DROP METRIC`](/sql/drop-metric)"
+    object: "Metric"
     labels:
       - "object"
   - command: "[`DROP NETWORK POLICY`](/sql/drop-network-policy)"


### PR DESCRIPTION
> **Merge last.** This PR is independent of the code PRs (based on `main`), but the docs publish as soon as they merge. Hold it until 1/3 and 2/3 have shipped so the docs don't advertise a feature users can't reach yet.

### Motivation

User-facing reference for the Prometheus metrics feature added in PRs 1/3 and 2/3. Kept separate from the implementation because our docs go live on merge while the code takes longer to roll out — merging docs alongside the code would document a feature that isn't accessible yet.

Design doc: MaterializeInc/materialize#34544.

### Description

A single docs commit adding:

- Reference pages for `CREATE API`, `CREATE METRIC`, `DROP API`, and `DROP METRIC`, with syntax examples.
- Create-time privilege headless includes for each statement.
- A "Scrape-time privileges" section plus a `scrape-api` headless include, documenting the role the `/metrics/custom` endpoint runs as, the required grants, the `anonymous_http_user` case for `authenticator_kind = "None"` listeners, and the `404`/`403` response codes.
- `sql_commands_all.yml` entries so the commands appear in the command index.

No code changes.

### Verification

Docs-only. Rendered locally / via the docs preview to confirm includes resolve and pages build.