### PR TITLE
Fix physical monotonicity analysis for MFP and FlatMap

### DIFF
--- a/src/compute-types/src/plan/interpret/physically_monotonic.rs
+++ b/src/compute-types/src/plan/interpret/physically_monotonic.rs
@@ -125,12 +125,15 @@ impl Interpreter for SingleTimeMonotonic<'_> {
         &self,
         _ctx: &Context<Self::Domain>,
         input: Self::Domain,
-        _mfp: &MapFilterProject,
+        mfp: &MapFilterProject,
         _input_key_val: &Option<(Vec<MirScalarExpr>, Option<Row>)>,
     ) -> Self::Domain {
-        // In a single-time context, we just propagate the monotonicity
-        // status of the input
-        input
+        // In a single-time context, we propagate the monotonicity status of the
+        // input, unless the MFP contains temporal predicates. Temporal predicates
+        // (i.e., `mz_now()`) can result in the future removal of records, thus
+        // breaking physical monotonicity. This matches the judgment made for
+        // `MirRelationExpr::Filter` in the MIR monotonicity analysis.
+        PhysicallyMonotonic(input.0 && !mfp.has_temporal_predicates())
     }
 
     fn flat_map(
@@ -139,12 +142,19 @@ impl Interpreter for SingleTimeMonotonic<'_> {
         _input_key: &Option<Vec<MirScalarExpr>>,
         input: Self::Domain,
         _exprs: &Vec<MirScalarExpr>,
-        _func: &TableFunc,
-        _mfp: &MapFilterProject,
+        func: &TableFunc,
+        mfp: &MapFilterProject,
     ) -> Self::Domain {
-        // In a single-time context, we just propagate the monotonicity
-        // status of the input
-        input
+        // In a single-time context, we propagate the monotonicity status of the
+        // input, but only if the table function preserves the append-only
+        // property of its input (e.g., `repeat_row` does not). Additionally, the
+        // MFP applied after the table function must not contain temporal
+        // predicates, as those can result in the future removal of records. This
+        // matches the judgment made for `MirRelationExpr::FlatMap` (combined with
+        // `MirRelationExpr::Filter`) in the MIR monotonicity analysis.
+        PhysicallyMonotonic(
+            input.0 && func.preserves_monotonicity() && !mfp.has_temporal_predicates(),
+        )
     }
 
     fn join(
@@ -247,5 +257,120 @@ impl Interpreter for SingleTimeMonotonic<'_> {
         // collection. With this information, we could eventually make more refined judgements
         // at the points of use.
         input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_expr::UnmaterializableFunc;
+
+    use super::*;
+
+    /// A `MapFilterProject` over `arity` columns that contains a temporal
+    /// predicate (i.e., a predicate referencing `mz_now()`).
+    fn temporal_mfp(arity: usize) -> MapFilterProject {
+        MapFilterProject::new(arity).filter([MirScalarExpr::CallUnmaterializable(
+            UnmaterializableFunc::MzNow,
+        )])
+    }
+
+    #[mz_ore::test]
+    fn flat_map_preserves_monotonicity_for_monotonicity_preserving_func() {
+        let monotonic_ids = BTreeSet::new();
+        let interpreter = SingleTimeMonotonic::new(&monotonic_ids);
+        let ctx = Context::default();
+        let mfp = MapFilterProject::new(1);
+
+        // A monotonicity-preserving table function (e.g., `generate_series`)
+        // propagates the input's monotonicity.
+        let result = interpreter.flat_map(
+            &ctx,
+            &None,
+            PhysicallyMonotonic(true),
+            &vec![],
+            &TableFunc::GenerateSeriesInt64,
+            &mfp,
+        );
+        assert_eq!(result, PhysicallyMonotonic(true));
+
+        // A non-monotonic input stays non-monotonic.
+        let result = interpreter.flat_map(
+            &ctx,
+            &None,
+            PhysicallyMonotonic(false),
+            &vec![],
+            &TableFunc::GenerateSeriesInt64,
+            &mfp,
+        );
+        assert_eq!(result, PhysicallyMonotonic(false));
+    }
+
+    #[mz_ore::test]
+    fn flat_map_breaks_monotonicity_for_non_monotonicity_preserving_func() {
+        let monotonic_ids = BTreeSet::new();
+        let interpreter = SingleTimeMonotonic::new(&monotonic_ids);
+        let ctx = Context::default();
+        let mfp = MapFilterProject::new(1);
+
+        // `repeat_row` does not preserve monotonicity (it can emit retractions),
+        // so even a physically monotonic input yields a non-monotonic output.
+        // This is the bug from CLU-68: the interpreter used to blindly propagate
+        // the input's monotonicity here.
+        let result = interpreter.flat_map(
+            &ctx,
+            &None,
+            PhysicallyMonotonic(true),
+            &vec![],
+            &TableFunc::RepeatRow,
+            &mfp,
+        );
+        assert_eq!(result, PhysicallyMonotonic(false));
+    }
+
+    #[mz_ore::test]
+    fn flat_map_breaks_monotonicity_for_temporal_mfp() {
+        let monotonic_ids = BTreeSet::new();
+        let interpreter = SingleTimeMonotonic::new(&monotonic_ids);
+        let ctx = Context::default();
+
+        // Even with a monotonicity-preserving table function and a monotonic
+        // input, a temporal predicate in the after-MFP breaks monotonicity, as
+        // it can result in the future removal of records.
+        let result = interpreter.flat_map(
+            &ctx,
+            &None,
+            PhysicallyMonotonic(true),
+            &vec![],
+            &TableFunc::GenerateSeriesInt64,
+            &temporal_mfp(1),
+        );
+        assert_eq!(result, PhysicallyMonotonic(false));
+    }
+
+    #[mz_ore::test]
+    fn mfp_propagates_monotonicity_without_temporal_predicates() {
+        let monotonic_ids = BTreeSet::new();
+        let interpreter = SingleTimeMonotonic::new(&monotonic_ids);
+        let ctx = Context::default();
+        let mfp = MapFilterProject::new(1);
+
+        // Without temporal predicates, the MFP just propagates its input's
+        // monotonicity.
+        let result = interpreter.mfp(&ctx, PhysicallyMonotonic(true), &mfp, &None);
+        assert_eq!(result, PhysicallyMonotonic(true));
+
+        let result = interpreter.mfp(&ctx, PhysicallyMonotonic(false), &mfp, &None);
+        assert_eq!(result, PhysicallyMonotonic(false));
+    }
+
+    #[mz_ore::test]
+    fn mfp_breaks_monotonicity_for_temporal_predicates() {
+        let monotonic_ids = BTreeSet::new();
+        let interpreter = SingleTimeMonotonic::new(&monotonic_ids);
+        let ctx = Context::default();
+
+        // A temporal predicate breaks monotonicity even for a monotonic input.
+        let result = interpreter.mfp(&ctx, PhysicallyMonotonic(true), &temporal_mfp(1), &None);
+        assert_eq!(result, PhysicallyMonotonic(false));
     }
 }

--- a/src/compute-types/src/plan/interpret/physically_monotonic.rs
+++ b/src/compute-types/src/plan/interpret/physically_monotonic.rs
@@ -151,11 +151,14 @@ impl Interpreter for SingleTimeMonotonic<'_> {
     ) -> Self::Domain {
         // In a single-time context, we propagate the monotonicity status of the
         // input, but only if the table function preserves the append-only
-        // property of its input (e.g., `repeat_row` does not). Additionally, the
-        // MFP applied after the table function must not contain temporal
-        // predicates, as those can result in the future removal of records. This
-        // matches the judgment made for `MirRelationExpr::FlatMap` (combined with
-        // `MirRelationExpr::Filter`) in the MIR monotonicity analysis.
+        // property of its input. A table function such as `repeat_row` can emit
+        // negative diffs and so does not preserve monotonicity; this is the only
+        // substantive check here. The post-MFP temporal-predicate check is, as in
+        // `mfp()` above, conservative defense-in-depth: temporal predicates only
+        // introduce retractions across timestamps and a one-shot dataflow runs at
+        // a single time. Together this mirrors the judgment made for
+        // `MirRelationExpr::FlatMap` (combined with `MirRelationExpr::Filter`) in
+        // the MIR monotonicity analysis.
         PhysicallyMonotonic(
             input.0 && func.preserves_monotonicity() && !mfp.has_temporal_predicates(),
         )

--- a/src/compute-types/src/plan/interpret/physically_monotonic.rs
+++ b/src/compute-types/src/plan/interpret/physically_monotonic.rs
@@ -129,9 +129,13 @@ impl Interpreter for SingleTimeMonotonic<'_> {
         _input_key_val: &Option<(Vec<MirScalarExpr>, Option<Row>)>,
     ) -> Self::Domain {
         // In a single-time context, we propagate the monotonicity status of the
-        // input, unless the MFP contains temporal predicates. Temporal predicates
-        // (i.e., `mz_now()`) can result in the future removal of records, thus
-        // breaking physical monotonicity. This matches the judgment made for
+        // input, conservatively treating an MFP with temporal predicates as
+        // breaking physical monotonicity. Note that an MFP cannot itself produce
+        // negative diffs (map/filter/project never negate), so this is stricter
+        // than strictly necessary for a single-time dataflow: temporal predicates
+        // (`mz_now()`) only introduce retractions *across* timestamps, and a
+        // one-shot dataflow runs at a single time. We keep the check anyway as
+        // defense-in-depth and to mirror the judgment made for
         // `MirRelationExpr::Filter` in the MIR monotonicity analysis.
         PhysicallyMonotonic(input.0 && !mfp.has_temporal_predicates())
     }


### PR DESCRIPTION
### Motivation

CLU-68: The `SingleTimeMonotonic` physical-monotonicity interpreter propagated
the input's monotonicity through `mfp` and `flat_map` without consulting the
MFP's predicates or the table function's properties. The MIR monotonicity
analysis (`src/transform/src/analysis/monotonic.rs`) already accounts for both,
so the LIR interpreter was inconsistent with it.

### Severity

The practical correctness impact is low, and this is best understood as
defense-in-depth / consistency rather than a live bug fix:

- This analysis only ever **relaxes** the safe default. Single-time peeks set
  `must_consolidate = true` on hierarchical reductions / TopK by default; a
  positive physical-monotonicity result is what lets that be relaxed to
  `false`. A spuriously monotonic result is therefore the only way to cause
  trouble.
- The only LIR-reachable operator that can actually emit negative diffs is
  `repeat_row` with a negative count, which requires the unsafe
  `enable_repeat_row` flag and is not meaningfully representable in a
  single-time peek (a consolidated `-1` row has no SQL meaning).
- `preserves_monotonicity()` also returns `false` for `AclExplode`,
  `MzAclExplode`, and `GuardSubquerySize`, but those classifications are
  conservative — they do not emit negative diffs.

So no known query produces wrong results today; the change keeps the LIR
interpreter honest and aligned with the MIR analysis.

### Description

Corrects `mfp` and `flat_map` in `SingleTimeMonotonic`:

1. **`flat_map`** — now requires `func.preserves_monotonicity()` (the
   substantive check; e.g. `repeat_row` does not preserve it) in addition to
   propagating the input status. Mirrors `MirRelationExpr::FlatMap`.

2. **Temporal-predicate checks** (`mfp`, and the post-MFP of `flat_map`) — now
   reject MFPs containing temporal predicates (`mz_now()`). Note this is
   *conservative*: an MFP cannot itself negate diffs, and temporal predicates
   only introduce retractions *across* timestamps, while a one-shot dataflow
   runs at a single time. We keep the check as defense-in-depth and to mirror
   `MirRelationExpr::Filter`.

The code comments document this severity nuance inline.

### Verification

Added unit tests covering:
- `flat_map` with a monotonicity-preserving function (`GenerateSeriesInt64`)
- `flat_map` with a non-preserving function (`RepeatRow`)
- `flat_map` with a temporal predicate in the post-MFP
- `mfp` with and without temporal predicates

https://claude.ai/code/session_013EEMmczcmK98tcSa9B9vvQ