### PR TITLE
expr: infer non-nullable columns from regex capture groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7571,6 +7571,7 @@ dependencies = [
  "prost-build",
  "rand 0.9.4",
  "regex",
+ "regex-syntax",
  "ryu",
  "serde",
  "serde_json",

--- a/misc/python/materialize/checks/all_checks/regex.py
+++ b/misc/python/materialize/checks/all_checks/regex.py
@@ -22,12 +22,10 @@ class RegexpExtractNonNullable(Check):
     """
 
     def initialize(self) -> Testdrive:
-        return Testdrive(
-            dedent("""
+        return Testdrive(dedent("""
             > CREATE TABLE regexp_extract_nn_table (f1 STRING);
             > INSERT INTO regexp_extract_nn_table VALUES ('ab');
-            """)
-        )
+            """))
 
     def manipulate(self) -> list[Testdrive]:
         return [
@@ -49,8 +47,7 @@ class RegexpExtractNonNullable(Check):
         ]
 
     def validate(self) -> Testdrive:
-        return Testdrive(
-            dedent("""
+        return Testdrive(dedent("""
             > SELECT a, b FROM regexp_extract_nn_view1 ORDER BY a;
             a b
             k l
@@ -72,20 +69,17 @@ class RegexpExtractNonNullable(Check):
               WHERE v.name = 'regexp_extract_nn_view2' ORDER BY c.position;
             a false
             b false
-            """)
-        )
+            """))
 
 
 class RegexpExtract(Check):
     """The regex from regexp_extract has its own ProtoAnalyzedRegex"""
 
     def initialize(self) -> Testdrive:
-        return Testdrive(
-            dedent("""
+        return Testdrive(dedent("""
             > CREATE TABLE regexp_extract_table (f1 STRING);
             > INSERT INTO regexp_extract_table VALUES ('abc');
-            """)
-        )
+            """))
 
     def manipulate(self) -> list[Testdrive]:
         return [
@@ -103,26 +97,22 @@ class RegexpExtract(Check):
         ]
 
     def validate(self) -> Testdrive:
-        return Testdrive(
-            dedent("""
+        return Testdrive(dedent("""
             > SELECT c1::string FROM regexp_extract_view1;
             (,,,xyz,x,yz)
             (abc,a,bc,,,)
             > SELECT c1::string FROM regexp_extract_view2;
             (,,,xyz,x,yz)
             (abc,a,bc,,,)
-            """)
-        )
+            """))
 
 
 class Regex(Check):
     def initialize(self) -> Testdrive:
-        return Testdrive(
-            dedent("""
+        return Testdrive(dedent("""
             > CREATE TABLE regex_table (f1 STRING, f2 STRING);
             > INSERT INTO regex_table VALUES ('abc', 'abc');
-            """)
-        )
+            """))
 
     def manipulate(self) -> list[Testdrive]:
         return [
@@ -140,8 +130,7 @@ class Regex(Check):
         ]
 
     def validate(self) -> Testdrive:
-        return Testdrive(
-            dedent("""
+        return Testdrive(dedent("""
             > SELECT * FROM regex_view1;
             true true false false
             true true true true
@@ -151,5 +140,4 @@ class Regex(Check):
             true true false false
             true true true true
             true true true true
-            """)
-        )
+            """))

--- a/misc/python/materialize/checks/all_checks/regex.py
+++ b/misc/python/materialize/checks/all_checks/regex.py
@@ -12,14 +12,80 @@ from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 
 
+class RegexpExtractNonNullable(Check):
+    """Capture groups that always participate in a match yield non-nullable
+    columns (database-issues#612). This exercises that such a narrowed,
+    persisted desc survives restart/upgrade: an MV created on the previous
+    release registers all-nullable columns, while the current build re-derives
+    the desc with non-nullable columns. (The persist schema is
+    nullability-invariant, see database-issues#2488, so this must not conflict.)
+    """
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent("""
+            > CREATE TABLE regexp_extract_nn_table (f1 STRING);
+            > INSERT INTO regexp_extract_nn_table VALUES ('ab');
+            """)
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE MATERIALIZED VIEW regexp_extract_nn_view1 AS
+                  SELECT g.a, g.b FROM regexp_extract_nn_table,
+                    regexp_extract('(?P<a>[a-z])(?P<b>[a-z])', f1) AS g;
+                > INSERT INTO regexp_extract_nn_table VALUES ('kl');
+            """,
+                """
+                > CREATE MATERIALIZED VIEW regexp_extract_nn_view2 AS
+                  SELECT g.a, g.b FROM regexp_extract_nn_table,
+                    regexp_extract('(?P<a>[a-z])(?P<b>[a-z])', f1) AS g;
+                > INSERT INTO regexp_extract_nn_table VALUES ('yz');
+            """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent("""
+            > SELECT a, b FROM regexp_extract_nn_view1 ORDER BY a;
+            a b
+            k l
+            y z
+
+            > SELECT a, b FROM regexp_extract_nn_view2 ORDER BY a;
+            a b
+            k l
+            y z
+
+            > SELECT c.name, c.nullable FROM mz_columns c
+              JOIN mz_materialized_views v ON c.id = v.id
+              WHERE v.name = 'regexp_extract_nn_view1' ORDER BY c.position;
+            a false
+            b false
+
+            > SELECT c.name, c.nullable FROM mz_columns c
+              JOIN mz_materialized_views v ON c.id = v.id
+              WHERE v.name = 'regexp_extract_nn_view2' ORDER BY c.position;
+            a false
+            b false
+            """)
+        )
+
+
 class RegexpExtract(Check):
     """The regex from regexp_extract has its own ProtoAnalyzedRegex"""
 
     def initialize(self) -> Testdrive:
-        return Testdrive(dedent("""
+        return Testdrive(
+            dedent("""
             > CREATE TABLE regexp_extract_table (f1 STRING);
             > INSERT INTO regexp_extract_table VALUES ('abc');
-            """))
+            """)
+        )
 
     def manipulate(self) -> list[Testdrive]:
         return [
@@ -37,22 +103,26 @@ class RegexpExtract(Check):
         ]
 
     def validate(self) -> Testdrive:
-        return Testdrive(dedent("""
+        return Testdrive(
+            dedent("""
             > SELECT c1::string FROM regexp_extract_view1;
             (,,,xyz,x,yz)
             (abc,a,bc,,,)
             > SELECT c1::string FROM regexp_extract_view2;
             (,,,xyz,x,yz)
             (abc,a,bc,,,)
-            """))
+            """)
+        )
 
 
 class Regex(Check):
     def initialize(self) -> Testdrive:
-        return Testdrive(dedent("""
+        return Testdrive(
+            dedent("""
             > CREATE TABLE regex_table (f1 STRING, f2 STRING);
             > INSERT INTO regex_table VALUES ('abc', 'abc');
-            """))
+            """)
+        )
 
     def manipulate(self) -> list[Testdrive]:
         return [
@@ -70,7 +140,8 @@ class Regex(Check):
         ]
 
     def validate(self) -> Testdrive:
-        return Testdrive(dedent("""
+        return Testdrive(
+            dedent("""
             > SELECT * FROM regex_view1;
             true true false false
             true true true true
@@ -80,4 +151,5 @@ class Regex(Check):
             true true false false
             true true true true
             true true true true
-            """))
+            """)
+        )

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3240,6 +3240,10 @@ pub struct AnalyzedRegex(ReprRegex, Vec<CaptureGroupDesc>, AnalyzedRegexOpts);
 impl AnalyzedRegex {
     pub fn new(s: &str, opts: AnalyzedRegexOpts) -> Result<Self, RegexCompilationError> {
         let r = ReprRegex::new(s, opts.case_insensitive)?;
+        // A capture group that always participates in a match (when the regex
+        // matches at all) extracts a non-null value, so its column can be
+        // marked non-nullable.
+        let non_nullable = r.non_nullable_capture_groups();
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
         let descs: Vec<_> = r
@@ -3253,9 +3257,7 @@ impl AnalyzedRegex {
             .map(|(i, name)| CaptureGroupDesc {
                 index: i as u32,
                 name: name.map(String::from),
-                // TODO -- we can do better.
-                // https://github.com/MaterializeInc/database-issues/issues/612
-                nullable: true,
+                nullable: !non_nullable.contains(&(i as u32)),
             })
             .collect();
         Ok(Self(r, descs, opts))

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -62,6 +62,7 @@ ordered-float.workspace = true
 postgres-protocol.workspace = true
 prost.workspace = true
 regex.workspace = true
+regex-syntax.workspace = true
 ryu.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision", "preserve_order"] }

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -11,6 +11,7 @@
 
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::collections::BTreeSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -106,6 +107,87 @@ impl Regex {
         // `as_str` returns the raw pattern as provided during construction,
         // and doesn't include any of the flags.
         self.regex.as_str()
+    }
+
+    /// Returns the indices of the capture groups that are guaranteed to
+    /// participate in every successful match of this regex.
+    ///
+    /// A capture group does *not* participate in a match when it is skipped
+    /// over by an optional construct: a `?` or `*` quantifier, a `{0,n}`-style
+    /// repetition, or an unmatched branch of an alternation. The indices
+    /// returned here are the complement of that set — capture groups that
+    /// always capture a value when the regex matches at all, and whose
+    /// extracted value is therefore non-nullable.
+    ///
+    /// Capture group indices match those used by [`regex::Captures`], where
+    /// index 0 refers to the entire match and is always included (it
+    /// necessarily participates whenever the regex matches).
+    ///
+    /// If the pattern cannot be parsed — which should not happen for a regex
+    /// that compiled successfully — an empty set is returned, conservatively
+    /// treating every capture group as nullable.
+    pub fn non_nullable_capture_groups(&self) -> BTreeSet<u32> {
+        let mut groups = BTreeSet::new();
+        if let Ok(ast) = regex_syntax::ast::parse::Parser::new().parse(self.pattern()) {
+            // The entire match (index 0) always participates in a match.
+            groups.insert(0);
+            collect_non_nullable_capture_groups(&ast, false, &mut groups);
+        }
+        groups
+    }
+}
+
+/// Walks `ast`, recording into `groups` the index of every capture group that
+/// is guaranteed to participate in a match. `optional` tracks whether `ast` is
+/// nested inside a construct that a match may skip over, in which case any
+/// capture group found within is *not* guaranteed to participate.
+fn collect_non_nullable_capture_groups(
+    ast: &regex_syntax::ast::Ast,
+    optional: bool,
+    groups: &mut BTreeSet<u32>,
+) {
+    use regex_syntax::ast::Ast;
+    match ast {
+        Ast::Repetition(rep) => {
+            let optional = optional || repetition_is_optional(&rep.op.kind);
+            collect_non_nullable_capture_groups(&rep.ast, optional, groups);
+        }
+        Ast::Group(group) => {
+            if !optional {
+                if let Some(index) = group.capture_index() {
+                    groups.insert(index);
+                }
+            }
+            collect_non_nullable_capture_groups(&group.ast, optional, groups);
+        }
+        Ast::Alternation(alternation) => {
+            // Only one branch of an alternation matches, so any capture group
+            // inside a branch might be skipped over by a given match.
+            for ast in &alternation.asts {
+                collect_non_nullable_capture_groups(ast, true, groups);
+            }
+        }
+        Ast::Concat(concat) => {
+            for ast in &concat.asts {
+                collect_non_nullable_capture_groups(ast, optional, groups);
+            }
+        }
+        // The remaining AST node kinds cannot contain a capture group.
+        _ => {}
+    }
+}
+
+/// Returns whether a repetition with the given kind may match zero times, in
+/// which case the repeated subexpression might be skipped over by a match.
+fn repetition_is_optional(kind: &regex_syntax::ast::RepetitionKind) -> bool {
+    use regex_syntax::ast::{RepetitionKind, RepetitionRange};
+    match kind {
+        RepetitionKind::ZeroOrOne | RepetitionKind::ZeroOrMore => true,
+        RepetitionKind::OneOrMore => false,
+        RepetitionKind::Range(range) => match range {
+            RepetitionRange::Exactly(min) | RepetitionRange::AtLeast(min) => *min == 0,
+            RepetitionRange::Bounded(min, _) => *min == 0,
+        },
     }
 }
 
@@ -377,6 +459,58 @@ mod tests {
             assert_eq!(orig_regex.regex.is_match("axxx\nxxxb"), true);
             assert_eq!(roundtrip_result.regex.is_match("axxx\nxxxb"), true);
             assert_eq!(pattern, roundtrip_result.pattern());
+        }
+    }
+
+    #[mz_ore::test]
+    fn regex_non_nullable_capture_groups() {
+        // `(idx, expected_non_nullable_indices)`. Index 0 (the whole match)
+        // always participates and is always reported.
+        let cases: &[(&str, &[u32])] = &[
+            // A plain capture group always participates.
+            ("(a)(b)", &[0, 1, 2]),
+            // `?` and `*` make the group optional.
+            ("(a)(b)?", &[0, 1]),
+            ("(a)(b)*", &[0, 1]),
+            // `+` and `{1,n}` keep the group required.
+            ("(a)(b)+", &[0, 1, 2]),
+            ("(a)(b){1,3}", &[0, 1, 2]),
+            // `{0,n}` and `{0}` make the group optional.
+            ("(a)(b){0,3}", &[0, 1]),
+            ("(a)(b){0}", &[0, 1]),
+            // Both branches of a top-level alternation are optional.
+            ("(a)|(b)", &[0]),
+            // A group wrapping an alternation still always participates, even
+            // though groups *inside* the branches do not.
+            ("(a|b)", &[0, 1]),
+            ("((a)|(b))", &[0, 1]),
+            // Nesting inside an optional construct is contagious.
+            ("((a)(b))?", &[0]),
+            // A required group following an optional one is still required.
+            ("(a)?(b)", &[0, 2]),
+            // Named groups are handled the same way.
+            ("(?P<x>a)(?P<y>b)?", &[0, 1]),
+            // Non-capturing groups don't introduce indices.
+            ("(?:a)(b)", &[0, 1]),
+            // Real-world patterns exercised by our test suite. The request-log
+            // regex used by `test/testdrive/regex-sources.td`: `ip` (1), `ts`
+            // (2), `path` (3), and `code` (6) always participate, while
+            // `search_kw` (4) and `product_detail_id` (5) live inside
+            // alternation branches and are therefore nullable.
+            (
+                r#"(?P<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<ts>[^]]+)\] "(?P<path>(?:GET /search/\?kw=(?P<search_kw>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<product_detail_id>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<code>\d{3}) -"#,
+                &[0, 1, 2, 3, 6],
+            ),
+            // The key/value regexes from
+            // `test/testdrive/kafka-include-key-sources.td`, where both groups
+            // always participate.
+            (r#"(?P<animal>[^,]+),(?P<food>\w+)"#, &[0, 1, 2]),
+        ];
+        for (pattern, expected) in cases {
+            let regex = Regex::new(pattern, false).unwrap();
+            let got = regex.non_nullable_capture_groups();
+            let expected: BTreeSet<u32> = expected.iter().copied().collect();
+            assert_eq!(got, expected, "pattern: {pattern}");
         }
     }
 

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -131,48 +131,41 @@ impl Regex {
         if let Ok(ast) = regex_syntax::ast::parse::Parser::new().parse(self.pattern()) {
             // The entire match (index 0) always participates in a match.
             groups.insert(0);
-            collect_non_nullable_capture_groups(&ast, false, &mut groups);
+            collect_non_nullable_capture_groups(&ast, &mut groups);
         }
         groups
     }
 }
 
-/// Walks `ast`, recording into `groups` the index of every capture group that
-/// is guaranteed to participate in a match. `optional` tracks whether `ast` is
-/// nested inside a construct that a match may skip over, in which case any
-/// capture group found within is *not* guaranteed to participate.
-fn collect_non_nullable_capture_groups(
-    ast: &regex_syntax::ast::Ast,
-    optional: bool,
-    groups: &mut BTreeSet<u32>,
-) {
+/// Walks the always-matched portion of `ast`, recording into `groups` the index
+/// of every capture group that is guaranteed to participate in a match.
+///
+/// This only recurses through nodes that a match cannot skip over, so every
+/// capture group it reaches is non-nullable. It stops descending at any node
+/// that introduces an optional context — an optional repetition or an
+/// alternation — since nothing beneath such a node is guaranteed to match.
+fn collect_non_nullable_capture_groups(ast: &regex_syntax::ast::Ast, groups: &mut BTreeSet<u32>) {
     use regex_syntax::ast::Ast;
     match ast {
-        Ast::Repetition(rep) => {
-            let optional = optional || repetition_is_optional(&rep.op.kind);
-            collect_non_nullable_capture_groups(&rep.ast, optional, groups);
-        }
         Ast::Group(group) => {
-            if !optional {
-                if let Some(index) = group.capture_index() {
-                    groups.insert(index);
-                }
+            if let Some(index) = group.capture_index() {
+                groups.insert(index);
             }
-            collect_non_nullable_capture_groups(&group.ast, optional, groups);
+            collect_non_nullable_capture_groups(&group.ast, groups);
         }
-        Ast::Alternation(alternation) => {
-            // Only one branch of an alternation matches, so any capture group
-            // inside a branch might be skipped over by a given match.
-            for ast in &alternation.asts {
-                collect_non_nullable_capture_groups(ast, true, groups);
-            }
+        // A required repetition (e.g. `+` or `{1,n}`) still always matches, so
+        // keep descending; an optional one is handled by the catch-all below.
+        Ast::Repetition(rep) if !repetition_is_optional(&rep.op.kind) => {
+            collect_non_nullable_capture_groups(&rep.ast, groups);
         }
         Ast::Concat(concat) => {
             for ast in &concat.asts {
-                collect_non_nullable_capture_groups(ast, optional, groups);
+                collect_non_nullable_capture_groups(ast, groups);
             }
         }
-        // The remaining AST node kinds cannot contain a capture group.
+        // Everything else — alternations (only one branch matches), optional
+        // repetitions, and leaf nodes — cannot contribute a non-nullable
+        // capture group, so we stop here.
         _ => {}
     }
 }

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -144,6 +144,11 @@ impl Regex {
 /// capture group it reaches is non-nullable. It stops descending at any node
 /// that introduces an optional context — an optional repetition or an
 /// alternation — since nothing beneath such a node is guaranteed to match.
+///
+/// The recursion depth is bounded by the AST nesting depth. This is safe
+/// because the only caller obtains `ast` from `regex_syntax`'s parser, whose
+/// default `nest_limit` (250) rejects more deeply nested patterns before we
+/// ever get here.
 fn collect_non_nullable_capture_groups(ast: &regex_syntax::ast::Ast, groups: &mut BTreeSet<u32>) {
     use regex_syntax::ast::Ast;
     match ast {
@@ -477,6 +482,13 @@ mod tests {
             // though groups *inside* the branches do not.
             ("(a|b)", &[0, 1]),
             ("((a)|(b))", &[0, 1]),
+            // The soundness crux: a group that *wraps* an optional sub-expression
+            // still always captures (the empty string), so it is non-nullable —
+            // unlike a group that is *itself* made optional (`(a)?`, tested
+            // above). Note the difference in `?`/`*` position.
+            ("(a*)", &[0, 1]),
+            ("(a?)", &[0, 1]),
+            ("(a*)(b)?", &[0, 1]),
             // Nesting inside an optional construct is contagious.
             ("((a)(b))?", &[0]),
             // A required group following an optional one is still required.

--- a/src/storage-types/src/sources/encoding.rs
+++ b/src/storage-types/src/sources/encoding.rs
@@ -168,23 +168,31 @@ impl<C: ConnectionAccess> DataEncoding<C> {
                     desc.with_column(name, ty.clone())
                 })
                 .finish(),
-            Self::Regex(RegexEncoding { regex }) => regex
-                .capture_names()
-                .enumerate()
-                // The first capture is the entire matched string. This will
-                // often not be useful, so skip it. If people want it they can
-                // just surround their entire regex in an explicit capture
-                // group.
-                .skip(1)
-                .fold(RelationDesc::builder(), |desc, (i, name)| {
-                    let name = match name {
-                        None => format!("column{}", i),
-                        Some(name) => name.to_owned(),
-                    };
-                    let ty = SqlScalarType::String.nullable(true);
-                    desc.with_column(name, ty)
-                })
-                .finish(),
+            Self::Regex(RegexEncoding { regex }) => {
+                // A capture group that always participates in a match (when the
+                // regex matches at all) extracts a non-null value, so its column
+                // can be marked non-nullable.
+                let non_nullable = regex.non_nullable_capture_groups();
+                regex
+                    .capture_names()
+                    .enumerate()
+                    // The first capture is the entire matched string. This will
+                    // often not be useful, so skip it. If people want it they can
+                    // just surround their entire regex in an explicit capture
+                    // group.
+                    .skip(1)
+                    .fold(RelationDesc::builder(), |desc, (i, name)| {
+                        let name = match name {
+                            None => format!("column{}", i),
+                            Some(name) => name.to_owned(),
+                        };
+                        // `capture_names` yields at most `u32::MAX` groups.
+                        let nullable = !non_nullable.contains(&u32::try_from(i).unwrap());
+                        let ty = SqlScalarType::String.nullable(nullable);
+                        desc.with_column(name, ty)
+                    })
+                    .finish()
+            }
             Self::Csv(CsvEncoding { columns, .. }) => match columns {
                 ColumnSpec::Count(n) => (1..=*n)
                     .fold(RelationDesc::builder(), |desc, i| {

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -30,7 +30,23 @@ asdf asdf NULL
 asdfjkl asdf NULL
 jkl NULL jkl
 
-# TODO - Test that the columns have the correct nullability, once they actually do (database-issues#612)
+# Regression test for database-issues#612: capture groups that always
+# participate in a match produce non-nullable columns, while those guarded by a
+# `?`, `*`, or `{0,n}` quantifier or an alternation branch are nullable.
+statement ok
+CREATE VIEW regex_nullability AS
+SELECT * FROM regexp_extract('(?P<g1>a)(?P<g2>b)?(?P<g3>(?P<g4>c)|d)', 'x') AS r
+
+query TT
+SELECT c.name, c.nullable::text
+FROM mz_columns c JOIN mz_views v ON c.id = v.id
+WHERE v.name = 'regex_nullability'
+ORDER BY c.position
+----
+g1  false
+g2  true
+g3  false
+g4  true
 
 # Standard regex matching.
 query TTT

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -32,10 +32,12 @@ jkl NULL jkl
 
 # Regression test for database-issues#612: capture groups that always
 # participate in a match produce non-nullable columns, while those guarded by a
-# `?`, `*`, or `{0,n}` quantifier or an alternation branch are nullable.
+# `?`, `*`, or `{0,n}` quantifier or an alternation branch are nullable. The
+# haystack is a column rather than a literal so that the table function isn't
+# constant-folded into an (always non-nullable) empty constant.
 statement ok
 CREATE VIEW regex_nullability AS
-SELECT * FROM regexp_extract('(?P<g1>a)(?P<g2>b)?(?P<g3>(?P<g4>c)|d)', 'x') AS r
+SELECT r.* FROM data, regexp_extract('(?P<g1>a)(?P<g2>b)?(?P<g3>(?P<g4>c)|d)', data.input) AS r
 
 query TT
 SELECT c.name, c.nullable::text

--- a/test/testdrive-old-kafka-src-syntax/regex-sources.td
+++ b/test/testdrive-old-kafka-src-syntax/regex-sources.td
@@ -30,12 +30,12 @@ $ kafka-ingest topic=request-log format=bytes
 > SHOW COLUMNS FROM regex_source
 name               nullable  type  comment
 ------------------------------------------
-ip                 true      text  ""
-ts                 true      text  ""
-path               true      text  ""
+ip                 false     text  ""
+ts                 false     text  ""
+path               false     text  ""
 search_kw          true      text  ""
 product_detail_id  true      text  ""
-code               true      text  ""
+code               false     text  ""
 
 > SELECT * FROM regex_source
 ip            ts                      path                                           search_kw           product_detail_id  code
@@ -58,12 +58,12 @@ helper+ins+hennaed
 > SHOW COLUMNS FROM regex_source_named_cols
 name               nullable  type  comment
 ------------------------------------------
-ip                 true      text  ""
-ts                 true      text  ""
-path               true      text  ""
+ip                 false     text  ""
+ts                 false     text  ""
+path               false     text  ""
 search_kw          true      text  ""
 product_detail_id  true      text  ""
-code               true      text  ""
+code               false     text  ""
 
 # verify metadata column renaming
 > CREATE CLUSTER regex_source_renamed_cols_cluster SIZE '${arg.default-storage-size}';
@@ -75,12 +75,12 @@ code               true      text  ""
 > SHOW COLUMNS FROM regex_source_renamed_cols
 name               nullable  type  comment
 ------------------------------------------
-ip                 true      text  ""
-ts                 true      text  ""
-path               true      text  ""
+ip                 false     text  ""
+ts                 false     text  ""
+path               false     text  ""
 search_kw          true      text  ""
 product_detail_id  true      text  ""
-code               true      text  ""
+code               false     text  ""
 
 > SELECT * FROM regex_source_named_cols
 ip            ts                      path                                           search_kw           product_detail_id  code

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -30,12 +30,12 @@ $ kafka-ingest topic=request-log format=bytes
 > SHOW COLUMNS FROM regex_source_tbl
 name               nullable  type  comment
 ------------------------------------------
-ip                 true      text  ""
-ts                 true      text  ""
-path               true      text  ""
+ip                 false     text  ""
+ts                 false     text  ""
+path               false     text  ""
 search_kw          true      text  ""
 product_detail_id  true      text  ""
-code               true      text  ""
+code               false     text  ""
 
 > SELECT * FROM regex_source_tbl
 ip            ts                      path                                           search_kw           product_detail_id  code
@@ -60,12 +60,12 @@ helper+ins+hennaed
 > SHOW COLUMNS FROM regex_source_named_cols_tbl
 name               nullable  type  comment
 ------------------------------------------
-ip                 true      text  ""
-ts                 true      text  ""
-path               true      text  ""
+ip                 false     text  ""
+ts                 false     text  ""
+path               false     text  ""
 search_kw          true      text  ""
 product_detail_id  true      text  ""
-code               true      text  ""
+code               false     text  ""
 
 # verify metadata column renaming
 > CREATE CLUSTER regex_source_renamed_cols_cluster SIZE '${arg.default-storage-size}';
@@ -79,12 +79,12 @@ code               true      text  ""
 > SHOW COLUMNS FROM regex_source_renamed_cols_tbl
 name               nullable  type  comment
 ------------------------------------------
-ip                 true      text  ""
-ts                 true      text  ""
-path               true      text  ""
+ip                 false     text  ""
+ts                 false     text  ""
+path               false     text  ""
 search_kw          true      text  ""
 product_detail_id  true      text  ""
-code               true      text  ""
+code               false     text  ""
 
 > SELECT * FROM regex_source_named_cols_tbl
 ip            ts                      path                                           search_kw           product_detail_id  code


### PR DESCRIPTION
### Motivation

Columns derived from regex capture groups were unconditionally marked nullable, with a long-standing `TODO` referencing database-issues#612 noting "we can do better." A capture group that is **not** nested inside an optional construct always participates whenever the regex matches at all, so its extracted column is non-nullable.

### Changes

- **`src/repr/src/adt/regex.rs`**: add `Regex::non_nullable_capture_groups()`, which parses the pattern AST (via `regex-syntax`, already a workspace dep) and returns the indices of capture groups guaranteed to participate in a match. A group is considered nullable only when nested inside an optional context: a `?`/`*` quantifier, a `{0,n}`/`{0}`-style repetition, or an alternation branch (`a|b`). If the pattern somehow fails to parse (shouldn't happen for a regex that compiled), it conservatively returns the empty set, preserving the previous all-nullable behavior.
- **`src/expr/src/relation/func.rs`**: `regexp_extract` now uses the analysis instead of hardcoding `nullable: true`; removes the `TODO`.
- **`src/storage-types/src/sources/encoding.rs`**: `FORMAT REGEX` source encoding uses the same analysis.

The traversal only recurses through nodes a match cannot skip over, so every capture group it reaches is non-nullable; it stops descending at optional repetitions and alternations.

**Soundness**: the runtime decode path only emits a row on a full regex match, and a structurally-required group always captures when the whole regex matches, so a non-nullable column never receives a null at runtime.

### Tests

- Unit tests in `regex.rs` covering `?`, `*`, `+`, `{0,n}`, `{1,n}`, top-level vs. nested alternation, named/non-capturing groups, plus the exact production patterns from the testdrive suite.
- New `mz_columns`-based nullability assertion in `test/sqllogictest/regex.slt` (replacing the old TODO).
- Updated `SHOW COLUMNS` expectations in both `regex-sources.td` variants (`ip`/`ts`/`path`/`code` → non-nullable; `search_kw`/`product_detail_id` remain nullable since they live in alternation branches).

Resolves the TODO for database-issues#612.

https://claude.ai/code/session_01193gm1qtyQcSHSaZNMbx6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01193gm1qtyQcSHSaZNMbx6e)_