### PR TITLE
console: only surface oidc auth errors from active sign-in attempts

### DIFF
--- a/console/src/api/materialize/auth.ts
+++ b/console/src/api/materialize/auth.ts
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import { NOT_SUPPORTED_MESSAGE } from "~/config/AppConfig";
+import storageAvailable from "~/utils/storageAvailable";
 
 import { apiClient, type SelfManagedApiClient } from "../apiClient";
 
@@ -30,8 +31,10 @@ const getApiClient = () => {
 
 export const LOGIN_PATH = "/account/login";
 
-// Search-param on LOGIN_PATH carrying a sanitized auth-error message.
-export const LOGIN_ERROR_PARAM = "error";
+// sessionStorage key used to hand a one-shot auth-error message to the login
+// page after a callback/logout redirect. The Login component reads and
+// removes the entry on mount, so the error never persists across refresh.
+export const LOGIN_ERROR_STORAGE_KEY = "mz-login-error";
 
 // Login API for to self-managed in password auth mode.
 // Throws if the API isn't supported for the deployment/auth mode.
@@ -89,10 +92,10 @@ export async function logoutAndRedirect(logoutParams: {
   error?: string;
 }) {
   logout(logoutParams);
-  const url = logoutParams.error
-    ? `${LOGIN_PATH}?${new URLSearchParams({ [LOGIN_ERROR_PARAM]: logoutParams.error }).toString()}`
-    : LOGIN_PATH;
-  window.location.href = url;
+  if (logoutParams.error && storageAvailable("sessionStorage")) {
+    window.sessionStorage.setItem(LOGIN_ERROR_STORAGE_KEY, logoutParams.error);
+  }
+  window.location.href = LOGIN_PATH;
 }
 
 export async function logoutAndRedirectOrThrow() {

--- a/console/src/platform/auth/Login.tsx
+++ b/console/src/platform/auth/Login.tsx
@@ -23,9 +23,9 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
-import { LOGIN_ERROR_PARAM, loginOrThrow } from "~/api/materialize/auth";
+import { LOGIN_ERROR_STORAGE_KEY, loginOrThrow } from "~/api/materialize/auth";
 import Alert from "~/components/Alert";
 import { LabeledInput } from "~/components/formComponentsV2";
 import { MaterializeLogo } from "~/components/MaterializeLogo";
@@ -34,6 +34,7 @@ import { AuthContentContainer, AuthLayout } from "~/layouts/AuthLayout";
 import EyeClosedIcon from "~/svg/EyeClosedIcon";
 import EyeOpenIcon from "~/svg/EyeOpenIcon";
 import { MaterializeTheme } from "~/theme";
+import storageAvailable from "~/utils/storageAvailable";
 
 type LoginFormState = {
   username: string;
@@ -197,10 +198,14 @@ const SsoLoginLink = () => {
 };
 
 export const Login = () => {
-  const [searchParams] = useSearchParams();
   const { data: auth, error: oidcInitializationError } = useOidcManagerQuery();
 
-  const oidcError = searchParams.get(LOGIN_ERROR_PARAM);
+  const [oidcError] = useState<string | null>(() => {
+    if (!storageAvailable("sessionStorage")) return null;
+    const msg = window.sessionStorage.getItem(LOGIN_ERROR_STORAGE_KEY);
+    if (msg) window.sessionStorage.removeItem(LOGIN_ERROR_STORAGE_KEY);
+    return msg;
+  });
 
   return (
     <AuthLayout>

--- a/console/src/platform/auth/OidcCallback.tsx
+++ b/console/src/platform/auth/OidcCallback.tsx
@@ -10,9 +10,10 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
 
-import { LOGIN_ERROR_PARAM, LOGIN_PATH } from "~/api/materialize/auth";
+import { LOGIN_ERROR_STORAGE_KEY, LOGIN_PATH } from "~/api/materialize/auth";
 import LoadingScreen from "~/components/LoadingScreen";
 import { useAuth } from "~/external-library-wrappers/oidc";
+import storageAvailable from "~/utils/storageAvailable";
 
 // Forwards IdP callback errors to the login page so all sign-in errors
 // render in one place.
@@ -25,8 +26,10 @@ export const OidcCallback = () => {
   }
   if (auth.error) {
     const message = auth.error.message?.trim() || "Sign-in failed";
-    const params = new URLSearchParams({ [LOGIN_ERROR_PARAM]: message });
-    return <Navigate to={`${LOGIN_PATH}?${params.toString()}`} replace />;
+    if (storageAvailable("sessionStorage")) {
+      window.sessionStorage.setItem(LOGIN_ERROR_STORAGE_KEY, message);
+    }
+    return <Navigate to={LOGIN_PATH} replace />;
   }
   return <LoadingScreen />;
 };


### PR DESCRIPTION
Auth errors were sticky on the login page across refresh and back navigation. Switched the url param to a sessionStorage key that login component reads and removes on mount so the error doesn't persist on reload.

Remove these sections if your commit already has a good description!

### Motivation

Fixes [CNS-88](https://linear.app/materializeinc/issue/CNS-88/sso-error-persisting-on-page-reload)

### Description

What does this PR actually do? Focus on the approach and any non-obvious  <br>decisions. The diff shows the code --- use this space to explain what the  <br>diff *can't* tell a reviewer.

### Verification

Before the fix error keeps persisting:

https://github.com/user-attachments/assets/a9b6ba48-fd78-4104-9761-96ca1e415509

After fix error doesn't persist on refresh:

https://github.com/user-attachments/assets/0c74f83a-9672-427d-b6c7-f1f7df67168a