### PR TITLE
Fix panic when attempting to set default_timestamp_interval to 0

### DIFF
--- a/src/sql/src/session/vars/constraints.rs
+++ b/src/sql/src/session/vars/constraints.rs
@@ -11,6 +11,7 @@
 
 use std::fmt::Debug;
 use std::ops::{RangeBounds, RangeFrom, RangeInclusive};
+use std::time::Duration;
 
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::bytes::ByteSize;
@@ -18,6 +19,8 @@ use mz_repr::bytes::ByteSize;
 use super::{Value, Var, VarError};
 
 pub static NUMERIC_NON_NEGATIVE: NumericNonNegNonNan = NumericNonNegNonNan;
+
+pub static NON_ZERO_DURATION: NonZeroDuration = NonZeroDuration;
 
 pub static NUMERIC_BOUNDED_0_1_INCLUSIVE: NumericInRange<RangeInclusive<f64>> =
     NumericInRange(0.0f64..=1.0);
@@ -107,6 +110,25 @@ impl DomainConstraint for NumericNonNegNonNan {
                 name: var.name(),
                 invalid_values: vec![n.to_string()],
                 reason: "only supports non-negative, non-NaN numeric values".to_string(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NonZeroDuration;
+
+impl DomainConstraint for NonZeroDuration {
+    type Value = Duration;
+
+    fn check(&self, var: &dyn Var, d: &Duration) -> Result<(), VarError> {
+        if d.is_zero() {
+            Err(VarError::InvalidParameterValue {
+                name: var.name(),
+                invalid_values: vec![format!("{:?}", d)],
+                reason: "only supports durations greater than zero".to_string(),
             })
         } else {
             Ok(())

--- a/src/sql/src/session/vars/constraints.rs
+++ b/src/sql/src/session/vars/constraints.rs
@@ -128,7 +128,7 @@ impl DomainConstraint for NonZeroDuration {
             Err(VarError::InvalidParameterValue {
                 name: var.name(),
                 invalid_values: vec![format!("{:?}", d)],
-                reason: "only supports durations greater than zero".to_string(),
+                reason: "only supports non-zero durations".to_string(),
             })
         } else {
             Ok(())

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -39,8 +39,8 @@ use uncased::UncasedStr;
 
 use crate::session::user::{SUPPORT_USER, SYSTEM_USER, User};
 use crate::session::vars::constraints::{
-    BYTESIZE_AT_LEAST_1MB, DomainConstraint, NUMERIC_BOUNDED_0_1_INCLUSIVE, NUMERIC_NON_NEGATIVE,
-    ValueConstraint,
+    BYTESIZE_AT_LEAST_1MB, DomainConstraint, NON_ZERO_DURATION, NUMERIC_BOUNDED_0_1_INCLUSIVE,
+    NUMERIC_NON_NEGATIVE, ValueConstraint,
 };
 use crate::session::vars::errors::VarError;
 use crate::session::vars::polyfill::{LazyValueFn, lazy_value, value};
@@ -1441,7 +1441,8 @@ pub static DEFAULT_TIMESTAMP_INTERVAL: VarDefinition = VarDefinition::new(
     value!(Duration; Duration::from_millis(1000)),
     "The interval at which timestamps are assigned to data from sources and tables.",
     false,
-);
+)
+.with_constraint(&NON_ZERO_DURATION);
 
 pub static MIN_TIMESTAMP_INTERVAL: VarDefinition = VarDefinition::new(
     "min_timestamp_interval",

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -213,12 +213,12 @@ COMPLETE 0
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET default_timestamp_interval = '0';
 ----
-db error: ERROR:  parameter "default_timestamp_interval" cannot have value "0ns": only supports durations greater than zero
+db error: ERROR: parameter "default_timestamp_interval" cannot have value "0ns": only supports durations greater than zero
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET default_timestamp_interval = '-1';
 ----
-db error: ERROR:  parameter "default_timestamp_interval" requires a "duration" value
+db error: ERROR: parameter "default_timestamp_interval" requires a "duration" value
 
 statement ok
 ALTER SOURCE s SET (TIMESTAMP INTERVAL '2s')

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -213,12 +213,12 @@ COMPLETE 0
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET default_timestamp_interval = '0';
 ----
-db error ERROR:  parameter "default_timestamp_interval" cannot have value "0ns": only supports durations greater than zero
+db error: ERROR:  parameter "default_timestamp_interval" cannot have value "0ns": only supports durations greater than zero
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET default_timestamp_interval = '-1';
 ----
-db error ERROR:  parameter "default_timestamp_interval" requires a "duration" value
+db error: ERROR:  parameter "default_timestamp_interval" requires a "duration" value
 
 statement ok
 ALTER SOURCE s SET (TIMESTAMP INTERVAL '2s')

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -213,7 +213,7 @@ COMPLETE 0
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET default_timestamp_interval = '0';
 ----
-db error: ERROR: parameter "default_timestamp_interval" cannot have value "0ns": only supports durations greater than zero
+db error: ERROR: parameter "default_timestamp_interval" cannot have value "0ns": only supports non-zero durations
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET default_timestamp_interval = '-1';

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -205,6 +205,21 @@ ALTER SYSTEM SET max_timestamp_interval = '10s';
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET default_timestamp_interval = '1';
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET default_timestamp_interval = '0';
+----
+db error ERROR:  parameter "default_timestamp_interval" cannot have value "0ns": only supports durations greater than zero
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET default_timestamp_interval = '-1';
+----
+db error ERROR:  parameter "default_timestamp_interval" requires a "duration" value
+
 statement ok
 ALTER SOURCE s SET (TIMESTAMP INTERVAL '2s')
 


### PR DESCRIPTION
### Motivation

Closes [ss-147](https://linear.app/materializeinc/issue/SS-147/thread-coordinator-panicked-at-srcadaptersrccoordddlrs56155-period)

### Description

Adds a non-zero constraint to the "default_timestamp_interval" system parameter. This prevents an issue where setting it to 0 causes a panic and the database won't start up until you go in and update the parameter by different means.

### Verification

1. Reproduced the issue locally, updated code and confirmed we received an error instead of crashing when the `ALTER ...` statement is issued
2. Added basic sqllogictest tests
