### PR TITLE
mzcompose: raise Postgres SSI predicate-lock limits for the metadata store

### DIFF
--- a/misc/python/materialize/mzcompose/services/postgres.py
+++ b/misc/python/materialize/mzcompose/services/postgres.py
@@ -93,6 +93,23 @@ class PostgresMetadata(Postgres):
             setup_materialize=True,
             ports=["26257"],
             restart=restart,
+            # Persist's compare-and-append runs the consensus connection at
+            # SERIALIZABLE isolation, so all metadata-store traffic goes through
+            # Postgres SSI. Under a concurrent compare-and-append burst (e.g.
+            # many clusterds cold-starting at once) the default predicate-lock
+            # pool exhausts and Postgres throws "not enough elements in
+            # RWConflictPool", triggering a retry storm. Raise the limits well
+            # above defaults. These GUCs only matter for the SSI consensus path,
+            # which is why they live on PostgresMetadata, not the base Postgres
+            # used for CDC/source instances.
+            extra_command=[
+                "-c",
+                "max_pred_locks_per_transaction=1024",
+                "-c",
+                "max_pred_locks_per_relation=10000",
+                "-c",
+                "max_pred_locks_per_page=512",
+            ],
         )
 
     @staticmethod


### PR DESCRIPTION
### Motivation

Persist's compare-and-append runs the consensus connection at `SERIALIZABLE` isolation, so all metadata-store traffic goes through Postgres SSI.
Under a concurrent compare-and-append burst (e.g. many clusterds cold-starting at once) the default predicate-lock pool exhausts and Postgres throws `not enough elements in RWConflictPool`, triggering a retry storm.
The `test/limits` committer-comparison observed this as a hydration collapse (399s wall, 214s tail at 1600 MVs) that vanished once the limits were raised, confirming it was a misconfigured-Postgres artifact.

### Description

Set `max_pred_locks_per_transaction`, `max_pred_locks_per_relation`, and `max_pred_locks_per_page` on `PostgresMetadata`, so every CI composition that uses Postgres as the metadata store inherits a correctly-configured server.
Scoped to `PostgresMetadata` rather than the base `Postgres`, since CDC/source instances do not run `SERIALIZABLE` consensus and don't need the larger pool.

### Verification

Brought up a Postgres with the flags and confirmed `SHOW max_pred_locks_per_transaction/_per_relation/_per_page` return `1024`/`10000`/`512`.
Postgres rejects invalid GUCs at boot, so a healthy container already implies the names are valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)