### PR TITLE
Fix `ConstantVisitor` to recurse into `TableFactor`s

### DIFF
--- a/src/sql/src/ast.rs
+++ b/src/sql/src/ast.rs
@@ -44,5 +44,8 @@ impl<'ast, T: AstInfo> Visit<'ast, T> for ConstantVisitor {
         if matches!(node, TableFactor::Table { .. }) {
             self.constant = false;
         }
+        // Recurse so that non-`Table` table factors (e.g. `Derived`, `Function`,
+        // `NestedJoin`) still have their inner table references inspected.
+        visit::visit_table_factor(self, node);
     }
 }

--- a/test/testdrive/insert-select.td
+++ b/test/testdrive/insert-select.td
@@ -47,6 +47,49 @@ contains:column "i" is of type integer but expression is of type text
 ! INSERT INTO t SELECT * FROM t;
 contains:cannot be run inside a transaction block
 
+# Regression tests for ConstantVisitor (SQL-298)
+
+# Each of the following cases needs its own transaction because a failed
+# statement aborts the surrounding block ("current transaction is aborted,
+# commands ignored until end of transaction block").
+
+> ROLLBACK
+> BEGIN
+> INSERT INTO t VALUES (11, 12, 'f')
+
+# TableFactor::Derived — table reference hidden inside a parenthesized subquery.
+! INSERT INTO t SELECT * FROM (SELECT * FROM t) AS s;
+contains:cannot be run inside a transaction block
+
+> ROLLBACK
+> BEGIN
+> INSERT INTO t VALUES (11, 12, 'f')
+
+# TableFactor::Derived — table reference inside a nested subquery via UNION.
+! INSERT INTO t SELECT * FROM (SELECT * FROM t UNION ALL SELECT 99, 99, 'z') AS s;
+contains:cannot be run inside a transaction block
+
+> ROLLBACK
+> BEGIN
+> INSERT INTO t VALUES (11, 12, 'f')
+
+# TableFactor::Function — table reference hidden in a function argument
+# subquery. generate_series is a table function; the (SELECT ...) is an arg.
+! INSERT INTO t SELECT g::int, g::real, g::text
+    FROM generate_series(1, (SELECT max(i) FROM t)::bigint) AS g;
+contains:cannot be run inside a transaction block
+
+> ROLLBACK
+> BEGIN
+> INSERT INTO t VALUES (11, 12, 'f')
+
+# TableFactor::NestedJoin — parenthesized join hides the inner Table factors.
+! INSERT INTO t SELECT a.i, a.f, a.t FROM (t AS a CROSS JOIN t AS b);
+contains:cannot be run inside a transaction block
+
+> ROLLBACK
+> BEGIN
+
 > COMMIT
 
 > SELECT * FROM t ORDER BY i


### PR DESCRIPTION
Fixes https://linear.app/materializeinc/issue/SQL-298/non-constant-insert-select-are-classified-as-constant