### PR TITLE
pgwire: error instead of panicking on binary encoding of unsupported types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7304,6 +7304,8 @@ dependencies = [
  "mz-pgwire-common",
  "mz-repr",
  "postgres-types",
+ "proptest",
+ "proptest-derive",
  "uuid",
 ]
 

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -775,6 +775,14 @@ fn test_pgtest_mz_affected() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_copy_binary_unsupported() {
+    pg_test_inner(
+        Path::new("../../test/pgtest-mz/copy-binary-unsupported.pt"),
+        true,
+    );
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_copy_from_csv() {
     pg_test_inner(Path::new("../../test/pgtest-mz/copy-from-csv.pt"), true);
 }

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -22,5 +22,11 @@ mz-repr = { path = "../repr", default-features = false }
 postgres-types.workspace = true
 uuid.workspace = true
 
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }
+mz-repr = { path = "../repr", default-features = false, features = ["proptest"] }
+proptest.workspace = true
+proptest-derive.workspace = true
+
 [features]
 default = []

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -969,8 +969,8 @@ mod tests {
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // numeric/decimal contexts unsupported under miri
     fn proptest_binary_encoding_error_matches_encode_binary() {
-        let strat = any::<SqlScalarType>()
-            .prop_flat_map(|ty| (Just(ty.clone()), arb_datum_for_scalar(ty)));
+        let strat =
+            any::<SqlScalarType>().prop_flat_map(|ty| (Just(ty.clone()), arb_datum_for_scalar(ty)));
         proptest!(ProptestConfig::with_cases(256), |((ty, prop_datum) in strat)| {
             // `binary_encoding_error` is a precondition for callers of
             // `encode_binary`: if it returns `Ok`, then encoding must succeed

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -434,7 +434,7 @@ impl Value {
     /// format](Format::Binary).
     pub fn encode_binary(&self, ty: &Type, buf: &mut BytesMut) -> Result<(), io::Error> {
         // NOTE: If implementing binary encoding for a previously unsupported `Value` type,
-        // please update the `can_encode_binary` method below.
+        // please update the `binary_encoding_error` method below.
         let is_null = match self {
             Value::Array { dims, elements } => {
                 let ndims = pg_len("number of array dimensions", dims.len())?;
@@ -586,49 +586,61 @@ impl Value {
     }
 
     /// Static helper method to pre-validate that a given Datum corresponding to
-    /// the provided `SqlScalarType` can be converted into a `Value` and then encoded
-    /// as binary using `encode_binary` without an error.
-    pub fn can_encode_binary(typ: &SqlScalarType) -> bool {
+    /// the provided `SqlScalarType` can be converted into a `Value` and then
+    /// encoded as binary using `encode_binary` without an error.
+    ///
+    /// Returns `Ok(())` if the type (including all of its nested element/field
+    /// types) supports binary encoding, or `Err(reason)` describing the first
+    /// unsupported type encountered. Container types are checked recursively, so
+    /// e.g. a record or array that contains a `list` is rejected.
+    pub fn binary_encoding_error(typ: &SqlScalarType) -> Result<(), &'static str> {
         match typ {
-            SqlScalarType::Bool => true,
-            SqlScalarType::Int16 => true,
-            SqlScalarType::Int32 => true,
-            SqlScalarType::Int64 => true,
-            SqlScalarType::PgLegacyChar => true,
-            SqlScalarType::UInt16 => true,
-            SqlScalarType::Oid => true,
-            SqlScalarType::RegClass => true,
-            SqlScalarType::RegProc => true,
-            SqlScalarType::RegType => true,
-            SqlScalarType::UInt32 => true,
-            SqlScalarType::UInt64 => true,
-            SqlScalarType::Float32 => true,
-            SqlScalarType::Float64 => true,
-            SqlScalarType::Numeric { .. } => true,
-            SqlScalarType::MzTimestamp => true,
-            SqlScalarType::MzAclItem => true,
-            SqlScalarType::AclItem => false, // "aclitem has no binary encoding"
-            SqlScalarType::Date => true,
-            SqlScalarType::Time => true,
-            SqlScalarType::Timestamp { .. } => true,
-            SqlScalarType::TimestampTz { .. } => true,
-            SqlScalarType::Interval => true,
-            SqlScalarType::Bytes => true,
-            SqlScalarType::String => true,
-            SqlScalarType::VarChar { .. } => true,
-            SqlScalarType::Char { .. } => true,
-            SqlScalarType::PgLegacyName => true,
-            SqlScalarType::Jsonb => true,
-            SqlScalarType::Uuid => true,
-            SqlScalarType::Array(elem_type) => Self::can_encode_binary(elem_type),
-            SqlScalarType::Int2Vector => true,
-            SqlScalarType::List { .. } => false, // "binary encoding of list types is not implemented"
-            SqlScalarType::Map { .. } => false, // "binary encoding of map types is not implemented"
+            SqlScalarType::Bool => Ok(()),
+            SqlScalarType::Int16 => Ok(()),
+            SqlScalarType::Int32 => Ok(()),
+            SqlScalarType::Int64 => Ok(()),
+            SqlScalarType::PgLegacyChar => Ok(()),
+            SqlScalarType::UInt16 => Ok(()),
+            SqlScalarType::Oid => Ok(()),
+            SqlScalarType::RegClass => Ok(()),
+            SqlScalarType::RegProc => Ok(()),
+            SqlScalarType::RegType => Ok(()),
+            SqlScalarType::UInt32 => Ok(()),
+            SqlScalarType::UInt64 => Ok(()),
+            SqlScalarType::Float32 => Ok(()),
+            SqlScalarType::Float64 => Ok(()),
+            SqlScalarType::Numeric { .. } => Ok(()),
+            SqlScalarType::MzTimestamp => Ok(()),
+            SqlScalarType::MzAclItem => Ok(()),
+            SqlScalarType::AclItem => Err("binary encoding of aclitem types does not exist"),
+            SqlScalarType::Date => Ok(()),
+            SqlScalarType::Time => Ok(()),
+            SqlScalarType::Timestamp { .. } => Ok(()),
+            SqlScalarType::TimestampTz { .. } => Ok(()),
+            SqlScalarType::Interval => Ok(()),
+            SqlScalarType::Bytes => Ok(()),
+            SqlScalarType::String => Ok(()),
+            SqlScalarType::VarChar { .. } => Ok(()),
+            SqlScalarType::Char { .. } => Ok(()),
+            SqlScalarType::PgLegacyName => Ok(()),
+            SqlScalarType::Jsonb => Ok(()),
+            SqlScalarType::Uuid => Ok(()),
+            SqlScalarType::Array(elem_type) => Self::binary_encoding_error(elem_type),
+            SqlScalarType::Int2Vector => Ok(()),
+            SqlScalarType::List { .. } => Err("binary encoding of list types is not implemented"),
+            SqlScalarType::Map { .. } => Err("binary encoding of map types is not implemented"),
             SqlScalarType::Record { fields, .. } => fields
                 .iter()
-                .all(|(_, ty)| Self::can_encode_binary(&ty.scalar_type)),
-            SqlScalarType::Range { element_type } => Self::can_encode_binary(element_type),
+                .try_for_each(|(_, ty)| Self::binary_encoding_error(&ty.scalar_type)),
+            SqlScalarType::Range { element_type } => Self::binary_encoding_error(element_type),
         }
+    }
+
+    /// Returns whether a value of the given `SqlScalarType` can be encoded using
+    /// the binary format. See [`Value::binary_encoding_error`] for details,
+    /// including the (recursive) handling of container types.
+    pub fn can_encode_binary(typ: &SqlScalarType) -> bool {
+        Self::binary_encoding_error(typ).is_ok()
     }
 
     /// Deserializes a value of type `ty` from `raw` using the specified

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -585,7 +585,7 @@ impl Value {
         Ok(())
     }
 
-    /// Static helper method to pre-validate that a given Datum corresponding to
+    /// Static helper method to pre-validate that a Datum corresponding to
     /// the provided `SqlScalarType` can be converted into a `Value` and then
     /// encoded as binary using `encode_binary` without an error.
     ///

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -954,7 +954,43 @@ pub fn values_from_row(row: &RowRef, typ: &SqlRelationType) -> Vec<Option<Value>
 
 #[cfg(test)]
 mod tests {
+    use mz_repr::arb_datum_for_scalar;
+    use proptest::prelude::*;
+
     use super::*;
+
+    /// Property test: [`Value::binary_encoding_error`] agrees with the actual
+    /// behavior of [`Value::encode_binary`] for every `(SqlScalarType, Datum)`
+    /// pair the proptest infrastructure can generate.
+    ///
+    /// This guards against future drift between the static predicate and the
+    /// encoder: any new `SqlScalarType` variant whose classification disagrees
+    /// with what `encode_binary` actually does will surface here.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // numeric/decimal contexts unsupported under miri
+    fn proptest_binary_encoding_error_matches_encode_binary() {
+        let strat = any::<SqlScalarType>()
+            .prop_flat_map(|ty| (Just(ty.clone()), arb_datum_for_scalar(ty)));
+        proptest!(ProptestConfig::with_cases(256), |((ty, prop_datum) in strat)| {
+            // `binary_encoding_error` is a precondition for callers of
+            // `encode_binary`: if it returns `Ok`, then encoding must succeed
+            // (and not panic via the internal `.expect`).
+            if Value::binary_encoding_error(&ty).is_err() {
+                return Ok(());
+            }
+            let datum = Datum::from(&prop_datum);
+            let value = match Value::from_datum(datum, &ty) {
+                Some(v) => v,
+                // `Datum::Null` produces `None`; nothing to encode.
+                None => return Ok(()),
+            };
+            let pg_ty = Type::from(&ty);
+            let mut buf = BytesMut::new();
+            value
+                .encode_binary(&pg_ty, &mut buf)
+                .expect("encode_binary must succeed when binary_encoding_error returns Ok");
+        });
+    }
 
     /// Verifies that we correctly print the chain of parsing errors, all the way through the stack.
     #[mz_ore::test]

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -612,7 +612,7 @@ impl Value {
             SqlScalarType::Numeric { .. } => Ok(()),
             SqlScalarType::MzTimestamp => Ok(()),
             SqlScalarType::MzAclItem => Ok(()),
-            SqlScalarType::AclItem => Err("binary encoding of aclitem types does not exist"),
+            SqlScalarType::AclItem => Err("binary encoding of aclitem type does not exist"),
             SqlScalarType::Date => Ok(()),
             SqlScalarType::Time => Ok(()),
             SqlScalarType::Timestamp { .. } => Ok(()),

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1451,32 +1451,15 @@ where
         }) {
             if let Some(desc) = stmt.desc().relation_desc.clone() {
                 for (format, ty) in result_formats.iter().zip_eq(desc.iter_types()) {
-                    match (format, &ty.scalar_type) {
-                        (Format::Binary, mz_repr::SqlScalarType::List { .. }) => {
+                    if let Format::Binary = format {
+                        if let Err(msg) = mz_pgrepr::Value::binary_encoding_error(&ty.scalar_type) {
                             return self
                                 .send_error_and_get_state(ErrorResponse::error(
                                     SqlState::PROTOCOL_VIOLATION,
-                                    "binary encoding of list types is not implemented",
+                                    msg,
                                 ))
                                 .await;
                         }
-                        (Format::Binary, mz_repr::SqlScalarType::Map { .. }) => {
-                            return self
-                                .send_error_and_get_state(ErrorResponse::error(
-                                    SqlState::PROTOCOL_VIOLATION,
-                                    "binary encoding of map types is not implemented",
-                                ))
-                                .await;
-                        }
-                        (Format::Binary, mz_repr::SqlScalarType::AclItem) => {
-                            return self
-                                .send_error_and_get_state(ErrorResponse::error(
-                                    SqlState::PROTOCOL_VIOLATION,
-                                    "binary encoding of aclitem types does not exist",
-                                ))
-                                .await;
-                        }
-                        _ => (),
                     }
                 }
             }
@@ -2613,6 +2596,35 @@ where
                     .map(|state| (state, SendRowsEndedReason::Errored { error: text }));
             }
         };
+
+        // Binary encoding is not implemented for some types (e.g., list, map,
+        // and aclitem). Unlike the extended query protocol's Bind handler, COPY
+        // does not validate this when binding the portal: the portal's result
+        // formats describe the `CopyData` wrapper, not the COPY format itself,
+        // so the Bind handler explicitly skips `COPY TO` statements. We must
+        // therefore check here, before streaming any rows, otherwise
+        // `encode_binary` would panic mid-stream (SQL-323).
+        if let CopyFormat::Binary = format {
+            if let Some(msg) = row_desc
+                .iter_types()
+                .find_map(|ty| mz_pgrepr::Value::binary_encoding_error(&ty.scalar_type).err())
+            {
+                return self
+                    .send_error_and_get_state(ErrorResponse::error(
+                        SqlState::PROTOCOL_VIOLATION,
+                        msg,
+                    ))
+                    .await
+                    .map(|state| {
+                        (
+                            state,
+                            SendRowsEndedReason::Errored {
+                                error: msg.to_string(),
+                            },
+                        )
+                    });
+            }
+        }
 
         let encode_fn = |row: &RowRef, typ: &SqlRelationType, out: &mut Vec<u8>| {
             mz_pgcopy::encode_copy_format(&row_format, row, typ, out)

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -5405,9 +5405,29 @@ pub fn arb_datum_for_scalar(scalar_type: SqlScalarType) -> impl Strategy<Value =
         SqlScalarType::Array(element_type) => arb_array(arb_datum_for_scalar(*element_type))
             .prop_map(PropDatum::Array)
             .boxed(),
-        SqlScalarType::Int2Vector => arb_array(any::<i16>().prop_map(PropDatum::Int16).boxed())
-            .prop_map(PropDatum::Array)
-            .boxed(),
+        SqlScalarType::Int2Vector => {
+            // `int2vector` is, by definition, a 1-dimensional array of `int2`
+            // values (matching PostgreSQL's `int2vector` and Materialize's
+            // `Value::from_datum`, which asserts on multi-dimensional arrays).
+            // The generic `arb_array` strategy can produce multi-dimensional
+            // arrays, so we hand-roll a 1-D variant here.
+            let element_strategy = any::<i16>().prop_map(PropDatum::Int16).boxed();
+            prop::collection::vec(element_strategy, 0..16)
+                .prop_map(|elements| {
+                    let dims = [ArrayDimension {
+                        lower_bound: 1,
+                        length: elements.len(),
+                    }];
+                    let element_datums: Vec<Datum<'_>> =
+                        elements.iter().map(|pd| pd.into()).collect();
+                    let mut row = Row::default();
+                    row.packer()
+                        .try_push_array(&dims, element_datums)
+                        .unwrap();
+                    PropDatum::Array(PropArray(row, elements))
+                })
+                .boxed()
+        }
         SqlScalarType::Map { value_type, .. } => arb_dict(arb_datum_for_scalar(*value_type))
             .prop_map(PropDatum::Map)
             .boxed(),

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -5421,9 +5421,7 @@ pub fn arb_datum_for_scalar(scalar_type: SqlScalarType) -> impl Strategy<Value =
                     let element_datums: Vec<Datum<'_>> =
                         elements.iter().map(|pd| pd.into()).collect();
                     let mut row = Row::default();
-                    row.packer()
-                        .try_push_array(&dims, element_datums)
-                        .unwrap();
+                    row.packer().try_push_array(&dims, element_datums).unwrap();
                     PropDatum::Array(PropArray(row, elements))
                 })
                 .boxed()

--- a/test/pgtest-mz/copy-binary-unsupported.pt
+++ b/test/pgtest-mz/copy-binary-unsupported.pt
@@ -33,7 +33,7 @@ Query {"query": "COPY (SELECT makeaclitem(1, 2, 'CREATE', false)) TO STDOUT WITH
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of aclitem types does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of aclitem type does not exist"}]}
 ReadyForQuery {"status":"I"}
 
 # Container types are checked recursively: a record containing a list is also

--- a/test/pgtest-mz/copy-binary-unsupported.pt
+++ b/test/pgtest-mz/copy-binary-unsupported.pt
@@ -1,0 +1,63 @@
+# Binary encoding is not implemented for list, map, and aclitem types. COPY ...
+# TO STDOUT WITH (FORMAT binary) must return a clean error rather than panicking
+# (SQL-323). This is Materialize-specific behavior: list/map don't exist in
+# PostgreSQL, and our aclitem error message/SQLSTATE differs from PostgreSQL's
+# "no binary output function available for type aclitem" (42883), so this lives
+# in pgtest-mz rather than pgtest.
+
+send
+Query {"query": "COPY (SELECT LIST[1, 2, 3]) TO STDOUT WITH (FORMAT binary)"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of list types is not implemented"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY (SELECT '{a=>b}'::map[text=>text]) TO STDOUT WITH (FORMAT binary)"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of map types is not implemented"}]}
+ReadyForQuery {"status":"I"}
+
+# aclitem also has no binary encoding.
+send
+Query {"query": "COPY (SELECT makeaclitem(1, 2, 'CREATE', false)) TO STDOUT WITH (FORMAT binary)"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of aclitem types does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+# Container types are checked recursively: a record containing a list is also
+# rejected, naming the offending leaf type.
+send
+Query {"query": "COPY (SELECT ROW(1, LIST[1, 2])) TO STDOUT WITH (FORMAT binary)"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of list types is not implemented"}]}
+ReadyForQuery {"status":"I"}
+
+# The text format still works for these types.
+send
+Query {"query": "COPY (SELECT LIST[1, 2, 3]) TO STDOUT"}
+----
+
+until
+ReadyForQuery
+----
+CopyOut {"format":"text","column_formats":["text"]}
+CopyData "{1,2,3}\n"
+CopyDone
+CommandComplete {"tag":"COPY 1"}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/aclitem.slt
+++ b/test/sqllogictest/aclitem.slt
@@ -195,7 +195,7 @@ SELECT a::text from t
 statement ok
 DROP TABLE t
 
-query error binary encoding of aclitem types does not exist
+query error binary encoding of aclitem type does not exist
 SELECT makeaclitem(1, 2, 'CREATE', false)
 
 query T

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -89,7 +89,7 @@ EOF
 query error binary encoding of list types is not implemented
 SELECT ROW(1, LIST[1, 2])
 
-query error binary encoding of aclitem types does not exist
+query error binary encoding of aclitem type does not exist
 SELECT ROW(1, makeaclitem(1, 2, 'CREATE', false))
 
 query T

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -80,3 +80,19 @@ Source materialize.public.t1
 Target cluster: quickstart
 
 EOF
+
+# Binary encoding is not implemented for list, map, and aclitem types, and this
+# is checked recursively for container types. A record containing such a type
+# must return a clean error over the binary result format rather than panicking
+# the server (SQL-323). Casting the offending field to text avoids the error.
+
+query error binary encoding of list types is not implemented
+SELECT ROW(1, LIST[1, 2])
+
+query error binary encoding of aclitem types does not exist
+SELECT ROW(1, makeaclitem(1, 2, 'CREATE', false))
+
+query T
+SELECT (ROW(1, LIST[1, 2]))::text
+----
+(1,{1,2})


### PR DESCRIPTION
COPY ... TO STDOUT WITH (FORMAT binary) over a query whose result contained a list, map, or aclitem column panicked the connection's worker thread:

    encode_binary should never trigger a to_sql failure:
    "binary encoding of list types is not implemented"

These types have no binary encoding, so `Value::encode_binary` returns an error, which the surrounding `.expect()` turned into a panic. The invariant that `.expect()` relies on is that callers pre-validate types with `can_encode_binary`, but two gaps let unsupported types through:

  * COPY never validated its format at all. The extended-query Bind handler does validate result column formats, but it deliberately skips COPY TO statements -- a COPY portal's result formats describe the CopyData wrapper, not the COPY format chosen via WITH (FORMAT ...) -- and nothing validated the COPY format itself.

  * The Bind handler's check only inspected the top-level scalar type, so a binary result column whose type was a record/array/range *containing* a list, map, or aclitem slipped through and hit the same panic via the ordinary extended-query path (e.g. SELECT ROW(1, LIST[1, 2]) requested with a binary result format, as sqllogictest does).

Fix both:

  * Replace `can_encode_binary` with `binary_encoding_error`, which recurses into container types and returns the offending leaf type's error message. `can_encode_binary` is kept as a thin wrapper. This is now the single source of truth, shared by the COPY path, the Bind handler, and the Kafka BYTES sink.

  * Add a pre-stream check in `copy_rows` that rejects un-encodable types with a clean error before sending CopyOutResponse, mirroring the existing Parquet handling.

With every caller validating recursively, the `.expect()` invariant now genuinely holds for all entry points.

Tests:

  * test/pgtest-mz/copy-binary-unsupported.pt covers COPY binary of list, map, aclitem, and a record containing a list, plus the text-format success case. It lives in pgtest-mz because list/map do not exist in PostgreSQL and our aclitem message differs from PostgreSQL's.

  * test/sqllogictest/record.slt covers the recursive Bind-path cases that previously panicked the server.

Fixes SQL-323