### PR TITLE
docs: Add rollout instructions to system parameter configmap

### DIFF
--- a/doc/user/content/security/self-managed/sso-migration.md
+++ b/doc/user/content/security/self-managed/sso-migration.md
@@ -31,10 +31,9 @@ naturally matches.
 If no JWT claim maps to an existing role name, you will need to recreate the
 role.
 
-## Step 2. Configure OIDC
+## Step 2. Configure Single sign-on (SSO)
 
-Follow the steps in [Single sign-on (SSO)](/security/self-managed/sso/) to
-configure your identity provider and enable OIDC authentication.
+Follow the steps in [Single sign-on (SSO)](/security/self-managed/sso/).
 
 ## Step 3. Verify the migration
 

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -203,11 +203,22 @@ following fields:
 The following example Kubernetes manifest includes configuration for OIDC
 authentication:
 
-```hc {hl_lines="15 25"}
+```yaml {hl_lines="6-15 26 36 38"}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: materialize-environment
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mz-system-params
+  namespace: materialize-environment
+data:
+  # Create an empty system parameter configmap for later steps
+  system-params.json: |
+    {
+    }
 ---
 apiVersion: v1
 kind: Secret
@@ -230,6 +241,7 @@ spec:
   backendSecretName: materialize-backend
   authenticatorKind: Oidc
   requestRollout: 00000000-0000-0000-0000-000000000003 # Switching to Oidc requires a rollout
+  systemParameterConfigmapName: mz-system-params # Adding a system parameter configmap requires a rollout
 ```
 
 Apply the updated manifest to your Kubernetes cluster. See
@@ -265,10 +277,11 @@ Materialize, including tokens issued for other applications. **Always set
 
 ### Configure via ConfigMap
 
-Create a ConfigMap with your OIDC parameters and reference it in the Materialize
-CR's `spec.systemParameterConfigmapName` field. At this point, your manifest should look like:
+In [Step 2](#step-2-enable-oidc-authentication), you already created an empty
+`mz-system-params` ConfigMap. Now, populate that ConfigMap with your
+OIDC parameters by editing its `data`. At this point, your manifest should look like:
 
-```yaml {hl_lines="9-13 36"}
+```yaml {hl_lines="9-13"}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -283,28 +296,6 @@ data:
       "console_oidc_client_id": "YOUR_CLIENT_ID",
       "console_oidc_scopes": "openid email"
     }
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: materialize-backend
-  namespace: materialize-environment
-stringData:
-  metadata_backend_url: ...
-  persist_backend_url: ...
-  license_key: ...
-  external_login_password_mz_system: "enter_mz_system_password"
----
-apiVersion: materialize.cloud/v1alpha1
-kind: Materialize
-metadata:
-  name: 12345678-1234-1234-1234-123456789012
-  namespace: materialize-environment
-spec:
-  authenticatorKind: Oidc
-  backendSecretName: materialize-backend
-  requestRollout: 00000000-0000-0000-0000-000000000003 # Switching to Oidc requires a rollout
-  systemParameterConfigmapName: mz-system-params
 ```
 
 {{< note >}}
@@ -314,8 +305,8 @@ authentication claim references `email`, `console_oidc_scopes` includes the
 `email` scope to ensure that claim is present in the token.
 {{</ note >}}
 
-Apply the updated manifest to your Kubernetes cluster. For more on configuring
-system parameters via a ConfigMap, see [System parameters
+Apply the updated ConfigMap to your Kubernetes cluster. For more
+on configuring system parameters via a ConfigMap, see [System parameters
 configuration](/self-managed-deployments/configuration-system-parameters/#configure-system-parameters-via-configmap).
 
 ### Configure via SQL

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -199,11 +199,12 @@ following fields:
 |----------|---------------| ------------
 | Materialize CR | `spec.authenticatorKind` | Set to `Oidc` to enable OIDC authentication.
 | Kubernetes Secret | `external_login_password_mz_system` | Specify the password for the `mz_system` user. Add `external_login_password_mz_system` to the Kubernetes Secret referenced in the Materialize CR's `spec.backendSecretName` field. The `mz_system` user **always** authenticates with a password. This user is required by the Materialize Operator for upgrades and serves as an emergency administrative account.
+| ConfigMap | `mz-system-params` | Create an empty system parameter ConfigMap and reference it from the Materialize CR's `spec.systemParameterConfigmapName` field. You will populate it with your OIDC parameters in [Step 3](#step-3-configure-oidc-system-parameters).
 
 The following example Kubernetes manifest includes configuration for OIDC
 authentication:
 
-```yaml {hl_lines="6-15 26 36 38"}
+```yaml {hl_lines="6-15 26 36-38"}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -279,7 +280,7 @@ Materialize, including tokens issued for other applications. **Always set
 
 In [Step 2](#step-2-enable-oidc-authentication), you already created an empty
 `mz-system-params` ConfigMap. Now, populate that ConfigMap with your
-OIDC parameters by editing its `data`. At this point, your manifest should look like:
+OIDC parameters. At this point, your manifest should look like:
 
 ```yaml {hl_lines="9-13"}
 apiVersion: v1
@@ -305,7 +306,8 @@ authentication claim references `email`, `console_oidc_scopes` includes the
 `email` scope to ensure that claim is present in the token.
 {{</ note >}}
 
-Apply the updated ConfigMap to your Kubernetes cluster. For more
+Apply the updated ConfigMap to your Kubernetes cluster. The changes could take
+up to a minute to take effect. For more
 on configuring system parameters via a ConfigMap, see [System parameters
 configuration](/self-managed-deployments/configuration-system-parameters/#configure-system-parameters-via-configmap).
 

--- a/doc/user/content/self-managed-deployments/configuration-system-parameters.md
+++ b/doc/user/content/self-managed-deployments/configuration-system-parameters.md
@@ -67,7 +67,7 @@ kubectl apply -f system-params-configmap.yaml
 Reference the ConfigMap in your Materialize custom resource by setting the
 `systemParameterConfigmapName` field to the name of your ConfigMap:
 
-```yaml {hl_lines="9"}
+```yaml {hl_lines="9-10"}
 apiVersion: materialize.cloud/v1alpha1
 kind: Materialize
 metadata:
@@ -77,6 +77,7 @@ spec:
   environmentdImageRef: materialize/environmentd:v26.0.0
   backendSecretName: materialize-backend
   systemParameterConfigmapName: mz-system-params
+  requestRollout: 00000000-0000-0000-0000-000000000003 # Changing the CR requires a rollout
 ```
 
 Apply the updated Materialize resource:
@@ -86,6 +87,9 @@ kubectl apply -f materialize.yaml
 ```
 
 ## Updating ConfigMap System Parameters
+
+Unlike changes to the Materialize custom resource, updating the parameters in
+your ConfigMap does **not** require a rollout.
 
 To update system parameters defined in your ConfigMap, you can either:
 
@@ -138,7 +142,7 @@ spec:
 ```
 
 {{< note >}}
-Even after the ConfigMap is synced, some parameters may require a restart to
+Even after the ConfigMap is synced, some system parameters may require a restart to
 take effect.
 {{< /note >}}
 

--- a/doc/user/content/self-managed-deployments/configuration-system-parameters.md
+++ b/doc/user/content/self-managed-deployments/configuration-system-parameters.md
@@ -88,9 +88,6 @@ kubectl apply -f materialize.yaml
 
 ## Updating ConfigMap System Parameters
 
-Unlike changes to the Materialize custom resource, updating the parameters in
-your ConfigMap does **not** require a rollout.
-
 To update system parameters defined in your ConfigMap, you can either:
 
 - Use `kubectl edit configmap` to edit the ConfigMap and apply the changes:
@@ -104,6 +101,9 @@ To update system parameters defined in your ConfigMap, you can either:
   ```shell
   kubectl apply -f system-params-configmap.yaml
   ```
+
+Unlike changes to the Materialize custom resource, updating the parameters in
+your ConfigMap does **not** require a rollout.
 
 ### ConfigMap sync behavior
 


### PR DESCRIPTION
[docs: Add rollout instructions to system parameter configmap](https://github.com/MaterializeInc/materialize/pull/36855/changes/28f060b3191c15f8c0d0d3b18b782c900603b09a)
Setting up a system param config map requires a rollout. This change makes sure we surface this.