### PR TITLE
enable mcp agent query tool by default

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -183,7 +183,7 @@ pub const ENABLE_MCP_AGENT: Config<bool> = Config::new(
 /// Agents can still use `get_data_products` and `get_data_product_details`.
 pub const ENABLE_MCP_AGENT_QUERY_TOOL: Config<bool> = Config::new(
     "enable_mcp_agent_query_tool",
-    false,
+    true,
     "Whether the MCP agent query tool is enabled. When false, the query tool is not advertised and calls to it are rejected. Agents can still discover and inspect data products.",
 );
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5081,26 +5081,25 @@ fn run_mcp_datadriven(testdata_path: &str, harness: test_util::TestHarness) {
     });
 }
 
-/// Tests the MCP agent endpoint with default feature flags
-/// (enable_mcp_agent=true, enable_mcp_agent_query_tool=false).
+/// Tests the MCP agent endpoint with the query tool explicitly disabled.
 #[mz_ore::test]
 fn test_mcp_agent() {
-    let harness = test_util::TestHarness::default()
-        .with_mcp_routes(true, false)
-        .with_system_parameter_default("enable_mcp_agent".to_string(), "true".to_string());
-    run_mcp_datadriven("tests/testdata/mcp/agent", harness);
-}
-
-/// Tests the MCP agent endpoint with the query tool enabled.
-#[mz_ore::test]
-fn test_mcp_agent_query_tool() {
     let harness = test_util::TestHarness::default()
         .with_mcp_routes(true, false)
         .with_system_parameter_default("enable_mcp_agent".to_string(), "true".to_string())
         .with_system_parameter_default(
             "enable_mcp_agent_query_tool".to_string(),
-            "true".to_string(),
+            "false".to_string(),
         );
+    run_mcp_datadriven("tests/testdata/mcp/agent", harness);
+}
+
+/// Tests the MCP agent endpoint with the query tool enabled (default behavior).
+#[mz_ore::test]
+fn test_mcp_agent_query_tool() {
+    let harness = test_util::TestHarness::default()
+        .with_mcp_routes(true, false)
+        .with_system_parameter_default("enable_mcp_agent".to_string(), "true".to_string());
     run_mcp_datadriven("tests/testdata/mcp/agent_query_tool", harness);
 }
 
@@ -6048,7 +6047,7 @@ fn test_mcp_agent_runtime_flag_toggle() {
         "agent should work again after re-enabling"
     );
 
-    // Test query tool toggling: initially disabled.
+    // Test query tool toggling: enabled by default.
     let query_call = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 2,
@@ -6061,21 +6060,8 @@ fn test_mcp_agent_runtime_flag_toggle() {
     let (status, body) = mcp_post(&agents_url, query_call.clone());
     assert_eq!(status, StatusCode::OK);
     assert!(
-        body["error"]["message"]
-            .as_str()
-            .unwrap_or("")
-            .contains("query tool is not available"),
-        "query tool should be disabled by default"
-    );
-
-    // Enable query tool at runtime.
-    server.enable_feature_flags(&["enable_mcp_agent_query_tool"]);
-
-    let (status, body) = mcp_post(&agents_url, query_call.clone());
-    assert_eq!(status, StatusCode::OK);
-    assert!(
         body["error"].is_null(),
-        "query tool should work after enabling"
+        "query tool should be enabled by default"
     );
     let result_text = body["result"]["content"][0]["text"].as_str().unwrap();
     assert!(
@@ -6083,15 +6069,31 @@ fn test_mcp_agent_runtime_flag_toggle() {
         "query should return result with 1"
     );
 
-    // Disable query tool again.
+    // Disable query tool at runtime.
     server.disable_feature_flags(&["enable_mcp_agent_query_tool"]);
-    let (_, body) = mcp_post(&agents_url, query_call.clone());
+
+    let (status, body) = mcp_post(&agents_url, query_call.clone());
+    assert_eq!(status, StatusCode::OK);
     assert!(
         body["error"]["message"]
             .as_str()
             .unwrap_or("")
             .contains("query tool is not available"),
-        "query tool should be disabled again"
+        "query tool should be disabled after disabling"
+    );
+
+    // Re-enable query tool.
+    server.enable_feature_flags(&["enable_mcp_agent_query_tool"]);
+    let (status, body) = mcp_post(&agents_url, query_call.clone());
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["error"].is_null(),
+        "query tool should work after re-enabling"
+    );
+    let result_text = body["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(
+        result_text.contains("1"),
+        "query should return result with 1 after re-enabling"
     );
 }
 

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -86,8 +86,8 @@ def workflow_default(c: Composition) -> None:
             "get_data_product_details" in tool_names
         ), f"missing get_data_product_details: {tool_names}"
         assert (
-            "query" not in tool_names
-        ), f"query should be hidden by default: {tool_names}"
+            "query" in tool_names
+        ), f"query should be present by default: {tool_names}"
 
     with c.test_case("agent_get_data_products"):
         r = post_mcp(
@@ -587,6 +587,45 @@ def workflow_default(c: Composition) -> None:
             port=6877,
             print_statement=False,
         )
+
+    # -- agent: query tool disable/enable via flag --------------------------------
+
+    with c.test_case("agent_query_tool_disable_via_flag"):
+        # Query tool is enabled by default; confirm it appears in tools/list.
+        r = post_mcp(c, "agent", jsonrpc("tools/list"))
+        assert r.status_code == 200
+        tool_names = {t["name"] for t in r.json()["result"]["tools"]}
+        assert (
+            "query" in tool_names
+        ), f"query should be enabled by default: {tool_names}"
+
+        # Disable via system parameter.
+        c.sql(
+            "ALTER SYSTEM SET enable_mcp_agent_query_tool = false",
+            user="mz_system",
+            port=6877,
+            print_statement=False,
+        )
+
+        r = post_mcp(c, "agent", jsonrpc("tools/list"))
+        assert r.status_code == 200
+        tool_names = {t["name"] for t in r.json()["result"]["tools"]}
+        assert (
+            "query" not in tool_names
+        ), f"query should be hidden after disabling: {tool_names}"
+
+        # Re-enable.
+        c.sql(
+            "ALTER SYSTEM SET enable_mcp_agent_query_tool = true",
+            user="mz_system",
+            port=6877,
+            print_statement=False,
+        )
+
+        r = post_mcp(c, "agent", jsonrpc("tools/list"))
+        assert r.status_code == 200
+        tool_names = {t["name"] for t in r.json()["result"]["tools"]}
+        assert "query" in tool_names, f"query should be re-enabled: {tool_names}"
 
     # -- agent: disable/enable via flag ----------------------------------------
 


### PR DESCRIPTION
Remove these sections if your commit already has a good description!

### Motivation

Now that we can provide a path to restrict roles using mcp from accessing public catalog objects we should enable this by default. cc @bobbyiliev 

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
