### PR TITLE
pager: recycle scratch files and pool page-in read buffers

### DIFF
--- a/doc/developer/design/20260603_pager_pooling.md
+++ b/doc/developer/design/20260603_pager_pooling.md
@@ -1,0 +1,229 @@
+# Pager file + buffer pooling
+
+* Associated: [CLU-65](https://linear.app/materializeinc/issue/CLU-65/pager) (follow-up to the original pager design, `20260504_pager.md`).
+
+## The problem
+
+The original pager design parked cross-handle file pooling as out of scope:
+
+> Cross-handle file pooling (one shared scratch file with a free-list). Each
+> handle owns one named file in the scratch directory; pooling is a follow-up
+> if inode pressure shows up.
+
+Inode pressure shows up. A 15-minute on-CPU profile of a production `u6`
+clusterd dominated by columnar merge-batcher work puts
+`mz_ore::pager::file::try_take_file` second across the entire process at
+**1m17.8s cumulative**. The cost splits four ways:
+
+| Cost | Time | Share | What it is |
+|---|---|---|---|
+| `FileInner::drop` → `remove_file` (unlink) | 35.6s | 46% | Deleting the scratch file after read |
+| `read_at` (pread + `copy_to_user`) | 22.8s | 29% | The read itself |
+| `Vec<u64>::resize` (zero-fill) | 13.4s | 17% | Zeroing `dst` before reading into it |
+| `File::open` | 4.3s | 5% | Path walk + open syscall |
+
+Two findings drive this design:
+
+1. **Unlink is the dominant cost, and it is not the directory operation.** Of
+   the 35.6s, ~24.8s is `iput_final → evict → ext4_evict_inode`, and ~18.4s of
+   that is `truncate_inode_pages_final` — the kernel synchronously tearing down
+   every page-cache page that the immediately-preceding read populated, on the
+   worker thread, in the hot loop. For a write-once / read-once / delete temp
+   file the entire ext4 inode lifecycle is pure overhead: we create an inode,
+   populate its page cache, then destroy both, per spill.
+
+2. **An open-fd cache would not help the hot path.** The merge batcher drains
+   chains via `FetchIter::next`, which calls `ColumnPager::take` exactly once
+   per entry: open, read fully, delete. Each scratch file is touched by exactly
+   one open and one read in its lifetime. There is no second access to amortize
+   an open against, so retaining file descriptors keyed by handle buys nothing
+   here and reintroduces the fd-exhaustion risk the original design eliminated.
+   `read_at_many` (the write-once / read-many random-access API) is the only
+   shape an fd cache would help, and it is absent from this workload.
+
+The redundant zero-fill (row 3) is mostly irreducible in isolation: skipping
+`dst.resize(.., 0)` only saves the ~2.7s userspace memset. The
+`clear_page`/`alloc_anon_folio` faulting (~10s) is the kernel zeroing fresh
+anonymous pages on first write-fault, which `read_at`'s `copy_to_user` triggers
+regardless of whether we pre-zeroed. That cost is recoverable only by keeping
+the destination memory warm across takes (buffer reuse), not by reordering the
+zero.
+
+## Success criteria
+
+* The common merge-batcher churn (pageout and take interleaved within a merge)
+  stops paying inode create + unlink + page-cache evict per spill.
+* Peak open file descriptors stay bounded by a small constant, independent of
+  how many handles are simultaneously paged out. The original design's core
+  invariant — fd count decoupled from handle count — is preserved.
+* The destination-buffer faulting cost is addressed for the steady state
+  without holding unbounded resident memory off the pager's budget.
+* No change to existing `mz_ore::pager` signatures or the
+  handle-survives-backend-flip contract. The buffer-warmth change adds one
+  accessor — `Handle::is_file` — so the `ColumnPager` layer can route a warm
+  buffer only for file-backed takes (the swap backend keeps its allocation
+  resident, so a warm buffer there is wasted). The routing lives in the caller
+  rather than inside the pager because a pager-internal pool can't see the
+  caller's recycling chokepoint — the merge batcher's per-chunk reuse — where
+  the warm buffer has to come from and return to.
+* Crash-safety story is unchanged: stale scratch is reclaimed with the pod's
+  ephemeral volume; pooling adds no new persistent state.
+
+## Out of scope
+
+* Async / `io_uring`. Still sync syscalls.
+* The swap backend. Pooling is a file-backend concern only.
+* Compression interaction. The pool stores opaque `Vec<u64>` payloads exactly
+  as today; the `ColumnPager` codec layer is unaffected.
+
+## Solution proposal
+
+Two independent, separately-shippable changes. Tier 1 attacks the 35.6s unlink;
+Tier 2 attacks the 4.3s open; the buffer story attacks the ~13s faulting. They
+compose but do not depend on each other.
+
+### Tier 1 — inode free-list (reuse files instead of unlinking)
+
+Today `FileInner::drop` calls `remove_file`, which unlinks the dirent and, as
+the last link drops, evicts the inode and truncates its page cache. Instead,
+maintain a per-process free-list of **scratch slots** — named files that exist
+on disk but back no live handle.
+
+* `take` / drop, instead of `remove_file`, returns the slot id to the
+  free-list. The file stays linked; its inode and (warm) page cache survive.
+* `pageout` pops a free slot if one is available and writes the new payload at
+  offset 0. Reads are already bounded by `len_u64s`, so stale bytes past the
+  new length are never observed — no `ftruncate` needed.
+* The free-list is capped (à la the merge batcher's `STASH_CAP` /
+  `MAX_RECYCLE_BYTES`). Beyond the cap, or for payloads larger than a recycle
+  threshold, fall back to today's create-new / unlink-on-drop path so we don't
+  hoard inodes or pin oversized files.
+
+This preserves the no-fd-retained invariant exactly: a slot on the free-list
+holds no descriptor, and a slot backing a live handle holds no descriptor. It
+removes the unlink, the inode eviction, and the synchronous page-cache
+truncate — the entire 35.6s — for every spill that lands a recycled slot.
+Because pageout and take interleave during merges (take frees a slot, the next
+pageout immediately reuses it), steady-state reuse is high with a tiny cap.
+
+Reuse count being bounded by interleaving (not by the cap alone) is the same
+dynamic that makes `STASH_CAP = 2` sufficient for chunk recycling: during a
+phase that pages out N chunks before taking any, the free-list drains and the
+overflow falls back to fresh files; that long-tail keeps today's behavior.
+
+### Tier 2 — open-fd cache keyed by slot id
+
+Tier 1 still pays `File::open` on both pageout and take (4.3s on take in the
+profile; roughly the same again on pageout, so an ~8s ceiling). The fd cannot
+live in the handle: the spilled working set is thousands of cold chunks, each a
+live handle, and the no-fd-retained invariant exists precisely so fd count does
+not track handle count. The fd also cannot live only in the free-list slot,
+because it is needed at pageout *and* at the later take, with the cold in-use
+period in between — during which the slot is off the free-list.
+
+The reuse unit is therefore the recycled physical *slot id*, not the logical
+handle. Tier 1's free-list is LIFO, so the hot churn cycles through a small set
+of ids at the top of the stack while the large cold set holds ids that are off
+the free-list entirely. That gives strong temporal locality on a handful of
+ids, which a bounded LRU **fd cache keyed by slot id** turns into hits. The
+cache is a pure `open()` memoization over "the file at `scratch_path(id)`
+exists"; the handle stays `(id, len)`.
+
+* **pageout**: cache lookup the popped id; hit → pwrite via the cached fd, miss
+  → `open(O_RDWR | O_CREAT)`, insert (evict + close LRU if full), pwrite. Do not
+  close — leave the fd cached.
+* **take / read**: cache lookup; hit → pread (the open we are removing), miss →
+  open, insert, pread.
+* **recycle**: push the id to the free-list as in Tier 1; the fd stays cached.
+
+It self-regulates: a short-residency chunk (the merge frontier — paged out then
+taken almost immediately) keeps its fd across pageout→take, so both sides are
+open-free; a long-residency cold chunk's fd is evicted and closed by `N`
+intervening slots, so fds are never pinned for data that is actually cold. Open
+fds stay at `min(N, distinct slots in the recent window)`, bounded by `N`
+regardless of handle count.
+
+Correctness falls out cleanly: `O_RDWR` fds serve both pwrite and pread; recycle
+overwrites the *same inode* in place (pwrite at offset 0), so a cached fd never
+goes stale; fresh ids come from a monotonic counter and unlinked ids never
+reissue, so there is no inode-reuse-under-stale-fd hazard. The single
+invalidation rule: when Tier 1 unlinks a slot (oversize, cap overflow, or the
+write-error path), `remove` + close its cached fd first, or the open fd pins the
+inode and defeats the unlink. The cache incidentally also speeds the
+write-once / read-many `read_at_many` path, which re-opens per call today.
+
+**Concurrency (decided): process-global free-list, and what that implies for
+the fd cache.** Tier 1's free-list is a single process-global
+`Mutex<Vec<FileId>>`, not thread-local. `Handle` is `Send`, so a handle paged
+out by one worker can drop on another; a thread-local free-list would strand
+that slot on the dropping thread — away from the worker whose pageouts could
+reuse it — and the recycling would drift. A process-global list lets any thread
+recycle any slot. Contention is not a concern here: spills amortize to roughly
+one file operation per 2 MiB shipped, so the lock is taken far too rarely to
+register against the I/O it guards.
+
+This constrains the Tier 2 fd cache. A thread-local fd cache misses by
+construction whenever a slot recycled on thread A is popped on thread B — the
+cached fd lives on A — so an fd cache must either be process-global (one lock,
+like the free-list) or accept those cross-thread misses. The work-stealing
+layout lgalloc uses — small thread-local pools that refill from a global pool
+once drained, keeping the local pool small while bounding the worst case — is
+the alternative to reach for if and only if the global lock ever measurably
+contends. It is not justified up front; decide it on a profile, not a priori.
+
+Tier 2 is the smaller remaining lever (~8s) than buffer warmth (~13s) and adds
+eviction + invalidation complexity, so it sequences after buffer warmth.
+
+### Buffer warmth (orthogonal, `ColumnPager` layer)
+
+`ColumnPager::take` did `Vec::with_capacity(handle.len())` per call, so every
+file-backed take read into cold, freshly-faulted memory — the ~13s under
+`Vec::resize` in the profile, of which ~10.7s is the kernel faulting in and
+zeroing cold anonymous pages (`alloc_anon_folio`/`clear_page`) on the read's
+`copy_to_user`, and ~2.7s the redundant userspace memset. Reusing a buffer
+whose pages are already resident removes the faulting; the memset remains
+(removing it needs an uninitialized read, not worth an `unsafe` for ~2.7s).
+
+The existing chunk-recycling stash is the *wrong* pool: `recycle_chunk` only
+keeps `Column::Typed` and deliberately drops `Align`/`Bytes`, and `take`
+produces `Column::Align`. So buffer warmth gets its own pool: a per-worker
+(thread-local) free-list of warm `Vec<u64>` read buffers. File-backed take pulls
+one (gated on `Handle::is_file` so the swap backend, which fills from resident
+memory, is untouched); consumed `Align` chunks return their backing through the
+merge batcher's single `recycle_capped` chokepoint, which already sees every
+drained merge head. Capture is therefore the merge-internal head churn — shipped
+chunks flow on to the spine builder and are not pooled. The pool is bounded like
+the chunk stash (cap 4, ≤ 4 MiB each); its bytes are resident but not charged to
+the pager's `ResidentTicket` budget. Thread-local placement means no lock and
+per-worker locality, matching the one-batcher-per-worker structure.
+
+## Correctness and operational notes
+
+* **Crash cleanup is unchanged.** Free-list slots are ordinary named files in
+  the per-process scratch subdir, reclaimed with the ephemeral volume exactly
+  like today's per-handle files. No new persistent state, no orphan-tracking.
+* **Concurrency.** The free-list is process-global state behind the same
+  `SUBDIR`/atomic machinery the backend already uses, or sharded per worker to
+  avoid contention. Per-worker sharding matches the one-batcher-per-arrange-
+  per-worker structure and avoids a lock on the hot path; the cap is then
+  per-shard.
+* **Stale data safety.** Reuse writes at offset 0 and reads are length-bounded,
+  so a recycled slot never leaks a previous handle's bytes. A debug assertion
+  can confirm `len_u64s` never exceeds the bytes written.
+* **No API change.** `Handle` stays `(scratch_id, len)`; the id now names a
+  poolable slot rather than a single-use file. `pageout`/`take`/`read_at`
+  signatures are untouched.
+
+## Alternatives considered
+
+* **`O_TMPFILE`.** Unnamed temp files remove the dirent and the unlink syscall
+  and auto-reclaim on close. But they force fd retention for the file's whole
+  lifetime (no path to reopen), so fds track live-handle count — the exact
+  pressure we avoid — and they still pay the inode evict on close. Weaker than
+  the free-list on the dominant cost.
+* **`posix_fadvise(DONTNEED)` / `O_DIRECT`.** Drops or bypasses the page cache
+  to cut the evict, but does not remove the inode lifecycle and complicates the
+  read path. The free-list removes the evict by never destroying the inode.
+* **Open-fd LRU keyed by handle.** Addresses only the 4.3s open and only for
+  repeated reads of one handle, which the merge workload does not do. Tier 2
+  captures the open saving without per-handle fd accounting.

--- a/src/ore/src/pager.rs
+++ b/src/ore/src/pager.rs
@@ -57,6 +57,14 @@ impl Handle {
         self.len() == 0
     }
 
+    /// Returns `true` if this handle is backed by the file backend. Lets callers
+    /// route file-backed reads (which fault a fresh destination buffer) through
+    /// a warm buffer pool, while leaving the swap backend — which fills the
+    /// destination from resident memory — on its own path.
+    pub fn is_file(&self) -> bool {
+        matches!(self.inner, HandleInner::File(_))
+    }
+
     pub(crate) fn from_swap(inner: SwapInner) -> Self {
         Self {
             inner: HandleInner::Swap(inner),

--- a/src/ore/src/pager/file.rs
+++ b/src/ore/src/pager/file.rs
@@ -79,15 +79,102 @@ fn init_subdir(root: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-pub(crate) fn scratch_path(id: u64) -> PathBuf {
+/// Identifies a scratch file within the backend's subdir. Wraps the monotonic
+/// counter value so file ids don't blend into the many other `u64`s in this
+/// module (offsets, lengths, byte counts); the backing file is
+/// `scratch_path(id)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FileId(u64);
+
+impl std::fmt::Display for FileId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub(crate) fn scratch_path(id: FileId) -> PathBuf {
     SUBDIR
         .get()
         .expect("mz_ore::pager file backend used before set_scratch_dir")
         .join(format!("{id}.bin"))
 }
 
-pub(crate) fn alloc_scratch_id() -> u64 {
-    SCRATCH_ID.fetch_add(1, Ordering::Relaxed)
+pub(crate) fn alloc_scratch_id() -> FileId {
+    FileId(SCRATCH_ID.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Free-list of scratch slots: named files that still exist on disk but back no
+/// live handle. `take`/drop returns a slot here instead of unlinking, so the
+/// inode and its warm page cache survive for the next `pageout` to overwrite.
+/// This avoids the synchronous inode eviction and page-cache truncate that
+/// dominate unlink cost for the write-once / read-once / delete spill pattern.
+static FREE_SLOTS: Mutex<Vec<FileId>> = Mutex::new(Vec::new());
+
+/// Maximum slots retained on the free-list. A free slot pins up to
+/// [`MAX_RECYCLE_BYTES`] of (writeback-reclaimable) page cache, so the cap
+/// bounds retained memory at `FREE_LIST_CAP * MAX_RECYCLE_BYTES`. Reuse during
+/// a merge saturates at a handful of slots because `pageout` and `take`
+/// interleave (a `take` frees a slot the next `pageout` immediately reuses);
+/// the cap mostly absorbs burst phase transitions. Tuning candidate.
+const FREE_LIST_CAP: usize = 16;
+
+/// Don't recycle a slot whose payload exceeds this. A slot's on-disk file is
+/// the high-water mark of payloads written to it (reuse overwrites from offset
+/// 0 without truncating); refusing to recycle past this bound keeps every
+/// free-list file — and thus retained page cache — under the threshold.
+///
+/// Enforced at drop, not at pageout: an oversize payload can still pop and
+/// overwrite a free slot, growing that file past the bound, but the resulting
+/// handle's `len_u64s` then exceeds the threshold, so its drop unlinks rather
+/// than recycling. The grown file never re-enters the free-list, so free-listed
+/// files stay within the bound regardless of the unchecked pop.
+///
+/// Other recycling sites (the column pager's warm read-buffer pool, the merge
+/// batcher's column recycler) hold their own size caps; they share this value
+/// today but are tuned independently.
+const MAX_RECYCLE_BYTES: usize = 1 << 22;
+
+/// Locks the free-list, recovering from poisoning instead of propagating it.
+/// [`push_free_slot`] runs in [`FileInner::drop`], where an unwrap-on-poison
+/// would panic-in-drop and abort the process. A panic mid-operation can't
+/// corrupt the list beyond a lost or duplicated slot id, both harmless: a lost
+/// id just unlinks later, a duplicate is overwritten on reuse.
+fn lock_free_slots() -> std::sync::MutexGuard<'static, Vec<FileId>> {
+    FREE_SLOTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Pops a recycled slot id, or `None` if the free-list is empty. The returned
+/// id usually names an existing file at `scratch_path(id)` holding stale bytes
+/// the caller overwrites — but not always: a slot recycled after its file was
+/// unlinked out from under us (a `take` that unlinked, then failed) names a
+/// missing file. The reused-slot write path opens with `create(true)` for
+/// exactly this case, recreating the file rather than erroring.
+fn pop_free_slot() -> Option<FileId> {
+    lock_free_slots().pop()
+}
+
+/// Returns slot `id` to the free-list, retaining its file for reuse. Returns
+/// `false` (and keeps nothing) if the list is already at [`FREE_LIST_CAP`], so
+/// the caller unlinks instead.
+fn push_free_slot(id: FileId) -> bool {
+    let mut slots = lock_free_slots();
+    if slots.len() >= FREE_LIST_CAP {
+        return false;
+    }
+    slots.push(id);
+    true
+}
+
+#[cfg(test)]
+fn free_slots_snapshot() -> Vec<FileId> {
+    lock_free_slots().clone()
+}
+
+#[cfg(test)]
+fn clear_free_slots() {
+    lock_free_slots().clear();
 }
 
 /// Storage for a file-backed handle. The file at `scratch_path(id)` holds the
@@ -96,12 +183,12 @@ pub(crate) fn alloc_scratch_id() -> u64 {
 /// No file descriptor is retained.
 #[derive(Debug)]
 pub(crate) struct FileInner {
-    pub(crate) id: u64,
+    pub(crate) id: FileId,
     pub(crate) len_u64s: usize,
 }
 
 impl FileInner {
-    pub(crate) fn new(id: u64, len_u64s: usize) -> Self {
+    pub(crate) fn new(id: FileId, len_u64s: usize) -> Self {
         Self { id, len_u64s }
     }
 }
@@ -117,6 +204,14 @@ impl Drop for FileInner {
         let Some(subdir) = SUBDIR.get() else {
             return;
         };
+        // Recycle the slot instead of unlinking: keep the file (and its warm
+        // page cache) alive for the next `pageout` to overwrite, sidestepping
+        // the inode eviction + page-cache truncate that unlink forces. Slots
+        // over the size bound, or past the free-list cap, fall through to
+        // unlink so retained page cache stays bounded.
+        if self.len_u64s.saturating_mul(8) <= MAX_RECYCLE_BYTES && push_free_slot(self.id) {
+            return;
+        }
         let path = subdir.join(format!("{}.bin", self.id));
         if let Err(err) = std::fs::remove_file(&path) {
             // ENOENT is fine: a successful `take` already unlinked.
@@ -138,9 +233,15 @@ pub(crate) fn try_pageout_file(chunks: &mut [Vec<u64>]) -> std::io::Result<Handl
         // short-circuits when `len_u64s == 0`.
         return Ok(Handle::from_file(FileInner::new(alloc_scratch_id(), 0)));
     }
-    let id = alloc_scratch_id();
+    // Reuse a recycled slot if one is free; otherwise mint a fresh id. A reused
+    // slot's file already exists and is overwritten from offset 0; a fresh slot
+    // must not collide with an existing file.
+    let (id, reused) = match pop_free_slot() {
+        Some(id) => (id, true),
+        None => (alloc_scratch_id(), false),
+    };
     let path = scratch_path(id);
-    match write_chunks(&path, chunks) {
+    match write_chunks(&path, chunks, reused) {
         Ok(()) => {
             for c in chunks.iter_mut() {
                 c.clear();
@@ -149,7 +250,9 @@ pub(crate) fn try_pageout_file(chunks: &mut [Vec<u64>]) -> std::io::Result<Handl
         }
         Err(err) => {
             // Best-effort cleanup; ignore secondary errors here so we surface
-            // the primary write error to the caller.
+            // the primary write error to the caller. A reused slot is unlinked
+            // rather than returned to the free-list: a failed write may have
+            // left it in an unknown state on a possibly-broken volume.
             let _ = std::fs::remove_file(&path);
             Err(err)
         }
@@ -161,8 +264,20 @@ pub(crate) fn pageout_file(chunks: &mut [Vec<u64>]) -> Handle {
         .unwrap_or_else(|err| panic!("mz_ore::pager: file pageout failed: {err}"))
 }
 
-fn write_chunks(path: &Path, chunks: &[Vec<u64>]) -> std::io::Result<()> {
-    let file = File::options().write(true).create_new(true).open(path)?;
+fn write_chunks(path: &Path, chunks: &[Vec<u64>], reused: bool) -> std::io::Result<()> {
+    // Reused slots already have a file; open it and overwrite from offset 0.
+    // Deliberately no `truncate`: shrinking would re-evict the tail pages — the
+    // cost recycling exists to avoid — and reads are length-bounded, so a stale
+    // tail is never observed. Fresh slots use `create_new` to catch id-reuse
+    // bugs: a fresh id must never name an existing file.
+    let mut opts = File::options();
+    opts.write(true);
+    if reused {
+        opts.create(true);
+    } else {
+        opts.create_new(true);
+    }
+    let file = opts.open(path)?;
     let mut slices: Vec<IoSlice<'_>> = chunks
         .iter()
         .filter(|c| !c.is_empty())
@@ -324,7 +439,8 @@ pub(crate) fn try_take_file(handle: Handle, dst: &mut Vec<u64>) -> std::io::Resu
         filled += n;
     }
     drop(file);
-    // FileInner::drop will unlink the scratch file.
+    // FileInner::drop reclaims the scratch file: recycled to the free-list for
+    // reuse, or unlinked if the list is full or the payload is oversize.
     drop(inner);
     Ok(())
 }
@@ -338,14 +454,28 @@ pub(crate) fn take_file(handle: Handle, dst: &mut Vec<u64>) {
 mod backend_tests {
     use super::*;
 
-    fn setup_dir() {
+    /// Serializes backend tests so the process-global free-list is exclusive to
+    /// one test at a time. `cargo test` runs a binary's tests on shared threads,
+    /// so without this a peer's `pageout`/`take` would pop or push slots
+    /// mid-assertion. (Under nextest each test is its own process and the lock
+    /// is uncontended.)
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    /// Acquires the serialization lock, sets up the shared scratch dir, and
+    /// hands back a clean free-list. The returned guard (already `#[must_use]`
+    /// as a `MutexGuard`) must outlive the test body. Recovers from a poisoned
+    /// lock so a `should_panic` test doesn't wedge its peers.
+    fn setup_dir() -> std::sync::MutexGuard<'static, ()> {
+        let guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         let _ = super::tests::shared_scratch();
+        clear_free_slots();
+        guard
     }
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
     fn pageout_writes_file_and_clears_capacity() {
-        setup_dir();
+        let _guard = setup_dir();
         let mut chunks = [vec![10u64, 20, 30], vec![40, 50]];
         let cap_before_0 = chunks[0].capacity();
         let cap_before_1 = chunks[1].capacity();
@@ -367,7 +497,7 @@ mod backend_tests {
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
     fn file_read_at_basic() {
-        setup_dir();
+        let _guard = setup_dir();
         let mut chunks = [vec![1u64, 2, 3, 4, 5]];
         let h = pageout_file(&mut chunks);
         let mut dst = Vec::new();
@@ -378,7 +508,7 @@ mod backend_tests {
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
     fn file_read_at_many_concats_and_coalesces() {
-        setup_dir();
+        let _guard = setup_dir();
         let mut chunks = [vec![10u64, 20, 30, 40, 50, 60]];
         let h = pageout_file(&mut chunks);
         let mut dst = Vec::new();
@@ -391,7 +521,7 @@ mod backend_tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
     #[should_panic(expected = "out of bounds")]
     fn file_read_at_panics_on_oob() {
-        setup_dir();
+        let _guard = setup_dir();
         let mut chunks = [vec![1u64, 2]];
         let h = pageout_file(&mut chunks);
         let mut dst = Vec::new();
@@ -400,8 +530,8 @@ mod backend_tests {
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
-    fn file_take_returns_data_and_unlinks() {
-        setup_dir();
+    fn file_take_returns_data_and_recycles() {
+        let _guard = setup_dir();
         let mut chunks = [vec![7u64; 100]];
         let h = pageout_file(&mut chunks);
         let inner_id = h.file_inner().unwrap().id;
@@ -410,25 +540,96 @@ mod backend_tests {
         let mut dst = Vec::new();
         take_file(h, &mut dst);
         assert_eq!(dst, vec![7u64; 100]);
-        assert!(!path.exists(), "scratch file should be unlinked after take");
+        // Recycled, not unlinked: the file survives for reuse and the slot is
+        // parked on the free-list.
+        assert!(path.exists(), "scratch file should survive take for reuse");
+        assert!(
+            free_slots_snapshot().contains(&inner_id),
+            "taken slot should be recycled onto the free-list"
+        );
     }
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
-    fn file_drop_unlinks_when_not_taken() {
-        setup_dir();
+    fn file_drop_recycles_when_not_taken() {
+        let _guard = setup_dir();
         let mut chunks = [vec![1u64, 2, 3]];
         let h = pageout_file(&mut chunks);
         let id = h.file_inner().unwrap().id;
         let path = scratch_path(id);
         assert!(path.exists());
         drop(h);
-        assert!(!path.exists(), "scratch file should be unlinked on drop");
+        assert!(path.exists(), "scratch file should survive drop for reuse");
+        assert!(
+            free_slots_snapshot().contains(&id),
+            "dropped slot should be recycled onto the free-list"
+        );
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
+    fn file_pageout_reuses_recycled_slot() {
+        let _guard = setup_dir();
+        // First handle: page out, then take to recycle the slot.
+        let mut a = [vec![1u64, 2, 3, 4, 5]];
+        let h1 = pageout_file(&mut a);
+        let id1 = h1.file_inner().unwrap().id;
+        let mut dst = Vec::new();
+        take_file(h1, &mut dst);
+        assert_eq!(dst, vec![1, 2, 3, 4, 5]);
+
+        // Second, shorter handle should reuse the freed slot and read back
+        // cleanly — the stale tail from the longer first payload is past the
+        // logical length and never observed.
+        let mut b = [vec![9u64; 3]];
+        let h2 = pageout_file(&mut b);
+        assert_eq!(
+            h2.file_inner().unwrap().id,
+            id1,
+            "pageout should reuse the recycled slot"
+        );
+        let mut dst2 = Vec::new();
+        take_file(h2, &mut dst2);
+        assert_eq!(dst2, vec![9u64; 3], "reused slot must not leak stale tail");
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
+    fn file_oversize_payload_is_unlinked_not_recycled() {
+        let _guard = setup_dir();
+        // One u64 past the recycle threshold.
+        let len = (MAX_RECYCLE_BYTES / 8) + 1;
+        let mut chunks = [vec![0u64; len]];
+        let h = pageout_file(&mut chunks);
+        let id = h.file_inner().unwrap().id;
+        let path = scratch_path(id);
+        drop(h);
+        assert!(!path.exists(), "oversize scratch file should be unlinked");
+        assert!(
+            !free_slots_snapshot().contains(&id),
+            "oversize slot must not be recycled"
+        );
+    }
+
+    #[mz_ore::test]
+    fn free_list_respects_cap() {
+        let _guard = setup_dir();
+        for i in 0..u64::cast_from(FREE_LIST_CAP) {
+            assert!(
+                push_free_slot(FileId(i)),
+                "slots under the cap are accepted"
+            );
+        }
+        assert!(
+            !push_free_slot(FileId(u64::MAX)),
+            "a slot past the cap is rejected so the caller unlinks"
+        );
+        assert_eq!(free_slots_snapshot().len(), FREE_LIST_CAP);
     }
 
     #[mz_ore::test]
     fn file_empty_handle_round_trips() {
-        setup_dir();
+        let _guard = setup_dir();
         let mut chunks: [Vec<u64>; 0] = [];
         let h = pageout_file(&mut chunks);
         assert_eq!(h.len(), 0);
@@ -450,7 +651,7 @@ mod backend_tests {
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `writev` on OS `linux`
     fn try_read_at_file_surfaces_missing_file() {
-        setup_dir();
+        let _guard = setup_dir();
         let mut chunks = [vec![1u64, 2, 3]];
         let h = pageout_file(&mut chunks);
         // Concurrently unlink the scratch file out from under us.

--- a/src/timely-util/src/column_pager.rs
+++ b/src/timely-util/src/column_pager.rs
@@ -35,6 +35,7 @@
 pub mod metrics;
 pub mod policy;
 
+use std::cell::RefCell;
 use std::io::{self, Read};
 use std::sync::{Arc, LazyLock, RwLock};
 
@@ -45,6 +46,65 @@ use timely::bytes::arc::BytesMut;
 use timely::dataflow::channels::ContainerBytes;
 
 use crate::columnar::Column;
+
+thread_local! {
+    /// Per-worker pool of warm `Vec<u64>` read buffers for file-backed
+    /// [`ColumnPager::take`]. Reading a paged column back from the file backend
+    /// otherwise lands in a freshly allocated buffer, so the kernel faults in
+    /// and zeroes cold anonymous pages on the read's `copy_to_user` — the
+    /// dominant non-I/O cost on the page-in path. Reusing a buffer whose pages
+    /// are already resident sidesteps that. Consumed [`Column::Align`] chunks
+    /// are returned here via [`recycle_body`]; the next file-backed `take`
+    /// reads into one. Like the merge batcher's chunk stash it is a small
+    /// hot-buffer cache, not a hoard, and its parked bytes are resident but not
+    /// tracked by the pager's [`ResidentTicket`] budget.
+    static BODY_POOL: RefCell<Vec<Vec<u64>>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Maximum warm read buffers parked per worker. Bounds resident pool bytes at
+/// `BODY_POOL_CAP * BODY_POOL_MAX_BYTES`. A 2-way merge has only a handful of
+/// `Align` heads live at once, so a tight cap captures steady-state reuse.
+const BODY_POOL_CAP: usize = 4;
+
+/// Don't park a buffer whose capacity exceeds this (bytes). A transiently
+/// oversize read buffer kept warm would pin more pool memory than the avoided
+/// faulting is worth, so it goes back to the allocator and a fresh default
+/// regrows. Shares [`crate::columnar::OVERSIZE_RECYCLE_BYTES`] with the merge
+/// batcher's column recycler — both park ship-chunk-sized payloads, so they
+/// track one ship-derived bound rather than separate literals.
+const BODY_POOL_MAX_BYTES: usize = crate::columnar::OVERSIZE_RECYCLE_BYTES;
+
+/// Takes a (possibly warm) read buffer from the pool, or a fresh empty one.
+/// `pager::take` clears and resizes it before reading, so its contents are
+/// irrelevant — only its resident capacity matters.
+fn take_body_buffer() -> Vec<u64> {
+    BODY_POOL.with(|p| p.borrow_mut().pop()).unwrap_or_default()
+}
+
+/// Returns `buf` to the warm-buffer pool for reuse, dropping it if the pool is
+/// full or the buffer is oversize. Public so the merge batcher can hand back
+/// the backing of a consumed [`Column::Align`] chunk.
+pub fn recycle_body(buf: Vec<u64>) {
+    if buf.capacity().saturating_mul(8) > BODY_POOL_MAX_BYTES {
+        return;
+    }
+    BODY_POOL.with(|p| {
+        let mut pool = p.borrow_mut();
+        if pool.len() < BODY_POOL_CAP {
+            pool.push(buf);
+        }
+    });
+}
+
+#[cfg(test)]
+fn clear_body_pool() {
+    BODY_POOL.with(|p| p.borrow_mut().clear());
+}
+
+#[cfg(test)]
+fn body_pool_len() -> usize {
+    BODY_POOL.with(|p| p.borrow().len())
+}
 
 /// Compression codec applied to a paged-out column.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -437,7 +497,14 @@ impl ColumnPager {
             // `_ticket` drops here and fires `PageEvent::ResidentReleased`.
             PagedColumn::Resident(c, _ticket) => c,
             PagedColumn::Paged { handle, meta } => {
-                let mut body: Vec<u64> = Vec::with_capacity(handle.len());
+                // File-backed reads fault a cold destination buffer; pull a warm
+                // one from the pool. The swap backend fills from resident memory
+                // and keeps its own path.
+                let mut body: Vec<u64> = if handle.is_file() {
+                    take_body_buffer()
+                } else {
+                    Vec::with_capacity(handle.len())
+                };
                 pager::take(handle, &mut body);
                 debug_assert_eq!(body.len() * 8, meta.len_bytes);
                 metrics::observe_pagein(meta.len_bytes);
@@ -455,12 +522,18 @@ impl ColumnPager {
                             .expect("lz4 decode from memory");
                     }
                     CompressedInner::Paged(h) => {
-                        let mut padded = Vec::with_capacity(h.len());
+                        // Compressed-file payloads are always file-backed, so a
+                        // warm buffer applies here too. `padded` is transient —
+                        // return it to the pool once decoding has copied out.
+                        let mut padded = take_body_buffer();
                         pager::take(h, &mut padded);
-                        let src: &[u8] = bytemuck::cast_slice(&padded);
-                        FrameDecoder::new(src)
-                            .read_to_end(&mut decoded)
-                            .expect("lz4 decode from pager");
+                        {
+                            let src: &[u8] = bytemuck::cast_slice(&padded);
+                            FrameDecoder::new(src)
+                                .read_to_end(&mut decoded)
+                                .expect("lz4 decode from pager");
+                        }
+                        recycle_body(padded);
                     }
                 }
                 debug_assert_eq!(decoded.len(), meta.len_bytes);
@@ -569,6 +642,40 @@ mod tests {
     /// Drains a column into a `Vec<i64>` for comparison via `borrow`.
     fn collect_i64(col: &Column<i64>) -> Vec<i64> {
         col.borrow().into_index_iter().copied().collect()
+    }
+
+    #[mz_ore::test]
+    fn body_pool_recycles_and_reuses() {
+        clear_body_pool();
+        let buf = Vec::<u64>::with_capacity(128);
+        let cap = buf.capacity();
+        recycle_body(buf);
+        assert_eq!(body_pool_len(), 1);
+        let got = take_body_buffer();
+        assert!(
+            got.capacity() >= cap,
+            "take should reuse the parked buffer's capacity"
+        );
+        assert_eq!(body_pool_len(), 0);
+        // Empty pool yields a fresh, zero-capacity buffer.
+        assert_eq!(take_body_buffer().capacity(), 0);
+    }
+
+    #[mz_ore::test]
+    fn body_pool_caps_count_and_rejects_oversize() {
+        clear_body_pool();
+        for _ in 0..(BODY_POOL_CAP + 2) {
+            recycle_body(Vec::with_capacity(16));
+        }
+        assert_eq!(
+            body_pool_len(),
+            BODY_POOL_CAP,
+            "pool must not grow past its cap"
+        );
+
+        clear_body_pool();
+        recycle_body(vec![0u64; (BODY_POOL_MAX_BYTES / 8) + 1]);
+        assert_eq!(body_pool_len(), 0, "oversize buffers are not parked");
     }
 
     #[mz_ore::test]

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -174,6 +174,15 @@ where
 /// merger and chunks shipped from the builder are sized comparably.
 const SHIP_WORDS: usize = 1 << 18;
 
+/// Size above which a transient buffer is treated as pathologically oversize and
+/// dropped rather than parked for reuse: the merge batcher's column free-list
+/// and the column pager's warm read-buffer pool both bound their parked
+/// payloads by this. Two ship chunks' worth (~4 MiB), so ordinary ship-sized
+/// payloads stay poolable while post-explosion outliers go back to the
+/// allocator. Derived from [`SHIP_WORDS`] so both recyclers track the ship
+/// granularity instead of drifting from a hand-copied literal.
+pub(crate) const OVERSIZE_RECYCLE_BYTES: usize = 2 * SHIP_WORDS * size_of::<u64>();
+
 /// Returns true once the serialized size of `borrow` is within 10% of the next
 /// `SHIP_WORDS` boundary.
 ///

--- a/src/timely-util/src/columnar/merge_batcher.rs
+++ b/src/timely-util/src/columnar/merge_batcher.rs
@@ -42,8 +42,8 @@ use timely::progress::Timestamp;
 use timely::progress::frontier::{Antichain, AntichainRef};
 
 use crate::column_pager::{self, ColumnPager, PagedColumn};
-use crate::columnar::Column;
 use crate::columnar::batcher::{empty_chunk, recycle_chunk};
+use crate::columnar::{Column, OVERSIZE_RECYCLE_BYTES};
 
 /// Max recycled empty chunks held in the per-batcher stash. Deliberately
 /// tight: the stash is a hot-buffer cache for the result/keep/ship churn,
@@ -61,20 +61,19 @@ use crate::columnar::batcher::{empty_chunk, recycle_chunk};
 /// entirely — only a small minority ever flow back through the stash.
 const STASH_CAP: usize = 2;
 
-/// Don't park a buffer larger than this in the free-list. A transiently
-/// oversize merge buffer (post-explosion, past the natural ship threshold)
-/// held resident would compete with the pager's budget; drop it and let a
-/// fresh default regrow. 2 × the natural ship word count (≈ 4 MiB
-/// serialized) keeps normal ship-sized chunks while excluding pathological
-/// ones.
-const MAX_RECYCLE_BYTES: usize = 1 << 22;
-
-/// Recycle `chunk` only if the stash isn't already at [`STASH_CAP`] and the
-/// chunk isn't oversize per [`MAX_RECYCLE_BYTES`]. `length_in_bytes` is
-/// measured before clear, so it reflects the data the chunk was carrying
-/// (a proxy for the capacity we'd park).
+/// Recycle `chunk` for reuse. `Align` chunks — the warm buffers materialized by
+/// a file-backed [`ColumnPager::take`] — hand their `Vec<u64>` backing to the
+/// pager's body pool so the next page-in reads into resident memory. `Typed`
+/// chunks go to the local `stash` (unless it is full or the chunk is oversize
+/// per [`OVERSIZE_RECYCLE_BYTES`]); `length_in_bytes` is measured before clear,
+/// so it reflects the data the chunk was carrying (a proxy for the capacity we'd
+/// park). `Bytes` chunks have no reusable allocation and are dropped.
 fn recycle_capped<C: Columnar>(chunk: Column<C>, stash: &mut Vec<Column<C>>) {
-    if stash.len() < STASH_CAP && chunk.length_in_bytes() <= MAX_RECYCLE_BYTES {
+    if let Column::Align(buf) = chunk {
+        column_pager::recycle_body(buf);
+        return;
+    }
+    if stash.len() < STASH_CAP && chunk.length_in_bytes() <= OVERSIZE_RECYCLE_BYTES {
         recycle_chunk(chunk, stash);
     }
 }


### PR DESCRIPTION
## What

Profile-driven optimization of the file-backed pager (`mz_ore::pager` file
backend) that spills columnar merge-batcher data. A CPU profile of a production
clusterd put `mz_ore::pager::file::try_take_file` as the #2 on-CPU frame across
the whole process (~1m18s in a 15-minute window). This PR removes ~46s of that
with two independent changes, plus the design doc.

Take-path cost breakdown from the profile:

| Cost | Before | After this PR |
|---|---|---|
| unlink / inode-evict | 35.6s | ~0 (recycle) |
| read copy (`copy_to_user`, irreducible) | 22.8s | 22.8s |
| destination-buffer zero + page-fault | 13.4s | ~2.7s (memset only) |
| `File::open` | 4.3s | 4.3s (left for a follow-up) |

## Tier 1 — recycle scratch files instead of unlinking (`ore/pager`)

The backend unlinked each scratch file on take/drop. Unlink was dominated not
by the directory op but by `ext4_evict_inode -> truncate_inode_pages_final` —
synchronously tearing down the page cache the read had just populated, on the
worker thread. For a write-once / read-once / delete temp file the whole inode
lifecycle is pure overhead.

Instead, take/drop returns the slot to a capped free-list, keeping the inode and
its warm page cache for the next `pageout` to overwrite from offset 0. Reads are
length-bounded so a stale tail is never observed. Slots over a size bound or
past the cap fall back to unlink, bounding retained (writeback-reclaimable) page
cache. The no-fd-retained invariant is preserved.

## Buffer warmth — warm page-in read buffers (`timely-util`)

`ColumnPager::take` read each file-backed payload into a freshly allocated
`Vec<u64>`, so the kernel faulted in and zeroed cold anonymous pages on the
read's `copy_to_user` — the bulk of the 13.4s above. A per-worker
(thread-local) pool of warm read buffers lets file-backed take read into
resident memory; consumed `Column::Align` chunks return their backing at the
merge batcher's single `recycle_capped` chokepoint. The pool is bounded like the
existing chunk stash. Swap-backed reads keep their own path via a new
`Handle::is_file()`. (The existing `recycle_chunk` stash could not be reused: it
keeps only `Column::Typed` and drops `Align`/`Bytes`, which is exactly what
`take` produces.)

## Design

`doc/developer/design/20260603_pager_pooling.md` documents both changes and a
third tier — an open-fd cache keyed by slot id — that is designed but
intentionally **not** implemented here. It is the smallest remaining lever
(~8s, hit-rate-gated) and is gated on a re-profile after these land.

## Tests

Added to `mz_ore::pager::file`: recycle-on-take, recycle-on-drop, slot reuse with
stale-tail safety, oversize-not-recycled, and free-list cap. Added to
`column_pager`: warm-buffer reuse and cap/oversize rejection. Existing
file-backed round-trip tests in both crates now exercise the recycle and pooling
paths.

Part of [CLU-65](https://linear.app/materializeinc/issue/CLU-65).
