### PR TITLE
compute: make correction buffer reads slice-proportional

### DIFF
--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -62,6 +62,13 @@ rand.workspace = true
 
 [features]
 default = []
+# Exposes internal types for benchmarks.
+bench = []
+
+[[bench]]
+name = "correction"
+harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "columnar_merger_row"

--- a/src/compute/benches/correction.rs
+++ b/src/compute/benches/correction.rs
@@ -1,0 +1,352 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Micro-benchmark comparing `CorrectionV1` and `CorrectionV2` on hydration-style
+//! workloads, i.e., workloads where the input catches up with the current time by
+//! passing through many distinct timestamps.
+//!
+//! The scenario this models: an MV sink restarts with an old as-of and the desired
+//! input replays through `T` distinct timestamps while persist writes (and thus
+//! `advance_since`/`updates_before` calls) trail behind. Reads and since advancement
+//! must only do work proportional to the drained slice, otherwise the catch-up
+//! degenerates into quadratic behavior in `T`.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo bench -p mz-compute --features bench --bench correction
+//! ```
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::measurement::WallTime;
+use criterion::{
+    BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
+};
+use mz_compute::sink::correction::CorrectionV1;
+use mz_compute::sink::correction_v2::CorrectionV2;
+use mz_ore::metrics::MetricsRegistry;
+use mz_persist_client::cfg::PersistConfig;
+use mz_persist_client::metrics::{Metrics, SinkMetrics};
+use mz_repr::{Datum, Diff, Row, Timestamp};
+use timely::progress::Antichain;
+
+/// Default value of `compute_correction_v2_chain_proportionality`.
+const CHAIN_PROPORTIONALITY: f64 = 3.0;
+/// Default value of `compute_correction_v2_chunk_size`.
+const CHUNK_SIZE: usize = 8 * 1024;
+/// Default value of `consolidating_vec_growth_dampener`.
+const GROWTH_DAMPENER: usize = 1;
+
+/// Number of updates inserted per distinct timestamp.
+const UPDATES_PER_TS: u64 = 16;
+
+/// Time offset of far-future retractions in the temporal-filter pattern.
+const TEMPORAL_OFFSET: u64 = 1 << 40;
+
+#[derive(Clone, Copy)]
+enum Version {
+    V1,
+    V2,
+}
+
+impl Version {
+    fn name(self) -> &'static str {
+        match self {
+            Self::V1 => "v1",
+            Self::V2 => "v2",
+        }
+    }
+}
+
+/// Local dispatch over the correction buffer implementations.
+///
+/// The production `Correction` enum only contains v1 and v2, so the bench carries its own.
+enum Corr {
+    V1(CorrectionV1<Row>),
+    V2(CorrectionV2<Row>),
+}
+
+impl Corr {
+    fn insert(&mut self, updates: &mut Vec<(Row, Timestamp, Diff)>) {
+        match self {
+            Self::V1(c) => c.insert(updates),
+            Self::V2(c) => c.insert(updates),
+        }
+    }
+
+    fn insert_negated(&mut self, updates: &mut Vec<(Row, Timestamp, Diff)>) {
+        match self {
+            Self::V1(c) => c.insert_negated(updates),
+            Self::V2(c) => c.insert_negated(updates),
+        }
+    }
+
+    fn updates_before(
+        &mut self,
+        upper: &Antichain<Timestamp>,
+    ) -> Box<dyn Iterator<Item = (Row, Timestamp, Diff)> + '_> {
+        match self {
+            Self::V1(c) => Box::new(c.updates_before(upper)),
+            Self::V2(c) => Box::new(c.updates_before(upper)),
+        }
+    }
+
+    fn advance_since(&mut self, since: Antichain<Timestamp>) {
+        match self {
+            Self::V1(c) => c.advance_since(since),
+            Self::V2(c) => c.advance_since(since),
+        }
+    }
+
+    fn consolidate_at_since(&mut self) {
+        match self {
+            Self::V1(c) => c.consolidate_at_since(),
+            Self::V2(c) => c.consolidate_at_since(),
+        }
+    }
+}
+
+/// The shape of the update stream fed into the correction buffer.
+#[derive(Clone, Copy)]
+enum Pattern {
+    /// Every timestamp appends new, distinct rows. Nothing consolidates away.
+    Append,
+    /// Every timestamp updates the same set of keys: an addition for the new value and a
+    /// retraction of the previous one. Retraction-heavy, consolidates down to a small set.
+    Upsert,
+    /// Every timestamp appends new rows accompanied by their far-future retractions, and deletes
+    /// the previous timestamp's rows, retracting now and re-adding the far-future retraction at a
+    /// slightly different future time. Models an MV behind a temporal filter (e.g. a last-30-days
+    /// view): an ever-growing mass of far-future updates that never participates in reads.
+    TemporalFilter,
+}
+
+impl Pattern {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Append => "append",
+            Self::Upsert => "upsert",
+            Self::TemporalFilter => "temporal_filter",
+        }
+    }
+}
+
+fn sink_metrics() -> SinkMetrics {
+    let registry = MetricsRegistry::new();
+    let metrics = Metrics::new(&PersistConfig::new_for_tests(), &registry);
+    metrics.sink.clone()
+}
+
+fn make_correction(version: Version, metrics: &SinkMetrics) -> Corr {
+    let worker_metrics = metrics.for_worker(0);
+    match version {
+        Version::V1 => Corr::V1(CorrectionV1::new(
+            metrics.clone(),
+            worker_metrics,
+            GROWTH_DAMPENER,
+        )),
+        Version::V2 => Corr::V2(CorrectionV2::new(
+            metrics.clone(),
+            worker_metrics,
+            None,
+            CHAIN_PROPORTIONALITY,
+            CHUNK_SIZE,
+        )),
+    }
+}
+
+fn row(key: u64, value: u64) -> Row {
+    let payload = format!("payload-{value:016}");
+    Row::pack_slice(&[Datum::UInt64(key), Datum::String(&payload)])
+}
+
+/// Generate one batch of updates per distinct timestamp `0..num_ts`.
+fn make_batches(num_ts: u64, pattern: Pattern) -> Vec<Vec<(Row, Timestamp, Diff)>> {
+    (0..num_ts)
+        .map(|t| {
+            let time = Timestamp::from(t);
+            match pattern {
+                Pattern::Append => (0..UPDATES_PER_TS)
+                    .map(|i| (row(t * UPDATES_PER_TS + i, t), time, Diff::ONE))
+                    .collect(),
+                Pattern::Upsert => (0..UPDATES_PER_TS / 2)
+                    .flat_map(|key| {
+                        let addition = (row(key, t), time, Diff::ONE);
+                        let retraction = t
+                            .checked_sub(1)
+                            .map(|prev| (row(key, prev), time, -Diff::ONE));
+                        std::iter::once(addition).chain(retraction)
+                    })
+                    .collect(),
+                Pattern::TemporalFilter => (0..UPDATES_PER_TS / 4)
+                    .flat_map(|i| {
+                        let key = t * (UPDATES_PER_TS / 4) + i;
+                        // New row, plus its retraction when the temporal filter window closes.
+                        let this = [
+                            (row(key, t), time, Diff::ONE),
+                            (
+                                row(key, t),
+                                Timestamp::from(t + TEMPORAL_OFFSET),
+                                -Diff::ONE,
+                            ),
+                        ];
+                        // Delete the previous timestamp's row: retract it now and cancel its
+                        // window-close retraction. The cancellation lands at a different future
+                        // time than the original retraction, so the far-future mass grows.
+                        let prev = t.checked_sub(1).map(|p| {
+                            let key = p * (UPDATES_PER_TS / 4) + i;
+                            [
+                                (row(key, p), time, -Diff::ONE),
+                                (row(key, p), Timestamp::from(t + TEMPORAL_OFFSET), Diff::ONE),
+                            ]
+                        });
+                        this.into_iter().chain(prev.into_iter().flatten())
+                    })
+                    .collect(),
+            }
+        })
+        .collect()
+}
+
+/// Fill a fresh correction buffer with all batches, mimicking desired input that has
+/// run far ahead of persist writes.
+fn filled_correction(
+    version: Version,
+    metrics: &SinkMetrics,
+    batches: &[Vec<(Row, Timestamp, Diff)>],
+) -> Corr {
+    let mut correction = make_correction(version, metrics);
+    for batch in batches {
+        correction.insert(&mut batch.clone());
+    }
+    correction
+}
+
+impl Corr {
+    /// Emulate one `write_batches` write: read the updates before `upper` and feed back their
+    /// negations, like the persist input does.
+    fn write_step(&mut self, upper: &Antichain<Timestamp>) -> usize {
+        let mut written: Vec<_> = self.updates_before(upper).collect();
+        let count = written.len();
+        self.insert_negated(&mut written);
+        count
+    }
+
+    /// Read and count the updates before `upper`, without persist feedback.
+    fn read_count(&mut self, upper: &Antichain<Timestamp>) -> usize {
+        self.updates_before(upper).count()
+    }
+}
+
+/// Drain the correction buffer one timestamp at a time, like the `write_batches`
+/// operator does when persist writes catch up step by step.
+///
+/// `updates_before` does not remove updates from the buffer. In the real sink, written
+/// updates come back through the persist input and are removed by `insert_negated`. We
+/// model that feedback here, otherwise the buffer re-emits all previous updates on every
+/// step and clone costs drown out the structure-management costs we want to measure.
+fn drain_stepwise(mut correction: Corr, num_ts: u64) -> Corr {
+    for t in 0..num_ts {
+        let upper = Antichain::from_elem(Timestamp::from(t + 1));
+        let count = correction.write_step(&upper);
+        black_box(count);
+        correction.advance_since(upper);
+    }
+    correction
+}
+
+/// Advance the since across all buffered times at once, then consolidate and drain.
+/// This exercises `Cursor::advance_by` with many distinct times below the since.
+fn advance_jump(mut correction: Corr, num_ts: u64) -> Corr {
+    correction.advance_since(Antichain::from_elem(Timestamp::from(num_ts)));
+    correction.consolidate_at_since();
+    let upper = Antichain::from_elem(Timestamp::from(num_ts + 1));
+    let count = correction.read_count(&upper);
+    black_box(count);
+    correction
+}
+
+fn bench_scenario<F>(
+    group: &mut BenchmarkGroup<WallTime>,
+    metrics: &SinkMetrics,
+    pattern: Pattern,
+    num_ts: u64,
+    routine: F,
+) where
+    F: Fn(Corr, u64) -> Corr,
+{
+    let batches = make_batches(num_ts, pattern);
+    for version in [Version::V1, Version::V2] {
+        group.bench_function(BenchmarkId::new(version.name(), num_ts), |b| {
+            b.iter_batched(
+                || filled_correction(version, metrics, &batches),
+                |correction| routine(correction, num_ts),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+}
+
+/// Configure a benchmark group for short wall-clock time.
+///
+/// The interesting effects here are order-of-magnitude differences between implementations, so we
+/// trade statistical rigor for execution speed.
+fn configure(group: &mut BenchmarkGroup<WallTime>) {
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2));
+}
+
+fn bench_correction(c: &mut Criterion) {
+    let metrics = sink_metrics();
+    let num_ts_values = [1024, 4096, 16384];
+
+    for pattern in [Pattern::Append, Pattern::Upsert, Pattern::TemporalFilter] {
+        let mut group = c.benchmark_group(format!("correction_drain_stepwise/{}", pattern.name()));
+        configure(&mut group);
+        for num_ts in num_ts_values {
+            bench_scenario(&mut group, &metrics, pattern, num_ts, drain_stepwise);
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group(format!("correction_advance_jump/{}", pattern.name()));
+        configure(&mut group);
+        for num_ts in num_ts_values {
+            bench_scenario(&mut group, &metrics, pattern, num_ts, advance_jump);
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group(format!("correction_insert/{}", pattern.name()));
+        configure(&mut group);
+        for num_ts in num_ts_values {
+            let batches = make_batches(num_ts, pattern);
+            for version in [Version::V1, Version::V2] {
+                group.bench_function(BenchmarkId::new(version.name(), num_ts), |b| {
+                    b.iter_batched(
+                        || (make_correction(version, &metrics), batches.clone()),
+                        |(mut correction, mut batches)| {
+                            for batch in &mut batches {
+                                correction.insert(batch);
+                            }
+                            correction
+                        },
+                        BatchSize::PerIteration,
+                    )
+                });
+            }
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_correction);
+criterion_main!(benches);

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -21,5 +21,9 @@ mod extensions;
 mod logging;
 mod metrics;
 mod render;
+/// MV sink machinery, exposed for benchmarks.
+#[cfg(feature = "bench")]
+pub mod sink;
+#[cfg(not(feature = "bench"))]
 mod sink;
 mod typedefs;

--- a/src/compute/src/sink.rs
+++ b/src/compute/src/sink.rs
@@ -8,7 +8,13 @@
 // by the Apache License, Version 2.0.
 
 mod copy_to_s3_oneshot;
+#[cfg(feature = "bench")]
+pub mod correction;
+#[cfg(not(feature = "bench"))]
 mod correction;
+#[cfg(feature = "bench")]
+pub mod correction_v2;
+#[cfg(not(feature = "bench"))]
 mod correction_v2;
 mod materialized_view;
 mod materialized_view_v2;

--- a/src/compute/src/sink/correction.rs
+++ b/src/compute/src/sink/correction.rs
@@ -43,8 +43,10 @@ use crate::sink::correction_v2::{CorrectionV2, Data};
 /// implementation that stores updates in non-spillable memory. `V2` improves on `V1` by supporting
 /// spill-to-disk but is less battle-tested so for now we want to keep the option of reverting to
 /// `V1` in a pinch. The plan is to remove `V1` eventually.
-pub(super) enum Correction<D: Data> {
+pub enum Correction<D: Data> {
+    /// Correction buffer based on a [`CorrectionV1`].
     V1(CorrectionV1<D>),
+    /// Correction buffer based on a [`CorrectionV2`].
     V2(CorrectionV2<D>),
 }
 
@@ -131,7 +133,7 @@ impl<D: Data> Correction<D> {
 ///    are removed by inserting them again, with negated diffs. Stored updates are continuously
 ///    consolidated to give them opportunity to cancel each other out.
 ///  * It provides an interface for advancing all contained updates to a given frontier.
-pub(super) struct CorrectionV1<D> {
+pub struct CorrectionV1<D> {
     /// Stashed updates by time.
     updates: BTreeMap<Timestamp, ConsolidatingVec<D>>,
     /// Frontier to which all update times are advanced.
@@ -537,11 +539,16 @@ impl AddAssign<Self> for SizeMetrics {
 
 /// A logging event sent from the Tokio task back to the Timely thread.
 #[derive(Debug)]
-pub(super) enum LoggingEvent {
+pub enum LoggingEvent {
+    /// A chain with the given number of updates was created.
     ChainCreated(usize),
+    /// A chain with the given number of updates was dropped.
     ChainDropped(usize),
+    /// The heap size of the correction buffer changed by the given amount.
     SizeDiff(NonZeroIsize),
+    /// The heap capacity of the correction buffer changed by the given amount.
     CapacityDiff(NonZeroIsize),
+    /// The number of allocations of the correction buffer changed by the given amount.
     AllocationsDiff(NonZeroIsize),
 }
 
@@ -551,33 +558,39 @@ pub(super) enum LoggingEvent {
 /// instance. This allows corrections on the Tokio task to participate in introspection logging
 /// without holding `Rc<RefCell<..>>`.
 #[derive(Clone, Debug)]
-pub(super) struct ChannelLogging(mpsc::UnboundedSender<LoggingEvent>);
+pub struct ChannelLogging(mpsc::UnboundedSender<LoggingEvent>);
 
 impl ChannelLogging {
+    /// Construct a new `ChannelLogging` sending events on the given channel.
     pub fn new(tx: mpsc::UnboundedSender<LoggingEvent>) -> Self {
         Self(tx)
     }
 
+    /// Report the creation of a chain with the given number of updates.
     pub fn chain_created(&self, updates: usize) {
         let _ = self.0.send(LoggingEvent::ChainCreated(updates));
     }
 
+    /// Report the dropping of a chain with the given number of updates.
     pub fn chain_dropped(&self, updates: usize) {
         let _ = self.0.send(LoggingEvent::ChainDropped(updates));
     }
 
+    /// Report a change in heap size by the given amount.
     pub fn report_size_diff(&self, diff: isize) {
         if let Some(diff) = NonZeroIsize::new(diff) {
             let _ = self.0.send(LoggingEvent::SizeDiff(diff));
         }
     }
 
+    /// Report a change in heap capacity by the given amount.
     pub fn report_capacity_diff(&self, diff: isize) {
         if let Some(diff) = NonZeroIsize::new(diff) {
             let _ = self.0.send(LoggingEvent::CapacityDiff(diff));
         }
     }
 
+    /// Report a change in the number of allocations by the given amount.
     pub fn report_allocations_diff(&self, diff: isize) {
         if let Some(diff) = NonZeroIsize::new(diff) {
             let _ = self.0.send(LoggingEvent::AllocationsDiff(diff));

--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -28,9 +28,22 @@
 //! Stored updates are of the form `(data, time, diff)`, where `time` and `diff` are fixed to
 //! [`mz_repr::Timestamp`] and [`mz_repr::Diff`], respectively.
 //!
-//! [`CorrectionV2`] holds onto a list of [`Chain`]s containing [`Chunk`]s of stashed updates. Each
-//! [`Chunk`] is a columnation region containing a fixed maximum number of updates. All updates in
+//! [`CorrectionV2`] holds onto a list of `Chain`s containing `Chunk`s of stashed updates. Each
+//! `Chunk` is a columnation region containing a fixed maximum number of updates. All updates in
 //! a chunk, and all updates in a chain, are ordered by (time, data) and consolidated.
+//!
+//! Chains live in three places:
+//!
+//!  * A [`BucketChain`] partitions times at or beyond the `boundary` (the largest read `upper`
+//!    seen so far) into buckets of exponentially growing time ranges, each holding a list of
+//!    chains. Reads only touch the buckets below their `upper`, so the bulk of the buffered
+//!    updates — in particular far-future retractions produced by temporal filters — is left
+//!    alone.
+//!  * `pending_low` holds chains at times below the `boundary`, mostly insertions arriving
+//!    through the persist feedback.
+//!  * `emitted` is a single chain holding the updates returned by the last read. Updates must
+//!    stay in the buffer until their feedback retractions arrive, and keeping them separate from
+//!    the bucket chain means reads never have to re-merge future updates.
 //!
 //! ```text
 //!       chain[0]   |   chain[1]   |   chain[2]
@@ -49,13 +62,13 @@
 //!       (c, 3, +1) |              |
 //! ```
 //!
-//! The "chain invariant" states that each chain has at least `chain_proportionality` times as
+//! The "chain invariant" states that each chain in a bucket has at least `chain_proportionality` times as
 //! many updates as the next one. This means that chain sizes will often be powers of
 //! `chain_proportionality`, but they don't have to be. For example, for a proportionality of 2,
 //! the chain sizes `[11, 5, 2, 1]` would satisfy the chain invariant.
 //!
 //! Note that the invariant is maintained on update counts, not chunk counts. Chunks are
-//! byte-bounded (see [`ChunkBuilder`]), so chunk count is not proportional to update count and
+//! byte-bounded (see `ChunkBuilder`), so chunk count is not proportional to update count and
 //! would be a poor proxy: any chain below the chunk byte boundary is a single chunk regardless
 //! of how many updates it holds, which would let the geometric invariant collapse and break the
 //! O(log N) amortization of inserts.
@@ -66,39 +79,32 @@
 //!
 //! ## Inserting Updates
 //!
-//! A batch of updates is appended as a new chain. Then chains are merged at the end of the chain
-//! list until the chain invariant is restored.
+//! A batch of updates is routed by time: updates below the `boundary` become a `pending_low`
+//! chain, the rest is appended as new chains to their respective buckets. Appending to a bucket
+//! merges chains until the chain invariant is restored.
 //!
 //! Inserting an update into the correction buffer can be expensive: It involves allocating a new
 //! chunk, copying the update in, and then likely merging with an existing chain to restore the
 //! chain invariant. If updates trickle in in small batches, this can cause a considerable
-//! overhead. The amortize this overhead, new updates aren't immediately inserted into the sorted
-//! chains but instead stored in a [`Stage`] buffer. Once enough updates have been staged to fill a
-//! [`Chunk`], they are sorted an inserted into the chains.
+//! overhead. To amortize this overhead, new updates aren't immediately inserted into the sorted
+//! chains but instead stored in a `Stage` buffer. Once enough updates have been staged to fill a
+//! `Chunk`, they are sorted and routed.
 //!
 //! The insert operation has an amortized complexity of O(log N), with N being the current number
 //! of updates stored.
 //!
 //! ## Retrieving Consolidated Updates
 //!
-//! Retrieving consolidated updates before a given `upper` works by first consolidating all updates
-//! at times before the `upper`, merging them all into one chain, then returning an iterator over
-//! that chain.
+//! Retrieving consolidated updates before a given `upper` works by peeling all buckets below the
+//! `upper` off the bucket chain, splitting their chains, the pending low chains, and the previous
+//! `emitted` chain at the `upper`, merging the parts below the `upper` into the new `emitted`
+//! chain, and returning an iterator over that chain.
 //!
-//! Because each chain contains updates ordered by time first, consolidation of all updates before
-//! an `upper` is possible without touching updates at future times. It works by merging the chains
-//! only up to the `upper`, producing a merged chain containing consolidated times before the
-//! `upper` and leaving behind the chain parts containing later times. The complexity of this
-//! operation is O(U log K), with U being the number of updates before `upper` and K the number
-//! of chains.
-//!
-//! Unfortunately, performing consolidation as described above can break the chain invariant and we
-//! might need to restore it by merging chains, including ones containing future updates. This is
-//! something that would be great to fix! In the meantime the hope is that in steady state it
-//! doesn't matter too much because either there are no future retractions and U is approximately
-//! equal to N, or the amount of future retractions is much larger than the amount of current
-//! changes, in which case removing the current changes has a good chance of leaving the chain
-//! invariant intact.
+//! Because each chain contains updates ordered by time first, splitting a chain at the `upper`
+//! reuses whole chunks and copies at most one chunk straddling the split point. Updates at times
+//! at or beyond the `upper` are never touched, no matter how many the buffer holds. The
+//! complexity of a read is O(U log K), with U being the number of updates before `upper` and K
+//! the number of chains containing them.
 //!
 //! ## Merging Chains
 //!
@@ -119,15 +125,23 @@
 //! Merging them naively yields [(b, 2, +1), (a, 2, +1), (b, 2, -1), (a, 3, -1)], a chain that's
 //! neither sorted nor consolidated.
 //!
-//! Instead we need to merge sub-chains, one for each distinct time that's before or at the
-//! `since`. Each of these sub-chains retains the (time, data) ordering after the time advancement
-//! to `since`, so merging those yields the expected result.
+//! Times below the `since` can only exist in chains read by `consolidate_before`, and only if
+//! the `since` advanced past buffered times since the previous read. For few distinct stale
+//! times — the steady state, where the previously emitted chain was written just before the
+//! since advanced past it — we merge sub-chains, one for each distinct time that's before or at
+//! the `since`. Each of these sub-chains retains the (time, data) ordering after the time
+//! advancement to `since`, so merging those yields the expected result.
 //!
 //! For the above example, the chains we would merge are:
 //!   chain 1.a: [(c, 2, +1)]
 //!   chain 1.b: [(b, 2, -1), (a, 3, -1)]
 //!   chain 2.a: [(b, 2, +1)],
 //!   chain 2.b: [(a, 2, +1), (c, 2, -1)]
+//!
+//! For many distinct stale times — e.g. a since jump across many buffered timestamps when a sink
+//! restarts with an old as-of — the number of sub-chains grows with the number of distinct times,
+//! so we instead materialize the affected updates, advance their times, and sort and consolidate
+//! them in one O(U log U) pass.
 
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, VecDeque};
@@ -136,9 +150,11 @@ use std::rc::Rc;
 
 use columnar::{Columnar, Index, Len, Ref};
 use mz_ore::cast::CastLossy;
+use mz_ore::soft_assert_or_log;
 use mz_persist_client::metrics::{SinkMetrics, SinkWorkerMetrics, UpdateDelta};
 use mz_repr::{Diff, Timestamp};
 use mz_timely_util::columnar::Column;
+use mz_timely_util::temporal::{Bucket, BucketChain};
 use timely::PartialOrder;
 use timely::dataflow::channels::ContainerBytes;
 use timely::progress::Antichain;
@@ -172,15 +188,32 @@ impl<D> Data for D where
 /// In contrast to `CorrectionV1`, this implementation stores updates in columnation regions,
 /// allowing their memory to be transparently spilled to disk.
 #[derive(Debug)]
-pub(super) struct CorrectionV2<D: Data> {
-    /// Chains containing sorted updates.
-    chains: Vec<Chain<D>>,
+pub struct CorrectionV2<D: Data> {
+    /// Bucketed storage for updates at times at or beyond `boundary`.
+    ///
+    /// Buckets cover exponentially growing time ranges, so reads only touch the buckets below
+    /// their `upper`, and far-future updates (e.g. retractions produced by temporal filters) are
+    /// rarely touched.
+    chain: BucketChain<ChainBucket<D>>,
+    /// Chains at times below `boundary` that were not yet emitted.
+    ///
+    /// Filled by inserts at times below the boundary (mostly persist feedback) and by the
+    /// remainders of `emitted` when a read uses a smaller `upper` than the previous one. Merged
+    /// into `emitted` by the next read.
+    pending_low: Vec<Chain<D>>,
+    /// Updates that were emitted by `updates_before` but not yet cancelled by persist feedback.
+    ///
+    /// Sorted and consolidated, with all times advanced to the `since`.
+    emitted: Chain<D>,
     /// A staging area for updates, to speed up small inserts.
     stage: Stage<D>,
+    /// The lower bound of times stored in `chain`. Only ever advances.
+    ///
+    /// Times below the boundary have been peeled off the bucket chain and can only be stored in
+    /// `pending_low` or `emitted`.
+    boundary: Antichain<Timestamp>,
     /// The frontier by which all contained times are advanced.
     since: Antichain<Timestamp>,
-    /// The size factor of subsequent chains required by the chain invariant.
-    chain_proportionality: f64,
 
     /// Total count of updates in the correction buffer.
     ///
@@ -198,6 +231,19 @@ pub(super) struct CorrectionV2<D: Data> {
     logging: Option<ChannelLogging>,
 }
 
+/// Fuel for restoring the bucket chain invariant after peeling.
+///
+/// Bounds the restoration work per buffer operation. The bucket chain remains functional when
+/// restoration is incomplete -- peeling and finding work on ill-formed chains, at the cost of
+/// more in-line splitting -- so leftover restoration is simply picked up by the next operation.
+///
+/// `restore` spends one unit of fuel per bucket split, and a single `peel` leaves at most
+/// `BucketTimestamp::DOMAIN` (64) buckets to re-split, so this budget completes restoration in one
+/// call for any realistic buffer. It is deliberately generous: the "incomplete restoration is
+/// picked up next op" path is a correctness safety net for pathological bucket counts, not a hot
+/// path we expect to exercise. Lower it if restoration ever needs to interleave with other work.
+const RESTORE_FUEL: i64 = 1_000_000;
+
 impl<D: Data> CorrectionV2<D> {
     /// Construct a new [`CorrectionV2`] instance.
     pub fn new(
@@ -211,10 +257,12 @@ impl<D: Data> CorrectionV2<D> {
         let chunk_capacity = std::cmp::max(chunk_size / update_size, 1);
 
         Self {
-            chains: Default::default(),
+            chain: BucketChain::new(ChainBucket::new(chain_proportionality, logging.clone())),
+            pending_low: Vec::new(),
+            emitted: Chain::new(),
             stage: Stage::new(logging.clone(), chunk_capacity),
+            boundary: Antichain::from_elem(Timestamp::MIN),
             since: Antichain::from_elem(Timestamp::MIN),
-            chain_proportionality,
             prev_update_count: 0,
             prev_size: Default::default(),
             metrics,
@@ -254,40 +302,53 @@ impl<D: Data> CorrectionV2<D> {
         self.insert_inner(updates);
     }
 
-    /// Insert a batch of updates.
+    /// Insert a batch of updates into the stage, flushing it when full.
     ///
     /// All times are expected to be >= the `since`.
     fn insert_inner(&mut self, updates: &mut Vec<(D, Timestamp, Diff)>) {
         debug_assert!(updates.iter().all(|(_, t, _)| self.since.less_equal(t)));
 
-        if let Some(chain) = self.stage.insert(updates) {
-            self.log_chain_created(&chain);
-            self.chains.push(chain);
-
-            // Restore the chain invariant.
-            let prop = self.chain_proportionality;
-            let merge_needed = |chains: &[Chain<_>]| match chains {
-                [.., prev, last] => {
-                    let last_len = f64::cast_lossy(last.update_count);
-                    let prev_len = f64::cast_lossy(prev.update_count);
-                    last_len * prop > prev_len
-                }
-                _ => false,
-            };
-
-            while merge_needed(&self.chains) {
-                let a = self.chains.pop().unwrap();
-                let b = self.chains.pop().unwrap();
-                self.log_chain_dropped(&a);
-                self.log_chain_dropped(&b);
-
-                let merged = self.merge_chains([a, b]);
-                self.log_chain_created(&merged);
-                self.chains.push(merged);
-            }
-        };
+        if let Some(mut ready) = self.stage.insert(updates) {
+            self.route(&mut ready);
+        }
 
         self.update_metrics();
+    }
+
+    /// Route a batch of sorted, consolidated updates to `pending_low` or their chain buckets.
+    fn route(&mut self, updates: &mut Vec<(D, Timestamp, Diff)>) {
+        // Updates at times below the boundary become a pending low chain.
+        let idx = updates.partition_point(|(_, t, _)| !self.boundary.less_equal(t));
+        if idx > 0 {
+            let mut builder = ChainBuilder::default();
+            builder.extend(updates.drain(..idx));
+            let chain = builder.finish();
+            if !chain.is_empty() {
+                self.log_chain_created(&chain);
+                self.pending_low.push(chain);
+            }
+        }
+
+        // Updates at times at or beyond the boundary go into their chain buckets. Walk ranges of
+        // times that fall into the same bucket, to push batches of updates at once.
+        let mut drain = updates.drain(..).peekable();
+        while let Some(update) = drain.next() {
+            let time = update.1;
+            let range = self
+                .chain
+                .range_of(&time)
+                .expect("bucket chain covers all times at or beyond the boundary");
+            let mut builder = ChainBuilder::default();
+            builder.extend(std::iter::once(update));
+            while let Some(update) = drain.next_if(|(_, t, _)| range.contains(t)) {
+                builder.extend(std::iter::once(update));
+            }
+            let bucket = self
+                .chain
+                .find_mut(&range.start)
+                .expect("bucket chain covers all times at or beyond the boundary");
+            bucket.push_chain(builder.finish());
+        }
     }
 
     /// Return consolidated updates before the given `upper`.
@@ -295,95 +356,184 @@ impl<D: Data> CorrectionV2<D> {
         &'a mut self,
         upper: &Antichain<Timestamp>,
     ) -> impl Iterator<Item = (D, Timestamp, Diff)> + Send + 'a {
-        let mut result = None;
-
+        // All contained times are advanced to at least the `since`, so a read at an `upper` that
+        // is not beyond the `since` is always empty. Short-circuit to avoid the eager peel, merge,
+        // and `boundary` advancement that `consolidate_before` would otherwise perform. Normal
+        // reads and `consolidate_at_since` always pass an `upper` beyond the `since`.
         if !PartialOrder::less_than(&self.since, upper) {
-            // All contained updates are beyond the upper.
-            return result.into_iter().flatten();
+            return None.into_iter().flatten();
         }
 
         self.consolidate_before(upper);
 
-        // There is at most one chain that contains updates before `upper` now.
-        result = self
-            .chains
-            .iter()
-            .find(|c| c.first().is_some_and(|(_, t, _)| !upper.less_equal(&t)))
-            .map(move |c| {
-                let upper = upper.clone();
-                c.iter().take_while(move |(_, t, _)| !upper.less_equal(t))
-            });
-
-        result.into_iter().flatten()
+        // After `consolidate_before`, `emitted` holds exactly the updates before `upper`: every
+        // path that populates it splits at `upper` (pushing the remainder to `pending_low`), and
+        // the guard above guarantees `upper > since`, so advancing stale times to the `since`
+        // cannot lift them to or beyond `upper`. We can therefore yield all of `emitted`. Guard
+        // the invariant: a violation would write updates beyond the batch upper to persist.
+        soft_assert_or_log!(
+            self.emitted
+                .last()
+                .is_none_or(|(_, t, _)| !upper.less_equal(&t)),
+            "emitted contains times at or beyond the upper",
+        );
+        Some(self.emitted.iter()).into_iter().flatten()
     }
 
-    /// Consolidate all updates before the given `upper`.
+    /// Consolidate all updates before the given `upper` into the `emitted` chain.
     ///
-    /// Once this method returns, all remaining updates before `upper` are contained in a single
-    /// chain. Note that this chain might also contain updates beyond `upper` though!
+    /// Once this method returns, `emitted` contains all updates at times before `upper`,
+    /// consolidated. It can also contain updates at times at or beyond `upper` if `upper` is not
+    /// beyond the `since`.
     fn consolidate_before(&mut self, upper: &Antichain<Timestamp>) {
-        if self.chains.is_empty() && self.stage.is_empty() {
-            return;
+        if let Some(mut ready) = self.stage.flush() {
+            self.route(&mut ready);
         }
 
-        let mut chains = std::mem::take(&mut self.chains);
+        let Some(&since_ts) = self.since.as_option() else {
+            // If the since is the empty frontier, discard all updates.
+            let peeled = self.chain.peel(Antichain::new().borrow());
+            for bucket in peeled {
+                for chain in bucket.into_chains() {
+                    self.log_chain_dropped(&chain);
+                }
+            }
+            for chain in std::mem::take(&mut self.pending_low) {
+                self.log_chain_dropped(&chain);
+            }
+            let emitted = std::mem::replace(&mut self.emitted, Chain::new());
+            if !emitted.is_empty() {
+                self.log_chain_dropped(&emitted);
+            }
+            self.update_metrics();
+            return;
+        };
 
-        // To keep things simple, we log the dropping of all chains here and log the creation of
-        // all remaining chains at the end. This causes more event churn than necessary, but the
-        // consolidated result is correct.
-        chains.iter().for_each(|c| self.log_chain_dropped(c));
+        // Peel the buckets below the upper off the bucket chain. Bucket splits during the peel
+        // only touch chunks around the upper; chunks wholly on either side are reused.
+        let peeled = self.chain.peel(upper.borrow());
+        if PartialOrder::less_than(&self.boundary, upper) {
+            self.boundary = upper.clone();
+        }
 
-        Extend::extend(&mut chains, self.stage.flush());
+        // Collect candidate chains: peeled bucket contents, pending low chains, and the previous
+        // emitted chain. All contain only times below the boundary.
+        let emitted = std::mem::replace(&mut self.emitted, Chain::new());
+        let mut candidates: Vec<Chain<D>> = Vec::new();
+        for bucket in peeled {
+            candidates.extend(bucket.into_chains());
+        }
+        candidates.append(&mut self.pending_low);
+        if !emitted.is_empty() {
+            candidates.push(emitted);
+        }
 
-        if chains.is_empty() {
-            // We can only get here if the stage contained updates but they all got consolidated
-            // away by `flush`, so we need to update the metrics before we return.
+        if candidates.is_empty() {
+            self.restore_chain();
             self.update_metrics();
             return;
         }
 
-        let (merged, remains) = self.merge_chains_up_to(chains, upper);
+        candidates.iter().for_each(|c| self.log_chain_dropped(c));
 
-        self.chains = remains;
-        if !merged.is_empty() {
-            // We put the merged chain at the end, assuming that its contents are likely to
-            // consolidate with retractions that will arrive soon.
-            self.chains.push(merged);
-        }
-
-        // Restore the chain invariant.
-        //
-        // This part isn't great. We've taken great care so far to only look at updates with times
-        // before `upper`, but now we might end up merging all chains anyway in the worst case.
-        // There might be something smarter we could do to avoid merging as much as possible. For
-        // example, we could consider sorting chains by length first, or inspect the contained
-        // times and prefer merging chains that have a chance at consolidating with one another.
-        let mut i = self.chains.len().saturating_sub(1);
-        while i > 0 {
-            let needs_merge = self.chains.get(i).is_some_and(|a| {
-                let b = &self.chains[i - 1];
-                let a_len = f64::cast_lossy(a.update_count);
-                let b_len = f64::cast_lossy(b.update_count);
-                a_len * self.chain_proportionality > b_len
-            });
-            if needs_merge {
-                let a = self.chains.remove(i);
-                let b = std::mem::replace(&mut self.chains[i - 1], Chain::new());
-                let merged = self.merge_chains([a, b]);
-                self.chains[i - 1] = merged;
-            } else {
-                // Only advance the index if we didn't merge. A merge can reduce the size of the
-                // chain at `i - 1`, causing an violation of the chain invariant with the next
-                // chain, so we might need to merge the two before proceeding to lower indexes.
-                i -= 1;
+        // Split the candidates at the upper. Parts at or beyond the upper (possible when `upper`
+        // regresses below a previous one) stay pending.
+        let mut lowers = Vec::new();
+        for chain in candidates {
+            match upper.as_option() {
+                Some(&upper_ts) => {
+                    let (lower, remainder) = chain.split_at_time(upper_ts);
+                    if !lower.is_empty() {
+                        lowers.push(lower);
+                    }
+                    if !remainder.is_empty() {
+                        self.log_chain_created(&remainder);
+                        self.pending_low.push(remainder);
+                    }
+                }
+                // The empty upper is greater than all times.
+                None => lowers.push(chain),
             }
         }
 
-        self.chains.iter().for_each(|c| self.log_chain_created(c));
+        // Merge the lower parts into the new emitted chain, advancing times below the since.
+        // Advancing times in a (time, data)-sorted chain can break its sort order, so chains
+        // containing stale times cannot be merged as they are. Stale times are expected in steady
+        // state: the previous emitted chain was written before the since advanced past it.
+        //
+        // Count the distinct stale times, up to a small cap. For few distinct stale times -- the
+        // steady state -- split cursors into runs that remain sorted under advancement and merge
+        // those. For many distinct stale times -- e.g. a since jump across many buffered
+        // timestamps when a sink restarts with an old as-of -- the number of runs and the cost of
+        // cloning cursor state per run grow with the number of distinct times, so materialize,
+        // advance, and consolidate in one O(U log U) pass instead.
+        const MAX_STALE_RUNS: usize = 32;
+        let mut stale_times = 0;
+        for chain in &lowers {
+            stale_times += chain.distinct_times_before(since_ts, MAX_STALE_RUNS - stale_times);
+            if stale_times >= MAX_STALE_RUNS {
+                break;
+            }
+        }
+
+        let merged = if stale_times == 0 {
+            let cursors: Vec<_> = lowers.into_iter().filter_map(Chain::into_cursor).collect();
+            merge_cursors(cursors)
+        } else if stale_times < MAX_STALE_RUNS {
+            let mut runs = Vec::new();
+            for chain in lowers {
+                if let Some(cursor) = chain.into_cursor() {
+                    runs.append(&mut cursor.advance_by(since_ts));
+                }
+            }
+            merge_cursors(runs)
+        } else {
+            let mut updates: Vec<_> = lowers.iter().flat_map(|c| c.iter()).collect();
+            for (_, time, _) in &mut updates {
+                *time = std::cmp::max(*time, since_ts);
+            }
+            consolidate(&mut updates);
+            let mut builder = ChainBuilder::default();
+            builder.extend(updates);
+            let chain = builder.finish();
+
+            // Advancement can move updates to or beyond the upper; such updates stay pending.
+            match upper.as_option() {
+                Some(&upper_ts) => {
+                    let (lower, remainder) = chain.split_at_time(upper_ts);
+                    if !remainder.is_empty() {
+                        self.log_chain_created(&remainder);
+                        self.pending_low.push(remainder);
+                    }
+                    lower
+                }
+                None => chain,
+            }
+        };
+
+        if !merged.is_empty() {
+            self.log_chain_created(&merged);
+        }
+        self.emitted = merged;
+
+        self.restore_chain();
         self.update_metrics();
     }
 
+    /// Perform a bounded amount of work towards restoring the bucket chain invariant.
+    ///
+    /// Restoration is allowed to remain incomplete: the bucket chain supports peeling and finding
+    /// on ill-formed chains, so any leftover work is picked up by subsequent operations. The fuel
+    /// bound keeps individual buffer operations from stalling the operator that owns the buffer.
+    fn restore_chain(&mut self) {
+        let mut fuel = RESTORE_FUEL;
+        self.chain.restore(&mut fuel);
+    }
+
     /// Advance the since frontier.
+    ///
+    /// Time advancement of updates in the bucket chain is lazy: it happens when the updates are
+    /// consolidated by a read.
     ///
     /// # Panics
     ///
@@ -419,9 +569,17 @@ impl<D: Data> CorrectionV2<D> {
     fn update_metrics(&mut self) {
         let mut new_size = self.stage.get_size();
         let mut new_length = self.stage.data.len();
-        for chain in &self.chains {
+        for chain in &self.pending_low {
             new_size += chain.get_size();
             new_length += chain.update_count;
+        }
+        new_size += self.emitted.get_size();
+        new_length += self.emitted.update_count;
+        for bucket in self.chain.buckets() {
+            for chain in &bucket.chains {
+                new_size += chain.get_size();
+                new_length += chain.update_count;
+            }
         }
 
         self.update_metrics_inner(new_size, new_length);
@@ -448,161 +606,217 @@ impl<D: Data> CorrectionV2<D> {
         self.prev_size = new_size;
         self.prev_update_count = new_length;
     }
+}
 
-    /// Merge the given chains, advancing times by the current `since` in the process.
-    fn merge_chains(&self, chains: impl IntoIterator<Item = Chain<D>>) -> Chain<D> {
-        let Some(&since_ts) = self.since.as_option() else {
-            return Chain::new();
-        };
-
-        let mut to_merge = Vec::new();
-        for chain in chains {
-            if let Some(cursor) = chain.into_cursor() {
-                let mut runs = cursor.advance_by(since_ts);
-                to_merge.append(&mut runs);
-            }
+/// Merge the given cursors into one chain.
+fn merge_cursors<D: Data>(cursors: Vec<Cursor<D>>) -> Chain<D> {
+    match cursors.len() {
+        0 => Chain::new(),
+        1 => {
+            let [cur] = cursors.try_into().unwrap();
+            cur.into_chain()
         }
-
-        self.merge_cursors(to_merge)
+        2 => {
+            let [a, b] = cursors.try_into().unwrap();
+            merge_2(a, b)
+        }
+        _ => merge_many(cursors),
     }
+}
 
-    /// Merge the given chains, advancing times by the current `since` in the process, but only up
-    /// to the given `upper`.
-    ///
-    /// Returns the merged chain and a list of non-empty remainders of the input chains.
-    fn merge_chains_up_to(
-        &self,
-        chains: Vec<Chain<D>>,
-        upper: &Antichain<Timestamp>,
-    ) -> (Chain<D>, Vec<Chain<D>>) {
-        let Some(&since_ts) = self.since.as_option() else {
-            return (Chain::new(), Vec::new());
-        };
-        let Some(&upper_ts) = upper.as_option() else {
-            let merged = self.merge_chains(chains);
-            return (merged, Vec::new());
-        };
+/// Merge the given two cursors using a 2-way merge.
+///
+/// This function is a specialization of `merge_many` that avoids the overhead of a binary heap.
+fn merge_2<D: Data>(cursor1: Cursor<D>, cursor2: Cursor<D>) -> Chain<D> {
+    let mut rest1 = Some(cursor1);
+    let mut rest2 = Some(cursor2);
+    let mut merged = ChainBuilder::default();
 
-        if since_ts >= upper_ts {
-            // After advancing by `since` there will be no updates before `upper`.
-            return (Chain::new(), chains);
-        }
+    loop {
+        match (rest1, rest2) {
+            (Some(c1), Some(c2)) => {
+                let (d1, t1, r1) = c1.get();
+                let (d2, t2, r2) = c2.get();
 
-        let mut to_merge = Vec::new();
-        let mut to_keep = Vec::new();
-        for chain in chains {
-            if let Some(cursor) = chain.into_cursor() {
-                let mut runs = cursor.advance_by(since_ts);
-                if let Some(last) = runs.pop() {
-                    let (before, beyond) = last.split_at_time(upper_ts);
-                    before.map(|c| runs.push(c));
-                    beyond.map(|c| to_keep.push(c));
-                }
-                to_merge.append(&mut runs);
-            }
-        }
-
-        let merged = self.merge_cursors(to_merge);
-        let remains = to_keep
-            .into_iter()
-            .map(|c| c.try_unwrap().expect("unwrapable"))
-            .collect();
-
-        (merged, remains)
-    }
-
-    /// Merge the given cursors into one chain.
-    fn merge_cursors(&self, cursors: Vec<Cursor<D>>) -> Chain<D> {
-        match cursors.len() {
-            0 => Chain::new(),
-            1 => {
-                let [cur] = cursors.try_into().unwrap();
-                cur.into_chain()
-            }
-            2 => {
-                let [a, b] = cursors.try_into().unwrap();
-                self.merge_2(a, b)
-            }
-            _ => self.merge_many(cursors),
-        }
-    }
-
-    /// Merge the given two cursors using a 2-way merge.
-    ///
-    /// This function is a specialization of `merge_many` that avoids the overhead of a binary heap.
-    fn merge_2(&self, cursor1: Cursor<D>, cursor2: Cursor<D>) -> Chain<D> {
-        let mut rest1 = Some(cursor1);
-        let mut rest2 = Some(cursor2);
-        let mut merged = ChainBuilder::default();
-
-        loop {
-            match (rest1, rest2) {
-                (Some(c1), Some(c2)) => {
-                    let (d1, t1, r1) = c1.get();
-                    let (d2, t2, r2) = c2.get();
-
-                    match (t1, d1).cmp(&(t2, d2)) {
-                        Ordering::Less => {
-                            merged.push_ref((d1, t1, r1));
-                            rest1 = c1.step();
-                            rest2 = Some(c2);
+                match (t1, d1).cmp(&(t2, d2)) {
+                    Ordering::Less => {
+                        merged.push_ref((d1, t1, r1));
+                        rest1 = c1.step();
+                        rest2 = Some(c2);
+                    }
+                    Ordering::Greater => {
+                        merged.push_ref((d2, t2, r2));
+                        rest1 = Some(c1);
+                        rest2 = c2.step();
+                    }
+                    Ordering::Equal => {
+                        let r = r1 + r2;
+                        if r != Diff::ZERO {
+                            merged.push_ref((d1, t1, r));
                         }
-                        Ordering::Greater => {
-                            merged.push_ref((d2, t2, r2));
-                            rest1 = Some(c1);
-                            rest2 = c2.step();
-                        }
-                        Ordering::Equal => {
-                            let r = r1 + r2;
-                            if r != Diff::ZERO {
-                                merged.push_ref((d1, t1, r));
-                            }
-                            rest1 = c1.step();
-                            rest2 = c2.step();
-                        }
+                        rest1 = c1.step();
+                        rest2 = c2.step();
                     }
                 }
-                (Some(c), None) | (None, Some(c)) => {
-                    merged.push_cursor(c);
-                    break;
-                }
-                (None, None) => break,
+            }
+            (Some(c), None) | (None, Some(c)) => {
+                merged.push_cursor(c);
+                break;
+            }
+            (None, None) => break,
+        }
+    }
+
+    merged.finish()
+}
+
+/// Merge the given cursors using a k-way merge with a binary heap.
+fn merge_many<D: Data>(cursors: Vec<Cursor<D>>) -> Chain<D> {
+    let mut heap = MergeHeap::from_iter(cursors);
+    let mut merged = ChainBuilder::default();
+    while let Some(cursor1) = heap.pop() {
+        let (data, time, mut diff) = cursor1.get();
+
+        while let Some((cursor2, r)) = heap.pop_equal(data, time) {
+            diff += r;
+            if let Some(cursor2) = cursor2.step() {
+                heap.push(cursor2);
             }
         }
 
-        merged.finish()
-    }
-
-    /// Merge the given cursors using a k-way merge with a binary heap.
-    fn merge_many(&self, cursors: Vec<Cursor<D>>) -> Chain<D> {
-        let mut heap = MergeHeap::from_iter(cursors);
-        let mut merged = ChainBuilder::default();
-        while let Some(cursor1) = heap.pop() {
-            let (data, time, mut diff) = cursor1.get();
-
-            while let Some((cursor2, r)) = heap.pop_equal(data, time) {
-                diff += r;
-                if let Some(cursor2) = cursor2.step() {
-                    heap.push(cursor2);
-                }
-            }
-
-            if diff != Diff::ZERO {
-                merged.push_ref((data, time, diff));
-            }
-            if let Some(cursor1) = cursor1.step() {
-                heap.push(cursor1);
-            }
+        if diff != Diff::ZERO {
+            merged.push_ref((data, time, diff));
         }
-
-        merged.finish()
+        if let Some(cursor1) = cursor1.step() {
+            heap.push(cursor1);
+        }
     }
+
+    merged.finish()
 }
 
 impl<D: Data> Drop for CorrectionV2<D> {
     fn drop(&mut self) {
-        self.chains.iter().for_each(|c| self.log_chain_dropped(c));
+        for bucket in self.chain.buckets() {
+            bucket.chains.iter().for_each(|c| self.log_chain_dropped(c));
+        }
+        self.pending_low
+            .iter()
+            .for_each(|c| self.log_chain_dropped(c));
+        if !self.emitted.is_empty() {
+            self.log_chain_dropped(&self.emitted);
+        }
         self.update_metrics_inner(Default::default(), 0);
+    }
+}
+
+/// A bucket of `Chain`s, for use in a [`BucketChain`].
+///
+/// All chains are individually sorted by (time, data) and consolidated, but updates can appear in
+/// multiple chains, so consumers must merge the chains to obtain consolidated updates.
+struct ChainBucket<D: Data> {
+    /// The contained chains.
+    ///
+    /// Maintained with the chain invariant on pushes; splits can leave it violated until the next
+    /// push restores it.
+    chains: Vec<Chain<D>>,
+    /// The size factor of subsequent chains required by the chain invariant.
+    chain_proportionality: f64,
+    /// Introspection logging.
+    logging: Option<ChannelLogging>,
+}
+
+impl<D: Data> fmt::Debug for ChainBucket<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChainBucket")
+            .field("chains", &self.chains)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<D: Data> ChainBucket<D> {
+    /// Construct a new, empty `ChainBucket`.
+    fn new(chain_proportionality: f64, logging: Option<ChannelLogging>) -> Self {
+        Self {
+            chains: Vec::new(),
+            chain_proportionality,
+            logging,
+        }
+    }
+
+    /// Push a chain onto the bucket, restoring the chain invariant.
+    fn push_chain(&mut self, chain: Chain<D>) {
+        if chain.is_empty() {
+            return;
+        }
+        if let Some(logging) = &self.logging {
+            logging.chain_created(chain.update_count);
+        }
+        self.chains.push(chain);
+
+        // Restore the chain invariant.
+        let prop = self.chain_proportionality;
+        let merge_needed = |chains: &[Chain<_>]| match chains {
+            [.., prev, last] => {
+                let last_len = f64::cast_lossy(last.update_count);
+                let prev_len = f64::cast_lossy(prev.update_count);
+                last_len * prop > prev_len
+            }
+            _ => false,
+        };
+
+        while merge_needed(&self.chains) {
+            let a = self.chains.pop().unwrap();
+            let b = self.chains.pop().unwrap();
+            if let Some(logging) = &self.logging {
+                logging.chain_dropped(a.update_count);
+                logging.chain_dropped(b.update_count);
+            }
+
+            let cursors = [a, b].into_iter().filter_map(Chain::into_cursor).collect();
+            let merged = merge_cursors(cursors);
+            if !merged.is_empty() {
+                if let Some(logging) = &self.logging {
+                    logging.chain_created(merged.update_count);
+                }
+                self.chains.push(merged);
+            }
+        }
+    }
+
+    /// Convert the bucket into its contained chains.
+    fn into_chains(self) -> Vec<Chain<D>> {
+        self.chains
+    }
+}
+
+impl<D: Data> Bucket for ChainBucket<D> {
+    type Timestamp = Timestamp;
+
+    fn split(self, timestamp: &Self::Timestamp, fuel: &mut i64) -> (Self, Self) {
+        let mut lower = Self::new(self.chain_proportionality, self.logging.clone());
+        let mut upper = Self::new(self.chain_proportionality, self.logging.clone());
+
+        for chain in self.chains {
+            // Whole chunks are reused; at most one chunk straddling the timestamp is copied per
+            // chain. Account fuel at chunk granularity.
+            *fuel = fuel.saturating_sub(i64::try_from(chain.chunks.len()).expect("must fit"));
+
+            if let Some(logging) = &self.logging {
+                logging.chain_dropped(chain.update_count);
+            }
+            let (lo, hi) = chain.split_at_time(*timestamp);
+            for (part, target) in [(lo, &mut lower), (hi, &mut upper)] {
+                if !part.is_empty() {
+                    if let Some(logging) = &self.logging {
+                        logging.chain_created(part.update_count);
+                    }
+                    target.chains.push(part);
+                }
+            }
+        }
+
+        (lower, upper)
     }
 }
 
@@ -655,11 +869,6 @@ impl<D: Data> Chain<D> {
         })
     }
 
-    /// Return the first update in the chain, if any.
-    fn first(&self) -> Option<Ref<'_, (D, Timestamp, Diff)>> {
-        self.chunks.first().map(|c| c.first())
-    }
-
     /// Return the last update in the chain, if any.
     fn last(&self) -> Option<Ref<'_, (D, Timestamp, Diff)>> {
         self.chunks.last().map(|c| c.last())
@@ -679,6 +888,87 @@ impl<D: Data> Chain<D> {
                 (D::into_owned(d), t, r)
             })
         })
+    }
+
+    /// Count the distinct times of updates at times before `time`, up to the given cap.
+    ///
+    /// The scan uses one binary search per distinct time, so its cost is bounded by
+    /// O(cap log chunks).
+    fn distinct_times_before(&self, time: Timestamp, cap: usize) -> usize {
+        let mut count = 0;
+        let mut chunk_idx = 0;
+        let mut offset = 0;
+        while count < cap && chunk_idx < self.chunks.len() {
+            let chunk = &self.chunks[chunk_idx];
+            let current = chunk.index(offset).1;
+            if current >= time {
+                break;
+            }
+            count += 1;
+            // Skip to the first update at a time greater than `current`.
+            match chunk.find_time_greater_than(current) {
+                Some(idx) => offset = idx,
+                None => {
+                    // All later updates at `current` are in subsequent chunks.
+                    chunk_idx += 1;
+                    offset = 0;
+                    while chunk_idx < self.chunks.len() {
+                        match self.chunks[chunk_idx].find_time_greater_than(current) {
+                            Some(idx) => {
+                                offset = idx;
+                                break;
+                            }
+                            None => chunk_idx += 1,
+                        }
+                    }
+                }
+            }
+        }
+        count
+    }
+
+    /// Split the chain at the given time.
+    ///
+    /// Returns two chains, the first containing all updates at times < `time`, the second
+    /// containing all updates at times >= `time`. Chunks fully on either side of `time` are
+    /// reused; only a chunk straddling `time` is copied.
+    fn split_at_time(mut self, time: Timestamp) -> (Self, Self) {
+        let mut lower = Self::new();
+        let mut upper = Self::new();
+
+        let Some(skip_ts) = time.step_back() else {
+            // Nothing sorts before `time`.
+            return (lower, self);
+        };
+
+        for chunk in self.chunks.drain(..) {
+            if chunk.last().1 < time {
+                lower.push_chunk(chunk);
+            } else if chunk.first().1 >= time {
+                upper.push_chunk(chunk);
+            } else {
+                // The chunk straddles `time`; copy its two halves.
+                let idx = chunk
+                    .find_time_greater_than(skip_ts)
+                    .expect("straddles time");
+                let mut builder = ChainBuilder::default();
+                for i in 0..idx {
+                    builder.push_ref(chunk.index(i));
+                }
+                for part in builder.finish().chunks {
+                    lower.push_chunk(part);
+                }
+                let mut builder = ChainBuilder::default();
+                for i in idx..chunk.len() {
+                    builder.push_ref(chunk.index(i));
+                }
+                for part in builder.finish().chunks {
+                    upper.push_chunk(part);
+                }
+            }
+        }
+
+        (lower, upper)
     }
 
     /// Return the size of the chain, for use in metrics.
@@ -958,22 +1248,6 @@ impl<D: Data> Cursor<D> {
         splits
     }
 
-    /// Split the cursor at the given time.
-    ///
-    /// Returns two cursors, the first yielding all updates at times < `time`, the second yielding
-    /// all updates at times >= `time`. Both can be `None` if they would be empty.
-    fn split_at_time(self, time: Timestamp) -> (Option<Self>, Option<Self>) {
-        let Some(skip_ts) = time.step_back() else {
-            return (None, Some(self));
-        };
-
-        let before = self.clone();
-        match self.skip_time(skip_ts) {
-            Some((beyond, skipped)) => (before.set_limit(skipped), Some(beyond)),
-            None => (Some(before), None),
-        }
-    }
-
     /// Drain the cursor into a [`Chain`].
     ///
     /// This reuses the underlying chunks if possible, and writes new ones otherwise.
@@ -1206,12 +1480,12 @@ impl<D: Data> Stage<D> {
         }
     }
 
-    fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-
-    /// Insert a batch of updates, possibly producing a ready [`Chain`].
-    fn insert(&mut self, updates: &mut Vec<(D, Timestamp, Diff)>) -> Option<Chain<D>> {
+    /// Insert a batch of updates, possibly producing a batch of sorted, consolidated updates
+    /// ready to be stored.
+    fn insert(
+        &mut self,
+        updates: &mut Vec<(D, Timestamp, Diff)>,
+    ) -> Option<Vec<(D, Timestamp, Diff)>> {
         if updates.is_empty() {
             return None;
         }
@@ -1225,8 +1499,8 @@ impl<D: Data> Stage<D> {
 
         let mut new_updates = updates.drain(..);
 
-        // If we have enough shipable updates, collect them, consolidate, and build a chain.
-        let maybe_chain = if chunk_count > 0 {
+        // If we have enough shipable updates, collect them and consolidate.
+        let maybe_ready = if chunk_count > 0 {
             let ship_count = chunk_count * chunk_capacity;
             let mut buffer = Vec::with_capacity(ship_count);
 
@@ -1238,9 +1512,7 @@ impl<D: Data> Stage<D> {
 
             consolidate(&mut buffer);
 
-            let mut chain = ChainBuilder::default();
-            chain.extend(buffer);
-            Some(chain.finish())
+            Some(buffer)
         } else {
             None
         };
@@ -1250,11 +1522,11 @@ impl<D: Data> Stage<D> {
 
         self.log_length_diff(self.ilen() - prev_length);
 
-        maybe_chain
+        maybe_ready
     }
 
-    /// Flush all currently staged updates into a chain.
-    fn flush(&mut self) -> Option<Chain<D>> {
+    /// Flush all currently staged updates, returning them sorted and consolidated.
+    fn flush(&mut self) -> Option<Vec<(D, Timestamp, Diff)>> {
         self.log_length_diff(-self.ilen());
 
         consolidate(&mut self.data);
@@ -1263,9 +1535,9 @@ impl<D: Data> Stage<D> {
             return None;
         }
 
-        let mut chain = ChainBuilder::default();
-        chain.extend(self.data.drain(..));
-        Some(chain.finish())
+        let capacity = self.data.capacity();
+        let data = std::mem::replace(&mut self.data, Vec::with_capacity(capacity));
+        Some(data)
     }
 
     /// Advance the times of staged updates by the given `since`.
@@ -1446,9 +1718,13 @@ impl<D: Data> Ord for MergeCursor<D> {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_persist_client::cfg::PersistConfig;
+    use mz_persist_client::metrics::Metrics;
     use mz_repr::{Diff, Timestamp};
 
-    use super::ChainBuilder;
+    use super::*;
+    use crate::sink::correction::CorrectionV1;
 
     #[mz_ore::test]
     fn chain_builder_update_count_matches_items() {
@@ -1503,5 +1779,155 @@ mod tests {
             expected += 1;
         }
         assert_eq!(expected, count);
+    }
+
+    fn sink_metrics() -> SinkMetrics {
+        let registry = MetricsRegistry::new();
+        let metrics = Metrics::new(&PersistConfig::new_for_tests(), &registry);
+        metrics.sink.clone()
+    }
+
+    /// Run the same stepwise-drain workload through `CorrectionV1` and `CorrectionV2` and assert
+    /// that they emit the same updates at every step.
+    ///
+    /// Models the `write_batches` operator catching up through many distinct timestamps: the
+    /// desired input runs ahead, batches are written one timestamp at a time, and written updates
+    /// come back negated through the persist feedback.
+    #[mz_ore::test]
+    // Columnation regions are not Stacked Borrows compliant: later pushes invalidate the
+    // provenance of previously stored items under Miri.
+    #[cfg_attr(miri, ignore)]
+    fn equivalence_with_v1() {
+        let sink_metrics = sink_metrics();
+
+        let mut v1 =
+            CorrectionV1::<String>::new(sink_metrics.clone(), sink_metrics.for_worker(0), 1);
+        let mut v2 = CorrectionV2::<String>::new(
+            sink_metrics.clone(),
+            sink_metrics.for_worker(0),
+            None,
+            3.0,
+            8 * 1024,
+        );
+
+        let num_ts = 50;
+        let keys = 4;
+
+        // Upsert-style input: every timestamp updates each key, retracting the previous value.
+        let batch = |t: u64| -> Vec<(String, Timestamp, Diff)> {
+            (0..keys)
+                .flat_map(|k| {
+                    let addition = (format!("{k}-{t}"), Timestamp::from(t), Diff::ONE);
+                    let retraction = t
+                        .checked_sub(1)
+                        .map(|p| (format!("{k}-{p}"), Timestamp::from(t), -Diff::ONE));
+                    std::iter::once(addition).chain(retraction)
+                })
+                .collect()
+        };
+
+        // Pre-fill both with all batches, like a catch-up where the input runs ahead.
+        for t in 0..num_ts {
+            v1.insert(&mut batch(t));
+            v2.insert(&mut batch(t));
+        }
+
+        // Drain stepwise, with persist feedback, comparing emissions.
+        for t in 0..num_ts {
+            let upper = Antichain::from_elem(Timestamp::from(t + 1));
+
+            let mut out1: Vec<_> = v1.updates_before(&upper).collect();
+            let mut out2: Vec<_> = v2.updates_before(&upper).collect();
+            out1.sort();
+            out2.sort();
+            assert_eq!(out1, out2, "diverged at t={t}");
+
+            v1.insert_negated(&mut out1.clone());
+            v2.insert_negated(&mut out2);
+            v1.advance_since(upper.clone());
+            v2.advance_since(upper);
+        }
+
+        // Compare the final state at the since.
+        let upper = Antichain::from_elem(Timestamp::from(num_ts + 1));
+        v1.consolidate_at_since();
+        v2.consolidate_at_since();
+        let mut out1: Vec<_> = v1.updates_before(&upper).collect();
+        let mut out2: Vec<_> = v2.updates_before(&upper).collect();
+        out1.sort();
+        out2.sort();
+        assert_eq!(out1, out2);
+    }
+
+    /// A since jump across many distinct buffered timestamps must collapse them onto the since.
+    #[mz_ore::test]
+    // Columnation regions are not Stacked Borrows compliant: later pushes invalidate the
+    // provenance of previously stored items under Miri.
+    #[cfg_attr(miri, ignore)]
+    fn since_jump() {
+        let sink_metrics = sink_metrics();
+        let mut v2 = CorrectionV2::<String>::new(
+            sink_metrics.clone(),
+            sink_metrics.for_worker(0),
+            None,
+            3.0,
+            8 * 1024,
+        );
+
+        let num_ts = 100;
+        for t in 0..num_ts {
+            v2.insert(&mut vec![
+                (format!("a-{t}"), Timestamp::from(t), Diff::ONE),
+                (format!("a-{t}"), Timestamp::from(t), -Diff::ONE),
+                (format!("b-{t}"), Timestamp::from(t), Diff::ONE),
+            ]);
+        }
+
+        v2.advance_since(Antichain::from_elem(Timestamp::from(num_ts)));
+        v2.consolidate_at_since();
+
+        let upper = Antichain::from_elem(Timestamp::from(num_ts + 1));
+        let out: Vec<_> = v2.updates_before(&upper).collect();
+        assert_eq!(out.len(), usize::try_from(num_ts).unwrap());
+        assert!(
+            out.iter()
+                .all(|(_, t, r)| *t == Timestamp::from(num_ts) && *r == Diff::ONE)
+        );
+    }
+
+    /// Reads must not observe updates at or beyond their `upper`, even when the `upper` is not
+    /// beyond the `since`.
+    #[mz_ore::test]
+    // Columnation regions are not Stacked Borrows compliant: later pushes invalidate the
+    // provenance of previously stored items under Miri.
+    #[cfg_attr(miri, ignore)]
+    fn upper_not_beyond_since() {
+        let sink_metrics = sink_metrics();
+        let mut v2 = CorrectionV2::<String>::new(
+            sink_metrics.clone(),
+            sink_metrics.for_worker(0),
+            None,
+            3.0,
+            8 * 1024,
+        );
+
+        v2.insert(&mut vec![(
+            "a".to_owned(),
+            Timestamp::from(5_u64),
+            Diff::ONE,
+        )]);
+        v2.advance_since(Antichain::from_elem(Timestamp::from(10_u64)));
+
+        // The update logically lives at time 10 now, so a read before 7 must be empty.
+        let upper = Antichain::from_elem(Timestamp::from(7_u64));
+        assert_eq!(v2.updates_before(&upper).count(), 0);
+
+        // A read before 11 must emit it, advanced to the since.
+        let upper = Antichain::from_elem(Timestamp::from(11_u64));
+        let out: Vec<_> = v2.updates_before(&upper).collect();
+        assert_eq!(
+            out,
+            vec![("a".to_owned(), Timestamp::from(10_u64), Diff::ONE)]
+        );
     }
 }

--- a/src/timely-util/src/temporal.rs
+++ b/src/timely-util/src/temporal.rs
@@ -207,6 +207,18 @@ impl<S: Bucket> BucketChain<S> {
         self.content.len()
     }
 
+    /// An iterator over the buckets in the chain, in time order.
+    #[inline]
+    pub fn buckets(&self) -> impl Iterator<Item = &S> {
+        self.content.values().map(|(_, storage)| storage)
+    }
+
+    /// A mutable iterator over the buckets in the chain, in time order.
+    #[inline]
+    pub fn buckets_mut(&mut self) -> impl Iterator<Item = &mut S> {
+        self.content.values_mut().map(|(_, storage)| storage)
+    }
+
     /// Split the bucket specified by `(bits, offset, storage)` and insert the new buckets.
     /// Updates `fuel`.
     ///


### PR DESCRIPTION
### Motivation

MVs using the v2 correction buffer can stall during hydration when the input has to catch up through many distinct timestamps.
`CorrectionV2::updates_before` restructures the entire buffer on every call — Rc-wrapping every chunk, merging to the upper, rebuilding remainders, and re-merging chains for the chain invariant — so each read costs O(total buffered chunks) instead of O(drained slice), and a catch-up through T timestamps pays O(T²/chunk_capacity).
A micro-benchmark reproduces this: at 65536 timestamps (one day of 1s ticks at 16 updates/tick) a stepwise drain takes 13.5s per worker against CorrectionV1's 0.47s, with the ratio growing in T (~T^1.8).

### Description

Restructures `CorrectionV2` so reads only do work proportional to the drained slice, keeping the public interface, metrics, introspection logging, and dyncfgs unchanged.
`CorrectionV1` remains the fallback via `enable_correction_v2`. Rebased on top of #36577, so chunks use the columnar chunk region storage.

* Times at or beyond the largest read upper live in a `BucketChain` of exponentially growing time-range buckets, each holding (time, data)-sorted chains under the chain invariant. Reads peel only the buckets below their upper; far-future updates (e.g. temporal-filter retractions) are never touched.
* Chains split at the upper at chunk granularity (`Chain::split_at_time`), reusing whole chunks and copying at most one straddling chunk per chain.
* Emitted-but-not-yet-cancelled updates live in a designated `emitted` chain outside any invariant, so reads never re-merge future chains. (We also evaluated a destructive `take_before`/`insert_batch` interface; it measured CPU-neutral because feedback cancellation forces the same merge either way, so the interface stays as-is.)
* Times below the since are advanced with a hybrid strategy, decided by a bounded count of distinct stale times: few stale times — the steady state, since the previously emitted chain was written just before the since advanced past it — use the existing `Cursor::advance_by` run-splitting; many stale times (a since jump, e.g. a sink restarting with an old as-of) are collapsed in one sort-and-consolidate pass. The always-bulk variant regressed the ReplicaExpiration feature benchmark by 31%; with the hybrid it is 3.3% faster than the merge base.
* `BucketChain` exposes bucket iterators for metrics reporting, and `restore` is invoked with bounded fuel per buffer operation — incomplete restoration is picked up by the next operation, so reads never stall the operator. Builds on the `restore` fast path from #36897.

Benchmark results (stepwise drain with persist feedback, 16 updates per timestamp, medians, on top of #36577's columnar chunks):

| T | v1 | v2 before | v2 after |
|---:|---:|---:|---:|
| 1024 | 5.2 ms | 32 ms | ~16 ms |
| 4096 | 21 ms | 104 ms | ~64 ms |
| 16384 | 85 ms | 858 ms | 270 ms |

Scaling is now linear in T (was ~T^1.8); the since-jump scenario improves ~3× and inserts are unchanged. ("v2 before" measured pre-#36577; the columnar chunk storage adds a constant on this microbenchmark but does not change the asymptotics.)

### Verification

New micro-benchmark `cargo bench -p mz-compute --features bench --bench correction` covering insert, stepwise drain with feedback, since jumps, and a temporal-filter pattern; the `bench` feature only gates `pub` visibility.
New tests assert emission equivalence with `CorrectionV1` under a stepwise-drain-with-feedback workload, since-jump collapse onto the since, and that reads never observe times at or beyond their upper.
The ReplicaExpiration feature benchmark scenario was verified locally against the merge base (3.3% faster, less memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)