### PR TITLE
console: add k6 load test harness for cluster detail performance

### DIFF
--- a/console/.gitignore
+++ b/console/.gitignore
@@ -12,6 +12,7 @@ yarn-error.log
 
 # Playwrite E2E tests
 /e2e-tests/state*.json
+/e2e-tests/k6/queries.json
 /test-results
 
 # Vite

--- a/console/doc/guide-testing.md
+++ b/console/doc/guide-testing.md
@@ -320,6 +320,65 @@ clusters (useClusters)                       1/1.161 595/1072.983 1/1.545
 High queue times indicate browser connection pool contention (HTTP/1.1 6-connection
 limit). High server times indicate slow SQL execution on the Materialize side.
 
+### Running Load Tests (k6)
+
+[k6](https://k6.io) scripts in `e2e-tests/k6/` replay the console's `/api/sql`
+traffic against Materialize at increasing virtual-user counts. Complements the
+Playwright scalability tests above: Playwright covers end-to-end browser UX
+under load, k6 isolates pure server-side concurrency on `mz_catalog_server`.
+
+#### Setup
+
+```shell
+brew install k6
+```
+
+#### Step 1: Dump live queries
+
+The k6 script replays exact `/api/sql` POSTs. Capture them once against your
+running stack:
+
+```shell
+cd console
+npx playwright test --project=scalability dump-queries
+```
+
+Writes one entry per query label to `e2e-tests/k6/queries.json` (gitignored —
+environment-specific). Re-run whenever the console's query set changes.
+
+Defaults: `BASE_URL=http://localhost:3000`, `CLUSTER_ID=s2`,
+`CLUSTER_NAME=mz_catalog_server`. Same env vars as the Playwright scalability
+tests.
+
+#### Step 2: Run k6
+
+```shell
+cd console/e2e-tests/k6
+MZ_HTTP_URL=http://localhost:6876 k6 run cluster-detail.ts
+```
+
+`MZ_HTTP_URL` points at Materialize's HTTP SQL endpoint. For workload-replay,
+find the host port mapping with `docker port workload-replay-materialized-1`.
+
+Sanity check first at 1 VU to confirm the dump is faithful:
+
+```shell
+MZ_HTTP_URL=http://localhost:6876 k6 run --vus 1 --duration 30s cluster-detail.ts
+```
+
+Default ramp goes 5 → 20 → 50 → 100 VUs over ~6 minutes. Override per stage:
+
+```shell
+VUS_STAGE_1=10 VUS_STAGE_2=50 VUS_STAGE_3=100 VUS_STAGE_4=200 k6 run cluster-detail.ts
+```
+
+#### Reading the output
+
+The end-of-run summary prints per-label `http_req_duration` percentiles using
+the same label scheme as the Playwright audits (`clusters.list`, `healthCheck`,
+etc.). Threshold lines (`✓` / `✗`) show pass/fail against per-query SLA gates
+defined in `cluster-detail.ts`. Baseline runs live in `e2e-tests/k6/baselines/`.
+
 ## Testing Philosophy
 
 We follow the same testing philosophy as the rest of the company. In particular:

--- a/console/e2e-tests/k6/baselines/workload_replay_2026_05_29.md
+++ b/console/e2e-tests/k6/baselines/workload_replay_2026_05_29.md
@@ -1,0 +1,43 @@
+# k6 Baseline: Cluster Detail under VU Ramp
+
+**Date:** 2026-05-29
+**Workload:** workload-replay (continuous ingestion grew the catalog between dump and run)
+**Environment:** Local workload-replay
+**Console:** Production code, no optimizations (`main`)
+**Cluster tested:** `mz_catalog_server` (system cluster, id: `s2`, default replica size)
+**Script:** `cluster-detail.ts`, ramp 0→5→20→50→100 VUs over 6m
+
+## Per-label `http_req_duration` (full ramp, 6m)
+
+| Label | Cadence | Min | Med | Avg | p95 | p99 | Max | Threshold | Pass? |
+|---|---|---|---|---|---|---|---|---|---|
+| healthCheck | 5s | 2.04ms | 2.79ms | 3.42ms | 6.66ms | 11.66ms | 47.51ms | p95<500ms | ✓ |
+| clusters.clusterFreshness | 5s | 432.69ms | 6.59s | 7.46s | 15.83s | 16.58s | 16.63s | p95<2s | ✗ |
+| clusters.largestClusterReplica | 60s | 701.49ms | 6.14s | 7.93s | 19.39s | 20.12s | 20.48s | p95<5s | ✗ |
+| clusters.replicaUtilizationHistory | 20s | 157.83ms | 10.69s | 11.89s | 30.26s | 33.09s | 34.09s | p95<2s | ✗ |
+| clusters.list | 5s | 319.5ms | 19.45s | 21.24s | 45.26s | 45.88s | 50.95s | p95<2s | ✗ |
+| clusters.largestMaintainedQueries | 60s | 1m0s | 1m0s | 1m0s | 1m0s | 1m0s | 1m0s | p95<5s | ✗ (timeouts) |
+| clusters.materializationLag | 5s | — | — | — | — | — | — | p95<2s | not captured by dump |
+
+**Total:** 1538 requests, 51 failures (3.31%), throughput 3.94 RPS
+
+## Execution
+
+| Metric | Value |
+|---|---|
+| Iterations completed | 248 (71 interrupted) |
+| Iteration duration (avg) | 48.23s |
+| Iteration duration (p95) | 2m3s |
+| Iteration duration (max) | 2m37s |
+| Peak VUs | 100 |
+| Data received | 266 MB |
+| Data sent | 3.0 MB |
+
+## Key observations
+
+- All polling queries that touch `mz_catalog_server` with real work degrade 16–45×; `healthCheck` stays flat at p95 6.66ms — the bottleneck is catalog_server compute, not request handling or networking.
+- `clusters.list` is the worst non-timeout offender: p95 45.26s, 23× over its 2s budget.
+- `largestMaintainedQueries` pins at the 60s k6 request-timeout ceiling and accounts for all 51 failed requests. **Partial artifact:** the dumped request has `replicaHeapLimit: 0` baked in (the React Query hook short-circuits on null/undefined but not on 0). With a realistic heap-limit value the query would still be slow under load, but probably not at the timeout ceiling.
+- `materializationLag` did not fire during the dump (only 11 labels captured this run vs 12 prior). Its threshold pass is k6's no-data default, not a real result.
+- Throughput plateaus at ~4 RPS; VUs run ~10× slower than their 5s polling target (iter_duration avg 48s, p95 2m3s).
+- Re-runs against the same workload-replay container are not directly comparable — continuous ingestion grows the catalog between runs, which makes catalog_server queries heavier each time. Capture the docker container state alongside any new baseline.

--- a/console/e2e-tests/k6/cluster-detail.ts
+++ b/console/e2e-tests/k6/cluster-detail.ts
@@ -1,0 +1,187 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// File-local declarations for k6-injected runtime globals (not modules).
+// k6 module shapes (`k6`, `k6/http`) live in ./k6.d.ts.
+declare const __ENV: Record<string, string | undefined>;
+declare const __ITER: number;
+declare function open(path: string): string;
+
+/**
+ * k6 load test for the cluster-detail page.
+ *
+ * Replays the SQL queries captured by `dump-queries.spec.ts` against
+ * Materialize's HTTP SQL endpoint at increasing virtual-user counts. Each VU
+ * simulates one browser tab; each iteration is one ~5s polling tick. Used to
+ * characterize how cluster-detail queries behave on `mz_catalog_server`
+ * under multi-user load.
+ *
+ * See `console/doc/guide-testing.md` ("Running Load Tests (k6)") for setup,
+ * dumping `queries.json`, and run examples.
+ */
+
+import { check, sleep } from "k6";
+import http from "k6/http";
+
+interface CapturedQuery {
+  urlPath: string;
+  body: unknown;
+}
+
+type CapturedQueries = Record<string, CapturedQuery>;
+
+/**
+ * Reads queries.json or throws a guided error if it's missing.
+ * `open()` is k6's sync init-time file read; it surfaces an unhelpful "no
+ * such file or directory" by default. We catch that to point users at the
+ * dump step.
+ */
+function loadQueries(): CapturedQueries {
+  try {
+    return JSON.parse(open("./queries.json")) as CapturedQueries;
+  } catch {
+    throw new Error(
+      "queries.json not found in console/e2e-tests/k6/. " +
+        "Generate it first by running:\n" +
+        "  cd console && npx playwright test --project=scalability dump-queries",
+    );
+  }
+}
+
+/** Captured `/api/sql` POSTs keyed by query label (see ../scalability/helpers.ts). */
+const QUERIES: CapturedQueries = loadQueries();
+
+/**
+ * How often each query polls (ms), matching `refetchInterval` in
+ * `src/platform/clusters/queries.ts`. `Infinity` = fire once on cold load.
+ */
+const POLL_INTERVAL_MS: Record<string, number> = {
+  "clusters.largestClusterReplica": 60_000,
+  "clusters.largestMaintainedQueries": 60_000,
+  "clusters.replicaUtilizationHistory": 20_000,
+  canCreateCluster: Infinity,
+  canCreateObjects: Infinity,
+  currentUser: Infinity,
+  isSuperUser: Infinity,
+  privileges: Infinity,
+};
+
+/** Polling interval used when a label isn't listed in `POLL_INTERVAL_MS`. */
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/** One VU iteration = one polling tick. Drives sleep and interval math. */
+const TICK_MS = 5_000;
+
+const MZ_URL = (__ENV.MZ_HTTP_URL || "http://localhost:6876").replace(
+  /\/$/,
+  "",
+);
+
+/**
+ * k6 scenario, threshold, and summary configuration.
+ *
+ * - Ramps 0→100 VUs over 6 minutes via 5 stages. Each stage's target is
+ *   overridable through `VUS_STAGE_N` env vars (handy for narrower sweeps).
+ * - Each threshold doubles as an SLA gate AND forces k6 to render that
+ *   label's `http_req_duration` breakdown in the end-of-run summary —
+ *   without a threshold the metric is collected but hidden.
+ */
+export const options = {
+  scenarios: {
+    cluster_detail_ramp: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: [
+        { duration: "30s", target: parseInt(__ENV.VUS_STAGE_1 || "5", 10) },
+        { duration: "1m", target: parseInt(__ENV.VUS_STAGE_2 || "20", 10) },
+        { duration: "2m", target: parseInt(__ENV.VUS_STAGE_3 || "50", 10) },
+        { duration: "2m", target: parseInt(__ENV.VUS_STAGE_4 || "100", 10) },
+        { duration: "30s", target: 0 },
+      ],
+      gracefulRampDown: "30s",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    "http_req_duration{label:healthCheck}": ["p(95)<500"],
+    "http_req_duration{label:clusters.list}": ["p(95)<2000"],
+    "http_req_duration{label:clusters.materializationLag}": ["p(95)<2000"],
+    "http_req_duration{label:clusters.clusterFreshness}": ["p(95)<2000"],
+    "http_req_duration{label:clusters.replicaUtilizationHistory}": [
+      "p(95)<2000",
+    ],
+    "http_req_duration{label:clusters.largestClusterReplica}": ["p(95)<5000"],
+    "http_req_duration{label:clusters.largestMaintainedQueries}": [
+      "p(95)<5000",
+    ],
+  },
+  summaryTrendStats: ["min", "med", "avg", "p(95)", "p(99)", "max"],
+};
+
+/**
+ * POSTs one captured query and records pass/fail checks. Silently skips
+ * labels missing from `queries.json`.
+ */
+function fireQuery(label: string) {
+  const entry = QUERIES[label];
+  if (!entry) return;
+
+  const res = http.post(
+    `${MZ_URL}${entry.urlPath}`,
+    JSON.stringify(entry.body),
+    {
+      headers: { "Content-Type": "application/json" },
+      tags: { label },
+    },
+  );
+
+  check(
+    res,
+    {
+      "status 200": (r) => r.status === 200,
+      "no sql error": (r) => {
+        try {
+          const body = JSON.parse(r.body as string) as {
+            results?: Array<unknown>;
+          };
+          return !(body.results ?? []).some(
+            (x) => x && typeof x === "object" && "error" in x,
+          );
+        } catch {
+          return false;
+        }
+      },
+    },
+    { label },
+  );
+}
+
+/**
+ * Default VU loop — one polling tick per iteration.
+ *
+ * - Iteration 0 is the cold-mount burst: fires every captured query once.
+ * - Later iterations fire each query only when its poll interval has elapsed.
+ *   The check `elapsedMs % intervalMs < TICK_MS` picks the first tick on or
+ *   after each boundary; `Infinity` intervals never satisfy it, so one-shot
+ *   queries stay out of the polling loop.
+ */
+export default function () {
+  if (__ITER === 0) {
+    for (const label of Object.keys(QUERIES)) fireQuery(label);
+    sleep(TICK_MS / 1000);
+    return;
+  }
+
+  const elapsedMs = __ITER * TICK_MS;
+  for (const label of Object.keys(QUERIES)) {
+    const intervalMs = POLL_INTERVAL_MS[label] ?? DEFAULT_POLL_INTERVAL_MS;
+    if (elapsedMs % intervalMs < TICK_MS) fireQuery(label);
+  }
+  sleep(TICK_MS / 1000);
+}

--- a/console/e2e-tests/k6/k6.d.ts
+++ b/console/e2e-tests/k6/k6.d.ts
@@ -1,0 +1,36 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Minimal type declarations for k6's runtime APIs used by cluster-detail.ts.
+// k6 publishes a more complete `@types/k6` package; declaring only what we
+// touch keeps this single-script change self-contained.
+
+declare module "k6" {
+  export function check<R>(
+    val: R,
+    sets: Record<string, (r: R) => boolean>,
+    tags?: Record<string, string>,
+  ): boolean;
+  export function sleep(t: number): void;
+}
+
+declare module "k6/http" {
+  export interface RefinedResponse {
+    status: number;
+    body: string | ArrayBuffer | null;
+  }
+  interface Params {
+    headers?: Record<string, string>;
+    tags?: Record<string, string>;
+  }
+  const http: {
+    post(url: string, body: string, params?: Params): RefinedResponse;
+  };
+  export default http;
+}

--- a/console/e2e-tests/scalability/dump-queries.spec.ts
+++ b/console/e2e-tests/scalability/dump-queries.spec.ts
@@ -1,0 +1,117 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * Captures one console page's /api/sql traffic into a JSON file that the k6
+ * harness in console/e2e-tests/k6/ replays under load. One entry per query
+ * label (clusters.list, healthCheck, ...) using the helpers.ts label scheme.
+ *
+ * Output: e2e-tests/k6/queries.json (gitignored — environment-specific).
+ *
+ * Run from console/:
+ *   npx playwright test --project=scalability dump-queries
+ */
+
+import { Request, test } from "@playwright/test";
+
+import {
+  assertNoErrors,
+  CLUSTER_ID,
+  CLUSTER_NAME,
+  clusterDetailUrl,
+  createAuthenticatedContext,
+  labelRequest,
+  waitForPageLoad,
+} from "./helpers";
+
+// Resolved against process.cwd() — script must be invoked from console/.
+const OUTPUT_PATH = "e2e-tests/k6/queries.json";
+
+// Long enough to capture 60s-cadence queries at least once after cold load.
+const CAPTURE_DURATION_MS = 75_000;
+
+interface CapturedQuery {
+  urlPath: string;
+  body: unknown;
+}
+
+type CapturedQueries = Record<string, CapturedQuery>;
+
+/** Opens a page, watches every /api/sql POST, returns the latest one per label. */
+async function dumpPage(
+  pageName: string,
+  url: string,
+  browser: import("@playwright/test").Browser,
+): Promise<CapturedQueries> {
+  const context = await createAuthenticatedContext(browser);
+  const page = await context.newPage();
+  const captured = new Map<string, CapturedQuery>();
+
+  page.on("request", (request) => {
+    const entry = parseSqlRequest(request);
+    if (entry) captured.set(entry.label, entry.query);
+  });
+
+  console.log(`Dumping ${pageName}: ${url}`);
+  await page.goto(url);
+  await waitForPageLoad(page);
+  await assertNoErrors(page, `dump ${pageName}`);
+  await page.waitForTimeout(CAPTURE_DURATION_MS);
+
+  console.log(`  Captured ${captured.size} labels:`);
+  for (const label of [...captured.keys()].sort()) {
+    console.log(`    ${label}`);
+  }
+
+  await context.close();
+  return Object.fromEntries(captured);
+}
+
+/** Returns {label, query} for a /api/sql POST; undefined for anything else. */
+function parseSqlRequest(
+  request: Request,
+): { label: string; query: CapturedQuery } | undefined {
+  if (!request.url().includes("/api/sql")) return;
+  if (request.method() !== "POST") return;
+
+  let body: unknown;
+  try {
+    body = JSON.parse(request.postData() || "{}");
+  } catch {
+    return;
+  }
+
+  const url = new URL(request.url());
+  return {
+    label: labelRequest(request),
+    query: { urlPath: url.pathname + url.search, body },
+  };
+}
+
+async function writeQueriesJson(queries: CapturedQueries) {
+  // Dynamic imports — Playwright's runtime mismatches ESM/CJS on static ones.
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(queries, null, 2));
+  console.log(
+    `\nWrote ${Object.keys(queries).length} queries to ${OUTPUT_PATH}`,
+  );
+}
+
+test("dump cluster detail queries", async ({ browser }) => {
+  test.setTimeout(3 * 60_000);
+
+  const queries = await dumpPage(
+    "Cluster detail",
+    clusterDetailUrl(CLUSTER_ID, CLUSTER_NAME),
+    browser,
+  );
+  await writeQueriesJson(queries);
+});

--- a/console/e2e-tests/scalability/helpers.ts
+++ b/console/e2e-tests/scalability/helpers.ts
@@ -141,7 +141,7 @@ function labelFromSql(sql: string): string | undefined {
  *   2. SQL body regex match (V1 useSqlTyped)
  *   3. Truncated SQL
  */
-function labelRequest(request: Request): string {
+export function labelRequest(request: Request): string {
   const fromKey = labelFromQueryKey(request);
   if (fromKey) return fromKey;
 


### PR DESCRIPTION
Replays the console's per-page /api/sql traffic against Materialize at concurrent virtual-user counts.  k6 isolates server-side concurrency on mz_catalog_server.

Ships:
* `dump-queries.spec.ts `— Playwright spec that captures live /api/sql POSTs against the cluster detail page and writes them to e2e-tests/k6/queries.json (gitignored, environment-specific).
* `cluster-detail.js `— k6 script that replays the captured POSTs at ramping VU counts (default 5→100 over 6m), with per-label SLA thresholds and a per-tag latency breakdown. *baselines/workload_replay_2026_05_29.md — first baseline run on 50 cc mz_catalog_server replica size
Setup and run instructions: console/doc/guide-testing.md under "Running Load Tests (k6)".


### Motivation
Motivated by the console scalability initiative. Fixes [CNS-86](https://linear.app/materializeinc/issue/CNS-86/simulate-100s-of-users-connecting-to-the-console-and-how-clusters-page)

### Tips For The Reviewer
There are two critical pieces of this PR. First part is recording the queries being dumped in a json file that k6 can play back captured HTTP requests for concurrent virtual users. 

**Piece 1 — Recording (dump-queries.spec.ts)**

A Playwright test. Opens the console's cluster detail page in a real browser, watches every /api/sql POST for 75 seconds, and writes the latest one per query label to queries.json. That file ends up looking like:

```

{
  "clusters.list":       { "urlPath": "/api/sql?...", "body": {...} },
  "healthCheck":         { "urlPath": "/api/sql?...", "body": {...} },
  "clusters.materializationLag": { ... },
  ...
}
```
Why we need this step at all: the console builds its SQL dynamically with Kysely (no SQL files anywhere) and bakes in environment-specific values like cluster IDs and replica names. The only way to faithfully replay what the browser actually sends is to record it once. The file is gitignored

**Piece 2 — Playback (cluster-detail.js)**

A k6 script. Reads queries.json and POSTs those exact requests, but at increasing concurrent virtual-user counts:

Each "VU" = one simulated browser tab
Each iteration = one polling tick (~5 seconds)
Iteration 0 = fires every query (cold-mount burst, simulates page load)
Later iterations = fires each query only when its real polling interval has elapsed (5s for most, 60s for the heavy ones)
Every request is tagged with its label so the summary shows per-query latency
The script ramps from 5 → 100 VUs over 6 minutes, then prints per-label percentiles.


