### PR TITLE
Fix generate_subscripts to respect array lower bounds

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -2960,16 +2960,21 @@ fn generate_subscripts_array(
             .try_into()
             .map_err(|_| EvalError::Int32OutOfRange((dim - 1).to_string().into()))?,
     ) {
-        Some(requested_dim) => Ok(Box::new(generate_series::<i32>(
-            requested_dim.lower_bound.try_into().map_err(|_| {
+        Some(requested_dim) => {
+            let lower_bound: i32 = requested_dim.lower_bound.try_into().map_err(|_| {
                 EvalError::Int32OutOfRange(requested_dim.lower_bound.to_string().into())
-            })?,
-            requested_dim
+            })?;
+            // The subscripts run from the lower bound to the upper bound,
+            // inclusive. The upper bound is `lower_bound + length - 1`.
+            let length: i32 = requested_dim
                 .length
                 .try_into()
-                .map_err(|_| EvalError::Int32OutOfRange(requested_dim.length.to_string().into()))?,
-            1,
-        )?)),
+                .map_err(|_| EvalError::Int32OutOfRange(requested_dim.length.to_string().into()))?;
+            let upper_bound = lower_bound
+                .checked_add(length - 1)
+                .ok_or_else(|| EvalError::Int32OutOfRange(requested_dim.length.to_string().into()))?;
+            Ok(Box::new(generate_series::<i32>(lower_bound, upper_bound, 1)?))
+        }
         None => Ok(Box::new(iter::empty())),
     }
 }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -2970,10 +2970,14 @@ fn generate_subscripts_array(
                 .length
                 .try_into()
                 .map_err(|_| EvalError::Int32OutOfRange(requested_dim.length.to_string().into()))?;
-            let upper_bound = lower_bound
-                .checked_add(length - 1)
-                .ok_or_else(|| EvalError::Int32OutOfRange(requested_dim.length.to_string().into()))?;
-            Ok(Box::new(generate_series::<i32>(lower_bound, upper_bound, 1)?))
+            let upper_bound = lower_bound.checked_add(length - 1).ok_or_else(|| {
+                EvalError::Int32OutOfRange(requested_dim.length.to_string().into())
+            })?;
+            Ok(Box::new(generate_series::<i32>(
+                lower_bound,
+                upper_bound,
+                1,
+            )?))
         }
         None => Ok(Box::new(iter::empty())),
     }

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1578,6 +1578,24 @@ select generate_subscripts(ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]], 2);
 query error could not determine polymorphic type because input has type unknown
 SELECT generate_subscripts(NULL, 1)
 
+# Regression test for database-issues#11268: generate_subscripts must respect
+# the array's lower bound. array_fill with a custom lower bound of 5 and length
+# 3 yields subscripts 5, 6, 7.
+query I
+SELECT * FROM generate_subscripts(array_fill(7, ARRAY[3], ARRAY[5]), 1);
+----
+5
+6
+7
+
+# A multi-dimensional array_fill with custom lower bounds.
+query I
+SELECT * FROM generate_subscripts(array_fill(0, ARRAY[2, 3], ARRAY[10, 20]), 2);
+----
+20
+21
+22
+
 # Regression test for database-issues#2939: LATERAL column references in ROWS FROM
 
 query III


### PR DESCRIPTION
### Motivation

Fixes database-issues#11268: `generate_subscripts` was not respecting custom lower bounds on arrays. When an array was created with a custom lower bound (e.g., via `array_fill` with a lower bound parameter), `generate_subscripts` would incorrectly start from 1 instead of the array's actual lower bound.

### Description

The issue was in `generate_subscripts_array` in `src/expr/src/relation/func.rs`. The function was calling `generate_series` with only the `lower_bound` and `length` parameters, but `generate_series` expects the upper bound as the second argument, not the length.

The fix:
1. Extract `lower_bound` and `length` from the dimension into separate variables
2. Calculate the actual `upper_bound` as `lower_bound + length - 1` (since subscripts are inclusive on both ends)
3. Add overflow checking when computing the upper bound
4. Pass the correct `lower_bound` and `upper_bound` to `generate_series`

This ensures that `generate_subscripts` correctly generates subscripts from the array's actual lower bound through its upper bound, inclusive.

### Verification

Added two regression tests in `test/sqllogictest/table_func.slt`:
1. Single-dimensional array with custom lower bound 5 and length 3, expecting subscripts 5, 6, 7
2. Multi-dimensional array with custom lower bounds (10, 20) and lengths (2, 3), expecting subscripts 20, 21, 22 for dimension 2

Both tests verify the fix works correctly for arrays created with `array_fill` using custom lower bounds.

https://claude.ai/code/session_01C2n4d7MhwFRXVezyxs3DgQ