### PR TITLE
sql: drop multiple co-dependent items in one statement

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5357,8 +5357,10 @@ pub fn plan_drop_objects(
                 plan_drop_role(scx, if_exists, name)?.map(ObjectId::Role)
             }
             UnresolvedObjectName::Item(name) => {
-                plan_drop_item(scx, object_type, if_exists, name.clone(), cascade)?
-                    .map(ObjectId::Item)
+                // Defer the dependency check until all names are resolved, so a
+                // dependent that is itself being dropped in this same statement
+                // does not block a non-cascade drop.
+                plan_drop_item_name(scx, object_type, if_exists, name.clone())?.map(ObjectId::Item)
             }
             UnresolvedObjectName::NetworkPolicy(name) => {
                 plan_drop_network_policy(scx, if_exists, name)?.map(ObjectId::NetworkPolicy)
@@ -5372,6 +5374,24 @@ pub fn plan_drop_objects(
             }),
         }
     }
+
+    // Now that the full set of explicitly-named items is known, run the
+    // non-cascade dependency check. A dependent that is itself being dropped in
+    // this statement does not block the drop, matching PostgreSQL.
+    if !cascade {
+        let dropped_items: BTreeSet<CatalogItemId> = referenced_ids
+            .iter()
+            .filter_map(|id| match id {
+                ObjectId::Item(id) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        for id in &dropped_items {
+            let catalog_item = scx.catalog.get_item(id);
+            ensure_no_blocking_dependents(scx, object_type, catalog_item, &dropped_items)?;
+        }
+    }
+
     let drop_ids = scx.catalog.object_dependents(&referenced_ids);
 
     Ok(Plan::DropObjects(DropObjectsPlan {
@@ -5508,6 +5528,25 @@ fn plan_drop_item(
     name: UnresolvedItemName,
     cascade: bool,
 ) -> Result<Option<CatalogItemId>, PlanError> {
+    let Some(id) = plan_drop_item_name(scx, object_type, if_exists, name)? else {
+        return Ok(None);
+    };
+    if !cascade {
+        let catalog_item = scx.catalog.get_item(&id);
+        ensure_no_blocking_dependents(scx, object_type, catalog_item, &BTreeSet::new())?;
+    }
+    Ok(Some(id))
+}
+
+/// Resolves `name` to the [`CatalogItemId`] of the item to drop, performing the
+/// system-object check but *not* the dependency check. Returns `None` if the
+/// item does not exist and `if_exists` is set.
+fn plan_drop_item_name(
+    scx: &StatementContext,
+    object_type: ObjectType,
+    if_exists: bool,
+    name: UnresolvedItemName,
+) -> Result<Option<CatalogItemId>, PlanError> {
     let resolved = match resolve_item_or_type(scx, object_type, name, if_exists) {
         Ok(r) => r,
         // Return a more helpful error on `DROP VIEW <materialized-view>`.
@@ -5530,31 +5569,44 @@ fn plan_drop_item(
                     scx.catalog.minimal_qualification(catalog_item.name()),
                 );
             }
-
-            if !cascade {
-                for id in catalog_item.used_by() {
-                    let dep = scx.catalog.get_item(id);
-                    if dependency_prevents_drop(object_type, dep) {
-                        return Err(PlanError::DependentObjectsStillExist {
-                            object_type: catalog_item.item_type().to_string(),
-                            object_name: scx
-                                .catalog
-                                .minimal_qualification(catalog_item.name())
-                                .to_string(),
-                            dependents: vec![(
-                                dep.item_type().to_string(),
-                                scx.catalog.minimal_qualification(dep.name()).to_string(),
-                            )],
-                        });
-                    }
-                }
-                // TODO(jkosh44) It would be nice to also check if any active subscribe or pending peek
-                //  relies on entry. Unfortunately, we don't have that information readily available.
-            }
             Some(catalog_item.id())
         }
         None => None,
     })
+}
+
+/// Errors if dropping `catalog_item` would leave a dangling dependent, i.e. an
+/// object that depends on it and is not itself being dropped. Dependents whose
+/// ids are in `also_dropped` are ignored, since they are being dropped as part
+/// of the same statement.
+fn ensure_no_blocking_dependents(
+    scx: &StatementContext,
+    object_type: ObjectType,
+    catalog_item: &dyn CatalogItem,
+    also_dropped: &BTreeSet<CatalogItemId>,
+) -> Result<(), PlanError> {
+    for id in catalog_item.used_by() {
+        if also_dropped.contains(id) {
+            continue;
+        }
+        let dep = scx.catalog.get_item(id);
+        if dependency_prevents_drop(object_type, dep) {
+            return Err(PlanError::DependentObjectsStillExist {
+                object_type: catalog_item.item_type().to_string(),
+                object_name: scx
+                    .catalog
+                    .minimal_qualification(catalog_item.name())
+                    .to_string(),
+                dependents: vec![(
+                    dep.item_type().to_string(),
+                    scx.catalog.minimal_qualification(dep.name()).to_string(),
+                )],
+            });
+        }
+    }
+    // TODO(jkosh44) It would be nice to also check if any active subscribe or pending peek
+    //  relies on entry. Unfortunately, we don't have that information readily available.
+    Ok(())
 }
 
 /// Does the dependency `dep` prevent a drop of a non-cascade query?

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -91,6 +91,54 @@ contains:cannot drop view "test1": still depended upon by view "test2"
 
 > DROP VIEW test1;
 
+# Test that a single DROP statement can drop an object together with its
+# dependents (without CASCADE): a dependent that is itself being dropped in the
+# same statement must not block the drop.
+
+> CREATE VIEW test1 AS SELECT 1;
+
+> CREATE VIEW test2 AS SELECT * FROM test1;
+
+> CREATE VIEW test3 AS SELECT * FROM test2;
+
+> DROP VIEW test1, test2, test3;
+
+# The order in which the objects are named must not matter.
+
+> CREATE VIEW test1 AS SELECT 1;
+
+> CREATE VIEW test2 AS SELECT * FROM test1;
+
+> CREATE VIEW test3 AS SELECT * FROM test2;
+
+> DROP VIEW test3, test1, test2;
+
+# Dropping an intermediate object together with its dependent still works while
+# leaving an upstream object in place.
+
+> CREATE VIEW test1 AS SELECT 1;
+
+> CREATE VIEW test2 AS SELECT * FROM test1;
+
+> CREATE VIEW test3 AS SELECT * FROM test2;
+
+> DROP VIEW test2, test3;
+
+# test1 has no dependents anymore, so it drops on its own.
+
+> DROP VIEW test1;
+
+# But omitting a dependent from the statement still errors without CASCADE.
+
+> CREATE VIEW test1 AS SELECT 1;
+
+> CREATE VIEW test2 AS SELECT * FROM test1;
+
+! DROP VIEW test1;
+contains:cannot drop view "test1": still depended upon by view "test2"
+
+> DROP VIEW test1 CASCADE;
+
 # Test that CASCADE causes all dependent views to be dropped along with the
 # named view.
 


### PR DESCRIPTION
`DROP VIEW v1, v2` (and analogously for other item types) failed with "still depended upon by ..." when v2 depended on v1, even though v2 was explicitly named in the same statement. `plan_drop_objects` resolved names one at a time and ran the non-CASCADE dependency check inside `plan_drop_item` before knowing the full set of objects being dropped, so a dependent that was itself being dropped still blocked the drop.

Split `plan_drop_item` into a name-resolution step (`plan_drop_item_name`) and a dependency-check helper (`ensure_no_blocking_dependents`) that takes a set of co-dropped item ids. `plan_drop_objects` now resolves all names first, then runs the dependency check with the full set of explicitly-named items, skipping dependents that are themselves being dropped. The two CREATE OR REPLACE callers of `plan_drop_item` are unaffected: they pass an empty co-dropped set and preserve the prior behavior.

This matches PostgreSQL, which lets you drop an object together with its dependents in a single statement without CASCADE.

Fixes SQL-151