### PR TITLE
adapter,sql: Add backtraces to `RecursionLimitError`

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -563,6 +563,9 @@ impl AdapterError {
     }
 
     pub fn code(&self) -> SqlState {
+        // We define this up here to make sure `AdapterError::` and `OptimizerError::` act the same way.
+        const RECURSION_LIMIT_ERROR_CODE: SqlState = SqlState::INTERNAL_ERROR;
+
         // TODO(benesch): we should only use `SqlState::INTERNAL_ERROR` for
         // those errors that are truly internal errors. At the moment we have
         // a various classes of uncategorized errors that use this error code
@@ -641,7 +644,7 @@ impl AdapterError {
             AdapterError::IdleInTransactionSessionTimeout => {
                 SqlState::IDLE_IN_TRANSACTION_SESSION_TIMEOUT
             }
-            AdapterError::RecursionLimit(_) => SqlState::INTERNAL_ERROR,
+            AdapterError::RecursionLimit(_) => RECURSION_LIMIT_ERROR_CODE,
             AdapterError::RelationOutsideTimeDomain { .. } => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::ResourceExhaustion { .. } => SqlState::INSUFFICIENT_RESOURCES,
             AdapterError::ResultSize(_) => SqlState::OUT_OF_MEMORY,
@@ -661,9 +664,7 @@ impl AdapterError {
                     SqlState::UNDEFINED_PARAMETER
                 }
                 OptimizerError::PlanError(_) => SqlState::INTERNAL_ERROR,
-                OptimizerError::RecursionLimitError(e) => {
-                    AdapterError::RecursionLimit(e.clone()).code() // Delegate to outer
-                }
+                OptimizerError::RecursionLimitError(_) => RECURSION_LIMIT_ERROR_CODE,
                 OptimizerError::Internal(s) => {
                     AdapterError::Internal(s.clone()).code() // Delegate to outer
                 }

--- a/src/expr/src/scalar/optimizable.rs
+++ b/src/expr/src/scalar/optimizable.rs
@@ -174,7 +174,7 @@ impl OptimizableExpr for MirScalarExpr {
     where
         F: FnMut(&Self),
     {
-        self.visit_pre(f);
+        MirScalarExpr::visit_pre(self, f);
         Ok(())
     }
 }

--- a/src/ore/src/stack.rs
+++ b/src/ore/src/stack.rs
@@ -15,6 +15,7 @@
 
 //! Stack management utilities.
 
+use std::backtrace::Backtrace;
 use std::cell::RefCell;
 use std::error::Error;
 use std::fmt;
@@ -239,7 +240,11 @@ impl RecursionGuard {
             *depth += 1;
             Ok(())
         } else {
-            Err(RecursionLimitError { limit: self.limit })
+            let backtrace = Backtrace::force_capture();
+            Err(RecursionLimitError {
+                limit: self.limit,
+                backtrace,
+            })
         }
     }
 
@@ -249,15 +254,17 @@ impl RecursionGuard {
 }
 
 /// A [`RecursionGuard`]'s recursion limit was reached.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct RecursionLimitError {
     limit: usize,
-    // todo: add backtrace (say, bottom 20 frames) once `std::backtrace` stabilizes in Rust 1.65
+    backtrace: Backtrace,
 }
 
 impl fmt::Display for RecursionLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "exceeded recursion limit of {}", self.limit)
+        writeln!(f, "exceeded recursion limit of {}", self.limit)?;
+        writeln!(f, "backtrace:")?;
+        write!(f, "{}", self.backtrace)
     }
 }
 

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -42,7 +42,7 @@ pub fn empty_typechecking_context() -> SharedTypecheckingContext {
 ///
 /// Every variant has a `source` field identifying the MIR term that is home
 /// to the error (though not necessarily the root cause of the error).
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum TypeError<'a> {
     /// Unbound identifiers (local or global)
     Unbound {


### PR DESCRIPTION
### Motivation

Makes good on an old TODO. Improves diagnosis of recursion errors.

### Description

Adds a `std::backtrace::Backtrace` to `RecursionLimitError`. These are not `Clone`, which means some other small code changes as well.

Backtraces are _enormous_ (e.g., 10k frames). There is no stable way to limit the size of the backtrace.

I use `Backtrace::force_capture()`, which ignores environment variables. This feels right for blowing the stack (where paying the cost of the trace is not so bad). We could use `Backtrace::capture()` to instead rely on the environment variables.

### Verification

CI green. Any test of concrete backtraces will be _very_ brittle, so I'm reluctant to add things there. This is fundamentally debugging tooling for us.
