### PR TITLE
Fix timestamp overflow when applying timezone offset

### DIFF
--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -762,11 +762,14 @@ fn checked_sub_with_leapsecond(lhs: &NaiveDateTime, rhs: &FixedOffset) -> Option
     let nanos = lhs.nanosecond();
     let lhs = lhs.with_nanosecond(0).unwrap();
     let rhs = rhs.local_minus_utc();
-    lhs.checked_sub_signed(match chrono::Duration::try_seconds(i64::from(rhs)) {
-        Some(dur) => dur,
-        None => return None,
-    })
-    .map(|dt| dt.with_nanosecond(nanos).unwrap())
+    let dt = lhs.checked_sub_signed(chrono::Duration::try_seconds(i64::from(rhs))?)?;
+    // See `checked_add_with_leapsecond` for why we have to special-case
+    // leap-second nanos that no longer land on `:59` after applying the offset.
+    if nanos >= 1_000_000_000 && dt.second() != 59 {
+        dt.checked_add_signed(chrono::Duration::nanoseconds(i64::from(nanos)))
+    } else {
+        Some(dt.with_nanosecond(nanos).unwrap())
+    }
 }
 
 #[derive(

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -727,7 +727,8 @@ pub fn timezone_timestamp(
             }
         },
     };
-    DateTime::from_naive_utc_and_offset(dt - offset, Utc)
+    let dt = checked_sub_with_leapsecond(&dt, &offset).ok_or(EvalError::TimestampOutOfRange)?;
+    DateTime::from_naive_utc_and_offset(dt, Utc)
         .try_into()
         .err_into()
 }
@@ -749,6 +750,19 @@ fn checked_add_with_leapsecond(lhs: &NaiveDateTime, rhs: &FixedOffset) -> Option
     let lhs = lhs.with_nanosecond(0).unwrap();
     let rhs = rhs.local_minus_utc();
     lhs.checked_add_signed(match chrono::Duration::try_seconds(i64::from(rhs)) {
+        Some(dur) => dur,
+        None => return None,
+    })
+    .map(|dt| dt.with_nanosecond(nanos).unwrap())
+}
+
+/// Checked subtraction that is missing from chrono. Adapt its methods here but add a check.
+fn checked_sub_with_leapsecond(lhs: &NaiveDateTime, rhs: &FixedOffset) -> Option<NaiveDateTime> {
+    // extract and temporarily remove the fractional part and later recover it
+    let nanos = lhs.nanosecond();
+    let lhs = lhs.with_nanosecond(0).unwrap();
+    let rhs = rhs.local_minus_utc();
+    lhs.checked_sub_signed(match chrono::Duration::try_seconds(i64::from(rhs)) {
         Some(dur) => dur,
         None => return None,
     })

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -144,6 +144,10 @@ SELECT pg_catalog.timezone(-INTERVAL '1' MINUTE, TIMESTAMP '95143-12-31 23:59:59
 query error timestamp out of range
 SELECT pg_catalog.timezone('JAPAN', TIMESTAMPTZ '95143-12-31 23:59:59+06' + INTERVAL '167 MILLENNIUM')
 
+# Regression for CLU-93: applying a fixed offset to a near-max timestamp must not panic
+query error timestamp out of range
+SELECT (8210266876799000::mz_timestamp::timestamptz AT TIME ZONE 'UTC') AT TIME ZONE '+15:00'
+
 # Test that POSIX is used for timezone() and AT TIME ZONE.
 
 query T


### PR DESCRIPTION
### Motivation

Fixes CLU-93: applying a fixed timezone offset to a near-maximum timestamp could cause a panic instead of properly returning a "timestamp out of range" error.

### Description

The `timezone_timestamp` function was performing unchecked subtraction when applying a timezone offset to a timestamp. When the offset subtraction would overflow the valid timestamp range, this could panic or produce incorrect results.

The fix introduces a new `checked_sub_with_leapsecond` helper function (mirroring the existing `checked_add_with_leapsecond`) that safely performs the subtraction with proper overflow checking. This function:
- Temporarily removes the nanosecond component to avoid precision loss
- Uses `checked_sub_signed` to safely perform the subtraction
- Returns `None` if the operation would overflow
- Recovers the nanosecond component in the result

The caller now properly converts the `Option` result to an `EvalError::TimestampOutOfRange` error instead of panicking.

### Verification

Added a regression test in `timezone.slt` that verifies applying a `+15:00` offset to a near-maximum timestamp returns a "timestamp out of range" error rather than panicking. Existing timezone tests continue to pass.

https://claude.ai/code/session_019Bu679om3fCETwm3nMLmtN