### PR TITLE
[SCIM] make oidc_group_claim and oidc_group_role_sync_strict user-modifiable

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -76,6 +76,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use imbl::OrdMap;
+use mz_adapter_types::dyncfgs::{OIDC_GROUP_CLAIM, OIDC_GROUP_ROLE_SYNC_STRICT};
 use mz_build_info::BuildInfo;
 use mz_dyncfg::{ConfigSet, ConfigType, ConfigUpdates, ConfigVal};
 use mz_persist_client::cfg::{
@@ -1248,33 +1249,51 @@ impl SystemVars {
         let dyncfgs = mz_dyncfgs::all_dyncfgs();
         let dyncfg_vars: Vec<_> = dyncfgs
             .entries()
-            .map(|cfg| match cfg.default() {
-                ConfigVal::Bool(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
-                }
-                ConfigVal::U32(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
-                }
-                ConfigVal::Usize(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
-                }
-                ConfigVal::OptUsize(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
-                }
-                ConfigVal::F64(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
-                }
-                ConfigVal::String(default) => {
-                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
-                }
-                ConfigVal::OptString(default) => {
-                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
-                }
-                ConfigVal::Duration(default) => {
-                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
-                }
-                ConfigVal::Json(default) => {
-                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
+            .map(|cfg| {
+                // Most dyncfgs are internal-only; these two must be visible to
+                // environment superusers so ALTER SYSTEM SET can reach them.
+                let user_visible = cfg.name() == OIDC_GROUP_CLAIM.name()
+                    || cfg.name() == OIDC_GROUP_ROLE_SYNC_STRICT.name();
+                match cfg.default() {
+                    ConfigVal::Bool(default) => {
+                        VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), user_visible)
+                    }
+                    ConfigVal::U32(default) => {
+                        VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), user_visible)
+                    }
+                    ConfigVal::Usize(default) => {
+                        VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), user_visible)
+                    }
+                    ConfigVal::OptUsize(default) => {
+                        VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), user_visible)
+                    }
+                    ConfigVal::F64(default) => {
+                        VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), user_visible)
+                    }
+                    ConfigVal::String(default) => VarDefinition::new_runtime(
+                        cfg.name(),
+                        default.clone(),
+                        cfg.desc(),
+                        user_visible,
+                    ),
+                    ConfigVal::OptString(default) => VarDefinition::new_runtime(
+                        cfg.name(),
+                        default.clone(),
+                        cfg.desc(),
+                        user_visible,
+                    ),
+                    ConfigVal::Duration(default) => VarDefinition::new_runtime(
+                        cfg.name(),
+                        default.clone(),
+                        cfg.desc(),
+                        user_visible,
+                    ),
+                    ConfigVal::Json(default) => VarDefinition::new_runtime(
+                        cfg.name(),
+                        default.clone(),
+                        cfg.desc(),
+                        user_visible,
+                    ),
                 }
             })
             .collect();
@@ -1375,6 +1394,8 @@ impl SystemVars {
         SESSION_SYSTEM_VARS.contains_key(UncasedStr::new(name))
             || name == ENABLE_RBAC_CHECKS.name()
             || name == NETWORK_POLICY.name()
+            || name == OIDC_GROUP_CLAIM.name()
+            || name == OIDC_GROUP_ROLE_SYNC_STRICT.name()
     }
 
     /// Returns a [`Var`] representing the configuration parameter with the

--- a/test/sqllogictest/oidc_group_sync_vars.slt
+++ b/test/sqllogictest/oidc_group_sync_vars.slt
@@ -1,0 +1,166 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that oidc_group_claim and oidc_group_role_sync_strict are user-modifiable
+# system variables: settable via ALTER SYSTEM SET, with the right error for
+# non-superusers (must be superuser, not must be mz_system).
+
+mode standard
+
+reset-server
+
+# --- oidc_group_claim ---
+
+# Default value is "groups"
+simple conn=mz_system,user=mz_system
+SHOW oidc_group_claim
+----
+groups
+COMPLETE 1
+
+# Can be set
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET oidc_group_claim = 'my_groups'
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+SHOW oidc_group_claim
+----
+my_groups
+COMPLETE 1
+
+# Can be reset back to default
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET oidc_group_claim
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+SHOW oidc_group_claim
+----
+groups
+COMPLETE 1
+
+# --- oidc_group_role_sync_strict ---
+
+# Default value is off (false)
+simple conn=mz_system,user=mz_system
+SHOW oidc_group_role_sync_strict
+----
+off
+COMPLETE 1
+
+# Can be set
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET oidc_group_role_sync_strict = on
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+SHOW oidc_group_role_sync_strict
+----
+on
+COMPLETE 1
+
+# Can be reset back to default
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET oidc_group_role_sync_strict
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+SHOW oidc_group_role_sync_strict
+----
+off
+COMPLETE 1
+
+# --- Invalid values ---
+
+# Invalid value for bool var returns typed error (not permission error)
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET oidc_group_role_sync_strict = 'not_a_bool'
+----
+db error: ERROR: parameter "oidc_group_role_sync_strict" requires a "boolean" value
+
+# --- Authorization: requires superuser ---
+#
+# These vars are user_modifiable so the error for a non-superuser says
+# "must be a superuser" rather than "must be mz_system", indicating that
+# any environment superuser (not just internal mz_system) can set them.
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE r_nonsuperuser
+----
+COMPLETE 0
+
+simple conn=r_nonsuperuser,user=r_nonsuperuser
+ALTER SYSTEM SET oidc_group_claim = 'should_fail'
+----
+db error: ERROR: permission denied to toggle the 'oidc_group_claim' system configuration parameter
+DETAIL: You must be a superuser to toggle the 'oidc_group_claim' system configuration parameter
+
+simple conn=r_nonsuperuser,user=r_nonsuperuser
+ALTER SYSTEM SET oidc_group_role_sync_strict = on
+----
+db error: ERROR: permission denied to toggle the 'oidc_group_role_sync_strict' system configuration parameter
+DETAIL: You must be a superuser to toggle the 'oidc_group_role_sync_strict' system configuration parameter
+
+simple conn=mz_system,user=mz_system
+DROP ROLE r_nonsuperuser
+----
+COMPLETE 0
+
+# --- Authorization: environment superuser (non-internal SUPERUSER) can set these vars ---
+#
+# Because dyncfg-backed vars default to user_visible=false, an external superuser
+# would get "unrecognized configuration parameter" unless we explicitly mark these
+# two as user_visible=true. Verify that a real (non-mz_system) superuser can set them.
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE r_env_superuser SUPERUSER
+----
+COMPLETE 0
+
+simple conn=r_env_superuser,user=r_env_superuser
+ALTER SYSTEM SET oidc_group_claim = 'env_groups'
+----
+COMPLETE 0
+
+simple conn=r_env_superuser,user=r_env_superuser
+SHOW oidc_group_claim
+----
+env_groups
+COMPLETE 1
+
+simple conn=r_env_superuser,user=r_env_superuser
+ALTER SYSTEM SET oidc_group_role_sync_strict = on
+----
+COMPLETE 0
+
+simple conn=r_env_superuser,user=r_env_superuser
+SHOW oidc_group_role_sync_strict
+----
+on
+COMPLETE 1
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET oidc_group_claim
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET oidc_group_role_sync_strict
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP ROLE r_env_superuser
+----
+COMPLETE 0

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -64,6 +64,8 @@ max_sources                              200                     "The maximum nu
 max_sql_server_connections               1000                    "The maximum number of SQL Server connections in the region, across all schemas (Materialize)."
 max_tables                               200                     "The maximum number of tables in the region, across all schemas (Materialize)."
 network_policy                           default                 "Sets the fallback network policy applied to all users without an explicit policy."
+oidc_group_claim                         groups                  "JWT claim name containing group memberships for role sync."
+oidc_group_role_sync_strict              off                     "When true, reject login if OIDC group-to-role sync fails (fail-closed)."
 optimizer_e2e_latency_warning_threshold  "500 ms"                "Sets the duration that a query can take to compile; queries that take longer will trigger a warning. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout (Materialize)."
 mz_version                               <VARIES>                "Shows the Materialize server version (Materialize)."
 scram_iterations                         600000                  "Iterations to use when hashing passwords. Higher iterations are more secure, but take longer to validated. Please consider the security risks before reducing this below the default value."


### PR DESCRIPTION
Allow environment superusers to configure OIDC group-sync settings via ALTER SYSTEM SET without needing mz_system access. This is appropriate since these control how a customer's own OIDC claims map to roles.

Fixes SQL-321