### PR TITLE
Fix nightly test failure

### DIFF
--- a/test/testdrive/show-create-sink.td
+++ b/test/testdrive/show-create-sink.td
@@ -27,4 +27,4 @@ $ kafka-create-topic topic=data
 > ALTER SINK sink SET FROM table; --bumps version
 
 > SELECT create_sql FROM (SHOW CREATE SINK sink);
-"CREATE SINK materialize.public.sink\nIN CLUSTER quickstart\nFROM materialize.public.table\nINTO\n    KAFKA CONNECTION materialize.public.kafka_conn (TOPIC = 'testdrive-show-create-sink-${testdrive.seed}')\nFORMAT JSON\nENVELOPE DEBEZIUM;"
+"CREATE SINK materialize.public.sink\nIN CLUSTER ${arg.single-replica-cluster}\nFROM materialize.public.table\nINTO\n    KAFKA CONNECTION materialize.public.kafka_conn (TOPIC = 'testdrive-show-create-sink-${testdrive.seed}')\nFORMAT JSON\nENVELOPE DEBEZIUM;"


### PR DESCRIPTION
### Motivation

This failed on nightly testing because the cluster name was different https://buildkite.com/materialize/nightly/builds/16673/annotations?jid=019e8586-2e23-44e0-8d2b-e4030bbf9271&tab=output.

Diff shows the cluster name wasn't right on the nightly build:
```
- "CREATE SINK materialize.public.sink\nIN CLUSTER quickstart\nFROM materialize.public.table\nINTO\n    KAFKA CONNECTION materialize.public.kafka_conn (TOPIC = 'testdrive-show-create-sink-2655571750')\nFORMAT JSON\nENVELOPE DEBEZIUM;"
--
+ "CREATE SINK materialize.public.sink\nIN CLUSTER testdrive_single_replica_cluster\nFROM materialize.public.table\nINTO\n    KAFKA CONNECTION materialize.public.kafka_conn (TOPIC = 'testdrive-show-create-sink-2655571750')\nFORMAT JSON\nENVELOPE DEBEZIUM;"
```

### Description

Use the cluster name variable in assertion/expectation.

### Verification
Just re-ran locally to make sure it wouldn't break non-nightly runs.