### PR TITLE
adapter: bump with_0dt_deployment_max_wait default to 1 year

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -22,7 +22,9 @@ pub const ALLOW_USER_SESSIONS: Config<bool> = Config::new(
 // Slightly awkward with the WITH prefix, but we can't start with a 0..
 pub const WITH_0DT_DEPLOYMENT_MAX_WAIT: Config<Duration> = Config::new(
     "with_0dt_deployment_max_wait",
-    Duration::from_secs(60 * 60 * 72),
+    // One year, which in practice makes it so we never cut over when not
+    // hydrated. To prevent cutting over unilaterally when there is an issue.
+    Duration::from_hours(365 * 24),
     "How long to wait at most for clusters to be hydrated, when doing a zero-downtime deployment.",
 );
 


### PR DESCRIPTION
This matches the default we use in LD, and is a safer choice as the comment explains.

Contributes to SQL-322