### PR TITLE
Error gracefully if a `SUBSCRIBE` key has duplicate columns

### DIFF
--- a/src/adapter/src/active_compute_sink.rs
+++ b/src/adapter/src/active_compute_sink.rs
@@ -269,7 +269,18 @@ impl ActiveSubscribe {
                     // [(key, v1, -1), (key, v2, +1)] => ("upsert", key, v1, v2)
                     // [(key, value, -1)] => ("delete", key, value, NULL)
                     // everything else => ("key_violation", key, NULL, NULL)
-                    let value_columns = self.arity - order_by_keys.len();
+                    // Defense in depth: the planner ensures that KEY columns are
+                    // distinct columns of the underlying relation, so this
+                    // subtraction must never underflow. If it does, we'd OOM
+                    // the coordinator with a giant loop, so check it here.
+                    mz_ore::soft_assert_or_log!(
+                        order_by_keys.len() <= self.arity,
+                        "SUBSCRIBE ENVELOPE has more KEY columns ({}) than \
+                         relation arity ({}); planner should have rejected this",
+                        order_by_keys.len(),
+                        self.arity,
+                    );
+                    let value_columns = self.arity.saturating_sub(order_by_keys.len());
                     let mut packer = row_buf.packer();
                     match &group[..] {
                         [(row, _, Diff::ONE)] => {
@@ -307,7 +318,7 @@ impl ActiveSubscribe {
                                     }
                                 }
                             }
-                            for _ in 0..self.arity - order_by_keys.len() {
+                            for _ in 0..value_columns {
                                 packer.push(Datum::Null);
                             }
                             push_row(row_buf.as_row_ref(), *start.1, Diff::ZERO)
@@ -341,11 +352,11 @@ impl ActiveSubscribe {
                                 packer.push(datums[column_order.column]);
                             }
                             if debezium {
-                                for _ in 0..(self.arity - order_by_keys.len()) {
+                                for _ in 0..value_columns {
                                     packer.push(Datum::Null);
                                 }
                             }
-                            for _ in 0..(self.arity - order_by_keys.len()) {
+                            for _ in 0..value_columns {
                                 packer.push(Datum::Null);
                             }
                             push_row(row_buf.as_row_ref(), *start.1, Diff::ZERO)

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -246,6 +246,9 @@ pub enum PlanError {
     },
     InvalidKeysInSubscribeEnvelopeUpsert,
     InvalidKeysInSubscribeEnvelopeDebezium,
+    DuplicateKeyColumnInSubscribeEnvelope {
+        column_name: String,
+    },
     InvalidPartitionByEnvelopeDebezium {
         column_name: String,
     },
@@ -451,6 +454,9 @@ impl PlanError {
             }
             Self::InvalidKeysInSubscribeEnvelopeDebezium => {
                 Some("All keys must be columns on the underlying relation.".into())
+            }
+            Self::DuplicateKeyColumnInSubscribeEnvelope { .. } => {
+                Some("Each KEY column must be listed at most once.".into())
             }
             Self::InvalidOrderByInSubscribeWithinTimestampOrderBy => {
                 Some("All order bys must be output columns.".into())
@@ -749,6 +755,13 @@ impl fmt::Display for PlanError {
             }
             Self::InvalidKeysInSubscribeEnvelopeDebezium => {
                 write!(f, "invalid keys in SUBSCRIBE ENVELOPE DEBEZIUM (KEY (..))")
+            }
+            Self::DuplicateKeyColumnInSubscribeEnvelope { column_name } => {
+                write!(
+                    f,
+                    "column {} appears more than once in SUBSCRIBE ENVELOPE KEY clause",
+                    column_name.quoted(),
+                )
             }
             Self::InvalidPartitionByEnvelopeDebezium { column_name } => {
                 write!(

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::Itertools;
 use mz_arrow_util::builder::ArrowBuilder;
-use mz_expr::RowSetFinishing;
+use mz_expr::{ColumnOrder, RowSetFinishing};
 use mz_ore::num::NonNeg;
 use mz_ore::soft_panic_or_log;
 use mz_ore::str::separated;
@@ -1723,6 +1723,7 @@ pub fn plan_subscribe(
             if !map_exprs.is_empty() {
                 return Err(PlanError::InvalidKeysInSubscribeEnvelopeUpsert);
             }
+            check_distinct_key_columns(&order_by, &output_columns)?;
             plan::SubscribeOutput::EnvelopeUpsert {
                 order_by_keys: order_by,
             }
@@ -1748,6 +1749,7 @@ pub fn plan_subscribe(
             if !map_exprs.is_empty() {
                 return Err(PlanError::InvalidKeysInSubscribeEnvelopeDebezium);
             }
+            check_distinct_key_columns(&order_by, &output_columns)?;
             plan::SubscribeOutput::EnvelopeDebezium {
                 order_by_keys: order_by,
             }
@@ -1799,6 +1801,23 @@ pub fn plan_subscribe(
         emit_progress: progress.unwrap_or(false),
         output,
     }))
+}
+
+/// Ensures each `ColumnOrder` in `order_by` references a distinct column,
+/// returning `DuplicateKeyColumnInSubscribeEnvelope` on the first repeat.
+fn check_distinct_key_columns(
+    order_by: &[ColumnOrder],
+    output_columns: &[(usize, &mz_repr::ColumnName)],
+) -> Result<(), PlanError> {
+    let mut seen = BTreeSet::new();
+    for co in order_by {
+        if !seen.insert(co.column) {
+            return Err(PlanError::DuplicateKeyColumnInSubscribeEnvelope {
+                column_name: output_columns[co.column].1.to_string(),
+            });
+        }
+    }
+    Ok(())
 }
 
 pub fn describe_copy_from_table(

--- a/test/sqllogictest/subscribe_error.slt
+++ b/test/sqllogictest/subscribe_error.slt
@@ -89,3 +89,88 @@ SUBSCRIBE mv UP TO current_database();
 
 statement error calling an unmaterializable function in AS OF or UP TO not yet supported
 SUBSCRIBE mv UP TO current_database()::mz_timestamp;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_envelope_debezium_in_subscribe = true
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t_envelope_dup (a INT, b INT)
+
+statement ok
+INSERT INTO t_envelope_dup VALUES (1, 2)
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c1 CURSOR FOR SUBSCRIBE t_envelope_dup ENVELOPE UPSERT (KEY (a, a))
+
+statement error column "a" appears more than once in SUBSCRIBE ENVELOPE KEY clause
+FETCH 1 c1
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c2 CURSOR FOR SUBSCRIBE t_envelope_dup ENVELOPE DEBEZIUM (KEY (a, a, a))
+
+statement error column "a" appears more than once in SUBSCRIBE ENVELOPE KEY clause
+FETCH 1 c2
+
+statement ok
+ROLLBACK
+
+# Mixed-case unquoted identifiers fold to the same column and must also be rejected.
+statement ok
+BEGIN
+
+statement ok
+DECLARE c3 CURSOR FOR SUBSCRIBE t_envelope_dup ENVELOPE UPSERT (KEY (a, A))
+
+statement error column "a" appears more than once in SUBSCRIBE ENVELOPE KEY clause
+FETCH 1 c3
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c4 CURSOR FOR SUBSCRIBE t_envelope_dup ENVELOPE DEBEZIUM (KEY (a, A))
+
+statement error column "a" appears more than once in SUBSCRIBE ENVELOPE KEY clause
+FETCH 1 c4
+
+statement ok
+ROLLBACK
+
+# Duplicate among 3+ key columns must also be rejected.
+statement ok
+BEGIN
+
+statement ok
+DECLARE c5 CURSOR FOR SUBSCRIBE t_envelope_dup ENVELOPE UPSERT (KEY (a, b, a))
+
+statement error column "a" appears more than once in SUBSCRIBE ENVELOPE KEY clause
+FETCH 1 c5
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c6 CURSOR FOR SUBSCRIBE t_envelope_dup ENVELOPE DEBEZIUM (KEY (a, b, a))
+
+statement error column "a" appears more than once in SUBSCRIBE ENVELOPE KEY clause
+FETCH 1 c6
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Fixes https://linear.app/materializeinc/issue/SQL-307/subscribe-envelope-upsert-key-a-a-crashes-environmentd