### PR TITLE
compute: always export memory limiter metrics, gate enforcement

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -494,7 +494,7 @@ metrics:
   source: src/compute/src/memory_limiter.rs
   visibility: internal
 - name: mz_memory_limiter_memory_limit_bytes
-  help: The configured memory limit.
+  help: The configured memory limit. Zero if no limit is configured.
   source: src/compute/src/memory_limiter.rs
   visibility: internal
 - name: mz_memory_limiter_memory_usage_bytes

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -510,6 +510,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "memory_limiter_usage_bias",
     "memory_limiter_burst_factor",
     "catalog_info_metrics_reconcile_interval",
+    "memory_limiter_enforce",
     "compute_server_maintenance_interval",
     "compute_dataflow_max_inflight_bytes_cc",
     "compute_flat_map_fuel",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1668,6 +1668,7 @@ class FlipFlagsAction(Action):
             "memory_limiter_interval",
             "memory_limiter_usage_bias",
             "memory_limiter_burst_factor",
+            "memory_limiter_enforce",
             "enable_columnation_lgalloc",
             "enable_columnar_lgalloc",
             "catalog_info_metrics_reconcile_interval",

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -231,11 +231,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_alloc::register_metrics_into(&metrics_registry).await;
     mz_metrics::register_metrics_into(&metrics_registry, mz_dyncfgs::all_dyncfgs()).await;
 
-    if let Some(heap_limit) = args.heap_limit {
-        mz_compute::memory_limiter::start_limiter(heap_limit, &metrics_registry);
-    } else {
-        info!("no heap limit announced; disabling memory limiter");
+    if args.heap_limit.is_none() {
+        info!("no heap limit announced; memory limiter running in observe-only mode");
     }
+    mz_compute::memory_limiter::start_limiter(args.heap_limit, &metrics_registry);
 
     let secrets_reader = args
         .secrets

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -238,6 +238,14 @@ pub const MEMORY_LIMITER_BURST_FACTOR: Config<f64> = Config::new(
     "Multiplicative burst factor to the memory limiter's limit.",
 );
 
+/// Whether the memory limiter enforces the memory limit by terminating the process. When
+/// disabled, the limiter only observes memory usage and exports metrics.
+pub const MEMORY_LIMITER_ENFORCE: Config<bool> = Config::new(
+    "memory_limiter_enforce",
+    true,
+    "Whether the memory limiter enforces the memory limit by terminating the process.",
+);
+
 /// Enable lgalloc for columnation.
 pub const ENABLE_COLUMNATION_LGALLOC: Config<bool> = Config::new(
     "enable_columnation_lgalloc",
@@ -506,6 +514,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&MEMORY_LIMITER_INTERVAL)
         .add(&MEMORY_LIMITER_USAGE_BIAS)
         .add(&MEMORY_LIMITER_BURST_FACTOR)
+        .add(&MEMORY_LIMITER_ENFORCE)
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_COLUMNATION_LGALLOC)
         .add(&COMPUTE_SERVER_MAINTENANCE_INTERVAL)

--- a/src/compute/src/memory_limiter.rs
+++ b/src/compute/src/memory_limiter.rs
@@ -156,6 +156,11 @@ struct LimiterTask {
     config: LimiterConfig,
     /// The amount of burst budget remaining.
     burst_budget_remaining: usize,
+    /// Whether we have already logged that the limit was exceeded.
+    ///
+    /// Used to log only on the transition to over-limit, rather than at every check interval
+    /// while enforcement is disabled.
+    limit_exceeded_logged: bool,
     /// The time of the last check.
     last_check: Instant,
     /// Metrics tracked by the limiter task.
@@ -169,6 +174,7 @@ impl LimiterTask {
         let mut task = Self {
             config: LimiterConfig::disabled(),
             burst_budget_remaining: 0,
+            limit_exceeded_logged: false,
             last_check: Instant::now(),
             metrics,
         };
@@ -254,10 +260,13 @@ impl LimiterTask {
             } else {
                 // Burst budget exhausted.
                 self.burst_budget_remaining = 0;
-                warn!(
-                    memory_usage,
-                    memory_limit, "memory utilization exceeded configured limits",
-                );
+                if !self.limit_exceeded_logged {
+                    warn!(
+                        memory_usage,
+                        memory_limit, "memory utilization exceeded configured limits",
+                    );
+                    self.limit_exceeded_logged = true;
+                }
                 if self.config.enforce {
                     // We terminate with a recognizable exit code so the orchestrator knows the
                     // termination was caused by exceeding memory limits, as opposed to another,
@@ -268,6 +277,7 @@ impl LimiterTask {
         } else {
             // Reset burst budget if under limit.
             self.burst_budget_remaining = self.config.burst_budget;
+            self.limit_exceeded_logged = false;
         }
 
         self.last_check = Instant::now();
@@ -283,6 +293,7 @@ impl LimiterTask {
         info!(?config, "applying memory limiter config");
         self.config = config;
         self.burst_budget_remaining = config.burst_budget;
+        self.limit_exceeded_logged = false;
         // Reset `last_check` so the next `check` measures the excess interval
         // against the new config, not against a stale checkpoint left over from
         // a period when the limiter was disabled or running with a different
@@ -356,6 +367,7 @@ mod tests {
         LimiterTask {
             config: LimiterConfig::disabled(),
             burst_budget_remaining: 0,
+            limit_exceeded_logged: false,
             last_check: Instant::now(),
             metrics,
         }
@@ -409,6 +421,10 @@ mod tests {
 
     /// In observe-only mode (no memory limit), `check` must never terminate the
     /// process, regardless of memory usage.
+    //
+    // Linux only: on other platforms `current_utilization` falls back to all-zero
+    // proc stats, so the usage metric assertion below would fail.
+    #[cfg(target_os = "linux")]
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // reads /proc/self/status
     fn check_without_limit_observes_only() {
@@ -430,6 +446,10 @@ mod tests {
 
     /// With enforcement disabled, exceeding the limit with an exhausted burst
     /// budget must not terminate the process.
+    //
+    // Linux only: on other platforms `current_utilization` falls back to all-zero
+    // proc stats, so the zero limit would not be exceeded.
+    #[cfg(target_os = "linux")]
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // reads /proc/self/status
     fn check_without_enforce_does_not_terminate() {
@@ -446,6 +466,12 @@ mod tests {
         task.check().unwrap();
 
         assert_eq!(task.burst_budget_remaining, 0);
+        assert!(task.limit_exceeded_logged);
+
+        // Repeated checks while over limit must not terminate either, and must
+        // not re-log the exceeded warning.
+        task.check().unwrap();
+        assert!(task.limit_exceeded_logged);
     }
 }
 

--- a/src/compute/src/memory_limiter.rs
+++ b/src/compute/src/memory_limiter.rs
@@ -17,7 +17,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use mz_compute_types::dyncfgs::{
-    MEMORY_LIMITER_BURST_FACTOR, MEMORY_LIMITER_INTERVAL, MEMORY_LIMITER_USAGE_BIAS,
+    MEMORY_LIMITER_BURST_FACTOR, MEMORY_LIMITER_ENFORCE, MEMORY_LIMITER_INTERVAL,
+    MEMORY_LIMITER_USAGE_BIAS,
 };
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::{CastFrom, CastLossy};
@@ -35,10 +36,13 @@ static LIMITER: Mutex<Option<Limiter>> = Mutex::new(None);
 
 /// Start the process-global memory limiter.
 ///
+/// If no `memory_limit` is given, the limiter runs in observe-only mode: it still samples memory
+/// usage and exports metrics, but never terminates the process.
+///
 /// # Panics
 ///
 /// Panics if the limiter was already started previously.
-pub fn start_limiter(memory_limit: usize, metrics_registry: &MetricsRegistry) {
+pub fn start_limiter(memory_limit: Option<usize>, metrics_registry: &MetricsRegistry) {
     let mut limiter = LIMITER.lock().expect("poisoned");
 
     if limiter.is_some() {
@@ -67,15 +71,15 @@ pub fn apply_limiter_config(config: &ConfigSet) {
 /// Get the current effective memory limit.
 pub fn get_memory_limit() -> Option<usize> {
     let limiter = LIMITER.lock().expect("poisoned");
-    limiter.as_ref().map(|l| l.effective_memory_limit)
+    limiter.as_ref().and_then(|l| l.effective_memory_limit)
 }
 
 /// A handle to a running memory limiter task.
 struct Limiter {
-    /// The base process memory limit.
-    base_memory_limit: usize,
+    /// The base process memory limit, if one was announced.
+    base_memory_limit: Option<usize>,
     /// The effective memory limit, obtained by applying dyncfgs to the base limit.
-    effective_memory_limit: usize,
+    effective_memory_limit: Option<usize>,
     /// A sender for limiter configuration updates.
     config_tx: UnboundedSender<LimiterConfig>,
 }
@@ -90,12 +94,17 @@ impl Limiter {
             interval = Duration::MAX;
         }
 
-        let memory_limit =
-            f64::cast_lossy(self.base_memory_limit) * MEMORY_LIMITER_USAGE_BIAS.get(config);
-        let memory_limit = usize::cast_lossy(memory_limit);
+        let memory_limit = self.base_memory_limit.map(|base| {
+            let limit = f64::cast_lossy(base) * MEMORY_LIMITER_USAGE_BIAS.get(config);
+            usize::cast_lossy(limit)
+        });
 
-        let burst_budget = f64::cast_lossy(memory_limit) * MEMORY_LIMITER_BURST_FACTOR.get(config);
-        let burst_budget = usize::cast_lossy(burst_budget);
+        let burst_budget = memory_limit.map_or(0, |limit| {
+            let budget = f64::cast_lossy(limit) * MEMORY_LIMITER_BURST_FACTOR.get(config);
+            usize::cast_lossy(budget)
+        });
+
+        let enforce = MEMORY_LIMITER_ENFORCE.get(config);
 
         self.effective_memory_limit = memory_limit;
 
@@ -104,6 +113,7 @@ impl Limiter {
                 interval,
                 memory_limit,
                 burst_budget,
+                enforce,
             })
             .expect("limiter task never shuts down");
     }
@@ -114,10 +124,12 @@ impl Limiter {
 struct LimiterConfig {
     /// The interval at which memory usage is checked against the memory limit.
     interval: Duration,
-    /// The memory limit.
-    memory_limit: usize,
+    /// The memory limit, if one is known. Without a limit the task only observes memory usage.
+    memory_limit: Option<usize>,
     /// Budget to allow memory usage above the memory limit, in byte-seconds.
     burst_budget: usize,
+    /// Whether to enforce the memory limit by terminating the process.
+    enforce: bool,
 }
 
 impl LimiterConfig {
@@ -125,19 +137,20 @@ impl LimiterConfig {
     fn disabled() -> Self {
         Self {
             interval: Duration::MAX,
-            memory_limit: 0,
+            memory_limit: None,
             burst_budget: 0,
+            enforce: false,
         }
     }
 }
 
-/// A task that enforces configured memory limits.
+/// A task that observes memory usage and enforces configured memory limits.
 ///
 /// The task operates by performing limit checks at a configured interval. For each check it
-/// obtains the current memory utilization from proc stats. It then compares the utilization against
-/// the configured memory limit, and if it exceeds the limit, reduces the burst budget by the amount
-/// of memory utilization that exceeds the limit. If the burst budget is exhausted, the limiter
-/// terminates the process.
+/// obtains the current memory utilization from proc stats and exports it as metrics. If a memory
+/// limit is configured, it then compares the utilization against the limit, and if it exceeds the
+/// limit, reduces the burst budget by the amount of memory utilization that exceeds the limit. If
+/// the burst budget is exhausted and enforcement is enabled, the limiter terminates the process.
 struct LimiterTask {
     /// The current limiter configuration.
     config: LimiterConfig,
@@ -200,7 +213,8 @@ impl LimiterTask {
         }
     }
 
-    /// Perform a memory usage check, terminating the process if the configured limits are exceeded.
+    /// Perform a memory usage check, terminating the process if the configured limits are exceeded
+    /// and enforcement is enabled.
     fn check(&mut self) -> Result<(), anyhow::Error> {
         debug!("checking memory limits");
 
@@ -213,7 +227,11 @@ impl LimiterTask {
 
         debug!(
             memory_usage,
-            memory_limit, burst_budget_remaining, vm_rss, vm_swap, "memory utilization check",
+            ?memory_limit,
+            burst_budget_remaining,
+            vm_rss,
+            vm_swap,
+            "memory utilization check",
         );
 
         self.metrics.vm_rss.set(u64::cast_from(vm_rss));
@@ -223,7 +241,9 @@ impl LimiterTask {
             .burst_budget
             .set(u64::cast_from(burst_budget_remaining));
 
-        if memory_usage > memory_limit {
+        if let Some(memory_limit) = memory_limit
+            && memory_usage > memory_limit
+        {
             // Calculate excess usage in byte-seconds.
             let elapsed = self.last_check.elapsed().as_secs_f64();
             let excess = memory_usage - memory_limit;
@@ -232,15 +252,18 @@ impl LimiterTask {
             if burst_budget_remaining >= excess_bs {
                 self.burst_budget_remaining -= excess_bs;
             } else {
-                // Burst budget exhausted, terminate the process.
+                // Burst budget exhausted.
+                self.burst_budget_remaining = 0;
                 warn!(
                     memory_usage,
                     memory_limit, "memory utilization exceeded configured limits",
                 );
-                // We terminate with a recognizable exit code so the orchestrator knows the
-                // termination was caused by exceeding memory limits, as opposed to another,
-                // unexpected cause.
-                mz_ore::process::exit_thread_safe(167);
+                if self.config.enforce {
+                    // We terminate with a recognizable exit code so the orchestrator knows the
+                    // termination was caused by exceeding memory limits, as opposed to another,
+                    // unexpected cause.
+                    mz_ore::process::exit_thread_safe(167);
+                }
             }
         } else {
             // Reset burst budget if under limit.
@@ -270,7 +293,7 @@ impl LimiterTask {
 
         self.metrics
             .memory_limit
-            .set(u64::cast_from(config.memory_limit));
+            .set(u64::cast_from(config.memory_limit.unwrap_or(0)));
     }
 }
 
@@ -293,7 +316,7 @@ impl LimiterMetrics {
             )),
             memory_limit: registry.register(metric!(
                 name: "mz_memory_limiter_memory_limit_bytes",
-                help: "The configured memory limit.",
+                help: "The configured memory limit. Zero if no limit is configured.",
             )),
             memory_usage: registry.register(metric!(
                 name: "mz_memory_limiter_memory_usage_bytes",
@@ -354,8 +377,9 @@ mod tests {
 
         let new_config = LimiterConfig {
             interval: Duration::from_secs(1),
-            memory_limit: 1024,
+            memory_limit: Some(1024),
             burst_budget: 1024,
+            enforce: true,
         };
         task.apply_config(new_config);
 
@@ -381,6 +405,47 @@ mod tests {
         task.apply_config(LimiterConfig::disabled());
 
         assert_eq!(task.last_check, stale);
+    }
+
+    /// In observe-only mode (no memory limit), `check` must never terminate the
+    /// process, regardless of memory usage.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // reads /proc/self/status
+    fn check_without_limit_observes_only() {
+        let mut task = task_for_test();
+        task.apply_config(LimiterConfig {
+            interval: Duration::from_secs(1),
+            memory_limit: None,
+            burst_budget: 0,
+            enforce: true,
+        });
+
+        // If this terminated the process, the test would fail by aborting.
+        task.check().unwrap();
+
+        // Usage metrics must be populated even without a limit.
+        assert_ne!(task.metrics.memory_usage.get(), 0);
+        assert_eq!(task.metrics.memory_limit.get(), 0);
+    }
+
+    /// With enforcement disabled, exceeding the limit with an exhausted burst
+    /// budget must not terminate the process.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // reads /proc/self/status
+    fn check_without_enforce_does_not_terminate() {
+        let mut task = task_for_test();
+        // A zero limit guarantees the current usage exceeds it.
+        task.apply_config(LimiterConfig {
+            interval: Duration::from_secs(1),
+            memory_limit: Some(0),
+            burst_budget: 0,
+            enforce: false,
+        });
+
+        // If this terminated the process, the test would fail by aborting.
+        task.check().unwrap();
+
+        assert_eq!(task.burst_budget_remaining, 0);
     }
 }
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -6037,6 +6037,31 @@ def workflow_test_memory_limiter(c: Composition) -> None:
 
         c.kill("clusterd1")
 
+        # Test 4: With enforcement disabled, the MV should be able to hydrate
+        # even with a memory limit of 205 MiB, which would otherwise cause the
+        # replica to be terminated (see Test 2).
+        c.sql(
+            """
+            ALTER SYSTEM SET memory_limiter_usage_bias = 0.2;
+            ALTER SYSTEM SET memory_limiter_burst_factor = 0;
+            ALTER SYSTEM SET memory_limiter_enforce = false;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        setup_workload()
+        c.up("clusterd1")
+
+        c.testdrive("> SELECT count(*) FROM mv\n1000000")
+
+        c.kill("clusterd1")
+
+        c.sql(
+            "ALTER SYSTEM RESET memory_limiter_enforce",
+            port=6877,
+            user="mz_system",
+        )
+
 
 def workflow_test_paused_cluster_readhold_downgrade(c: Composition):
     """
@@ -6154,9 +6179,11 @@ def workflow_test_swap_heap_limiting(c: Composition) -> None:
 
             return None
 
-        assert get_heap_limit("swap_nolimit") is None
+        # The limiter always exports its metrics; a limit of 0 means no limit
+        # is configured and the limiter runs in observe-only mode.
+        assert get_heap_limit("swap_nolimit") == 0
         assert get_heap_limit("swap_limit") == 2000000000
-        assert get_heap_limit("noswap") is None
+        assert get_heap_limit("noswap") == 0
 
 
 def workflow_test_operator_hydration_status_reconciliation(c: Composition) -> None:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -6057,7 +6057,11 @@ def workflow_test_memory_limiter(c: Composition) -> None:
         c.kill("clusterd1")
 
         c.sql(
-            "ALTER SYSTEM RESET memory_limiter_enforce",
+            """
+            ALTER SYSTEM RESET memory_limiter_usage_bias;
+            ALTER SYSTEM RESET memory_limiter_burst_factor;
+            ALTER SYSTEM RESET memory_limiter_enforce;
+            """,
             port=6877,
             user="mz_system",
         )


### PR DESCRIPTION
### Motivation

The `mz_memory_limiter_%` metrics are absent in self-managed: the limiter only started when clusterd received `--heap-limit`, which the controller only passes for swap-enabled sizes with a nonzero disk limit. The self-managed helm chart forces `disk_limit=0` (the unlimited-swap special case), so the limiter never ran there and its metrics were never registered.

Investigation in https://linear.app/materializeinc/issue/CLU-102.

### Description

Decouples observation from enforcement:

* The limiter task always starts, so the usage gauges (`vm_rss`, `vm_swap`, `memory_usage`) are exported even without an announced heap limit.
* Process termination (exit 167) is gated behind a known limit and a new `memory_limiter_enforce` dyncfg (default `true`), so cloud behavior is unchanged and self-managed runs in observe-only mode.
* `mz_memory_limiter_memory_limit_bytes` reports 0 when no limit is announced.
* `memory_limiter_interval = 0` remains the full-disable switch.

### Verification

New unit tests cover that observe-only mode (no limit) and `enforce = false` never terminate the process while still updating the usage metrics; existing limiter tests updated for the new config shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)