### PR TITLE
Mark v26.26 as released

### DIFF
--- a/doc/user/content/releases/v26.26.md
+++ b/doc/user/content/releases/v26.26.md
@@ -1,9 +1,8 @@
 ---
 title: Materialize v26.26
 date: 2026-05-27
-released: false
+released: true
 patch: 0
-rc: 1
 publish_helm_chart: true
 build:
   render: never


### PR DESCRIPTION
We also need to trigger the self-managed deploy again. Edit: Doing that now: https://buildkite.com/materialize/publish-helm-charts/builds/168