### PR TITLE
sqlsmith: allowlist date/timestamp out-of-range parse errors

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -101,6 +101,8 @@ known_errors = [
     "coalesce types text and text list cannot be matched",  # Bad typing for ||
     "coalesce types text list and text cannot be matched",  # Bad typing for ||
     "is out of range for type numeric: exceeds maximum precision",
+    "is out of range for type date",
+    "is out of range for type timestamp",
     "CAST does not support casting from ",  # TODO: Improve type system
     "SET clause does not support casting from ",  # TODO: Improve type system
     "coalesce types integer and interval cannot be matched",  # TODO: Implicit cast from timestamp to date in (date - timestamp)


### PR DESCRIPTION
### Motivation

SQLsmith flagged a query that casts an out-of-range value to `date`:

```
ERROR: "14714-12-31 18:01:00+00 BC" is out of range for type date
```

Rejecting an out-of-range or malformed value is correct behavior — this is
just SQLsmith generating nonsense input — so the message should be on the
known-errors allowlist rather than treated as a bug.

### Description

Add two entries to the SQLsmith `known_errors` allowlist:

- `is out of range for type date`
- `is out of range for type timestamp` (also covers `timestamptz`)

This matches how the other out-of-range parse errors (e.g. numeric) are
already handled.

Per @def-'s review, this drops the earlier approach of changing the
SQLSTATE codes in `src/adapter/src/error.rs`; we just allowlist these
messages instead.

https://claude.ai/code/session_013pDom9j3DoUvAVztRk4pAe