### PR TITLE
compute-types: fix FlatMap column refs for non-column arrangement keys

### DIFF
--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -607,23 +607,36 @@ impl Context {
                     // in logical order, so no permutation is required.
                     let input_key = if keys.raw {
                         None
-                    } else if let Some((k, permutation, _)) = keys.arbitrary_arrangement() {
+                    } else if let Some((k, permutation, thinning)) = keys.arbitrary_arrangement() {
                         // Reading from this arrangement exposes input columns in arrangement
                         // order (key columns followed by thinned value columns). We must
                         // permute every reference to an input column accordingly: the
                         // `expr`s feeding the table function arguments, and the `mfp` running
                         // after the table function (which still references input columns at
-                        // positions `0..input_arity`). Table-function output columns at
-                        // positions `input_arity..` are appended after the table function in
-                        // a fixed order, so we leave those references alone.
+                        // positions `0..input_arity`).
+                        //
+                        // The renderer hands the `mfp` the *whole* arranged row and appends the
+                        // table-function output after it. The arranged row can be wider than the
+                        // logical input row when the key is not a set of distinct columns (an
+                        // expression, functional, or repeated-column key carries extra key
+                        // values). So the table-function output columns at positions
+                        // `input_arity..` must be shifted to land after the arranged row, and the
+                        // `mfp`'s new input arity must reflect the arranged width.
                         for expr in &mut exprs {
                             expr.permute(permutation);
                         }
                         let input_arity = permutation.len();
-                        let mfp_input_arity = mfp.input_arity;
+                        let arranged_arity = thinning.len() + k.len();
+                        let output_arity = mfp.input_arity - input_arity;
                         mfp.permute_fn(
-                            |c| if c < input_arity { permutation[c] } else { c },
-                            mfp_input_arity,
+                            |c| {
+                                if c < input_arity {
+                                    permutation[c]
+                                } else {
+                                    arranged_arity + (c - input_arity)
+                                }
+                            },
+                            arranged_arity + output_arity,
                         );
                         Some(k.clone())
                     } else {

--- a/test/sqllogictest/github-11280.slt
+++ b/test/sqllogictest/github-11280.slt
@@ -50,3 +50,61 @@ query IIII rowsort
 SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1 AND t.a = 1
 ----
 1 2 3 1
+
+# The same bug also affects arrangements whose key is not a set of distinct
+# column references (expression, functional, or repeated-column index): the
+# arranged row is wider than the logical row, so the table-function output lands
+# after it and the MFP must reference it at that wider position.
+
+# --- Expression-keyed index: CREATE INDEX ON t (a + b) ---
+statement ok
+DROP INDEX idx_b
+
+statement ok
+CREATE INDEX idx_expr ON t (a + b)
+
+# Empty-result failure mode: the predicate ends up testing a value column.
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
+----
+1 2 3 1
+10 20 30 1
+
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1 AND t.a = 1
+----
+1 2 3 1
+
+# Wrong-column-projection failure mode: the MFP projects a value column where
+# the table-function output should be (here gs.v = t.a, distinct from t.c).
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL unnest(ARRAY[t.a]) AS gs(v)
+----
+1 2 3 1
+10 20 30 10
+
+# --- Functional index: CREATE INDEX ON t (abs(a)) ---
+statement ok
+DROP INDEX idx_expr
+
+statement ok
+CREATE INDEX idx_func ON t (abs(a))
+
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
+----
+1 2 3 1
+10 20 30 1
+
+# --- Repeated-column index: CREATE INDEX ON t (c, c) ---
+statement ok
+DROP INDEX idx_func
+
+statement ok
+CREATE INDEX idx_rep ON t (c, c)
+
+query IIII rowsort
+SELECT t.a, t.b, t.c, gs.v FROM t, LATERAL generate_series(1, t.c) AS gs(v) WHERE gs.v = 1
+----
+1 2 3 1
+10 20 30 1


### PR DESCRIPTION
When a FlatMap reads from an arrangement whose key is not a set of distinct column references (an expression, functional, or repeated-column index), the arranged row is wider than the logical input row because it carries the extra key value(s). The renderer hands the MFP the whole arranged row and appends the table-function output after it, so the MFP must reference the output columns at that wider position and use the wider input arity. Leaving them at their logical positions produced silently wrong results: an empty result when an output column was filtered, or a wrong-column projection otherwise.

Account for the arranged width (thinning.len() + key.len()) when permuting the MFP, and extend github-11280.slt to cover expression, functional, and repeated-column keys.

Closes CLU-70

Sorry for only noticing after https://github.com/MaterializeInc/materialize/pull/36756 merged!