### PR TITLE
storage: drop already-persisted updates in upsert-v2 so lagging writers converge

### DIFF
--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -1308,4 +1308,176 @@ mod test {
             handle.join().expect("threads completed successfully");
         }
     }
+
+    /// v1 counterpart of v2's `lagging_replacement_below_upper_strands_data`,
+    /// under the IDENTICAL setup: the external writer has advanced the feedback
+    /// `persist_upper` to T = 10 with no operator output, and the lagging
+    /// replacement then produces source data at ts BELOW that upper (5 and 7).
+    ///
+    /// v1's drain classifies any `ts` in the past of `persist_upper` as not
+    /// relevant (`relevant = persist_upper.less_equal(ts)`) and DROPS it — the
+    /// downstream persist_sink would filter it anyway since the shard upper is
+    /// already further ahead. So v1 strands nothing and its output frontier
+    /// advances cleanly past persist_upper (here to the input upper, 11),
+    /// unlike v2, which without its drop-fix pins below.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)]
+    fn lagging_replacement_below_upper_is_dropped() {
+        let mz_ts = |ts| (MzTimestamp::new(ts), Subtime::minimum());
+        let (tx, rx) = mpsc::channel::<std::thread::JoinHandle<()>>();
+
+        let rocksdb_dir = tempfile::tempdir().unwrap();
+        let (frontier, capture) = timely::execute_directly(move |worker| {
+            let tx = tx.clone();
+            let (mut input, mut persist, probe, capture) =
+                worker.dataflow::<MzTimestamp, _, _>(|scope| {
+                    scope.scoped::<(MzTimestamp, Subtime), _, _>("upsert", |scope| {
+                        let (input_handle, input) = scope.new_input();
+                        let (persist_handle, persist_input) = scope.new_input();
+                        let upsert_config = UpsertConfig {
+                            shrink_upsert_unused_buffers_by_ratio: 0,
+                        };
+                        let source_id = GlobalId::User(0);
+                        let metrics_registry = MetricsRegistry::new();
+                        let upsert_metrics_defs =
+                            UpsertMetricDefs::register_with(&metrics_registry);
+                        let upsert_metrics =
+                            UpsertMetrics::new(&upsert_metrics_defs, source_id, 0, None);
+                        let rocksdb_shared_metrics = Arc::clone(&upsert_metrics.rocksdb_shared);
+                        let rocksdb_instance_metrics =
+                            Arc::clone(&upsert_metrics.rocksdb_instance_metrics);
+
+                        let metrics_registry = MetricsRegistry::new();
+                        let storage_metrics = StorageMetrics::register_with(&metrics_registry);
+
+                        let metrics_registry = MetricsRegistry::new();
+                        let source_statistics_defs =
+                            SourceStatisticsMetricDefs::register_with(&metrics_registry);
+                        let envelope = SourceEnvelope::Upsert(UpsertEnvelope {
+                            source_arity: 2,
+                            style: UpsertStyle::Default(KeyEnvelope::Flattened),
+                            key_indices: vec![0],
+                        });
+                        let source_statistics = SourceStatistics::new(
+                            source_id,
+                            0,
+                            &source_statistics_defs,
+                            source_id,
+                            &ShardId::new(),
+                            envelope,
+                            Antichain::from_elem(Timestamp::minimum()),
+                        );
+
+                        let source_config = SourceExportCreationConfig {
+                            id: GlobalId::User(0),
+                            worker_id: 0,
+                            metrics: storage_metrics,
+                            source_statistics,
+                        };
+
+                        let rocksdb_init_fn = move || async move {
+                            let merge_operator = Some((
+                                "upsert_state_snapshot_merge_v1".to_string(),
+                                |a: &[u8],
+                                 b: ValueIterator<
+                                    BincodeOpts,
+                                    StateValue<(MzTimestamp, Subtime), u64>,
+                                >| {
+                                    consolidating_merge_function::<(MzTimestamp, Subtime), u64>(
+                                        a.into(),
+                                        b,
+                                    )
+                                },
+                            ));
+                            let rocksdb_cleanup_tries = 5;
+                            let tuning = RocksDBConfig::new(Default::default(), None);
+                            let mut rocksdb_inst = mz_rocksdb::RocksDBInstance::new(
+                                rocksdb_dir.path(),
+                                mz_rocksdb::InstanceOptions::new(
+                                    Env::mem_env().unwrap(),
+                                    rocksdb_cleanup_tries,
+                                    merge_operator,
+                                    upsert_bincode_opts(),
+                                ),
+                                tuning,
+                                rocksdb_shared_metrics,
+                                rocksdb_instance_metrics,
+                            )
+                            .unwrap();
+
+                            let handle = rocksdb_inst.take_core_loop_handle().expect("join handle");
+                            tx.send(handle).expect("sent joinhandle");
+                            crate::upsert::rocksdb::RocksDB::new(rocksdb_inst)
+                        };
+
+                        let (output, _, _, button) = upsert_inner(
+                            input.as_collection(),
+                            vec![0],
+                            Antichain::from_elem(Timestamp::minimum()),
+                            persist_input.as_collection(),
+                            None,
+                            upsert_metrics,
+                            source_config,
+                            rocksdb_init_fn,
+                            upsert_config,
+                            true,
+                            None,
+                        );
+                        std::mem::forget(button);
+
+                        let (probe, stream) = output.inner.probe();
+                        (input_handle, persist_handle, probe, stream.capture())
+                    })
+                });
+
+            let key0 = UpsertKey::from_key(Ok(&Row::pack_slice(&[Datum::Int64(0)])));
+            let key1 = UpsertKey::from_key(Ok(&Row::pack_slice(&[Datum::Int64(1)])));
+            let value0 = Row::pack_slice(&[Datum::Int64(0), Datum::Int64(1)]);
+            let value1 = Row::pack_slice(&[Datum::Int64(1), Datum::Int64(2)]);
+
+            // External writer has advanced the feedback persist_upper to T = 10
+            // WITHOUT the operator emitting anything itself.
+            persist.advance_to(mz_ts(10));
+            for _ in 0..20 {
+                worker.step();
+            }
+
+            // Lagging replacement produces source data at ts BELOW the current
+            // persist_upper (5 and 7 while persist_upper = 10).
+            input.send(((key0, Some(Ok(value0)), 1), mz_ts(5), Diff::ONE));
+            input.send(((key1, Some(Ok(value1)), 2), mz_ts(7), Diff::ONE));
+            input.advance_to(mz_ts(11));
+            for _ in 0..20 {
+                worker.step();
+            }
+
+            (probe.with_frontier(|f| f.to_vec()), capture)
+        });
+
+        let mut emitted: Vec<_> = capture
+            .extract()
+            .into_iter()
+            .flat_map(|(_cap, c)| c)
+            .collect();
+        differential_dataflow::consolidation::consolidate_updates(&mut emitted);
+
+        // v1 drops the below-upper data and lets its output frontier advance
+        // freely (here to the input upper, 11): nothing is stranded, and the
+        // frontier is never pinned below the shard upper (10).
+        assert!(emitted.is_empty(), "v1 emitted {emitted:?}");
+        assert_eq!(
+            frontier,
+            vec![mz_ts(11)],
+            "v1 output frontier should advance to the input upper, not pin below \
+             persist_upper as v2 does"
+        );
+        assert!(
+            frontier[0] >= mz_ts(10),
+            "v1 output frontier {frontier:?} should reach at least persist_upper (10)"
+        );
+
+        while let Ok(handle) = rx.recv() {
+            handle.join().expect("threads completed successfully");
+        }
+    }
 }

--- a/src/storage/src/upsert_continual_feedback_v2.rs
+++ b/src/storage/src/upsert_continual_feedback_v2.rs
@@ -48,6 +48,10 @@
 //!      cursor, emit a retraction if present, and emit the new value.
 //!    - **Ineligible** (between persist and input frontiers): persist hasn't
 //!      caught up yet. Push back into the batcher for the next iteration.
+//!    - **Already persisted** (below the persist frontier): some writer has
+//!      already advanced the shard past this time, so it is dropped. See
+//!      [`drain_sealed_input`] for why re-stashing it would strand the data
+//!      and pin the output frontier below the shard upper.
 //!
 //! 4. **Capability management.** Downgrade the output capability to the
 //!    minimum time of any remaining buffered data (in the batcher or pushed
@@ -59,7 +63,9 @@
 //! For a total-order timestamp with `input_upper = {i}` and
 //! `persist_upper = {p}`, an entry at time `ts` is eligible when
 //! `ts == p < i` — the source has finalized it and persist is exactly at
-//! that time, so the trace cursor returns the correct prior state.
+//! that time, so the trace cursor returns the correct prior state. An entry
+//! with `p < ts` is ineligible (persist hasn't caught up), and one with
+//! `ts < p` is already persisted and dropped.
 
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -592,9 +598,11 @@ struct DrainStats {
     output_count: u64,
 }
 
-/// Process sealed chunks from the batcher. Entries at the persist frontier are
-/// eligible for processing (cursor lookup + output); all others are returned
-/// in `ineligible` for re-stashing.
+/// Process sealed chunks from the batcher, classifying each entry by its
+/// timestamp relative to `persist_upper`: entries at the frontier are eligible
+/// for processing now (cursor lookup + output), entries above it are returned
+/// in `ineligible` for re-stashing, and entries below it are already persisted
+/// and dropped (see the body for why).
 ///
 /// The sealed chunks are already sorted and consolidated by the MergeBatcher,
 /// so the trace cursor walks forward through keys in order — seeks amortize.
@@ -612,15 +620,34 @@ where
     T: columnation::Columnation,
     FromTime: timely::ExchangeData + Clone + Ord + Sync,
 {
-    // Separate eligible (at persist frontier) from ineligible.
+    // Classify each entry by its timestamp relative to `persist_upper`:
+    //
+    //   * `ts == persist_upper`: eligible for processing now.
+    //   * `ts >  persist_upper`: not yet processable; re-stashed (ineligible)
+    //     until the feedback frontier catches up to it.
+    //   * `ts <  persist_upper`: already persisted by some writer and not
+    //     relevant anymore. We DROP it. The downstream persist_sink would
+    //     filter such updates out anyway since the shard upper is further
+    //     ahead, and our state is already up-to-date to `persist_upper` so we
+    //     could not emit correct retractions for it. Re-stashing it would
+    //     strand the data forever (`persist_upper` only advances, so
+    //     `ts == persist_upper` can never again hold) and pin the operator's
+    //     output frontier below the shard upper. This mirrors v1's
+    //     `relevant = persist_upper.less_equal(ts)`.
     let mut eligible = Vec::new();
     for chunk in sealed {
         for entry in chunk {
             let (_, ref ts, _) = entry;
-            if !persist_upper.less_than(ts) && persist_upper.less_equal(ts) {
-                eligible.push(entry);
-            } else {
+            if !persist_upper.less_equal(ts) {
+                // ts < persist_upper: drop.
+                continue;
+            }
+            if persist_upper.less_than(ts) {
+                // ts > persist_upper: re-stash for later.
                 ineligible.push(entry);
+            } else {
+                // ts == persist_upper: process now.
+                eligible.push(entry);
             }
         }
     }
@@ -1093,5 +1120,131 @@ mod test {
         let expected: Vec<(Result<Row, DataflowError>, _, _)> =
             vec![(Ok(val), new_ts(0), Diff::ONE)];
         assert_eq!(actual, expected);
+    }
+
+    /// Operator-level repro of the 0dt read-only-handoff stranding bug.
+    ///
+    /// Models a lagging replacement generation: the external (old) writer has
+    /// already advanced the shard — and therefore the feedback `persist_upper`
+    /// — to `T = 10`, while the operator itself has emitted nothing. The
+    /// lagging replacement now produces source data at timestamps BELOW that
+    /// upper (`ts = 5, 7`), i.e. data the external writer has already persisted.
+    ///
+    /// `drain_sealed_input` DROPS such already-persisted data (it satisfies
+    /// neither `ts == persist_upper` nor `ts > persist_upper`), mirroring v1's
+    /// `relevant = persist_upper.less_equal(ts)`. Were it instead re-stashed,
+    /// the data would be stranded forever — `persist_upper` only advances, so
+    /// `ts == persist_upper` could never again hold — and `min_ineligible_ts`
+    /// would pin the operator's output capability at `ts = 5`, BELOW the shard
+    /// upper, where it would stay for good. Dropping it lets the frontier
+    /// advance freely.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)]
+    fn lagging_replacement_below_upper_strands_data() {
+        let (frontier, emitted) = run_below_upper_scenario_v2();
+
+        // The below-upper data is discarded (no output) and the output frontier
+        // is not pinned below the shard upper (10); it advances to the input
+        // upper (11), matching v1's behavior.
+        assert!(
+            emitted.is_empty(),
+            "below-upper data should be dropped, not emitted; got {emitted:?}"
+        );
+        assert_eq!(
+            frontier,
+            vec![new_ts(11)],
+            "v2 output frontier should advance to the input upper, not pin below \
+             persist_upper"
+        );
+        assert!(
+            frontier[0] >= new_ts(10),
+            "v2 output frontier {frontier:?} should reach at least persist_upper (10)"
+        );
+    }
+
+    /// Shared driver for the lagging-replacement scenario against v2. Returns
+    /// `(output_frontier, consolidated_emitted_updates)`.
+    fn run_below_upper_scenario_v2() -> (Vec<Ts>, Vec<(Result<Row, DataflowError>, Ts, Diff)>) {
+        use timely::dataflow::operators::Probe;
+
+        let (frontier, capture) = timely::execute_directly(move |worker| {
+            let (mut input, mut persist, probe, capture) =
+                worker.dataflow::<MzTimestamp, _, _>(|scope| {
+                    scope.scoped::<Ts, _, _>("upsert", |scope| {
+                        let (input_handle, input) = scope.new_input();
+                        let (persist_handle, persist_input) = scope.new_input();
+                        let source_id = GlobalId::User(0);
+
+                        let reg = MetricsRegistry::new();
+                        let upsert_defs = UpsertMetricDefs::register_with(&reg);
+                        let upsert_metrics = UpsertMetrics::new(&upsert_defs, source_id, 0, None);
+
+                        let reg2 = MetricsRegistry::new();
+                        let storage_metrics = StorageMetrics::register_with(&reg2);
+
+                        let reg3 = MetricsRegistry::new();
+                        let stats_defs = SourceStatisticsMetricDefs::register_with(&reg3);
+                        let envelope = SourceEnvelope::Upsert(UpsertEnvelope {
+                            source_arity: 2,
+                            style: UpsertStyle::Default(KeyEnvelope::Flattened),
+                            key_indices: vec![0],
+                        });
+                        let source_statistics = SourceStatistics::new(
+                            source_id,
+                            0,
+                            &stats_defs,
+                            source_id,
+                            &ShardId::new(),
+                            envelope,
+                            Antichain::from_elem(Timestamp::minimum()),
+                        );
+                        let source_config = SourceExportCreationConfig {
+                            id: source_id,
+                            worker_id: 0,
+                            metrics: storage_metrics,
+                            source_statistics,
+                        };
+
+                        let (output, _, _, button) = upsert_inner(
+                            input.as_collection(),
+                            vec![0],
+                            Antichain::from_elem(Timestamp::minimum()),
+                            persist_input.as_collection(),
+                            None,
+                            upsert_metrics,
+                            source_config,
+                        );
+                        std::mem::forget(button);
+                        let (probe, stream) = output.inner.probe();
+                        (input_handle, persist_handle, probe, stream.capture())
+                    })
+                });
+
+            // The external writer has advanced the shard (feedback persist_upper)
+            // to T = 10 WITHOUT the operator emitting anything itself.
+            persist.advance_to(new_ts(10));
+            for _ in 0..20 {
+                worker.step();
+            }
+
+            // The lagging replacement produces source data at ts BELOW the
+            // current persist_upper (5 and 7 while persist_upper = 10).
+            input.send(((key(0), Some(Ok(row(0, 1))), 1), new_ts(5), Diff::ONE));
+            input.send(((key(1), Some(Ok(row(1, 2))), 2), new_ts(7), Diff::ONE));
+            input.advance_to(new_ts(11));
+            for _ in 0..20 {
+                worker.step();
+            }
+
+            (probe.with_frontier(|f| f.to_vec()), capture)
+        });
+
+        let mut emitted: Vec<_> = capture
+            .extract()
+            .into_iter()
+            .flat_map(|(_cap, c)| c)
+            .collect();
+        differential_dataflow::consolidation::consolidate_updates(&mut emitted);
+        (frontier, emitted)
     }
 }


### PR DESCRIPTION
An upsert-v2 Kafka data export's output shard could freeze permanently whenever
a second writer advanced the shard ahead of this operator: the export's persist
write_frontier stopped advancing, the parent source kept ingesting, the source
reported `running` with no error, and the downstream stayed stale for hours.

## The bug

The upsert continual-feedback operators read their own output shard back as a
"feedback" input and emit a datum at `ts` only once the feedback frontier
(the shard upper) reaches it. v2's `drain_sealed_input` classified each
buffered datum two ways: eligible iff `ts == persist_upper`, everything else
ineligible and re-stashed. That "everything else" lumped together two very
different cases -- `ts > persist_upper` (legitimately not yet emittable) and
`ts < persist_upper` (already persisted by another writer). Re-stashing the
latter is a trap: `persist_upper` only advances, so `ts == persist_upper`
can never again hold, the datum is re-stashed forever, and -- because the
operator downgrades its output capability to `min_ineligible_ts` -- its output
frontier gets pinned BELOW the shard upper. With the output frontier pinned,
`mint_batch_descriptions` mints nothing, the sink never appends, the shard
never advances, and the feedback loop is wedged.

## Why a single writer never hits it, but any concurrent writer can

The bug needs a datum at `ts < persist_upper` in the batcher, and a single
writer can never produce one. The only thing that advances `persist_upper` is
this operator's own output flowing back through its sink: it emits at `ts`
exactly when `persist_upper == ts`, the sink writes `[ts, ts+1)`, and
`persist_upper` becomes `ts+1`. By the time `persist_upper` is past `ts` that
datum has already been emitted -- the operator is never holding a datum while
the feedback races past it, because it is itself what moves the feedback.

A *second* writer on the same shard breaks that invariant. The persist sink is
a multi-writer `compare_and_append` race: peers render the same deterministic
dataflow, reclock the same offsets to the same timestamps, and CaS-dedup their
identical batches -- whoever wins advances the shard, the others find the upper
already moved (see persist_sink's "it was us or someone" accounting). The loser
of a race then holds buffered data at timestamps a peer has already committed,
i.e. `ts < persist_upper`, and -- on the old code -- strands it. This arises
in any configuration with a concurrent writer:

  * Active-active storage replication, in ordinary steady state and BY DESIGN:
    both replicas write, race every batch, and the one that loses a CaS jump
    can strand. No upgrade or read-only mode required.
  * 0dt cutover: the old generation is read-write and far ahead while the new
    (replacement) generation rehydrates cold and read-only. (The startup
    `resume_upper` filter drops already-persisted data, but it is captured once
    at startup; data the old writer overtakes *during* catch-up slips past it.)
  * Controller restart / reconnect / failover windows where a fresh instance
    hydrates while a prior incarnation's writes are still landing.

## It is a race -- hit rate scales with the lag

Stranding requires a peer to jump `persist_upper` past a datum in the window
between when this writer buffers it and its next drain, with that datum still
buffered at the deciding instant. So the probability scales with how far behind
the at-risk writer is:

  * Warm active-active (both hydrated, racing in lockstep): the gap is at most
    a little CaS jitter plus one batch, so stranding is RARE -- but a GC pause,
    scheduling hiccup, or source burst can widen the window, so it is not zero.
  * Cold 0dt catch-up (replacement far behind a caught-up writer): a large
    backlog sits below the upper essentially the whole time, so stranding is
    NEAR-CERTAIN. This is where it was actually observed.

Either way the failure is sticky and silent: once it strands, the earliest
stranded `ts` pins the frontier for good (`persist_upper` only climbs, so the
datum can never become eligible again), status stays `running` with no error,
and only a dataflow restart clears it (`resume_upper` re-drops the sub-upper
data) -- but nothing triggers one. A rare per-moment event over a long-running
deployment converges toward "happens eventually," and is terminal when it does.

## The fix

Classify three ways and DROP `ts < persist_upper` (already persisted by a
peer; we could not emit correct retractions for it and the sink would filter
it anyway), re-stash only `ts > persist_upper`, process `ts == persist_upper`.
This mirrors v1's `relevant = persist_upper.less_equal(ts)` and lets the output
frontier advance past the shard upper instead of pinning below it. The happy
path (`==` and `>`) is unchanged; only the below-upper case flips from
"re-stash forever / pin the frontier" to "drop and advance."

## Tested

- `lagging_replacement_below_upper_strands_data` (v2): drives the exact shape
  -- feedback advanced to T=10 with no operator output, then source data at
  ts=5,7 < T. Without the fix the output frontier pins at 5 (verified: the test
  fails with `left: [(5)]`); with the fix the data is dropped and the frontier
  advances to 11.
- `lagging_replacement_below_upper_is_dropped` (v1): the same scenario against
  v1, asserting it already drops the data and advances cleanly -- the contrast
  that makes v2 the outlier.
