### PR TITLE
http-util: skip handle_prometheus rules-header test under Miri

### DIFF
--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -352,6 +352,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `zlibVersion` on OS `linux`
     async fn handle_prometheus_emits_rules_header_when_opted_in() {
         let registry = registry_with_rules();
         let mut headers = HeaderMap::new();


### PR DESCRIPTION
### Motivation

The Miri nightly is failing on `main`:

```
error: unsupported operation: can't call foreign function `zlibVersion` on OS `linux`
   FAIL mz-http-util tests::handle_prometheus_emits_rules_header_when_opted_in
```

`handle_prometheus_emits_rules_header_when_opted_in` exercises `encode_enrich_rules`, which gzips the enrichment-rules header via flate2's zlib backend. Miri can't call the foreign `zlibVersion` C function, so the test aborts and fails the Miri run. This was introduced by #36633 and is failing nightly on main (e.g. build 16684) as well as on branches stacked on top of it.

### Tips for reviewer

Single-line change: annotate the test with `#[cfg_attr(miri, ignore)]`, matching how other foreign-function-dependent tests are excluded from Miri across the repo. The other two `handle_prometheus_*` tests don't reach the gzip path, so they continue to run under Miri.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [release note](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#release-notes), or is a part of a feature that will be released in the future.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)