### PR TITLE
Use #[mz_ore::test] in the pager integration tests

### DIFF
--- a/src/ore-proc/src/test.rs
+++ b/src/ore-proc/src/test.rs
@@ -45,7 +45,14 @@ pub fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 fn expand_logging_init() -> TokenStream2 {
     let crate_name = std::env::var("CARGO_PKG_NAME").unwrap();
-    if crate_name == "mz-ore" {
+    // Only the `mz-ore` *library* target can (and must) reach the logging
+    // helpers via `crate::`. Integration tests live in their own binary crates
+    // within the same package, so `crate` there is the test binary, not the
+    // library; they must go through `::mz_ore` like every other crate.
+    // `CARGO_CRATE_NAME` is `mz_ore` for the library (and its unit tests) but
+    // the test/bench name for separate binaries, so it distinguishes the two.
+    let crate_target = std::env::var("CARGO_CRATE_NAME").unwrap_or_default();
+    if crate_name == "mz-ore" && crate_target == "mz_ore" {
         quote! {
           {
             use crate::test;

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -89,7 +89,7 @@ yansi = { workspace = true, optional = true }
 [dev-dependencies]
 anyhow.workspace = true
 criterion.workspace = true
-mz-ore = { path = "../ore", features = ["id_gen", "chrono"] }
+mz-ore = { path = "../ore", features = ["id_gen", "chrono", "test"] }
 proptest.workspace = true
 scopeguard.workspace = true
 serde_json.workspace = true

--- a/src/ore/tests/pager_integration.rs
+++ b/src/ore/tests/pager_integration.rs
@@ -27,7 +27,7 @@ fn ensure_scratch() {
     set_scratch_dir(dir.path().to_owned());
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `madvise` on OS `linux`
 fn round_trip_swap() {
     set_backend(Backend::Swap);
@@ -39,7 +39,7 @@ fn round_trip_swap() {
     assert_eq!(dst, payload);
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
 fn round_trip_file() {
     ensure_scratch();
@@ -53,7 +53,7 @@ fn round_trip_file() {
     set_backend(Backend::Swap);
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
 fn handle_survives_backend_flip() {
     ensure_scratch();
@@ -74,7 +74,7 @@ fn handle_survives_backend_flip() {
     assert_eq!(dst2, payload);
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 fn empty_input_yields_zero_len_handle() {
     set_backend(Backend::Swap);
     let mut chunks: [Vec<u64>; 0] = [];
@@ -83,7 +83,7 @@ fn empty_input_yields_zero_len_handle() {
     assert!(h.is_empty());
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 fn try_api_swap_round_trip() {
     set_backend(Backend::Swap);
     let payload: Vec<u64> = (0..128).collect();
@@ -99,7 +99,7 @@ fn try_api_swap_round_trip() {
     assert_eq!(dst2, payload);
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
 fn try_api_file_round_trip() {
     ensure_scratch();
@@ -113,7 +113,7 @@ fn try_api_file_round_trip() {
     set_backend(Backend::Swap);
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 fn empty_input_file_backend_round_trip() {
     ensure_scratch();
     set_backend(Backend::File);
@@ -127,7 +127,7 @@ fn empty_input_file_backend_round_trip() {
     set_backend(Backend::Swap);
 }
 
-#[test] // allow(test-attribute)
+#[mz_ore::test]
 fn scatter_round_trip() {
     set_backend(Backend::Swap);
     let mut chunks = [vec![1u64, 2, 3], vec![4, 5], vec![6, 7, 8, 9]];


### PR DESCRIPTION
### Motivation

The pager integration tests in `src/ore/tests/pager_integration.rs` used plain
`#[test] // allow(test-attribute)` instead of the crate's `#[mz_ore::test]`
macro (which initializes logging). They had to, because the macro was unusable
in `mz-ore`'s own integration tests:

`expand_logging_init` keyed off `CARGO_PKG_NAME`, which is `mz-ore` for *every*
compilation unit in the package — the library, its unit tests, and each
integration-test binary. For `mz-ore` it emitted `use crate::test;`, which only
resolves for the library and its unit tests. In an integration-test binary
`crate` is the test binary, not the library, so the macro failed to compile
(`no `test` in the root`). The `allow(test-attribute)` suppression was the
workaround.

(The miri ignores that were originally part of this branch landed separately in
#36808; this PR is now scoped to the test-macro change only.)

### Description

- **Macro fix** (`src/ore-proc/src/test.rs`): distinguish the library target
  from sibling binaries via `CARGO_CRATE_NAME` (`mz_ore` for the library and its
  unit tests, the test/bench name otherwise). The library keeps `crate::test`;
  integration tests now route through `::mz_ore::test`.
- **Dev-dependency feature** (`src/ore/Cargo.toml`): the `test` module is gated
  behind `#[cfg(any(test, feature = "test"))]`, so enable the `test` feature on
  the `mz-ore` self dev-dependency so `::mz_ore::test` resolves in test builds.
- **Tests** (`src/ore/tests/pager_integration.rs`): switch all 8 tests from
  `#[test] // allow(test-attribute)` to `#[mz_ore::test]`, dropping the lint
  suppression.

### Tips for reviewer

The macro change only affects `mz-ore`'s own integration tests/benches — which
previously couldn't use `#[mz_ore::test]` at all. The library and its unit tests
keep the existing `crate::test` path, so there's no behavior change there.

https://claude.ai/code/session_016VYGjYuvp3k8BBrhQRw6sM