### PR TITLE
console: show real balancerd host in the OIDC connect modal

### DIFF
--- a/console/src/components/McpConnectInstructions.tsx
+++ b/console/src/components/McpConnectInstructions.tsx
@@ -61,12 +61,15 @@ const McpConnectInstructions = ({
 
   if (!envAddress) return null;
 
-  // Cloud: HTTPS with the environment's HTTP address hostname.
-  // Self-managed: Use a placeholder since the MCP endpoint may be behind a
-  // load balancer or custom domain that we can't determine from the console.
+  const balancerdHost =
+    appConfig.mode === "self-managed"
+      ? appConfig.balancerdDnsNames?.[0]
+      : undefined;
   const baseUrl = isCloud
     ? `https://${envAddress.split(":")[0]}`
-    : "<your-materialize-host>";
+    : balancerdHost
+      ? `https://${balancerdHost}`
+      : "<your-materialize-host>";
 
   const user = userStr || "<user>";
   const base64Command = `printf '${user}:<password>' | base64 -w0`;

--- a/console/src/components/OidcConnectModal.tsx
+++ b/console/src/components/OidcConnectModal.tsx
@@ -28,6 +28,7 @@ import {
 import McpConnectInstructions from "~/components/McpConnectInstructions";
 import { Modal } from "~/components/Modal";
 import TextLink from "~/components/TextLink";
+import { useAppConfig } from "~/config/useAppConfig";
 import { type AuthContextProps } from "~/external-library-wrappers/oidc";
 import { useSelfManagedProfile } from "~/hooks/useSelfManagedProfile";
 import ConnectionIcon from "~/svg/ConnectionIcon";
@@ -47,6 +48,7 @@ const OidcConnectModal = ({
   auth: AuthContextProps;
 }) => {
   const { colors } = useTheme<MaterializeTheme>();
+  const appConfig = useAppConfig();
   const idToken = auth.user?.id_token;
 
   const { sqlRole } = useSelfManagedProfile(auth);
@@ -54,7 +56,13 @@ const OidcConnectModal = ({
 
   const obfuscated = idToken ? obfuscateSecret(idToken) : "";
 
-  const sqlAddress = `${HOST_PLACEHOLDER}:6875`;
+  const balancerdHost =
+    appConfig.mode === "self-managed"
+      ? appConfig.balancerdDnsNames?.[0]
+      : undefined;
+  const sqlAddress = balancerdHost
+    ? `${balancerdHost}:6875`
+    : `${HOST_PLACEHOLDER}:6875`;
 
   return (
     <Modal size="3xl" isOpen={isOpen} onClose={onClose}>
@@ -68,12 +76,13 @@ const OidcConnectModal = ({
             whiteSpace="normal"
             color={colors.foreground.secondary}
           >
-            Replace <Code fontSize="xs">{HOST_PLACEHOLDER}</Code> with your
-            Materialize SQL endpoint. For Terraform installs, run{" "}
-            <Code fontSize="xs">
-              terraform output -raw balancerd_load_balancer_ip
-            </Code>{" "}
-            to get it. See the{" "}
+            {!balancerdHost && (
+              <>
+                Replace <Code fontSize="xs">{HOST_PLACEHOLDER}</Code> with your
+                Materialize SQL endpoint.{" "}
+              </>
+            )}
+            See the{" "}
             <TextLink
               href="https://materialize.com/docs/self-managed-deployments/installation/install-on-gcp/#step-3-apply-the-terraform"
               isExternal

--- a/console/src/config/AppConfig.ts
+++ b/console/src/config/AppConfig.ts
@@ -207,6 +207,8 @@ export class SelfManagedAppConfig implements IBaseAppConfig {
 
   authMode: SelfManagedAuthMode = appConfigJson.auth.mode;
 
+  balancerdDnsNames: string[] | undefined = appConfigJson.balancerdDnsNames;
+
   environmentdScheme = getEnvironmentdScheme({
     buildConstants,
     isLocalImpersonation: false,

--- a/console/src/config/importAppConfig.ts
+++ b/console/src/config/importAppConfig.ts
@@ -34,14 +34,20 @@ export function importAppConfig(): {
   auth: {
     mode: SelfManagedAuthMode;
   };
+  balancerdDnsNames?: string[];
 } {
   if (process.env.NODE_ENV === "test") {
     return DEFAULT_APP_CONFIG;
   }
 
-  return appConfigJson as {
+  const json = appConfigJson as {
     auth: {
       mode: SelfManagedAuthMode;
     };
+    balancerd_dns_names?: string[];
+  };
+  return {
+    auth: json.auth,
+    balancerdDnsNames: json.balancerd_dns_names,
   };
 }


### PR DESCRIPTION
Read balancerd_dns_names from app-config and use
the first entry as the SQL host in the OIDC connect modal and the MCP server hostname. Falls back to the <host> placeholder when the field is absent. Drop the "Replace <host>..." instruction from the intro when a real host is available.


### Motivation

Fixes [CNS-87](https://linear.app/materializeinc/issue/CNS-87/use-balancerd-dns-names-in-console-app-config-to-show-host-name-in)

### Verification
- Reading the host name from app config
<img width="1732" height="1114" alt="image" src="https://github.com/user-attachments/assets/44acf302-a6b6-4a8f-b8a5-8cad33ff79fa" />

- Host name in MCP connect modal
<img width="1490" height="1326" alt="image" src="https://github.com/user-attachments/assets/73987aeb-c0a9-4b36-8d46-9ea93e072b65" />

- When no host name is available 
<img width="1496" height="890" alt="image" src="https://github.com/user-attachments/assets/2baf4ea6-4e27-4bb9-9818-6bdc2f09b4d3" />

