### PR TITLE
sql-parser: fix `AstDisplay` panic for `CREATE TABLE FROM SOURCE` with constraints only

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1760,7 +1760,7 @@ impl<T: AstInfo> AstDisplay for CreateTableFromSourceStatement<T> {
             f.write_str(" (");
 
             match columns {
-                TableFromSourceColumns::NotSpecified => unreachable!(),
+                TableFromSourceColumns::NotSpecified => {}
                 TableFromSourceColumns::Named(columns) => {
                     f.write_node(&display::comma_separated(columns))
                 }
@@ -1769,7 +1769,9 @@ impl<T: AstInfo> AstDisplay for CreateTableFromSourceStatement<T> {
                 }
             };
             if !constraints.is_empty() {
-                f.write_str(", ");
+                if !matches!(columns, TableFromSourceColumns::NotSpecified) {
+                    f.write_str(", ");
+                }
                 f.write_node(&display::comma_separated(constraints));
             }
             f.write_str(")");

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -284,6 +284,30 @@ error: cannot mix column definitions and column names
 CREATE TABLE t (c, d int4) FROM SOURCE foo (REFERENCE bar)
                          ^
 
+# Regression: constraints-only (no columns) used to panic in AstDisplay.
+parse-statement
+CREATE TABLE t (PRIMARY KEY (c)) FROM SOURCE foo (REFERENCE bar)
+----
+CREATE TABLE t (PRIMARY KEY (c)) FROM SOURCE foo (REFERENCE = bar)
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [Unique { name: None, columns: [Ident("c")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: None, envelope: None })
+
+# Columns + constraints together: ensure exactly one comma separates them.
+parse-statement
+CREATE TABLE t (c int4, d int4, PRIMARY KEY (c)) FROM SOURCE foo (REFERENCE bar)
+----
+CREATE TABLE t (c int4, d int4, PRIMARY KEY (c)) FROM SOURCE foo (REFERENCE = bar)
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: Defined([ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("d"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }]), constraints: [Unique { name: None, columns: [Ident("c")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: None, envelope: None })
+
+# Named columns + constraints together.
+parse-statement
+CREATE TABLE t (c, d, PRIMARY KEY (c)) FROM SOURCE foo (REFERENCE bar)
+----
+CREATE TABLE t (c, d, PRIMARY KEY (c)) FROM SOURCE foo (REFERENCE = bar)
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: Named([Ident("c"), Ident("d")]), constraints: [Unique { name: None, columns: [Ident("c")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: None, envelope: None })
+
 parse-statement
 CREATE TABLE t FROM SOURCE foo
 ----


### PR DESCRIPTION
CreateTableFromSourceStatement's AstDisplay entered the parenthesized block whenever columns were specified OR constraints were non-empty, but the inner match panicked on `TableFromSourceColumns::NotSpecified`. A statement like
```
    CREATE TABLE t (PRIMARY KEY (c)) FROM SOURCE foo (REFERENCE bar)
```
would crash as soon as the AST was formatted (e.g. via statement logging). Treat `NotSpecified` as a no-op and gate the ", " separator so constraints-only output stays valid SQL. Adds round-trip tests for the constraints-only case and for columns + constraints (both Defined and Named).
