### PR TITLE
SS-16: E2E testing for AWS Glue schema registry

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -949,6 +949,23 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: aws-localstack
 
+      - id: aws-glue-schema-registry-real
+        label: AWS Glue Schema Registry (Real)
+        depends_on: build-aarch64
+        timeout_in_minutes: 30
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
+        agents:
+          # Because of scratch-aws-access
+          queue: linux-aarch64-small
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: aws-glue-schema-registry
+              run: aws
+
       - id: secrets-local-file
         label: "Secrets Local File"
         depends_on: build-aarch64

--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -50,6 +50,7 @@ check_default_workflow_references_others() {
         -not -wholename "./test/cluster-spec-sheet/mzcompose.py" `# Handled differently` \
         -not -wholename "./test/orchestratord/mzcompose.py" `# Handled differently` \
         -not -wholename "./test/workload-replay/mzcompose.py" `# Handled differently` \
+        -not -wholename "./test/aws-glue-schema-registry/mzcompose.py" `# 'aws' workflow runs against real AWS, opt-in via nightly only` \
     )
 
     for file in "${MZCOMPOSE_TEST_FILES[@]}"; do

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -478,6 +478,17 @@ steps:
         agents:
           queue: hetzner-aarch64-4cpu-8gb
 
+      - id: aws-glue-schema-registry
+        label: AWS Glue Schema Registry (Moto)
+        depends_on: build-aarch64
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: aws-glue-schema-registry
+        agents:
+          queue: hetzner-aarch64-4cpu-8gb
+
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
     depends_on: build-aarch64

--- a/test/aws-glue-schema-registry/glue-schema-registry.td
+++ b/test/aws-glue-schema-registry/glue-schema-registry.td
@@ -1,0 +1,540 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# End-to-end test for FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY against Moto.
+# Covers:
+#   - Connection validate() path
+#   - Simple-schema source decode
+#   - Nested-record / array / nullable-union source decode
+#   - Schema evolution: records framed with v1 + v2 UUIDs against a v2 reader
+#   - KEY FORMAT + VALUE FORMAT (both Glue) under ENVELOPE UPSERT
+#   - ENVELOPE DEBEZIUM (Glue key + before/after envelope value)
+#   - Negative cases (bad registry, missing/nonexistent SCHEMA NAME,
+#     non-Avro data format, wrong connection type, bare format + UPSERT,
+#     non-Kafka source)
+#
+# Each schema is defined once as a pretty-printed `$ set` variable and then
+# referenced twice: by `glue-create-schema` (which registers it and returns its
+# version UUID) and by `kafka-ingest` (which frames records with that UUID). The
+# registries are created by the workflow (mzcompose.py); the schemas inside them
+# are registered here so the schema bodies live in exactly one place.
+#
+# Cross-schema references (CSR's `VALUE REFERENCES (...)`) are *intentionally*
+# not exercised here: AWS Glue Schema Registry has no equivalent concept
+# (`RegisterSchemaVersion` takes one self-contained JSON blob; there is no
+# `references` field on the API). Our `AvroSchema::Glue` grammar has no
+# `REFERENCES` clause, so there is nothing to test. Intra-document
+# named-type reuse — which is a property of Avro itself, not the registry —
+# is exercised by the nested schema below: `inner_t` is defined once and
+# reused by name in the `inner2` field.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_glue_schema_registry = true;
+
+# ---------------------------------------------------------------------------
+# Schema names
+# ---------------------------------------------------------------------------
+#
+# These need no per-run uniqueness: each schema lives inside a per-run registry
+# (created by mzcompose.py), which already isolates it across concurrent runs.
+# Only the registries and the shared default-registry schema need run-id-suffixed
+# names, so those are passed in as `--var`s by the workflow instead.
+
+$ set simple-schema-name=mz-test-schema
+$ set nested-schema-name=mz-nested-schema
+$ set evolving-schema-name=mz-evolving-schema
+$ set json-schema-name=mz-json-schema
+$ set upsert-key-schema-name=mz-upsert-key-schema
+$ set upsert-value-schema-name=mz-upsert-value-schema
+$ set dbz-key-schema-name=mz-dbz-key-schema
+$ set dbz-value-schema-name=mz-dbz-value-schema
+
+# ---------------------------------------------------------------------------
+# Connections
+# ---------------------------------------------------------------------------
+#
+# `aws_conn` is created by the workflow (mzcompose.py) before this script
+# runs, because real-AWS runs need an optional SESSION TOKEN clause that
+# testdrive can't conditionally template.
+
+# Happy path: GSR connection. validate() pings GetRegistry against the
+# configured backend (moto or real AWS).
+> CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_conn,
+    REGISTRY = '${arg.registry-name}'
+  )
+
+> SELECT name, type FROM mz_connections WHERE name = 'glue_conn'
+glue_conn glue-schema-registry
+
+# Negative: validate() rejects a registry that doesn't exist. The name is
+# passed in so workflow_aws can use a guaranteed-absent UUID-suffixed value.
+! CREATE CONNECTION bad_registry TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_conn,
+    REGISTRY = '${arg.nonexistent-registry-name}'
+  )
+contains:registry
+
+> CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+
+# ---------------------------------------------------------------------------
+# Happy path 1: simple flat schema
+# ---------------------------------------------------------------------------
+
+$ set simple-schema={
+    "type": "record",
+    "name": "row",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "string"}
+    ]
+  }
+
+$ kafka-create-topic topic=simple partitions=1
+
+$ glue-create-schema registry=${arg.registry-name} name=${simple-schema-name} set-version-id-var=simple-version-id schema=${simple-schema}
+
+$ kafka-ingest format=avro topic=simple glue-schema-version-id=${simple-version-id} schema=${simple-schema} timestamp=1
+{"a": 1, "b": "hello"}
+{"a": 2, "b": "world"}
+{"a": 42, "b": "glue"}
+
+> CREATE SOURCE simple_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+> CREATE TABLE simple_table FROM SOURCE simple_source (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${simple-schema-name}')
+  ENVELOPE NONE
+
+> SELECT a, b FROM simple_table ORDER BY a
+1 hello
+2 world
+42 glue
+
+# ---------------------------------------------------------------------------
+# Happy path 2: nested record + array + nullable union
+# ---------------------------------------------------------------------------
+
+$ set nested-schema={
+    "type": "record",
+    "name": "outer",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {
+        "name": "inner",
+        "type": {
+          "type": "record",
+          "name": "inner_t",
+          "fields": [
+            {"name": "x", "type": "int"},
+            {"name": "y", "type": "string"}
+          ]
+        }
+      },
+      {"name": "inner2", "type": "inner_t"},
+      {"name": "tags", "type": {"type": "array", "items": "string"}},
+      {"name": "note", "type": ["null", "string"], "default": null}
+    ]
+  }
+
+$ kafka-create-topic topic=nested partitions=1
+
+$ glue-create-schema registry=${arg.registry-name} name=${nested-schema-name} set-version-id-var=nested-version-id schema=${nested-schema}
+
+$ kafka-ingest format=avro topic=nested glue-schema-version-id=${nested-version-id} schema=${nested-schema} timestamp=1
+{"id": 1, "inner": {"x": 10, "y": "ten"},   "inner2": {"x": 11, "y": "eleven"},     "tags": ["a", "b"], "note": null}
+{"id": 2, "inner": {"x": 20, "y": "twenty"}, "inner2": {"x": 21, "y": "twenty-one"}, "tags": [],         "note": {"string": "hi"}}
+
+> CREATE SOURCE nested_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-nested-${testdrive.seed}')
+
+> CREATE TABLE nested_table FROM SOURCE nested_source (REFERENCE "testdrive-nested-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${nested-schema-name}')
+  ENVELOPE NONE
+
+# `tags` is cast to text because materialize's binary pgwire encoding does
+# not yet support list types (unrelated to the Glue decode path).
+> SELECT id, (inner).x, (inner).y, (inner2).x, (inner2).y, tags::text, note FROM nested_table ORDER BY id
+1 10 ten 11 eleven "{a,b}" <null>
+2 20 twenty 21 twenty-one "{}" hi
+
+# ---------------------------------------------------------------------------
+# Happy path 3: schema evolution — records framed with v1 and v2 UUIDs both
+# decode against the v2 reader pulled at planning time. The added nullable
+# field with default appears as NULL for v1-framed records.
+# ---------------------------------------------------------------------------
+
+$ set evolving-v1-schema={
+    "type": "record",
+    "name": "evolving",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {"name": "value", "type": "string"}
+    ]
+  }
+
+$ set evolving-v2-schema={
+    "type": "record",
+    "name": "evolving",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {"name": "value", "type": "string"},
+      {"name": "extra", "type": ["null", "string"], "default": null}
+    ]
+  }
+
+$ kafka-create-topic topic=evolving partitions=1
+
+# Register v1, then a second version (v2) of the same schema name. Registering
+# the same name again creates a new version rather than a new schema; CREATE
+# TABLE below pins the latest (v2) as the reader.
+$ glue-create-schema registry=${arg.registry-name} name=${evolving-schema-name} set-version-id-var=evolving-v1-id schema=${evolving-v1-schema}
+
+$ glue-create-schema registry=${arg.registry-name} name=${evolving-schema-name} set-version-id-var=evolving-v2-id schema=${evolving-v2-schema}
+
+# Two records framed with V1 (no `extra` field):
+$ kafka-ingest format=avro topic=evolving glue-schema-version-id=${evolving-v1-id} schema=${evolving-v1-schema} timestamp=1
+{"id": 1, "value": "v1-first"}
+{"id": 2, "value": "v1-second"}
+
+# Two records framed with V2 (extra field present, including null):
+$ kafka-ingest format=avro topic=evolving glue-schema-version-id=${evolving-v2-id} schema=${evolving-v2-schema} timestamp=1
+{"id": 3, "value": "v2-with-extra",    "extra": {"string": "bonus"}}
+{"id": 4, "value": "v2-without-extra", "extra": null}
+
+> CREATE SOURCE evolving_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-evolving-${testdrive.seed}')
+
+> CREATE TABLE evolving_table FROM SOURCE evolving_source (REFERENCE "testdrive-evolving-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${evolving-schema-name}')
+  ENVELOPE NONE
+
+> SELECT id, value, extra FROM evolving_table ORDER BY id
+1 v1-first        <null>
+2 v1-second       <null>
+3 v2-with-extra   bonus
+4 v2-without-extra <null>
+
+# ---------------------------------------------------------------------------
+# Happy path 4: KEY FORMAT AVRO + VALUE FORMAT AVRO, both Glue-framed, under
+# ENVELOPE UPSERT. Exercises the key decode path (each clause fetches its own
+# seed) plus update + tombstone (key-only row) upsert semantics.
+# ---------------------------------------------------------------------------
+
+$ set upsert-key-schema={
+    "type": "record",
+    "name": "upsert_key",
+    "fields": [
+      {"name": "key", "type": "string"}
+    ]
+  }
+
+# No `key` field in the value: ENVELOPE UPSERT promotes the key columns into the
+# relation, so a `key` field here would collide with the key schema's column.
+$ set upsert-value-schema={
+    "type": "record",
+    "name": "upsert_val",
+    "fields": [
+      {"name": "f", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=upsert partitions=1
+
+$ glue-create-schema registry=${arg.registry-name} name=${upsert-key-schema-name} set-version-id-var=upsert-key-version-id schema=${upsert-key-schema}
+
+$ glue-create-schema registry=${arg.registry-name} name=${upsert-value-schema-name} set-version-id-var=upsert-value-version-id schema=${upsert-value-schema}
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-glue-schema-version-id=${upsert-key-version-id} key-schema=${upsert-key-schema} glue-schema-version-id=${upsert-value-version-id} schema=${upsert-value-schema} timestamp=1
+{"key": "fish"} {"f": 1000}
+{"key": "bird"} {"f": 1}
+{"key": "fish"} {"f": 2000}
+{"key": "bird"}
+{"key": "cat"} {"f": 7}
+
+> CREATE SOURCE upsert_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-${testdrive.seed}')
+
+> CREATE TABLE upsert_table FROM SOURCE upsert_source (REFERENCE "testdrive-upsert-${testdrive.seed}")
+  KEY FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${upsert-key-schema-name}')
+  VALUE FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${upsert-value-schema-name}')
+  ENVELOPE UPSERT
+
+# fish updated to 2000, bird tombstoned, cat inserted.
+> SELECT key, f FROM upsert_table ORDER BY key
+cat  7
+fish 2000
+
+# ---------------------------------------------------------------------------
+# Happy path 5: ENVELOPE DEBEZIUM with a Glue-framed key + a Glue-framed
+# before/after envelope value. CSR can use a bare format for Debezium, but
+# Glue resolves one named schema per FORMAT clause, so KEY FORMAT + VALUE
+# FORMAT are required. Exercises create/update (after set) and delete
+# (after = null).
+# ---------------------------------------------------------------------------
+
+$ set dbz-key-schema={
+    "type": "record",
+    "name": "dbz_key",
+    "fields": [
+      {"name": "id", "type": "long"}
+    ]
+  }
+
+# The planner only requires an `after` record (and a matching `before` if
+# present); `op` / `source` are not needed.
+$ set dbz-value-schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "type": "record",
+            "name": "row",
+            "fields": [
+              {"name": "id", "type": "long"},
+              {"name": "name", "type": "string"}
+            ]
+          },
+          "null"
+        ]
+      },
+      {"name": "after", "type": ["row", "null"]}
+    ]
+  }
+
+$ kafka-create-topic topic=dbz partitions=1
+
+$ glue-create-schema registry=${arg.registry-name} name=${dbz-key-schema-name} set-version-id-var=dbz-key-version-id schema=${dbz-key-schema}
+
+$ glue-create-schema registry=${arg.registry-name} name=${dbz-value-schema-name} set-version-id-var=dbz-value-version-id schema=${dbz-value-schema}
+
+$ kafka-ingest format=avro topic=dbz key-format=avro key-glue-schema-version-id=${dbz-key-version-id} key-schema=${dbz-key-schema} glue-schema-version-id=${dbz-value-version-id} schema=${dbz-value-schema} timestamp=1
+{"id": 1} {"before": null, "after": {"row": {"id": 1, "name": "first"}}}
+{"id": 2} {"before": null, "after": {"row": {"id": 2, "name": "second"}}}
+{"id": 1} {"before": {"row": {"id": 1, "name": "first"}}, "after": {"row": {"id": 1, "name": "first-updated"}}}
+{"id": 2} {"before": {"row": {"id": 2, "name": "second"}}, "after": null}
+
+> CREATE SOURCE dbz_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbz-${testdrive.seed}')
+
+> CREATE TABLE dbz_table FROM SOURCE dbz_source (REFERENCE "testdrive-dbz-${testdrive.seed}")
+  KEY FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${dbz-key-schema-name}')
+  VALUE FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${dbz-value-schema-name}')
+  ENVELOPE DEBEZIUM
+
+# id 1 updated to first-updated, id 2 deleted (after = null).
+> SELECT id, name FROM dbz_table ORDER BY id
+1 first-updated
+
+# ---------------------------------------------------------------------------
+# Negative: a bare (value-only) Glue FORMAT under ENVELOPE UPSERT must be
+# rejected — UPSERT requires a key, so a KEY FORMAT clause is mandatory.
+# ---------------------------------------------------------------------------
+
+> CREATE SOURCE neg_upsert_no_key_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+! CREATE TABLE neg_upsert_no_key_table FROM SOURCE neg_upsert_no_key_source (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${simple-schema-name}')
+  ENVELOPE UPSERT
+contains:requires that KEY FORMAT be specified
+
+> DROP SOURCE neg_upsert_no_key_source
+
+# ---------------------------------------------------------------------------
+# Negative: SCHEMA NAME points to a schema that doesn't exist in the registry.
+# Purification should fail with a clear error before CREATE TABLE commits.
+# ---------------------------------------------------------------------------
+
+> CREATE SOURCE neg_missing_schema_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+! CREATE TABLE neg_missing_schema_table FROM SOURCE neg_missing_schema_source (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'no-such-schema')
+  ENVELOPE NONE
+contains:Glue schema lookup failed
+
+> DROP SOURCE neg_missing_schema_source
+
+# ---------------------------------------------------------------------------
+# Negative: SCHEMA NAME option is required by the planner.
+# ---------------------------------------------------------------------------
+
+> CREATE SOURCE neg_no_schema_name_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+! CREATE TABLE neg_no_schema_name_table FROM SOURCE neg_no_schema_name_source (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn
+  ENVELOPE NONE
+contains:SCHEMA NAME option is required
+
+> DROP SOURCE neg_no_schema_name_source
+
+# ---------------------------------------------------------------------------
+# Negative: schema exists in the registry but its data-format is not AVRO.
+# Purification must reject this with a clear SQL error before any record
+# decode is attempted — the runtime path only handles Avro. The JSON-format
+# schema is registered just to be rejected, so it has no version-id var and is
+# never ingested. The contents are irrelevant — the data-format check fires
+# before the body is parsed.
+# ---------------------------------------------------------------------------
+
+$ glue-create-schema registry=${arg.registry-name} name=${json-schema-name} data-format=json compatibility=none
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {"id": {"type": "integer"}}
+}
+
+> CREATE SOURCE neg_json_format_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+! CREATE TABLE neg_json_format_table FROM SOURCE neg_json_format_source (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${json-schema-name}')
+  ENVELOPE NONE
+contains:unsupported data format JSON
+
+> DROP SOURCE neg_json_format_source
+
+# ---------------------------------------------------------------------------
+# Negative: FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY pointed at a
+# non-Glue connection (here the Kafka connection itself). Purification
+# rejects this before any AWS call.
+# ---------------------------------------------------------------------------
+
+> CREATE SOURCE neg_wrong_conn_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+! CREATE TABLE neg_wrong_conn_table FROM SOURCE neg_wrong_conn_source (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION kafka_conn (SCHEMA NAME = '${simple-schema-name}')
+  ENVELOPE NONE
+contains:is not an AWS GLUE SCHEMA REGISTRY CONNECTION
+
+> DROP SOURCE neg_wrong_conn_source
+
+# ---------------------------------------------------------------------------
+# Negative: Glue is only supported on Kafka sources. The parser accepts a
+# FORMAT clause on any source (it only sees the source name), so the
+# restriction is enforced during purification. A load-generator source is the
+# cheapest non-Kafka source to drive this — no external system required.
+# ---------------------------------------------------------------------------
+
+> CREATE SOURCE neg_loadgen_source
+  IN CLUSTER quickstart
+  FROM LOAD GENERATOR COUNTER (UP TO 5)
+
+! CREATE TABLE neg_non_kafka_table FROM SOURCE neg_loadgen_source
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${simple-schema-name}')
+  ENVELOPE NONE
+contains:only supported with Kafka sources
+
+> DROP SOURCE neg_loadgen_source
+
+# ---------------------------------------------------------------------------
+# Runtime registry enforcement: a record framed with a UUID from a schema
+# that has the SAME name but lives in a DIFFERENT registry must be rejected
+# at decode time. Glue schema-version UUIDs are globally unique within an
+# account and GetSchemaVersion(uuid) is not registry-scoped, so without
+# this check the source would silently accept records from any registry
+# the credentials can read.
+# ---------------------------------------------------------------------------
+
+# Same schema NAME as the primary registry's simple schema, but a different
+# definition (extra `c` field), registered in the OTHER registry.
+$ set other-samename-schema={
+    "type": "record",
+    "name": "row",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "string"},
+      {"name": "c", "type": "string"}
+    ]
+  }
+
+$ glue-create-schema registry=${arg.other-registry-name} name=${simple-schema-name} set-version-id-var=other-samename-version-id schema=${other-samename-schema}
+
+$ kafka-create-topic topic=cross-registry partitions=1
+
+# One legit record (UUID belongs to the configured registry):
+$ kafka-ingest format=avro topic=cross-registry glue-schema-version-id=${simple-version-id} schema=${simple-schema} timestamp=1
+{"a": 100, "b": "good"}
+
+# One bogus record (same schema name, but UUID belongs to OTHER_REGISTRY):
+$ kafka-ingest format=avro topic=cross-registry glue-schema-version-id=${other-samename-version-id} schema=${other-samename-schema} timestamp=1
+{"a": 200, "b": "wrong-registry", "c": "extra"}
+
+> CREATE SOURCE cross_registry_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-cross-registry-${testdrive.seed}')
+
+> CREATE TABLE cross_registry_table FROM SOURCE cross_registry_source (REFERENCE "testdrive-cross-registry-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${simple-schema-name}')
+  ENVELOPE NONE
+
+# The bogus record surfaces as a permanent decode error on the table; the
+# legit record is unobservable from the error-bearing query but the error
+# message itself proves the cross-registry UUID was caught.
+! SELECT * FROM cross_registry_table
+contains:lives in registry "${arg.other-registry-name}"
+
+# ---------------------------------------------------------------------------
+# Glue's implicit default registry, addressed by the literal name
+# "default-registry". Verifies the no-RegistryId code path works end to end.
+# ---------------------------------------------------------------------------
+
+$ set default-schema={
+    "type": "record",
+    "name": "default_row",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {"name": "label", "type": "string"}
+    ]
+  }
+
+# Register the schema (no registry= → the implicit default registry) *before*
+# creating the connection: the connection's validate() pings
+# GetRegistry('default-registry'), and moto only materializes the implicit
+# default registry once something has been created in it.
+$ glue-create-schema name=${arg.default-schema-name} set-version-id-var=default-version-id schema=${default-schema}
+
+> CREATE CONNECTION default_glue_conn TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_conn,
+    REGISTRY = '${arg.default-registry-name}'
+  )
+
+$ kafka-create-topic topic=default-registry partitions=1
+
+$ kafka-ingest format=avro topic=default-registry glue-schema-version-id=${default-version-id} schema=${default-schema} timestamp=1
+{"id": 1, "label": "first"}
+{"id": 2, "label": "second"}
+
+> CREATE SOURCE default_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-default-registry-${testdrive.seed}')
+
+> CREATE TABLE default_table FROM SOURCE default_source (REFERENCE "testdrive-default-registry-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION default_glue_conn (SCHEMA NAME = '${arg.default-schema-name}')
+  ENVELOPE NONE
+
+> SELECT id, label FROM default_table ORDER BY id
+1 first
+2 second

--- a/test/aws-glue-schema-registry/mzcompose
+++ b/test/aws-glue-schema-registry/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/aws-glue-schema-registry/mzcompose.py
+++ b/test/aws-glue-schema-registry/mzcompose.py
@@ -1,0 +1,336 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""End-to-end tests for the AWS Glue Schema Registry source path.
+
+Two workflows are provided:
+
+* `default` — runs against `motoserver/moto` inside the compose network.
+  Wired into the `test` pipeline under the Kafka group. LocalStack Community
+  does not implement the Glue API (it's a Pro service), so moto is the
+  open-source mock we use.
+* `aws` — runs against real AWS Glue using credentials from the ambient
+  environment (env vars, `AWS_PROFILE`, SSO session, instance role, ...).
+  Wired into the `nightly` pipeline under the AWS group via the
+  `scratch-aws-access` plugin. Catches API/IAM drift that moto papers over.
+"""
+
+import os
+import uuid
+from collections.abc import Iterator
+
+import boto3
+
+from materialize.mzcompose import DEFAULT_CLOUD_REGION
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.kafka import Kafka
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.moto import Moto
+from materialize.mzcompose.services.testdrive import Testdrive
+
+# Moto-mode constants. workflow_aws derives its own per-run names.
+MOTO_AWS_ACCESS_KEY_ID = "test"
+MOTO_AWS_SECRET_ACCESS_KEY = "test"
+MOTO_AWS_ENDPOINT_URL = "http://moto:5000"
+
+REGISTRY_NAME_BASE = "mz-test-registry"
+OTHER_REGISTRY_NAME_BASE = "mz-other-registry"
+# Glue's implicit default registry is addressed by the literal name
+# "default-registry". It's an account-wide singleton — we suffix only the
+# *schema* name inside it, never the registry itself.
+DEFAULT_REGISTRY_NAME = "default-registry"
+
+# Schemas that live inside a per-run registry need no per-run-unique name (the
+# registry already isolates them), so their names and definitions both live in
+# glue-schema-registry.td. The only schema name owned here is the one in the
+# shared default registry, which *does* need a run-id suffix and which the
+# cleanup hook deletes by name (the default registry can't be dropped).
+DEFAULT_SCHEMA_NAME_BASE = "mz-default-schema"
+
+SERVICES = [
+    Moto(),
+    Kafka(),
+    Materialized(
+        depends_on=["moto"],
+        environment_extra=[
+            f"AWS_REGION={DEFAULT_CLOUD_REGION}",
+            f"AWS_ENDPOINT_URL={MOTO_AWS_ENDPOINT_URL}",
+            f"AWS_ACCESS_KEY_ID={MOTO_AWS_ACCESS_KEY_ID}",
+            f"AWS_SECRET_ACCESS_KEY={MOTO_AWS_SECRET_ACCESS_KEY}",
+        ],
+    ),
+    Testdrive(
+        default_timeout="30s",
+        no_reset=True,
+        # Point testdrive's AWS client at moto so the `glue-create-schema`
+        # action registers schemas in the same backend Materialize reads from.
+        # workflow_aws overrides this to talk to real AWS.
+        aws_endpoint=MOTO_AWS_ENDPOINT_URL,
+        aws_access_key_id=MOTO_AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=MOTO_AWS_SECRET_ACCESS_KEY,
+    ),
+]
+
+
+def _create_registries(
+    glue,
+    *,
+    registry_name: str,
+    other_registry_name: str,
+) -> None:
+    """Create the named registries.
+
+    The schemas inside them are registered by the testdrive script via the
+    `glue-create-schema` action; here we only create the registries those
+    schemas land in (the implicit default registry needs no creation). Deleting
+    a registry cascades to its schemas, so this is all the cleanup hook below
+    needs to undo for the named registries.
+    """
+    glue.create_registry(RegistryName=registry_name)
+    glue.create_registry(RegistryName=other_registry_name)
+
+
+def _cleanup_glue(
+    glue,
+    *,
+    registries: Iterator[str],
+    default_schema_name: str | None,
+) -> None:
+    """Best-effort cleanup. Never raises on missing resources."""
+    for reg in registries:
+        try:
+            glue.delete_registry(RegistryId={"RegistryName": reg})
+        except glue.exceptions.EntityNotFoundException:
+            pass
+        except Exception as e:
+            print(f"warning: failed to delete registry {reg!r}: {e}")
+    if default_schema_name is not None:
+        try:
+            glue.delete_schema(
+                SchemaId={
+                    "RegistryName": DEFAULT_REGISTRY_NAME,
+                    "SchemaName": default_schema_name,
+                }
+            )
+        except glue.exceptions.EntityNotFoundException:
+            pass
+        except Exception as e:
+            print(f"warning: failed to delete default-registry schema: {e}")
+
+
+def _run_testdrive(
+    c: Composition,
+    *,
+    aws_conn_sql: str,
+    registry_name: str,
+    other_registry_name: str,
+    nonexistent_registry_name: str,
+    default_schema_name: str,
+) -> None:
+    # Bring up the AWS connection out-of-band so we can include SESSION TOKEN
+    # only when present.
+    #
+    # Only the resources whose names must be unique per run and are managed here
+    # — the registries and the shared default-registry schema — are passed in.
+    # In-registry schema names are constants defined in the script, and every
+    # schema body + version UUID is produced there by `glue-create-schema`.
+    c.testdrive(input=aws_conn_sql)
+    c.run_testdrive_files(
+        f"--var=registry-name={registry_name}",
+        f"--var=other-registry-name={other_registry_name}",
+        f"--var=default-registry-name={DEFAULT_REGISTRY_NAME}",
+        f"--var=nonexistent-registry-name={nonexistent_registry_name}",
+        f"--var=default-schema-name={default_schema_name}",
+        "glue-schema-registry.td",
+    )
+
+
+def workflow_default(c: Composition) -> None:
+    """CI workflow: run against motoserver/moto."""
+    c.up("moto")
+
+    aws_endpoint_url = f"http://localhost:{c.port('moto', 5000)}"
+    glue = boto3.client(
+        "glue",
+        endpoint_url=aws_endpoint_url,
+        region_name=DEFAULT_CLOUD_REGION,
+        aws_access_key_id=MOTO_AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=MOTO_AWS_SECRET_ACCESS_KEY,
+    )
+
+    # Moto starts empty, but re-running against the same instance shouldn't
+    # blow up. Fixed names are fine here — moto is per-compose-network.
+    _cleanup_glue(
+        glue,
+        registries=iter([REGISTRY_NAME_BASE, OTHER_REGISTRY_NAME_BASE]),
+        default_schema_name=DEFAULT_SCHEMA_NAME_BASE,
+    )
+
+    _create_registries(
+        glue,
+        registry_name=REGISTRY_NAME_BASE,
+        other_registry_name=OTHER_REGISTRY_NAME_BASE,
+    )
+
+    c.up("kafka", "materialized")
+
+    aws_conn_sql = f"""
+> CREATE SECRET aws_secret_access_key AS '{MOTO_AWS_SECRET_ACCESS_KEY}'
+
+> CREATE CONNECTION aws_conn TO AWS (
+    ACCESS KEY ID = '{MOTO_AWS_ACCESS_KEY_ID}',
+    SECRET ACCESS KEY = SECRET aws_secret_access_key
+  )
+"""
+
+    _run_testdrive(
+        c,
+        aws_conn_sql=aws_conn_sql,
+        registry_name=REGISTRY_NAME_BASE,
+        other_registry_name=OTHER_REGISTRY_NAME_BASE,
+        nonexistent_registry_name="no-such-registry",
+        default_schema_name=DEFAULT_SCHEMA_NAME_BASE,
+    )
+
+
+def workflow_aws(c: Composition) -> None:
+    """Run the same test suite against real AWS Glue.
+
+    In CI, the `scratch-aws-access` Buildkite plugin assumes the scratch
+    role and exports `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
+    `AWS_SESSION_TOKEN` before this workflow runs; locally, any credential
+    source the default boto3 chain resolves (env vars / AWS_PROFILE / SSO
+    session / instance role) works the same way. The resolved credentials
+    are forwarded to Materialize so its in-process Glue client uses the
+    same identity as the test harness. Region is read from `AWS_REGION` /
+    `AWS_DEFAULT_REGION`, falling back to `us-east-1`.
+
+    Registry and schema names are suffixed with a per-run UUID so concurrent
+    runs and prior leaks do not collide. A try/finally guarantees teardown.
+    """
+    region = (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "us-east-1"
+    )
+    session = boto3.Session(region_name=region)
+    creds = session.get_credentials()
+    if creds is None:
+        raise RuntimeError(
+            "no AWS credentials resolvable; configure AWS_PROFILE / env vars / "
+            "SSO before running workflow_aws"
+        )
+    frozen = creds.get_frozen_credentials()
+    if not frozen.access_key or not frozen.secret_key:
+        raise RuntimeError("resolved AWS credentials are missing access/secret key")
+
+    run_id = uuid.uuid4().hex[:8]
+    registry_name = f"{REGISTRY_NAME_BASE}-{run_id}"
+    other_registry_name = f"{OTHER_REGISTRY_NAME_BASE}-{run_id}"
+    # The default registry is account-wide shared, so its schema needs a unique
+    # name; the per-run registries above isolate every other schema.
+    default_schema_name = f"{DEFAULT_SCHEMA_NAME_BASE}-{run_id}"
+    nonexistent_registry_name = f"mz-no-such-registry-{uuid.uuid4().hex}"
+
+    glue = session.client("glue")
+
+    # Re-point Materialize at real AWS by dropping the moto endpoint override
+    # and feeding it the resolved credentials. Region must match.
+    #
+    # SSL_CERT_FILE: Materialize's AWS client uses vendored OpenSSL, whose
+    # compiled-in trust-store dir doesn't match where the image's
+    # `ca-certificates` lives, so TLS to real AWS Glue fails to verify without
+    # this. (moto runs over plaintext HTTP, so the `default` workflow doesn't
+    # need it.)
+    materialized_env = [
+        f"AWS_REGION={region}",
+        f"AWS_ACCESS_KEY_ID={frozen.access_key}",
+        f"AWS_SECRET_ACCESS_KEY={frozen.secret_key}",
+        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt",
+    ]
+    if frozen.token:
+        materialized_env.append(f"AWS_SESSION_TOKEN={frozen.token}")
+
+    # The Testdrive service forwards AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+    # AWS_SESSION_TOKEN from this process's environment into the container, where
+    # testdrive's `glue-create-schema` action resolves them via the default AWS
+    # provider chain. Set them here so the container gets the same identity even
+    # when our own credentials came from an SSO profile rather than env vars.
+    os.environ["AWS_ACCESS_KEY_ID"] = frozen.access_key
+    os.environ["AWS_SECRET_ACCESS_KEY"] = frozen.secret_key
+    if frozen.token:
+        os.environ["AWS_SESSION_TOKEN"] = frozen.token
+
+    aws_conn_sql_lines = [
+        f"> CREATE SECRET aws_secret_access_key AS '{frozen.secret_key}'",
+    ]
+    if frozen.token:
+        aws_conn_sql_lines.append(
+            f"> CREATE SECRET aws_session_token AS '{frozen.token}'"
+        )
+    conn_body = [
+        f"    ACCESS KEY ID = '{frozen.access_key}'",
+        "    SECRET ACCESS KEY = SECRET aws_secret_access_key",
+        f"    REGION = '{region}'",
+    ]
+    if frozen.token:
+        conn_body.append("    SESSION TOKEN = SECRET aws_session_token")
+    aws_conn_sql_lines.append("> CREATE CONNECTION aws_conn TO AWS (")
+    aws_conn_sql_lines.append(",\n".join(conn_body))
+    aws_conn_sql_lines.append("  )")
+    aws_conn_sql = "\n".join(aws_conn_sql_lines) + "\n"
+
+    print(f"workflow_aws: region={region} run_id={run_id}")
+    print(f"workflow_aws: registry={registry_name}")
+    print(f"workflow_aws: other-registry={other_registry_name}")
+    print(f"workflow_aws: default-registry-schema={default_schema_name}")
+
+    try:
+        # Best-effort precleanup in case a prior run with this exact run_id
+        # ever happened (collision is astronomically unlikely but cheap).
+        _cleanup_glue(
+            glue,
+            registries=iter([registry_name, other_registry_name]),
+            default_schema_name=default_schema_name,
+        )
+
+        _create_registries(
+            glue,
+            registry_name=registry_name,
+            other_registry_name=other_registry_name,
+        )
+
+        with c.override(
+            Materialized(depends_on=[], environment_extra=materialized_env),
+            # Point testdrive at real AWS (region, no moto endpoint); credentials
+            # are resolved from the environment set above.
+            Testdrive(
+                default_timeout="30s",
+                no_reset=True,
+                aws_region=region,
+                aws_endpoint=None,
+                aws_access_key_id=None,
+                aws_secret_access_key=None,
+            ),
+        ):
+            c.up("kafka", "materialized")
+            _run_testdrive(
+                c,
+                aws_conn_sql=aws_conn_sql,
+                registry_name=registry_name,
+                other_registry_name=other_registry_name,
+                nonexistent_registry_name=nonexistent_registry_name,
+                default_schema_name=default_schema_name,
+            )
+    finally:
+        _cleanup_glue(
+            glue,
+            registries=iter([registry_name, other_registry_name]),
+            default_schema_name=default_schema_name,
+        )


### PR DESCRIPTION
Adds E2E testing for AWS Glue schema registry with a Kafka source.

AWS Glue supports multiple registries, including a default. Schemas exist within registries. mzcompose.py takes care of registry setup and teardown, testdrive takes care of schema creation (glue-schema-create).

- local/test pipeline use [Moto](https://github.com/getmoto/moto) to emulate schema registry (default workflow)
- nightly pipeline uses AWS (aws workflow)


This is not an exhaustive list of tests, we are missing availability/connectivity tests (MZ restart, glue schema registry unreachable, etc.).  I'll draft a separate PR for those.