### PR TITLE
http-util: disable miri for handle_prometheus rules header test

### DIFF
--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -352,6 +352,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function on OS `linux`
     async fn handle_prometheus_emits_rules_header_when_opted_in() {
         let registry = registry_with_rules();
         let mut headers = HeaderMap::new();


### PR DESCRIPTION
## Motivation

The `mz-http-util` test `tests::handle_prometheus_emits_rules_header_when_opted_in` fails under miri:

```
FAIL [   2.802s] (248/786) mz-http-util tests::handle_prometheus_emits_rules_header_when_opted_in
```

The test exercises metric registration and prometheus encoding, which transitively calls foreign functions that miri cannot execute.

## Changes

Adds `#[cfg_attr(miri, ignore)]` to the test, matching the convention used elsewhere in the codebase for tests that aren't supported under miri.

https://claude.ai/code/session_01Y3j699CNXf64TEN16PRHqX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3j699CNXf64TEN16PRHqX)_