### PR TITLE
ssh-util: FIPS OpenSSH build on AWS-LC-FIPS 3.x (draft, pending NIST cert)

### DIFF
--- a/misc/images/openssh-static/Dockerfile
+++ b/misc/images/openssh-static/Dockerfile
@@ -86,23 +86,11 @@ RUN AWS_LC_REF="$([ "$AWS_LC_FIPS" = "1" ] && echo "$AWS_LC_FIPS_VERSION" || ech
 WORKDIR /build/openssh
 RUN git clone --depth 1 --branch ${OPENSSH_VERSION} https://github.com/openssh/openssh-portable.git . \
     && autoreconf \
-    # Inject -DBN_FLG_CONSTTIME=0 via CPPFLAGS at configure time rather than
-    # as `make CFLAGS=...`. OpenSSH's Makefile.in uses a plain `CFLAGS=@CFLAGS@`
-    # assignment (no override, no CFLAGS_EXTRA in this version), so a
-    # command-line `make CFLAGS=...` REPLACES configure's flags — silently
-    # dropping the hardening/optimization flags (-O2, -fstack-protector-strong,
-    # -fPIE, -ftrapv, ...) and producing an unhardened binary. CPPFLAGS merges
-    # with those flags instead.
-    #
-    # AWS-LC does not define the legacy OpenSSL BN_FLG_CONSTTIME flag. Setting
-    # it to 0 satisfies #ifdef checks in OpenSSH source code. This is safe:
-    # AWS-LC handles constant-time bignum operations internally and does not
-    # rely on this flag.
-    #
-    # --disable-pkcs11 avoids link errors from ssh-pkcs11.c calling
-    # RSA_meth_dup/EC_KEY_METHOD_get_sign which AWS-LC does not provide.
+    # OpenSSH >= 10 stubs BN_set_flags() for AWS-LC, so no -DBN_FLG_CONSTTIME
+    # shim is needed. Use a plain configure + make: a `make CFLAGS=...` override
+    # would clobber configure's hardening flags. --disable-pkcs11 avoids link
+    # errors from ssh-pkcs11.c referencing RSA/EC APIs that AWS-LC omits.
     && ./configure \
-        CPPFLAGS="-DBN_FLG_CONSTTIME=0" \
         --with-ssl-dir=/opt/aws-lc \
         --with-zlib \
         --with-ldflags=-static \

--- a/misc/images/openssh-static/Dockerfile
+++ b/misc/images/openssh-static/Dockerfile
@@ -15,9 +15,10 @@
 # OpenSSH natively supports AWS-LC as a crypto backend (no patches needed).
 # See: https://github.com/openssh/openssh-portable/blob/master/INSTALL
 #
-# FIPS support is built separately; see the SEC-236 FIPS draft (it requires a
-# FIPS-branch AWS-LC tag and OpenSSH >= 10.0, and is gated on AWS-LC-FIPS 3.x
-# completing NIST CMVP validation).
+# A FIPS build is available via AWS_LC_FIPS=1 (see the SEC-236 FIPS draft): it
+# builds AWS-LC from a FIPS-branch tag and requires OpenSSH >= 10.0. It is gated
+# on AWS-LC-FIPS 3.x completing NIST CMVP validation, so it is not yet
+# production-FIPS-ready.
 #
 # Usage:
 #   docker build -t openssh-static .
@@ -27,9 +28,27 @@
 
 FROM ubuntu:noble-20260509.1 AS builder
 
+# Non-FIPS builds use a regular AWS-LC release tag.
 ARG AWS_LC_VERSION=v1.54.0
-# OpenSSH >= 10.0 is required: it natively stubs BN_set_flags() for AWS-LC,
-# avoiding any need to hand-define the removed BN_FLG_CONSTTIME flag.
+# FIPS builds MUST use a tag from a FIPS branch, not a regular release tag.
+# Passing -DFIPS=1 against an arbitrary release produces a "FIPS-style" module
+# (self-tests + integrity check) that is NOT the NIST-validated module, so it
+# provides no actual FIPS 140-3 compliance.
+#
+#   AWS-LC-FIPS-2.0.x  -> NIST cert #4816 (static), but does NOT include EdDSA.
+#   AWS-LC-FIPS-3.x    -> adds EdDSA/Ed25519 to the module boundary.
+#
+# We pin the 3.x line because Materialize's SSH connection keys are Ed25519
+# (see mz-ssh-util keys.rs), so Ed25519 must be inside the validated boundary.
+# NOTE: AWS-LC-FIPS 3.x is currently "in process" with NIST CMVP (the static
+# module is in Comment Resolution), not yet certified. This image is therefore
+# NOT production-FIPS-ready until that certificate is awarded. Track status:
+#   https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list
+#
+# Ed25519 also only executes inside the module with OpenSSH >= 10.0, which
+# routes ed25519 through libcrypto instead of OpenSSH's bundled implementation.
+ARG AWS_LC_FIPS=0
+ARG AWS_LC_FIPS_VERSION=AWS-LC-FIPS-3.3.0
 ARG OPENSSH_VERSION=V_10_3_P1
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -48,9 +67,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     && rm -rf /var/lib/apt/lists/*
 
 # Build AWS-LC as a static library.
+# When AWS_LC_FIPS=1, enables FIPS mode (requires Go for the delocator).
 WORKDIR /build/aws-lc
-RUN git clone --depth 1 --branch ${AWS_LC_VERSION} https://github.com/aws/aws-lc.git . \
+RUN AWS_LC_REF="$([ "$AWS_LC_FIPS" = "1" ] && echo "$AWS_LC_FIPS_VERSION" || echo "$AWS_LC_VERSION")" \
+    && git clone --depth 1 --branch "$AWS_LC_REF" https://github.com/aws/aws-lc.git . \
     && cmake -GNinja -B build \
+        $([ "$AWS_LC_FIPS" = "1" ] && echo "-DFIPS=1") \
         -DBUILD_SHARED_LIBS=0 \
         -DBUILD_TESTING=OFF \
         -DBUILD_TOOL=OFF \
@@ -64,11 +86,23 @@ RUN git clone --depth 1 --branch ${AWS_LC_VERSION} https://github.com/aws/aws-lc
 WORKDIR /build/openssh
 RUN git clone --depth 1 --branch ${OPENSSH_VERSION} https://github.com/openssh/openssh-portable.git . \
     && autoreconf \
-    # OpenSSH >= 10 stubs BN_set_flags() for AWS-LC, so no -DBN_FLG_CONSTTIME
-    # shim is needed. Use a plain configure + make: a `make CFLAGS=...` override
-    # would clobber configure's hardening flags. --disable-pkcs11 avoids link
-    # errors from ssh-pkcs11.c referencing RSA/EC APIs that AWS-LC omits.
+    # Inject -DBN_FLG_CONSTTIME=0 via CPPFLAGS at configure time rather than
+    # as `make CFLAGS=...`. OpenSSH's Makefile.in uses a plain `CFLAGS=@CFLAGS@`
+    # assignment (no override, no CFLAGS_EXTRA in this version), so a
+    # command-line `make CFLAGS=...` REPLACES configure's flags — silently
+    # dropping the hardening/optimization flags (-O2, -fstack-protector-strong,
+    # -fPIE, -ftrapv, ...) and producing an unhardened binary. CPPFLAGS merges
+    # with those flags instead.
+    #
+    # AWS-LC does not define the legacy OpenSSL BN_FLG_CONSTTIME flag. Setting
+    # it to 0 satisfies #ifdef checks in OpenSSH source code. This is safe:
+    # AWS-LC handles constant-time bignum operations internally and does not
+    # rely on this flag.
+    #
+    # --disable-pkcs11 avoids link errors from ssh-pkcs11.c calling
+    # RSA_meth_dup/EC_KEY_METHOD_get_sign which AWS-LC does not provide.
     && ./configure \
+        CPPFLAGS="-DBN_FLG_CONSTTIME=0" \
         --with-ssl-dir=/opt/aws-lc \
         --with-zlib \
         --with-ldflags=-static \
@@ -76,7 +110,10 @@ RUN git clone --depth 1 --branch ${OPENSSH_VERSION} https://github.com/openssh/o
         --without-libedit \
         --disable-pkcs11 \
     && make -j"$(nproc)" ssh \
-    && strip ssh
+    # Stripping removes the symbols the FIPS integrity self-test needs to locate
+    # the module boundary, so a stripped FIPS binary fails its power-on
+    # self-test at the first crypto operation. Only strip non-FIPS builds.
+    && if [ "$AWS_LC_FIPS" != "1" ]; then strip ssh; fi
 
 # Verify the binary is not dynamically linked and is functional.
 RUN ! ldd ssh 2>/dev/null \

--- a/src/ssh-util/src/tunnel.rs
+++ b/src/ssh-util/src/tunnel.rs
@@ -232,6 +232,35 @@ impl SshTunnelHandle {
     }
 }
 
+/// Returns true if FIPS mode is enabled via the MZ_FIPS environment variable.
+fn fips_mode_enabled() -> bool {
+    std::env::var("MZ_FIPS").map_or(false, |v| v == "1" || v == "true")
+}
+
+/// Writes a temporary SSH config file that restricts algorithms to FIPS 140-3
+/// approved choices only. Returns the path to the config file.
+fn write_fips_ssh_config(dir: &std::path::Path) -> Result<std::path::PathBuf, anyhow::Error> {
+    let config_path = dir.join("ssh_config");
+    // EdDSA/Ed25519 is FIPS-approved under FIPS 186-5 and is in the AWS-LC-FIPS
+    // 3.x module boundary, so ssh-ed25519 is permitted for both the bastion host
+    // key (HostKeyAlgorithms) and our own client key (PubkeyAcceptedAlgorithms).
+    // Materialize's SSH connection keys are Ed25519 (see keys.rs), so omitting
+    // ssh-ed25519 from PubkeyAcceptedAlgorithms would break authentication; both
+    // lists must include it for parity. Requires the openssh-static binary built
+    // against AWS-LC-FIPS 3.x with OpenSSH >= 10.0 (ed25519 via libcrypto).
+    let config_contents = "\
+# FIPS 140-3 compliant SSH configuration.
+# Only NIST-approved algorithms are permitted.
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
+HostKeyAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-256,rsa-sha2-512,ssh-ed25519
+PubkeyAcceptedAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-256,rsa-sha2-512,ssh-ed25519
+";
+    fs::write(&config_path, config_contents)?;
+    Ok(config_path)
+}
+
 async fn connect(
     config: &SshTunnelConfig,
     timeout_config: SshTimeoutConfig,
@@ -247,6 +276,14 @@ async fn connect(
     // Remove write permissions as soon as the key is written.
     // Mostly helpful to ensure the file is not accidentally overwritten.
     tempfile.set_permissions(std::fs::Permissions::from_mode(0o400))?;
+
+    // In FIPS mode, write a restrictive SSH config that only allows
+    // NIST-approved algorithms.
+    let fips_config_path = if fips_mode_enabled() {
+        Some(write_fips_ssh_config(tempdir.path())?)
+    } else {
+        None
+    };
 
     // Try connecting to each host in turn.
     let mut connect_err = None;
@@ -264,6 +301,10 @@ async fn connect(
             .keyfile(&path)
             .server_alive_interval(timeout_config.keepalives_idle)
             .connect_timeout(timeout_config.connect_timeout);
+
+        if let Some(ref fips_config) = fips_config_path {
+            builder.config_file(fips_config);
+        }
 
         match builder.connect_mux(host.clone()).await {
             Ok(session) => {


### PR DESCRIPTION
## Summary

The FIPS portion carved out of #35858, reworked per the post-merge QA review (https://github.com/MaterializeInc/materialize/pull/35858#issuecomment-4582060423) and re-targeted at the AWS-LC-FIPS **3.x** line.

> [!WARNING]
> **Not production-FIPS-ready yet.** AWS-LC-FIPS 3.x is still *in process* with NIST CMVP (the static module is in Comment Resolution), so it provides no validated-module compliance until the certificate is awarded. This PR stays a **draft** until then. Track status: https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list

Depends on / pairs with #36858 (removes this FIPS code from `main`). Once #36858 merges, this branch will be rebased so its diff is a clean "add FIPS".

### Why AWS-LC-FIPS 3.x + OpenSSH 10

Materialize's SSH connection keys are **Ed25519** (`mz-ssh-util` `keys.rs`). Ed25519 is FIPS-approved under FIPS 186-5, but only enters a *validated module boundary* on the **AWS-LC-FIPS 3.x** line (2.0 / cert #4816 does not include EdDSA). It also only executes inside the module with **OpenSSH ≥ 10.0**, which routes ed25519 through libcrypto instead of OpenSSH's bundled implementation. Both bumps are required for the ed25519 client key to be in-boundary.

### Changes (addressing the QA findings)

- **F1 (HIGH)**: strip only non-FIPS builds — stripping removes the symbols the FIPS integrity self-test needs to locate the module, so a stripped FIPS binary fails its power-on self-test.
- **F2 (MED)**: pin the FIPS build to a FIPS-branch tag (`AWS-LC-FIPS-3.3.0`) via a dedicated `AWS_LC_FIPS_VERSION` arg, not a generic release tag (`-DFIPS=1` on a release tag yields a non-validated "FIPS-style" module).
- **F3 (MED)**: inject `-DBN_FLG_CONSTTIME=0` via configure `CPPFLAGS` instead of `make CFLAGS=...`, preserving hardening/optimization flags.
- **F4 (LOW)**: keep `ssh-ed25519` in **both** `HostKeyAlgorithms` and `PubkeyAcceptedAlgorithms` (required for the ed25519 client key; valid for host keys on the 3.x module).
- Bump OpenSSH to `V_10_3_P1`.

Part of [SEC-236](https://linear.app/materializeinc/issue/SEC-236).

## Test plan

- [x] `cargo check -p mz-ssh-util` passes (rustc 1.96.0)
- [x] `cargo fmt -p mz-ssh-util --check` clean
- [x] Docker build of `misc/images/openssh-static/ --build-arg AWS_LC_FIPS=1` produces a working static binary (verified: `OpenSSH_10.3p1, AWS-LC FIPS 3.3.0`; 6.5M, statically linked, **not** stripped, integrity symbols intact)
- [x] FIPS load-time integrity self-test passes (binary runs to exit 0 rather than aborting in the self-test loop). Full power-on KAT suite under a real connection still untested.
- [ ] Block on AWS-LC-FIPS 3.x NIST certificate before un-drafting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
