### PR TITLE
ci/deploy: add phase markers to devsite.sh

### DIFF
--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -13,17 +13,31 @@
 
 set -euo pipefail
 
+. misc/shlib/shlib.bash
+
+ci_collapsed_heading "Generate license breakdown"
 cargo about generate ci/deploy/licenses.hbs > misc/www/licenses.html
 
+ci_collapsed_heading "Upload misc/www to S3"
 aws s3 cp --recursive misc/www/ s3://materialize-dev-website/
 
 # We exclude all of these pages from search engines for SEO purposes. We don't
 # want to spend our crawl budget on these pages, nor have these pages appear
 # ahead of our marketing content.
+ci_collapsed_heading "Build public Rust docs (bin/doc)"
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc
+
+ci_collapsed_heading "Build private Rust docs (bin/doc --document-private-items)"
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc --document-private-items
+
+ci_collapsed_heading "Sync public Rust docs to S3"
 aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
+
+ci_collapsed_heading "Sync private Rust docs to S3"
 aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
 
+ci_collapsed_heading "Build Python docs (bin/pydoc)"
 bin/pydoc
+
+ci_collapsed_heading "Sync Python docs to S3"
 aws s3 sync --size-only --delete target/pydoc/ s3://materialize-dev-website/api/python


### PR DESCRIPTION
## Summary

Wraps each step of `ci/deploy/devsite.sh` in `ci_collapsed_heading` (from `misc/shlib/shlib.bash`) so the Buildkite UI gets per-phase sections and so log scraping can pin down which sub-step dominates the deploy time.

## Motivation

The `deploy-devsite` Buildkite step has grown from **~25m → ~48m p50** over the past 60 days (data: 783 builds on main). It runs serially on a single concurrency slot (`concurrency_group: deploy/devsite`), so on burst days a 5-10 commit run can queue 4-8 hours of downstream work.

Today the script logs only three intermediate markers:
- Two `Docs are in /mnt/build/doc/index.html` lines from `bin/doc`
- The `pdoc failed to precompile the search index` line from `bin/pydoc`

That is enough to identify two growth modes:
- `bin/doc` (public rustdoc) stepped from **3m to 10m between Apr 15 and Apr 30** and has been stable since
- The combined `aws s3 sync` x 3 + `bin/pydoc` phase has grown **linearly 19m to 33m** with no markers in between

But it is not enough to attribute that ~14m of linear growth to any one of: aws sync of `target-xcompile/doc/` (rustdoc HTML count keeps growing), aws sync of `target/pydoc/`, or `bin/pydoc` itself (the failing search-index step suggests Python doc volume is hitting a scaling limit).

## Change

Sources `misc/shlib/shlib.bash` and adds eight `ci_collapsed_heading` lines, one before each existing command. No command changes, no behavior changes.

After a week of post-merge data we will know which phase is the linear-creep driver and can decide whether to invest in faster pdoc, S3 sync parallelism, or path-based skipping for non-docs commits.

## Test plan

- [ ] Buildkite log for the next `deploy` build on main shows eight collapsed sections with durations
- [ ] No change to the artifacts uploaded to S3
- [ ] `bash -n ci/deploy/devsite.sh` passes (verified locally)
