### PR TITLE
sql: return NULL from pg_cancel_backend(NULL) instead of panicking

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2223,6 +2223,15 @@ impl Coordinator {
     ) {
         match plan {
             SideEffectingFunc::PgCancelBackend { connection_id } => {
+                let Some(connection_id) = connection_id else {
+                    // The argument was `NULL`, so, like in PostgreSQL, the
+                    // function returns `NULL`.
+                    ctx.retire(Ok(Self::send_immediate_rows(Row::pack_slice(&[
+                        Datum::Null,
+                    ]))));
+                    return;
+                };
+
                 if ctx.session().conn_id().unhandled() == connection_id {
                     // As a special case, if we're canceling ourselves, we send
                     // back a canceled resposne to the client issuing the query,
@@ -2261,6 +2270,12 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         match plan {
             SideEffectingFunc::PgCancelBackend { connection_id } => {
+                let Some(connection_id) = connection_id else {
+                    // The argument was `NULL`, so, like in PostgreSQL, the
+                    // function returns `NULL`.
+                    return Ok(Self::send_immediate_rows(Row::pack_slice(&[Datum::Null])));
+                };
+
                 if conn_id.unhandled() == connection_id {
                     // As a special case, if we're canceling ourselves, we return
                     // a canceled response to the client issuing the query,

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3098,6 +3098,40 @@ fn test_pg_cancel_backend() {
     );
 }
 
+/// Regression test for SQL-295: `pg_cancel_backend(NULL)` used to panic while
+/// planning the call (`Datum::unwrap_int32 called on Null`). Like in
+/// PostgreSQL, a `NULL` argument must return `NULL` instead.
+#[mz_ore::test]
+fn test_pg_cancel_backend_null() {
+    mz_ore::test::init_logging();
+    let server = test_util::TestHarness::default().start_blocking();
+
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    // A `NULL` argument returns `NULL`, matching PostgreSQL, rather than
+    // panicking. Cover the literal `NULL`, an explicitly-typed `NULL`, a `NULL`
+    // bound parameter, and an expression that evaluates to `NULL`.
+    for query in [
+        "SELECT pg_cancel_backend(NULL)",
+        "SELECT pg_cancel_backend(NULL::int4)",
+    ] {
+        let found_conn: Option<bool> = client.query_one(query, &[]).unwrap().get(0);
+        assert_eq!(found_conn, None, "query: {query}");
+    }
+
+    let found_conn: Option<bool> = client
+        .query_one("SELECT pg_cancel_backend($1)", &[&None::<i32>])
+        .unwrap()
+        .get(0);
+    assert_eq!(found_conn, None);
+
+    let found_conn: Option<bool> = client
+        .query_one("SELECT pg_cancel_backend($1 + 42)", &[&None::<i32>])
+        .unwrap()
+        .get(0);
+    assert_eq!(found_conn, None);
+}
+
 // Test params in interesting places.
 #[mz_ore::test]
 fn test_params() {

--- a/src/sql/src/plan/side_effecting_func.rs
+++ b/src/sql/src/plan/side_effecting_func.rs
@@ -60,8 +60,9 @@ use crate::plan::{PlanError, QueryContext};
 pub enum SideEffectingFunc {
     /// The `pg_cancel_backend` function.
     PgCancelBackend {
-        // The ID of the connection to cancel.
-        connection_id: u32,
+        // The ID of the connection to cancel, or `None` if the argument was
+        // `NULL`, in which case the function returns `NULL`.
+        connection_id: Option<u32>,
     },
 }
 
@@ -287,10 +288,14 @@ const PG_CANCEL_BACKEND: SideEffectingFuncImpl = SideEffectingFuncImpl {
     name: "pg_cancel_backend",
     oid: 2171,
     param_types: &[SqlScalarType::Int32],
-    return_type: SqlScalarType::Bool.nullable(false),
+    // Like in PostgreSQL, the function returns `NULL` when its argument is
+    // `NULL`, so the output column is nullable.
+    return_type: SqlScalarType::Bool.nullable(true),
     plan_fn: |datums| -> SideEffectingFunc {
-        SideEffectingFunc::PgCancelBackend {
-            connection_id: u32::reinterpret_cast(datums[0].unwrap_int32()),
-        }
+        let connection_id = match datums[0] {
+            Datum::Null => None,
+            datum => Some(u32::reinterpret_cast(datum.unwrap_int32())),
+        };
+        SideEffectingFunc::PgCancelBackend { connection_id }
     },
 };

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -1469,9 +1469,15 @@ fn generate_rbac_requirements(
         },
         Plan::SideEffectingFunc(func) => {
             let role_membership = match func {
-                SideEffectingFunc::PgCancelBackend { connection_id } => active_conns
-                    .expect("active_conns is required for Plan::SideEffectingFunc")(
-                    *connection_id
+                // A `NULL` argument cancels no connection (the function returns
+                // `NULL`), so there is no role membership to require.
+                SideEffectingFunc::PgCancelBackend {
+                    connection_id: None,
+                } => BTreeSet::new(),
+                SideEffectingFunc::PgCancelBackend {
+                    connection_id: Some(connection_id),
+                } => active_conns.expect("active_conns is required for Plan::SideEffectingFunc")(
+                    *connection_id,
                 )
                 .map(|x| [x].into())
                 .unwrap_or_default(),


### PR DESCRIPTION
`SELECT pg_cancel_backend(null)` panicked in the planner with `Datum::unwrap_int32 called on Null` because the side-effecting-function plan_fn unconditionally unwrapped the argument as an int32.

PostgreSQL treats pg_cancel_backend as strict (NULL input -> NULL
output), so match that: PgCancelBackend now carries an Option<u32>
connection id, the planned return type is nullable, and a None id short-circuits to a NULL result.

Note on duplication: the NULL short-circuit and its explanatory comment are duplicated across sequence_side_effecting_func (old peek sequencing) and execute_side_effecting_func (frontend peek path). This mirrors the existing duplication of the cancel logic between those two functions -- the old peek-sequencing path is slated for removal (see the existing TODO(peek-seq)), at which point the duplicate goes away with it. Rather than introduce a shared helper for code that is about to be deleted, the behavior is kept duplicated alongside the code it lives next to.

Fixes SQL-295.