### PR TITLE
sql-227: Fix statement-logging throttling when sample rate is changed

### DIFF
--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -470,7 +470,8 @@ impl StatementLoggingFrontend {
     ///
     /// This function processes prepared statement logging info and builds the event rows.
     /// It does NOT do throttling - that is handled externally by the caller in `begin_statement_execution`.
-    /// It DOES mutate the logging info to mark the statement as already logged.
+    /// This is a read-only operation that does not mutate
+    /// the `PreparedStatementLoggingInfo` metadata.
     ///
     /// # Arguments
     /// * `session` - The session executing the statement
@@ -483,14 +484,13 @@ impl StatementLoggingFrontend {
     /// - `Uuid`: The UUID of the prepared statement.
     fn get_prepared_statement_info(
         &self,
-        session: &mut Session,
+        session: &Session,
         logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
     ) -> (Option<PreparedStatementEvent>, Uuid) {
-        let logging_ref = session.qcell_rw(&*logging);
-        let mut prepared_statement_event = None;
+        let logging_ref = session.qcell_ro(&*logging);
 
-        let ps_uuid = match logging_ref {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => *uuid,
+        match logging_ref {
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => (None, *uuid),
             PreparedStatementLoggingInfo::StillToLog {
                 sql,
                 redacted_sql,
@@ -506,18 +506,13 @@ impl StatementLoggingFrontend {
                     "accounting for logging should be done in `begin_statement_execution`"
                 );
                 let uuid = epoch_to_uuid_v7(prepared_at);
-                let sql = std::mem::take(sql);
-                let redacted_sql = std::mem::take(redacted_sql);
                 let sql_hash: [u8; 32] = Sha256::digest(sql.as_bytes()).into();
-
-                // Copy session_id before mutating logging_ref
-                let sid = *session_id;
 
                 let record = StatementPreparedRecord {
                     id: uuid,
                     sql_hash,
-                    name: std::mem::take(name),
-                    session_id: sid,
+                    name: name.clone(),
+                    session_id: *session_id,
                     prepared_at: *prepared_at,
                     kind: *kind,
                 };
@@ -526,6 +521,10 @@ impl StatementLoggingFrontend {
                 let mut mpsh_row = Row::default();
                 let mut mpsh_packer = mpsh_row.packer();
                 pack_statement_prepared_update(&record, &mut mpsh_packer);
+
+                // Read throttled_count from shared state
+                let throttled_count = self.throttling_state.get_throttled_count();
+                mpsh_packer.push(Datum::UInt64(CastFrom::cast_from(throttled_count)));
 
                 let sql_row = Row::pack([
                     Datum::TimestampTz(
@@ -539,23 +538,34 @@ impl StatementLoggingFrontend {
                     Datum::String(redacted_sql.as_str()),
                 ]);
 
-                // Read throttled_count from shared state
-                let throttled_count = self.throttling_state.get_throttled_count();
-
-                mpsh_packer.push(Datum::UInt64(CastFrom::cast_from(throttled_count)));
-
-                prepared_statement_event = Some(PreparedStatementEvent {
+                let prepared_statement_event = PreparedStatementEvent {
                     prepared_statement: mpsh_row,
                     sql_text: sql_row,
-                    session_id: sid,
-                });
+                    session_id: *session_id,
+                };
 
-                *logging_ref = PreparedStatementLoggingInfo::AlreadyLogged { uuid };
-                uuid
+                (Some(prepared_statement_event), uuid)
             }
-        };
+        }
+    }
 
-        (prepared_statement_event, ps_uuid)
+    /// Marks a prepared statement as "already logged", so future executions only reference its
+    /// UUID rather than logging it again.
+    ///
+    /// This must only be called once we are committed to logging the prepared statement, i.e.
+    /// after the sampling and throttling checks in [`Self::begin_statement_execution`] have
+    /// passed. Mirrors `Coordinator::record_prepared_statement_as_logged` used by the old peek
+    /// sequencing.
+    fn record_prepared_statement_as_logged(
+        &self,
+        uuid: Uuid,
+        session: &mut Session,
+        logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
+    ) {
+        let logging = session.qcell_rw(&*logging);
+        if let PreparedStatementLoggingInfo::StillToLog { .. } = logging {
+            *logging = PreparedStatementLoggingInfo::AlreadyLogged { uuid };
+        }
     }
 
     /// Begin statement execution logging from the frontend. (Corresponds to
@@ -646,7 +656,7 @@ impl StatementLoggingFrontend {
             return None;
         }
 
-        // Get prepared statement info (this also marks it as logged)
+        // Get prepared statement info.
         let (prepared_statement_event, ps_uuid) =
             self.get_prepared_statement_info(session, logging);
 
@@ -704,6 +714,10 @@ impl StatementLoggingFrontend {
             self.throttling_state.increment_throttled_count();
             return None;
         }
+
+        // Throttling passed, so we are now committed to mark the
+        // prepared statement as logged.
+        self.record_prepared_statement_as_logged(ps_uuid, session, logging);
 
         // When we successfully log the first instance of a prepared statement
         // (i.e., it is not throttled), reset the throttled count for future tracking.

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -750,7 +750,7 @@ fn test_statement_logging_prepared_statement_throttling() {
 
 /// throttling the first execution of a prepared statement must not make
 //  every subsequent execution of that statement invisible in
-// `mz_recent_activity_log`.
+//  `mz_recent_activity_log`.
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
 fn test_statement_logging_throttled_prepared_statement_stays_visible() {

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -748,6 +748,112 @@ fn test_statement_logging_prepared_statement_throttling() {
     run_throttling_test(true);
 }
 
+/// throttling the first execution of a prepared statement must not make
+//  every subsequent execution of that statement invisible in
+// `mz_recent_activity_log`.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_statement_logging_throttled_prepared_statement_stays_visible() {
+    const APPLICATION_NAME: &str = "throttled_prepared_repro";
+    const NUM_SUBSEQUENT_STATEMENT_EXECUTIONS: i64 = 5;
+
+    let (server, mut client) = setup_statement_logging(1.0, 1.0, "1");
+    let mut mz_client = server.connect_internal(postgres::NoTls).unwrap();
+
+    // cap the credit at a single byte such that the first execution of our
+    // prepared statement is guaranteed to be throttled.
+    mz_client
+        .batch_execute("ALTER SYSTEM SET statement_logging_target_data_rate = 1")
+        .unwrap();
+    mz_client
+        .batch_execute("ALTER SYSTEM SET statement_logging_max_data_credit = 1")
+        .unwrap();
+
+    client
+        .batch_execute(&format!("SET application_name = '{APPLICATION_NAME}'"))
+        .unwrap();
+
+    // First execution of the prepared statement. This one gets throttled, and so
+    // is never logged.
+    let stmt = client.prepare("SELECT $1::text").unwrap();
+    assert_eq!(
+        client
+            .query_one(&stmt, &[&"first"])
+            .unwrap()
+            .get::<_, String>(0),
+        "first"
+    );
+
+    // Lift the throttle so subsequent executions are logged. Sleep afterwards so
+    // the token bucket has time to refill before the next execution
+    mz_client
+        .batch_execute("ALTER SYSTEM SET statement_logging_target_data_rate = 1000000000")
+        .unwrap();
+    mz_client
+        .batch_execute("ALTER SYSTEM SET statement_logging_max_data_credit = 1000000000")
+        .unwrap();
+    thread::sleep(Duration::from_secs(2));
+
+    // Subsequent executions of the same prepared statement.
+    for _ in 0..NUM_SUBSEQUENT_STATEMENT_EXECUTIONS {
+        assert_eq!(
+            client
+                .query_one(&stmt, &[&"again"])
+                .unwrap()
+                .get::<_, String>(0),
+            "again"
+        );
+    }
+
+    // Statement logging flushes asynchronously; wait until the
+    // subsequent executions have landed in `mz_statement_execution_history`.
+    Retry::default()
+        .max_duration(Duration::from_secs(30))
+        .retry(|_| {
+            let mseh_count: i64 = mz_client
+                .query_one(
+                    &format!(
+                        "SELECT count(*)
+                         FROM mz_internal.mz_statement_execution_history
+                         WHERE application_name = '{APPLICATION_NAME}'"
+                    ),
+                    &[],
+                )
+                .unwrap()
+                .get(0);
+            if mseh_count >= NUM_SUBSEQUENT_STATEMENT_EXECUTIONS {
+                Ok(())
+            } else {
+                Err(format!(
+                    "only {mseh_count} of {NUM_SUBSEQUENT_STATEMENT_EXECUTIONS} executions logged so far"
+                ))
+            }
+        })
+        .expect("subsequent executions never appeared in mz_statement_execution_history");
+
+    // The subsequent executions in mz_statement_execution_history should
+    // have a matching entry in mz_prepared_statement_history
+    let orphan_count: i64 = mz_client
+        .query_one(
+            &format!(
+                "SELECT count(*)
+                 FROM mz_internal.mz_statement_execution_history mseh
+                 LEFT JOIN mz_internal.mz_prepared_statement_history mpsh
+                   ON mseh.prepared_statement_id = mpsh.id
+                 WHERE mseh.application_name = '{APPLICATION_NAME}'
+                   AND mpsh.id IS NULL"
+            ),
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        orphan_count, 0,
+        "{orphan_count} mz_statement_execution_history rows reference a \
+         prepared_statement_id with no matching mz_prepared_statement_history row"
+    );
+}
+
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
 fn test_statement_logging_subscribes() {


### PR DESCRIPTION
In the frontend peek, we mutate mark a prepared statement as logged before the throttling check. Whileas in the original coordinator path, we wait until after. This causes a bug where if we initially throttled a statement, subsequent non-throttled executions will cause a prepared statement to never be logged in mz_prepared_statement_history
### Motivation

Fixes https://linear.app/materializeinc/review/sql-227-fix-statement-logging-throttling-when-sample-rate-is-changed-0624907ce490