### PR TITLE
compute: fix SUM(float8) for large finite values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6086,6 +6086,7 @@ dependencies = [
  "mz-storage-types",
  "mz-timely-util",
  "mz-txn-wal",
+ "num-traits",
  "prometheus",
  "proptest",
  "prost",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -39,6 +39,7 @@ mz-storage-operators = { path = "../storage-operators" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
+num-traits.workspace = true
 prometheus.workspace = true
 prost.workspace = true
 scopeguard.workspace = true

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -12,7 +12,6 @@
 //! Consult [ReducePlan] documentation for details.
 
 use std::collections::BTreeMap;
-use std::sync::LazyLock;
 
 use columnation::{Columnation, CopyRegion};
 use dec::OrderedDecimal;
@@ -1555,7 +1554,9 @@ fn accumulable_zero(aggr_func: &AggregateFunc) -> Accum {
 /// scale is `FLOAT_SCALE == 2^FLOAT_SCALE_EXP`.
 const FLOAT_SCALE_EXP: u32 = 24;
 
-static FLOAT_SCALE: LazyLock<f64> = LazyLock::new(|| f64::from(1_i32 << FLOAT_SCALE_EXP));
+/// The fixed-point scale applied to float sums, i.e. `2^FLOAT_SCALE_EXP`.
+#[allow(clippy::as_conversions)] // Integer-to-float cast, exact and const-evaluable.
+const FLOAT_SCALE: f64 = (1_u64 << FLOAT_SCALE_EXP) as f64;
 
 /// Maps a finite `f64` onto the fixed-point `i128` domain used to accumulate
 /// float sums, i.e. computes `trunc(n * FLOAT_SCALE)` reduced modulo `2^128`.
@@ -1839,7 +1840,7 @@ fn finalize_accum<'a>(aggr_func: &'a AggregateFunc, accum: &'a Accum, total: Dif
                 } else if neg_infs.is_positive() {
                     Datum::from(f32::NEG_INFINITY)
                 } else {
-                    let sum = f64::cast_lossy(accum.into_inner()) / *FLOAT_SCALE;
+                    let sum = f64::cast_lossy(accum.into_inner()) / FLOAT_SCALE;
                     Datum::from(f32::cast_lossy(sum))
                 }
             }
@@ -1862,7 +1863,7 @@ fn finalize_accum<'a>(aggr_func: &'a AggregateFunc, accum: &'a Accum, total: Dif
                 } else if neg_infs.is_positive() {
                     Datum::from(f64::NEG_INFINITY)
                 } else {
-                    Datum::from(f64::cast_lossy(accum.into_inner()) / *FLOAT_SCALE)
+                    Datum::from(f64::cast_lossy(accum.into_inner()) / FLOAT_SCALE)
                 }
             }
             (
@@ -2552,7 +2553,7 @@ mod tests {
     /// where the old conversion was already correct.
     #[allow(clippy::as_conversions)]
     fn saturating_convert(n: f64) -> i128 {
-        (n * *FLOAT_SCALE) as i128
+        (n * FLOAT_SCALE) as i128
     }
 
     #[mz_ore::test]

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -41,6 +41,7 @@ use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{Datum, DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_timely_util::operator::CollectionExt;
+use num_traits::Float;
 use serde::{Deserialize, Serialize};
 use timely::Container;
 use timely::container::{CapacityContainerBuilder, PushInto};
@@ -1575,23 +1576,12 @@ static FLOAT_SCALE: LazyLock<f64> = LazyLock::new(|| f64::from(1_i32 << FLOAT_SC
 fn float_to_fixed_point(n: f64) -> i128 {
     debug_assert!(n.is_finite());
 
-    let bits = n.to_bits();
-    let raw_exponent = (bits >> 52) & 0x7ff;
-    let raw_mantissa = bits & 0x000f_ffff_ffff_ffff;
-
-    // Zero and subnormals. Subnormals have magnitude below `2^-1022`, so even
-    // after scaling by `2^FLOAT_SCALE_EXP` they truncate to zero.
-    if raw_exponent == 0 {
-        return 0;
-    }
-
-    // Reconstruct the 53-bit significand (restoring the implicit leading bit)
-    // and the base-2 exponent `exp` such that `|n| * FLOAT_SCALE == significand
-    // * 2^exp`. The bias is 1023 and the significand carries 52 fractional bits,
-    // and we fold in the `* 2^FLOAT_SCALE_EXP` scaling by shifting the exponent.
-    let significand = u128::from(raw_mantissa | 0x0010_0000_0000_0000);
-    let raw_exponent = i64::try_from(raw_exponent).expect("11-bit value fits in i64");
-    let exp = raw_exponent - 1023 - 52 + i64::from(FLOAT_SCALE_EXP);
+    // Decompose `n` into integer parts such that `n == sign * mantissa *
+    // 2^exponent`. Folding in the `* 2^FLOAT_SCALE_EXP` scaling then amounts to
+    // shifting `mantissa` left by `exponent + FLOAT_SCALE_EXP` bits.
+    let (mantissa, exponent, sign) = Float::integer_decode(n);
+    let significand = u128::from(mantissa);
+    let exp = i64::from(exponent) + i64::from(FLOAT_SCALE_EXP);
 
     let magnitude: u128 = if exp >= 0 {
         // Left shifts of 128 or more bits leave nothing within the 128-bit
@@ -1601,7 +1591,8 @@ fn float_to_fixed_point(n: f64) -> i128 {
             _ => 0,
         }
     } else {
-        // Right shift truncates the fractional part towards zero.
+        // Right shift truncates the fractional part towards zero. Subnormals
+        // (and zero) shift entirely out of the window and become zero.
         match u32::try_from(-exp) {
             Ok(shift) if shift < 128 => significand >> shift,
             _ => 0,
@@ -1610,11 +1601,11 @@ fn float_to_fixed_point(n: f64) -> i128 {
 
     // Reinterpret the magnitude as a signed `i128` (wrapping into the signed
     // domain) and apply the sign of `n`.
-    let signed = magnitude.cast_signed();
-    if bits >> 63 == 1 {
-        signed.wrapping_neg()
+    let magnitude = magnitude.cast_signed();
+    if sign < 0 {
+        magnitude.wrapping_neg()
     } else {
-        signed
+        magnitude
     }
 }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -36,6 +36,7 @@ use mz_compute_types::plan::reduce::{
 use mz_expr::{
     AggregateExpr, AggregateFunc, EvalError, MapFilterProject, MirScalarExpr, SafeMfpPlan,
 };
+use mz_ore::cast::CastLossy;
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{Datum, DatumVec, Diff, Row, RowArena, SharedRow};
@@ -1548,7 +1549,74 @@ fn accumulable_zero(aggr_func: &AggregateFunc) -> Accum {
     }
 }
 
-static FLOAT_SCALE: LazyLock<f64> = LazyLock::new(|| f64::from(1 << 24));
+/// The number of fractional bits of binary precision retained by the
+/// fixed-point representation used to accumulate float sums. The fixed-point
+/// scale is `FLOAT_SCALE == 2^FLOAT_SCALE_EXP`.
+const FLOAT_SCALE_EXP: u32 = 24;
+
+static FLOAT_SCALE: LazyLock<f64> = LazyLock::new(|| f64::from(1_i32 << FLOAT_SCALE_EXP));
+
+/// Maps a finite `f64` onto the fixed-point `i128` domain used to accumulate
+/// float sums, i.e. computes `trunc(n * FLOAT_SCALE)` reduced modulo `2^128`.
+///
+/// Conceptually this multiplies `n` by `FLOAT_SCALE` and truncates towards zero,
+/// but it does so using *wrapping* (modulo `2^128`) rather than *saturating*
+/// semantics, and it never forms the intermediate product `n * FLOAT_SCALE` as
+/// an `f64` (which could itself overflow to infinity for very large `n`).
+///
+/// Wrapping is what makes this conversion a group homomorphism into the additive
+/// group of `i128` (mod `2^128`), matching the wrapping arithmetic used when
+/// accumulators are combined and retracted. As a result, a set of large finite
+/// values whose *sum* is representable produces the correct result even when the
+/// individual values fall outside the representable fixed-point range. Saturating
+/// instead breaks this: e.g. `1.1e31` and `-1.1e31` both overflow the domain and
+/// would saturate to `i128::MAX` and `i128::MIN`, which sum to `-1` rather than
+/// `0` (see database-issues#11265).
+fn float_to_fixed_point(n: f64) -> i128 {
+    debug_assert!(n.is_finite());
+
+    let bits = n.to_bits();
+    let raw_exponent = (bits >> 52) & 0x7ff;
+    let raw_mantissa = bits & 0x000f_ffff_ffff_ffff;
+
+    // Zero and subnormals. Subnormals have magnitude below `2^-1022`, so even
+    // after scaling by `2^FLOAT_SCALE_EXP` they truncate to zero.
+    if raw_exponent == 0 {
+        return 0;
+    }
+
+    // Reconstruct the 53-bit significand (restoring the implicit leading bit)
+    // and the base-2 exponent `exp` such that `|n| * FLOAT_SCALE == significand
+    // * 2^exp`. The bias is 1023 and the significand carries 52 fractional bits,
+    // and we fold in the `* 2^FLOAT_SCALE_EXP` scaling by shifting the exponent.
+    let significand = u128::from(raw_mantissa | 0x0010_0000_0000_0000);
+    let raw_exponent = i64::try_from(raw_exponent).expect("11-bit value fits in i64");
+    let exp = raw_exponent - 1023 - 52 + i64::from(FLOAT_SCALE_EXP);
+
+    let magnitude: u128 = if exp >= 0 {
+        // Left shifts of 128 or more bits leave nothing within the 128-bit
+        // window; smaller shifts keep only the low 128 bits (i.e. mod `2^128`).
+        match u32::try_from(exp) {
+            Ok(shift) if shift < 128 => significand << shift,
+            _ => 0,
+        }
+    } else {
+        // Right shift truncates the fractional part towards zero.
+        match u32::try_from(-exp) {
+            Ok(shift) if shift < 128 => significand >> shift,
+            _ => 0,
+        }
+    };
+
+    // Reinterpret the magnitude as a signed `i128` (wrapping into the signed
+    // domain) and apply the sign of `n`.
+    let signed = magnitude.cast_signed();
+    if bits >> 63 == 1 {
+        signed.wrapping_neg()
+    } else {
+        signed
+    }
+}
 
 fn datum_to_accumulator(aggregate_func: &AggregateFunc, datum: Datum) -> Accum {
     match aggregate_func {
@@ -1600,10 +1668,10 @@ fn datum_to_accumulator(aggregate_func: &AggregateFunc, datum: Datum) -> Accum {
             let accum = if nans.is_positive() || pos_infs.is_positive() || neg_infs.is_positive() {
                 AccumCount::ZERO
             } else {
-                // This operation will truncate to i128::MAX if out of range.
-                // TODO(benesch): rewrite to avoid `as`.
-                #[allow(clippy::as_conversions)]
-                { (n * *FLOAT_SCALE) as i128 }.into()
+                // Wrap (rather than saturate) on overflow, so that the mapping is
+                // a group homomorphism and large finite values whose sum is in
+                // range still produce correct results (database-issues#11265).
+                float_to_fixed_point(n).into()
             };
 
             Accum::Float {
@@ -1780,11 +1848,8 @@ fn finalize_accum<'a>(aggr_func: &'a AggregateFunc, accum: &'a Accum, total: Dif
                 } else if neg_infs.is_positive() {
                     Datum::from(f32::NEG_INFINITY)
                 } else {
-                    // TODO(benesch): remove potentially dangerous usage of `as`.
-                    #[allow(clippy::as_conversions)]
-                    {
-                        Datum::from(((accum.into_inner() as f64) / *FLOAT_SCALE) as f32)
-                    }
+                    let sum = f64::cast_lossy(accum.into_inner()) / *FLOAT_SCALE;
+                    Datum::from(f32::cast_lossy(sum))
                 }
             }
             (
@@ -1806,11 +1871,7 @@ fn finalize_accum<'a>(aggr_func: &'a AggregateFunc, accum: &'a Accum, total: Dif
                 } else if neg_infs.is_positive() {
                     Datum::from(f64::NEG_INFINITY)
                 } else {
-                    // TODO(benesch): remove potentially dangerous usage of `as`.
-                    #[allow(clippy::as_conversions)]
-                    {
-                        Datum::from((accum.into_inner() as f64) / *FLOAT_SCALE)
-                    }
+                    Datum::from(f64::cast_lossy(accum.into_inner()) / *FLOAT_SCALE)
                 }
             }
             (
@@ -2488,5 +2549,99 @@ mod window_agg_helpers {
         fn get_current_aggregate<'a>(&self, temp_storage: &'a RowArena) -> Datum<'a> {
             temp_storage.make_datum(|packer| packer.extend(self.monoid.finalize().iter()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The saturating conversion that `float_to_fixed_point` replaces. Used to
+    /// assert that the new wrapping conversion agrees on the in-range values
+    /// where the old conversion was already correct.
+    #[allow(clippy::as_conversions)]
+    fn saturating_convert(n: f64) -> i128 {
+        (n * *FLOAT_SCALE) as i128
+    }
+
+    #[mz_ore::test]
+    fn float_to_fixed_point_matches_saturating_in_range() {
+        // For values whose scaled magnitude comfortably fits in an `i128`, the
+        // wrapping conversion must produce exactly the same result the previous
+        // saturating cast did.
+        let cases = [
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            0.1,
+            -0.1,
+            0.5,
+            -0.5,
+            3.25,
+            -3.25,
+            123456.789,
+            -123456.789,
+            1e10,
+            -1e10,
+            1e20,
+            -1e20,
+            5e30, // large, but scaled magnitude still fits comfortably in i128
+            -5e30,
+        ];
+        for n in cases {
+            assert_eq!(
+                float_to_fixed_point(n),
+                saturating_convert(n),
+                "mismatch for n = {n}"
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    fn float_to_fixed_point_truncates_toward_zero() {
+        // 1.75 * 2^24 = 29360128, exactly representable.
+        assert_eq!(float_to_fixed_point(1.75), 29_360_128);
+        assert_eq!(float_to_fixed_point(-1.75), -29_360_128);
+
+        // Fractional results truncate toward zero, matching the previous cast.
+        let frac = 0.123_456_7_f64;
+        assert_eq!(float_to_fixed_point(frac), saturating_convert(frac));
+        assert_eq!(float_to_fixed_point(-frac), saturating_convert(-frac));
+        assert_eq!(float_to_fixed_point(-frac), -float_to_fixed_point(frac));
+    }
+
+    #[mz_ore::test]
+    fn float_to_fixed_point_subnormals_round_to_zero() {
+        assert_eq!(float_to_fixed_point(0.0), 0);
+        assert_eq!(float_to_fixed_point(-0.0), 0);
+        assert_eq!(float_to_fixed_point(f64::MIN_POSITIVE / 2.0), 0);
+        assert_eq!(float_to_fixed_point(5e-324), 0); // smallest subnormal
+    }
+
+    #[mz_ore::test]
+    fn float_to_fixed_point_cancels_large_finite_values() {
+        // Regression test for database-issues#11265: large finite values that
+        // individually overflow the fixed-point domain must still sum to the
+        // correct result when their mathematical sum is representable. The
+        // previous saturating conversion produced `i128::MAX + i128::MIN == -1`.
+        for &n in &[1.1e31_f64, 1e32, 5e33, 1e284] {
+            assert_eq!(
+                float_to_fixed_point(n).wrapping_add(float_to_fixed_point(-n)),
+                0,
+                "n = {n} did not cancel with -n"
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    fn float_to_fixed_point_sum_via_accumulator() {
+        // Exercise the full accumulate-then-finalize path for the reported case.
+        let func = AggregateFunc::SumFloat64;
+        let mut acc = accumulable_zero(&func);
+        acc.plus_equals(&datum_to_accumulator(&func, Datum::from(1.1e31_f64)));
+        acc.plus_equals(&datum_to_accumulator(&func, Datum::from(-1.1e31_f64)));
+        let datum = finalize_accum(&func, &acc, Diff::from(2_i64));
+        assert_eq!(datum, Datum::from(0.0_f64));
     }
 }

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -283,6 +283,8 @@ cast_lossy!(f64, i64);
 cast_lossy!(u64, f64);
 cast_lossy!(f64, u64);
 cast_lossy!(f64, u32);
+cast_lossy!(i128, f64);
+cast_lossy!(f64, f32);
 
 #[crate::test]
 fn test_try_cast_from() {

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -158,6 +158,26 @@ SELECT MIN(f1+f2)-SUM(f1) FROM t1
 ----
 20282409603651670423947251286016.000
 
+# Regression test for database-issues#11265: SUM(float8) of large finite values
+# whose mathematical sum is representable must be exact. These values individually
+# overflow the fixed-point accumulator domain; previously each saturated to
+# i128::MAX/i128::MIN, which sum to -1 and produced a spurious -5.96e-8 instead
+# of 0.
+statement ok
+CREATE TABLE float_boundary (f1 float8)
+
+statement ok
+INSERT INTO float_boundary VALUES (1.1e31), (-1.1e31)
+
+query TTT
+SELECT
+    SUM(f1)::text,
+    (SUM(f1) = 0.0)::text,
+    ((SUM(f1) * 16777216)::bigint)::text
+  FROM float_boundary
+----
+0  true  0
+
 query error invalid input syntax
 SELECT ''::float::text
 


### PR DESCRIPTION
### Motivation

Fixes CLU-75 / database-issues#11265: `SUM(float8)` returns incorrect results for large finite values when read from a table.

```sql
CREATE TABLE float_boundary (f1 float8);
INSERT INTO float_boundary VALUES (1.1e31), (-1.1e31);
SELECT SUM(f1) FROM float_boundary;
-- before:  -5.960464477539063e-8
-- after:   0
```

### Root cause

The accumulable float sum maps each input onto a fixed-point `i128` domain (scaled by `2^24`) and combines accumulators with **wrapping** arithmetic so the representation forms a commutative group, as required for incremental maintenance with retractions.

The per-datum conversion, however, used a **saturating** `as i128` cast. Values whose scaled magnitude exceeds `i128`'s range (`|n| > ~1.01e31`) saturated to `i128::MAX` or `i128::MIN`. Because `i128`'s range is asymmetric (`MIN = -(MAX + 1)`), summing two cancelling values such as `1.1e31` and `-1.1e31` produced `MAX + MIN = -1`, surfacing as `-5.96e-8` (`= -1 / 2^24`) instead of `0`. (Without a table the query is constant-folded through the scalar path and was already correct.)

### Changes

- Add `float_to_fixed_point`, which computes `trunc(n * 2^24)` reduced modulo `2^128` (wrapping) directly from the `f64` bit pattern. This makes the conversion a group homomorphism consistent with the wrapping accumulation, so large finite values whose mathematical sum is representable now yield the correct result. Working in the integer domain also avoids forming the intermediate `f64` product `n * FLOAT_SCALE`, which could itself overflow to infinity.
- Replace the remaining raw `as` casts on the finalize path with `cast_lossy`, adding the `i128 -> f64` and `f64 -> f32` impls in `mz_ore::cast`.
- Add Rust unit tests for `float_to_fixed_point` (agreement with the old cast in range, truncation toward zero, subnormals, cancellation of out-of-range values, full accumulate/finalize path) and a `float.slt` regression test mirroring the issue.

Note: sums whose **mathematical result** is itself outside the representable fixed-point range (e.g. `SUM` of `1e31 + 1e31 = 2e31`) remain approximate — the fixed-point domain simply cannot represent them — and continue to log the existing overflow warning. This change makes the *representable* cases (including exact cancellation) correct.

### Tip

`cargo test -p mz-compute --lib render::reduce::tests`

https://claude.ai/code/session_01HXYJ6TAz8GawjxdC6TNr8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXYJ6TAz8GawjxdC6TNr8R)_