### PR TITLE
Refactor peek optimizer dispatch with PeekOptimizer enum

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -87,7 +87,7 @@ use futures::StreamExt;
 use futures::future::{BoxFuture, FutureExt, LocalBoxFuture};
 use http::Uri;
 use ipnet::IpNet;
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use mz_adapter_types::bootstrap_builtin_cluster_config::BootstrapBuiltinClusterConfig;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
@@ -608,7 +608,7 @@ pub struct PeekStageLinearizeTimestamp {
     source_ids: BTreeSet<GlobalId>,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
-    optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
+    optimizer: optimize::PeekOptimizer,
     /// An optional context set iff the state machine is initiated from
     /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
@@ -623,7 +623,7 @@ pub struct PeekStageRealTimeRecency {
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
     oracle_read_ts: Option<Timestamp>,
-    optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
+    optimizer: optimize::PeekOptimizer,
     /// An optional context set iff the state machine is initiated from
     /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
@@ -639,7 +639,7 @@ pub struct PeekStageTimestampReadHold {
     timeline_context: TimelineContext,
     oracle_read_ts: Option<Timestamp>,
     real_time_recency_ts: Option<mz_repr::Timestamp>,
-    optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
+    optimizer: optimize::PeekOptimizer,
     /// An optional context set iff the state machine is initiated from
     /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
@@ -654,7 +654,7 @@ pub struct PeekStageOptimize {
     id_bundle: CollectionIdBundle,
     target_replica: Option<ReplicaId>,
     determination: TimestampDetermination,
-    optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
+    optimizer: optimize::PeekOptimizer,
     /// An optional context set iff the state machine is initiated from
     /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -650,8 +650,7 @@ impl Coordinator {
                             }
                         }
                         Ok(optimize::PeekGlobalLirPlan::CopyTo(global_lir_plan)) => {
-                            let optimizer =
-                                optimizer.into_copy_to().expect("a COPY TO optimizer");
+                            let optimizer = optimizer.into_copy_to().expect("a COPY TO optimizer");
                             PeekStage::CopyToPreflight(PeekStageCopyTo {
                                 validity,
                                 optimizer,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -10,7 +10,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use itertools::Either;
 use mz_adapter_types::dyncfgs::PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION;
 use mz_compute_types::sinks::ComputeSinkConnection;
 use mz_controller_types::ClusterId;
@@ -50,7 +49,7 @@ use crate::error::AdapterError;
 use crate::explain::insights::PlanInsightsContext;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::notice::AdapterNotice;
-use crate::optimize::{self, Optimize};
+use crate::optimize;
 use crate::session::{RequireLinearization, Session, TransactionOps, TransactionStatus};
 use crate::statement_logging::StatementLifecycleEvent;
 use crate::statement_logging::WatchSetCreation;
@@ -274,7 +273,7 @@ impl Coordinator {
                 let (_, index_id) = self.allocate_transient_id();
 
                 // Build an optimizer for this SELECT.
-                Either::Left(optimize::peek::Optimizer::new(
+                optimize::PeekOptimizer::Select(optimize::peek::Optimizer::new(
                     Arc::clone(&catalog),
                     compute_instance,
                     plan.finishing.clone(),
@@ -304,7 +303,7 @@ impl Coordinator {
                 copy_to_ctx.output_batch_count = Some(max_worker_count);
                 let (_, view_id) = self.allocate_transient_id();
                 // Build an optimizer for this COPY TO.
-                Either::Right(optimize::copy_to::Optimizer::new(
+                optimize::PeekOptimizer::CopyTo(optimize::copy_to::Optimizer::new(
                     Arc::clone(&catalog),
                     compute_instance,
                     view_id,
@@ -451,10 +450,7 @@ impl Coordinator {
             explain_ctx,
         }: PeekStageTimestampReadHold,
     ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
-        let cluster_id = match optimizer.as_ref() {
-            Either::Left(optimizer) => optimizer.cluster_id(),
-            Either::Right(optimizer) => optimizer.cluster_id(),
-        };
+        let cluster_id = optimizer.cluster_id();
         let id_bundle = self
             .dataflow_builder(cluster_id)
             .sufficient_collections(source_ids.iter().copied());
@@ -533,61 +529,30 @@ impl Coordinator {
             || "optimize peek",
             move || {
                 span.in_scope(|| {
-                    let pipeline = || -> Result<
-                        Either<
-                            optimize::peek::GlobalLirPlan,
-                            optimize::copy_to::GlobalLirPlan,
-                        >,
-                        AdapterError,
-                    > {
+                    // Run the optimization pipeline. This is wrapped in a closure
+                    // so that we control where the `?`s return from: even when a
+                    // `catch_unwind_optimize` call inside `optimize` fails, we can
+                    // still handle `EXPLAIN BROKEN` below.
+                    let pipeline = || -> Result<optimize::PeekGlobalLirPlan, AdapterError> {
                         let _dispatch_guard = explain_ctx.dispatch_guard();
 
                         let raw_expr = plan.source.clone();
 
-                        match optimizer.as_mut() {
-                            // Optimize SELECT statement.
-                            Either::Left(optimizer) => {
-                                // HIR ⇒ MIR lowering and MIR optimization (local)
-                                let local_mir_plan =
-                                    optimizer.catch_unwind_optimize(raw_expr)?;
-                                // Attach resolved context required to continue the pipeline.
-                                let local_mir_plan = local_mir_plan.resolve(
-                                    timestamp_context.clone(),
-                                    &session,
-                                    stats,
-                                );
-                                // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
-                                let global_lir_plan =
-                                    optimizer.catch_unwind_optimize(local_mir_plan)?;
-
-                                Ok(Either::Left(global_lir_plan))
-                            }
-                            // Optimize COPY TO statement.
-                            Either::Right(optimizer) => {
-                                // HIR ⇒ MIR lowering and MIR optimization (local)
-                                let local_mir_plan =
-                                    optimizer.catch_unwind_optimize(raw_expr)?;
-                                // Attach resolved context required to continue the pipeline.
-                                let local_mir_plan = local_mir_plan.resolve(
-                                    timestamp_context.clone(),
-                                    &session,
-                                    stats,
-                                );
-                                // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
-                                let global_lir_plan =
-                                    optimizer.catch_unwind_optimize(local_mir_plan)?;
-
-                                Ok(Either::Right(global_lir_plan))
-                            }
-                        }
+                        Ok(optimizer.optimize(
+                            raw_expr,
+                            timestamp_context.clone(),
+                            &session,
+                            stats,
+                        )?)
                     };
 
                     let pipeline_result = pipeline();
                     let optimization_finished_at = now();
 
                     let stage = match pipeline_result {
-                        Ok(Either::Left(global_lir_plan)) => {
-                            let optimizer = optimizer.unwrap_left();
+                        Ok(optimize::PeekGlobalLirPlan::Select(global_lir_plan)) => {
+                            let optimizer =
+                                optimizer.into_select().expect("a SELECT/EXPLAIN optimizer");
                             // Enable fast path cluster calculation for slow path plans.
                             let needs_plan_insights = explain_ctx.needs_plan_insights();
                             // Disable anything that uses the optimizer if we only want the notice and
@@ -687,8 +652,9 @@ impl Coordinator {
                                 }
                             }
                         }
-                        Ok(Either::Right(global_lir_plan)) => {
-                            let optimizer = optimizer.unwrap_right();
+                        Ok(optimize::PeekGlobalLirPlan::CopyTo(global_lir_plan)) => {
+                            let optimizer =
+                                optimizer.into_copy_to().expect("a COPY TO optimizer");
                             PeekStage::CopyToPreflight(PeekStageCopyTo {
                                 validity,
                                 optimizer,
@@ -700,7 +666,7 @@ impl Coordinator {
                         // Internal optimizer errors are handled differently
                         // depending on the caller.
                         Err(err) => {
-                            let Some(optimizer) = optimizer.left() else {
+                            let Some(optimizer) = optimizer.into_select() else {
                                 // In `COPY TO` contexts, immediately retire the
                                 // execution with the error.
                                 return Err(err);

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -529,24 +529,21 @@ impl Coordinator {
             || "optimize peek",
             move || {
                 span.in_scope(|| {
-                    // Run the optimization pipeline. This is wrapped in a closure
-                    // so that we control where the `?`s return from: even when a
-                    // `catch_unwind_optimize` call inside `optimize` fails, we can
-                    // still handle `EXPLAIN BROKEN` below.
-                    let pipeline = || -> Result<optimize::PeekGlobalLirPlan, AdapterError> {
+                    // Run the optimization pipeline. The dispatch guard borrows
+                    // `explain_ctx`, so we scope it in a block to drop it before
+                    // `explain_ctx` is inspected below. A failed optimization is
+                    // captured in `pipeline_result` rather than returned, so that
+                    // `EXPLAIN BROKEN` can still be handled in the match.
+                    let pipeline_result = {
                         let _dispatch_guard = explain_ctx.dispatch_guard();
 
                         let raw_expr = plan.source.clone();
 
-                        Ok(optimizer.optimize(
-                            raw_expr,
-                            timestamp_context.clone(),
-                            &session,
-                            stats,
-                        )?)
+                        optimizer
+                            .optimize(raw_expr, timestamp_context.clone(), &session, stats)
+                            .map_err(AdapterError::from)
                     };
 
-                    let pipeline_result = pipeline();
                     let optimization_finished_at = now();
 
                     let stage = match pipeline_result {

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -65,6 +65,7 @@ use std::fmt::Debug;
 use mz_adapter_types::connection::ConnectionId;
 use mz_adapter_types::dyncfgs::PERSIST_FAST_PATH_ORDER;
 use mz_catalog::memory::objects::{CatalogCollectionEntry, CatalogEntry, Index};
+use mz_compute_types::ComputeInstanceId;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::SUBSCRIBE_SNAPSHOT_OPTIMIZATION;
 use mz_compute_types::plan::Plan;
@@ -75,9 +76,12 @@ use mz_repr::adt::timestamp::TimestampError;
 use mz_repr::optimize::{OptimizerFeatureOverrides, OptimizerFeatures, OverrideFrom};
 use mz_repr::{CatalogItemId, GlobalId};
 use mz_sql::names::{FullItemName, QualifiedItemName};
-use mz_sql::plan::PlanError;
+use mz_sql::plan::{HirRelationExpr, PlanError};
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::SystemVars;
-use mz_transform::{MaybeShouldPanic, TransformCtx, TransformError};
+use mz_transform::{MaybeShouldPanic, StatisticsOracle, TransformCtx, TransformError};
+
+use crate::TimestampContext;
 
 // Alias types
 // -----------
@@ -118,6 +122,121 @@ pub trait Optimize<From> {
     fn catch_unwind_optimize(&mut self, plan: From) -> Result<Self::To, OptimizerError> {
         mz_transform::catch_unwind_optimize(|| self.optimize(plan))
     }
+}
+
+// One-shot peek optimizer dispatch
+// --------------------------------
+
+/// The optimizer driving a one-shot statement through the peek sequencing state
+/// machine.
+///
+/// `SELECT` and `EXPLAIN` are optimized by the [`peek::Optimizer`], while `COPY
+/// TO` is optimized by the [`copy_to::Optimizer`]. Both share the same
+/// surrounding state machine (timestamp selection, read holds, off-thread
+/// optimization, …), so this enum lets that shared machinery carry either
+/// optimizer without caring which one it is. The variants are kept distinct
+/// (rather than abstracted behind a trait object) because the downstream stages
+/// need to recover the concrete optimizer and its statement-specific result.
+#[derive(Debug)]
+pub enum PeekOptimizer {
+    /// Optimizer for `SELECT` and `EXPLAIN` statements.
+    Select(peek::Optimizer),
+    /// Optimizer for `COPY TO` statements.
+    CopyTo(copy_to::Optimizer),
+}
+
+/// The global LIR plan produced by [`PeekOptimizer::optimize`], tagged with the
+/// path that produced it.
+#[derive(Debug)]
+pub enum PeekGlobalLirPlan {
+    /// The result of the `SELECT`/`EXPLAIN` pipeline.
+    Select(peek::GlobalLirPlan),
+    /// The result of the `COPY TO` pipeline.
+    CopyTo(copy_to::GlobalLirPlan),
+}
+
+impl PeekOptimizer {
+    /// The cluster that will run the optimized dataflow.
+    pub fn cluster_id(&self) -> ComputeInstanceId {
+        match self {
+            PeekOptimizer::Select(optimizer) => optimizer.cluster_id(),
+            PeekOptimizer::CopyTo(optimizer) => optimizer.cluster_id(),
+        }
+    }
+
+    /// Runs the full one-shot optimization pipeline end-to-end:
+    ///
+    /// 1. HIR ⇒ MIR lowering and local MIR optimization,
+    /// 2. timestamp resolution,
+    /// 3. global MIR optimization, MIR ⇒ LIR lowering, and global LIR
+    ///    optimization.
+    ///
+    /// The pipeline shape is identical for both variants; only the concrete
+    /// (statement-specific) plan types differ, so the steps are shared via
+    /// [`optimize_oneshot`].
+    pub fn optimize(
+        &mut self,
+        raw_expr: HirRelationExpr,
+        timestamp_ctx: TimestampContext,
+        session: &dyn SessionMetadata,
+        stats: Box<dyn StatisticsOracle>,
+    ) -> Result<PeekGlobalLirPlan, OptimizerError> {
+        match self {
+            PeekOptimizer::Select(optimizer) => {
+                let plan = optimize_oneshot(optimizer, raw_expr, |local_mir_plan| {
+                    local_mir_plan.resolve(timestamp_ctx, session, stats)
+                })?;
+                Ok(PeekGlobalLirPlan::Select(plan))
+            }
+            PeekOptimizer::CopyTo(optimizer) => {
+                let plan = optimize_oneshot(optimizer, raw_expr, |local_mir_plan| {
+                    local_mir_plan.resolve(timestamp_ctx, session, stats)
+                })?;
+                Ok(PeekGlobalLirPlan::CopyTo(plan))
+            }
+        }
+    }
+
+    /// Consumes `self`, returning the inner [`peek::Optimizer`] if this is the
+    /// `SELECT`/`EXPLAIN` path and `None` otherwise.
+    pub fn into_select(self) -> Option<peek::Optimizer> {
+        match self {
+            PeekOptimizer::Select(optimizer) => Some(optimizer),
+            PeekOptimizer::CopyTo(_) => None,
+        }
+    }
+
+    /// Consumes `self`, returning the inner [`copy_to::Optimizer`] if this is
+    /// the `COPY TO` path and `None` otherwise.
+    pub fn into_copy_to(self) -> Option<copy_to::Optimizer> {
+        match self {
+            PeekOptimizer::CopyTo(optimizer) => Some(optimizer),
+            PeekOptimizer::Select(_) => None,
+        }
+    }
+}
+
+/// Runs the shared one-shot optimization pipeline for a single optimizer.
+///
+/// This factors out the (otherwise duplicated) HIR ⇒ local MIR ⇒ resolve ⇒
+/// global LIR sequence that is common to the `SELECT`/`EXPLAIN` and `COPY TO`
+/// paths. The `resolve` closure attaches the timestamp/session/stats context to
+/// the local plan; it is path-specific only in the concrete plan type it
+/// operates on.
+fn optimize_oneshot<O, LocalPlan, ResolvedPlan, GlobalPlan>(
+    optimizer: &mut O,
+    raw_expr: HirRelationExpr,
+    resolve: impl FnOnce(LocalPlan) -> ResolvedPlan,
+) -> Result<GlobalPlan, OptimizerError>
+where
+    O: Optimize<HirRelationExpr, To = LocalPlan> + Optimize<ResolvedPlan, To = GlobalPlan>,
+{
+    // HIR ⇒ MIR lowering and MIR optimization (local).
+    let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
+    // Attach resolved context required to continue the pipeline.
+    let resolved_mir_plan = resolve(local_mir_plan);
+    // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global).
+    optimizer.catch_unwind_optimize(resolved_mir_plan)
 }
 
 // Optimizer configuration


### PR DESCRIPTION
### Motivation

The peek sequencing state machine currently uses `Either<peek::Optimizer, copy_to::Optimizer>` to dispatch between `SELECT`/`EXPLAIN` and `COPY TO` optimization paths. This approach is verbose and requires pattern matching at multiple sites. Consolidating this into a dedicated enum improves code clarity and reduces duplication.

### Description

This PR introduces a `PeekOptimizer` enum that wraps the two optimizer variants and provides a unified interface for the shared optimization pipeline:

1. **New `PeekOptimizer` enum** (`src/adapter/src/optimize.rs`):
   - `Select(peek::Optimizer)` variant for `SELECT`/`EXPLAIN` statements
   - `CopyTo(copy_to::Optimizer)` variant for `COPY TO` statements
   - Methods: `cluster_id()`, `optimize()`, `into_select()`, `into_copy_to()`

2. **New `PeekGlobalLirPlan` enum** (`src/adapter/src/optimize.rs`):
   - Tagged result type that preserves which optimization path was taken
   - `Select(peek::GlobalLirPlan)` and `CopyTo(copy_to::GlobalLirPlan)` variants

3. **Shared `optimize_oneshot()` helper** (`src/adapter/src/optimize.rs`):
   - Factors out the duplicated HIR → local MIR → resolve → global LIR pipeline
   - Uses generic bounds to work with both optimizer types
   - Eliminates ~30 lines of duplicated optimization logic

4. **Updated state machine** (`src/adapter/src/coord.rs`, `src/adapter/src/coord/sequencer/inner/peek.rs`):
   - Replaces `Either<peek::Optimizer, copy_to::Optimizer>` with `PeekOptimizer` in all peek stage structs
   - Simplifies pattern matching in the optimization stage
   - Uses `into_select()` and `into_copy_to()` to recover concrete optimizers after optimization

5. **Removed unused imports**:
   - Removes `itertools::Either` from `coord.rs` and `peek.rs` (no longer needed)
   - Removes unused `Optimize` trait import from `peek.rs`

### Verification

This is a refactoring that preserves the existing optimization pipeline behavior. The changes:
- Consolidate duplicated code paths into a single `optimize_oneshot()` function
- Replace verbose `Either` pattern matching with cleaner enum dispatch
- Maintain the same optimization semantics for both `SELECT` and `COPY TO` paths

Existing tests cover the optimization pipeline for both statement types and will verify correctness.

https://claude.ai/code/session_018q73DM2B1dQAb6MQbqTHHk