### PR TITLE
Fix issue where SHOW CREATE SINK returns a version which can not be used to create a new sink

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -20,10 +20,7 @@ use mz_ore::collections::CollectionExt;
 use mz_repr::{CatalogItemId, Datum, RelationDesc, Row, SqlScalarType};
 use mz_sql_parser::ast::display::{AstDisplay, FormatMode};
 use mz_sql_parser::ast::{
-    CreateSubsourceOptionName, ExternalReferenceExport, ExternalReferences, ObjectType,
-    ShowCreateClusterStatement, ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement,
-    ShowCreateTypeStatement, ShowObjectType, SqlServerConfigOptionName, SystemObjectType,
-    UnresolvedItemName, WithOptionValue,
+    CreateSinkOptionName, CreateSubsourceOptionName, ExternalReferenceExport, ExternalReferences, ObjectType, ShowCreateClusterStatement, ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement, ShowCreateTypeStatement, ShowObjectType, SqlServerConfigOptionName, SystemObjectType, UnresolvedItemName, WithOptionValue
 };
 use mz_sql_pretty::PrettyConfig;
 use query::QueryContext;
@@ -1254,7 +1251,17 @@ fn humanize_sql_for_show_create(
                 }
             });
         }
-
+        Statement::CreateSink(stmt) => {
+            stmt.with_options.retain_mut(|o| {
+                match o.name {
+                    CreateSinkOptionName::CommitInterval => true,
+                    CreateSinkOptionName::PartitionStrategy => true,
+                    CreateSinkOptionName::Snapshot => true,
+                    // Drop version, which does not roundtrip.
+                    CreateSinkOptionName::Version => false,
+                }
+            });
+        }
         _ => (),
     }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -20,7 +20,10 @@ use mz_ore::collections::CollectionExt;
 use mz_repr::{CatalogItemId, Datum, RelationDesc, Row, SqlScalarType};
 use mz_sql_parser::ast::display::{AstDisplay, FormatMode};
 use mz_sql_parser::ast::{
-    CreateSinkOptionName, CreateSubsourceOptionName, ExternalReferenceExport, ExternalReferences, ObjectType, ShowCreateClusterStatement, ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement, ShowCreateTypeStatement, ShowObjectType, SqlServerConfigOptionName, SystemObjectType, UnresolvedItemName, WithOptionValue
+    CreateSinkOptionName, CreateSubsourceOptionName, ExternalReferenceExport, ExternalReferences,
+    ObjectType, ShowCreateClusterStatement, ShowCreateConnectionStatement,
+    ShowCreateMaterializedViewStatement, ShowCreateTypeStatement, ShowObjectType,
+    SqlServerConfigOptionName, SystemObjectType, UnresolvedItemName, WithOptionValue,
 };
 use mz_sql_pretty::PrettyConfig;
 use query::QueryContext;

--- a/test/testdrive/show-create-sink.td
+++ b/test/testdrive/show-create-sink.td
@@ -1,0 +1,21 @@
+$ set-arg-default default-replica-size=scale=1,workers=1
+$ set-arg-default single-replica-cluster=quickstart
+
+$ kafka-create-topic topic=data
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE TABLE table (a int);
+
+> CREATE SINK sink
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM table
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-show-create-sink-${testdrive.seed}')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM;
+
+> ALTER SINK sink SET FROM table; --bumps version
+
+> SELECT create_sql FROM (SHOW CREATE SINK sink);
+"CREATE SINK materialize.public.sink\nIN CLUSTER quickstart\nFROM materialize.public.table\nINTO\n    KAFKA CONNECTION materialize.public.kafka_conn (TOPIC = 'testdrive-show-create-sink-${testdrive.seed}')\nFORMAT JSON\nENVELOPE DEBEZIUM;"

--- a/test/testdrive/show-create-sink.td
+++ b/test/testdrive/show-create-sink.td
@@ -1,3 +1,12 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 $ set-arg-default default-replica-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 


### PR DESCRIPTION
### Motivation

Closes https://linear.app/materializeinc/issue/SS-160/show-create-sink-includes-internal-version-n-round-trip-fails

### Description

Scrubs the version output by `SHOW CREATE SINK`. Test simply asserts the version isn't output

### Verification

1. I confirmed locally that the round trip with the internal version fails as described in the ticket.
2. I wrote the fix/test to scrub the version.
3. I ran the test against the old version of the code locally to confirm it would have failed before.
