### PR TITLE
[SSO] support dot-separated paths in oidc_group_claim

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -142,11 +142,13 @@ pub const OIDC_GROUP_ROLE_SYNC_ENABLED: Config<bool> = Config::new(
     "Enable OIDC JWT group-to-role membership sync on login.",
 );
 
-/// The JWT claim name that contains group memberships.
+/// The JWT claim path that contains group memberships. May be a bare claim
+/// name (e.g. `groups`) or a dot-separated path into nested objects (e.g.
+/// `customClaims.groups`).
 pub const OIDC_GROUP_CLAIM: Config<&'static str> = Config::new(
     "oidc_group_claim",
     "groups",
-    "JWT claim name containing group memberships for role sync.",
+    "JWT claim path containing group memberships for role sync. Supports dot-separated paths into nested objects (e.g. customClaims.groups).",
 );
 
 /// Whether to reject login when group sync fails (strict/fail-closed mode).

--- a/src/authenticator/src/oidc.rs
+++ b/src/authenticator/src/oidc.rs
@@ -249,6 +249,14 @@ impl OidcClaims {
 
     /// Extracts group names from the specified JWT claim for group-to-role sync.
     ///
+    /// `claim_path` may be a bare claim name (e.g. `"groups"`) or a
+    /// dot-separated path into nested JSON objects (e.g.
+    /// `"customClaims.groups"`). Keys that contain a literal `.` are not
+    /// reachable; this is a known limitation matching CockroachDB's
+    /// `group_claim` semantics. Empty path segments (leading/trailing/double
+    /// dots, or an empty path) yield `None` and emit a `warn!`-level log so
+    /// misconfiguration is visible.
+    ///
     /// Returns `None` if the claim is absent (skip sync, preserve current state),
     /// `Some(vec![])` if the claim is present but empty (revoke all sync-granted
     /// roles), or `Some(vec![...])` with deduplicated, sorted group names
@@ -257,8 +265,8 @@ impl OidcClaims {
     ///
     /// Accepts arrays of strings, single strings, or mixed arrays (non-string
     /// elements are filtered out). Other JSON types are treated as absent.
-    pub fn groups(&self, claim_name: &str) -> Option<Vec<String>> {
-        let value = self.unknown_claims.get(claim_name)?;
+    pub fn groups(&self, claim_path: &str) -> Option<Vec<String>> {
+        let value = self.resolve_claim_path(claim_path)?;
 
         let raw_groups: Vec<String> = match value {
             serde_json::Value::Array(arr) => arr
@@ -274,7 +282,7 @@ impl OidcClaims {
             }
             _ => {
                 warn!(
-                    claim_name,
+                    claim_path,
                     "OIDC group claim has unexpected type; skipping group sync"
                 );
                 return None;
@@ -289,6 +297,47 @@ impl OidcClaims {
             .collect();
 
         Some(groups)
+    }
+
+    /// Walks a dot-separated claim path into nested JSON objects. Returns
+    /// `None` if the path is empty, any segment is empty, an intermediate
+    /// segment is missing, or an intermediate segment resolves to a
+    /// non-object value.
+    fn resolve_claim_path(&self, claim_path: &str) -> Option<&serde_json::Value> {
+        let mut segments = claim_path.split('.');
+        let first = segments
+            .next()
+            .expect("str::split always yields at least one segment");
+        if first.is_empty() {
+            warn!(
+                claim_path,
+                "OIDC group claim path has an empty segment; skipping group sync"
+            );
+            return None;
+        }
+        let mut current = self.unknown_claims.get(first)?;
+        for segment in segments {
+            if segment.is_empty() {
+                warn!(
+                    claim_path,
+                    "OIDC group claim path has an empty segment; skipping group sync"
+                );
+                return None;
+            }
+            let obj = match current {
+                serde_json::Value::Object(map) => map,
+                _ => {
+                    warn!(
+                        claim_path,
+                        segment,
+                        "OIDC group claim intermediate segment is not an object; skipping group sync"
+                    );
+                    return None;
+                }
+            };
+            current = obj.get(segment)?;
+        }
+        Some(current)
     }
 }
 
@@ -975,5 +1024,95 @@ mod tests {
                 "zebra".to_string(),
             ])
         );
+    }
+
+    #[mz_ore::test]
+    fn test_groups_nested_path_array() {
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","customClaims":{"groups":["analytics","platform_eng"]}}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            claims.groups("customClaims.groups"),
+            Some(vec!["analytics".to_string(), "platform_eng".to_string()])
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_groups_nested_path_single_string() {
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","customClaims":{"groups":"analytics"}}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            claims.groups("customClaims.groups"),
+            Some(vec!["analytics".to_string()])
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_groups_nested_path_deeply_nested() {
+        let json =
+            r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","a":{"b":{"c":["eng"]}}}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups("a.b.c"), Some(vec!["eng".to_string()]));
+    }
+
+    #[mz_ore::test]
+    fn test_groups_nested_path_missing_intermediate() {
+        // The top-level key exists but the nested key doesn't.
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","customClaims":{"other":["eng"]}}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups("customClaims.groups"), None);
+    }
+
+    #[mz_ore::test]
+    fn test_groups_nested_path_missing_root() {
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app"}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups("customClaims.groups"), None);
+    }
+
+    #[mz_ore::test]
+    fn test_groups_nested_path_first_segment_not_object() {
+        // `customClaims` is an array, can't be descended into.
+        let json =
+            r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","customClaims":["nope"]}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups("customClaims.groups"), None);
+    }
+
+    #[mz_ore::test]
+    fn test_groups_nested_path_terminal_not_array_or_string() {
+        // The terminal value is a number, treated as absent (matches the
+        // flat-path behavior for unexpected types).
+        let json =
+            r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","customClaims":{"groups":42}}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups("customClaims.groups"), None);
+    }
+
+    #[mz_ore::test]
+    fn test_groups_path_leading_dot() {
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","groups":["eng"]}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups(".groups"), None);
+    }
+
+    #[mz_ore::test]
+    fn test_groups_path_trailing_dot() {
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","customClaims":{"groups":["eng"]}}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups("customClaims.groups."), None);
+    }
+
+    #[mz_ore::test]
+    fn test_groups_path_double_dot() {
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","customClaims":{"groups":["eng"]}}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups("customClaims..groups"), None);
+    }
+
+    #[mz_ore::test]
+    fn test_groups_path_empty() {
+        let json = r#"{"sub":"user","iss":"issuer","exp":1234,"aud":"app","groups":["eng"]}"#;
+        let claims: OidcClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.groups(""), None);
     }
 }

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -64,7 +64,7 @@ max_sources                              200                     "The maximum nu
 max_sql_server_connections               1000                    "The maximum number of SQL Server connections in the region, across all schemas (Materialize)."
 max_tables                               200                     "The maximum number of tables in the region, across all schemas (Materialize)."
 network_policy                           default                 "Sets the fallback network policy applied to all users without an explicit policy."
-oidc_group_claim                         groups                  "JWT claim name containing group memberships for role sync."
+oidc_group_claim                         groups                  "JWT claim path containing group memberships for role sync. Supports dot-separated paths into nested objects (e.g. customClaims.groups)."
 oidc_group_role_sync_strict              off                     "When true, reject login if OIDC group-to-role sync fails (fail-closed)."
 optimizer_e2e_latency_warning_threshold  "500 ms"                "Sets the duration that a query can take to compile; queries that take longer will trigger a warning. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout (Materialize)."
 mz_version                               <VARIES>                "Shows the Materialize server version (Materialize)."


### PR DESCRIPTION
Problem:
Frontegg-issued JWTs cannot place group memberships at a top-level groups claim. The only way to surface group info on the Frontegg path is to configure a JWT-generation webhook that injects a nested customClaims object `{ "customClaims": { "groups": ["analytics", "platform_eng"] } }`

The existing OIDC group sync only looks up oidc_group_claim as a single top-level key, so there is no way to reach customClaims.groups.

Solution:
Allow oidc_group_claim to be a dot-separated path into nested JSON objects. A bare claim name like groups continues to behave exactly as before. A path like customClaims.groups iterates through the intermediate object before applying the existing array/string coercion.

Testing
12 new unit tests in covering nested arrays, nested single strings, deeply nested paths, etc.
