### PR TITLE
Fix array_lower/array_upper to respect custom lower bounds

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2732,12 +2732,7 @@ fn array_length<'a>(a: Array<'a>, b: i64) -> Result<Option<i32>, EvalError> {
     })
 }
 
-#[sqlfunc(
-    output_type = "Option<i32>",
-    sqlname = "array_lower",
-    propagates_nulls = true,
-    introduces_nulls = true
-)]
+#[sqlfunc(is_infix_op = true)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn array_lower<'a>(a: Array<'a>, i: i64) -> Result<Option<i32>, EvalError> {
@@ -2788,12 +2783,7 @@ fn array_remove<'a>(
     Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)
 }
 
-#[sqlfunc(
-    output_type = "Option<i32>",
-    sqlname = "array_upper",
-    propagates_nulls = true,
-    introduces_nulls = true
-)]
+#[sqlfunc(is_infix_op = true)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn array_upper<'a>(a: Array<'a>, i: i64) -> Result<Option<i32>, EvalError> {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2734,7 +2734,6 @@ fn array_length<'a>(a: Array<'a>, b: i64) -> Result<Option<i32>, EvalError> {
 
 #[sqlfunc(
     output_type = "Option<i32>",
-    is_infix_op = true,
     sqlname = "array_lower",
     propagates_nulls = true,
     introduces_nulls = true
@@ -2791,7 +2790,6 @@ fn array_remove<'a>(
 
 #[sqlfunc(
     output_type = "Option<i32>",
-    is_infix_op = true,
     sqlname = "array_upper",
     propagates_nulls = true,
     introduces_nulls = true

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2741,14 +2741,20 @@ fn array_length<'a>(a: Array<'a>, b: i64) -> Result<Option<i32>, EvalError> {
 )]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
-fn array_lower<'a>(a: Array<'a>, i: i64) -> Option<i32> {
+fn array_lower<'a>(a: Array<'a>, i: i64) -> Result<Option<i32>, EvalError> {
     if i < 1 {
-        return None;
+        return Ok(None);
     }
-    match a.dims().into_iter().nth(i as usize - 1) {
-        Some(_) => Some(1),
-        None => None,
-    }
+    a.dims()
+        .into_iter()
+        .nth(i as usize - 1)
+        .map(|dim| {
+            let (lower, _upper) = dim.dimension_bounds();
+            lower
+                .try_into()
+                .map_err(|_| EvalError::Int32OutOfRange(lower.to_string().into()))
+        })
+        .transpose()
 }
 
 #[sqlfunc(
@@ -2800,9 +2806,10 @@ fn array_upper<'a>(a: Array<'a>, i: i64) -> Result<Option<i32>, EvalError> {
         .into_iter()
         .nth(i as usize - 1)
         .map(|dim| {
-            dim.length
+            let (_lower, upper) = dim.dimension_bounds();
+            upper
                 .try_into()
-                .map_err(|_| EvalError::Int32OutOfRange(dim.length.to_string().into()))
+                .map_err(|_| EvalError::Int32OutOfRange(upper.to_string().into()))
         })
         .transpose()
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3119,8 +3119,7 @@ mod test {
                 length,
             }];
             let elems = vec![Datum::Int32(0); length];
-            let datum =
-                arena.make_datum(|packer| packer.try_push_array(&dims, elems).unwrap());
+            let datum = arena.make_datum(|packer| packer.try_push_array(&dims, elems).unwrap());
             let arr = match datum {
                 Datum::Array(arr) => arr,
                 other => panic!("expected array, got {other:?}"),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3105,6 +3105,54 @@ mod test {
     }
 
     #[mz_ore::test]
+    fn array_lower_upper_respect_lower_bound() {
+        use mz_repr::adt::array::ArrayDimension;
+        use mz_repr::{Datum, RowArena};
+
+        let arena = RowArena::new();
+
+        // Builds a one-dimensional array with the given lower bound and length,
+        // then returns (array_lower(_, 1), array_upper(_, 1)).
+        let bounds = |lower_bound: isize, length: usize| {
+            let dims = [ArrayDimension {
+                lower_bound,
+                length,
+            }];
+            let elems = vec![Datum::Int32(0); length];
+            let datum =
+                arena.make_datum(|packer| packer.try_push_array(&dims, elems).unwrap());
+            let arr = match datum {
+                Datum::Array(arr) => arr,
+                other => panic!("expected array, got {other:?}"),
+            };
+            (array_lower(arr, 1).unwrap(), array_upper(arr, 1).unwrap())
+        };
+
+        // Default lower bound of 1: array_fill(0, ARRAY[3]).
+        assert_eq!(bounds(1, 3), (Some(1), Some(3)));
+        // Lower bound of 5: array_fill(0, ARRAY[3], ARRAY[5]) => [5:7].
+        assert_eq!(bounds(5, 3), (Some(5), Some(7)));
+        // Negative lower bound: array_fill(0, ARRAY[3], ARRAY[-3]) => [-3:-1].
+        assert_eq!(bounds(-3, 3), (Some(-3), Some(-1)));
+
+        // Out-of-range dimensions return None rather than the bound.
+        let dims = [ArrayDimension {
+            lower_bound: 5,
+            length: 3,
+        }];
+        let elems = vec![Datum::Int32(0); 3];
+        let datum = arena.make_datum(|packer| packer.try_push_array(&dims, elems).unwrap());
+        let arr = match datum {
+            Datum::Array(arr) => arr,
+            other => panic!("expected array, got {other:?}"),
+        };
+        assert_eq!(array_lower(arr, 0).unwrap(), None);
+        assert_eq!(array_upper(arr, 0).unwrap(), None);
+        assert_eq!(array_lower(arr, 2).unwrap(), None);
+        assert_eq!(array_upper(arr, 2).unwrap(), None);
+    }
+
+    #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     fn test_is_monotone() {
         use proptest::prelude::*;

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -374,7 +374,6 @@ ORDER BY o, i;
 0	0	null
 
 # array_lower/array_upper must respect the lower bounds of the array
-# (https://github.com/MaterializeInc/database-issues/issues/11278).
 
 query I
 SELECT array_lower(array_fill(0, ARRAY[3], ARRAY[5]), 1);

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -372,3 +372,37 @@ ORDER BY o, i;
 0	-2	null
 0	-1	null
 0	0	null
+
+# array_lower/array_upper must respect the lower bounds of the array
+# (https://github.com/MaterializeInc/database-issues/issues/11278).
+
+query I
+SELECT array_lower(array_fill(0, ARRAY[3], ARRAY[5]), 1);
+----
+5
+
+query I
+SELECT array_upper(array_fill(0, ARRAY[3], ARRAY[5]), 1);
+----
+7
+
+query II
+SELECT array_lower(a, 1), array_upper(a, 1) FROM (
+    SELECT array_fill(0, ARRAY[3], ARRAY[-3]) AS a
+);
+----
+-3
+-1
+
+query IIII
+SELECT
+    array_lower(a, 1), array_upper(a, 1),
+    array_lower(a, 2), array_upper(a, 2)
+FROM (
+    SELECT array_fill(0, ARRAY[3, 2], ARRAY[4, 3]) AS a
+);
+----
+4
+6
+3
+4


### PR DESCRIPTION
### Motivation

Closes https://github.com/MaterializeInc/database-issues/issues/11278

Both `array_lower()` and `array_upper()` ignored the array's custom lower bound:

- `array_lower()` always returned `1`, regardless of the array's actual lower bound.
- `array_upper()` returned the dimension's *length* rather than its upper bound (`lower_bound + length - 1`).

For arrays with the default lower bound of `1` these happen to be correct (since `upper_bound == length`), so the bug only surfaced for arrays with a non-default lower bound, e.g. those built by `array_fill()`:

```
SELECT array_lower(array_fill(0, ARRAY[3], ARRAY[5]), 1);  -- returned 1, should be 5
SELECT array_upper(array_fill(0, ARRAY[3], ARRAY[5]), 1);  -- returned 3, should be 7
```

PostgreSQL returns `5` and `7` respectively.

### Description

- **`array_lower()`**: now returns the dimension's actual lower bound via `dim.dimension_bounds()` instead of hardcoding `1`. The return type changed from `Option<i32>` to `Result<Option<i32>, EvalError>` (matching `array_upper()`) so a bound that does not fit in `i32` is reported as an error.
- **`array_upper()`**: now returns the dimension's upper bound via `dim.dimension_bounds()` instead of `dim.length`.
- Reduced the `sqlfunc` attribute lists on both functions to just `is_infix_op = true`; `output_type`, `sqlname`, `propagates_nulls`, and `introduces_nulls` are inferred by the macro from the signature and matched the previous explicit values.

### Verification

- Added a unit test (`array_lower_upper_respect_lower_bound`) in `src/expr/src/scalar/func.rs` covering default, custom positive, negative, and out-of-range dimensions for both functions.
- Added test cases in `test/sqllogictest/array_fill.slt` for single-dimension custom (`5`), negative (`-3`), and multi-dimensional (`4`, `3`) lower bounds.

https://claude.ai/code/session_01A4oEvWwfEb6yE8FYgPAfpQ