### PR TITLE
SS-16: Introduce general Wireformat<C> for schema registries

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -18,7 +18,7 @@ pub use crate::avro::encode::{
     AvroEncoder, AvroSchemaGenerator, DocTarget, encode_datums_as_avro,
     encode_debezium_transaction_unchecked, get_debezium_transaction_schema,
 };
-pub use crate::avro::schema::{ConfluentAvroResolver, parse_schema, schema_to_relationdesc};
+pub use crate::avro::schema::{AvroSchemaResolver, parse_schema, schema_to_relationdesc};
 
 fn is_null(schema: &SchemaPieceOrNamed) -> bool {
     matches!(schema, SchemaPieceOrNamed::Piece(SchemaPiece::Null))

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -26,12 +26,12 @@ use serde::{Deserialize, Serialize};
 use tracing::trace;
 use uuid::Uuid;
 
-use crate::avro::ConfluentAvroResolver;
+use crate::avro::AvroSchemaResolver;
 
 /// Manages decoding of Avro-encoded bytes.
 #[derive(Debug)]
 pub struct Decoder {
-    csr_avro: ConfluentAvroResolver,
+    csr_avro: AvroSchemaResolver,
     debug_name: String,
     buf1: Vec<u8>,
     row_buf: Row,
@@ -82,7 +82,7 @@ impl Decoder {
         debug_name: String,
         confluent_wire_format: bool,
     ) -> anyhow::Result<Decoder> {
-        let csr_avro = ConfluentAvroResolver::new(
+        let csr_avro = AvroSchemaResolver::new(
             reader_schema,
             reader_reference_schemas,
             ccsr_client,

--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -360,13 +360,13 @@ mod tests {
     }
 }
 
-pub struct ConfluentAvroResolver {
+pub struct AvroSchemaResolver {
     reader_schema: Schema,
     writer_schemas: Option<SchemaCache>,
     confluent_wire_format: bool,
 }
 
-impl ConfluentAvroResolver {
+impl AvroSchemaResolver {
     pub fn new(
         reader_schema: &str,
         reader_reference_schemas: &[String],
@@ -432,9 +432,9 @@ impl ConfluentAvroResolver {
     }
 }
 
-impl fmt::Debug for ConfluentAvroResolver {
+impl fmt::Debug for AvroSchemaResolver {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("ConfluentAvroResolver")
+        f.debug_struct("AvroSchemaResolver")
             .field("reader_schema", &self.reader_schema)
             .field(
                 "write_schema",

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -119,6 +119,7 @@ use mz_storage_types::sources::{
     SourceExportDetails, SourceExportStatementDetails, SqlServerSourceConnection,
     SqlServerSourceExtras, Timeline,
 };
+use mz_storage_types::wire_format::WireFormat;
 use prost::Message;
 
 use crate::ast::display::AstDisplay;
@@ -2372,27 +2373,41 @@ fn get_encoding_inner(
                 }
             };
 
+            // Map the legacy (csr_connection, confluent_wire_format) pair to
+            // the unified `WireFormat`. `(Some, false)` is unreachable in
+            // practice (the planner only sets `confluent_wire_format = false`
+            // on inline schemas, which never carry a CSR connection) but is
+            // rejected explicitly here to keep the invariant local.
+            let wire_format = match (csr_connection.clone(), confluent_wire_format) {
+                (None, false) => WireFormat::None,
+                (None, true) => WireFormat::Confluent { registry: None },
+                (Some(c), true) => WireFormat::Confluent { registry: Some(c) },
+                (Some(_), false) => {
+                    sql_bail!(
+                        "internal error: AVRO source has CSR connection but \
+                         CONFLUENT WIRE FORMAT = false"
+                    )
+                }
+            };
+
             if let Some(key_schema) = key_schema {
                 return Ok(SourceDataEncoding {
                     key: Some(DataEncoding::Avro(AvroEncoding {
                         schema: key_schema,
                         reference_schemas: key_reference_schemas,
-                        csr_connection: csr_connection.clone(),
-                        confluent_wire_format,
+                        wire_format: wire_format.clone(),
                     })),
                     value: DataEncoding::Avro(AvroEncoding {
                         schema: value_schema,
                         reference_schemas: value_reference_schemas,
-                        csr_connection,
-                        confluent_wire_format,
+                        wire_format,
                     }),
                 });
             } else {
                 DataEncoding::Avro(AvroEncoding {
                     schema: value_schema,
                     reference_schemas: value_reference_schemas,
-                    csr_connection,
-                    confluent_wire_format,
+                    wire_format,
                 })
             }
         }
@@ -3898,7 +3913,9 @@ fn kafka_sink_builder(
                 } else {
                     options.value_compatibility_level
                 },
-                csr_connection,
+                wire_format: WireFormat::Confluent {
+                    registry: Some(csr_connection),
+                },
             })
         }
         format => bail_unsupported!(format!("sink format {:?}", format)),

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -26,6 +26,7 @@ pub mod sinks;
 pub mod sources;
 pub mod stats;
 pub mod time_dependence;
+pub mod wire_format;
 
 /// Explicitly states the contract between storage and higher levels of
 /// Materialize w/r/t which facets of objects managed by storage (e.g. sources,

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -31,6 +31,7 @@ use crate::connections::inline::{
 };
 use crate::connections::{ConnectionContext, KafkaConnection, KafkaTopicOptions};
 use crate::controller::AlterError;
+use crate::wire_format::WireFormat;
 
 pub mod s3_oneshot_sink;
 
@@ -457,7 +458,9 @@ pub enum KafkaSinkFormatType<C: ConnectionAccess = InlinedConnection> {
     Avro {
         schema: String,
         compatibility_level: Option<mz_ccsr::CompatibilityLevel>,
-        csr_connection: C::Csr,
+        /// Wire-format dispatch and the registry to publish to. Sinks
+        /// require a registry
+        wire_format: WireFormat<C>,
     },
     Json,
     Text,
@@ -507,18 +510,16 @@ impl<C: ConnectionAccess> KafkaSinkFormat<C> {
                 KafkaSinkFormatType::Avro {
                     schema,
                     compatibility_level: _,
-                    csr_connection,
+                    wire_format,
                 },
                 KafkaSinkFormatType::Avro {
                     schema: other_schema,
                     compatibility_level: _,
-                    csr_connection: other_csr_connection,
+                    wire_format: other_wire_format,
                 },
             ) => {
                 if schema != other_schema
-                    || csr_connection
-                        .alter_compatible(id, other_csr_connection)
-                        .is_err()
+                    || wire_format.alter_compatible(id, other_wire_format).is_err()
                 {
                     tracing::warn!(
                         "KafkaSinkFormat::Avro incompatible at value_format:\nself:\n{:#?}\n\nother\n{:#?}",
@@ -546,18 +547,16 @@ impl<C: ConnectionAccess> KafkaSinkFormat<C> {
                 Some(KafkaSinkFormatType::Avro {
                     schema,
                     compatibility_level: _,
-                    csr_connection,
+                    wire_format,
                 }),
                 Some(KafkaSinkFormatType::Avro {
                     schema: other_schema,
                     compatibility_level: _,
-                    csr_connection: other_csr_connection,
+                    wire_format: other_wire_format,
                 }),
             ) => {
                 if schema != other_schema
-                    || csr_connection
-                        .alter_compatible(id, other_csr_connection)
-                        .is_err()
+                    || wire_format.alter_compatible(id, other_wire_format).is_err()
                 {
                     tracing::warn!(
                         "KafkaSinkFormat::Avro incompatible at key_format:\nself:\n{:#?}\n\nother\n{:#?}",
@@ -603,11 +602,11 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkFormatType, R>
             KafkaSinkFormatType::Avro {
                 schema,
                 compatibility_level,
-                csr_connection,
+                wire_format,
             } => KafkaSinkFormatType::Avro {
                 schema,
                 compatibility_level,
-                csr_connection: r.resolve_connection(csr_connection).unwrap_csr(),
+                wire_format: wire_format.into_inline_connection(r),
             },
             KafkaSinkFormatType::Json => KafkaSinkFormatType::Json,
             KafkaSinkFormatType::Text => KafkaSinkFormatType::Text,

--- a/src/storage-types/src/sources/encoding.rs
+++ b/src/storage-types/src/sources/encoding.rs
@@ -20,6 +20,7 @@ use crate::connections::inline::{
     ReferencedConnection,
 };
 use crate::controller::AlterError;
+use crate::wire_format::WireFormat;
 
 /// A description of how to interpret data from various sources
 ///
@@ -256,8 +257,9 @@ pub struct AvroEncoding<C: ConnectionAccess = InlinedConnection> {
     /// These are fetched from the schema registry when the source is created.
     #[serde(default)]
     pub reference_schemas: Vec<String>,
-    pub csr_connection: Option<C::Csr>,
-    pub confluent_wire_format: bool,
+    /// How schema identifiers are framed in the Kafka payload, and the
+    /// registry (if any) used to resolve writer schemas.
+    pub wire_format: WireFormat<C>,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<AvroEncoding, R>
@@ -267,14 +269,12 @@ impl<R: ConnectionResolver> IntoInlineConnection<AvroEncoding, R>
         let AvroEncoding {
             schema,
             reference_schemas,
-            csr_connection,
-            confluent_wire_format,
+            wire_format,
         } = self;
         AvroEncoding {
             schema,
             reference_schemas,
-            csr_connection: csr_connection.map(|csr| r.resolve_connection(csr).unwrap_csr()),
-            confluent_wire_format,
+            wire_format: wire_format.into_inline_connection(r),
         }
     }
 }
@@ -288,8 +288,7 @@ impl<C: ConnectionAccess> AlterCompatible for AvroEncoding<C> {
         let AvroEncoding {
             schema,
             reference_schemas,
-            csr_connection,
-            confluent_wire_format,
+            wire_format,
         } = self;
 
         let compatibility_checks = [
@@ -299,15 +298,8 @@ impl<C: ConnectionAccess> AlterCompatible for AvroEncoding<C> {
                 "reference_schemas",
             ),
             (
-                match (csr_connection, &other.csr_connection) {
-                    (Some(s), Some(o)) => s.alter_compatible(id, o).is_ok(),
-                    (s, o) => s == o,
-                },
-                "csr_connection",
-            ),
-            (
-                confluent_wire_format == &other.confluent_wire_format,
-                "confluent_wire_format",
+                wire_format.alter_compatible(id, &other.wire_format).is_ok(),
+                "wire_format",
             ),
         ];
 

--- a/src/storage-types/src/wire_format.rs
+++ b/src/storage-types/src/wire_format.rs
@@ -1,0 +1,134 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Wire-format dispatch for Avro encoding/decoding on Kafka topics.
+//!
+//! [`WireFormat`] picks how schema identifiers are framed inside a Kafka
+//! record payload. Both source decode and sink encode share this enum. Sinks
+//! always require a registry; that invariant is upheld by construction, since
+//! the only sink-Avro constructor produces `Confluent { registry: Some(_) }`
+//! and other variants are never built for a sink.
+//!
+//! Variants:
+//!
+//! * [`WireFormat::None`] — no framing. The single schema carried by the
+//!   surrounding `AvroEncoding` applies to every record. Source-only.
+//! * [`WireFormat::Confluent`] — Confluent Schema Registry framing
+//!   (magic byte + i32 schema id). `registry` is `None` for sources that
+//!   ingest Confluent-framed bytes without an attached CSR connection
+//!   (the schema id is read but the schema is not fetched).
+//! * [`WireFormat::Glue`] — AWS Glue Schema Registry framing
+//!   (magic byte + UUID schema-version id). Not yet wired to the planner, so
+//!   currently unconstructable from SQL — defined here so the in-memory shape
+//!   is stable while the rest of the support lands.
+
+use mz_repr::GlobalId;
+use serde::{Deserialize, Serialize};
+
+use crate::AlterCompatible;
+use crate::connections::inline::{
+    ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
+    ReferencedConnection,
+};
+use crate::controller::AlterError;
+
+/// How schema identifiers are framed in a Kafka record payload.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum WireFormat<C: ConnectionAccess = InlinedConnection> {
+    /// No framing; the surrounding `AvroEncoding`'s single schema applies
+    /// to every record. Source-only — never constructed for a sink.
+    None,
+    /// Confluent Schema Registry framing (magic byte + i32 schema id).
+    Confluent {
+        /// CSR connection used to fetch writer schemas (sources) or
+        /// register schemas (sinks). `None` is only valid on the source
+        /// side, when the user supplied `CONFLUENT WIRE FORMAT` without a
+        /// registry.
+        registry: Option<C::Csr>,
+    },
+    /// AWS Glue Schema Registry framing (magic byte + UUID schema-version id).
+    Glue {
+        /// Glue Schema Registry connection. `None` is reserved for future
+        /// source configurations that consume Glue-framed bytes without
+        /// fetching writer schemas.
+        registry: Option<C::GlueSchemaRegistry>,
+    },
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<WireFormat, R>
+    for WireFormat<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> WireFormat {
+        match self {
+            WireFormat::None => WireFormat::None,
+            WireFormat::Confluent { registry } => WireFormat::Confluent {
+                registry: registry.map(|c| r.resolve_connection(c).unwrap_csr()),
+            },
+            WireFormat::Glue { registry } => WireFormat::Glue {
+                registry: registry.map(|c| r.resolve_connection(c).unwrap_glue_schema_registry()),
+            },
+        }
+    }
+}
+
+impl<C: ConnectionAccess> AlterCompatible for WireFormat<C> {
+    fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), AlterError> {
+        if self == other {
+            return Ok(());
+        }
+        let compatible = match (self, other) {
+            (WireFormat::None, WireFormat::None) => true,
+            (
+                WireFormat::Confluent { registry: Some(s) },
+                WireFormat::Confluent { registry: Some(o) },
+            ) => s.alter_compatible(id, o).is_ok(),
+            (
+                WireFormat::Confluent { registry: None },
+                WireFormat::Confluent { registry: None },
+            ) => true,
+            (WireFormat::Glue { registry: Some(s) }, WireFormat::Glue { registry: Some(o) }) => {
+                s.alter_compatible(id, o).is_ok()
+            }
+            (WireFormat::Glue { registry: None }, WireFormat::Glue { registry: None }) => true,
+            _ => false,
+        };
+        if !compatible {
+            tracing::warn!(
+                "WireFormat incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
+                self,
+                other
+            );
+            return Err(AlterError { id });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn wire_format_alter_compatible_cross_variant_rejected() {
+        let id = GlobalId::User(1);
+        let none = WireFormat::<InlinedConnection>::None;
+        let conf_none = WireFormat::<InlinedConnection>::Confluent { registry: None };
+        let glue_none = WireFormat::<InlinedConnection>::Glue { registry: None };
+
+        // Same-variant, no registry on either side: compatible.
+        assert!(none.alter_compatible(id, &none).is_ok());
+        assert!(conf_none.alter_compatible(id, &conf_none).is_ok());
+        assert!(glue_none.alter_compatible(id, &glue_none).is_ok());
+
+        // Cross-variant: rejected.
+        assert!(none.alter_compatible(id, &conf_none).is_err());
+        assert!(none.alter_compatible(id, &glue_none).is_err());
+        assert!(conf_none.alter_compatible(id, &glue_none).is_err());
+    }
+}

--- a/src/storage/src/decode.rs
+++ b/src/storage/src/decode.rs
@@ -27,6 +27,7 @@ use mz_repr::{Datum, Diff, Row};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::errors::{CsrConnectError, DecodeError, DecodeErrorKind};
 use mz_storage_types::sources::encoding::{AvroEncoding, DataEncoding, RegexEncoding};
+use mz_storage_types::wire_format::WireFormat;
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
@@ -352,16 +353,23 @@ async fn get_decoder(
         DataEncoding::Avro(AvroEncoding {
             schema,
             reference_schemas,
-            csr_connection,
-            confluent_wire_format,
+            wire_format,
         }) => {
-            let csr_client = match csr_connection {
-                None => None,
-                Some(csr_connection) => {
-                    let csr_client = csr_connection
+            // Only the Confluent variant is reachable from SQL today; Glue
+            // is not yet wired to the planner.
+            let (csr_client, confluent_wire_format) = match wire_format {
+                WireFormat::None => (None, false),
+                WireFormat::Confluent { registry: None } => (None, true),
+                WireFormat::Confluent {
+                    registry: Some(csr_connection),
+                } => {
+                    let client = csr_connection
                         .connect(storage_configuration, InTask::Yes)
                         .await?;
-                    Some(csr_client)
+                    (Some(client), true)
+                }
+                WireFormat::Glue { .. } => {
+                    unreachable!("AWS Glue Schema Registry not supported yet")
                 }
             };
             let state = avro::AvroDecoderState::new(

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -124,6 +124,7 @@ use mz_storage_types::sinks::{
     KafkaSinkConnection, KafkaSinkFormatType, SinkEnvelope, StorageSinkDesc,
 };
 use mz_storage_types::sources::SourceData;
+use mz_storage_types::wire_format::WireFormat;
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
     Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
@@ -1437,12 +1438,24 @@ fn encode_collection<'scope>(
                     (Some(desc), Some(KafkaSinkFormatType::Avro {
                         schema,
                         compatibility_level,
-                        csr_connection,
+                        wire_format,
                     })) => {
                         // Ensure that schemas are registered with the schema registry.
                         //
                         // Note that where this lies in the rendering cycle means that we will publish the
                         // schemas each time the sink is rendered.
+                        let csr_connection = match wire_format {
+                            WireFormat::Confluent {
+                                registry: Some(csr),
+                            } => csr,
+                            // Sinks are only ever built with a Confluent
+                            // registry (see the sink planner), so anything
+                            // else is unreachable.
+                            other => unreachable!(
+                                "sink Avro key wire_format must be Confluent with registry, got {:?}",
+                                other
+                            ),
+                        };
                         let ccsr = csr_connection
                             .connect(&storage_configuration, InTask::Yes)
                             .await?;
@@ -1479,8 +1492,17 @@ fn encode_collection<'scope>(
                 KafkaSinkFormatType::Avro {
                     schema,
                     compatibility_level,
-                    csr_connection,
+                    wire_format,
                 } => {
+                    let csr_connection = match wire_format {
+                        WireFormat::Confluent {
+                            registry: Some(csr),
+                        } => csr,
+                        other => unreachable!(
+                            "sink Avro value wire_format must be Confluent with registry, got {:?}",
+                            other
+                        ),
+                    };
                     // Ensure that schemas are registered with the schema registry.
                     //
                     // Note that where this lies in the rendering cycle means that we will publish the


### PR DESCRIPTION
Introduces a `WireFormat` to describe the different binary layouts of messages in order to support different schema registries (AWS Glue Schema Registry).

This doesn't change any behavior for our existing confluent schema registry, we rely on existing tests to verify nothing breaks.