### PR TITLE
docs: document how to reduce Claude Code skill read prompts

### DIFF
--- a/doc/user/content/integrations/coding-agent-skills.md
+++ b/doc/user/content/integrations/coding-agent-skills.md
@@ -31,6 +31,30 @@ Materialize-specific question such as "How do I create a source from Kafka in
 Materialize?" and confirm it references Materialize documentation in its
 response.
 
+## Reduce permission prompts (Claude Code)
+
+Claude Code prompts before reading files outside your project. Since globally
+installed skills live under `~/.claude/skills/`, it may ask to approve reads
+each time the skill opens a new documentation subdirectory.
+
+To stop these prompts, grant read access to just the Materialize skill in
+`~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "additionalDirectories": ["~/.claude/skills/materialize-docs"]
+  }
+}
+```
+
+This grants the narrowest access needed. If you have multiple skills installed
+and want to cover them all at once, you can broaden the path to
+`~/.claude/skills`, though scoping to a single skill is the safer default.
+
+Claude Code's `auto` permission mode also removes the prompts, but applies to
+all tools rather than just this directory.
+
 ## What's included
 
 The **materialize-docs** skill bundles reference files across categories including:

--- a/doc/user/content/integrations/coding-agent-skills.md
+++ b/doc/user/content/integrations/coding-agent-skills.md
@@ -37,7 +37,7 @@ Claude Code prompts before reading files outside your project. Since globally
 installed skills live under `~/.claude/skills/`, it may ask to approve reads
 each time the skill opens a new documentation subdirectory.
 
-To stop these prompts, grant read access to just the Materialize skill in
+To stop these prompts, grant read access to the `materialize-docs` skill in
 `~/.claude/settings.json`:
 
 ```json

--- a/doc/user/content/integrations/coding-agent-skills.md
+++ b/doc/user/content/integrations/coding-agent-skills.md
@@ -34,8 +34,9 @@ response.
 ## Reduce permission prompts (Claude Code)
 
 Claude Code prompts before reading files outside your project. Since globally
-installed skills live under `~/.claude/skills/`, it may ask to approve reads
-each time the skill opens a new documentation subdirectory.
+installed skills live under `~/.claude/skills/`, if you installed the
+`materialize-docs` skill globally, Claude Code may ask to approve reads each
+time the skill opens a new documentation subdirectory.
 
 To stop these prompts, grant read access to the `materialize-docs` skill in
 `~/.claude/settings.json`:
@@ -48,7 +49,7 @@ To stop these prompts, grant read access to the `materialize-docs` skill in
 }
 ```
 
-This grants the narrowest access needed. If you have multiple skills installed
+This grants access to just that one skill's directory. If you have multiple skills installed
 and want to cover them all at once, you can broaden the path to
 `~/.claude/skills`, though scoping to a single skill is the safer default.
 


### PR DESCRIPTION
Globally installed agent skills live outside the project directory, so Claude Code prompts to approve reads each time the skill opens a new docs subdirectory. So adding a short section to the Coding Agent Skills page explaining how to scope read access via `additionalDirectories` (or `auto` mode) to stop the prompts.