### PR TITLE
sqlsmith: restore out-of-range allowlist entries dropped in #36814

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -100,6 +100,9 @@ known_errors = [
     "not supported for type time",
     "coalesce types text and text list cannot be matched",  # Bad typing for ||
     "coalesce types text list and text cannot be matched",  # Bad typing for ||
+    "is out of range for type numeric: exceeds maximum precision",
+    "is out of range for type date",
+    "is out of range for type timestamp",
     "CAST does not support casting from ",  # TODO: Improve type system
     "SET clause does not support casting from ",  # TODO: Improve type system
     "coalesce types integer and interval cannot be matched",  # TODO: Implicit cast from timestamp to date in (date - timestamp)


### PR DESCRIPTION
### Motivation

#36814 dropped three `known_errors` entries (`is out of range for type
numeric/date/timestamp`) on the assumption that giving parse/cast errors proper
class-22 SQLSTATEs would stop SQLsmith reporting them. **A SQLsmith run
disproves that assumption:**

- The allowlist is matched **by message, independent of SQLSTATE**.
- SQLsmith reports class-22 data exceptions too (the run surfaced
  `22003` / `22008` / `22015` / `22007` errors as unknown, not just `XX000`).
- The **dataflow-execution** path still returns `XX000` (`ERROR: Evaluation
  error: …`) for the *same* messages — only the constant-folding path gets the
  new code.

So those messages still need to be allowlisted, and #36814's removals put the
SQLsmith job at risk on `main`.

### Description

Restores the three entries #36814 removed (the other 13 in that family were
never actually merged — that removal only ever lived on this branch — so they
remain present in `main`). Net effect vs `main`: `+3` entries, bringing the
allowlist back to a complete state.

The SQLSTATE improvements from #36814 are still valuable for clients on their
own merits (`1/0` → `22012`, etc.); they simply don't obviate the SQLsmith
allowlist.

### Follow-up

Aligning the dataflow-execution error path with const eval — so it carries
structured SQLSTATEs instead of a stringified `XX000` "Evaluation error: …" —
is tracked separately in Linear.

Part of SQL-326.

https://claude.ai/code/session_013pDom9j3DoUvAVztRk4pAe