### PR TITLE
optimizer: include panic location and backtrace in caught panic errors

### DIFF
--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -19,6 +19,7 @@ use std::any::Any;
 use std::backtrace::Backtrace;
 use std::borrow::Cow;
 use std::cell::RefCell;
+use std::fmt;
 use std::fs::File;
 use std::io::{self, Write as _};
 use std::os::fd::FromRawFd;
@@ -39,6 +40,50 @@ use crate::iter::IteratorExt;
 thread_local! {
     /// Keeps track of how many `catch_unwind` calls we are inside.
     static CATCHING_UNWIND: RefCell<usize> = const { RefCell::new(0) };
+
+    /// Keeps track of how many [`catch_unwind_with_details`] calls we are inside.
+    ///
+    /// When non-zero, the enhanced panic handler records details (the panic
+    /// location and a backtrace) about caught panics into [`CAUGHT_PANIC_DETAILS`]
+    /// before letting the unwind proceed.
+    static CAPTURE_PANIC_DETAILS: RefCell<usize> = const { RefCell::new(0) };
+
+    /// Details about the most recently caught panic, recorded by the enhanced
+    /// panic handler when [`CAPTURE_PANIC_DETAILS`] is non-zero. Consumed by
+    /// [`catch_unwind_with_details`].
+    static CAUGHT_PANIC_DETAILS: RefCell<Option<PanicDetails>> = const { RefCell::new(None) };
+}
+
+/// Details about a caught panic, captured at the panic site by the enhanced
+/// panic handler. See [`catch_unwind_with_details`].
+#[derive(Clone, Debug, Default)]
+pub struct PanicDetails {
+    /// The source code location at which the panic occurred, if known.
+    pub location: Option<String>,
+    /// A backtrace captured at the panic site, if one was captured.
+    pub backtrace: Option<String>,
+}
+
+/// A panic recovered by [`catch_unwind_with_details`], bundling the panic
+/// message with the location and backtrace captured at the panic site.
+#[derive(Clone, Debug)]
+pub struct CaughtPanic {
+    /// The panic message.
+    pub message: Cow<'static, str>,
+    /// The source code location at which the panic occurred, if known.
+    pub location: Option<String>,
+    /// A backtrace captured at the panic site, if one was captured.
+    pub backtrace: Option<String>,
+}
+
+impl fmt::Display for CaughtPanic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)?;
+        if let Some(location) = &self.location {
+            write!(f, ", at {location}")?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(feature = "async")]
@@ -93,6 +138,24 @@ pub fn install_enhanced_handler() {
         #[cfg(not(feature = "async"))]
         let catching_unwind_async = false;
         if catching_unwind != 0 || catching_unwind_async {
+            // We're letting the unwind proceed without printing or reporting the
+            // panic. The location and backtrace would normally be lost here,
+            // because `catch_unwind` only recovers the panic payload (the
+            // message). If a caller has opted in via `catch_unwind_with_details`,
+            // stash those details now so they can be attached to the resulting
+            // error. We only pay the cost of capturing a backtrace when a panic
+            // actually occurs, which is the exceptional case.
+            let capture_details = CAPTURE_PANIC_DETAILS.with(|v| *v.borrow()) != 0;
+            if capture_details {
+                let location = panic_info.location().map(|loc| loc.to_string());
+                let backtrace = Backtrace::force_capture().to_string();
+                CAUGHT_PANIC_DETAILS.with(|details| {
+                    *details.borrow_mut() = Some(PanicDetails {
+                        location,
+                        backtrace: Some(backtrace),
+                    });
+                });
+            }
             return;
         }
 
@@ -245,5 +308,50 @@ where
                 None => Err(Cow::Borrowed("Box<Any>")),
             },
         },
+    }
+}
+
+/// Like [`catch_unwind_str`], but on panic also recovers the panic's source
+/// location and a backtrace captured at the panic site, bundled together in a
+/// [`CaughtPanic`].
+///
+/// The standard catch-unwind machinery only recovers the panic payload (the
+/// message); the location and backtrace are otherwise only available inside the
+/// panic handler, which runs before the stack is unwound. This function opts in
+/// to having the enhanced panic handler (see [`install_enhanced_handler`]) stash
+/// those details so they can be attached to the returned error.
+///
+/// Capturing a backtrace is relatively expensive, but the cost is only paid when
+/// a panic actually occurs, so this is suitable for enriching internal errors
+/// with extra context. If [`install_enhanced_handler`] has not been installed,
+/// the `location` and `backtrace` fields will be absent, but the `message` is
+/// still recovered.
+pub fn catch_unwind_with_details<F, R>(f: F) -> Result<R, CaughtPanic>
+where
+    F: FnOnce() -> R + UnwindSafe,
+{
+    CAPTURE_PANIC_DETAILS.with(|v| *v.borrow_mut() += 1);
+    let res = catch_unwind(f);
+    CAPTURE_PANIC_DETAILS.with(|v| *v.borrow_mut() -= 1);
+
+    match res {
+        Ok(res) => Ok(res),
+        Err(opaque) => {
+            let message = match opaque.downcast_ref::<&'static str>() {
+                Some(s) => Cow::Borrowed(*s),
+                None => match opaque.downcast_ref::<String>() {
+                    Some(s) => Cow::Owned(s.to_owned()),
+                    None => Cow::Borrowed("Box<Any>"),
+                },
+            };
+            let details = CAUGHT_PANIC_DETAILS
+                .with(|details| details.borrow_mut().take())
+                .unwrap_or_default();
+            Err(CaughtPanic {
+                message,
+                location: details.location,
+                backtrace: details.backtrace,
+            })
+        }
     }
 }

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -67,11 +67,7 @@ struct PanicDetails {
 
 /// A panic recovered by [`catch_unwind_with_details`], bundling the panic
 /// message with the location and backtrace captured at the panic site.
-///
-/// Marked `#[non_exhaustive]` because it is likely to grow more context (e.g.
-/// thread name) over time; construct it only via [`catch_unwind_with_details`].
 #[derive(Clone, Debug)]
-#[non_exhaustive]
 pub struct CaughtPanic {
     /// The panic message.
     pub message: Cow<'static, str>,

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -54,25 +54,32 @@ thread_local! {
     static CAUGHT_PANIC_DETAILS: RefCell<Option<PanicDetails>> = const { RefCell::new(None) };
 }
 
-/// Details about a caught panic, captured at the panic site by the enhanced
-/// panic handler. See [`catch_unwind_with_details`].
-#[derive(Clone, Debug, Default)]
-pub struct PanicDetails {
+/// Details about a caught panic, recorded at the panic site by the enhanced
+/// panic handler and consumed by [`catch_unwind_with_details`]. Internal: the
+/// public-facing type is [`CaughtPanic`].
+#[derive(Clone, Debug)]
+struct PanicDetails {
     /// The source code location at which the panic occurred, if known.
-    pub location: Option<String>,
-    /// A backtrace captured at the panic site, if one was captured.
-    pub backtrace: Option<String>,
+    location: Option<String>,
+    /// A backtrace captured at the panic site. Always populated by the handler.
+    backtrace: String,
 }
 
 /// A panic recovered by [`catch_unwind_with_details`], bundling the panic
 /// message with the location and backtrace captured at the panic site.
+///
+/// Marked `#[non_exhaustive]` because it is likely to grow more context (e.g.
+/// thread name) over time; construct it only via [`catch_unwind_with_details`].
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct CaughtPanic {
     /// The panic message.
     pub message: Cow<'static, str>,
     /// The source code location at which the panic occurred, if known.
     pub location: Option<String>,
-    /// A backtrace captured at the panic site, if one was captured.
+    /// A backtrace captured at the panic site, if one was captured. Absent if
+    /// the enhanced panic handler (see [`install_enhanced_handler`]) was not
+    /// installed.
     pub backtrace: Option<String>,
 }
 
@@ -80,7 +87,7 @@ impl fmt::Display for CaughtPanic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.message)?;
         if let Some(location) = &self.location {
-            write!(f, ", at {location}")?;
+            write!(f, " (at {location})")?;
         }
         Ok(())
     }
@@ -152,7 +159,7 @@ pub fn install_enhanced_handler() {
                 CAUGHT_PANIC_DETAILS.with(|details| {
                     *details.borrow_mut() = Some(PanicDetails {
                         location,
-                        backtrace: Some(backtrace),
+                        backtrace,
                     });
                 });
             }
@@ -291,23 +298,29 @@ where
     })
 }
 
-/// Like [`crate::panic::catch_unwind`], but downcasts the returned `Box<dyn Any>` error to a
-/// string which is almost always is.
+/// Downcasts an opaque panic payload (as returned by [`catch_unwind`]) to its
+/// message string, which it almost always is.
 ///
 /// See: <https://doc.rust-lang.org/stable/std/panic/struct.PanicHookInfo.html#method.payload>
+fn downcast_panic_message(payload: &(dyn Any + Send)) -> Cow<'static, str> {
+    match payload.downcast_ref::<&'static str>() {
+        Some(s) => Cow::Borrowed(*s),
+        None => match payload.downcast_ref::<String>() {
+            Some(s) => Cow::Owned(s.to_owned()),
+            None => Cow::Borrowed("Box<Any>"),
+        },
+    }
+}
+
+/// Like [`crate::panic::catch_unwind`], but downcasts the returned `Box<dyn Any>` error to a
+/// string which is almost always is.
 pub fn catch_unwind_str<F, R>(f: F) -> Result<R, Cow<'static, str>>
 where
     F: FnOnce() -> R + UnwindSafe,
 {
     match crate::panic::catch_unwind(f) {
         Ok(res) => Ok(res),
-        Err(opaque) => match opaque.downcast_ref::<&'static str>() {
-            Some(s) => Err(Cow::Borrowed(*s)),
-            None => match opaque.downcast_ref::<String>() {
-                Some(s) => Err(Cow::Owned(s.to_owned())),
-                None => Err(Cow::Borrowed("Box<Any>")),
-            },
-        },
+        Err(opaque) => Err(downcast_panic_message(&*opaque)),
     }
 }
 
@@ -326,6 +339,11 @@ where
 /// with extra context. If [`install_enhanced_handler`] has not been installed,
 /// the `location` and `backtrace` fields will be absent, but the `message` is
 /// still recovered.
+///
+/// Note that the captured backtrace is always a full backtrace
+/// ([`Backtrace::force_capture`]); unlike the aborting path in
+/// [`install_enhanced_handler`], it does not honor `RUST_BACKTRACE`, since these
+/// caught panics are rare and the extra context is worth the verbosity.
 pub fn catch_unwind_with_details<F, R>(f: F) -> Result<R, CaughtPanic>
 where
     F: FnOnce() -> R + UnwindSafe,
@@ -337,20 +355,16 @@ where
     match res {
         Ok(res) => Ok(res),
         Err(opaque) => {
-            let message = match opaque.downcast_ref::<&'static str>() {
-                Some(s) => Cow::Borrowed(*s),
-                None => match opaque.downcast_ref::<String>() {
-                    Some(s) => Cow::Owned(s.to_owned()),
-                    None => Cow::Borrowed("Box<Any>"),
-                },
+            let message = downcast_panic_message(&*opaque);
+            let details = CAUGHT_PANIC_DETAILS.with(|details| details.borrow_mut().take());
+            let (location, backtrace) = match details {
+                Some(details) => (details.location, Some(details.backtrace)),
+                None => (None, None),
             };
-            let details = CAUGHT_PANIC_DETAILS
-                .with(|details| details.borrow_mut().take())
-                .unwrap_or_default();
             Err(CaughtPanic {
                 message,
-                location: details.location,
-                backtrace: details.backtrace,
+                location,
+                backtrace,
             })
         }
     }

--- a/src/ore/tests/panic.rs
+++ b/src/ore/tests/panic.rs
@@ -15,7 +15,7 @@
 
 use std::panic;
 
-use mz_ore::panic::{catch_unwind_str, install_enhanced_handler};
+use mz_ore::panic::{catch_unwind_str, catch_unwind_with_details, install_enhanced_handler};
 use scopeguard::defer;
 
 // IMPORTANT!!! Do not add any additional tests to this file. This test sets and
@@ -37,4 +37,39 @@ fn catch_panic() {
     .unwrap_err();
 
     assert_eq!(result, "panicked");
+
+    // `catch_unwind_with_details` additionally recovers the panic location and a
+    // backtrace captured at the panic site.
+    let line = line!() + 2;
+    let caught = catch_unwind_with_details(|| {
+        panic!("panicked with details");
+    })
+    .unwrap_err();
+
+    assert_eq!(caught.message, "panicked with details");
+
+    let location = caught
+        .location
+        .as_deref()
+        .expect("location should be captured");
+    assert!(
+        location.contains("tests/panic.rs"),
+        "unexpected location: {location}"
+    );
+    assert!(
+        location.contains(&format!(":{line}:")),
+        "location {location} should reference line {line}"
+    );
+
+    let backtrace = caught
+        .backtrace
+        .as_deref()
+        .expect("backtrace should be captured");
+    assert!(!backtrace.is_empty());
+
+    // The `Display` impl appends the location to the message.
+    assert_eq!(
+        caught.to_string(),
+        format!("panicked with details, at {location}")
+    );
 }

--- a/src/ore/tests/panic.rs
+++ b/src/ore/tests/panic.rs
@@ -70,6 +70,6 @@ fn catch_panic() {
     // The `Display` impl appends the location to the message.
     assert_eq!(
         caught.to_string(),
-        format!("panicked with details, at {location}")
+        format!("panicked with details (at {location})")
     );
 }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -333,7 +333,7 @@ where
             // panic the caller.
             panic!("{}", e.should_panic().expect("checked above"));
         }
-        Ok(result) => result.map_err(|e| e),
+        Ok(result) => result,
         Err(panic) => {
             // A panic during optimization is always a bug; log an error, including the panic
             // location and a backtrace from the panic site, so we learn about it. Pass the
@@ -351,11 +351,9 @@ where
             );
 
             // Surface at least the panic location in the user-facing error, so that internal
-            // errors are actionable without having to grep the logs for the backtrace.
-            let msg = format!(
-                "unexpected panic during query optimization: {} (at {})",
-                panic.message, location,
-            );
+            // errors are actionable without having to grep the logs for the backtrace. The
+            // `CaughtPanic` `Display` impl appends the panic location to the message.
+            let msg = format!("unexpected panic during query optimization: {panic}");
             Err(TransformError::Internal(msg).into())
         }
     }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -326,7 +326,7 @@ where
     Opt: FnOnce() -> Result<To, E>,
     E: From<TransformError> + MaybeShouldPanic,
 {
-    match mz_ore::panic::catch_unwind_str(AssertUnwindSafe(optimization)) {
+    match mz_ore::panic::catch_unwind_with_details(AssertUnwindSafe(optimization)) {
         Ok(Err(e)) if e.should_panic().is_some() => {
             // Promote a `CallerShouldPanic` error from the result to a proper panic. This is
             // needed in order to ensure that `mz_unsafe.mz_panic('forced panic')` calls still
@@ -335,11 +335,26 @@ where
         }
         Ok(result) => result.map_err(|e| e),
         Err(panic) => {
-            // A panic during optimization is always a bug; log an error so we learn about it.
-            // TODO(teskje): collect and log a backtrace from the panic site
-            tracing::error!("caught a panic during query optimization: {panic}");
+            // A panic during optimization is always a bug; log an error, including the panic
+            // location and a backtrace from the panic site, so we learn about it.
+            let location = panic.location.as_deref().unwrap_or("<unknown location>");
+            let backtrace = panic
+                .backtrace
+                .as_deref()
+                .unwrap_or("<backtrace unavailable>");
+            tracing::error!(
+                "caught a panic during query optimization: {} (at {})\n{}",
+                panic.message,
+                location,
+                backtrace,
+            );
 
-            let msg = format!("unexpected panic during query optimization: {panic}");
+            // Surface at least the panic location in the user-facing error, so that internal
+            // errors are actionable without having to grep the logs for the backtrace.
+            let msg = format!(
+                "unexpected panic during query optimization: {} (at {})",
+                panic.message, location,
+            );
             Err(TransformError::Internal(msg).into())
         }
     }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -336,17 +336,18 @@ where
         Ok(result) => result.map_err(|e| e),
         Err(panic) => {
             // A panic during optimization is always a bug; log an error, including the panic
-            // location and a backtrace from the panic site, so we learn about it.
+            // location and a backtrace from the panic site, so we learn about it. Pass the
+            // pieces as structured fields rather than encoding them into the message string.
             let location = panic.location.as_deref().unwrap_or("<unknown location>");
             let backtrace = panic
                 .backtrace
                 .as_deref()
                 .unwrap_or("<backtrace unavailable>");
             tracing::error!(
-                "caught a panic during query optimization: {} (at {})\n{}",
-                panic.message,
                 location,
                 backtrace,
+                message = %panic.message,
+                "caught a panic during query optimization",
             );
 
             // Surface at least the panic location in the user-facing error, so that internal


### PR DESCRIPTION
### Motivation

When a transform panics, `catch_unwind_optimize` demotes it to an internal optimizer error. Today we only get the panic *message* — no location, no backtrace — so an error like:

```
internal error in optimizer: internal transform error: unexpected panic during query optimization: index out of bounds: the len is 2 but the index is 18446744073709551615
```

gives no hint about *where* in the optimizer the panic happened, making these bugs hard to track down.

The panic location and backtrace are only available inside the panic handler (which runs *before* the stack is unwound), but `mz_ore`'s enhanced panic handler returns early — without printing or reporting — while catching an unwind. So that context was discarded, and `catch_unwind_str` only recovered the payload message. There was even a long-standing `TODO(teskje): collect and log a backtrace from the panic site` at the call site.

### Changes

* **`mz_ore::panic`** — add an opt-in capture path:
  * `catch_unwind_with_details(...)` works like `catch_unwind_str`, but on panic returns a `CaughtPanic { message, location, backtrace }`.
  * While inside such a call, the enhanced panic handler stashes the panic location and a backtrace into a thread-local before letting the unwind proceed, instead of throwing them away.
  * This is a *parallel* infra: the backtrace is only captured when a panic actually fires (the exceptional case), so there's **no per-optimization cost**, and other `catch_unwind` callers are completely unaffected. If the enhanced handler isn't installed, the message is still recovered and `location`/`backtrace` are simply absent.

* **`mz_transform`** — `catch_unwind_optimize` now uses `catch_unwind_with_details`:
  * The **user-facing error** includes at least the panic location: `... unexpected panic during query optimization: <msg> (at <file:line:col>)`.
  * The **full backtrace** is logged via `tracing::error!` (resolving the old TODO).

### Tips for reviewer

The behavioral change for existing `catch_unwind`/`catch_unwind_str` callers is nil — they don't set the `CAPTURE_PANIC_DETAILS` thread-local, so the handler's early-return path is unchanged for them.

This PR was drafted by Claude Code at the request of @mh.

https://claude.ai/code/session_01Av4N3HccSLB4Y3EAjvdngx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Av4N3HccSLB4Y3EAjvdngx)_