### PR TITLE
clusterd: remove unused CTP server-FQDN validation

### DIFF
--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -81,12 +81,6 @@ struct Args {
         default_value = "127.0.0.1:6878"
     )]
     internal_http_listen_addr: SocketAddr,
-    /// The FQDN of this process, for GRPC request validation.
-    ///
-    /// Not providing this value or setting it to the empty string disables host validation for
-    /// GRPC requests.
-    #[clap(long, env = "GRPC_HOST", value_name = "NAME")]
-    grpc_host: Option<String>,
 
     // === Timely cluster options. ===
     /// Configuration for the storage Timely cluster.
@@ -406,7 +400,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         None,
     );
 
-    let grpc_host = args.grpc_host.and_then(|h| (!h.is_empty()).then_some(h));
     let cluster_server_metrics = ClusterServerMetrics::register_with(&metrics_registry);
 
     let mut storage_timely_config = args.storage_timely_config;
@@ -451,7 +444,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         transport::serve(
             args.storage_controller_listen_addr,
             BUILD_INFO.semver_version(),
-            grpc_host.clone(),
             Duration::MAX,
             storage_client_builder,
             cluster_server_metrics.for_server("storage"),
@@ -483,7 +475,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         transport::serve(
             args.compute_controller_listen_addr,
             BUILD_INFO.semver_version(),
-            grpc_host.clone(),
             Duration::MAX,
             compute_client_builder,
             cluster_server_metrics.for_server("compute"),

--- a/src/service/src/transport.rs
+++ b/src/service/src/transport.rs
@@ -66,29 +66,12 @@ impl<Out: Message, In: Message> Client<Out, In> {
         idle_timeout: Duration,
         metrics: impl Metrics<Out, In>,
     ) -> anyhow::Result<Self> {
-        let dest_host = host_from_address(address);
         let stream = mz_ore::future::timeout(connect_timeout, Stream::connect(address)).await?;
         info!(%address, "ctp: connected to server");
 
-        let conn = Connection::start(stream, version, dest_host, idle_timeout, metrics).await?;
+        let conn = Connection::start(stream, version, idle_timeout, metrics).await?;
         Ok(Self { conn })
     }
-}
-
-/// Helper function to extract the host part from an address string.
-///
-/// This function assumes addresses to be of the form `<host>:<port>` or `<protocol>:<host>:<port>`
-/// and yields `None` otherwise.
-fn host_from_address(address: &str) -> Option<String> {
-    let mut p = address.split(':');
-    let (host, port) = match (p.next(), p.next(), p.next(), p.next()) {
-        (Some(host), Some(port), None, None) => (host, port),
-        (Some(_protocol), Some(host), Some(port), None) => (host, port),
-        _ => return None,
-    };
-
-    let _: u16 = port.parse().ok()?;
-    Some(host.into())
 }
 
 impl<Out, In> Client<Out, In>
@@ -138,7 +121,6 @@ impl<Out: Message, In: Message> GenericClient<Out, In> for Client<Out, In> {
 pub async fn serve<In, Out, H>(
     address: SocketAddr,
     version: Version,
-    server_fqdn: Option<String>,
     idle_timeout: Duration,
     handler_fn: impl Fn() -> H,
     metrics: impl Metrics<Out, In>,
@@ -171,7 +153,6 @@ where
 
         let handler = handler_fn();
         let version = version.clone();
-        let server_fqdn = server_fqdn.clone();
         let metrics = metrics.clone();
         let (cancel_tx, cancel_rx) = oneshot::channel();
 
@@ -179,16 +160,9 @@ where
         let handle = mz_ore::task::spawn(
             || "ctp::connection",
             async move {
-                let Err(error) = serve_connection(
-                    stream,
-                    handler,
-                    version,
-                    server_fqdn,
-                    idle_timeout,
-                    cancel_rx,
-                    metrics,
-                )
-                .await;
+                let Err(error) =
+                    serve_connection(stream, handler, version, idle_timeout, cancel_rx, metrics)
+                        .await;
                 info!("ctp: connection failed: {error}");
             }
             .instrument(span),
@@ -203,7 +177,6 @@ async fn serve_connection<In, Out, H>(
     stream: Stream,
     mut handler: H,
     version: Version,
-    server_fqdn: Option<String>,
     timeout: Duration,
     cancel_rx: oneshot::Receiver<()>,
     metrics: impl Metrics<Out, In>,
@@ -213,7 +186,7 @@ where
     Out: Message,
     H: GenericClient<In, Out>,
 {
-    let mut conn = Connection::start(stream, version, server_fqdn, timeout, metrics).await?;
+    let mut conn = Connection::start(stream, version, timeout, metrics).await?;
 
     let mut cancel_rx = cancel_rx;
     loop {
@@ -271,7 +244,6 @@ impl<Out: Message, In: Message> Connection<Out, In> {
     async fn start(
         stream: Stream,
         version: Version,
-        server_fqdn: Option<String>,
         mut timeout: Duration,
         metrics: impl Metrics<Out, In>,
     ) -> anyhow::Result<Self> {
@@ -292,7 +264,7 @@ impl<Out: Message, In: Message> Connection<Out, In> {
         let mut reader = metrics::Reader::new(reader, metrics.clone());
         let mut writer = metrics::Writer::new(writer, metrics.clone());
 
-        handshake(&mut reader, &mut writer, version, server_fqdn).await?;
+        handshake(&mut reader, &mut writer, version).await?;
 
         let (out_tx, out_rx) = mpsc::unbounded_channel();
         let (in_tx, in_rx) = mpsc::unbounded_channel();
@@ -420,12 +392,7 @@ impl<Out: Message, In: Message> Connection<Out, In> {
 /// `Hello` message. The `Hello` message contains information about the originating endpoint that
 /// is used by the receiver to validate compatibility with its peer. Only if both endpoints
 /// determine that they are compatible does the handshake succeed.
-async fn handshake<R, W>(
-    mut reader: R,
-    mut writer: W,
-    version: Version,
-    server_fqdn: Option<String>,
-) -> anyhow::Result<()>
+async fn handshake<R, W>(mut reader: R, mut writer: W, version: Version) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
@@ -437,7 +404,6 @@ where
 
     let hello = Hello {
         version: version.clone(),
-        server_fqdn: server_fqdn.clone(),
     };
     write_message(&mut writer, Some(&hello)).await?;
 
@@ -448,16 +414,10 @@ where
 
     let Hello {
         version: peer_version,
-        server_fqdn: peer_server_fqdn,
     } = read_message(&mut reader).await?;
 
     if peer_version != version {
         bail!("version mismatch: {peer_version} != {version}");
-    }
-    if let (Some(other), Some(mine)) = (&peer_server_fqdn, &server_fqdn) {
-        if other != mine {
-            bail!("server FQDN mismatch: {other} != {mine}");
-        }
     }
 
     Ok(())
@@ -468,8 +428,6 @@ where
 struct Hello {
     /// The version of the originating endpoint.
     version: Version,
-    /// The FQDN of the server endpoint.
-    server_fqdn: Option<String>,
 }
 
 /// Write a message into the given writer.

--- a/src/service/tests/transport.rs
+++ b/src/service/tests/transport.rs
@@ -105,7 +105,6 @@ fn test_bidirectional_communication() {
             transport::serve(
                 "turmoil:0.0.0.0:7777".parse().unwrap(),
                 VERSION,
-                Some("server".into()),
                 TIMEOUT,
                 move || handler.lock().unwrap().take().unwrap(),
                 NoopMetrics,
@@ -160,7 +159,6 @@ fn test_server_error() {
             transport::serve(
                 "turmoil:0.0.0.0:7777".parse().unwrap(),
                 VERSION,
-                Some("server".into()),
                 TIMEOUT,
                 move || handler.lock().unwrap().take().unwrap(),
                 NoopMetrics,
@@ -241,7 +239,6 @@ fn test_handshake_version_mismatch() {
             transport::serve(
                 "turmoil:0.0.0.0:7777".parse().unwrap(),
                 SERVER_VERSION,
-                Some("server".into()),
                 TIMEOUT,
                 move || handler.lock().unwrap().take().unwrap(),
                 NoopMetrics,
@@ -270,49 +267,6 @@ fn test_handshake_version_mismatch() {
 
 #[test] // allow(test-attribute)
 #[cfg_attr(miri, ignore)] // too slow
-fn test_handshake_fqdn_mismatch() {
-    let mut sim = setup();
-
-    sim.host("server", move || async {
-        let (in_tx, mut in_rx) = mpsc::unbounded_channel::<()>();
-        let (_out_tx, out_rx) = mpsc::unbounded_channel::<()>();
-        let handler = ChannelHandler::new(in_tx, out_rx);
-        let handler = Arc::new(Mutex::new(Some(handler)));
-
-        mz_ore::task::spawn(
-            || "serve",
-            transport::serve(
-                "turmoil:0.0.0.0:7777".parse().unwrap(),
-                VERSION,
-                Some("wrong.server".into()),
-                TIMEOUT,
-                move || handler.lock().unwrap().take().unwrap(),
-                NoopMetrics,
-            ),
-        );
-
-        // Client has disconnected.
-        assert_none!(in_rx.recv().await);
-
-        Ok(())
-    });
-
-    sim.client("client", async move {
-        connect_ctp_error::<(), ()>(
-            "turmoil:server:7777",
-            VERSION,
-            "server FQDN mismatch: wrong.server != server",
-        )
-        .await?;
-
-        Ok(())
-    });
-
-    sim.run().unwrap();
-}
-
-#[test] // allow(test-attribute)
-#[cfg_attr(miri, ignore)] // too slow
 fn test_idle_timeout() {
     let mut sim = setup();
 
@@ -327,7 +281,6 @@ fn test_idle_timeout() {
             transport::serve(
                 "turmoil:0.0.0.0:7777".parse().unwrap(),
                 VERSION,
-                Some("server".into()),
                 TIMEOUT,
                 move || handler.lock().unwrap().take().unwrap(),
                 NoopMetrics,
@@ -381,7 +334,6 @@ fn test_keepalive() {
             transport::serve(
                 "turmoil:0.0.0.0:7777".parse().unwrap(),
                 VERSION,
-                Some("server".into()),
                 TIMEOUT,
                 move || handler.lock().unwrap().take().unwrap(),
                 NoopMetrics,
@@ -420,7 +372,6 @@ fn test_connection_cancelation() {
         transport::serve(
             "turmoil:0.0.0.0:7777".parse().unwrap(),
             VERSION,
-            Some("server".into()),
             TIMEOUT,
             OneOutputHandler::new,
             NoopMetrics,
@@ -510,7 +461,6 @@ fn test_metrics() {
             transport::serve(
                 "turmoil:0.0.0.0:7777".parse().unwrap(),
                 VERSION,
-                Some("server".into()),
                 TIMEOUT,
                 move || handler.lock().unwrap().take().unwrap(),
                 metrics.clone(),
@@ -523,8 +473,9 @@ fn test_metrics() {
         // Wait for message to be transmitted.
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        assert!(metrics.bytes_sent.load(Ordering::SeqCst) >= 63);
-        assert!(metrics.bytes_received.load(Ordering::SeqCst) >= 44);
+        // Loose lower bounds; exact counts vary by a keepalive frame.
+        assert!(metrics.bytes_sent.load(Ordering::SeqCst) >= 40);
+        assert!(metrics.bytes_received.load(Ordering::SeqCst) >= 30);
         assert_eq!(metrics.messages_sent.load(Ordering::SeqCst), 1);
         assert_eq!(metrics.messages_received.load(Ordering::SeqCst), 1);
 
@@ -546,8 +497,9 @@ fn test_metrics() {
         // Wait for message to be transmitted.
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        assert!(metrics.bytes_sent.load(Ordering::SeqCst) >= 44);
-        assert!(metrics.bytes_received.load(Ordering::SeqCst) >= 63);
+        // Loose lower bounds; exact counts vary by a keepalive frame.
+        assert!(metrics.bytes_sent.load(Ordering::SeqCst) >= 30);
+        assert!(metrics.bytes_received.load(Ordering::SeqCst) >= 40);
         assert_eq!(metrics.messages_sent.load(Ordering::SeqCst), 1);
         assert_eq!(metrics.messages_received.load(Ordering::SeqCst), 1);
 


### PR DESCRIPTION
Removes the CTP `server_fqdn` handshake check that `CLUSTERD_GRPC_HOST` fed. Despite the name it has **nothing to do with gRPC** (which is now only persist pubsub). In the CTP handshake, clusterd advertised its FQDN and the controller compared it against the address it dialed, failing on mismatch (`transport.rs::handshake`). That check is:

- **optional** — only fires when both sides set a value, so it's already a no-op when the host is unset;
- **narrow** — guards only against reaching a misrouted/stale replica (DNS / pod-IP reuse);
- **misnamed**, which is what prompted the review question on the previous PR.

The distroless migration removes `entrypoint.sh`, which set `CLUSTERD_GRPC_HOST` via `hostname --fqdn`. Rather than re-plumb that, this removes the feature: drops `--grpc-host`/`CLUSTERD_GRPC_HOST`, the `server_fqdn` field from the CTP `Hello`, the `host_from_address` helper, and the `test_handshake_fqdn_mismatch` test.

This is rebased to a single commit on `main` and stands alone: it touches only `clusterd`/`service`, not `entrypoint.sh` or any Dockerfile, so it can merge ahead of the distroless image PR (#36099).

### Notes
- Wire change: `Hello` loses a field. CTP version-gates the handshake (mismatched versions fail and reconnect), so this is safe across a release boundary.
- `test_metrics` byte-count bounds were loosened (the handshake shrank).

This is the "rip it out" answer to the FQDN question; it makes #36100 (in-process resolve) unnecessary.

## Test plan
- [x] `cargo check -p mz-clusterd -p mz-service -p mz-compute-client -p mz-storage-controller` (rustc 1.96.0)
- [x] `cargo test -p mz-service --test transport` — green across 10 consecutive runs
- [x] Confirm controller↔replica CTP connects in a k8s/kind cluster — verified via cloudtest on kind: `test_smoke` (`test_wait`: default cluster `u1` replica reached `Ready`, i.e. the CTP handshake succeeded; `test_sql`) and `test_testdrive` (multi-replica: `c1` with `r1`/`r2`, `c2` at replication factor 2, Kafka source, materialized views) all pass. Confirmed the deployed `clusterd` binary no longer exposes `--grpc-host`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
