### PR TITLE
Fix FlatMap column references when using non-leading arrangements

### DIFF
--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -616,10 +616,8 @@ impl Context {
                         // positions `0..input_arity`). Table-function output columns at
                         // positions `input_arity..` are appended after the table function in
                         // a fixed order, so we leave those references alone.
-                        let perm_map: BTreeMap<usize, usize> =
-                            permutation.iter().cloned().enumerate().collect();
                         for expr in &mut exprs {
-                            expr.permute_map(&perm_map);
+                            expr.permute(permutation);
                         }
                         let input_arity = permutation.len();
                         let mfp_input_arity = mfp.input_arity;

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -601,20 +601,32 @@ impl Context {
                         has_future_updates: input_future,
                     } = self.lower_mir_expr(flat_map_input)?;
                     // This stage can absorb arbitrary MFP instances.
-                    let mfp = mfp.take();
+                    let mut mfp = mfp.take();
                     let mut exprs = exprs.clone();
-                    let input_key = if let Some((k, permutation, _)) = keys.arbitrary_arrangement()
-                    {
-                        // We don't permute the MFP here, because it runs _after_ the table function,
-                        // whose output is in a fixed order.
-                        //
-                        // We _do_, however, need to permute the `expr`s that provide input to the
-                        // `func`.
-                        let permutation = permutation.iter().cloned().enumerate().collect();
+                    // Prefer the unarranged collection when present: it presents input columns
+                    // in logical order, so no permutation is required.
+                    let input_key = if keys.raw {
+                        None
+                    } else if let Some((k, permutation, _)) = keys.arbitrary_arrangement() {
+                        // Reading from this arrangement exposes input columns in arrangement
+                        // order (key columns followed by thinned value columns). We must
+                        // permute every reference to an input column accordingly: the
+                        // `expr`s feeding the table function arguments, and the `mfp` running
+                        // after the table function (which still references input columns at
+                        // positions `0..input_arity`). Table-function output columns at
+                        // positions `input_arity..` are appended after the table function in
+                        // a fixed order, so we leave those references alone.
+                        let perm_map: BTreeMap<usize, usize> =
+                            permutation.iter().cloned().enumerate().collect();
                         for expr in &mut exprs {
-                            expr.permute_map(&permutation);
+                            expr.permute_map(&perm_map);
                         }
-
+                        let input_arity = permutation.len();
+                        let mfp_input_arity = mfp.input_arity;
+                        mfp.permute_fn(
+                            |c| if c < input_arity { permutation[c] } else { c },
+                            mfp_input_arity,
+                        );
                         Some(k.clone())
                     } else {
                         None
@@ -629,7 +641,7 @@ impl Context {
                         plan: PlanNode::FlatMap {
                             input_key,
                             input: Box::new(input),
-                            exprs: exprs.clone(),
+                            exprs,
                             func: func.clone(),
                             mfp_after: mfp,
                         }

--- a/test/sqllogictest/github-11280.slt
+++ b/test/sqllogictest/github-11280.slt
@@ -1,0 +1,50 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for database-issues#11280: wrong results from a `FlatMap` whose
+# input is only available as an arrangement on a non-leading column. The MFP
+# above the table function references input columns at positions
+# `0..input_arity`, which are in arrangement order rather than logical order.
+# Previously, lowering forwarded the arrangement to the `FlatMap` without
+# permuting those references, so the MFP's projection picked up the wrong
+# columns.
+
+statement ok
+CREATE TABLE t (a INT, b INT, c INT)
+
+statement ok
+INSERT INTO t VALUES (1, 2, 3), (10, 20, 30)
+
+statement ok
+CREATE INDEX idx_c ON t(c)
+
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
+----
+1  2  3  1
+10  20  30  1
+
+# Same shape, but with the index on a different non-leading column.
+statement ok
+DROP INDEX idx_c
+
+statement ok
+CREATE INDEX idx_b ON t(b)
+
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
+----
+1  2  3  1
+10  20  30  1
+
+# A predicate on an input column referenced by the MFP.
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1 AND t.a = 1
+----
+1  2  3  1

--- a/test/sqllogictest/github-11280.slt
+++ b/test/sqllogictest/github-11280.slt
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+mode cockroach
+
 # Regression test for database-issues#11280: wrong results from a `FlatMap` whose
 # input is only available as an arrangement on a non-leading column. The MFP
 # above the table function references input columns at positions
@@ -27,8 +29,14 @@ CREATE INDEX idx_c ON t(c)
 query IIII rowsort
 SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
 ----
-1  2  3  1
-10  20  30  1
+1
+2
+3
+1
+10
+20
+30
+1
 
 # Same shape, but with the index on a different non-leading column.
 statement ok
@@ -40,11 +48,20 @@ CREATE INDEX idx_b ON t(b)
 query IIII rowsort
 SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
 ----
-1  2  3  1
-10  20  30  1
+1
+2
+3
+1
+10
+20
+30
+1
 
 # A predicate on an input column referenced by the MFP.
 query IIII rowsort
 SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1 AND t.a = 1
 ----
-1  2  3  1
+1
+2
+3
+1

--- a/test/sqllogictest/github-11280.slt
+++ b/test/sqllogictest/github-11280.slt
@@ -29,14 +29,8 @@ CREATE INDEX idx_c ON t(c)
 query IIII rowsort
 SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
 ----
-1
-2
-3
-1
-10
-20
-30
-1
+1 2 3 1
+10 20 30 1
 
 # Same shape, but with the index on a different non-leading column.
 statement ok
@@ -48,20 +42,11 @@ CREATE INDEX idx_b ON t(b)
 query IIII rowsort
 SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
 ----
-1
-2
-3
-1
-10
-20
-30
-1
+1 2 3 1
+10 20 30 1
 
 # A predicate on an input column referenced by the MFP.
 query IIII rowsort
 SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1 AND t.a = 1
 ----
-1
-2
-3
-1
+1 2 3 1


### PR DESCRIPTION
### Motivation

Fixes database-issues#11280: `FlatMap` operations were producing wrong results when their input was only available as an arrangement on a non-leading column.

### Description

When a table is arranged on a non-leading column (e.g., column `c` in a table with columns `a, b, c`), the arrangement exposes columns in arrangement order (key columns first, then value columns) rather than logical order. The lowering code was forwarding this arrangement to `FlatMap` operations without properly permuting column references.

The fix addresses two issues:

1. **Prefer unarranged input**: When available, use the raw unarranged collection which presents columns in logical order, avoiding permutation entirely.

2. **Permute MFP references**: When an arrangement must be used, permute not only the table function argument expressions (as before) but also the MFP (Map-Filter-Project) that runs after the table function. The MFP still references input columns at positions `0..input_arity`, which must be adjusted to account for the arrangement's reordering. Table function output columns are left unchanged since they're appended in a fixed order.

The key insight is that the MFP runs after the table function and still uses logical column positions for input references, so it requires the same permutation as the table function arguments.

### Verification

Added regression test `test/sqllogictest/github-11280.slt` that covers:
- `FlatMap` with `LATERAL generate_series` on a table with an index on a non-leading column
- Multiple index configurations (on column `c` and column `b`)
- Predicates on both the table function output and input columns

The test verifies that queries return correct results regardless of which non-leading column is indexed.

https://claude.ai/code/session_01DeVqtkFQNP1dxdkSCQ5Gxu