### PR TITLE
console: add subscribe health atom

### DIFF
--- a/console/src/components/AppInitializer.tsx
+++ b/console/src/components/AppInitializer.tsx
@@ -29,7 +29,7 @@ import IncidentStatusWidget from "./IncidentStatusWidget/IncidentStatusWidget";
 /** Initializes global features, rendered after frontegg token is available if Cloud */
 const useAppInitializer = () => {
   useTrackFocus();
-  usePollEnvironmentHealth({ intervalMs: 5000 });
+  usePollEnvironmentHealth({ intervalMs: 30_000 });
   useShowEnvironmentErrors();
   useSetInitialRegion();
   usePrivileges();

--- a/console/src/store/environments.ts
+++ b/console/src/store/environments.ts
@@ -341,6 +341,19 @@ export const mergeEnvironmentsWithHealth = atom(
   },
 );
 
+// Interval used while bootstrapping, before any environment is healthy.
+const BOOTSTRAP_POLL_INTERVAL_MS = 5_000;
+
+/** True once every enabled environment is healthy. */
+const allEnvironmentsHealthy = (environments?: EnvironmentsWithHealth) => {
+  const enabled = [...(environments?.values() ?? [])].filter(
+    (env): env is EnabledEnvironment => env.state === "enabled",
+  );
+  return (
+    enabled.length > 0 && enabled.every((e) => e.status.health === "healthy")
+  );
+};
+
 /**
  * Polls for region information and environment health.
  */
@@ -357,7 +370,13 @@ export const usePollEnvironmentHealth = (options: { intervalMs: number }) => {
   // eslint-disable-next-line @tanstack/query/exhaustive-deps
   useSuspenseQuery({
     queryKey: [...environmentQueryKeys.environmentHealth(cloudRegions)],
-    refetchInterval: options.intervalMs,
+    // Back off to the slower interval once healthy; a steady environment is
+    // already proven reachable, so frequent health checks just burn connection
+    // slots. Poll fast until then so bootstrap transitions surface promptly.
+    refetchInterval: (query) =>
+      allEnvironmentsHealthy(query.state.data)
+        ? options.intervalMs
+        : BOOTSTRAP_POLL_INTERVAL_MS,
     queryFn: async () => {
       return Sentry.startSpan(
         {


### PR DESCRIPTION
Environment health polls `SELECT mz_version()` on mz_catalog_server every 5s per tab. Once a global SUBSCRIBE is streaming, the environment is already proven reachable, so the poll is redundant.

Derive health from subscribe state (`subscribeDerivedHealthAtom`) and back the poll off to 30s while subscribes are healthy; keep 5s during bootstrap and when subscribes go down, so recovery and the crashed/blocked banner still surface.

This frees up browser connection slots that 5 second health poll check was taking. Tested against workload capture for production analytics workload. Health  checks requests on a 6 tab stress test have around 45 concurrent in flight requests in 2 mins. This change brought it down to 7-9 concurrent requests. Worse case requsest queue time shows one health request stuck at  240s behind a saturated pool. This change brought it down to 1 ms.

Fixes [CNS-83](https://linear.app/materializeinc/issue/CNS-83/fix-health-check-polling-in-the-console)