### PR TITLE
workload-replay: anonymize subsource child keys, broaden verify

### DIFF
--- a/misc/python/materialize/cli/mz_workload_anonymize.py
+++ b/misc/python/materialize/cli/mz_workload_anonymize.py
@@ -80,6 +80,61 @@ def keywords() -> set[str]:
     return result
 
 
+# Keys that are part of the workload file format itself, not user identifiers.
+# The verify pass must not treat these as leaks when a user object happens to
+# share a name with one of them (e.g. a column named `transaction_id`). Their
+# *values* are still checked; only the structural key name is exempt.
+RESERVED_FORMAT_KEYS = frozenset(
+    {
+        # top level
+        "databases",
+        "clusters",
+        "queries",
+        "mz_workload_version",
+        # schema-level containers
+        "tables",
+        "views",
+        "materialized_views",
+        "indexes",
+        "types",
+        "connections",
+        "sources",
+        "sinks",
+        # object / column fields
+        "create_sql",
+        "name",
+        "type",
+        "schema",
+        "database",
+        "columns",
+        "managed",
+        "children",
+        "nullable",
+        "default",
+        "rows",
+        "avg_size",
+        # source statistics fields
+        "bytes_total",
+        "messages_total",
+        "bytes_second",
+        "messages_second",
+        # query record fields
+        "sql",
+        "cluster",
+        "search_path",
+        "statement_type",
+        "finished_status",
+        "params",
+        "transaction_isolation",
+        "session_id",
+        "transaction_id",
+        "began_at",
+        "duration",
+        "result_size",
+    }
+)
+
+
 def _iter_sql(obj: Any, path: str = "") -> Any:
     """Yield (location, sql) for every create_sql/sql string in the workload."""
     if isinstance(obj, dict):
@@ -94,17 +149,38 @@ def _iter_sql(obj: Any, path: str = "") -> Any:
             yield from _iter_sql(value, f"{path}[{i}]")
 
 
+def _iter_strings(obj: Any, path: str = "") -> Any:
+    """Yield (location, string) for every string in the workload, keys included.
+
+    Identifiers leak through structural positions too — notably dict keys such
+    as a source child's fully-qualified name — so the identifier check must look
+    beyond create_sql/sql values.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            child_path = f"{path}.{key}"
+            if isinstance(key, str):
+                yield f"{child_path}.<KEY>", key
+            yield from _iter_strings(value, child_path)
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            yield from _iter_strings(value, f"{path}[{i}]")
+    elif isinstance(obj, str):
+        yield path, obj
+
+
 def verify_anonymized(
     new: dict[str, Any], mapping: dict[str, str], args: argparse.Namespace
 ) -> list[str]:
     """Best-effort scan of anonymized output for data that should have been scrubbed.
 
     This is a backstop for the heuristic text substitution, not a proof: it
-    catches whole-word survivals of original identifiers and any single-quoted
-    literal that was not reduced to a placeholder ('<REDACTED>' from the
-    parser-based path, or 'literal_N' from the regex fallback). It cannot detect
-    sensitive data hidden in dollar-quoted strings, comments, or numeric
-    literals when the regex fallback is in use.
+    catches whole-word survivals of original identifiers (in any string,
+    including structural dict keys) and any single-quoted literal in SQL that
+    was not reduced to a placeholder ('<REDACTED>' from the parser-based path,
+    or 'literal_N' from the regex fallback). It cannot detect sensitive data
+    hidden in dollar-quoted strings, comments, or numeric literals when the
+    regex fallback is in use.
 
     Cluster create_sql is exempt from the literal check: its literals (SIZE,
     replication factor, availability zones) are non-sensitive configuration that
@@ -127,12 +203,24 @@ def verify_anonymized(
     string_literal = re.compile(r"'(?:[^']|'')*'")
     placeholder = re.compile(r"^'(?:literal_\d+|<REDACTED>)'$")
 
-    for location, sql in _iter_sql(new):
+    # The identifier check runs over identifier positions only: SQL text and
+    # structural dict keys (e.g. a source child's fully-qualified key). It must
+    # NOT scan arbitrary scalar values — a kept literal like 'secret note' can
+    # contain a word that matches a renamed column without being a leak.
+    def check_identifiers(location: str, text: str) -> None:
         for original, pattern in identifier_checks:
-            if pattern.search(sql):
+            if pattern.search(text):
                 problems.append(
                     f"{location}: original identifier {original!r} survived"
                 )
+
+    for location, text in _iter_strings(new):
+        if location.endswith(".<KEY>") and text not in RESERVED_FORMAT_KEYS:
+            check_identifiers(location, text)
+
+    for location, sql in _iter_sql(new):
+        check_identifiers(location, sql)
+        # Literal check runs only over SQL, and exempts cluster create_sql.
         if args.literals and not location.startswith(".clusters"):
             for match in string_literal.finditer(sql):
                 if not placeholder.fullmatch(match.group(0)):
@@ -322,8 +410,17 @@ def main() -> int:
                             if args.literals:
                                 anonymize_column_default(column)
                             child["columns"].append(column)
+                        # Build the child's fully-qualified key from the mapped
+                        # database/schema names. child["name"] is already
+                        # anonymized above, but database/schema are remapped
+                        # later (pass 2); without mapping them here the key
+                        # leaks the original database and schema names. When
+                        # --identifiers is off the mapping is empty and these
+                        # resolve back to the originals, as intended.
                         source["children"][
-                            f"{child['database']}.{child['schema']}.{child['name']}"
+                            f"{mapping.get(child['database'], child['database'])}."
+                            f"{mapping.get(child['schema'], child['schema'])}."
+                            f"{child['name']}"
                         ] = child
                 new_schema["sources"][new_source_name] = source
 

--- a/misc/python/materialize/cli/mz_workload_anonymize_test.py
+++ b/misc/python/materialize/cli/mz_workload_anonymize_test.py
@@ -270,3 +270,119 @@ def test_parser_path_redacts_numeric_literal(tmp_path: Any) -> None:
     assert rc == 0
     assert "987654321" not in text
     assert "<REDACTED>" in text
+
+
+def cdc_workload() -> dict[str, Any]:
+    """A workload with a CDC source whose subsources (children) are keyed by
+    their fully-qualified `database.schema.name`."""
+    return {
+        "clusters": {},
+        "databases": {
+            "upstream_db": {
+                "ingest_schema": {
+                    "tables": {},
+                    "views": {},
+                    "materialized_views": {},
+                    "indexes": {},
+                    "types": {},
+                    "connections": {},
+                    "sources": {
+                        "pg_src": {
+                            "create_sql": "CREATE SOURCE pg_src FROM POSTGRES CONNECTION c",
+                            "type": "postgres",
+                            "children": {
+                                "upstream_db.ingest_schema.people": {
+                                    "name": "people",
+                                    "database": "upstream_db",
+                                    "schema": "ingest_schema",
+                                    "create_sql": "CREATE SUBSOURCE people (id int)",
+                                    "columns": [{"name": "id", "type": "int4"}],
+                                },
+                            },
+                        },
+                    },
+                    "sinks": {},
+                },
+            },
+        },
+        "queries": [],
+    }
+
+
+def test_subsource_child_key_is_anonymized(tmp_path: Any, force_regex: None) -> None:
+    # Regression: the child's fully-qualified dict key must not leak the
+    # original database/schema/name.
+    rc, _out, text = run_tool(tmp_path, cdc_workload())
+    assert rc == 0
+    for original in ("upstream_db", "ingest_schema", "people"):
+        assert original not in text, f"{original!r} leaked via a child key"
+
+
+def test_verify_catches_leaked_child_key() -> None:
+    # A surviving original identifier in a structural dict key must be flagged.
+    new = {
+        "clusters": {},
+        "databases": {
+            "db_0": {
+                "schema_1": {
+                    "sources": {
+                        "source_1": {
+                            "children": {
+                                # Leaky: original schema name survived in the key.
+                                "db_0.ingest_schema.child_1": {"name": "child_1"},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        "queries": [],
+    }
+    mapping = {"ingest_schema": "schema_1"}
+    args = mock.Mock(identifiers=True, literals=True)
+    problems = mz_workload_anonymize.verify_anonymized(new, mapping, args)
+    assert any("ingest_schema" in p for p in problems)
+
+
+def test_verify_ignores_reserved_format_key_collision() -> None:
+    # A user column named like a reserved format key (e.g. transaction_id) must
+    # not make verify flag the query record's own field name.
+    new = {
+        "clusters": {},
+        "databases": {},
+        "queries": [{"sql": "SELECT column_1 FROM table_1", "transaction_id": 7}],
+    }
+    mapping = {"transaction_id": "column_1"}
+    args = mock.Mock(identifiers=True, literals=True)
+    assert mz_workload_anonymize.verify_anonymized(new, mapping, args) == []
+
+
+def test_verify_ignores_identifier_word_in_scalar_value() -> None:
+    # A scalar value (here a column default) may contain a word matching a
+    # renamed column; that is data, not an identifier leak, so the identifier
+    # check must not scan scalar values. (SQL text is scanned separately.)
+    new = {
+        "clusters": {},
+        "databases": {
+            "db_0": {
+                "public": {
+                    "tables": {
+                        "table_1": {
+                            "create_sql": "CREATE TABLE table_1 (column_1 text)",
+                            "columns": [
+                                {
+                                    "name": "column_1",
+                                    "type": "text",
+                                    "default": "'secret note'",
+                                }
+                            ],
+                        }
+                    },
+                }
+            }
+        },
+        "queries": [],
+    }
+    mapping = {"note": "column_1"}
+    args = mock.Mock(identifiers=True, literals=False)
+    assert mz_workload_anonymize.verify_anonymized(new, mapping, args) == []


### PR DESCRIPTION
**Fourth in the stack** — base `workload-anonymize-tests` (#36749). Found by actually running the tool against a real Materialize Cloud capture.

## The bug

Captures with Postgres/MySQL CDC sources store each source's subsources (`children`) in a dict **keyed by the child's fully-qualified `database.schema.name`**. That key was built during the mapping pass from `child["database"]`/`child["schema"]`, which are only remapped *later* (pass 2) — so the key kept the **original database and schema names**, even though the child's own fields and every other position were correctly anonymized.

Real example from the capture, anonymized output **before** this fix:
```
children:
  qa_canary_environment.public_loadgen.child_25:   # <-- original db + schema leaked in the key
    name: child_25
    database: db_5      # correctly anonymized
    schema: schema_18   # correctly anonymized
```
After: `db_5.schema_18.child_25`.

8 distinct original database/schema names leaked this way in a 5-minute prod capture.

## Why verify didn't catch it

`verify_anonymized` only scanned `create_sql`/`sql` *values*, never structural dict keys — so it reported all-clear. This PR broadens it to also scan dict keys, with two guards to avoid false positives (both learned the hard way while writing it):

1. **Reserved format keys** (`RESERVED_FORMAT_KEYS`): the workload file's own field names (`sql`, `cluster`, `transaction_id`, `tables`, …). Without this, a user column named `transaction_id` (which maps to `column_N`) makes verify flag every query record's own `transaction_id` field. Their *values* are still checked — only the structural key name is exempt.
2. **Scalar values are not identifier-scanned.** A kept literal — e.g. a column default `'secret note'` under `--no-literals` — can contain a word matching a renamed column (`note`) without being a leak. SQL text is still scanned (as before).

## Validation

- Re-ran against the real prod capture: non-keyword identifier survivors dropped **8 → 0** (the one remaining match is the legitimate `transaction_id` *format key*, not data). `--verify` passes and writes; before the fix it correctly **refused to write**.
- 4 new regression tests (19 total): end-to-end child-key anonymization, verify catching a leaked child key, and the two false-positive guards.
- `bin/fmt`, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)