### PR TITLE
ci-builder: Bump cargo-* versions

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -238,13 +238,13 @@ RUN mkdir rust \
     && gpg --verify rust.asc rust.tar.gz \
     && tar -xzf rust.tar.gz -C /usr/local/lib/rustlib/ --strip-components=4 \
     && rm -rf rust.asc rust.tar.gz rust \
-    && cargo install --root /usr/local --version "=0.8.2" --locked cargo-about \
-    && cargo install --root /usr/local --version "=3.6.2" --locked cargo-deb \
-    && cargo install --root /usr/local --version "=0.18.9" --locked cargo-deny \
+    && cargo install --root /usr/local --version "=0.9.0" --locked --features=cli cargo-about \
+    && cargo install --root /usr/local --version "=3.7.0" --locked cargo-deb \
+    && cargo install --root /usr/local --version "=0.19.8" --locked cargo-deny \
     && cargo install --root /usr/local --version "=0.1.0" --locked cargo-deplint \
-    && cargo install --root /usr/local --version "=0.9.114" --locked cargo-nextest \
-    && cargo install --root /usr/local --version "=0.6.21" --locked cargo-llvm-cov \
-    && cargo install --root /usr/local --version "=0.1.60" --locked --features=vendored-openssl cargo-udeps \
+    && cargo install --root /usr/local --version "=0.9.137" --locked cargo-nextest \
+    && cargo install --root /usr/local --version "=0.8.7" --locked cargo-llvm-cov \
+    && cargo install --root /usr/local --version "=0.1.61" --locked --features=vendored-openssl cargo-udeps \
     && cargo install --root /usr/local --version "=0.4.0" --locked cargo-binutils \
     && cargo install --root /usr/local --version "=0.13.1" --locked wasm-pack \
     && rm -rf /cargo/registry /cargo/git

--- a/deny.toml
+++ b/deny.toml
@@ -96,10 +96,6 @@ skip = [
     # Used by tempfile
     { name = "linux-raw-sys", version = "0.4.15" },
     { name = "rustix", version = "0.38.44" },
-    # Used by axum
-    { name = "tower", version = "0.4.13" },
-    # Used by tower-lsp
-    { name = "dashmap", version = "5.5.3" },
     # Used by bindgen
     { name = "itertools", version = "0.13.0" },
     # Used by pprof
@@ -108,6 +104,8 @@ skip = [
     { name = "socket2", version = "0.5.10" },
     # Used by azure_core
     { name = "quick-xml", version = "0.31.0" },
+    # Used by reqsign (via iceberg); opendal pulls quick-xml 0.38
+    { name = "quick-xml", version = "0.37.5" },
     # Conflicts between `bon` in apache-avro and `derive_builder` in iceberg
     { name = "darling_macro", version = "0.20.11" },
     { name = "darling_core", version = "0.20.11" },
@@ -122,8 +120,6 @@ skip = [
     { name = "phf_shared", version = "0.11.3" },
     { name = "phf_generator", version = "0.11.2" },
     { name = "phf_codegen", version = "0.11.3" },
-    # insta
-    { name = "console", version = "0.15.11" },
     # duckdb
     { name = "fallible-iterator", version = "0.3.0" },
     # arrow


### PR DESCRIPTION
Inspired by https://materializeinc.slack.com/archives/C01LKF361MZ/p1780090028190879 to fix cargo-deny issues in most recent version, discovered by @peterdukelarsen 