### PR TITLE
release: fix mark_release_complete for python-frontmatter 1.3.0

### DIFF
--- a/misc/python/materialize/release/mark_release_complete.py
+++ b/misc/python/materialize/release/mark_release_complete.py
@@ -33,10 +33,10 @@ def main():
     metadata["patch"] = int(args.patch)
     if "rc" in metadata:
         del metadata["rc"]
-    with open(release_version_doc_file, "wb") as f:
+    with open(release_version_doc_file, "w", encoding="utf-8") as f:
         frontmatter.dump(metadata, f, sort_keys=False)
         # Always have a trailing newline
-        f.write(b"\n")
+        f.write("\n")
 
     git.add_file(str(release_version_doc_file))
     git.commit_all_changed(f"release: mark {args.release_version} as released")

--- a/misc/python/stubs/frontmatter.pyi
+++ b/misc/python/stubs/frontmatter.pyi
@@ -7,9 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from io import BufferedWriter
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 def load(path: Path) -> dict[Any, Any]: ...
-def dump(obj: dict[Any, Any], file: BufferedWriter, sort_keys: bool = True) -> None: ...
+def dump(obj: dict[Any, Any], file: TextIO, sort_keys: bool = True) -> None: ...


### PR DESCRIPTION
The `complete-release` CI job is failing with:

```
File ".../materialize/release/mark_release_complete.py", line 37, in main
    frontmatter.dump(metadata, f, sort_keys=False)
TypeError: a bytes-like object is required, not 'str'
```

`python-frontmatter` was bumped 1.1.0 → 1.3.0 in #36710 (2026-05-25). In 1.1.0, `frontmatter.dump()` encoded the content to bytes (`.encode(encoding)`) before writing, so the doc file was opened in binary mode (`"wb"`). In 1.3.0, `dump()` writes a `str` directly and expects a text-mode file, so writing to the `"wb"` handle now raises `TypeError`.