### PR TITLE
Update columnar, timely, and differential dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,9 +1979,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "columnar"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161f39fb04ec1e1446e76f65ee5fc19f59240d9095b0b89b9a325da608c927f1"
+checksum = "31b280b1509d6a79dccc29a809a4eda5916af652d479afb0e27f7718af6639f1"
 dependencies = [
  "bytemuck",
  "columnar_derive",
@@ -1990,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "columnar_derive"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d874c276acb8ce8e425e2822c54ce67a444dc407ec97767bbfc6490acc9fa2d"
+checksum = "72c9c88441fb60d0d5d9e939b5765abdff87d1a4d4cc80a90e0f945a6711c438"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2799,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dataflow"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d842a3e5e50bcd08a7f247c01a41cb057fde0c16f3865772682bff2edef5f40a"
+checksum = "befdc46c04f5671a2dfe32a9d06ce8efe44f650f0f6f974d190b9a6ee1c17665"
 dependencies = [
  "columnar",
  "columnation",
@@ -2814,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dogs3"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8665214a200212ff3bb3009da66cf0807a666ea2d722ff1816b27430f3e9c9d4"
+checksum = "6a8ec406d5dc1cb6ce0101df2b383de91ae0de283b1cf7812433ef57e031141c"
 dependencies = [
  "differential-dataflow",
  "serde",
@@ -3326,9 +3326,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -12030,9 +12030,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdba58f1357fd65576620166d88afb7911b0d4f83b97c0624b03797e85ef4e9"
+checksum = "c5af6859fde675a87f12da672e0bdf08bfc809e68d8c6728f50942d09c0480a3"
 dependencies = [
  "bincode",
  "byteorder",
@@ -12050,15 +12050,15 @@ dependencies = [
 
 [[package]]
 name = "timely_bytes"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb91e9fc11841c4b07af1c95cea20470aaf144d6b412daddf63593cd8e7df50"
+checksum = "4b427b919d60d815c9c30b52d8080ebde599380db18c7c98a8c99fc172601ca1"
 
 [[package]]
 name = "timely_communication"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9efbf4f3899dc9905b780ec3646920022de3323086cc05ba84f4ffaad9a80c8"
+checksum = "2137e50f9c368c04d9971b7909c6fceadedb24c6e4fa4173bf55bf6d415329db"
 dependencies = [
  "byteorder",
  "columnar",
@@ -12071,15 +12071,15 @@ dependencies = [
 
 [[package]]
 name = "timely_container"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39eed4292e8e49f341c3d6cdfc8c43431634676a42dc8021cfd67e939c129a9"
+checksum = "b45d41809553b99db9abc2ad2c5f5b8f755df1f2191051527deaadeea12d5a7e"
 
 [[package]]
 name = "timely_logging"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ef86afa8b06f1bfa6e088b87909592a14622189f91ae4b5a49e76ac10ab73c"
+checksum = "00582f3cfc652e3173eb9a140981133f359029e6b746667414a8d334285163d6"
 dependencies = [
  "timely_container",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ cfg-if = "1.0.4"
 chrono = { version = "0.4.39", default-features = false, features = ["clock", "serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["case-insensitive", "serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
-columnar = "0.12.1"
+columnar = "0.13.0"
 columnation = "0.1.2"
 compact_bytes = "0.2.1"
 compile-time-run = "0.2.12"
@@ -328,8 +328,8 @@ datadriven = "0.9.0"
 deadpool-postgres = "0.10.3"
 dec = "0.4.9"
 derivative = "2.2.0"
-differential-dataflow = "0.23.0"
-differential-dogs3 = "0.23.0"
+differential-dataflow = "0.24.0"
+differential-dogs3 = "0.24.0"
 digest = "0.10.7"
 dirs = "6.0.0"
 domain = { version = "0.11.1", default-features = false, features = ["resolv"] }
@@ -341,7 +341,7 @@ enum-iterator = "2.1.0"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 fallible-iterator = "0.2.0"
-fancy-regex = "0.18.0"
+fancy-regex = "0.17.0"
 flate2 = "1.1.9"
 foundationdb = { version = "0.10.0", default-features = false, features = ["embedded-fdb-include", "fdb-7_3"] }
 futures = "0.3.32"
@@ -502,7 +502,7 @@ tiberius = { version = "0.12", default-features = false, features = ["chrono", "
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
 tikv-jemallocator = { version = "0.6", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 time = "0.3.17"
-timely = "0.29.0"
+timely = "0.30.0"
 tokio = { version = "1.52.3", features = ["full", "test-util"] }
 tokio-metrics = "0.5.0"
 tokio-native-tls = "0.3.1"

--- a/src/cluster/src/client.rs
+++ b/src/cluster/src/client.rs
@@ -328,8 +328,8 @@ mod alloc {
     // SAFETY: `LgallocHandle` exclusively owns its allocation (either an
     // lgalloc handle or a leaked `Vec`), and the `NonNull<u8>` is just a pointer
     // into that owned memory. Transferring the handle transfers ownership, so it
-    // is safe to send across threads. Required because timely 0.30's
-    // `BytesRefill` produces `Box<dyn DerefMut<Target=[u8]> + Send>`.
+    // is safe to send across threads. Required because timely's `BytesRefill`
+    // produces `Box<dyn DerefMut<Target=[u8]> + Send>`.
     unsafe impl Send for LgallocHandle {}
 
     impl std::ops::Deref for LgallocHandle {

--- a/src/cluster/src/client.rs
+++ b/src/cluster/src/client.rs
@@ -325,6 +325,13 @@ mod alloc {
         capacity: usize,
     }
 
+    // SAFETY: `LgallocHandle` exclusively owns its allocation (either an
+    // lgalloc handle or a leaked `Vec`), and the `NonNull<u8>` is just a pointer
+    // into that owned memory. Transferring the handle transfers ownership, so it
+    // is safe to send across threads. Required because timely 0.30's
+    // `BytesRefill` produces `Box<dyn DerefMut<Target=[u8]> + Send>`.
+    unsafe impl Send for LgallocHandle {}
+
     impl std::ops::Deref for LgallocHandle {
         type Target = [u8];
         #[inline(always)]

--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -164,7 +164,7 @@ where
     }
 
     // Choose the intra-process allocator flavor up front.
-    // TODO(CLU-99): wire our zero-copy pager into the timely 0.30 spill policy
+    // TODO(CLU-99): wire our zero-copy pager into the timely spill policy
     // instead of passing `None` here.
     let process_allocators = if enable_zero_copy_binary {
         ProcessBuilder::new_bytes_vector(workers, refill.clone(), None)
@@ -172,9 +172,9 @@ where
         ProcessBuilder::new_typed_vector(workers, refill.clone(), None)
     };
 
-    // Since timely 0.30 the refill, spill policy, and per-thread logger hook are
-    // bundled into `Hooks`. We don't install a comm logger, and the spill policy
-    // is left unset pending CLU-99.
+    // Timely bundles the refill, spill policy, and per-thread logger hook into
+    // `Hooks`. We don't install a comm logger, and the spill policy is left
+    // unset pending CLU-99.
     let hooks = Hooks {
         log_fn: Arc::new(|_| None),
         refill,

--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -84,6 +84,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::netio::{Listener, Stream};
 use mz_ore::retry::Retry;
 use regex::Regex;
+use timely::communication::Hooks;
 use timely::communication::allocator::ProcessBuilder;
 use timely::communication::allocator::generic::AllocatorBuilder;
 use timely::communication::allocator::zero_copy::bytes_slab::BytesRefill;
@@ -163,20 +164,24 @@ where
     }
 
     // Choose the intra-process allocator flavor up front.
+    // TODO(CLU-99): wire our zero-copy pager into the timely 0.30 spill policy
+    // instead of passing `None` here.
     let process_allocators = if enable_zero_copy_binary {
-        ProcessBuilder::new_bytes_vector(workers, refill.clone())
+        ProcessBuilder::new_bytes_vector(workers, refill.clone(), None)
     } else {
-        ProcessBuilder::new_typed_vector(workers, refill.clone())
+        ProcessBuilder::new_typed_vector(workers, refill.clone(), None)
     };
 
-    match initialize_networking_from_sockets(
-        process_allocators,
-        sockets,
-        process,
-        workers,
+    // Since timely 0.30 the refill, spill policy, and per-thread logger hook are
+    // bundled into `Hooks`. We don't install a comm logger, and the spill policy
+    // is left unset pending CLU-99.
+    let hooks = Hooks {
+        log_fn: Arc::new(|_| None),
         refill,
-        Arc::new(|_| None),
-    ) {
+        spill: None,
+    };
+
+    match initialize_networking_from_sockets(process_allocators, sockets, process, workers, hooks) {
         Ok((tcp_builders, guard)) => {
             info!(process = process, "successfully initialized network");
             let builders = tcp_builders

--- a/src/compute/benches/columnar_merge_batcher_row.rs
+++ b/src/compute/benches/columnar_merge_batcher_row.rs
@@ -28,18 +28,18 @@
 //! consume the same pre-built [`Column<Tuple>`] inputs so the chunker
 //! sees identical input shape.
 
-use std::marker::PhantomData;
 use std::mem::size_of;
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use differential_dataflow::trace::Batcher;
 use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
-use differential_dataflow::trace::{Batcher, Builder, Description};
 use mz_ore::cast::{CastFrom, CastLossy, ReinterpretCast};
 use mz_repr::{Datum, Row};
 use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::batcher::{Chunker, ColumnChunker, ColumnMerger};
 use mz_timely_util::columnation::{ColInternalMerger, ColumnationStack};
 use rand::{Rng, SeedableRng, rngs::StdRng};
+use timely::container::ContainerBuilder;
 use timely::container::PushInto;
 use timely::progress::Antichain;
 
@@ -50,16 +50,15 @@ type Tuple = (Data, Time, Diff);
 
 /// Legacy path: input is `Column<Tuple>`, chunker produces
 /// `ColumnationStack<Tuple>` chunks, merger operates on those.
-type ColumnationBatcher = MergeBatcher<
-    Column<Tuple>,
-    Chunker<ColumnationStack<Tuple>>,
-    ColInternalMerger<Data, Time, Diff>,
->;
+type ColumnationBatcher = MergeBatcher<ColInternalMerger<Data, Time, Diff>>;
+/// Chunker feeding [`ColumnationBatcher`].
+type ColumnationBatcherChunker = Chunker<ColumnationStack<Tuple>>;
 
 /// All-`Column` path: input is `Column<Tuple>`, chunker produces
 /// `Column<Tuple>` chunks, merger operates on those.
-type ColumnBatcher =
-    MergeBatcher<Column<Tuple>, ColumnChunker<Tuple>, ColumnMerger<Data, Time, Diff>>;
+type ColumnBatcher = MergeBatcher<ColumnMerger<Data, Time, Diff>>;
+/// Chunker feeding [`ColumnBatcher`].
+type ColumnBatcherChunker = ColumnChunker<Tuple>;
 
 /// Per-side payload-byte targets. Element counts are derived from
 /// [`ROW_PAYLOAD_BYTES`]. Same shape as [`columnar_merger_row`] so
@@ -79,27 +78,6 @@ const ROW_PAYLOAD_BYTES: usize = 32;
 /// push. Round size is bounded so every config triggers at least one
 /// internal `merge_by` chain compaction.
 const PER_ROUND: usize = 4 * 1024;
-
-/// No-op `Builder` so we can call `Batcher::seal` without dragging in a
-/// real trace builder. Drops chunks as they arrive — for benchmarking the
-/// batcher's internals we don't care what `seal` produces, only that we
-/// drive the merge + extract path.
-struct NoopBuilder<C>(PhantomData<C>);
-
-impl<C: 'static> Builder for NoopBuilder<C> {
-    type Input = C;
-    type Time = Time;
-    type Output = ();
-
-    fn with_capacity(_keys: usize, _vals: usize, _upds: usize) -> Self {
-        Self(PhantomData)
-    }
-    fn push(&mut self, _chunk: &mut Self::Input) {}
-    fn done(self, _description: Description<Self::Time>) -> Self::Output {}
-    fn seal(chain: &mut Vec<Self::Input>, _description: Description<Self::Time>) -> Self::Output {
-        chain.clear();
-    }
-}
 
 /// Build a deterministic `Row` from `key`. 24-character hex string suffix
 /// overflows `CompactBytes`'s inline budget so columnation actually
@@ -220,18 +198,26 @@ fn rounds_to_columns(rounds: &[Vec<Tuple>]) -> Vec<Column<Tuple>> {
 /// `B::Output` because the columnation path produces `ColumnationStack`
 /// chunks while the column path produces `Column` chunks; the no-op
 /// builder accommodates either.
-fn drive_batcher<B>(prebuilt_rounds: &[Column<Tuple>])
+fn drive_batcher<B, Chu>(prebuilt_rounds: &[Column<Tuple>])
 where
-    B: Batcher<Input = Column<Tuple>, Time = Time>,
+    B: Batcher<Time = Time>,
+    Chu: ContainerBuilder<Container = B::Output> + for<'a> PushInto<&'a mut Column<Tuple>>,
     B::Output: 'static,
 {
     let mut batcher = B::new(None, 0);
+    let mut chunker = Chu::default();
     for round in prebuilt_rounds {
         let mut col = round.clone();
-        batcher.push_container(&mut col);
+        chunker.push_into(&mut col);
+        while let Some(chunk) = chunker.extract() {
+            batcher.push_into(std::mem::take(chunk));
+        }
+    }
+    while let Some(chunk) = chunker.finish() {
+        batcher.push_into(std::mem::take(chunk));
     }
     let upper = Antichain::from_elem(Time::MAX);
-    let _: () = batcher.seal::<NoopBuilder<B::Output>>(upper);
+    let _ = batcher.seal(upper);
 }
 
 fn bench_batcher(c: &mut Criterion) {
@@ -279,7 +265,9 @@ fn bench_batcher(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("columnation", &id), &(), |bencher, _| {
                 bencher.iter_batched(
                     || prebuilt.clone(),
-                    |rounds| drive_batcher::<ColumnationBatcher>(&rounds),
+                    |rounds| {
+                        drive_batcher::<ColumnationBatcher, ColumnationBatcherChunker>(&rounds)
+                    },
                     BatchSize::LargeInput,
                 );
             });
@@ -287,7 +275,7 @@ fn bench_batcher(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("column", &id), &(), |bencher, _| {
                 bencher.iter_batched(
                     || prebuilt.clone(),
-                    |rounds| drive_batcher::<ColumnBatcher>(&rounds),
+                    |rounds| drive_batcher::<ColumnBatcher, ColumnBatcherChunker>(&rounds),
                     BatchSize::LargeInput,
                 );
             });

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -18,6 +18,7 @@ use differential_dataflow::trace::implementations::spine_fueled::Spine;
 use differential_dataflow::trace::{Batch, Batcher, Builder, Trace, TraceReader};
 use differential_dataflow::{Collection, Data, ExchangeData, Hashable, VecCollection};
 use timely::Container;
+use timely::container::{ContainerBuilder, PushInto};
 use timely::dataflow::Stream;
 use timely::dataflow::channels::pact::{Exchange, ParallelizationContract, Pipeline};
 use timely::dataflow::operators::Operator;
@@ -38,9 +39,12 @@ pub trait MzArrange<'scope>: MzArrangeCore<'scope> {
     /// This operator arranges a stream of values into a shared trace, whose contents it maintains.
     /// This trace is current for all times marked completed in the output stream, and probing this stream
     /// is the correct way to determine that times in the shared trace are committed.
-    fn mz_arrange<Ba, Bu, Tr>(self, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+    fn mz_arrange<Chu, Ba, Bu, Tr>(self, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
     where
-        Ba: Batcher<Input = Self::Input, Time = Self::Timestamp> + 'static,
+        Ba: Batcher<Time = Self::Timestamp> + 'static,
+        Chu: ContainerBuilder<Container = Ba::Output>
+            + for<'a> PushInto<&'a mut Self::Input>
+            + 'static,
         Bu: Builder<Time = Self::Timestamp, Input = Ba::Output, Output = Tr::Batch>,
         Tr: Trace + TraceReader<Time = Self::Timestamp> + 'static,
         Tr::Batch: Batch,
@@ -60,15 +64,17 @@ pub trait MzArrangeCore<'scope> {
     /// This operator arranges a stream of values into a shared trace, whose contents it maintains.
     /// This trace is current for all times marked completed in the output stream, and probing this stream
     /// is the correct way to determine that times in the shared trace are committed.
-    fn mz_arrange_core<P, Ba, Bu, Tr>(
+    fn mz_arrange_core<P, Chu, Ba, Bu, Tr>(
         self,
         pact: P,
         name: &str,
     ) -> Arranged<'scope, TraceAgent<Tr>>
     where
         P: ParallelizationContract<Self::Timestamp, Self::Input>,
-        Ba: Batcher<Input = Self::Input, Time = Self::Timestamp> + 'static,
-        // Ba::Input: Container + Clone + 'static,
+        Ba: Batcher<Time = Self::Timestamp> + 'static,
+        Chu: ContainerBuilder<Container = Ba::Output>
+            + for<'a> PushInto<&'a mut Self::Input>
+            + 'static,
         Bu: Builder<Time = Self::Timestamp, Input = Ba::Output, Output = Tr::Batch>,
         Tr: Trace + TraceReader<Time = Self::Timestamp> + 'static,
         Tr::Batch: Batch,
@@ -83,10 +89,17 @@ where
     type Timestamp = T;
     type Input = C;
 
-    fn mz_arrange_core<P, Ba, Bu, Tr>(self, pact: P, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+    fn mz_arrange_core<P, Chu, Ba, Bu, Tr>(
+        self,
+        pact: P,
+        name: &str,
+    ) -> Arranged<'scope, TraceAgent<Tr>>
     where
         P: ParallelizationContract<T, Self::Input>,
-        Ba: Batcher<Input = Self::Input, Time = T> + 'static,
+        Ba: Batcher<Time = T> + 'static,
+        Chu: ContainerBuilder<Container = Ba::Output>
+            + for<'a> PushInto<&'a mut Self::Input>
+            + 'static,
         Bu: Builder<Time = T, Input = Ba::Output, Output = Tr::Batch>,
         Tr: Trace + TraceReader<Time = T> + 'static,
         Tr::Batch: Batch,
@@ -94,7 +107,7 @@ where
     {
         // Allow access to `arrange_named` because we're within Mz's wrapper.
         #[allow(clippy::disallowed_methods)]
-        arrange_core::<_, Ba, Bu, _>(self, pact, name).log_arrangement_size()
+        arrange_core::<_, _, Chu, Ba, Bu, _>(self, pact, name).log_arrangement_size()
     }
 }
 
@@ -105,16 +118,19 @@ where
     V: ExchangeData,
     R: ExchangeData,
 {
-    fn mz_arrange<Ba, Bu, Tr>(self, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+    fn mz_arrange<Chu, Ba, Bu, Tr>(self, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
     where
-        Ba: Batcher<Input = Self::Input, Time = T> + 'static,
+        Ba: Batcher<Time = T> + 'static,
+        Chu: ContainerBuilder<Container = Ba::Output>
+            + for<'a> PushInto<&'a mut Self::Input>
+            + 'static,
         Bu: Builder<Time = T, Input = Ba::Output, Output = Tr::Batch>,
         Tr: Trace + TraceReader<Time = T> + 'static,
         Tr::Batch: Batch,
         Arranged<'scope, TraceAgent<Tr>>: ArrangementSize,
     {
         let exchange = Exchange::new(move |update: &((K, V), T, R)| (update.0).0.hashed().into());
-        self.mz_arrange_core::<_, Ba, Bu, _>(exchange, name)
+        self.mz_arrange_core::<_, Chu, Ba, Bu, _>(exchange, name)
     }
 }
 
@@ -126,16 +142,23 @@ where
     type Timestamp = T;
     type Input = C;
 
-    fn mz_arrange_core<P, Ba, Bu, Tr>(self, pact: P, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+    fn mz_arrange_core<P, Chu, Ba, Bu, Tr>(
+        self,
+        pact: P,
+        name: &str,
+    ) -> Arranged<'scope, TraceAgent<Tr>>
     where
         P: ParallelizationContract<T, Self::Input>,
-        Ba: Batcher<Input = Self::Input, Time = T> + 'static,
+        Ba: Batcher<Time = T> + 'static,
+        Chu: ContainerBuilder<Container = Ba::Output>
+            + for<'a> PushInto<&'a mut Self::Input>
+            + 'static,
         Bu: Builder<Time = T, Input = Ba::Output, Output = Tr::Batch>,
         Tr: Trace + TraceReader<Time = T> + 'static,
         Tr::Batch: Batch,
         Arranged<'scope, TraceAgent<Tr>>: ArrangementSize,
     {
-        self.inner.mz_arrange_core::<_, Ba, Bu, _>(pact, name)
+        self.inner.mz_arrange_core::<_, Chu, Ba, Bu, _>(pact, name)
     }
 }
 
@@ -160,15 +183,18 @@ where
     K: ExchangeData + Hashable,
     R: ExchangeData,
 {
-    fn mz_arrange<Ba, Bu, Tr>(self, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+    fn mz_arrange<Chu, Ba, Bu, Tr>(self, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
     where
-        Ba: Batcher<Input = Self::Input, Time = T> + 'static,
+        Ba: Batcher<Time = T> + 'static,
+        Chu: ContainerBuilder<Container = Ba::Output>
+            + for<'a> PushInto<&'a mut Self::Input>
+            + 'static,
         Bu: Builder<Time = T, Input = Ba::Output, Output = Tr::Batch>,
         Tr: Trace + TraceReader<Time = T> + 'static,
         Tr::Batch: Batch,
         Arranged<'scope, TraceAgent<Tr>>: ArrangementSize,
     {
-        self.0.map(|d| (d, ())).mz_arrange::<Ba, Bu, _>(name)
+        self.0.map(|d| (d, ())).mz_arrange::<Chu, Ba, Bu, _>(name)
     }
 }
 
@@ -181,10 +207,17 @@ where
     type Timestamp = T;
     type Input = Vec<((K, ()), T, R)>;
 
-    fn mz_arrange_core<P, Ba, Bu, Tr>(self, pact: P, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+    fn mz_arrange_core<P, Chu, Ba, Bu, Tr>(
+        self,
+        pact: P,
+        name: &str,
+    ) -> Arranged<'scope, TraceAgent<Tr>>
     where
         P: ParallelizationContract<T, Self::Input>,
-        Ba: Batcher<Input = Self::Input, Time = T> + 'static,
+        Ba: Batcher<Time = T> + 'static,
+        Chu: ContainerBuilder<Container = Ba::Output>
+            + for<'a> PushInto<&'a mut Self::Input>
+            + 'static,
         Bu: Builder<Time = T, Input = Ba::Output, Output = Tr::Batch>,
         Tr: Trace + TraceReader<Time = T> + 'static,
         Tr::Batch: Batch,
@@ -192,7 +225,7 @@ where
     {
         self.0
             .map(|d| (d, ()))
-            .mz_arrange_core::<_, Ba, Bu, _>(pact, name)
+            .mz_arrange_core::<_, Chu, Ba, Bu, _>(pact, name)
     }
 }
 
@@ -253,7 +286,7 @@ where
                     return;
                 };
 
-                trace.borrow().trace.map_batches(|batch| {
+                trace.borrow().trace().map_batches(|batch| {
                     batches.insert(Rc::as_ptr(batch), Rc::downgrade(batch));
                 });
 

--- a/src/compute/src/extensions/temporal_bucket.rs
+++ b/src/compute/src/extensions/temporal_bucket.rs
@@ -9,13 +9,11 @@
 
 //! Utilities and stream extensions for temporal bucketing.
 
-use std::marker::PhantomData;
-
 use differential_dataflow::Hashable;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Batcher;
 use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
-use differential_dataflow::trace::{Batcher, Builder, Description};
 use mz_timely_util::columnation::{ColInternalMerger, ColumnationChunker, ColumnationStack};
 use mz_timely_util::temporal::{Bucket, BucketChain, BucketTimestamp};
 use timely::container::PushInto;
@@ -113,7 +111,7 @@ where
                                     if !buffer.is_empty() {
                                         let bucket =
                                             chain.find_mut(&range.start).expect("Must exist");
-                                        bucket.inner.push_container(&mut buffer);
+                                        bucket.push_container(&mut buffer);
                                         buffer.clear();
                                     }
                                     range = chain.range_of(&time).expect("Must exist");
@@ -124,7 +122,7 @@ where
                             // Handle leftover data in the buffer.
                             if !buffer.is_empty() {
                                 let bucket = chain.find_mut(&range.start).expect("Must exist");
-                                bucket.inner.push_container(&mut buffer);
+                                bucket.push_container(&mut buffer);
                                 buffer.clear();
                             }
                         }
@@ -169,6 +167,10 @@ where
 }
 
 /// A wrapper around `MergeBatcher` that implements the `Storage` trait for bucketing.
+///
+/// Since differential-dataflow 0.24 the merge batcher no longer chunks its own
+/// input, so this wrapper carries a [`ColumnationChunker`] that consolidates the
+/// `Vec` input into the [`ColumnationStack`] chunks the batcher consumes.
 struct MergeBatcherWrapper<D, T, R>
 where
     D: MzData + Ord + Clone,
@@ -177,27 +179,49 @@ where
 {
     logger: Option<differential_dataflow::logging::Logger>,
     operator_id: usize,
-    inner: MergeBatcher<Vec<(D, T, R)>, ColumnationChunker<(D, T, R)>, ColInternalMerger<D, T, R>>,
+    chunker: ColumnationChunker<(D, T, R)>,
+    inner: MergeBatcher<ColInternalMerger<D, T, R>>,
 }
 
 impl<D, T, R> MergeBatcherWrapper<D, T, R>
 where
-    D: MzData + Ord + Clone,
+    D: MzData + Ord + Clone + 'static,
     T: MzData + Ord + PartialOrder + Clone + Timestamp,
-    R: MzData + Semigroup + Default,
+    R: MzData + Semigroup + Default + 'static,
 {
     /// Construct a new `MergeBatcherWrapper` with the given logger and operator ID.
     fn new(logger: Option<differential_dataflow::logging::Logger>, operator_id: usize) -> Self {
         Self {
             logger: logger.clone(),
             operator_id,
+            chunker: ColumnationChunker::default(),
             inner: MergeBatcher::new(logger, operator_id),
+        }
+    }
+
+    /// Consolidate `buffer` through the chunker and feed any complete chunks to
+    /// the batcher.
+    fn push_container(&mut self, buffer: &mut Vec<(D, T, R)>) {
+        use timely::container::ContainerBuilder as _;
+        self.chunker.push_into(buffer);
+        while let Some(chunk) = self.chunker.extract() {
+            self.inner.push_into(std::mem::take(chunk));
+        }
+    }
+
+    /// Flush any partial chunk still held by the chunker into the batcher.
+    fn flush(&mut self) {
+        use timely::container::ContainerBuilder as _;
+        while let Some(chunk) = self.chunker.finish() {
+            self.inner.push_into(std::mem::take(chunk));
         }
     }
 
     /// Reveal the contents of the `MergeBatcher`, returning a vector of `ColumnationStack`s.
     fn done(mut self) -> Vec<ColumnationStack<(D, T, R)>> {
-        self.inner.seal::<CapturingBuilder<_, _>>(Antichain::new())
+        self.flush();
+        let (chain, _description) = self.inner.seal(Antichain::new());
+        chain
     }
 }
 
@@ -205,7 +229,7 @@ impl<D, T, R> Bucket for MergeBatcherWrapper<D, T, R>
 where
     D: MzData + Ord + Clone + 'static,
     T: MzData + Ord + PartialOrder + Clone + 'static + BucketTimestamp,
-    R: MzData + Semigroup + Default,
+    R: MzData + Semigroup + Default + 'static,
 {
     type Timestamp = T;
 
@@ -214,44 +238,18 @@ where
         // different containers when not needed. The merge batcher we use can only accept
         // vectors as inputs, but not any other container type.
         // TODO: Allow the merge batcher to accept more generic containers.
+        self.flush();
         let upper = Antichain::from_elem(timestamp.clone());
         let mut lower = Self::new(self.logger.clone(), self.operator_id);
         let mut buffer = Vec::new();
-        for chunk in self.inner.seal::<CapturingBuilder<_, _>>(upper) {
+        let (chain, _description) = self.inner.seal(upper);
+        for chunk in chain {
             *fuel = fuel.saturating_sub(chunk.len().try_into().expect("must fit"));
             // TODO: Avoid this cloning.
             buffer.extend(chunk.into_iter().cloned());
-            lower.inner.push_container(&mut buffer);
+            lower.push_container(&mut buffer);
             buffer.clear();
         }
         (lower, self)
-    }
-}
-
-struct CapturingBuilder<D, T>(D, PhantomData<T>);
-
-impl<D, T: Timestamp> Builder for CapturingBuilder<D, T> {
-    type Input = D;
-    type Time = T;
-    type Output = Vec<D>;
-
-    fn with_capacity(_keys: usize, _vals: usize, _upds: usize) -> Self {
-        // Not needed for this implementation.
-        unimplemented!()
-    }
-
-    fn push(&mut self, _chunk: &mut Self::Input) {
-        // Not needed for this implementation.
-        unimplemented!()
-    }
-
-    fn done(self, _description: Description<Self::Time>) -> Self::Output {
-        // Not needed for this implementation.
-        unimplemented!()
-    }
-
-    #[inline]
-    fn seal(chain: &mut Vec<Self::Input>, _description: Description<Self::Time>) -> Self::Output {
-        std::mem::take(chain)
     }
 }

--- a/src/compute/src/extensions/temporal_bucket.rs
+++ b/src/compute/src/extensions/temporal_bucket.rs
@@ -168,9 +168,9 @@ where
 
 /// A wrapper around `MergeBatcher` that implements the `Storage` trait for bucketing.
 ///
-/// Since differential-dataflow 0.24 the merge batcher no longer chunks its own
-/// input, so this wrapper carries a [`ColumnationChunker`] that consolidates the
-/// `Vec` input into the [`ColumnationStack`] chunks the batcher consumes.
+/// The merge batcher consumes pre-chunked input, so this wrapper carries a
+/// [`ColumnationChunker`] that consolidates the `Vec` input into the
+/// [`ColumnationStack`] chunks the batcher consumes.
 struct MergeBatcherWrapper<D, T, R>
 where
     D: MzData + Ord + Clone,

--- a/src/compute/src/logging.rs
+++ b/src/compute/src/logging.rs
@@ -22,7 +22,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use std::time::Duration;
 
-use ::timely::container::CapacityContainerBuilder;
+use ::timely::container::{CapacityContainerBuilder, PushInto};
 use ::timely::dataflow::Stream;
 use ::timely::dataflow::channels::pact::Pipeline;
 use ::timely::dataflow::operators::capture::{Event, EventLink, EventPusher};
@@ -225,14 +225,15 @@ struct LogCollection {
 /// the updates into `(Row, Row)` pairs using the provided logic function. It is crucial that the
 /// data is not exchanged between workers, as the consolidation would not function as desired
 /// otherwise.
-pub(super) fn consolidate_and_pack<'scope, B, CB, L, F>(
-    input: Stream<'scope, Timestamp, B::Input>,
+pub(super) fn consolidate_and_pack<'scope, Chu, B, CB, L, F, C>(
+    input: Stream<'scope, Timestamp, C>,
     log: L,
     mut logic: F,
 ) -> Stream<'scope, Timestamp, CB::Container>
 where
     B: Batcher<Time = Timestamp> + 'static,
-    B::Input: Container + Clone + 'static,
+    Chu: ContainerBuilder<Container = B::Output> + for<'a> PushInto<&'a mut C> + 'static,
+    C: Container + Clone + 'static,
     B::Output: Clone,
     CB: ContainerBuilder,
     L: Into<LogVariant>,
@@ -243,7 +244,7 @@ where
     let c_name = &format!("Consolidate {log:?}");
     let u_name = &format!("ToRow {log:?}");
     let mut packer = PermutedRowPacker::new(log);
-    let consolidated = consolidate_pact::<B, _>(input, Pipeline, c_name);
+    let consolidated = consolidate_pact::<Chu, B, _, _>(input, Pipeline, c_name);
     consolidated.unary::<CB, _, _, _>(Pipeline, u_name, |_, _| {
         move |input, output| {
             input.for_each_time(|time, data| {

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -22,6 +22,7 @@ use differential_dataflow::trace::{BatchReader, Cursor};
 use mz_compute_types::plan::LirId;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowRef, Timestamp};
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Column, columnar_exchange};
 use mz_timely_util::replay::MzReplay;
@@ -435,6 +436,7 @@ pub(super) fn construct<'scope>(
                 let trace = stream
                     .mz_arrange_core::<
                         _,
+                        batcher::Chunker<_>,
                         Col2ValBatcher<_, _, _, _>,
                         RowRowBuilder<_, _>,
                         RowRowSpine<_, _>,

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -20,8 +20,10 @@ use differential_dataflow::logging::{
 };
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, Timestamp};
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, columnar_exchange};
+use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::replay::MzReplay;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::InputCapability;
@@ -142,19 +144,22 @@ pub(super) fn construct(
             Timestamp,
             mz_timely_util::columnar::Column<((mz_repr::Row, mz_repr::Row), Timestamp, Diff)>,
         > {
-            consolidate_and_pack::<KeyBatcher<_, _, _>, ColumnBuilder<_>, _, _>(
-                input,
-                log,
-                move |data, packer, session| {
-                    for ((op, ()), time, diff) in data.iter() {
-                        let data = packer.pack_slice(&[
-                            Datum::UInt64(u64::cast_from(*op)),
-                            Datum::UInt64(u64::cast_from(worker_id)),
-                        ]);
-                        session.give((data, *time, *diff))
-                    }
-                },
-            )
+            consolidate_and_pack::<
+                ColumnationChunker<_>,
+                KeyBatcher<_, _, _>,
+                ColumnBuilder<_>,
+                _,
+                _,
+                _,
+            >(input, log, move |data, packer, session| {
+                for ((op, ()), time, diff) in data.iter() {
+                    let data = packer.pack_slice(&[
+                        Datum::UInt64(u64::cast_from(*op)),
+                        Datum::UInt64(u64::cast_from(worker_id)),
+                    ]);
+                    session.give((data, *time, *diff))
+                }
+            })
         }
         let worker_id = scope.index();
 
@@ -190,6 +195,7 @@ pub(super) fn construct(
                 let trace = collection
                     .mz_arrange_core::<
                         _,
+                        batcher::Chunker<_>,
                         Col2ValBatcher<_, _, _, _>,
                         RowRowBuilder<_, _>,
                         RowRowSpine<_, _>,

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -20,6 +20,7 @@ use mz_repr::{Diff, Timestamp};
 use mz_storage_operators::persist_source::Subtime;
 use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::builder::ColumnBuilder;
+use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::CollectionExt;
 use mz_timely_util::scope_label::ScopeExt;
 use timely::ContainerBuilder;
@@ -185,7 +186,9 @@ impl LoggingContext<'_> {
                 let collection: KeyCollection<_, DataflowErrorSer, Diff> =
                     VecCollection::empty(scope).into();
                 collection
-                    .mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, _>("Arrange logging err")
+                    .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
+                        "Arrange logging err",
+                    )
                     .trace
             });
 

--- a/src/compute/src/logging/prometheus.rs
+++ b/src/compute/src/logging/prometheus.rs
@@ -20,6 +20,7 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::soft_panic_or_log;
 use mz_repr::{Datum, Diff, Timestamp};
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, columnar_exchange};
 use prometheus::proto::MetricType;
@@ -178,10 +179,13 @@ pub(super) fn construct(
         columnar_exchange::<mz_repr::Row, mz_repr::Row, Timestamp, mz_repr::Diff>,
     );
     let trace = stream
-        .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-            exchange,
-            "Arrange PrometheusMetrics",
-        )
+        .mz_arrange_core::<
+            _,
+            batcher::Chunker<_>,
+            Col2ValBatcher<_, _, _, _>,
+            RowRowBuilder<_, _>,
+            RowRowSpine<_, _>,
+        >(exchange, "Arrange PrometheusMetrics")
         .trace;
     let token: Rc<dyn std::any::Any> = Rc::new(());
     let collection = LogCollection { trace, token };

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -18,6 +18,7 @@ use columnar::Index;
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, Row, Timestamp};
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Column, columnar_exchange};
 use mz_timely_util::replay::MzReplay;
@@ -95,26 +96,32 @@ pub(super) fn construct(
         let logs_active = [LogVariant::Timely(TimelyLog::Reachability)];
         let worker_id = scope.index();
 
-        let updates =
-            consolidate_and_pack::<Col2ValBatcher<UpdatesKey, _, _, _>, ColumnBuilder<_>, _, _>(
-                logs,
-                TimelyLog::Reachability,
-                move |data, packer, session| {
-                    for ((datum, ()), time, diff) in data.iter() {
-                        let (update_type, operator_id, source, port, ts) = datum;
-                        let update_type = if *update_type { "source" } else { "target" };
-                        let data = packer.pack_slice(&[
-                            Datum::UInt64(u64::cast_from(*operator_id)),
-                            Datum::UInt64(u64::cast_from(worker_id)),
-                            Datum::UInt64(u64::cast_from(*source)),
-                            Datum::UInt64(u64::cast_from(*port)),
-                            Datum::String(update_type),
-                            Datum::from(*ts),
-                        ]);
-                        session.give((data, time, diff));
-                    }
-                },
-            );
+        let updates = consolidate_and_pack::<
+            batcher::Chunker<_>,
+            Col2ValBatcher<UpdatesKey, _, _, _>,
+            ColumnBuilder<_>,
+            _,
+            _,
+            _,
+        >(
+            logs,
+            TimelyLog::Reachability,
+            move |data, packer, session| {
+                for ((datum, ()), time, diff) in data.iter() {
+                    let (update_type, operator_id, source, port, ts) = datum;
+                    let update_type = if *update_type { "source" } else { "target" };
+                    let data = packer.pack_slice(&[
+                        Datum::UInt64(u64::cast_from(*operator_id)),
+                        Datum::UInt64(u64::cast_from(worker_id)),
+                        Datum::UInt64(u64::cast_from(*source)),
+                        Datum::UInt64(u64::cast_from(*port)),
+                        Datum::String(update_type),
+                        Datum::from(*ts),
+                    ]);
+                    session.give((data, time, diff));
+                }
+            },
+        );
 
         let mut result = BTreeMap::new();
         for variant in logs_active {
@@ -126,6 +133,7 @@ pub(super) fn construct(
                     .clone()
                     .mz_arrange_core::<
                         _,
+                        batcher::Chunker<_>,
                         Col2ValBatcher<_, _, _, _>,
                         RowRowBuilder<_, _>,
                         RowRowSpine<_, _>,

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -19,8 +19,10 @@ use columnation::{Columnation, CopyRegion};
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, Timestamp};
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, columnar_exchange};
+use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::replay::MzReplay;
 use timely::dataflow::Scope;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
@@ -178,7 +180,14 @@ pub(super) fn construct(
         // We pre-arrange the logging streams to force a consolidation and reduce the amount of
         // updates that reach `Row` encoding.
 
-        let operates = consolidate_and_pack::<KeyValBatcher<_, _, _, _>, ColumnBuilder<_>, _, _>(
+        let operates = consolidate_and_pack::<
+            ColumnationChunker<_>,
+            KeyValBatcher<_, _, _, _>,
+            ColumnBuilder<_>,
+            _,
+            _,
+            _,
+        >(
             operates,
             TimelyLog::Operates,
             move |data, packer, session| {
@@ -229,7 +238,14 @@ pub(super) fn construct(
         type KVB<K, V, T, D> = KeyValBatcher<K, V, T, D>;
         type KB<K, T, D> = KeyBatcher<K, T, D>;
 
-        let addresses = consolidate_and_pack::<KVB<_, _, _, _>, ColumnBuilder<_>, _, _>(
+        let addresses = consolidate_and_pack::<
+            ColumnationChunker<_>,
+            KVB<_, _, _, _>,
+            ColumnBuilder<_>,
+            _,
+            _,
+            _,
+        >(
             addresses,
             TimelyLog::Addresses,
             move |data, packer, session| {
@@ -248,112 +264,119 @@ pub(super) fn construct(
             },
         );
 
-        let parks = consolidate_and_pack::<KB<_, _, _>, ColumnBuilder<_>, _, _>(
-            parks,
-            TimelyLog::Parks,
-            move |data, packer, session| {
-                for ((datum, ()), time, diff) in data.iter() {
-                    let data = packer.pack_slice(&[
-                        Datum::UInt64(u64::cast_from(worker_id)),
-                        Datum::UInt64(datum.duration_pow),
-                        datum
-                            .requested_pow
-                            .map(Datum::UInt64)
-                            .unwrap_or(Datum::Null),
-                    ]);
-                    session.give((data, time, diff));
-                }
-            },
-        );
+        let parks =
+            consolidate_and_pack::<ColumnationChunker<_>, KB<_, _, _>, ColumnBuilder<_>, _, _, _>(
+                parks,
+                TimelyLog::Parks,
+                move |data, packer, session| {
+                    for ((datum, ()), time, diff) in data.iter() {
+                        let data = packer.pack_slice(&[
+                            Datum::UInt64(u64::cast_from(worker_id)),
+                            Datum::UInt64(datum.duration_pow),
+                            datum
+                                .requested_pow
+                                .map(Datum::UInt64)
+                                .unwrap_or(Datum::Null),
+                        ]);
+                        session.give((data, time, diff));
+                    }
+                },
+            );
 
-        let batches_sent = consolidate_and_pack::<KB<_, _, _>, ColumnBuilder<_>, _, _>(
-            batches_sent,
-            TimelyLog::BatchesSent,
-            move |data, packer, session| {
-                for ((datum, ()), time, diff) in data.iter() {
-                    let data = packer.pack_slice(&[
-                        Datum::UInt64(u64::cast_from(datum.channel)),
-                        Datum::UInt64(u64::cast_from(worker_id)),
-                        Datum::UInt64(u64::cast_from(datum.worker)),
-                    ]);
-                    session.give((data, time, diff));
-                }
-            },
-        );
+        let batches_sent =
+            consolidate_and_pack::<ColumnationChunker<_>, KB<_, _, _>, ColumnBuilder<_>, _, _, _>(
+                batches_sent,
+                TimelyLog::BatchesSent,
+                move |data, packer, session| {
+                    for ((datum, ()), time, diff) in data.iter() {
+                        let data = packer.pack_slice(&[
+                            Datum::UInt64(u64::cast_from(datum.channel)),
+                            Datum::UInt64(u64::cast_from(worker_id)),
+                            Datum::UInt64(u64::cast_from(datum.worker)),
+                        ]);
+                        session.give((data, time, diff));
+                    }
+                },
+            );
 
-        let batches_received = consolidate_and_pack::<KB<_, _, _>, ColumnBuilder<_>, _, _>(
-            batches_received,
-            TimelyLog::BatchesReceived,
-            move |data, packer, session| {
-                for ((datum, ()), time, diff) in data.iter() {
-                    let data = packer.pack_slice(&[
-                        Datum::UInt64(u64::cast_from(datum.channel)),
-                        Datum::UInt64(u64::cast_from(datum.worker)),
-                        Datum::UInt64(u64::cast_from(worker_id)),
-                    ]);
-                    session.give((data, time, diff));
-                }
-            },
-        );
+        let batches_received =
+            consolidate_and_pack::<ColumnationChunker<_>, KB<_, _, _>, ColumnBuilder<_>, _, _, _>(
+                batches_received,
+                TimelyLog::BatchesReceived,
+                move |data, packer, session| {
+                    for ((datum, ()), time, diff) in data.iter() {
+                        let data = packer.pack_slice(&[
+                            Datum::UInt64(u64::cast_from(datum.channel)),
+                            Datum::UInt64(u64::cast_from(datum.worker)),
+                            Datum::UInt64(u64::cast_from(worker_id)),
+                        ]);
+                        session.give((data, time, diff));
+                    }
+                },
+            );
 
-        let messages_sent = consolidate_and_pack::<KB<_, _, _>, ColumnBuilder<_>, _, _>(
-            messages_sent,
-            TimelyLog::MessagesSent,
-            move |data, packer, session| {
-                for ((datum, ()), time, diff) in data.iter() {
-                    let data = packer.pack_slice(&[
-                        Datum::UInt64(u64::cast_from(datum.channel)),
-                        Datum::UInt64(u64::cast_from(worker_id)),
-                        Datum::UInt64(u64::cast_from(datum.worker)),
-                    ]);
-                    session.give((data, time, diff));
-                }
-            },
-        );
+        let messages_sent =
+            consolidate_and_pack::<ColumnationChunker<_>, KB<_, _, _>, ColumnBuilder<_>, _, _, _>(
+                messages_sent,
+                TimelyLog::MessagesSent,
+                move |data, packer, session| {
+                    for ((datum, ()), time, diff) in data.iter() {
+                        let data = packer.pack_slice(&[
+                            Datum::UInt64(u64::cast_from(datum.channel)),
+                            Datum::UInt64(u64::cast_from(worker_id)),
+                            Datum::UInt64(u64::cast_from(datum.worker)),
+                        ]);
+                        session.give((data, time, diff));
+                    }
+                },
+            );
 
-        let messages_received = consolidate_and_pack::<KB<_, _, _>, ColumnBuilder<_>, _, _>(
-            messages_received,
-            TimelyLog::MessagesReceived,
-            move |data, packer, session| {
-                for ((datum, ()), time, diff) in data.iter() {
-                    let data = packer.pack_slice(&[
-                        Datum::UInt64(u64::cast_from(datum.channel)),
-                        Datum::UInt64(u64::cast_from(datum.worker)),
-                        Datum::UInt64(u64::cast_from(worker_id)),
-                    ]);
-                    session.give((data, time, diff));
-                }
-            },
-        );
+        let messages_received =
+            consolidate_and_pack::<ColumnationChunker<_>, KB<_, _, _>, ColumnBuilder<_>, _, _, _>(
+                messages_received,
+                TimelyLog::MessagesReceived,
+                move |data, packer, session| {
+                    for ((datum, ()), time, diff) in data.iter() {
+                        let data = packer.pack_slice(&[
+                            Datum::UInt64(u64::cast_from(datum.channel)),
+                            Datum::UInt64(u64::cast_from(datum.worker)),
+                            Datum::UInt64(u64::cast_from(worker_id)),
+                        ]);
+                        session.give((data, time, diff));
+                    }
+                },
+            );
 
-        let elapsed = consolidate_and_pack::<KB<_, _, _>, ColumnBuilder<_>, _, _>(
-            schedules_duration,
-            TimelyLog::Elapsed,
-            move |data, packer, session| {
-                for ((operator, ()), time, diff) in data.iter() {
-                    let data = packer.pack_slice(&[
-                        Datum::UInt64(u64::cast_from(*operator)),
-                        Datum::UInt64(u64::cast_from(worker_id)),
-                    ]);
-                    session.give((data, time, diff));
-                }
-            },
-        );
+        let elapsed =
+            consolidate_and_pack::<ColumnationChunker<_>, KB<_, _, _>, ColumnBuilder<_>, _, _, _>(
+                schedules_duration,
+                TimelyLog::Elapsed,
+                move |data, packer, session| {
+                    for ((operator, ()), time, diff) in data.iter() {
+                        let data = packer.pack_slice(&[
+                            Datum::UInt64(u64::cast_from(*operator)),
+                            Datum::UInt64(u64::cast_from(worker_id)),
+                        ]);
+                        session.give((data, time, diff));
+                    }
+                },
+            );
 
-        let histogram = consolidate_and_pack::<KB<_, _, _>, ColumnBuilder<_>, _, _>(
-            schedules_histogram,
-            TimelyLog::Histogram,
-            move |data, packer, session| {
-                for ((datum, ()), time, diff) in data.iter() {
-                    let data = packer.pack_slice(&[
-                        Datum::UInt64(u64::cast_from(datum.operator)),
-                        Datum::UInt64(u64::cast_from(worker_id)),
-                        Datum::UInt64(datum.duration_pow),
-                    ]);
-                    session.give((data, time, diff));
-                }
-            },
-        );
+        let histogram =
+            consolidate_and_pack::<ColumnationChunker<_>, KB<_, _, _>, ColumnBuilder<_>, _, _, _>(
+                schedules_histogram,
+                TimelyLog::Histogram,
+                move |data, packer, session| {
+                    for ((datum, ()), time, diff) in data.iter() {
+                        let data = packer.pack_slice(&[
+                            Datum::UInt64(u64::cast_from(datum.operator)),
+                            Datum::UInt64(u64::cast_from(worker_id)),
+                            Datum::UInt64(datum.duration_pow),
+                        ]);
+                        session.give((data, time, diff));
+                    }
+                },
+            );
 
         let logs = {
             use TimelyLog::*;
@@ -380,7 +403,13 @@ pub(super) fn construct(
                 type Batcher<K, V, T, R> = Col2ValBatcher<K, V, T, R>;
                 type Builder<T, R> = RowRowBuilder<T, R>;
                 let trace = collection
-                    .mz_arrange_core::<_, Batcher<_, _, _, _>, Builder<_, _>, RowRowSpine<_, _>>(
+                    .mz_arrange_core::<
+                        _,
+                        batcher::Chunker<_>,
+                        Batcher<_, _, _, _>,
+                        Builder<_, _>,
+                        RowRowSpine<_, _>,
+                    >(
                         ExchangeCore::<ColumnBuilder<_>, _>::new_core(
                             columnar_exchange::<mz_repr::Row, mz_repr::Row, Timestamp, Diff>,
                         ),

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -180,9 +180,7 @@ pub use join::LinearJoinSpec;
 
 /// Guard that presses a differential [`ShutdownButton`] when dropped.
 ///
-/// differential-dataflow 0.24 removed `ShutdownButton::press_on_drop`, so we
-/// reconstruct the press-on-drop behavior locally: dropping this guard releases
-/// the imported trace's capabilities.
+/// Dropping this guard releases the imported trace's capabilities.
 struct PressOnDrop<T>(ShutdownButton<T>);
 
 impl<T> Drop for PressOnDrop<T> {

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -113,6 +113,7 @@ use std::task::Poll;
 use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
+use differential_dataflow::operators::arrange::ShutdownButton;
 use differential_dataflow::operators::iterate::Variable;
 use differential_dataflow::trace::{BatchReader, TraceReader};
 use differential_dataflow::{AsCollection, Data, VecCollection};
@@ -135,6 +136,7 @@ use mz_repr::explain::DummyHumanizer;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, ReprRelationType, Row, SharedRow};
 use mz_storage_operators::persist_source;
 use mz_storage_types::controller::CollectionMetadata;
+use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use mz_timely_util::probe::{Handle as MzProbeHandle, ProbeNotify};
 use mz_timely_util::scope_label::ScopeExt;
@@ -175,6 +177,19 @@ mod top_k;
 
 pub use context::CollectionBundle;
 pub use join::LinearJoinSpec;
+
+/// Guard that presses a differential [`ShutdownButton`] when dropped.
+///
+/// differential-dataflow 0.24 removed `ShutdownButton::press_on_drop`, so we
+/// reconstruct the press-on-drop behavior locally: dropping this guard releases
+/// the imported trace's capabilities.
+struct PressOnDrop<T>(ShutdownButton<T>);
+
+impl<T> Drop for PressOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.press();
+    }
+}
 
 /// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
 ///
@@ -651,7 +666,7 @@ where
             self.update_id(Id::Global(idx.on_id), bundle);
             tokens.insert(
                 idx_id,
-                Rc::new((ok_button.press_on_drop(), err_button.press_on_drop(), token)),
+                Rc::new((PressOnDrop(ok_button), PressOnDrop(err_button), token)),
             );
         } else {
             panic!(
@@ -775,14 +790,19 @@ where
                 let mut oks = oks
                     .as_collection(|k, v| (k.to_row(), v.to_row()))
                     .leave(outer)
-                    .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, _>(
+                    .mz_arrange::<
+                        ColumnationChunker<_>,
+                        RowRowBatcher<_, _>,
+                        RowRowBuilder<_, _>,
+                        _,
+                    >(
                         "Arrange export iterative",
                     );
 
                 let mut errs = errs
                     .as_collection(|k, v| (k.clone(), v.clone()))
                     .leave(outer)
-                    .mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
+                    .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
                         "Arrange export iterative err",
                     );
 
@@ -947,7 +967,12 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // multiplicities of errors, but .. this seems to be the better call.
                 let err: KeyCollection<_, _, _> = err.into();
                 let errs = err
-                    .mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, ErrSpine<_, _>>(
+                    .mz_arrange::<
+                        ColumnationChunker<_>,
+                        ErrBatcher<_, _>,
+                        ErrBuilder<_, _>,
+                        ErrSpine<_, _>,
+                    >(
                         "Arrange recursive err",
                     )
                     .mz_reduce_abelian::<_, ErrBuilder<_, _>, ErrSpine<_, _>>(

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -30,8 +30,10 @@ use mz_ore::soft_assert_or_log;
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
 use mz_storage_types::controller::CollectionMetadata;
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
+use mz_timely_util::columnation::ColumnationChunker;
 use timely::ContainerBuilder;
 use timely::container::{CapacityContainerBuilder, PushInto};
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
@@ -1084,7 +1086,12 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 let errs_concat: KeyCollection<_, _, _> = errs.clone().concat(errs_keyed).into();
                 self.collection = Some((passthrough, errs));
                 let errs =
-                    errs_concat.mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, ErrSpine<_, _>>(
+                    errs_concat.mz_arrange::<
+                        ColumnationChunker<_>,
+                        ErrBatcher<_, _>,
+                        ErrBuilder<_, _>,
+                        ErrSpine<_, _>,
+                    >(
                         &format!("{}-errors", name),
                     );
                 self.arranged
@@ -1166,6 +1173,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         let oks = if use_paged_path {
             ok_stream.mz_arrange_core::<
                 _,
+                batcher::ColumnChunker<_>,
                 Col2ValPagedBatcher<_, _, _, _>,
                 RowRowColPagedBuilder<_, _>,
                 RowRowSpine<_, _>,
@@ -1173,6 +1181,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         } else {
             ok_stream.mz_arrange_core::<
                 _,
+                batcher::Chunker<_>,
                 Col2ValBatcher<_, _, _, _>,
                 RowRowBuilder<_, _>,
                 RowRowSpine<_, _>,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -27,6 +27,7 @@ use mz_dyncfg::ConfigSet;
 use mz_expr::Eval;
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
@@ -389,6 +390,7 @@ where
             let arranged = if ENABLE_COLUMN_PAGED_BATCHER.get(&self.config_set) {
                 keyed.mz_arrange_core::<
                     _,
+                    batcher::ColumnChunker<_>,
                     Col2ValPagedBatcher<_, _, _, _>,
                     RowRowColPagedBuilder<_, _>,
                     RowRowSpine<_, _>,
@@ -396,6 +398,7 @@ where
             } else {
                 keyed.mz_arrange_core::<
                     _,
+                    batcher::Chunker<_>,
                     Col2ValBatcher<_, _, _, _>,
                     RowRowBuilder<_, _>,
                     RowRowSpine<_, _>,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -22,7 +22,6 @@ use differential_dataflow::difference::{IsZero, Multiply, Semigroup};
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::implementations::BatchContainer;
-use differential_dataflow::trace::implementations::merge_batcher::container::InternalMerge;
 use differential_dataflow::trace::{Builder, Trace};
 use differential_dataflow::{Data, VecCollection};
 use itertools::Itertools;
@@ -39,6 +38,7 @@ use mz_ore::cast::CastLossy;
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{Datum, DatumVec, Diff, Row, RowArena, SharedRow};
+use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::CollectionExt;
 use num_traits::Float;
 use serde::{Deserialize, Serialize};
@@ -213,7 +213,9 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             0..key_arity,
             ArrangementFlavor::Local(
                 arrangement,
-                errs.mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, _>("Arrange bundle err"),
+                errs.mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
+                    "Arrange bundle err",
+                ),
             ),
         )
     }
@@ -302,7 +304,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
 
         let arranged = collection
-            .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowRowBatcher<_, _>,
+                RowRowBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(
                 "Arranged DistinctBy",
             );
         let output = arranged
@@ -408,7 +415,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
 
         let arranged = differential_dataflow::collection::concatenate(input.scope(), to_collect)
-            .mz_arrange::<RowValBatcher<_, _, _>, RowValBuilder<_, _, _>, RowValSpine<_, _, _>>(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowValBatcher<_, _, _>,
+                RowValBuilder<_, _, _>,
+                RowValSpine<_, _, _>,
+            >(
             "Arranged ReduceFuseBasic input",
         );
 
@@ -558,7 +570,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             "FusedReduceUnnestList"
         };
         let arranged = partial
-            .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(&format!(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowRowBatcher<_, _>,
+                RowRowBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(&format!(
                 "Arranged {name}"
             ));
         let oks = if !fused_unnest_list {
@@ -764,7 +781,6 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         Bu: Builder<
                 Time = T,
                 Input: Container
-                           + InternalMerge
                            + ClearContainer
                            + PushInto<((Row, Tr::ValOwn), Tr::Time, Tr::Diff)>,
                 Output = Tr::Batch,
@@ -780,7 +796,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 
         let input: KeyCollection<_, _, _> = input.into();
         input
-            .mz_arrange::<RowBatcher<_, _>, RowBuilder<_, _>, RowSpine<_, _>>(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowBatcher<_, _>,
+                RowBuilder<_, _>,
+                RowSpine<_, _>,
+            >(
                 "Arranged ReduceInaccumulable Distinct [val: empty]",
             )
             .mz_reduce_abelian::<_, Bu, Tr>(&output_name, move |_, source, t| {
@@ -905,7 +926,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
                 // view mz_introspection.mz_expected_group_size_advice.
                 let arranged = partial
-                    .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    .mz_arrange::<
+                        ColumnationChunker<_>,
+                        RowRowBatcher<_, _>,
+                        RowRowBuilder<_, _>,
+                        RowRowSpine<_, _>,
+                    >(
                         "Arrange ReduceMinsMaxes",
                     );
                 // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
@@ -1090,7 +1116,6 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         Bu: Builder<
                 Time = T,
                 Input: Container
-                           + InternalMerge
                            + ClearContainer
                            + PushInto<((Row, Tr::ValOwn), Tr::Time, Tr::Diff)>,
                 Output = Tr::Batch,
@@ -1101,7 +1126,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
         // view mz_introspection.mz_expected_group_size_advice.
         let arranged_input = input
-            .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowRowBatcher<_, _>,
+                RowRowBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(
                 "Arranged MinsMaxesHierarchical input",
             );
 
@@ -1221,7 +1251,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 
         let partial: KeyCollection<_, _, _> = partial.into();
         let arranged = partial
-            .mz_arrange::<RowBatcher<_, _>, RowBuilder<_, _>, RowSpine<_, Vec<ReductionMonoid>>>(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowBatcher<_, _>,
+                RowBuilder<_, _>,
+                RowSpine<_, Vec<ReductionMonoid>>,
+            >(
                 "ArrangeMonotonic [val: empty]",
             );
         let output = arranged
@@ -1368,7 +1403,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     let value = row.iter().nth(datum_index).unwrap();
                     (pairer.merge(&key, std::iter::once(value)), ())
                 })
-                .mz_arrange::<RowBatcher<_, _>, RowBuilder<_, _>, RowSpine<_, _>>(
+                .mz_arrange::<
+                    ColumnationChunker<_>,
+                    RowBatcher<_, _>,
+                    RowBuilder<_, _>,
+                    RowSpine<_, _>,
+                >(
                     "Arranged Accumulable Distinct [val: empty]",
                 )
                 .mz_reduce_abelian::<_, RowBuilder<_, _>, RowSpine<_, _>>(
@@ -1406,7 +1446,12 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let error_logger = self.error_logger();
         let err_full_aggrs = full_aggrs.clone();
         let arranged = collection
-            .mz_arrange::<RowBatcher<_, _>, RowBuilder<_, _>, RowSpine<_, (Vec<Accum>, Diff)>>(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowBatcher<_, _>,
+                RowBuilder<_, _>,
+                RowSpine<_, (Vec<Accum>, Diff)>,
+            >(
                 "ArrangeAccumulable [val: empty]",
             );
         let arranged_output = arranged

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -14,11 +14,11 @@
 use differential_dataflow::Data;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::implementations::BatchContainer;
-use differential_dataflow::trace::implementations::merge_batcher::container::InternalMerge;
 use differential_dataflow::trace::{Builder, Trace, TraceReader};
 use mz_compute_types::plan::threshold::{BasicThresholdPlan, ThresholdPlan};
 use mz_expr::MirScalarExpr;
 use mz_repr::Diff;
+use mz_timely_util::columnation::ColumnationChunker;
 use timely::Container;
 use timely::container::PushInto;
 
@@ -47,7 +47,6 @@ where
     Bu2: Builder<
             Time = Ts,
             Input: Container
-                       + InternalMerge
                        + ClearContainer
                        + PushInto<(
                 (<T1::KeyContainer as BatchContainer>::Owned, T1::ValOwn),
@@ -104,7 +103,9 @@ pub fn build_threshold_basic<'scope, T: RenderTimestamp>(
             );
             let errs: KeyCollection<_, _, _> = errs.as_collection(|k, _| k.clone()).into();
             let errs = errs
-                .mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, _>("Arrange threshold basic err");
+                .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
+                    "Arrange threshold basic err",
+                );
             CollectionBundle::from_expressions(key, ArrangementFlavor::Local(oks, errs))
         }
     }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -21,7 +21,6 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::operators::iterate::Variable as SemigroupVariable;
 use differential_dataflow::trace::implementations::BatchContainer;
-use differential_dataflow::trace::implementations::merge_batcher::container::InternalMerge;
 use differential_dataflow::trace::{Builder, Trace};
 use differential_dataflow::{Data, VecCollection};
 use mz_compute_types::dyncfgs::{ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY};
@@ -34,6 +33,7 @@ use mz_expr::{BinaryFunc, Columns, Eval, EvalError, MirScalarExpr, UnaryFunc, fu
 use mz_ore::cast::CastFrom;
 use mz_ore::soft_assert_or_log;
 use mz_repr::{Datum, DatumVec, Diff, ReprScalarType, Row, SharedRow};
+use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::CollectionExt;
 use timely::Container;
 use timely::container::{CapacityContainerBuilder, PushInto};
@@ -548,7 +548,12 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             })
             .into();
         let result = partial
-            .mz_arrange::<RowBatcher<_, _>, RowBuilder<_, _>, RowSpine<_, _>>(
+            .mz_arrange::<
+                ColumnationChunker<_>,
+                RowBatcher<_, _>,
+                RowBuilder<_, _>,
+                RowSpine<_, _>,
+            >(
                 "Arranged MonotonicTop1 partial [val: empty]",
             )
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
@@ -584,10 +589,7 @@ where
     T: MzTimestamp,
     Bu: Builder<
             Time = T,
-            Input: Container
-                       + InternalMerge
-                       + ClearContainer
-                       + PushInto<((Row, Tr::ValOwn), T, Diff)>,
+            Input: Container + ClearContainer + PushInto<((Row, Tr::ValOwn), T, Diff)>,
             Output = Tr::Batch,
         >,
     Tr: for<'a> Trace<
@@ -607,7 +609,12 @@ where
     // built-in view mz_introspection.mz_expected_group_size_advice.
     let arranged = input
         .clone()
-        .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+        .mz_arrange::<
+            ColumnationChunker<_>,
+            RowRowBatcher<_, _>,
+            RowRowBuilder<_, _>,
+            RowRowSpine<_, _>,
+        >(
             "Arranged TopK input",
         );
 

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -20,6 +20,7 @@ use mz_compute_types::dyncfgs::{
 use mz_compute_types::sinks::{ComputeSinkDesc, CopyToS3OneshotSinkConnection};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
+use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::consolidate_pact;
 use mz_timely_util::probe::{Handle, ProbeNotify};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
@@ -61,7 +62,7 @@ impl<'scope> SinkRender<'scope> for CopyToS3OneshotSinkConnection {
 
         // We exchange the data according to batch, but we don't want to send the batch ID to the
         // sink. The sink can re-compute the batch ID from the data.
-        let input = consolidate_pact::<KeyBatcher<_, _, _>, _>(
+        let input = consolidate_pact::<ColumnationChunker<_>, KeyBatcher<_, _, _>, _, _>(
             sinked_collection.map(move |row| (row, ())).inner,
             Exchange::new(move |((row, ()), _, _): &((Row, _), _, _)| row.hashed() % batch_count),
             "Consolidated COPY TO S3 input",
@@ -69,7 +70,7 @@ impl<'scope> SinkRender<'scope> for CopyToS3OneshotSinkConnection {
         .probe_notify_with(vec![output_probe.clone()]);
 
         // We need to consolidate the error collection to ensure we don't act on retracted errors.
-        let error = consolidate_pact::<KeyBatcher<_, _, _>, _>(
+        let error = consolidate_pact::<ColumnationChunker<_>, KeyBatcher<_, _, _>, _, _>(
             err_collection.map(move |err| (err, ())).inner,
             Exchange::new(move |((err, _), _, _): &((DataflowErrorSer, _), _, _)| {
                 err.hashed() % batch_count

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -18,7 +18,7 @@ use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
 use differential_dataflow::trace::wrappers::enter::TraceEnter;
 use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use mz_repr::Diff;
-use mz_timely_util::columnation::{ColInternalMerger, ColumnationChunker};
+use mz_timely_util::columnation::ColInternalMerger;
 
 use mz_row_spine::RowValBuilder;
 
@@ -121,11 +121,7 @@ pub type RowErrBuilder<T, R> = RowValBuilder<DataflowErrorSer, T, R>;
 
 // Batchers for consolidation
 pub type KeyBatcher<K, T, D> = KeyValBatcher<K, (), T, D>;
-pub type KeyValBatcher<K, V, T, D> = MergeBatcher<
-    Vec<((K, V), T, D)>,
-    ColumnationChunker<((K, V), T, D)>,
-    ColInternalMerger<(K, V), T, D>,
->;
+pub type KeyValBatcher<K, V, T, D> = MergeBatcher<ColInternalMerger<(K, V), T, D>>;
 
 /// Timestamp trait for rendering, constraint to support [`MzData`] and [timely::progress::Timestamp].
 pub trait MzTimestamp:

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -139,8 +139,10 @@ pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) {
 
 #[cfg(test)]
 mod tests {
-    use differential_dataflow::trace::Batcher;
+    use differential_dataflow::trace::implementations::chunker::ContainerChunker;
     use differential_dataflow::trace::implementations::{ValBatcher, ValBuilder};
+    use differential_dataflow::trace::{Batcher, Builder};
+    use timely::container::{ContainerBuilder, PushInto};
     use timely::progress::Antichain;
 
     use super::*;
@@ -150,11 +152,20 @@ mod tests {
     fn batch_from_tuples(
         mut tuples: Vec<((String, String), u64, Diff)>,
         upper: u64,
-    ) -> <ValBuilder<String, String, u64, Diff> as differential_dataflow::trace::Builder>::Output
-    {
+    ) -> <ValBuilder<String, String, u64, Diff> as Builder>::Output {
+        // Since differential-dataflow 0.24 the batcher consumes already-chunked
+        // input via `PushInto` and chunking is the caller's responsibility.
         let mut batcher = ValBatcher::<String, String, u64, Diff>::new(None, 0);
-        batcher.push_container(&mut tuples);
-        batcher.seal::<ValBuilder<String, String, u64, Diff>>(Antichain::from_elem(upper))
+        let mut chunker = ContainerChunker::<Vec<((String, String), u64, Diff)>>::default();
+        chunker.push_into(&mut tuples);
+        while let Some(chunk) = chunker.extract() {
+            batcher.push_into(std::mem::take(chunk));
+        }
+        while let Some(chunk) = chunker.finish() {
+            batcher.push_into(std::mem::take(chunk));
+        }
+        let (mut chain, description) = batcher.seal(Antichain::from_elem(upper));
+        ValBuilder::<String, String, u64, Diff>::seal(&mut chain, description)
     }
 
     /// Collects `for_each_diff_pair` invocations into a flat, deterministically

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -153,8 +153,8 @@ mod tests {
         mut tuples: Vec<((String, String), u64, Diff)>,
         upper: u64,
     ) -> <ValBuilder<String, String, u64, Diff> as Builder>::Output {
-        // Since differential-dataflow 0.24 the batcher consumes already-chunked
-        // input via `PushInto` and chunking is the caller's responsibility.
+        // The batcher consumes already-chunked input via `PushInto`; chunking
+        // is the caller's responsibility.
         let mut batcher = ValBatcher::<String, String, u64, Diff>::new(None, 0);
         let mut chunker = ContainerChunker::<Vec<((String, String), u64, Diff)>>::default();
         chunker.push_into(&mut tuples);

--- a/src/ore/src/overflowing.rs
+++ b/src/ore/src/overflowing.rs
@@ -184,6 +184,11 @@ mod columnar {
     }
 
     impl<'a, T: Copy, TC: AsBytes<'a>> AsBytes<'a> for Overflows<T, TC> {
+        const SLICE_COUNT: usize = TC::SLICE_COUNT;
+        #[inline(always)]
+        fn get_byte_slice(&self, index: usize) -> (u64, &'a [u8]) {
+            self.0.get_byte_slice(index)
+        }
         #[inline(always)]
         fn as_bytes(&self) -> impl Iterator<Item = (u64, &'a [u8])> {
             self.0.as_bytes()

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -549,9 +549,15 @@ mod columnar {
     }
 
     impl<'a, BC: AsBytes<'a>, VC: AsBytes<'a>> AsBytes<'a> for Rows<BC, VC> {
+        const SLICE_COUNT: usize = BC::SLICE_COUNT + VC::SLICE_COUNT;
         #[inline(always)]
-        fn as_bytes(&self) -> impl Iterator<Item = (u64, &'a [u8])> {
-            columnar::chain(self.bounds.as_bytes(), self.values.as_bytes())
+        fn get_byte_slice(&self, index: usize) -> (u64, &'a [u8]) {
+            debug_assert!(index < Self::SLICE_COUNT);
+            if index < BC::SLICE_COUNT {
+                self.bounds.get_byte_slice(index)
+            } else {
+                self.values.get_byte_slice(index - BC::SLICE_COUNT)
+            }
         }
     }
     impl<'a, BC: FromBytes<'a>, VC: FromBytes<'a>> FromBytes<'a> for Rows<BC, VC> {

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -163,6 +163,15 @@ mod columnar_timestamp {
     }
 
     impl<'a> columnar::AsBytes<'a> for Timestamps<&'a [Timestamp]> {
+        const SLICE_COUNT: usize = 1;
+        #[inline(always)]
+        fn get_byte_slice(&self, index: usize) -> (u64, &'a [u8]) {
+            debug_assert!(index < Self::SLICE_COUNT);
+            (
+                u64::cast_from(align_of::<Timestamp>()),
+                bytemuck::cast_slice(self.0),
+            )
+        }
         #[inline(always)]
         fn as_bytes(&self) -> impl Iterator<Item = (u64, &'a [u8])> {
             std::iter::once((

--- a/src/row-spine/src/lib.rs
+++ b/src/row-spine/src/lib.rs
@@ -41,17 +41,13 @@ mod spines {
     use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
     use mz_repr::Row;
     use mz_timely_util::columnar::Column;
-    use mz_timely_util::columnation::{ColInternalMerger, ColumnationChunker, ColumnationStack};
+    use mz_timely_util::columnation::{ColInternalMerger, ColumnationStack};
 
     use crate::{DatumContainer, OffsetOptimized};
 
     /// Batcher matching `mz_compute::typedefs::KeyValBatcher`, redeclared
     /// locally so this crate does not need to depend on `mz_compute`.
-    type KeyValBatcher<K, V, T, D> = MergeBatcher<
-        Vec<((K, V), T, D)>,
-        ColumnationChunker<((K, V), T, D)>,
-        ColInternalMerger<(K, V), T, D>,
-    >;
+    type KeyValBatcher<K, V, T, D> = MergeBatcher<ColInternalMerger<(K, V), T, D>>;
     type KeyBatcher<K, T, D> = KeyValBatcher<K, (), T, D>;
 
     pub type RowRowSpine<T, R> = Spine<Rc<OrdValBatch<RowRowLayout<((Row, Row), T, R)>>>>;

--- a/src/storage/src/upsert_continual_feedback_v2.rs
+++ b/src/storage/src/upsert_continual_feedback_v2.rs
@@ -68,7 +68,6 @@
 //! `ts < p` is already persisted and dropped.
 
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use differential_dataflow::difference::{IsZero, Semigroup};
@@ -77,10 +76,8 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::agent::TraceAgent;
 use differential_dataflow::operators::arrange::arrangement::arrange_core;
 use differential_dataflow::trace::implementations::chunker::ContainerChunker;
-use differential_dataflow::trace::implementations::merge_batcher::{
-    MergeBatcher, container::VecMerger,
-};
-use differential_dataflow::trace::{Batcher, Builder, Cursor, Description, TraceReader};
+use differential_dataflow::trace::implementations::merge_batcher::{MergeBatcher, vec::VecMerger};
+use differential_dataflow::trace::{Batcher, Cursor, TraceReader};
 use differential_dataflow::{AsCollection, VecCollection};
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_row_spine::{DatumSeq, ValRowBatcher, ValRowBuilder, ValRowSpine};
@@ -133,40 +130,12 @@ impl<O: Ord + Clone> Semigroup for UpsertDiff<O> {
 // Data is pushed in unsorted; the batcher maintains geometrically-sized sorted
 // chains and consolidates via the UpsertDiff Semigroup automatically.
 
-type UpsertBatcher<T, FromTime> = MergeBatcher<
-    Vec<(UpsertKey, T, UpsertDiff<FromTime>)>,
-    ContainerChunker<Vec<(UpsertKey, T, UpsertDiff<FromTime>)>>,
-    VecMerger<UpsertKey, T, UpsertDiff<FromTime>>,
->;
+type UpsertBatcher<T, FromTime> = MergeBatcher<VecMerger<UpsertKey, T, UpsertDiff<FromTime>>>;
 
-/// A minimal [`Builder`] that captures sealed chains without copying.
-///
-/// Used with [`MergeBatcher::seal`] to extract sorted, consolidated chunks
-/// directly as `Vec<Vec<...>>`.
-struct CapturingBuilder<D, T>(D, PhantomData<T>);
-
-impl<D, T: Timestamp> Builder for CapturingBuilder<D, T> {
-    type Input = D;
-    type Time = T;
-    type Output = Vec<D>;
-
-    fn with_capacity(_keys: usize, _vals: usize, _upds: usize) -> Self {
-        unimplemented!()
-    }
-
-    fn push(&mut self, _chunk: &mut Self::Input) {
-        unimplemented!()
-    }
-
-    fn done(self, _description: Description<Self::Time>) -> Self::Output {
-        unimplemented!()
-    }
-
-    #[inline]
-    fn seal(chain: &mut Vec<Self::Input>, _description: Description<Self::Time>) -> Self::Output {
-        std::mem::take(chain)
-    }
-}
+/// The chunker that consolidates raw `Vec` input into the chunks
+/// [`UpsertBatcher`] consumes. Since differential-dataflow 0.24 the chunker
+/// lives outside the batcher.
+type UpsertChunker<T, FromTime> = ContainerChunker<Vec<(UpsertKey, T, UpsertDiff<FromTime>)>>;
 
 // The persist-feedback arrangement uses a `ValRowSpine<UpsertKey, _, _>`: keys
 // land in a columnation arena (`UpsertKey` is `[u8; 32]` + `Copy`, so it uses
@@ -294,6 +263,8 @@ where
     let encoded = persist_keyed.map(|(k, v)| (k, upsert_value_to_row(&v)));
     let persist_arranged = arrange_core::<
         _,
+        _,
+        mz_timely_util::columnation::ColumnationChunker<((UpsertKey, Row), T, Diff)>,
         ValRowBatcher<UpsertKey, T, Diff>,
         ValRowBuilder<UpsertKey, T, Diff>,
         ValRowSpine<UpsertKey, T, Diff>,
@@ -343,8 +314,12 @@ where
         // UpsertDiff Semigroup as data is pushed in, bounding memory to
         // O(unique key-time pairs) even during large initial snapshots.
         let mut batcher: UpsertBatcher<T, FromTime> = Batcher::new(None, 0);
+        // Since differential-dataflow 0.24 the batcher no longer chunks its own
+        // input; this chunker consolidates raw `Vec` input into the chunks the
+        // batcher consumes.
+        let mut chunker: UpsertChunker<T, FromTime> = Default::default();
         // Scratch buffer for accumulating source events before flushing to
-        // the batcher. Drained on each iteration via `push_container`.
+        // the batcher. Drained on each iteration via the chunker.
         let mut push_buffer: Vec<(UpsertKey, T, UpsertDiff<FromTime>)> = Vec::new();
         // Capability held at the minimum time of any buffered data. When
         // Some, the operator may still produce output; when None, the
@@ -413,11 +388,15 @@ where
                 }
             }
 
-            // Flush buffered events into the batcher. This triggers the
-            // chunker + geometric chain merging, which consolidates entries
-            // for the same (key, time) via the UpsertDiff Semigroup.
+            // Flush buffered events through the chunker into the batcher. This
+            // triggers the chunker + geometric chain merging, which consolidates
+            // entries for the same (key, time) via the UpsertDiff Semigroup.
             if !push_buffer.is_empty() {
-                batcher.push_container(&mut push_buffer);
+                use timely::container::{ContainerBuilder as _, PushInto as _};
+                chunker.push_into(&mut push_buffer);
+                while let Some(chunk) = chunker.extract() {
+                    batcher.push_into(std::mem::take(chunk));
+                }
             }
 
             // ── Step 2: Read persist frontier ─────────────────────────────
@@ -498,7 +477,14 @@ where
                 && !persist_upper.less_than(cap.time())
                 && PartialOrder::less_than(&persist_upper, &input_upper)
             {
-                let sealed = batcher.seal::<CapturingBuilder<_, _>>(input_upper.clone());
+                // Flush any partial chunk into the batcher before sealing.
+                {
+                    use timely::container::{ContainerBuilder as _, PushInto as _};
+                    while let Some(chunk) = chunker.finish() {
+                        batcher.push_into(std::mem::take(chunk));
+                    }
+                }
+                let (sealed, _description) = batcher.seal(input_upper.clone());
                 // Frontier of data remaining in the batcher (ts >= input_upper).
                 let remaining_frontier = batcher.frontier().to_owned();
 
@@ -541,7 +527,11 @@ where
                 // input_upper) or ineligible entries being pushed back.
                 let min_ineligible_ts = ineligible.iter().map(|(_, ts, _)| ts).min().cloned();
                 if !ineligible.is_empty() {
-                    batcher.push_container(&mut ineligible);
+                    use timely::container::{ContainerBuilder as _, PushInto as _};
+                    chunker.push_into(&mut ineligible);
+                    while let Some(chunk) = chunker.extract() {
+                        batcher.push_into(std::mem::take(chunk));
+                    }
                 }
 
                 let has_remaining = !remaining_frontier.is_empty() || min_ineligible_ts.is_some();

--- a/src/storage/src/upsert_continual_feedback_v2.rs
+++ b/src/storage/src/upsert_continual_feedback_v2.rs
@@ -133,8 +133,7 @@ impl<O: Ord + Clone> Semigroup for UpsertDiff<O> {
 type UpsertBatcher<T, FromTime> = MergeBatcher<VecMerger<UpsertKey, T, UpsertDiff<FromTime>>>;
 
 /// The chunker that consolidates raw `Vec` input into the chunks
-/// [`UpsertBatcher`] consumes. Since differential-dataflow 0.24 the chunker
-/// lives outside the batcher.
+/// [`UpsertBatcher`] consumes.
 type UpsertChunker<T, FromTime> = ContainerChunker<Vec<(UpsertKey, T, UpsertDiff<FromTime>)>>;
 
 // The persist-feedback arrangement uses a `ValRowSpine<UpsertKey, _, _>`: keys
@@ -314,8 +313,7 @@ where
         // UpsertDiff Semigroup as data is pushed in, bounding memory to
         // O(unique key-time pairs) even during large initial snapshots.
         let mut batcher: UpsertBatcher<T, FromTime> = Batcher::new(None, 0);
-        // Since differential-dataflow 0.24 the batcher no longer chunks its own
-        // input; this chunker consolidates raw `Vec` input into the chunks the
+        // The chunker consolidates raw `Vec` input into the chunks the
         // batcher consumes.
         let mut chunker: UpsertChunker<T, FromTime> = Default::default();
         // Scratch buffer for accumulating source events before flushing to

--- a/src/timely-util/examples/column_paged_spill.rs
+++ b/src/timely-util/examples/column_paged_spill.rs
@@ -45,6 +45,7 @@ use mz_timely_util::column_pager::policy::TieredPolicy;
 use mz_timely_util::column_pager::{ColumnPager, set_global_pager};
 use mz_timely_util::columnar::Col2ValPagedBatcher;
 use mz_timely_util::columnar::Column;
+use mz_timely_util::columnar::batcher::ColumnChunker;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use timely::dataflow::InputHandle;
 use timely::dataflow::channels::pact::Pipeline;
@@ -53,6 +54,7 @@ use timely::dataflow::operators::probe::{Handle as ProbeHandle, Probe};
 
 type Update = ((u64, u64), u64, i64);
 
+type MyChunker = ColumnChunker<Update>;
 type MyBatcher = Col2ValPagedBatcher<u64, u64, u64, i64>;
 type MyBuilder = RcBuilder<OrdValBuilder<Vector<Update>, Column<Update>>>;
 type MySpine = Spine<Rc<OrdValBatch<Vector<Update>>>>;
@@ -129,7 +131,7 @@ fn run_dataflow(cfg: &Config, label: &str) -> Duration {
             // Demo wires the raw DD operator; production paths go through
             // `MzArrange::mz_arrange_core` in `mz-compute`.
             #[allow(clippy::disallowed_methods)]
-            let arranged = arrange_core::<_, MyBatcher, MyBuilder, MySpine>(
+            let arranged = arrange_core::<_, _, MyChunker, MyBatcher, MyBuilder, MySpine>(
                 stream,
                 Pipeline,
                 "ColumnPagedSpillArrange",

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -37,14 +37,16 @@ use timely::bytes::arc::Bytes;
 use timely::container::{DrainContainer, PushInto, SizableContainer};
 use timely::dataflow::channels::ContainerBytes;
 
-use crate::columnation::{ColInternalMerger, ColumnationStack};
+use crate::columnation::ColInternalMerger;
 
 /// A batcher for columnar storage.
-pub type Col2ValBatcher<K, V, T, R> = MergeBatcher<
-    Column<((K, V), T, R)>,
-    batcher::Chunker<ColumnationStack<((K, V), T, R)>>,
-    ColInternalMerger<(K, V), T, R>,
->;
+///
+/// Since differential-dataflow 0.24 the chunker is supplied to the arrange
+/// operator separately rather than being part of the batcher type. Callers pass
+/// the chunker explicitly: [`ColumnationChunker`](crate::columnation::ColumnationChunker)
+/// for `Vec<_>` input, or [`batcher::Chunker`] (over a `ColumnationStack<_>`) for
+/// [`Column`] input.
+pub type Col2ValBatcher<K, V, T, R> = MergeBatcher<ColInternalMerger<(K, V), T, R>>;
 /// A batcher for columnar storage with unit values.
 pub type Col2KeyBatcher<K, T, R> = Col2ValBatcher<K, (), T, R>;
 

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -41,9 +41,8 @@ use crate::columnation::ColInternalMerger;
 
 /// A batcher for columnar storage.
 ///
-/// Since differential-dataflow 0.24 the chunker is supplied to the arrange
-/// operator separately rather than being part of the batcher type. Callers pass
-/// the chunker explicitly: [`ColumnationChunker`](crate::columnation::ColumnationChunker)
+/// The chunker is supplied to the arrange operator separately. Callers pass
+/// it explicitly: [`ColumnationChunker`](crate::columnation::ColumnationChunker)
 /// for `Vec<_>` input, or [`batcher::Chunker`] (over a `ColumnationStack<_>`) for
 /// [`Column`] input.
 pub type Col2ValBatcher<K, V, T, R> = MergeBatcher<ColInternalMerger<(K, V), T, R>>;

--- a/src/timely-util/src/columnar/merge_batcher.rs
+++ b/src/timely-util/src/columnar/merge_batcher.rs
@@ -21,10 +21,10 @@
 //!
 //! Reuses the resident building blocks from [`super::batcher`]: the inherent
 //! `Column::merge_from` / `Column::extract` methods (per-chunk merge / split).
-//! Input consolidation happens upstream: since differential-dataflow 0.24 the
-//! chunker ([`super::batcher::ColumnChunker`]) is supplied to the arrange
-//! operator separately, so this batcher receives already-consolidated
-//! [`Column`] chunks via [`PushInto`].
+//! Input consolidation happens upstream: the chunker
+//! ([`super::batcher::ColumnChunker`]) is supplied to the arrange operator
+//! separately, so this batcher receives already-consolidated [`Column`] chunks
+//! via [`PushInto`].
 //!
 //! [`differential_dataflow`]: differential_dataflow::trace::implementations::merge_batcher
 
@@ -938,8 +938,8 @@ mod tests {
         let mut b: ColumnMergeBatcher<(u64, u64), u64, i64> =
             differential_dataflow::trace::Batcher::new(None, 0);
         // Two pushes; second has an equal-key collision with the first.
-        // Inputs arrive pre-consolidated chunk-by-chunk since the chunker
-        // moved out of the batcher in differential 0.24.
+        // Inputs arrive pre-consolidated chunk-by-chunk, as from the upstream
+        // chunker.
         let input1 = col(&[((1, 1), 0, 1), ((2, 0), 0, 1), ((3, 0), 0, 1)]);
         let input2 = col(&[((2, 0), 0, 2), ((4, 0), 0, 1)]);
         b.push_into(input1);

--- a/src/timely-util/src/columnar/merge_batcher.rs
+++ b/src/timely-util/src/columnar/merge_batcher.rs
@@ -19,9 +19,12 @@
 //! hold [`PagedColumn`] entries — letting the [`ColumnPager`] page chunks
 //! out as they're produced and fetch them back lazily during merge / extract.
 //!
-//! Reuses the resident building blocks from [`super::batcher`]:
-//! [`ColumnChunker`] (input consolidation) and the inherent
+//! Reuses the resident building blocks from [`super::batcher`]: the inherent
 //! `Column::merge_from` / `Column::extract` methods (per-chunk merge / split).
+//! Input consolidation happens upstream: since differential-dataflow 0.24 the
+//! chunker ([`super::batcher::ColumnChunker`]) is supplied to the arrange
+//! operator separately, so this batcher receives already-consolidated
+//! [`Column`] chunks via [`PushInto`].
 //!
 //! [`differential_dataflow`]: differential_dataflow::trace::implementations::merge_batcher
 
@@ -30,17 +33,17 @@ use std::collections::VecDeque;
 use columnar::{Columnar, Index, Len};
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::logging::{BatcherEvent, Logger};
-use differential_dataflow::trace::{Batcher, Builder, Description};
+use differential_dataflow::trace::{Batcher, Description};
 use timely::Accountable;
 use timely::PartialOrder;
-use timely::container::{ContainerBuilder, PushInto, SizableContainer};
+use timely::container::{PushInto, SizableContainer};
 use timely::dataflow::channels::ContainerBytes;
 use timely::progress::Timestamp;
 use timely::progress::frontier::{Antichain, AntichainRef};
 
 use crate::column_pager::{self, ColumnPager, PagedColumn};
 use crate::columnar::Column;
-use crate::columnar::batcher::{ColumnChunker, empty_chunk, recycle_chunk};
+use crate::columnar::batcher::{empty_chunk, recycle_chunk};
 
 /// Max recycled empty chunks held in the per-batcher stash. Deliberately
 /// tight: the stash is a hot-buffer cache for the result/keep/ship churn,
@@ -94,7 +97,6 @@ where
     T: Columnar,
     R: Columnar,
 {
-    chunker: ColumnChunker<(D, T, R)>,
     chains: Vec<VecDeque<PagedColumn<(D, T, R)>>>,
     lower: Antichain<T>,
     frontier: Antichain<T>,
@@ -226,7 +228,6 @@ where
     R: Columnar + Default + Semigroup + for<'a> Semigroup<columnar::Ref<'a, R>>,
     for<'a> columnar::Ref<'a, R>: Ord,
 {
-    type Input = Column<(D, T, R)>;
     type Output = Column<(D, T, R)>;
     type Time = T;
 
@@ -235,7 +236,6 @@ where
         // `column_pager::global_pager` per call, so dyncfg-driven re-installs
         // take effect on the next chunk.
         Self {
-            chunker: ColumnChunker::default(),
             chains: Vec::new(),
             lower: Antichain::from_elem(T::minimum()),
             frontier: Antichain::new(),
@@ -246,26 +246,11 @@ where
         }
     }
 
-    fn push_container(&mut self, container: &mut Self::Input) {
-        let pager = self.pager();
-        self.chunker.push_into(container);
-        while let Some(chunk) = self.chunker.extract() {
-            let paged = pager.page(chunk);
-            self.insert_chain(VecDeque::from([paged]));
-        }
-    }
-
-    fn seal<B: Builder<Input = Self::Output, Time = Self::Time>>(
+    fn seal(
         &mut self,
         upper: Antichain<Self::Time>,
-    ) -> B::Output {
+    ) -> (Vec<Self::Output>, Description<Self::Time>) {
         let pager = self.pager();
-        // Finish chunker, fold any tail chunks in.
-        while let Some(chunk) = self.chunker.finish() {
-            let paged = pager.page(chunk);
-            self.insert_chain(VecDeque::from([paged]));
-        }
-
         // Merge all remaining chains into one.
         while self.chains.len() > 1 {
             let a = self.chain_pop().unwrap();
@@ -304,22 +289,38 @@ where
             upper.clone(),
             Antichain::from_elem(T::minimum()),
         );
-        let seal = B::seal(&mut readied, description);
         self.lower = upper;
 
         // Drop the recycle stash now that this round's hot work is done.
-        // The next merge after the next `push_container` will re-pay one
+        // The next merge after the next `push_into` will re-pay one
         // chunk's worth of leaf-`Vec` grow tax, but that's a few hundred µs
         // amortized over a seal cycle, well worth handing the leaf bytes
         // back to the allocator so they're not held resident across what
         // may be a quiet stretch.
         self.stash.clear();
 
-        seal
+        (readied, description)
     }
 
     fn frontier(&mut self) -> AntichainRef<'_, Self::Time> {
         self.frontier.borrow()
+    }
+}
+
+impl<D, T, R> PushInto<Column<(D, T, R)>> for ColumnMergeBatcher<D, T, R>
+where
+    D: Columnar,
+    for<'a> columnar::Ref<'a, D>: Copy + Ord,
+    T: Columnar + Default + Clone + PartialOrder,
+    for<'a> columnar::Ref<'a, T>: Copy + Ord,
+    R: Columnar + Default + Semigroup + for<'a> Semigroup<columnar::Ref<'a, R>>,
+{
+    /// Accept an already-consolidated chunk from the upstream chunker, route
+    /// it through the pager, and insert it as a singleton chain.
+    fn push_into(&mut self, mut chunk: Column<(D, T, R)>) {
+        let pager = self.pager();
+        let paged = pager.page(&mut chunk);
+        self.insert_chain(VecDeque::from([paged]));
     }
 }
 
@@ -932,50 +933,22 @@ mod tests {
 
     // ----- ColumnMergeBatcher end-to-end ------------------------------------
 
-    /// Trivial Builder used by `seal`: collects inputs into a Vec for the
-    /// test to inspect.
-    #[derive(Default)]
-    struct VecBuilder;
-    impl differential_dataflow::trace::Builder for VecBuilder {
-        type Input = Column<KvUpdate>;
-        type Time = u64;
-        type Output = Vec<KvUpdate>;
-        fn with_capacity(_keys: usize, _vals: usize, _upds: usize) -> Self {
-            Self
-        }
-        fn push(&mut self, _chunk: &mut Self::Input) {}
-        fn done(
-            self,
-            _description: differential_dataflow::trace::Description<u64>,
-        ) -> Self::Output {
-            Vec::new()
-        }
-        fn seal(
-            chain: &mut Vec<Self::Input>,
-            _description: differential_dataflow::trace::Description<u64>,
-        ) -> Self::Output {
-            let mut out = Vec::new();
-            for c in chain.drain(..) {
-                out.extend(collect_column(&c));
-            }
-            out
-        }
-    }
-
     #[mz_ore::test]
     fn batcher_seal_round_trip() {
         let mut b: ColumnMergeBatcher<(u64, u64), u64, i64> =
             differential_dataflow::trace::Batcher::new(None, 0);
         // Two pushes; second has an equal-key collision with the first.
-        let mut input1 = col(&[((1, 1), 0, 1), ((2, 0), 0, 1), ((3, 0), 0, 1)]);
-        let mut input2 = col(&[((2, 0), 0, 2), ((4, 0), 0, 1)]);
-        differential_dataflow::trace::Batcher::push_container(&mut b, &mut input1);
-        differential_dataflow::trace::Batcher::push_container(&mut b, &mut input2);
+        // Inputs arrive pre-consolidated chunk-by-chunk since the chunker
+        // moved out of the batcher in differential 0.24.
+        let input1 = col(&[((1, 1), 0, 1), ((2, 0), 0, 1), ((3, 0), 0, 1)]);
+        let input2 = col(&[((2, 0), 0, 2), ((4, 0), 0, 1)]);
+        b.push_into(input1);
+        b.push_into(input2);
 
         // Seal everything (upper = ∞-ish, here just past any time we used).
         let upper = Antichain::from_elem(u64::MAX);
-        let out: Vec<KvUpdate> =
-            differential_dataflow::trace::Batcher::seal::<VecBuilder>(&mut b, upper);
+        let (chain, _description) = differential_dataflow::trace::Batcher::seal(&mut b, upper);
+        let out: Vec<KvUpdate> = chain.iter().flat_map(collect_column).collect();
 
         // (2, 0)@0 was pushed with +1 then +2; sums to +3 after consolidation.
         let mut expected = vec![
@@ -1026,11 +999,11 @@ mod tests {
         // shipped. Use enough records to fill at least one chunk.
         let n: u64 = 200;
         for i in 0..n {
-            let mut input = col(&[((i, 0), i % 10, 1)]);
-            differential_dataflow::trace::Batcher::push_container(&mut b, &mut input);
+            let input = col(&[((i, 0), i % 10, 1)]);
+            b.push_into(input);
         }
         let upper = Antichain::from_elem(5u64);
-        let _ = differential_dataflow::trace::Batcher::seal::<VecBuilder>(&mut b, upper);
+        let _ = differential_dataflow::trace::Batcher::seal(&mut b, upper);
 
         // Anything kept (times >= 5) should be sitting in b.chains as paged.
         let kept_records: usize = b

--- a/src/timely-util/src/columnation.rs
+++ b/src/timely-util/src/columnation.rs
@@ -17,7 +17,7 @@
 //!
 //! This module provides [`ColumnationStack`], a columnar container that stores data using the
 //! columnation library, along with [`ColumnationChunker`] for organizing streams into sorted
-//! chunks, and the [`InternalMerge`] implementation needed by the merge batcher.
+//! chunks, and the [`ColInternalMerger`] [`Merger`] implementation needed by the merge batcher.
 
 use std::collections::VecDeque;
 use std::iter::FromIterator;
@@ -26,7 +26,7 @@ use columnation::{Columnation, Region};
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::trace::implementations::merge_batcher::container::InternalMerge;
+use differential_dataflow::trace::implementations::merge_batcher::Merger;
 use differential_dataflow::trace::implementations::{BatchContainer, BuilderInput};
 use timely::container::{ContainerBuilder, DrainContainer, PushInto, SizableContainer};
 use timely::progress::Timestamp;
@@ -546,121 +546,242 @@ where
 }
 
 // ---------------------------------------------------------------------------
-// InternalMerge impl for ColumnationStack
+// ColInternalMerger: a `Merger` for `ColumnationStack` chunks
 // ---------------------------------------------------------------------------
 
-impl<D, T, R> InternalMerge for ColumnationStack<(D, T, R)>
+/// A [`Merger`] using internal iteration over [`ColumnationStack`] chunks.
+///
+/// Implements differential-dataflow's chunk-list merge-batcher interface by
+/// merging and splitting chains of sorted, consolidated `ColumnationStack`
+/// chunks. Elements are copied through `copy` / `copy_destructured` rather than
+/// moved out of their backing regions, which is why this operates by internal
+/// iteration rather than draining owned tuples like the stock `VecMerger`.
+pub struct ColInternalMerger<D, T, R> {
+    _marker: std::marker::PhantomData<(D, T, R)>,
+}
+
+impl<D, T, R> Default for ColInternalMerger<D, T, R> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<D, T, R> ColInternalMerger<D, T, R>
 where
     D: Ord + Columnation + Clone + 'static,
     T: Ord + Columnation + Clone + PartialOrder + 'static,
     R: Default + Semigroup + Columnation + Clone + 'static,
 {
-    type TimeOwned = T;
-
-    fn len(&self) -> usize {
-        self[..].len()
+    /// Target chunk capacity in elements, mirroring [`ColumnationChunker`].
+    fn chunk_capacity() -> usize {
+        const BUFFER_SIZE_BYTES: usize = 64 << 10;
+        let size = std::mem::size_of::<(D, T, R)>();
+        if size == 0 {
+            BUFFER_SIZE_BYTES
+        } else if size <= BUFFER_SIZE_BYTES {
+            BUFFER_SIZE_BYTES / size
+        } else {
+            1
+        }
     }
 
-    fn clear(&mut self) {
-        ColumnationStack::clear(self)
-    }
-
-    fn account(&self) -> (usize, usize, usize, usize) {
-        let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-        let cb = |siz, cap| {
-            size += siz;
-            capacity += cap;
-            allocations += 1;
-        };
-        self.heap_size(cb);
-        (self.len(), size, capacity, allocations)
-    }
-
-    fn merge_from(&mut self, others: &mut [Self], positions: &mut [usize]) {
-        use std::cmp::Ordering;
-        match others.len() {
-            0 => {}
-            1 => {
-                let other = &mut others[0];
-                let pos = &mut positions[0];
-                if self[..].is_empty() && *pos == 0 {
-                    std::mem::swap(self, other);
-                    return;
-                }
-                for i in *pos..other[..].len() {
-                    self.copy(&other[i]);
-                }
-                *pos = other[..].len();
+    /// Acquire an empty chunk with the target capacity, recycling from `stash`.
+    fn empty(stash: &mut Vec<ColumnationStack<(D, T, R)>>) -> ColumnationStack<(D, T, R)> {
+        let target = Self::chunk_capacity();
+        match stash.pop() {
+            Some(mut chunk) if chunk.capacity() >= target => {
+                chunk.clear();
+                chunk
             }
-            2 => {
-                let (left, right) = others.split_at_mut(1);
-                let other1 = &left[0];
-                let other2 = &right[0];
+            _ => ColumnationStack::with_capacity(target),
+        }
+    }
 
-                let mut stash = R::default();
+    /// Recycle a consumed chunk into `stash`, retaining its allocations.
+    fn recycle(
+        mut chunk: ColumnationStack<(D, T, R)>,
+        stash: &mut Vec<ColumnationStack<(D, T, R)>>,
+    ) {
+        chunk.clear();
+        stash.push(chunk);
+    }
 
-                while positions[0] < other1[..].len()
-                    && positions[1] < other2[..].len()
-                    && !self.at_capacity()
-                {
-                    let (d1, t1, _) = &other1[positions[0]];
-                    let (d2, t2, _) = &other2[positions[1]];
-                    match (d1, t1).cmp(&(d2, t2)) {
-                        Ordering::Less => {
-                            self.copy(&other1[positions[0]]);
-                            positions[0] += 1;
+    /// Drain remaining items from one side into `result`/`output`.
+    ///
+    /// Copies the partially-consumed head into `result` (swapping wholesale
+    /// when `result` is empty and the head untouched), then appends remaining
+    /// full chunks directly to `output` without copying.
+    fn drain_side(
+        head: &mut ColumnationStack<(D, T, R)>,
+        pos: &mut usize,
+        list: &mut std::vec::IntoIter<ColumnationStack<(D, T, R)>>,
+        result: &mut ColumnationStack<(D, T, R)>,
+        output: &mut Vec<ColumnationStack<(D, T, R)>>,
+        stash: &mut Vec<ColumnationStack<(D, T, R)>>,
+    ) {
+        // Copy the partially-consumed head into result.
+        if *pos < head[..].len() {
+            if result.is_empty() && *pos == 0 {
+                std::mem::swap(result, head);
+            } else {
+                for i in *pos..head[..].len() {
+                    result.copy(&head[i]);
+                }
+            }
+            *pos = head[..].len();
+        }
+        // Flush result before appending full chunks.
+        if !result.is_empty() {
+            output.push(std::mem::replace(result, Self::empty(stash)));
+        }
+        // Remaining full chunks go directly to output.
+        output.extend(list);
+    }
+}
+
+impl<D, T, R> Merger for ColInternalMerger<D, T, R>
+where
+    D: Ord + Columnation + Clone + 'static,
+    T: Ord + Columnation + Clone + PartialOrder + 'static,
+    R: Default + Semigroup + Columnation + Clone + 'static,
+{
+    type Chunk = ColumnationStack<(D, T, R)>;
+    type Time = T;
+
+    fn merge(
+        &mut self,
+        list1: Vec<Self::Chunk>,
+        list2: Vec<Self::Chunk>,
+        output: &mut Vec<Self::Chunk>,
+        stash: &mut Vec<Self::Chunk>,
+    ) {
+        use std::cmp::Ordering;
+
+        let mut list1 = list1.into_iter();
+        let mut list2 = list2.into_iter();
+        let mut head1 = list1.next().unwrap_or_default();
+        let mut head2 = list2.next().unwrap_or_default();
+        let mut pos1 = 0;
+        let mut pos2 = 0;
+        let mut result = Self::empty(stash);
+        let mut diff = R::default();
+
+        // Main merge loop: both sides have data.
+        while pos1 < head1[..].len() && pos2 < head2[..].len() {
+            // Tight inner loop bounded by the current heads and result capacity.
+            while pos1 < head1[..].len() && pos2 < head2[..].len() && !result.at_capacity() {
+                let (d1, t1, r1) = &head1[pos1];
+                let (d2, t2, r2) = &head2[pos2];
+                match (d1, t1).cmp(&(d2, t2)) {
+                    Ordering::Less => {
+                        result.copy(&head1[pos1]);
+                        pos1 += 1;
+                    }
+                    Ordering::Greater => {
+                        result.copy(&head2[pos2]);
+                        pos2 += 1;
+                    }
+                    Ordering::Equal => {
+                        diff.clone_from(r1);
+                        diff.plus_equals(r2);
+                        if !diff.is_zero() {
+                            result.copy_destructured(d1, t1, &diff);
                         }
-                        Ordering::Greater => {
-                            self.copy(&other2[positions[1]]);
-                            positions[1] += 1;
-                        }
-                        Ordering::Equal => {
-                            let (_, _, r1) = &other1[positions[0]];
-                            let (_, _, r2) = &other2[positions[1]];
-                            stash.clone_from(r1);
-                            stash.plus_equals(r2);
-                            if !stash.is_zero() {
-                                let (d, t, _) = &other1[positions[0]];
-                                self.copy_destructured(d, t, &stash);
-                            }
-                            positions[0] += 1;
-                            positions[1] += 1;
-                        }
+                        pos1 += 1;
+                        pos2 += 1;
                     }
                 }
             }
-            n => unimplemented!("{n}-way merge not yet supported"),
+            if result.at_capacity() {
+                output.push(std::mem::replace(&mut result, Self::empty(stash)));
+            }
+            if pos1 >= head1[..].len() {
+                let old = std::mem::replace(&mut head1, list1.next().unwrap_or_default());
+                Self::recycle(old, stash);
+                pos1 = 0;
+            }
+            if pos2 >= head2[..].len() {
+                let old = std::mem::replace(&mut head2, list2.next().unwrap_or_default());
+                Self::recycle(old, stash);
+                pos2 = 0;
+            }
+        }
+
+        // After the loop at least one side is exhausted; draining it is a
+        // no-op, and the other contributes its sorted tail in order — the
+        // partial head by copy, remaining full chunks by passthrough.
+        Self::drain_side(
+            &mut head1,
+            &mut pos1,
+            &mut list1,
+            &mut result,
+            output,
+            stash,
+        );
+        Self::drain_side(
+            &mut head2,
+            &mut pos2,
+            &mut list2,
+            &mut result,
+            output,
+            stash,
+        );
+
+        if !result.is_empty() {
+            output.push(result);
         }
     }
 
     fn extract(
         &mut self,
-        position: &mut usize,
+        merged: Vec<Self::Chunk>,
         upper: AntichainRef<T>,
         frontier: &mut Antichain<T>,
-        keep: &mut Self,
-        ship: &mut Self,
+        readied: &mut Vec<Self::Chunk>,
+        kept: &mut Vec<Self::Chunk>,
+        stash: &mut Vec<Self::Chunk>,
     ) {
-        let len = self[..].len();
-        while *position < len && !keep.at_capacity() && !ship.at_capacity() {
-            let (data, time, diff) = &self[*position];
-            if upper.less_equal(time) {
-                frontier.insert_with(time, |time| time.clone());
-                keep.copy_destructured(data, time, diff);
-            } else {
-                ship.copy_destructured(data, time, diff);
+        let mut keep = Self::empty(stash);
+        let mut ready = Self::empty(stash);
+
+        for chunk in merged {
+            let len = chunk[..].len();
+            for i in 0..len {
+                let (data, time, diff) = &chunk[i];
+                if upper.less_equal(time) {
+                    frontier.insert_with(time, |time| time.clone());
+                    keep.copy_destructured(data, time, diff);
+                } else {
+                    ready.copy_destructured(data, time, diff);
+                }
+                if keep.at_capacity() {
+                    kept.push(std::mem::replace(&mut keep, Self::empty(stash)));
+                }
+                if ready.at_capacity() {
+                    readied.push(std::mem::replace(&mut ready, Self::empty(stash)));
+                }
             }
-            *position += 1;
+            // Chunk fully consumed; recycle its allocations.
+            Self::recycle(chunk, stash);
+        }
+
+        if !keep.is_empty() {
+            kept.push(keep);
+        }
+        if !ready.is_empty() {
+            readied.push(ready);
         }
     }
+
+    fn account(chunk: &Self::Chunk) -> (usize, usize, usize, usize) {
+        let (mut size, mut capacity, mut allocations) = (0, 0, 0);
+        chunk.heap_size(|siz, cap| {
+            size += siz;
+            capacity += cap;
+            allocations += 1;
+        });
+        (chunk[..].len(), size, capacity, allocations)
+    }
 }
-
-// ---------------------------------------------------------------------------
-// ColInternalMerger type alias
-// ---------------------------------------------------------------------------
-
-/// A `Merger` using internal iteration for `ColumnationStack` containers.
-pub type ColInternalMerger<D, T, R> =
-    differential_dataflow::trace::implementations::merge_batcher::InternalMerger<
-        ColumnationStack<(D, T, R)>,
-    >;

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -16,13 +16,12 @@
 //! Common operator transformations on timely streams and differential collections.
 
 use std::hash::{BuildHasher, Hash, Hasher};
-use std::marker::PhantomData;
 
 use columnation::Columnation;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::difference::{Multiply, Semigroup};
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::trace::{Batcher, Builder, Description};
+use differential_dataflow::trace::Batcher;
 use differential_dataflow::{AsCollection, Collection, Hashable, VecCollection};
 use timely::container::{DrainContainer, PushInto};
 use timely::dataflow::channels::pact::{Exchange, ParallelizationContract, Pipeline};
@@ -39,7 +38,7 @@ use timely::progress::operate::FrontierInterest;
 use timely::progress::{Antichain, Timestamp};
 use timely::{Container, ContainerBuilder, PartialOrder};
 
-use crate::columnation::ColumnationStack;
+use crate::columnation::{ColumnationChunker, ColumnationStack};
 
 /// Extension methods for timely [`Stream`]s.
 pub trait StreamExt<'scope, T, C1>
@@ -199,11 +198,7 @@ where
         D1: differential_dataflow::ExchangeData + Hash + Columnation,
         R: Semigroup + differential_dataflow::ExchangeData + Columnation,
         T: Lattice + Columnation,
-        Ba: Batcher<
-                Input = Vec<((D1, ()), T, R)>,
-                Output = ColumnationStack<((D1, ()), T, R)>,
-                Time = T,
-            > + 'static;
+        Ba: Batcher<Time = T, Output = ColumnationStack<((D1, ()), T, R)>> + 'static;
 
     /// Consolidates the collection.
     fn consolidate_named<Ba>(self, name: &str) -> Self
@@ -211,11 +206,7 @@ where
         D1: differential_dataflow::ExchangeData + Hash + Columnation,
         R: Semigroup + differential_dataflow::ExchangeData + Columnation,
         T: Lattice + Columnation,
-        Ba: Batcher<
-                Input = Vec<((D1, ()), T, R)>,
-                Output = ColumnationStack<((D1, ()), T, R)>,
-                Time = T,
-            > + 'static;
+        Ba: Batcher<Time = T, Output = ColumnationStack<((D1, ()), T, R)>> + 'static;
 }
 
 impl<'scope, T, C1> StreamExt<'scope, T, C1> for Stream<'scope, T, C1>
@@ -460,11 +451,7 @@ where
         D1: differential_dataflow::ExchangeData + Hash + Columnation,
         R: Semigroup + differential_dataflow::ExchangeData + Columnation,
         T: Lattice + Ord + Columnation,
-        Ba: Batcher<
-                Input = Vec<((D1, ()), T, R)>,
-                Output = ColumnationStack<((D1, ()), T, R)>,
-                Time = T,
-            > + 'static,
+        Ba: Batcher<Time = T, Output = ColumnationStack<((D1, ()), T, R)>> + 'static,
     {
         if must_consolidate {
             // We employ AHash below instead of the default hasher in DD to obtain
@@ -496,40 +483,12 @@ where
                 data.hash(&mut h);
                 h.finish()
             });
-            consolidate_pact::<Ba, _>(self.map(|k| (k, ())).inner, exchange, name)
-                .unary(Pipeline, "unpack consolidated", |_, _| {
-                    |input, output| {
-                        input.for_each(|time, data| {
-                            let mut session = output.session(&time);
-                            for ((k, ()), t, d) in
-                                data.iter().flatten().flat_map(|chunk| chunk.iter())
-                            {
-                                session.give((k.clone(), t.clone(), d.clone()))
-                            }
-                        })
-                    }
-                })
-                .as_collection()
-        } else {
-            self
-        }
-    }
-
-    fn consolidate_named<Ba>(self, name: &str) -> Self
-    where
-        D1: differential_dataflow::ExchangeData + Hash + Columnation,
-        R: Semigroup + differential_dataflow::ExchangeData + Columnation,
-        T: Lattice + Ord + Columnation,
-        Ba: Batcher<
-                Input = Vec<((D1, ()), T, R)>,
-                Output = ColumnationStack<((D1, ()), T, R)>,
-                Time = T,
-            > + 'static,
-    {
-        let exchange = Exchange::new(move |update: &((D1, ()), T, R)| (update.0).0.hashed());
-
-        consolidate_pact::<Ba, _>(self.map(|k| (k, ())).inner, exchange, name)
-            .unary(Pipeline, &format!("Unpack {name}"), |_, _| {
+            consolidate_pact::<ColumnationChunker<((D1, ()), T, R)>, Ba, _, _>(
+                self.map(|k| (k, ())).inner,
+                exchange,
+                name,
+            )
+            .unary(Pipeline, "unpack consolidated", |_, _| {
                 |input, output| {
                     input.for_each(|time, data| {
                         let mut session = output.session(&time);
@@ -541,6 +500,36 @@ where
                 }
             })
             .as_collection()
+        } else {
+            self
+        }
+    }
+
+    fn consolidate_named<Ba>(self, name: &str) -> Self
+    where
+        D1: differential_dataflow::ExchangeData + Hash + Columnation,
+        R: Semigroup + differential_dataflow::ExchangeData + Columnation,
+        T: Lattice + Ord + Columnation,
+        Ba: Batcher<Time = T, Output = ColumnationStack<((D1, ()), T, R)>> + 'static,
+    {
+        let exchange = Exchange::new(move |update: &((D1, ()), T, R)| (update.0).0.hashed());
+
+        consolidate_pact::<ColumnationChunker<((D1, ()), T, R)>, Ba, _, _>(
+            self.map(|k| (k, ())).inner,
+            exchange,
+            name,
+        )
+        .unary(Pipeline, &format!("Unpack {name}"), |_, _| {
+            |input, output| {
+                input.for_each(|time, data| {
+                    let mut session = output.session(&time);
+                    for ((k, ()), t, d) in data.iter().flatten().flat_map(|chunk| chunk.iter()) {
+                        session.give((k.clone(), t.clone(), d.clone()))
+                    }
+                })
+            }
+        })
+        .as_collection()
     }
 }
 
@@ -550,16 +539,17 @@ where
 /// data is sorted according to `Ba`. For each timestamp, it produces at most one chain.
 ///
 /// The data are accumulated in place, each held back until their timestamp has completed.
-pub fn consolidate_pact<'scope, Ba, P>(
-    stream: Stream<'scope, Ba::Time, Ba::Input>,
+pub fn consolidate_pact<'scope, Chu, Ba, C, P>(
+    stream: Stream<'scope, Ba::Time, C>,
     pact: P,
     name: &str,
 ) -> StreamVec<'scope, Ba::Time, Vec<Ba::Output>>
 where
     Ba: Batcher + 'static,
-    Ba::Input: Container + Clone + 'static,
+    Chu: ContainerBuilder<Container = Ba::Output> + for<'a> PushInto<&'a mut C> + 'static,
+    C: Container + Clone + 'static,
     Ba::Output: Clone,
-    P: ParallelizationContract<Ba::Time, Ba::Input>,
+    P: ParallelizationContract<Ba::Time, C>,
 {
     let logger = stream
         .scope()
@@ -570,6 +560,10 @@ where
         // Acquire a logger for arrange events.
 
         let mut batcher = Ba::new(logger, info.global_id);
+        // The chunker consolidates raw input containers into the batcher's
+        // output chunks. Since differential-dataflow 0.24 this lives in the
+        // operator rather than inside the batcher.
+        let mut chunker = Chu::default();
         // Capabilities for the lower envelope of updates in `batcher`.
         let mut capabilities = Antichain::<Capability<Ba::Time>>::new();
         let mut prev_frontier = Antichain::from_elem(Ba::Time::minimum());
@@ -577,10 +571,19 @@ where
         move |(input, frontier), output| {
             input.for_each(|cap, data| {
                 capabilities.insert(cap.retain(0));
-                batcher.push_container(data);
+                chunker.push_into(data);
+                while let Some(chunk) = chunker.extract() {
+                    batcher.push_into(std::mem::take(chunk));
+                }
             });
 
             if prev_frontier.borrow() != frontier.frontier() {
+                // Flush any data the chunker is still accumulating into the
+                // batcher before we seal.
+                while let Some(chunk) = chunker.finish() {
+                    batcher.push_into(std::mem::take(chunk));
+                }
+
                 if capabilities
                     .elements()
                     .iter()
@@ -605,9 +608,8 @@ where
                             // send the batch to downstream consumers, empty or not.
                             let mut session = output.session(&capabilities.elements()[index]);
                             // Extract updates not in advance of `upper`.
-                            let output =
-                                batcher.seal::<ConsolidateBuilder<_, Ba::Output>>(upper.clone());
-                            session.give(output);
+                            let (chain, _description) = batcher.seal(upper.clone());
+                            session.give(chain);
                         }
                     }
 
@@ -637,43 +639,6 @@ where
             }
         }
     })
-}
-
-/// A builder that wraps a session for direct output to a stream.
-struct ConsolidateBuilder<T, I> {
-    _marker: PhantomData<(T, I)>,
-}
-
-impl<T, I> Builder for ConsolidateBuilder<T, I>
-where
-    T: Timestamp,
-    I: Clone,
-{
-    type Input = I;
-    type Time = T;
-    type Output = Vec<I>;
-
-    fn new() -> Self {
-        Self {
-            _marker: PhantomData,
-        }
-    }
-
-    fn with_capacity(_keys: usize, _vals: usize, _upds: usize) -> Self {
-        Self::new()
-    }
-
-    fn push(&mut self, _chunk: &mut Self::Input) {
-        unimplemented!("ConsolidateBuilder::push")
-    }
-
-    fn done(self, _: Description<Self::Time>) -> Self::Output {
-        unimplemented!("ConsolidateBuilder::done")
-    }
-
-    fn seal(chain: &mut Vec<Self::Input>, _description: Description<Self::Time>) -> Self::Output {
-        std::mem::take(chain)
-    }
 }
 
 /// Merge the contents of multiple streams and combine the containers using a container builder.

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -560,9 +560,8 @@ where
         // Acquire a logger for arrange events.
 
         let mut batcher = Ba::new(logger, info.global_id);
-        // The chunker consolidates raw input containers into the batcher's
-        // output chunks. Since differential-dataflow 0.24 this lives in the
-        // operator rather than inside the batcher.
+        // The chunker consolidates raw input containers into the chunks the
+        // batcher consumes.
         let mut chunker = Chu::default();
         // Capabilities for the lower envelope of updates in `batcher`.
         let mut capabilities = Antichain::<Capability<Ba::Time>>::new();


### PR DESCRIPTION
## Motivation

Bump the dataflow dependency family to their latest releases:

| crate | old | new |
| --- | --- | --- |
| `columnar` | 0.12.1 | 0.13.0 |
| `timely` | 0.29.0 | 0.30.0 |
| `differential-dataflow` | 0.23.0 | 0.24.0 |
| `differential-dogs3` | 0.23.0 | 0.24.0 |

These releases carry breaking changes that ripple through the batcher/arrange machinery and the timely communication layer.

## What changed

**columnar 0.13** — `AsBytes` now requires `SLICE_COUNT` and `get_byte_slice`, and the `chain` helper was removed. Updated the manual `AsBytes` impls for `Overflows`, `Timestamps`, and `Rows` (the `Rows` impl now relies on the default `as_bytes` built from `get_byte_slice`).

**differential 0.24** — removes the `Batcher::Input` / `push_container` API and the `merge_batcher::container` compatibility layer (`InternalMerge`, `InternalMerger`). The batcher now consumes already-chunked input via `PushInto<Output>`, `seal` returns `(chain, description)`, and chunking moves into the operator via a separate `ContainerBuilder`/chunker. `MergeBatcher` collapses to a single `Merger` type parameter.

- Reimplemented `ColInternalMerger` as a chunk-list `Merger` over `ColumnationStack` chunks (the old `InternalMerge`-based impl is gone). The `merge` drain phase keeps differential 0.23's zero-copy behavior: a partially-consumed head is copied (or swapped when untouched) and the remaining full chunks of the longer chain pass through to the output without copying; consumed chunks recycle into the stash. An earlier draft copied drained tails element-by-element, which regressed the MinMax feature benchmark by ~20% wallclock and +18% clusterd memory.
- Migrated the pageable `ColumnMergeBatcher` to the new `Batcher` trait.
- `mz_arrange` / `mz_arrange_core` / `consolidate_pact` / `consolidate_named*` / `consolidate_and_pack` gain an explicit `Chu` chunker type parameter, mirroring upstream's `arrange_core`. Call sites name the chunker: `ColumnationChunker<_>` for `Vec` input, `batcher::Chunker<_>` for `Column` input, and `batcher::ColumnChunker<_>` for the paged `Column` path.
- Updated `MergeBatcherWrapper` (temporal bucketing), the upsert-v2 source stash, and an interchange test to drive the chunker explicitly.
- `TraceBox.trace` is now read via `trace()`; `ShutdownButton::press_on_drop` was removed, replaced by a small local press-on-drop guard.

**timely 0.30** — adds a spill-policy parameter to the process allocators and bundles refill/spill/log hooks into `Hooks` for `initialize_networking_from_sockets`. `BytesRefill` now yields `Send` buffers, so `LgallocHandle` gains an `unsafe impl Send` (it exclusively owns its allocation).

https://claude.ai/code/session_01CrNqefrHBNbfJetgjRHsmH

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrNqefrHBNbfJetgjRHsmH)_