### PR TITLE
adapter, repr: canonicalize the exported desc of materialized views

### DIFF
--- a/misc/python/materialize/checks/all_checks/regex.py
+++ b/misc/python/materialize/checks/all_checks/regex.py
@@ -14,11 +14,15 @@ from materialize.checks.checks import Check
 
 class RegexpExtractNonNullable(Check):
     """Capture groups that always participate in a match yield non-nullable
-    columns (database-issues#612). This exercises that such a narrowed,
-    persisted desc survives restart/upgrade: an MV created on the previous
-    release registers all-nullable columns, while the current build re-derives
-    the desc with non-nullable columns. (The persist schema is
-    nullability-invariant, see database-issues#2488, so this must not conflict.)
+    columns inside the optimizer (database-issues#612), but the exported desc
+    of a materialized view is canonicalized: persisted history could
+    contradict optimizer-inferred constraints, so inferred non-nullability
+    (and unique keys) are dropped and all MV columns report as nullable.
+    This exercises that the canonical desc is stable across restart/upgrade:
+    an MV created on the previous release and one created on the current
+    build must register the same persist schema, regardless of optimizer
+    changes between the versions. (The persist schema is
+    nullability-invariant, see database-issues#2488.)
     """
 
     def initialize(self) -> Testdrive:
@@ -61,14 +65,14 @@ class RegexpExtractNonNullable(Check):
             > SELECT c.name, c.nullable FROM mz_columns c
               JOIN mz_materialized_views v ON c.id = v.id
               WHERE v.name = 'regexp_extract_nn_view1' ORDER BY c.position;
-            a false
-            b false
+            a true
+            b true
 
             > SELECT c.name, c.nullable FROM mz_columns c
               JOIN mz_materialized_views v ON c.id = v.id
               WHERE v.name = 'regexp_extract_nn_view2' ORDER BY c.position;
-            a false
-            b false
+            a true
+            b true
             """))
 
 

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1412,15 +1412,20 @@ impl CatalogState {
                         (Arc::new(raw_expr), Arc::new(optimized_expr))
                     }
                 };
-                let typ = infer_sql_type_for_catalog(&raw_expr, &optimized_expr);
+                let mut typ = infer_sql_type_for_catalog(&raw_expr, &optimized_expr);
+                for &i in &materialized_view.non_null_assertions {
+                    typ.column_types[i].nullable = false;
+                }
 
-                // Keep the optimizer-inferred unique keys for DDL planning
-                // (e.g. upsert sink key validation), but canonicalize the
-                // exported desc: it must not advertise inferred nullability or
-                // keys that persisted history could contradict. Enforced
-                // `ASSERT NOT NULL` columns stay non-nullable.
-                let inferred_keys = typ.keys.clone();
-                let desc = RelationDesc::new(typ, materialized_view.column_names)
+                // Keep the precise, optimizer-inferred desc for DDL planning
+                // (e.g. upsert sink key validation and sink schema
+                // generation), but canonicalize the exported desc: it must
+                // not advertise inferred nullability or keys that persisted
+                // history could contradict. Enforced `ASSERT NOT NULL`
+                // columns stay non-nullable.
+                let inferred_desc = RelationDesc::new(typ, materialized_view.column_names);
+                let desc = inferred_desc
+                    .clone()
                     .canonicalize_for_persisted_export(&materialized_view.non_null_assertions);
                 let desc = VersionedRelationDesc::new(desc);
 
@@ -1439,7 +1444,7 @@ impl CatalogState {
                     raw_expr,
                     locally_optimized_expr: optimized_expr,
                     desc,
-                    inferred_keys,
+                    inferred_desc,
                     resolved_ids,
                     dependencies,
                     replacement_target: materialized_view.replacement_target,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1412,12 +1412,16 @@ impl CatalogState {
                         (Arc::new(raw_expr), Arc::new(optimized_expr))
                     }
                 };
-                let mut typ = infer_sql_type_for_catalog(&raw_expr, &optimized_expr);
+                let typ = infer_sql_type_for_catalog(&raw_expr, &optimized_expr);
 
-                for &i in &materialized_view.non_null_assertions {
-                    typ.column_types[i].nullable = false;
-                }
-                let desc = RelationDesc::new(typ, materialized_view.column_names);
+                // Keep the optimizer-inferred unique keys for DDL planning
+                // (e.g. upsert sink key validation), but canonicalize the
+                // exported desc: it must not advertise inferred nullability or
+                // keys that persisted history could contradict. Enforced
+                // `ASSERT NOT NULL` columns stay non-nullable.
+                let inferred_keys = typ.keys.clone();
+                let desc = RelationDesc::new(typ, materialized_view.column_names)
+                    .canonicalize_for_persisted_export(&materialized_view.non_null_assertions);
                 let desc = VersionedRelationDesc::new(desc);
 
                 let initial_as_of = materialized_view.as_of.map(Antichain::from_elem);
@@ -1435,6 +1439,7 @@ impl CatalogState {
                     raw_expr,
                     locally_optimized_expr: optimized_expr,
                     desc,
+                    inferred_keys,
                     resolved_ids,
                     dependencies,
                     replacement_target: materialized_view.replacement_target,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2982,7 +2982,7 @@ impl Coordinator {
                 CatalogItem::Sink(sink) => {
                     let storage_sink_from_entry = self.catalog().get_entry_by_global_id(&sink.from);
                     let from_desc = storage_sink_from_entry
-                        .relation_desc()
+                        .relation_desc_for_sink()
                         .expect("sinks can only be built on items with descs")
                         .into_owned();
                     let collection_desc = CollectionDescription {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1009,7 +1009,7 @@ impl Coordinator {
         let storage_sink_desc = mz_storage_types::sinks::StorageSinkDesc {
             from: sink.from,
             from_desc: storage_sink_from_entry
-                .relation_desc()
+                .relation_desc_for_sink()
                 .expect("sinks can only be built on items with descs")
                 .into_owned(),
             connection: sink

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3451,7 +3451,7 @@ impl Coordinator {
         let storage_sink_desc = StorageSinkDesc {
             from: sink_plan.from,
             from_desc: from_entry
-                .relation_desc()
+                .relation_desc_for_sink()
                 .expect("sinks can only be built on items with descs")
                 .into_owned(),
             connection: sink_plan

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -680,6 +680,7 @@ impl Coordinator {
                     raw_expr: raw_expr.into(),
                     locally_optimized_expr: local_mir_plan.expr().into(),
                     desc,
+                    inferred_keys: local_mir_plan.typ().keys.clone(),
                     collections,
                     resolved_ids,
                     dependencies,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -21,7 +21,7 @@ use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::optimize::OverrideFrom;
 use mz_repr::refresh_schedule::RefreshSchedule;
-use mz_repr::{CatalogItemId, Datum, RelationVersion, Row, VersionedRelationDesc};
+use mz_repr::{CatalogItemId, Datum, RelationDesc, RelationVersion, Row, VersionedRelationDesc};
 use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
@@ -663,6 +663,16 @@ impl Coordinator {
         let desc = VersionedRelationDesc::new(global_lir_plan.desc().clone());
         let collections = [(RelationVersion::root(), global_id)].into_iter().collect();
 
+        // The precise, optimizer-inferred desc, kept next to the
+        // (canonicalized) exported desc for DDL planning purposes.
+        let inferred_desc = {
+            let mut typ = local_mir_plan.typ().clone();
+            for &i in &non_null_assertions {
+                typ.column_types[i].nullable = false;
+            }
+            RelationDesc::new(typ, global_lir_plan.desc().iter_names().cloned())
+        };
+
         let local_mir_for_cache = local_mir_plan.expr();
 
         let ops = vec![
@@ -680,7 +690,7 @@ impl Coordinator {
                     raw_expr: raw_expr.into(),
                     locally_optimized_expr: local_mir_plan.expr().into(),
                     desc,
-                    inferred_keys: local_mir_plan.typ().keys.clone(),
+                    inferred_desc,
                     collections,
                     resolved_ids,
                     dependencies,

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -200,6 +200,15 @@ impl LocalMirPlan {
     pub fn expr(&self) -> OptimizedMirRelationExpr {
         OptimizedMirRelationExpr(self.expr.clone())
     }
+
+    /// The precise, optimizer-inferred relation type of the materialized
+    /// view's output, including inferred nullability and unique keys.
+    ///
+    /// Note that the exported [`RelationDesc`] (see [`GlobalLirPlan::desc`])
+    /// is canonicalized and does *not* carry this information.
+    pub fn typ(&self) -> &SqlRelationType {
+        &self.typ
+    }
 }
 
 /// This is needed only because the pipeline in the bootstrap code starts from an
@@ -226,11 +235,14 @@ impl Optimize<LocalMirPlan> for Optimizer {
         let expr = OptimizedMirRelationExpr(plan.expr);
         let mut df_meta = plan.df_meta;
 
-        let mut rel_typ = plan.typ;
-        for &i in self.non_null_assertions.iter() {
-            rel_typ.column_types[i].nullable = false;
-        }
-        let rel_desc = RelationDesc::new(rel_typ, self.column_names.clone());
+        // The exported desc of a materialized view must not advertise
+        // optimizer-inferred nullability or unique keys: persist retains
+        // history that earlier versions or definitions wrote, which may
+        // contradict constraints inferred from the current plan. Only the
+        // enforced `ASSERT NOT NULL` columns stay non-nullable. Internal
+        // optimization of the dataflow continues to use the precise types.
+        let rel_desc = RelationDesc::new(plan.typ, self.column_names.clone())
+            .canonicalize_for_persisted_export(&self.non_null_assertions);
 
         let mut df_builder = {
             let compute = self.compute_instance.clone();

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -681,6 +681,17 @@ impl CatalogCollectionEntry {
     pub fn relation_desc(&self) -> Option<Cow<'_, RelationDesc>> {
         self.item().relation_desc(self.version)
     }
+
+    /// Reports the [`RelationDesc`] that a sink exporting this collection
+    /// should be planned and rendered against: the precise, optimizer-inferred
+    /// desc when one exists (materialized views), otherwise the exported
+    /// relation desc. See `MaterializedView::inferred_desc`.
+    pub fn relation_desc_for_sink(&self) -> Option<Cow<'_, RelationDesc>> {
+        match self.entry.materialized_view() {
+            Some(mv) => Some(Cow::Borrowed(&mv.inferred_desc)),
+            None => self.relation_desc(),
+        }
+    }
 }
 
 impl mz_sql::catalog::CatalogCollectionItem for CatalogCollectionEntry {
@@ -827,8 +838,8 @@ impl mz_sql::catalog::CatalogItem for CatalogCollectionEntry {
         self.entry.latest_version()
     }
 
-    fn inferred_unique_keys(&self) -> &[Vec<usize>] {
-        mz_sql::catalog::CatalogItem::inferred_unique_keys(&self.entry)
+    fn inferred_relation_desc(&self) -> Option<&RelationDesc> {
+        mz_sql::catalog::CatalogItem::inferred_relation_desc(&self.entry)
     }
 }
 
@@ -1408,15 +1419,17 @@ pub struct MaterializedView {
     pub locally_optimized_expr: Arc<OptimizedMirRelationExpr>,
     /// [`VersionedRelationDesc`] of this materialized view, derived from the `create_sql`.
     pub desc: VersionedRelationDesc,
-    /// Optimizer-inferred unique keys, derived from the `create_sql`.
+    /// The precise, optimizer-inferred [`RelationDesc`], derived from the
+    /// `create_sql`, including inferred column nullability and unique keys.
     ///
-    /// The exported `desc` deliberately drops inferred unique keys (and
-    /// inferred non-nullability) because persisted history may contradict
+    /// The exported `desc` deliberately drops inferred unique keys and
+    /// inferred non-nullability because persisted history may contradict
     /// them; see `RelationDesc::canonicalize_for_persisted_export`. The
-    /// inferred keys are kept here for DDL planning purposes only (e.g.
-    /// upsert sink key validation, default index key selection); they must
-    /// not influence how the contents of the collection are interpreted.
-    pub inferred_keys: Vec<Vec<usize>>,
+    /// inferred desc is kept here for DDL planning purposes only (e.g.
+    /// upsert sink key validation and sink schema generation, default index
+    /// key selection); it must not influence how the contents of the
+    /// collection are interpreted.
+    pub inferred_desc: RelationDesc,
     /// Other catalog items that this materialized view references, determined at name resolution.
     pub resolved_ids: ResolvedIds,
     /// All of the catalog objects that are referenced by this view.
@@ -1545,7 +1558,7 @@ impl MaterializedView {
             raw_expr: replacement.raw_expr,
             locally_optimized_expr: replacement.locally_optimized_expr,
             desc: replacement.desc,
-            inferred_keys: replacement.inferred_keys,
+            inferred_desc: replacement.inferred_desc,
             resolved_ids,
             dependencies,
             replacement_target: None,
@@ -3710,10 +3723,8 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
         self.table().map(|t| t.desc.latest_version())
     }
 
-    fn inferred_unique_keys(&self) -> &[Vec<usize>] {
-        self.materialized_view()
-            .map(|mv| mv.inferred_keys.as_slice())
-            .unwrap_or(&[])
+    fn inferred_relation_desc(&self) -> Option<&RelationDesc> {
+        self.materialized_view().map(|mv| &mv.inferred_desc)
     }
 }
 

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -826,6 +826,10 @@ impl mz_sql::catalog::CatalogItem for CatalogCollectionEntry {
     fn latest_version(&self) -> Option<RelationVersion> {
         self.entry.latest_version()
     }
+
+    fn inferred_unique_keys(&self) -> &[Vec<usize>] {
+        mz_sql::catalog::CatalogItem::inferred_unique_keys(&self.entry)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1404,6 +1408,15 @@ pub struct MaterializedView {
     pub locally_optimized_expr: Arc<OptimizedMirRelationExpr>,
     /// [`VersionedRelationDesc`] of this materialized view, derived from the `create_sql`.
     pub desc: VersionedRelationDesc,
+    /// Optimizer-inferred unique keys, derived from the `create_sql`.
+    ///
+    /// The exported `desc` deliberately drops inferred unique keys (and
+    /// inferred non-nullability) because persisted history may contradict
+    /// them; see `RelationDesc::canonicalize_for_persisted_export`. The
+    /// inferred keys are kept here for DDL planning purposes only (e.g.
+    /// upsert sink key validation, default index key selection); they must
+    /// not influence how the contents of the collection are interpreted.
+    pub inferred_keys: Vec<Vec<usize>>,
     /// Other catalog items that this materialized view references, determined at name resolution.
     pub resolved_ids: ResolvedIds,
     /// All of the catalog objects that are referenced by this view.
@@ -1532,6 +1545,7 @@ impl MaterializedView {
             raw_expr: replacement.raw_expr,
             locally_optimized_expr: replacement.locally_optimized_expr,
             desc: replacement.desc,
+            inferred_keys: replacement.inferred_keys,
             resolved_ids,
             dependencies,
             replacement_target: None,
@@ -3694,6 +3708,12 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 
     fn latest_version(&self) -> Option<RelationVersion> {
         self.table().map(|t| t.desc.latest_version())
+    }
+
+    fn inferred_unique_keys(&self) -> &[Vec<usize>] {
+        self.materialized_view()
+            .map(|mv| mv.inferred_keys.as_slice())
+            .unwrap_or(&[])
     }
 }
 

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -1456,6 +1456,32 @@ impl RelationDesc {
 
         new_desc
     }
+
+    /// Canonicalizes this [`RelationDesc`] for use as the exported schema of a
+    /// persisted collection (e.g. a materialized view).
+    ///
+    /// Persisted collections retain history: consumers may read at past
+    /// timestamps (`AS OF`, retained history, replicas catching up).
+    /// Optimizer-inferred constraints—column nullability and unique keys—are
+    /// derived from the *current* version's plan of the defining expression
+    /// and may not hold for data written by earlier versions or earlier
+    /// definitions. To avoid advertising constraints that history could
+    /// contradict, the exported desc marks every column as nullable and drops
+    /// all unique keys.
+    ///
+    /// Constraints that are *enforced* on every write are kept: the columns in
+    /// `non_null_cols` (e.g. `ASSERT NOT NULL` options on a materialized view)
+    /// remain non-nullable.
+    pub fn canonicalize_for_persisted_export(mut self, non_null_cols: &[usize]) -> Self {
+        for column_type in self.typ.column_types.iter_mut() {
+            column_type.nullable = true;
+        }
+        for &i in non_null_cols {
+            self.typ.column_types[i].nullable = false;
+        }
+        self.typ.keys.clear();
+        self
+    }
 }
 
 #[cfg(any(test, feature = "proptest"))]
@@ -2090,6 +2116,65 @@ pub fn arb_relation_desc_diff(
 mod tests {
     use super::*;
     use prost::Message;
+
+    #[mz_ore::test]
+    fn test_canonicalize_for_persisted_export() {
+        let desc = RelationDesc::builder()
+            .with_column("a", SqlScalarType::Bool.nullable(false))
+            .with_column("b", SqlScalarType::String.nullable(true))
+            .with_column("c", SqlScalarType::Int64.nullable(false))
+            .with_key(vec![0])
+            .with_key(vec![1, 2])
+            .finish();
+
+        // Without assertions: everything nullable, no keys.
+        let canonical = desc.clone().canonicalize_for_persisted_export(&[]);
+        assert!(canonical.typ().column_types.iter().all(|ct| ct.nullable));
+        assert!(canonical.typ().keys.is_empty());
+
+        // Non-null assertions are preserved, inferred non-nullability is not.
+        let canonical = desc.clone().canonicalize_for_persisted_export(&[2]);
+        let nullable: Vec<_> = canonical
+            .typ()
+            .column_types
+            .iter()
+            .map(|ct| ct.nullable)
+            .collect();
+        assert_eq!(nullable, [true, true, false]);
+        assert!(canonical.typ().keys.is_empty());
+
+        // Canonicalization is idempotent.
+        let twice = canonical.clone().canonicalize_for_persisted_export(&[2]);
+        assert_eq!(canonical, twice);
+
+        // Names and scalar types are untouched.
+        assert!(desc.iter_names().eq(canonical.iter_names()));
+        assert!(
+            desc.typ()
+                .column_types
+                .iter()
+                .map(|ct| &ct.scalar_type)
+                .eq(canonical
+                    .typ()
+                    .column_types
+                    .iter()
+                    .map(|ct| &ct.scalar_type))
+        );
+
+        // Descs that differ only in inferred nullability and keys (e.g. the
+        // same SQL planned by different optimizer versions) canonicalize to
+        // the same desc.
+        let other = RelationDesc::builder()
+            .with_column("a", SqlScalarType::Bool.nullable(true))
+            .with_column("b", SqlScalarType::String.nullable(false))
+            .with_column("c", SqlScalarType::Int64.nullable(false))
+            .with_key(vec![1])
+            .finish();
+        assert_eq!(
+            desc.clone().canonicalize_for_persisted_export(&[2]),
+            other.canonicalize_for_persisted_export(&[2]),
+        );
+    }
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `pipe2` on OS `linux`

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -905,6 +905,20 @@ pub trait CatalogItem {
 
     /// The latest version of this item, if it's version-able.
     fn latest_version(&self) -> Option<RelationVersion>;
+
+    /// Returns optimizer-inferred unique keys that are *not* part of the
+    /// item's relation description.
+    ///
+    /// The exported relation description of a persisted collection drops
+    /// inferred unique keys because persisted history may contradict them
+    /// (see `RelationDesc::canonicalize_for_persisted_export`). For such
+    /// items (currently materialized views), the inferred keys are available
+    /// here for DDL planning decisions only (e.g. upsert sink key validation,
+    /// default index key selection); they must never be used to interpret the
+    /// contents of the collection.
+    fn inferred_unique_keys(&self) -> &[Vec<usize>] {
+        &[]
+    }
 }
 
 /// An item in a [`SessionCatalog`] and the specific "collection"/pTVC that it

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -906,18 +906,21 @@ pub trait CatalogItem {
     /// The latest version of this item, if it's version-able.
     fn latest_version(&self) -> Option<RelationVersion>;
 
-    /// Returns optimizer-inferred unique keys that are *not* part of the
-    /// item's relation description.
+    /// Returns the precise, optimizer-inferred relation description of this
+    /// item, including inferred column nullability and unique keys that are
+    /// *not* part of the item's exported relation description.
     ///
     /// The exported relation description of a persisted collection drops
-    /// inferred unique keys because persisted history may contradict them
-    /// (see `RelationDesc::canonicalize_for_persisted_export`). For such
-    /// items (currently materialized views), the inferred keys are available
-    /// here for DDL planning decisions only (e.g. upsert sink key validation,
-    /// default index key selection); they must never be used to interpret the
-    /// contents of the collection.
-    fn inferred_unique_keys(&self) -> &[Vec<usize>] {
-        &[]
+    /// inferred unique keys and inferred non-nullability because persisted
+    /// history may contradict them (see
+    /// `RelationDesc::canonicalize_for_persisted_export`). For such items
+    /// (currently materialized views), the inferred desc is available here
+    /// for DDL planning decisions only (e.g. upsert sink key validation and
+    /// sink schema generation, default index key selection); it must never
+    /// be used to interpret the contents of the collection. Returns `None`
+    /// for items whose exported relation description is already precise.
+    fn inferred_relation_desc(&self) -> Option<&RelationDesc> {
+        None
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -12,6 +12,7 @@
 //! This module houses the handlers for statements that modify the catalog, like
 //! `ALTER`, `CREATE`, and `DROP`.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::iter;
@@ -3239,9 +3240,16 @@ fn plan_sink(
         bail_unsupported!("creating a sink directly on a catalog object");
     }
 
-    let desc = from
-        .relation_desc()
-        .ok_or_else(|| sql_err!("item does not have a relation description"))?;
+    // For materialized views, plan the sink against the precise,
+    // optimizer-inferred desc rather than the canonicalized exported desc:
+    // the sink's encoded schemas and natural-key selection keep reflecting
+    // the inferred nullability and unique keys.
+    let desc = match from.inferred_relation_desc() {
+        Some(desc) => Cow::Borrowed(desc),
+        None => from
+            .relation_desc()
+            .ok_or_else(|| sql_err!("item does not have a relation description"))?,
+    };
     let key_indices = match &connection {
         CreateSinkConnection::Kafka { key: Some(key), .. }
         | CreateSinkConnection::Iceberg { key: Some(key), .. } => {
@@ -3326,15 +3334,10 @@ fn plan_sink(
                 }
             }
 
-            // The exported desc of a materialized view does not carry the
-            // optimizer-inferred unique keys (persisted history may
-            // contradict them), so additionally consult the advisory keys
-            // kept on the catalog item.
             let is_valid_key = desc
                 .typ()
                 .keys
                 .iter()
-                .chain(from.inferred_unique_keys())
                 .any(|key_columns| key_columns.iter().all(|column| indices.contains(column)));
 
             if !is_valid_key && envelope == SinkEnvelope::Upsert {
@@ -3352,7 +3355,6 @@ fn plan_sink(
                             .typ()
                             .keys
                             .iter()
-                            .chain(from.inferred_unique_keys())
                             .map(|key| {
                                 key.iter()
                                     .map(|col| desc.get_name(*col).as_str().into())
@@ -3428,16 +3430,8 @@ fn plan_sink(
         _ => None,
     };
 
-    // Pick the first valid natural relation key, if any. For materialized
-    // views the inferred keys live next to the (canonicalized, key-less)
-    // desc; consult them so that sinks on materialized views keep their
-    // natural-key based message keying.
-    let relation_key_indices = desc
-        .typ()
-        .keys
-        .first()
-        .or_else(|| from.inferred_unique_keys().first())
-        .cloned();
+    // pick the first valid natural relation key, if any
+    let relation_key_indices = desc.typ().keys.get(0).cloned();
 
     let key_desc_and_indices = key_indices.map(|key_indices| {
         let cols = desc
@@ -4070,15 +4064,13 @@ pub fn plan_create_index(
             for name in on_desc.iter_names() {
                 *name_counts.entry(name).or_insert(0usize) += 1;
             }
-            // For materialized views the inferred keys live next to the
-            // (canonicalized, key-less) desc; fall back to them so that
-            // default indexes keep using a natural key when one is known.
-            let key = match on_desc.typ().keys.first() {
-                Some(_) => on_desc.typ().default_key(),
-                None => match on.inferred_unique_keys().first() {
-                    Some(key) if !key.is_empty() => key.clone(),
-                    _ => (0..on_desc.typ().arity()).collect(),
-                },
+            // For materialized views the inferred keys live on the precise,
+            // inferred desc next to the (canonicalized, key-less) exported
+            // desc; use it so that default indexes keep using a natural key
+            // when one is known.
+            let key = match on.inferred_relation_desc() {
+                Some(inferred_desc) => inferred_desc.typ().default_key(),
+                None => on_desc.typ().default_key(),
             };
             key.iter()
                 .map(|i| {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3326,10 +3326,15 @@ fn plan_sink(
                 }
             }
 
+            // The exported desc of a materialized view does not carry the
+            // optimizer-inferred unique keys (persisted history may
+            // contradict them), so additionally consult the advisory keys
+            // kept on the catalog item.
             let is_valid_key = desc
                 .typ()
                 .keys
                 .iter()
+                .chain(from.inferred_unique_keys())
                 .any(|key_columns| key_columns.iter().all(|column| indices.contains(column)));
 
             if !is_valid_key && envelope == SinkEnvelope::Upsert {
@@ -3347,6 +3352,7 @@ fn plan_sink(
                             .typ()
                             .keys
                             .iter()
+                            .chain(from.inferred_unique_keys())
                             .map(|key| {
                                 key.iter()
                                     .map(|col| desc.get_name(*col).as_str().into())
@@ -3422,8 +3428,16 @@ fn plan_sink(
         _ => None,
     };
 
-    // pick the first valid natural relation key, if any
-    let relation_key_indices = desc.typ().keys.get(0).cloned();
+    // Pick the first valid natural relation key, if any. For materialized
+    // views the inferred keys live next to the (canonicalized, key-less)
+    // desc; consult them so that sinks on materialized views keep their
+    // natural-key based message keying.
+    let relation_key_indices = desc
+        .typ()
+        .keys
+        .first()
+        .or_else(|| from.inferred_unique_keys().first())
+        .cloned();
 
     let key_desc_and_indices = key_indices.map(|key_indices| {
         let cols = desc
@@ -4056,7 +4070,16 @@ pub fn plan_create_index(
             for name in on_desc.iter_names() {
                 *name_counts.entry(name).or_insert(0usize) += 1;
             }
-            let key = on_desc.typ().default_key();
+            // For materialized views the inferred keys live next to the
+            // (canonicalized, key-less) desc; fall back to them so that
+            // default indexes keep using a natural key when one is known.
+            let key = match on_desc.typ().keys.first() {
+                Some(_) => on_desc.typ().default_key(),
+                None => match on.inferred_unique_keys().first() {
+                    Some(key) if !key.is_empty() => key.clone(),
+                    _ => (0..on_desc.typ().arity()).collect(),
+                },
+            };
             key.iter()
                 .map(|i| {
                     let name = on_desc.get_name(*i);

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -406,7 +406,7 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                                 "column_types": [
                                   {
                                     "scalar_type": "Int32",
-                                    "nullable": false
+                                    "nullable": true
                                   },
                                   {
                                     "scalar_type": "Int32",
@@ -551,7 +551,7 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                       "column_types": [
                         {
                           "scalar_type": "Int32",
-                          "nullable": false
+                          "nullable": true
                         },
                         {
                           "scalar_type": "Int32",
@@ -889,7 +889,7 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                                       "column_types": [
                                         {
                                           "scalar_type": "Int32",
-                                          "nullable": false
+                                          "nullable": true
                                         },
                                         {
                                           "scalar_type": "Int32",
@@ -1050,7 +1050,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                                   "column_types": [
                                     {
                                       "scalar_type": "Int32",
-                                      "nullable": false
+                                      "nullable": true
                                     },
                                     {
                                       "scalar_type": "Int32",
@@ -1959,7 +1959,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                       "column_types": [
                                                                         {
                                                                           "scalar_type": "Int32",
-                                                                          "nullable": false
+                                                                          "nullable": true
                                                                         },
                                                                         {
                                                                           "scalar_type": "Int32",
@@ -2390,7 +2390,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                           "column_types": [
                                                             {
                                                               "scalar_type": "Int32",
-                                                              "nullable": false
+                                                              "nullable": true
                                                             },
                                                             {
                                                               "scalar_type": "Int32",
@@ -3567,7 +3567,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                         "column_types": [
                                                                           {
                                                                             "scalar_type": "Int32",
-                                                                            "nullable": false
+                                                                            "nullable": true
                                                                           },
                                                                           {
                                                                             "scalar_type": "Int32",
@@ -3653,7 +3653,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                             },
                                                             {
                                                               "scalar_type": "Int32",
-                                                              "nullable": false
+                                                              "nullable": true
                                                             }
                                                           ],
                                                           "keys": [
@@ -3685,7 +3685,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                           },
                                                                           {
                                                                             "scalar_type": "Int32",
-                                                                            "nullable": false
+                                                                            "nullable": true
                                                                           }
                                                                         ],
                                                                         "keys": [
@@ -3771,7 +3771,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                         },
                                                         {
                                                           "scalar_type": "Int32",
-                                                          "nullable": false
+                                                          "nullable": true
                                                         }
                                                       ],
                                                       "keys": []
@@ -3807,7 +3807,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                                       },
                                                                                       {
                                                                                         "scalar_type": "Int32",
-                                                                                        "nullable": false
+                                                                                        "nullable": true
                                                                                       }
                                                                                     ],
                                                                                     "keys": []

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -329,7 +329,7 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                         "column_types": [
                           {
                             "scalar_type": "Int32",
-                            "nullable": false
+                            "nullable": true
                           },
                           {
                             "scalar_type": "Int32",
@@ -776,7 +776,7 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                                   "column_types": [
                                     {
                                       "scalar_type": "Int32",
-                                      "nullable": false
+                                      "nullable": true
                                     },
                                     {
                                       "scalar_type": "Int32",
@@ -894,7 +894,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                               "column_types": [
                                 {
                                   "scalar_type": "Int32",
-                                  "nullable": false
+                                  "nullable": true
                                 },
                                 {
                                   "scalar_type": "Int32",
@@ -1571,7 +1571,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                         "column_types": [
                                                           {
                                                             "scalar_type": "Int32",
-                                                            "nullable": false
+                                                            "nullable": true
                                                           },
                                                           {
                                                             "scalar_type": "Int32",
@@ -1897,7 +1897,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                         "column_types": [
                                                           {
                                                             "scalar_type": "Int32",
-                                                            "nullable": false
+                                                            "nullable": true
                                                           },
                                                           {
                                                             "scalar_type": "Int32",
@@ -2505,7 +2505,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                                       "column_types": [
                                                         {
                                                           "scalar_type": "Int32",
-                                                          "nullable": false
+                                                          "nullable": true
                                                         },
                                                         {
                                                           "scalar_type": "Int32",
@@ -2845,7 +2845,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                                     },
                                                     {
                                                       "scalar_type": "Int32",
-                                                      "nullable": false
+                                                      "nullable": true
                                                     }
                                                   ],
                                                   "keys": [
@@ -2879,7 +2879,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                                                       },
                                                                       {
                                                                         "scalar_type": "Int32",
-                                                                        "nullable": false
+                                                                        "nullable": true
                                                                       }
                                                                     ],
                                                                     "keys": [

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -365,14 +365,14 @@ Explained Query:
             Distinct project=[#0{a}] // { equivs: "[[█, (#0{a}) IS NULL]]" }
               Project (#0{a}) // { equivs: "[[█, (#0{a}) IS NULL]]" }
                 Filter (#0{a} < #1{a}) // { equivs: "[[█, (#0{a}) IS NULL, (#1{a}) IS NULL], [█, (#0{a} < #1{a})]]" }
-                  CrossJoin type=differential // { equivs: "[[█, (#1{a}) IS NULL]]" }
+                  CrossJoin type=differential // { equivs: "[]" }
                     ArrangeBy keys=[[]] // { equivs: "[]" }
                       Distinct project=[#0{a}] // { equivs: "[]" }
                         Project (#0{a}) // { equivs: "[]" }
                           ReadIndex on=t t_a_idx=[*** full scan ***] // { equivs: "[]" }
-                    ArrangeBy keys=[[]] // { equivs: "[[█, (#0{a}) IS NULL]]" }
-                      Project (#0{a}) // { equivs: "[[█, (#0{a}) IS NULL]]" }
-                        ReadStorage materialize.public.mv // { equivs: "[[█, (#0{a}) IS NULL]]" }
+                    ArrangeBy keys=[[]] // { equivs: "[]" }
+                      Project (#0{a}) // { equivs: "[]" }
+                        ReadStorage materialize.public.mv // { equivs: "[]" }
   Return // { equivs: "[[█, (#0{a}) IS NULL, (#1{b}) IS NULL]]" }
     Project (#0{a}, #1{b}) // { equivs: "[[█, (#0{a}) IS NULL, (#1{b}) IS NULL]]" }
       Join on=(#1{b} = #2{b}) type=differential // { equivs: "[[#1{b}, #2{b}], [█, (#0{a}) IS NULL, (#1{b}) IS NULL]]" }
@@ -389,7 +389,7 @@ Explained Query:
                         Get l0 // { equivs: "[[█, (#0{a}) IS NULL]]" }
                   ArrangeBy keys=[[]] // { equivs: "[]" }
                     Project (#1{b}) // { equivs: "[]" }
-                      ReadStorage materialize.public.mv // { equivs: "[[█, (#0{a}) IS NULL]]" }
+                      ReadStorage materialize.public.mv // { equivs: "[]" }
 
 Source materialize.public.mv
 

--- a/test/sqllogictest/explain/raw_plan_as_json.slt
+++ b/test/sqllogictest/explain/raw_plan_as_json.slt
@@ -54,7 +54,7 @@ SELECT a + 1, b, 4 FROM mv WHERE a > 0
                   "column_types": [
                     {
                       "scalar_type": "Int32",
-                      "nullable": false
+                      "nullable": true
                     },
                     {
                       "scalar_type": "Int32",
@@ -279,7 +279,7 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                             "column_types": [
                               {
                                 "scalar_type": "Int32",
-                                "nullable": false
+                                "nullable": true
                               },
                               {
                                 "scalar_type": "Int32",
@@ -594,7 +594,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
               "column_types": [
                 {
                   "scalar_type": "Int32",
-                  "nullable": false
+                  "nullable": true
                 },
                 {
                   "scalar_type": "Int32",
@@ -652,7 +652,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                   "column_types": [
                     {
                       "scalar_type": "Int32",
-                      "nullable": false
+                      "nullable": true
                     },
                     {
                       "scalar_type": "Int32",
@@ -797,7 +797,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                           "column_types": [
                             {
                               "scalar_type": "Int32",
-                              "nullable": false
+                              "nullable": true
                             },
                             {
                               "scalar_type": "Int32",

--- a/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
+++ b/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
@@ -34,8 +34,8 @@ SELECT mz_unsafe.mz_sleep(8)
 query IT
 SELECT id, global_id FROM mz_internal.mz_dataflow_global_ids ORDER BY id, global_id;
 ----
-5  u2
-5  u3
+6  u2
+6  u3
 
 query TI
 SELECT global_id, lir_id FROM mz_internal.mz_lir_mapping ORDER BY global_id, lir_id DESC;
@@ -119,17 +119,17 @@ SELECT mz_unsafe.mz_sleep(8)
 query IT
 SELECT id, global_id FROM mz_internal.mz_dataflow_global_ids ORDER BY id, global_id;
 ----
-10  t52
+11  t63
 
 
 query TI
 SELECT global_id, lir_id FROM mz_internal.mz_lir_mapping ORDER BY global_id, lir_id DESC;
 ----
-t52  5
-t52  4
-t52  3
-t52  2
-t52  1
+t63  5
+t63  4
+t63  3
+t63  2
+t63  1
 
 ## attribution queries
 
@@ -142,11 +142,11 @@ SELECT global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-t52  5  NULL  Differential␠Join␠%0␠»␠%1
-t52  4  5  ␠␠Arrange␠(#0{y})
-t52  3  4  ␠␠␠␠Read␠u4
-t52  2  5  ␠␠Arrange␠(#0{x})
-t52  1  2  ␠␠␠␠Read␠u4
+t63  5  NULL  Differential␠Join␠%0␠»␠%1
+t63  4  5  ␠␠Arrange␠(#0{y})
+t63  3  4  ␠␠␠␠Read␠u4
+t63  2  5  ␠␠Arrange␠(#0{x})
+t63  1  2  ␠␠␠␠Read␠u4
 
 # omitting pg_size_pretty(sum(size)) as size
 query TIIT
@@ -157,11 +157,11 @@ SELECT global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-t52  5  NULL  Differential␠Join␠%0␠»␠%1
-t52  4  5  ␠␠Arrange␠(#0{y})
-t52  3  4  ␠␠␠␠Read␠u4
-t52  2  5  ␠␠Arrange␠(#0{x})
-t52  1  2  ␠␠␠␠Read␠u4
+t63  5  NULL  Differential␠Join␠%0␠»␠%1
+t63  4  5  ␠␠Arrange␠(#0{y})
+t63  3  4  ␠␠␠␠Read␠u4
+t63  2  5  ␠␠Arrange␠(#0{x})
+t63  1  2  ␠␠␠␠Read␠u4
 
 statement ok
 DROP TABLE u CASCADE;
@@ -417,26 +417,26 @@ SELECT global_id, REPEAT(' ', nesting * 2) || operator AS operator
 FROM mz_internal.mz_lir_mapping mlm
 ORDER BY global_id, lir_id DESC;
 ----
-t77  Returning␠Distinct␠GroupAggregate
-t77  ␠␠Union
-t77  ␠␠␠␠Differential␠Join␠%0␠»␠%1
-t77  ␠␠␠␠␠␠Arrange␠(#0{messageid})
-t77  ␠␠␠␠␠␠␠␠Stream␠l0
-t77  ␠␠␠␠␠␠Arranged␠u15
-t77  ␠␠␠␠Arranged␠u13
-t77  With␠Recursive␠l0␠=␠Unarranged␠Raw␠Stream
-t77  ␠␠Distinct␠GroupAggregate
-t77  ␠␠␠␠Union
-t77  ␠␠␠␠␠␠Differential␠Join␠%0␠»␠%1
-t77  ␠␠␠␠␠␠␠␠Arrange␠(#0{messageid})
-t77  ␠␠␠␠␠␠␠␠␠␠Read␠l0
-t77  ␠␠␠␠␠␠␠␠Arrange␠(#1{parentcommentid})
-t77  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
-t77  ␠␠␠␠␠␠Differential␠Join␠%1␠»␠%0
-t77  ␠␠␠␠␠␠␠␠Arranged␠u13
-t77  ␠␠␠␠␠␠␠␠Arrange␠(#1{parentpostid})
-t77  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
-t77  ␠␠␠␠␠␠Arranged␠u13
+t80  Returning␠Distinct␠GroupAggregate
+t80  ␠␠Union
+t80  ␠␠␠␠Differential␠Join␠%0␠»␠%1
+t80  ␠␠␠␠␠␠Arrange␠(#0{messageid})
+t80  ␠␠␠␠␠␠␠␠Stream␠l0
+t80  ␠␠␠␠␠␠Arranged␠u15
+t80  ␠␠␠␠Arranged␠u13
+t80  With␠Recursive␠l0␠=␠Unarranged␠Raw␠Stream
+t80  ␠␠Distinct␠GroupAggregate
+t80  ␠␠␠␠Union
+t80  ␠␠␠␠␠␠Differential␠Join␠%0␠»␠%1
+t80  ␠␠␠␠␠␠␠␠Arrange␠(#0{messageid})
+t80  ␠␠␠␠␠␠␠␠␠␠Read␠l0
+t80  ␠␠␠␠␠␠␠␠Arrange␠(#1{parentcommentid})
+t80  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
+t80  ␠␠␠␠␠␠Differential␠Join␠%1␠»␠%0
+t80  ␠␠␠␠␠␠␠␠Arranged␠u13
+t80  ␠␠␠␠␠␠␠␠Arrange␠(#1{parentpostid})
+t80  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
+t80  ␠␠␠␠␠␠Arranged␠u13
 u10  Arrange␠(#1{person1id})
 u10  ␠␠Stream␠u9
 u11  Arrange␠(#2{person2id})
@@ -458,7 +458,7 @@ u21  ␠␠Read␠l0
 u21  ␠␠Stream␠l0
 u21  With␠l0␠=␠Map/Filter/Project
 u21  ␠␠Accumulable␠GroupAggregate
-u21  ␠␠␠␠Delta␠Join␠[%0␠»␠%1␠»␠%2][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
+u21  ␠␠␠␠Delta␠Join␠[%0␠»␠%1␠»␠%2]␠[%1␠»␠%0␠»␠%2]␠[%2␠»␠%0␠»␠%1]
 u21  ␠␠␠␠␠␠Arranged␠u9
 u21  ␠␠␠␠␠␠Arranged␠u17
 u21  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1{parentmessageid})
@@ -490,7 +490,7 @@ u23  ␠␠␠␠␠␠Arrange␠(#1{dst})
 u23  ␠␠␠␠␠␠␠␠Read␠l3
 u23  l4␠=␠Non-monotonic␠TopK
 u23  ␠␠Union
-u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
+u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1]␠[%1␠»␠%0␠»␠%2]␠[%2␠»␠%0␠»␠%1]
 u23  ␠␠␠␠␠␠Arranged␠l1
 u23  ␠␠␠␠␠␠Arranged␠l2
 u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1{dst})
@@ -501,7 +501,7 @@ u23  ␠␠␠␠␠␠␠␠Constant␠(1␠rows)
 u23  ␠␠␠␠␠␠Arranged␠l0
 u23  l3␠=␠Non-monotonic␠TopK
 u23  ␠␠Union
-u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
+u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1]␠[%1␠»␠%0␠»␠%2]␠[%2␠»␠%0␠»␠%1]
 u23  ␠␠␠␠␠␠Arranged␠l1
 u23  ␠␠␠␠␠␠Arranged␠l2
 u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1{dst})
@@ -592,7 +592,7 @@ materialize.public.v2_idx_x  u26  2
 materialize.public.v2_idx_x  u27  2
 materialize.public.v_idx_x  u28  5
 materialize.public.v_idx_x  u29  2
-materialize.public.w  t90  5
+materialize.public.w  t89  5
 
 # explain analyze SQL generation
 
@@ -1210,7 +1210,7 @@ FROM
     mz_introspection.mz_mappable_objects AS mo
         LEFT JOIN object_memory_totals AS omt USING(global_id)
 ORDER BY
-    total_memory DESC NULLS LAST,
+    omt.total_memory DESC NULLS LAST,
     total_records DESC NULLS LAST,
     mo.name DESC;
 EOF
@@ -1274,7 +1274,7 @@ FROM
         LEFT JOIN object_memory_totals AS omt USING(global_id)
         LEFT JOIN object_cpu_totals AS oct USING(global_id)
 ORDER BY
-    total_memory DESC NULLS LAST,
+    omt.total_memory DESC NULLS LAST,
     total_records DESC NULLS LAST,
     total_elapsed DESC NULLS LAST,
     mo.name DESC;
@@ -1507,7 +1507,7 @@ ORDER BY
     worker_id,
     max_operator_memory_ratio DESC NULLS LAST,
     max_operator_records_ratio DESC NULLS LAST,
-    worker_memory DESC NULLS LAST,
+    om.worker_memory DESC NULLS LAST,
     worker_records DESC NULLS LAST,
     mo.name DESC;
 EOF

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -541,7 +541,7 @@ Explained Query:
             ArrangeBy keys=[[#0{id}]] // { arity: 3 }
               Reduce group_by=[#0{id}] aggregates=[count(case when (#2{creationdate} < 2010-09-16 00:00:00 UTC) then #1{messageid} else null end), count(case when (#2{creationdate} >= 2010-09-16 00:00:00 UTC) then #1{messageid} else null end)] // { arity: 3 }
                 Project (#0{id}, #2{messageid}, #4{creationdate}) // { arity: 3 }
-                  Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
+                  Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) AND (#2{messageid}) IS NOT NULL // { arity: 17 }
                     Join on=(#0{id} = #3{tagid} AND #2{messageid} = #5{messageid}) type=delta // { arity: 17 }
                       implementation
                         %0:l1 » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KAiif
@@ -618,7 +618,7 @@ Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10{containerforumid}, #13{creationdate}, #15{title}, #16{moderatorpersonid}) // { arity: 4 }
-        Filter (#33{name} = "China") AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
+        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
               %0:message » %5[#0]UKA » %1:forum[#1{id}]KA » %2:person[#1{id}]KA » %3:city[#0{id}]KA » %4:country[#0{id}]KAef
@@ -640,17 +640,18 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#10{messageid}) // { arity: 1 }
-                  Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
-                    implementation
-                      %0:tagclass » %1:tag[#3{typetagclassid}]KA » %2:message_hastag_tag[#2{tagid}]KA
-                      %1:tag » %0:tagclass[#0{id}]KAe » %2:message_hastag_tag[#2{tagid}]KA
-                      %2:message_hastag_tag » %1:tag[#0{id}]KA » %0:tagclass[#0{id}]KAe
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
-                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+                  Filter (#5{id}) IS NOT NULL AND (#10{messageid}) IS NOT NULL // { arity: 12 }
+                    Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
+                      implementation
+                        %0:tagclass » %1:tag[#3{typetagclassid}]KA » %2:message_hastag_tag[#2{tagid}]KA
+                        %1:tag » %0:tagclass[#0{id}]KAe » %2:message_hastag_tag[#2{tagid}]KA
+                        %2:message_hastag_tag » %1:tag[#0{id}]KA » %0:tagclass[#0{id}]KAe
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                        ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
+                      ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                        ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                      ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                        ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -745,10 +746,11 @@ Explained Query:
     With
       cte l0 =
         Project (#0{id}) // { arity: 1 }
-          TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0{id}, #2{maxnumberofmembers}) // { arity: 2 }
-              Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
-                ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
+          Filter (#0{id}) IS NOT NULL // { arity: 2 }
+            TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
+              Project (#0{id}, #2{maxnumberofmembers}) // { arity: 2 }
+                Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
+                  ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
       cte l1 =
         Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
           Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
@@ -771,14 +773,20 @@ Explained Query:
           Get l1 // { arity: 4 }
       cte l3 =
         Project (#0{creationdate}..=#3{lastname}, #5{messageid}) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
+          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
             implementation
-              %0:l2 » %1:message[#9{creatorpersonid}]KA » %2[#0]UKA
-              %1:message » %2[#0]UKA » %0:l2[#1{id}]K
-              %2 » %1:message[#10{containerforumid}]KA » %0:l2[#1{id}]K
+              %0:l2 » %1:message[#9{creatorpersonid}]KA » %2[#0]UKA » %3[#0]UKA
+              %1:message » %2[#0]UKA » %3[#0]UKA » %0:l2[#1{id}]K
+              %2 » %3[#0]UKA » %1:message[#10{containerforumid}]KA » %0:l2[#1{id}]K
+              %3 » %2[#0]UKA » %1:message[#10{containerforumid}]KA » %0:l2[#1{id}]K
             Get l2 // { arity: 4 }
             ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
               ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
+              Distinct project=[#0{containerforumid}] // { arity: 1 }
+                Project (#10{containerforumid}) // { arity: 1 }
+                  Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                    ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Get l0 // { arity: 1 }
@@ -804,7 +812,7 @@ Used Indexes:
   - materialize.public.person_id (differential join)
   - materialize.public.forum_hasmember_person_forumid (differential join)
   - materialize.public.message_containerforumid (delta join lookup)
-  - materialize.public.message_creatorpersonid (delta join lookup)
+  - materialize.public.message_creatorpersonid (*** full scan ***, delta join lookup)
   - materialize.public.top100popularforumsq04_id (*** full scan ***)
 
 Target cluster: quickstart
@@ -848,17 +856,18 @@ Explained Query:
     With
       cte l0 =
         Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#5{messageid}) IS NOT NULL // { arity: 20 }
+            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
           Project (#12{parentmessageid}) // { arity: 1 }
@@ -867,7 +876,8 @@ Explained Query:
       cte l2 =
         Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
           Project (#2{messageid}) // { arity: 1 }
-            ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
+            Filter (#2{messageid}) IS NOT NULL // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{messageid}] // { arity: 1 }
           Project (#1{messageid}) // { arity: 1 }
@@ -975,17 +985,18 @@ Explained Query:
     With
       cte l0 =
         Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#6{messageid}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
@@ -1017,13 +1028,15 @@ Explained Query:
             Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
+        ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+          Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+            Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{creatorpersonid}, #1{personid}, #3{popularityscore}) // { arity: 3 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1{person2id}]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
+              %1:popularityscoreq06[#0{person2id}]KA » %0:l4[#1{person2id}]K
+            Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
     Return // { arity: 2 }
@@ -1033,10 +1046,18 @@ Explained Query:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
+                  Join on=(#1{personid} = #2{personid}) type=differential // { arity: 3 }
+                    implementation
+                      %1[#0]UKA » %0:l4[#1{person2id}]K
+                    Get l4 // { arity: 2 }
+                    ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                      Distinct project=[#0{personid}] // { arity: 1 }
+                        Project (#1{personid}) // { arity: 1 }
+                          Get l5 // { arity: 3 }
               Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{popularityscore}) // { arity: 2 }
+            Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1081,17 +1102,18 @@ Explained Query:
     With
       cte l0 =
         Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#6{messageid}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
@@ -1123,13 +1145,15 @@ Explained Query:
             Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
+        ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+          Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+            Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{creatorpersonid}, #1{personid}, #3{popularityscore}) // { arity: 3 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1{person2id}]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
+              %1:popularityscoreq06[#0{person2id}]KA » %0:l4[#1{person2id}]K
+            Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
     Return // { arity: 2 }
@@ -1139,10 +1163,18 @@ Explained Query:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
+                  Join on=(#1{personid} = #2{personid}) type=differential // { arity: 3 }
+                    implementation
+                      %1[#0]UKA » %0:l4[#1{person2id}]K
+                    Get l4 // { arity: 2 }
+                    ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                      Distinct project=[#0{personid}] // { arity: 1 }
+                        Project (#1{personid}) // { arity: 1 }
+                          Get l5 // { arity: 3 }
               Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{popularityscore}) // { arity: 2 }
+            Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1188,17 +1220,18 @@ Explained Query:
     With
       cte l0 =
         Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#5{messageid}) IS NOT NULL // { arity: 20 }
+            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         Project (#0{name}..=#2{creatorpersonid}, #4{personid}) // { arity: 4 }
           Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
@@ -1234,13 +1267,15 @@ Explained Query:
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
+        ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+          Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+            Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{creatorpersonid}, #1{personid}, #3{popularityscore}) // { arity: 3 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1{person2id}]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
+              %1:popularityscoreq06[#0{person2id}]KA » %0:l4[#1{person2id}]K
+            Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
     Return // { arity: 2 }
@@ -1250,10 +1285,18 @@ Explained Query:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
+                  Join on=(#1{personid} = #2{personid}) type=differential // { arity: 3 }
+                    implementation
+                      %1[#0]UKA » %0:l4[#1{person2id}]K
+                    Get l4 // { arity: 2 }
+                    ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                      Distinct project=[#0{personid}] // { arity: 1 }
+                        Project (#1{personid}) // { arity: 1 }
+                          Get l5 // { arity: 3 }
               Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{popularityscore}) // { arity: 2 }
+            Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1305,29 +1348,32 @@ Explained Query:
     With
       cte l0 =
         Project (#1{messageid}) // { arity: 1 }
-          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-            implementation
-              %1:tag[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KAe
-            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
+          Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
+            Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+              implementation
+                %1:tag[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KAe
+              ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
       cte l1 =
         Project (#2{messageid}, #18{name}) // { arity: 2 }
-          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
-            implementation
-              %0:l0 » %1:message[#12{parentmessageid}]KA » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA
-              %1:message » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
-              %2:message_hastag_tag » %1:message[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
-              %3:tag » %2:message_hastag_tag[#2{tagid}]KA » %1:message[#1{messageid}]KA » %0:l0[#0{messageid}]K
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Filter (#2{messageid}) IS NOT NULL AND (#16{tagid}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
+              implementation
+                %0:l0 » %1:message[#12{parentmessageid}]KA » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA
+                %1:message » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
+                %2:message_hastag_tag » %1:message[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
+                %3:tag » %2:message_hastag_tag[#2{tagid}]KA » %1:message[#1{messageid}]KA » %0:l0[#0{messageid}]K
+              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                Filter (#0{messageid}) IS NOT NULL // { arity: 1 }
+                  Get l0 // { arity: 1 }
+              ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
       cte l2 =
         Distinct project=[#0{messageid}] // { arity: 1 }
           Project (#0{messageid}) // { arity: 1 }
@@ -1343,15 +1389,16 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0{messageid}) // { arity: 1 }
-                    Join on=(#0{messageid} = #1{messageid}) type=differential // { arity: 2 }
-                      implementation
-                        %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                        Distinct project=[#0{messageid}] // { arity: 1 }
-                          Get l0 // { arity: 1 }
+                  Distinct project=[#0{messageid}] // { arity: 1 }
+                    Project (#0{messageid}) // { arity: 1 }
+                      Filter ((#1{messageid}) IS NULL OR (#0{messageid} = #1{messageid})) // { arity: 2 }
+                        CrossJoin type=differential // { arity: 2 }
+                          implementation
+                            %0:l2[×] » %1:l0[×]
+                          ArrangeBy keys=[[]] // { arity: 1 }
+                            Get l2 // { arity: 1 }
+                          ArrangeBy keys=[[]] // { arity: 1 }
+                            Get l0 // { arity: 1 }
                 Get l2 // { arity: 1 }
 
 Used Indexes:
@@ -1443,7 +1490,7 @@ Explained Query:
       cte l3 =
         Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
           Project (#17{creatorpersonid}) // { arity: 1 }
-            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
+            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) AND (#0{id}) IS NOT NULL AND (#6{messageid}) IS NOT NULL AND (#17{creatorpersonid}) IS NOT NULL // { arity: 32 }
               Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
                 implementation
                   %0:l1 » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KAiif » %3:l0[#1{id}]KA
@@ -1584,7 +1631,7 @@ Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
       Project (#1{id}..=#3{lastname}, #25{count}) // { arity: 4 }
-        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 26 }
+        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
               %0:person » %1:message[#9{creatorpersonid}]KAniif » %2[#0]UKA
@@ -1597,7 +1644,7 @@ Explained Query:
             ArrangeBy keys=[[#0{rootpostid}]] // { arity: 2 }
               Reduce group_by=[#0{rootpostid}] aggregates=[count(*)] // { arity: 2 }
                 Project (#2{rootpostid}) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 13 }
+                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#2{rootpostid}) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -1713,69 +1760,72 @@ Explained Query:
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{person2id}, #9{name}) // { arity: 2 }
-          Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
-            implementation
-              %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
-              %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
-              %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
-              %3 » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-              %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-              %5:tag » %4:message_hastag_tag[#2{tagid}]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Distinct project=[#0{person2id}] // { arity: 1 }
-                Threshold // { arity: 1 }
-                  Union // { arity: 1 }
-                    Distinct project=[#0{person2id}] // { arity: 1 }
-                      Project (#6{person2id}) // { arity: 1 }
-                        Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
-                          implementation
-                            %0:l2 » %1:person_knows_person[#1{person1id}]KA » %2:l0[#1{person1id}]KA
-                            %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1{person1id}]KA
-                            %2:l0 » %1:person_knows_person[#2{person2id}]KA » %0:l2[#0]UKA
-                          ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-                            Get l2 // { arity: 1 }
-                          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                          Get l0 // { arity: 3 }
-                    Negate // { arity: 1 }
-                      Get l2 // { arity: 1 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1{id}) // { arity: 1 }
-                  Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
-                    Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
-                      implementation
-                        %0:person » %1:city[#0{id}]KA » %2:country[#0{id}]KAef
-                        %1:city » %2:country[#0{id}]KAef » %0:person[#8{locationcityid}]KA
-                        %2:country » %1:city[#3{partofcountryid}]KA » %0:person[#8{locationcityid}]KA
-                      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-                        ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-                      ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-                        ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-                      ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                        ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
-                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
-                    implementation
-                      %0:message_hastag_tag » %1:tag[#0{id}]KA » %2:tagclass[#0{id}]KAe
-                      %1:tag » %2:tagclass[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KA
-                      %2:tagclass » %1:tag[#3{typetagclassid}]KA » %0:message_hastag_tag[#2{tagid}]KA
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Filter (#7{tagid}) IS NOT NULL // { arity: 12 }
+            Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
+              implementation
+                %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
+                %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
+                %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
+                %3 » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+                %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+                %5:tag » %4:message_hastag_tag[#2{tagid}]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                Distinct project=[#0{person2id}] // { arity: 1 }
+                  Threshold // { arity: 1 }
+                    Union // { arity: 1 }
+                      Distinct project=[#0{person2id}] // { arity: 1 }
+                        Project (#6{person2id}) // { arity: 1 }
+                          Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
+                            implementation
+                              %0:l2 » %1:person_knows_person[#1{person1id}]KA » %2:l0[#1{person1id}]KA
+                              %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1{person1id}]KA
+                              %2:l0 » %1:person_knows_person[#2{person2id}]KA » %0:l2[#0]UKA
+                            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                              Get l2 // { arity: 1 }
+                            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                            Get l0 // { arity: 3 }
+                      Negate // { arity: 1 }
+                        Get l2 // { arity: 1 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                Distinct project=[#0{id}] // { arity: 1 }
+                  Project (#1{id}) // { arity: 1 }
+                    Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
+                      Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
+                        implementation
+                          %0:person » %1:city[#0{id}]KA » %2:country[#0{id}]KAef
+                          %1:city » %2:country[#0{id}]KAef » %0:person[#8{locationcityid}]KA
+                          %2:country » %1:city[#3{partofcountryid}]KA » %0:person[#8{locationcityid}]KA
+                        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+                          ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
+                        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+                          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                          ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
+              ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+                Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                  Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
+                    Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                Distinct project=[#0{messageid}] // { arity: 1 }
+                  Project (#1{messageid}) // { arity: 1 }
+                    Filter (#1{messageid}) IS NOT NULL AND (#2{tagid}) IS NOT NULL // { arity: 12 }
+                      Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
+                        implementation
+                          %0:message_hastag_tag » %1:tag[#0{id}]KA » %2:tagclass[#0{id}]KAe
+                          %1:tag » %2:tagclass[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KA
+                          %2:tagclass » %1:tag[#3{typetagclassid}]KA » %0:message_hastag_tag[#2{tagid}]KA
+                        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
+                        ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                          ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                          ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1934,7 +1984,7 @@ Explained Query:
           ReadIndex on=person person_id=[differential join] // { arity: 11 }
       cte l1 =
         Project (#1{id}, #12{messageid}) // { arity: 2 }
-          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
+          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
                 %1:message[#9{creatorpersonid}]KAeiif » %0:l0[#1{id}]KAeiif
@@ -2153,7 +2203,7 @@ Explained Query:
           Get l3 // { arity: 1 }
       cte l5 =
         Project (#1{id}, #23{creatorpersonid}) // { arity: 2 }
-          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
+          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#13{messageid}) IS NOT NULL // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
                 %0:person » %1:person_likes_message[#1{personid}]KA » %2:message[#1{messageid}]KA » %3:l4[#0{zombieid}]K
@@ -2355,12 +2405,13 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9{creatorpersonid}, #22{creatorpersonid}) // { arity: 2 }
-                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
-                    implementation
-                      %0:l6[#1{messageid}]KA » %1:message[#12{parentmessageid}]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
-                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#22{creatorpersonid}) IS NOT NULL // { arity: 26 }
+                    Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
+                      implementation
+                        %0:l6[#1{messageid}]KA » %1:message[#12{parentmessageid}]KA
+                      Get l6 // { arity: 13 }
+                      ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
+                        ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
       cte l8 =
         Project (#0{id}..=#4, #7) // { arity: 6 }
           Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
@@ -2391,12 +2442,13 @@ Explained Query:
             ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9{creatorpersonid}, #14{personid}) // { arity: 2 }
-                  Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
-                    implementation
-                      %0:l6[#1{messageid}]KA » %1:person_likes_message[#2{messageid}]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-                      ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#14{personid}) IS NOT NULL // { arity: 16 }
+                    Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
+                      implementation
+                        %0:l6[#1{messageid}]KA » %1:person_likes_message[#2{messageid}]KA
+                      Get l6 // { arity: 13 }
+                      ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+                        ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l11 =
         Project (#0{id}..=#3{person2id}, #6{sum}) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
@@ -2549,10 +2601,11 @@ Explained Query:
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                     Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                      Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                     Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
-                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      Filter (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
@@ -2747,10 +2800,11 @@ Explained Query:
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                   Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                   Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
-                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                    Filter (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 Get l2 // { arity: 1 }
                 Get l2 // { arity: 1 }
@@ -3100,17 +3154,18 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
                 Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
-                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#2{tagid}) IS NOT NULL // { arity: 8 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                      implementation
+                        %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
+                      Get l1 // { arity: 3 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
       cte l4 =
         ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
@@ -3139,17 +3194,18 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
                 Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
-                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#2{tagid}) IS NOT NULL // { arity: 8 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                      implementation
+                        %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
+                      Get l1 // { arity: 3 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l7 =
         Project (#0{id}, #1{messageid}, #4{person2id}) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
@@ -3262,16 +3318,17 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
-                    implementation
-                      %1[#0]UKA » %0:message_hastag_tag[#2{tagid}]KA
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#0{id}) // { arity: 1 }
-                          Filter (#0{id}) IS NOT NULL // { arity: 5 }
-                            ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
+                  Filter (#1{messageid}) IS NOT NULL // { arity: 4 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
+                      implementation
+                        %1[#0]UKA » %0:message_hastag_tag[#2{tagid}]KA
+                      ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                        ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                        Distinct project=[#0{id}] // { arity: 1 }
+                          Project (#0{id}) // { arity: 1 }
+                            Filter (#0{id}) IS NOT NULL // { arity: 5 }
+                              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
       cte l1 =
         ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
@@ -3287,13 +3344,15 @@ Explained Query:
                 %4:l1 » %3:l1[#1{forumid}]KA » %0:l0[#2{containerforumid}]K » %1:l0[#2{creatorpersonid}]K » %2:l0[#0{creatorpersonid}, #1{parentmessageid}]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
                 Project (#0{creationdate}, #2{creatorpersonid}, #3{containerforumid}) // { arity: 3 }
-                  Get l0 // { arity: 5 }
+                  Filter (#3{containerforumid}) IS NOT NULL // { arity: 5 }
+                    Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
                 Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
-                  Get l0 // { arity: 5 }
+                  Filter (#2{creatorpersonid}) IS NOT NULL // { arity: 5 }
+                    Get l0 // { arity: 5 }
               ArrangeBy keys=[[#0{creatorpersonid}, #1{parentmessageid}]] // { arity: 2 }
                 Project (#2{creatorpersonid}, #4{parentmessageid}) // { arity: 2 }
-                  Filter (#4{parentmessageid}) IS NOT NULL // { arity: 5 }
+                  Filter (#2{creatorpersonid}) IS NOT NULL AND (#4{parentmessageid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
@@ -3604,11 +3663,13 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l1[#2{w}]K
           ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Get l1 // { arity: 3 }
+            Filter (#2{min}) IS NOT NULL // { arity: 3 }
+              Get l1 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2{min}) // { arity: 1 }
-                Get l1 // { arity: 3 }
+            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2{min}) // { arity: 1 }
+                  Get l1 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3766,11 +3827,13 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l5[#2{w}]K
           ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Get l5 // { arity: 3 }
+            Filter (#2{min}) IS NOT NULL // { arity: 3 }
+              Get l5 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2{min}) // { arity: 1 }
-                Get l5 // { arity: 3 }
+            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2{min}) // { arity: 1 }
+                  Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3997,11 +4060,13 @@ Explained Query:
               implementation
                 %1[#0]UK » %0:l9[#2{w}]K
               ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-                Get l9 // { arity: 3 }
+                Filter (#2{min}) IS NOT NULL // { arity: 3 }
+                  Get l9 // { arity: 3 }
               ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#2{min}) // { arity: 1 }
-                    Get l9 // { arity: 3 }
+                Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                  Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                    Project (#2{min}) // { arity: 1 }
+                      Get l9 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4080,7 +4145,8 @@ Explained Query:
                           %0:l0[#0{dst}]UK » %1:pathq20[#0{src}]KA
                         ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                           Project (#1{dst}, #2{min}) // { arity: 2 }
-                            Get l0 // { arity: 3 }
+                            Filter (#1{dst}) IS NOT NULL // { arity: 3 }
+                              Get l0 // { arity: 3 }
                         ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   Constant // { arity: 2 }
@@ -4094,7 +4160,8 @@ Explained Query:
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#1{dst}, #2{min}) // { arity: 2 }
-                  Get l0 // { arity: 3 }
+                  Filter (#1{dst}) IS NOT NULL // { arity: 3 }
+                    Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1{personid}) // { arity: 1 }
@@ -4185,7 +4252,8 @@ Explained Query:
                     implementation
                       %0:l0[#0{dst}]UK » %1:pathq20[#0{src}]KA
                     ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                      Get l0 // { arity: 2 }
+                      Filter (#0{dst}) IS NOT NULL // { arity: 2 }
+                        Get l0 // { arity: 2 }
                     ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                       ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
               Constant // { arity: 2 }
@@ -4198,7 +4266,8 @@ Explained Query:
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Get l0 // { arity: 2 }
+                Filter (#0{dst}) IS NOT NULL // { arity: 2 }
+                  Get l0 // { arity: 2 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1{personid}) // { arity: 1 }
@@ -4298,7 +4367,8 @@ Explained Query:
                             %1:pathq20[#0{src}]KA » %0:l0[#0{dst}]K
                           ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
                             Project (#1{dst}..=#3{min}) // { arity: 3 }
-                              Get l0 // { arity: 4 }
+                              Filter (#1{dst}) IS NOT NULL // { arity: 4 }
+                                Get l0 // { arity: 4 }
                           ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                     Constant // { arity: 3 }
@@ -4312,7 +4382,8 @@ Explained Query:
                 %1[#0]UKA » %0:l0[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
                 Project (#1{dst}..=#3{min}) // { arity: 3 }
-                  Get l0 // { arity: 4 }
+                  Filter (#1{dst}) IS NOT NULL // { arity: 4 }
+                    Get l0 // { arity: 4 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1{personid}) // { arity: 1 }
@@ -4454,6 +4525,9 @@ Explained Query:
     Return // { arity: 2 }
       With Mutually Recursive
         cte l3 =
+          Filter (#0{dst}) IS NOT NULL // { arity: 1 }
+            Get l4 // { arity: 1 }
+        cte l4 =
           Distinct project=[#0{dst}] // { arity: 1 }
             Union // { arity: 1 }
               Project (#2{dst}) // { arity: 1 }
@@ -4462,7 +4536,7 @@ Explained Query:
                     %0:l3 » %1:l1[#0{src}]KA » %2[×]
                     %1:l1 » %0:l3[#0{pos}]UK » %2[×]
                     %2 » %0:l3[×] » %1:l1[#0{src}]KA
-                  ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
+                  ArrangeBy keys=[[], [#0{pos}]] // { arity: 1 }
                     Get l3 // { arity: 1 }
                   Get l1 // { arity: 3 }
                   ArrangeBy keys=[[]] // { arity: 0 }
@@ -4470,62 +4544,64 @@ Explained Query:
                       Negate // { arity: 0 }
                         Distinct project=[] // { arity: 0 }
                           Project () // { arity: 0 }
-                            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                            Join on=(#0{pos} = #1{personid}) type=differential // { arity: 2 }
                               implementation
                                 %0:l3[#0{pos}]UK » %1:l2[#0{t}]K
-                              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                              ArrangeBy keys=[[#0{pos}]] // { arity: 1 }
                                 Get l3 // { arity: 1 }
                               Get l2 // { arity: 1 }
                       Constant // { arity: 0 }
                         - ()
               Constant // { arity: 1 }
                 - (10995116285979)
-        cte l4 =
+        cte l5 =
           TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
             Project (#0..=#3, #5) // { arity: 5 }
               Filter (#4{dead} = false) // { arity: 6 }
-                Get l12 // { arity: 6 }
-        cte l5 =
+                Get l13 // { arity: 6 }
+        cte l6 =
           Distinct project=[#0..=#2] // { arity: 3 }
             Project (#0..=#2{personid}) // { arity: 3 }
-              Get l12 // { arity: 6 }
-        cte l6 =
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l5 // { arity: 3 }
+              Get l13 // { arity: 6 }
         cte l7 =
+          Project (#0..=#3) // { arity: 4 }
+            Filter (#2{dst}) IS NOT NULL // { arity: 5 }
+              Get l5 // { arity: 5 }
+        cte l8 =
           Project (#0..=#2) // { arity: 3 }
             Join on=(#0 = #3{dir} AND #1 = #4{gsrc} AND #2 = #5{dst}) type=differential // { arity: 6 }
               implementation
                 %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-              Get l6 // { arity: 3 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Filter (#2{dst}) IS NOT NULL // { arity: 3 }
+                  Get l6 // { arity: 3 }
               ArrangeBy keys=[[#0{dir}..=#2{dst}]] // { arity: 3 }
                 Distinct project=[#0{dir}..=#2{dst}] // { arity: 3 }
                   Project (#0..=#2) // { arity: 3 }
-                    Get l4 // { arity: 5 }
-        cte l8 =
+                    Get l7 // { arity: 4 }
+        cte l9 =
           TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
             Union // { arity: 5 }
               Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
                 Map ((#6{w} + integer_to_bigint(#2{w})), false) // { arity: 9 }
                   Join on=(#0{src} = #5{dst}) type=differential // { arity: 7 }
                     implementation
-                      %0:l1[#0{src}]KA » %1:l4[#2{dst}]K
+                      %0:l1[#0{src}]KA » %1:l7[#2{dst}]K
                     Get l1 // { arity: 3 }
                     ArrangeBy keys=[[#2{dst}]] // { arity: 4 }
-                      Project (#0..=#3) // { arity: 4 }
-                        Get l4 // { arity: 5 }
+                      Get l7 // { arity: 4 }
               Project (#0..=#3, #9) // { arity: 5 }
                 Map ((#4{dead} OR #8)) // { arity: 10 }
                   Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                     implementation
-                      %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
+                      %0:l13[#0..=#2]KKK » %1[#0..=#2]KKK
                     ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                       Project (#0..=#4) // { arity: 5 }
-                        Get l12 // { arity: 6 }
+                        Get l13 // { arity: 6 }
                     ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                       Union // { arity: 4 }
                         Map (true) // { arity: 4 }
-                          Get l7 // { arity: 3 }
+                          Get l8 // { arity: 3 }
                         Project (#0..=#2, #6) // { arity: 4 }
                           Map (false) // { arity: 7 }
                             Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
@@ -4534,45 +4610,47 @@ Explained Query:
                               ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                                 Union // { arity: 3 }
                                   Negate // { arity: 3 }
-                                    Get l7 // { arity: 3 }
-                                  Get l5 // { arity: 3 }
-                              Get l6 // { arity: 3 }
-        cte l9 =
+                                    Get l8 // { arity: 3 }
+                                  Get l6 // { arity: 3 }
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Get l6 // { arity: 3 }
+        cte l10 =
           Reduce aggregates=[min((#0{w} + #1{w}))] // { arity: 1 }
             Project (#1, #3) // { arity: 2 }
               Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
                 implementation
-                  %0:l8[#0{dst}]Kef » %1:l8[#0{dst}]Kef
+                  %0:l9[#0{dst}]Kef » %1:l9[#0{dst}]Kef
                 ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                   Project (#2{dst}, #3) // { arity: 2 }
-                    Filter (#0{dir} = false) // { arity: 5 }
-                      Get l8 // { arity: 5 }
+                    Filter (#0{dir} = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l9 // { arity: 5 }
                 ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                   Project (#2{dst}, #3) // { arity: 2 }
-                    Filter (#0{dir} = true) // { arity: 5 }
-                      Get l8 // { arity: 5 }
-        cte l10 =
+                    Filter (#0{dir} = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l9 // { arity: 5 }
+        cte l11 =
           Project (#1) // { arity: 1 }
             Map ((#0{min} / 2)) // { arity: 2 }
               Union // { arity: 1 }
-                Get l9 // { arity: 1 }
+                Get l10 // { arity: 1 }
                 Map (null) // { arity: 1 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
                       Project () // { arity: 0 }
-                        Get l9 // { arity: 1 }
+                        Get l10 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
-        cte l11 =
+        cte l12 =
           Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
                 implementation
-                  %0:l3[#0{pos}]UK » %1:l2[#0{t}]K
+                  %0:l4[#0{pos}]UK » %1:l2[#0{t}]K
                 ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                  Get l3 // { arity: 1 }
+                  Filter (#0{dst}) IS NOT NULL // { arity: 1 }
+                    Get l4 // { arity: 1 }
                 Get l2 // { arity: 1 }
-        cte l12 =
+        cte l13 =
           Distinct project=[#0..=#5] // { arity: 6 }
             Union // { arity: 6 }
               Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
@@ -4581,79 +4659,82 @@ Explained Query:
                     Union // { arity: 3 }
                       Project (#1, #0, #0) // { arity: 3 }
                         Map (10995116285979, false) // { arity: 2 }
-                          Get l11 // { arity: 0 }
+                          Get l12 // { arity: 0 }
                       Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
                         Map (true) // { arity: 2 }
                           CrossJoin type=differential // { arity: 1 }
                             implementation
-                              %1:l11[×]U » %0:l0[×]
+                              %1:l12[×]U » %0:l0[×]
                             ArrangeBy keys=[[]] // { arity: 1 }
                               Get l0 // { arity: 1 }
                             ArrangeBy keys=[[]] // { arity: 0 }
-                              Get l11 // { arity: 0 }
+                              Get l12 // { arity: 0 }
               Project (#0..=#3, #7, #8) // { arity: 6 }
                 Map ((#4{dead} OR coalesce((#3{w} > #6), false)), (#5{iter} + 1)) // { arity: 9 }
                   CrossJoin type=delta // { arity: 7 }
                     implementation
-                      %0:l8 » %1[×]U » %2[×]U
-                      %1 » %2[×]U » %0:l8[×]
-                      %2 » %1[×]U » %0:l8[×]
+                      %0:l9 » %1[×]U » %2[×]U
+                      %1 » %2[×]U » %0:l9[×]
+                      %2 » %1[×]U » %0:l9[×]
                     ArrangeBy keys=[[]] // { arity: 5 }
-                      Get l8 // { arity: 5 }
+                      Get l9 // { arity: 5 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       TopK limit=1 // { arity: 1 }
                         Project (#4) // { arity: 1 }
-                          Get l4 // { arity: 5 }
+                          Get l5 // { arity: 5 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Union // { arity: 1 }
-                        Get l10 // { arity: 1 }
+                        Get l11 // { arity: 1 }
                         Map (null) // { arity: 1 }
                           Union // { arity: 0 }
                             Negate // { arity: 0 }
                               Project () // { arity: 0 }
-                                Get l10 // { arity: 1 }
+                                Get l11 // { arity: 1 }
                             Constant // { arity: 0 }
                               - ()
       Return // { arity: 2 }
         With
-          cte l13 =
+          cte l14 =
             Project (#0..=#3) // { arity: 4 }
               Join on=(#4{iter} = #5{max}) type=differential // { arity: 6 }
                 implementation
-                  %1[#0]UK » %0:l12[#4{iter}]K
+                  %1[#0]UK » %0:l13[#4{iter}]K
                 ArrangeBy keys=[[#4{iter}]] // { arity: 5 }
                   Project (#0..=#3, #5) // { arity: 5 }
-                    Get l12 // { arity: 6 }
+                    Filter (#2{personid}) IS NOT NULL // { arity: 6 }
+                      Get l13 // { arity: 6 }
                 ArrangeBy keys=[[#0{max}]] // { arity: 1 }
                   Reduce aggregates=[max(#0{iter})] // { arity: 1 }
                     Project (#5) // { arity: 1 }
-                      Get l12 // { arity: 6 }
-          cte l14 =
+                      Get l13 // { arity: 6 }
+          cte l15 =
             Project (#1{personid}, #2{min}) // { arity: 2 }
               Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1{w} + #3{w}))] // { arity: 3 }
                 Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
                   Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                     implementation
-                      %0:l13[#1{dst}]Kef » %1:l13[#1{dst}]Kef
+                      %0:l14[#1{dst}]Kef » %1:l14[#1{dst}]Kef
                     ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                       Project (#1{personid}..=#3) // { arity: 3 }
                         Filter (#0{dir} = false) // { arity: 4 }
-                          Get l13 // { arity: 4 }
+                          Get l14 // { arity: 4 }
                     ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                       Project (#1{personid}..=#3) // { arity: 3 }
                         Filter (#0{dir} = true) // { arity: 4 }
-                          Get l13 // { arity: 4 }
+                          Get l14 // { arity: 4 }
         Return // { arity: 2 }
           Project (#0{personid}, #1{min}) // { arity: 2 }
             Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
               implementation
-                %1[#0]UK » %0:l14[#1{w}]K
+                %1[#0]UK » %0:l15[#1{w}]K
               ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-                Get l14 // { arity: 2 }
+                Filter (#1{min}) IS NOT NULL // { arity: 2 }
+                  Get l15 // { arity: 2 }
               ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#1{min}) // { arity: 1 }
-                    Get l14 // { arity: 2 }
+                Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                  Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                    Project (#1{min}) // { arity: 1 }
+                      Get l15 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -548,7 +548,7 @@ Explained Query:
             ArrangeBy keys=[[#0{id}]] // { arity: 3 }
               Reduce group_by=[#0{id}] aggregates=[count(case when (#2{creationdate} < 2010-09-16 00:00:00 UTC) then #1{messageid} else null end), count(case when (#2{creationdate} >= 2010-09-16 00:00:00 UTC) then #1{messageid} else null end)] // { arity: 3 }
                 Project (#0{id}, #2{messageid}, #4{creationdate}) // { arity: 3 }
-                  Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
+                  Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) AND (#2{messageid}) IS NOT NULL // { arity: 17 }
                     Join on=(#0{id} = #3{tagid} AND #2{messageid} = #5{messageid}) type=delta // { arity: 17 }
                       implementation
                         %0:l1 » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KAiif
@@ -625,7 +625,7 @@ Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10{containerforumid}, #13{creationdate}, #15{title}, #16{moderatorpersonid}) // { arity: 4 }
-        Filter (#33{name} = "China") AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
+        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
               %0:message » %5[#0]UKA » %1:forum[#1{id}]KA » %2:person[#1{id}]KA » %3:city[#0{id}]KA » %4:country[#0{id}]KAef
@@ -647,17 +647,18 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#10{messageid}) // { arity: 1 }
-                  Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
-                    implementation
-                      %0:tagclass » %1:tag[#3{typetagclassid}]KA » %2:message_hastag_tag[#2{tagid}]KA
-                      %1:tag » %0:tagclass[#0{id}]KAe » %2:message_hastag_tag[#2{tagid}]KA
-                      %2:message_hastag_tag » %1:tag[#0{id}]KA » %0:tagclass[#0{id}]KAe
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
-                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+                  Filter (#5{id}) IS NOT NULL AND (#10{messageid}) IS NOT NULL // { arity: 12 }
+                    Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
+                      implementation
+                        %0:tagclass » %1:tag[#3{typetagclassid}]KA » %2:message_hastag_tag[#2{tagid}]KA
+                        %1:tag » %0:tagclass[#0{id}]KAe » %2:message_hastag_tag[#2{tagid}]KA
+                        %2:message_hastag_tag » %1:tag[#0{id}]KA » %0:tagclass[#0{id}]KAe
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                        ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
+                      ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                        ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                      ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                        ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -752,10 +753,11 @@ Explained Query:
     With
       cte l0 =
         Project (#0{id}) // { arity: 1 }
-          TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0{id}, #2{maxnumberofmembers}) // { arity: 2 }
-              Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
-                ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
+          Filter (#0{id}) IS NOT NULL // { arity: 2 }
+            TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
+              Project (#0{id}, #2{maxnumberofmembers}) // { arity: 2 }
+                Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
+                  ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
       cte l1 =
         Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
           Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
@@ -778,14 +780,20 @@ Explained Query:
           Get l1 // { arity: 4 }
       cte l3 =
         Project (#0{creationdate}..=#3{lastname}, #5{messageid}) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
+          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
             implementation
-              %0:l2 » %1:message[#9{creatorpersonid}]KA » %2[#0]UKA
-              %1:message » %2[#0]UKA » %0:l2[#1{id}]K
-              %2 » %1:message[#10{containerforumid}]KA » %0:l2[#1{id}]K
+              %0:l2 » %1:message[#9{creatorpersonid}]KA » %2[#0]UKA » %3[#0]UKA
+              %1:message » %2[#0]UKA » %3[#0]UKA » %0:l2[#1{id}]K
+              %2 » %3[#0]UKA » %1:message[#10{containerforumid}]KA » %0:l2[#1{id}]K
+              %3 » %2[#0]UKA » %1:message[#10{containerforumid}]KA » %0:l2[#1{id}]K
             Get l2 // { arity: 4 }
             ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
               ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
+              Distinct project=[#0{containerforumid}] // { arity: 1 }
+                Project (#10{containerforumid}) // { arity: 1 }
+                  Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                    ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Get l0 // { arity: 1 }
@@ -811,7 +819,7 @@ Used Indexes:
   - materialize.public.person_id (differential join)
   - materialize.public.forum_hasmember_person_forumid (differential join)
   - materialize.public.message_containerforumid (delta join lookup)
-  - materialize.public.message_creatorpersonid (delta join lookup)
+  - materialize.public.message_creatorpersonid (*** full scan ***, delta join lookup)
   - materialize.public.top100popularforumsq04_id (*** full scan ***)
 
 Target cluster: quickstart
@@ -855,17 +863,18 @@ Explained Query:
     With
       cte l0 =
         Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#5{messageid}) IS NOT NULL // { arity: 20 }
+            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
           Project (#12{parentmessageid}) // { arity: 1 }
@@ -874,7 +883,8 @@ Explained Query:
       cte l2 =
         Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
           Project (#2{messageid}) // { arity: 1 }
-            ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
+            Filter (#2{messageid}) IS NOT NULL // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{messageid}] // { arity: 1 }
           Project (#1{messageid}) // { arity: 1 }
@@ -982,17 +992,18 @@ Explained Query:
     With
       cte l0 =
         Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#6{messageid}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
@@ -1024,13 +1035,15 @@ Explained Query:
             Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
+        ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+          Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+            Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{creatorpersonid}, #1{personid}, #3{popularityscore}) // { arity: 3 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1{person2id}]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
+              %1:popularityscoreq06[#0{person2id}]KA » %0:l4[#1{person2id}]K
+            Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
     Return // { arity: 2 }
@@ -1040,10 +1053,18 @@ Explained Query:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
+                  Join on=(#1{personid} = #2{personid}) type=differential // { arity: 3 }
+                    implementation
+                      %1[#0]UKA » %0:l4[#1{person2id}]K
+                    Get l4 // { arity: 2 }
+                    ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                      Distinct project=[#0{personid}] // { arity: 1 }
+                        Project (#1{personid}) // { arity: 1 }
+                          Get l5 // { arity: 3 }
               Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{popularityscore}) // { arity: 2 }
+            Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1088,17 +1109,18 @@ Explained Query:
     With
       cte l0 =
         Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#6{messageid}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KAe » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KAe
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
@@ -1130,13 +1152,15 @@ Explained Query:
             Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
+        ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+          Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+            Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{creatorpersonid}, #1{personid}, #3{popularityscore}) // { arity: 3 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1{person2id}]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
+              %1:popularityscoreq06[#0{person2id}]KA » %0:l4[#1{person2id}]K
+            Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
     Return // { arity: 2 }
@@ -1146,10 +1170,18 @@ Explained Query:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
+                  Join on=(#1{personid} = #2{personid}) type=differential // { arity: 3 }
+                    implementation
+                      %1[#0]UKA » %0:l4[#1{person2id}]K
+                    Get l4 // { arity: 2 }
+                    ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                      Distinct project=[#0{personid}] // { arity: 1 }
+                        Project (#1{personid}) // { arity: 1 }
+                          Get l5 // { arity: 3 }
               Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{popularityscore}) // { arity: 2 }
+            Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1195,17 +1227,18 @@ Explained Query:
     With
       cte l0 =
         Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
-              %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
-              %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Filter (#0{id}) IS NOT NULL AND (#5{messageid}) IS NOT NULL // { arity: 20 }
+            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+              implementation
+                %0:tag » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KA
+                %1:message_hastag_tag » %0:tag[#0{id}]KA » %2:message[#1{messageid}]KA
+                %2:message » %1:message_hastag_tag[#1{messageid}]KA » %0:tag[#0{id}]KA
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         Project (#0{name}..=#2{creatorpersonid}, #4{personid}) // { arity: 4 }
           Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
@@ -1241,13 +1274,15 @@ Explained Query:
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
+        ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+          Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+            Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{creatorpersonid}, #1{personid}, #3{popularityscore}) // { arity: 3 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1{person2id}]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
+              %1:popularityscoreq06[#0{person2id}]KA » %0:l4[#1{person2id}]K
+            Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
     Return // { arity: 2 }
@@ -1257,10 +1292,18 @@ Explained Query:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
+                  Join on=(#1{personid} = #2{personid}) type=differential // { arity: 3 }
+                    implementation
+                      %1[#0]UKA » %0:l4[#1{person2id}]K
+                    Get l4 // { arity: 2 }
+                    ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                      Distinct project=[#0{personid}] // { arity: 1 }
+                        Project (#1{personid}) // { arity: 1 }
+                          Get l5 // { arity: 3 }
               Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{popularityscore}) // { arity: 2 }
+            Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1312,29 +1355,32 @@ Explained Query:
     With
       cte l0 =
         Project (#1{messageid}) // { arity: 1 }
-          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-            implementation
-              %1:tag[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KAe
-            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
+          Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
+            Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+              implementation
+                %1:tag[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KAe
+              ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
       cte l1 =
         Project (#2{messageid}, #18{name}) // { arity: 2 }
-          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
-            implementation
-              %0:l0 » %1:message[#12{parentmessageid}]KA » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA
-              %1:message » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
-              %2:message_hastag_tag » %1:message[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
-              %3:tag » %2:message_hastag_tag[#2{tagid}]KA » %1:message[#1{messageid}]KA » %0:l0[#0{messageid}]K
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Filter (#2{messageid}) IS NOT NULL AND (#16{tagid}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
+              implementation
+                %0:l0 » %1:message[#12{parentmessageid}]KA » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA
+                %1:message » %2:message_hastag_tag[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
+                %2:message_hastag_tag » %1:message[#1{messageid}]KA » %3:tag[#0{id}]KA » %0:l0[#0{messageid}]K
+                %3:tag » %2:message_hastag_tag[#2{tagid}]KA » %1:message[#1{messageid}]KA » %0:l0[#0{messageid}]K
+              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                Filter (#0{messageid}) IS NOT NULL // { arity: 1 }
+                  Get l0 // { arity: 1 }
+              ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
       cte l2 =
         Distinct project=[#0{messageid}] // { arity: 1 }
           Project (#0{messageid}) // { arity: 1 }
@@ -1350,15 +1396,16 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0{messageid}) // { arity: 1 }
-                    Join on=(#0{messageid} = #1{messageid}) type=differential // { arity: 2 }
-                      implementation
-                        %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                        Distinct project=[#0{messageid}] // { arity: 1 }
-                          Get l0 // { arity: 1 }
+                  Distinct project=[#0{messageid}] // { arity: 1 }
+                    Project (#0{messageid}) // { arity: 1 }
+                      Filter ((#1{messageid}) IS NULL OR (#0{messageid} = #1{messageid})) // { arity: 2 }
+                        CrossJoin type=differential // { arity: 2 }
+                          implementation
+                            %0:l2[×] » %1:l0[×]
+                          ArrangeBy keys=[[]] // { arity: 1 }
+                            Get l2 // { arity: 1 }
+                          ArrangeBy keys=[[]] // { arity: 1 }
+                            Get l0 // { arity: 1 }
                 Get l2 // { arity: 1 }
 
 Used Indexes:
@@ -1450,7 +1497,7 @@ Explained Query:
       cte l3 =
         Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
           Project (#17{creatorpersonid}) // { arity: 1 }
-            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
+            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) AND (#0{id}) IS NOT NULL AND (#6{messageid}) IS NOT NULL AND (#17{creatorpersonid}) IS NOT NULL // { arity: 32 }
               Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
                 implementation
                   %0:l1 » %1:message_hastag_tag[#2{tagid}]KA » %2:message[#1{messageid}]KAiif » %3:l0[#1{id}]KA
@@ -1591,7 +1638,7 @@ Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
       Project (#1{id}..=#3{lastname}, #25{count}) // { arity: 4 }
-        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 26 }
+        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
               %0:person » %1:message[#9{creatorpersonid}]KAniif » %2[#0]UKA
@@ -1604,7 +1651,7 @@ Explained Query:
             ArrangeBy keys=[[#0{rootpostid}]] // { arity: 2 }
               Reduce group_by=[#0{rootpostid}] aggregates=[count(*)] // { arity: 2 }
                 Project (#2{rootpostid}) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 13 }
+                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#2{rootpostid}) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -1720,69 +1767,72 @@ Explained Query:
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{person2id}, #9{name}) // { arity: 2 }
-          Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
-            implementation
-              %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
-              %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
-              %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
-              %3 » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-              %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-              %5:tag » %4:message_hastag_tag[#2{tagid}]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Distinct project=[#0{person2id}] // { arity: 1 }
-                Threshold // { arity: 1 }
-                  Union // { arity: 1 }
-                    Distinct project=[#0{person2id}] // { arity: 1 }
-                      Project (#6{person2id}) // { arity: 1 }
-                        Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
-                          implementation
-                            %0:l2 » %1:person_knows_person[#1{person1id}]KA » %2:l0[#1{person1id}]KA
-                            %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1{person1id}]KA
-                            %2:l0 » %1:person_knows_person[#2{person2id}]KA » %0:l2[#0]UKA
-                          ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-                            Get l2 // { arity: 1 }
-                          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                          Get l0 // { arity: 3 }
-                    Negate // { arity: 1 }
-                      Get l2 // { arity: 1 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1{id}) // { arity: 1 }
-                  Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
-                    Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
-                      implementation
-                        %0:person » %1:city[#0{id}]KA » %2:country[#0{id}]KAef
-                        %1:city » %2:country[#0{id}]KAef » %0:person[#8{locationcityid}]KA
-                        %2:country » %1:city[#3{partofcountryid}]KA » %0:person[#8{locationcityid}]KA
-                      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-                        ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-                      ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-                        ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-                      ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                        ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
-                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
-                    implementation
-                      %0:message_hastag_tag » %1:tag[#0{id}]KA » %2:tagclass[#0{id}]KAe
-                      %1:tag » %2:tagclass[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KA
-                      %2:tagclass » %1:tag[#3{typetagclassid}]KA » %0:message_hastag_tag[#2{tagid}]KA
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Filter (#7{tagid}) IS NOT NULL // { arity: 12 }
+            Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
+              implementation
+                %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
+                %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
+                %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA
+                %3 » %4:message_hastag_tag[#1{messageid}]KA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+                %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0{id}]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+                %5:tag » %4:message_hastag_tag[#2{tagid}]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                Distinct project=[#0{person2id}] // { arity: 1 }
+                  Threshold // { arity: 1 }
+                    Union // { arity: 1 }
+                      Distinct project=[#0{person2id}] // { arity: 1 }
+                        Project (#6{person2id}) // { arity: 1 }
+                          Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
+                            implementation
+                              %0:l2 » %1:person_knows_person[#1{person1id}]KA » %2:l0[#1{person1id}]KA
+                              %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1{person1id}]KA
+                              %2:l0 » %1:person_knows_person[#2{person2id}]KA » %0:l2[#0]UKA
+                            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                              Get l2 // { arity: 1 }
+                            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                            Get l0 // { arity: 3 }
+                      Negate // { arity: 1 }
+                        Get l2 // { arity: 1 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                Distinct project=[#0{id}] // { arity: 1 }
+                  Project (#1{id}) // { arity: 1 }
+                    Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
+                      Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
+                        implementation
+                          %0:person » %1:city[#0{id}]KA » %2:country[#0{id}]KAef
+                          %1:city » %2:country[#0{id}]KAef » %0:person[#8{locationcityid}]KA
+                          %2:country » %1:city[#3{partofcountryid}]KA » %0:person[#8{locationcityid}]KA
+                        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+                          ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
+                        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+                          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                          ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
+              ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+                Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                  Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
+                    Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                Distinct project=[#0{messageid}] // { arity: 1 }
+                  Project (#1{messageid}) // { arity: 1 }
+                    Filter (#1{messageid}) IS NOT NULL AND (#2{tagid}) IS NOT NULL // { arity: 12 }
+                      Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
+                        implementation
+                          %0:message_hastag_tag » %1:tag[#0{id}]KA » %2:tagclass[#0{id}]KAe
+                          %1:tag » %2:tagclass[#0{id}]KAe » %0:message_hastag_tag[#2{tagid}]KA
+                          %2:tagclass » %1:tag[#3{typetagclassid}]KA » %0:message_hastag_tag[#2{tagid}]KA
+                        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
+                        ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                          ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                          ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1941,7 +1991,7 @@ Explained Query:
           ReadIndex on=person person_id=[differential join] // { arity: 11 }
       cte l1 =
         Project (#1{id}, #12{messageid}) // { arity: 2 }
-          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
+          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
                 %1:message[#9{creatorpersonid}]KAeiif » %0:l0[#1{id}]KAeiif
@@ -2160,7 +2210,7 @@ Explained Query:
           Get l3 // { arity: 1 }
       cte l5 =
         Project (#1{id}, #23{creatorpersonid}) // { arity: 2 }
-          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
+          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#13{messageid}) IS NOT NULL // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
                 %0:person » %1:person_likes_message[#1{personid}]KA » %2:message[#1{messageid}]KA » %3:l4[#0{zombieid}]K
@@ -2362,12 +2412,13 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9{creatorpersonid}, #22{creatorpersonid}) // { arity: 2 }
-                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
-                    implementation
-                      %0:l6[#1{messageid}]KA » %1:message[#12{parentmessageid}]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
-                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#22{creatorpersonid}) IS NOT NULL // { arity: 26 }
+                    Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
+                      implementation
+                        %0:l6[#1{messageid}]KA » %1:message[#12{parentmessageid}]KA
+                      Get l6 // { arity: 13 }
+                      ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
+                        ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
       cte l8 =
         Project (#0{id}..=#4, #7) // { arity: 6 }
           Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
@@ -2398,12 +2449,13 @@ Explained Query:
             ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9{creatorpersonid}, #14{personid}) // { arity: 2 }
-                  Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
-                    implementation
-                      %0:l6[#1{messageid}]KA » %1:person_likes_message[#2{messageid}]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-                      ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#14{personid}) IS NOT NULL // { arity: 16 }
+                    Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
+                      implementation
+                        %0:l6[#1{messageid}]KA » %1:person_likes_message[#2{messageid}]KA
+                      Get l6 // { arity: 13 }
+                      ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+                        ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l11 =
         Project (#0{id}..=#3{person2id}, #6{sum}) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
@@ -2556,10 +2608,11 @@ Explained Query:
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                     Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                      Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                     Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
-                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      Filter (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
@@ -2754,10 +2807,11 @@ Explained Query:
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                   Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                   Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
-                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                    Filter (#9{creatorpersonid}) IS NOT NULL AND (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 Get l2 // { arity: 1 }
                 Get l2 // { arity: 1 }
@@ -3107,17 +3161,18 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
                 Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
-                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#2{tagid}) IS NOT NULL // { arity: 8 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                      implementation
+                        %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
+                      Get l1 // { arity: 3 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
       cte l4 =
         ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
@@ -3146,17 +3201,18 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
                 Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
-                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#9{creatorpersonid}) IS NOT NULL AND (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
+                  Filter (#1{messageid}) IS NOT NULL AND (#2{tagid}) IS NOT NULL // { arity: 8 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                      implementation
+                        %1:tag[#0{id}]KAe » %0:l1[#2{tagid}]KAe
+                      Get l1 // { arity: 3 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l7 =
         Project (#0{id}, #1{messageid}, #4{person2id}) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
@@ -3269,16 +3325,17 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1{messageid}) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
-                    implementation
-                      %1[#0]UKA » %0:message_hastag_tag[#2{tagid}]KA
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#0{id}) // { arity: 1 }
-                          Filter (#0{id}) IS NOT NULL // { arity: 5 }
-                            ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
+                  Filter (#1{messageid}) IS NOT NULL // { arity: 4 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
+                      implementation
+                        %1[#0]UKA » %0:message_hastag_tag[#2{tagid}]KA
+                      ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                        ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                        Distinct project=[#0{id}] // { arity: 1 }
+                          Project (#0{id}) // { arity: 1 }
+                            Filter (#0{id}) IS NOT NULL // { arity: 5 }
+                              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
       cte l1 =
         ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
@@ -3294,13 +3351,15 @@ Explained Query:
                 %4:l1 » %3:l1[#1{forumid}]KA » %0:l0[#2{containerforumid}]K » %1:l0[#2{creatorpersonid}]K » %2:l0[#0{creatorpersonid}, #1{parentmessageid}]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
                 Project (#0{creationdate}, #2{creatorpersonid}, #3{containerforumid}) // { arity: 3 }
-                  Get l0 // { arity: 5 }
+                  Filter (#3{containerforumid}) IS NOT NULL // { arity: 5 }
+                    Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
                 Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
-                  Get l0 // { arity: 5 }
+                  Filter (#2{creatorpersonid}) IS NOT NULL // { arity: 5 }
+                    Get l0 // { arity: 5 }
               ArrangeBy keys=[[#0{creatorpersonid}, #1{parentmessageid}]] // { arity: 2 }
                 Project (#2{creatorpersonid}, #4{parentmessageid}) // { arity: 2 }
-                  Filter (#4{parentmessageid}) IS NOT NULL // { arity: 5 }
+                  Filter (#2{creatorpersonid}) IS NOT NULL AND (#4{parentmessageid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
@@ -3611,11 +3670,13 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l1[#2{w}]K
           ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Get l1 // { arity: 3 }
+            Filter (#2{min}) IS NOT NULL // { arity: 3 }
+              Get l1 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2{min}) // { arity: 1 }
-                Get l1 // { arity: 3 }
+            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2{min}) // { arity: 1 }
+                  Get l1 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3773,11 +3834,13 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l5[#2{w}]K
           ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Get l5 // { arity: 3 }
+            Filter (#2{min}) IS NOT NULL // { arity: 3 }
+              Get l5 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2{min}) // { arity: 1 }
-                Get l5 // { arity: 3 }
+            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2{min}) // { arity: 1 }
+                  Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4004,11 +4067,13 @@ Explained Query:
               implementation
                 %1[#0]UK » %0:l9[#2{w}]K
               ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-                Get l9 // { arity: 3 }
+                Filter (#2{min}) IS NOT NULL // { arity: 3 }
+                  Get l9 // { arity: 3 }
               ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#2{min}) // { arity: 1 }
-                    Get l9 // { arity: 3 }
+                Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                  Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                    Project (#2{min}) // { arity: 1 }
+                      Get l9 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4087,7 +4152,8 @@ Explained Query:
                           %0:l0[#0{dst}]UK » %1:pathq20[#0{src}]KA
                         ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                           Project (#1{dst}, #2{min}) // { arity: 2 }
-                            Get l0 // { arity: 3 }
+                            Filter (#1{dst}) IS NOT NULL // { arity: 3 }
+                              Get l0 // { arity: 3 }
                         ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   Constant // { arity: 2 }
@@ -4101,7 +4167,8 @@ Explained Query:
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#1{dst}, #2{min}) // { arity: 2 }
-                  Get l0 // { arity: 3 }
+                  Filter (#1{dst}) IS NOT NULL // { arity: 3 }
+                    Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1{personid}) // { arity: 1 }
@@ -4192,7 +4259,8 @@ Explained Query:
                     implementation
                       %0:l0[#0{dst}]UK » %1:pathq20[#0{src}]KA
                     ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                      Get l0 // { arity: 2 }
+                      Filter (#0{dst}) IS NOT NULL // { arity: 2 }
+                        Get l0 // { arity: 2 }
                     ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                       ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
               Constant // { arity: 2 }
@@ -4205,7 +4273,8 @@ Explained Query:
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Get l0 // { arity: 2 }
+                Filter (#0{dst}) IS NOT NULL // { arity: 2 }
+                  Get l0 // { arity: 2 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1{personid}) // { arity: 1 }
@@ -4305,7 +4374,8 @@ Explained Query:
                             %1:pathq20[#0{src}]KA » %0:l0[#0{dst}]K
                           ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
                             Project (#1{dst}..=#3{min}) // { arity: 3 }
-                              Get l0 // { arity: 4 }
+                              Filter (#1{dst}) IS NOT NULL // { arity: 4 }
+                                Get l0 // { arity: 4 }
                           ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                     Constant // { arity: 3 }
@@ -4319,7 +4389,8 @@ Explained Query:
                 %1[#0]UKA » %0:l0[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
                 Project (#1{dst}..=#3{min}) // { arity: 3 }
-                  Get l0 // { arity: 4 }
+                  Filter (#1{dst}) IS NOT NULL // { arity: 4 }
+                    Get l0 // { arity: 4 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1{personid}) // { arity: 1 }
@@ -4461,6 +4532,9 @@ Explained Query:
     Return // { arity: 2 }
       With Mutually Recursive
         cte l3 =
+          Filter (#0{dst}) IS NOT NULL // { arity: 1 }
+            Get l4 // { arity: 1 }
+        cte l4 =
           Distinct project=[#0{dst}] // { arity: 1 }
             Union // { arity: 1 }
               Project (#2{dst}) // { arity: 1 }
@@ -4469,7 +4543,7 @@ Explained Query:
                     %0:l3 » %1:l1[#0{src}]KA » %2[×]
                     %1:l1 » %0:l3[#0{pos}]UK » %2[×]
                     %2 » %0:l3[×] » %1:l1[#0{src}]KA
-                  ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
+                  ArrangeBy keys=[[], [#0{pos}]] // { arity: 1 }
                     Get l3 // { arity: 1 }
                   Get l1 // { arity: 3 }
                   ArrangeBy keys=[[]] // { arity: 0 }
@@ -4477,62 +4551,64 @@ Explained Query:
                       Negate // { arity: 0 }
                         Distinct project=[] // { arity: 0 }
                           Project () // { arity: 0 }
-                            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                            Join on=(#0{pos} = #1{personid}) type=differential // { arity: 2 }
                               implementation
                                 %0:l3[#0{pos}]UK » %1:l2[#0{t}]K
-                              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                              ArrangeBy keys=[[#0{pos}]] // { arity: 1 }
                                 Get l3 // { arity: 1 }
                               Get l2 // { arity: 1 }
                       Constant // { arity: 0 }
                         - ()
               Constant // { arity: 1 }
                 - (10995116285979)
-        cte l4 =
+        cte l5 =
           TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
             Project (#0..=#3, #5) // { arity: 5 }
               Filter (#4{dead} = false) // { arity: 6 }
-                Get l12 // { arity: 6 }
-        cte l5 =
+                Get l13 // { arity: 6 }
+        cte l6 =
           Distinct project=[#0..=#2] // { arity: 3 }
             Project (#0..=#2{personid}) // { arity: 3 }
-              Get l12 // { arity: 6 }
-        cte l6 =
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l5 // { arity: 3 }
+              Get l13 // { arity: 6 }
         cte l7 =
+          Project (#0..=#3) // { arity: 4 }
+            Filter (#2{dst}) IS NOT NULL // { arity: 5 }
+              Get l5 // { arity: 5 }
+        cte l8 =
           Project (#0..=#2) // { arity: 3 }
             Join on=(#0 = #3{dir} AND #1 = #4{gsrc} AND #2 = #5{dst}) type=differential // { arity: 6 }
               implementation
                 %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-              Get l6 // { arity: 3 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Filter (#2{dst}) IS NOT NULL // { arity: 3 }
+                  Get l6 // { arity: 3 }
               ArrangeBy keys=[[#0{dir}..=#2{dst}]] // { arity: 3 }
                 Distinct project=[#0{dir}..=#2{dst}] // { arity: 3 }
                   Project (#0..=#2) // { arity: 3 }
-                    Get l4 // { arity: 5 }
-        cte l8 =
+                    Get l7 // { arity: 4 }
+        cte l9 =
           TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
             Union // { arity: 5 }
               Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
                 Map ((#6{w} + integer_to_bigint(#2{w})), false) // { arity: 9 }
                   Join on=(#0{src} = #5{dst}) type=differential // { arity: 7 }
                     implementation
-                      %0:l1[#0{src}]KA » %1:l4[#2{dst}]K
+                      %0:l1[#0{src}]KA » %1:l7[#2{dst}]K
                     Get l1 // { arity: 3 }
                     ArrangeBy keys=[[#2{dst}]] // { arity: 4 }
-                      Project (#0..=#3) // { arity: 4 }
-                        Get l4 // { arity: 5 }
+                      Get l7 // { arity: 4 }
               Project (#0..=#3, #9) // { arity: 5 }
                 Map ((#4{dead} OR #8)) // { arity: 10 }
                   Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                     implementation
-                      %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
+                      %0:l13[#0..=#2]KKK » %1[#0..=#2]KKK
                     ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                       Project (#0..=#4) // { arity: 5 }
-                        Get l12 // { arity: 6 }
+                        Get l13 // { arity: 6 }
                     ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                       Union // { arity: 4 }
                         Map (true) // { arity: 4 }
-                          Get l7 // { arity: 3 }
+                          Get l8 // { arity: 3 }
                         Project (#0..=#2, #6) // { arity: 4 }
                           Map (false) // { arity: 7 }
                             Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
@@ -4541,45 +4617,47 @@ Explained Query:
                               ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                                 Union // { arity: 3 }
                                   Negate // { arity: 3 }
-                                    Get l7 // { arity: 3 }
-                                  Get l5 // { arity: 3 }
-                              Get l6 // { arity: 3 }
-        cte l9 =
+                                    Get l8 // { arity: 3 }
+                                  Get l6 // { arity: 3 }
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Get l6 // { arity: 3 }
+        cte l10 =
           Reduce aggregates=[min((#0{w} + #1{w}))] // { arity: 1 }
             Project (#1, #3) // { arity: 2 }
               Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
                 implementation
-                  %0:l8[#0{dst}]Kef » %1:l8[#0{dst}]Kef
+                  %0:l9[#0{dst}]Kef » %1:l9[#0{dst}]Kef
                 ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                   Project (#2{dst}, #3) // { arity: 2 }
-                    Filter (#0{dir} = false) // { arity: 5 }
-                      Get l8 // { arity: 5 }
+                    Filter (#0{dir} = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l9 // { arity: 5 }
                 ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                   Project (#2{dst}, #3) // { arity: 2 }
-                    Filter (#0{dir} = true) // { arity: 5 }
-                      Get l8 // { arity: 5 }
-        cte l10 =
+                    Filter (#0{dir} = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l9 // { arity: 5 }
+        cte l11 =
           Project (#1) // { arity: 1 }
             Map ((#0{min} / 2)) // { arity: 2 }
               Union // { arity: 1 }
-                Get l9 // { arity: 1 }
+                Get l10 // { arity: 1 }
                 Map (null) // { arity: 1 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
                       Project () // { arity: 0 }
-                        Get l9 // { arity: 1 }
+                        Get l10 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
-        cte l11 =
+        cte l12 =
           Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
                 implementation
-                  %0:l3[#0{pos}]UK » %1:l2[#0{t}]K
+                  %0:l4[#0{pos}]UK » %1:l2[#0{t}]K
                 ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                  Get l3 // { arity: 1 }
+                  Filter (#0{dst}) IS NOT NULL // { arity: 1 }
+                    Get l4 // { arity: 1 }
                 Get l2 // { arity: 1 }
-        cte l12 =
+        cte l13 =
           Distinct project=[#0..=#5] // { arity: 6 }
             Union // { arity: 6 }
               Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
@@ -4588,79 +4666,82 @@ Explained Query:
                     Union // { arity: 3 }
                       Project (#1, #0, #0) // { arity: 3 }
                         Map (10995116285979, false) // { arity: 2 }
-                          Get l11 // { arity: 0 }
+                          Get l12 // { arity: 0 }
                       Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
                         Map (true) // { arity: 2 }
                           CrossJoin type=differential // { arity: 1 }
                             implementation
-                              %1:l11[×]U » %0:l0[×]
+                              %1:l12[×]U » %0:l0[×]
                             ArrangeBy keys=[[]] // { arity: 1 }
                               Get l0 // { arity: 1 }
                             ArrangeBy keys=[[]] // { arity: 0 }
-                              Get l11 // { arity: 0 }
+                              Get l12 // { arity: 0 }
               Project (#0..=#3, #7, #8) // { arity: 6 }
                 Map ((#4{dead} OR coalesce((#3{w} > #6), false)), (#5{iter} + 1)) // { arity: 9 }
                   CrossJoin type=delta // { arity: 7 }
                     implementation
-                      %0:l8 » %1[×]U » %2[×]U
-                      %1 » %2[×]U » %0:l8[×]
-                      %2 » %1[×]U » %0:l8[×]
+                      %0:l9 » %1[×]U » %2[×]U
+                      %1 » %2[×]U » %0:l9[×]
+                      %2 » %1[×]U » %0:l9[×]
                     ArrangeBy keys=[[]] // { arity: 5 }
-                      Get l8 // { arity: 5 }
+                      Get l9 // { arity: 5 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       TopK limit=1 // { arity: 1 }
                         Project (#4) // { arity: 1 }
-                          Get l4 // { arity: 5 }
+                          Get l5 // { arity: 5 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Union // { arity: 1 }
-                        Get l10 // { arity: 1 }
+                        Get l11 // { arity: 1 }
                         Map (null) // { arity: 1 }
                           Union // { arity: 0 }
                             Negate // { arity: 0 }
                               Project () // { arity: 0 }
-                                Get l10 // { arity: 1 }
+                                Get l11 // { arity: 1 }
                             Constant // { arity: 0 }
                               - ()
       Return // { arity: 2 }
         With
-          cte l13 =
+          cte l14 =
             Project (#0..=#3) // { arity: 4 }
               Join on=(#4{iter} = #5{max}) type=differential // { arity: 6 }
                 implementation
-                  %1[#0]UK » %0:l12[#4{iter}]K
+                  %1[#0]UK » %0:l13[#4{iter}]K
                 ArrangeBy keys=[[#4{iter}]] // { arity: 5 }
                   Project (#0..=#3, #5) // { arity: 5 }
-                    Get l12 // { arity: 6 }
+                    Filter (#2{personid}) IS NOT NULL // { arity: 6 }
+                      Get l13 // { arity: 6 }
                 ArrangeBy keys=[[#0{max}]] // { arity: 1 }
                   Reduce aggregates=[max(#0{iter})] // { arity: 1 }
                     Project (#5) // { arity: 1 }
-                      Get l12 // { arity: 6 }
-          cte l14 =
+                      Get l13 // { arity: 6 }
+          cte l15 =
             Project (#1{personid}, #2{min}) // { arity: 2 }
               Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1{w} + #3{w}))] // { arity: 3 }
                 Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
                   Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                     implementation
-                      %0:l13[#1{dst}]Kef » %1:l13[#1{dst}]Kef
+                      %0:l14[#1{dst}]Kef » %1:l14[#1{dst}]Kef
                     ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                       Project (#1{personid}..=#3) // { arity: 3 }
                         Filter (#0{dir} = false) // { arity: 4 }
-                          Get l13 // { arity: 4 }
+                          Get l14 // { arity: 4 }
                     ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                       Project (#1{personid}..=#3) // { arity: 3 }
                         Filter (#0{dir} = true) // { arity: 4 }
-                          Get l13 // { arity: 4 }
+                          Get l14 // { arity: 4 }
         Return // { arity: 2 }
           Project (#0{personid}, #1{min}) // { arity: 2 }
             Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
               implementation
-                %1[#0]UK » %0:l14[#1{w}]K
+                %1[#0]UK » %0:l15[#1{w}]K
               ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-                Get l14 // { arity: 2 }
+                Filter (#1{min}) IS NOT NULL // { arity: 2 }
+                  Get l15 // { arity: 2 }
               ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#1{min}) // { arity: 1 }
-                    Get l14 // { arity: 2 }
+                Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                  Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                    Project (#1{min}) // { arity: 1 }
+                      Get l15 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -48,13 +48,16 @@ Explained Query:
   Project (#0{a}..=#2{u}, #0{a})
     Join on=(#0{a} = #3{a}) type=differential
       ArrangeBy keys=[[#0{a}]]
-        ReadStorage materialize.public.foo
+        Filter (#0{a}) IS NOT NULL
+          ReadStorage materialize.public.foo
       ArrangeBy keys=[[#0{a}]]
-        Project (#0{a})
-          Filter (#0{a}) IS NOT NULL
-            ReadStorage materialize.public.bar
+        Distinct project=[#0{a}]
+          Project (#0{a})
+            Filter (#0{a}) IS NOT NULL
+              ReadStorage materialize.public.bar
 
 Source materialize.public.foo
+  filter=((#0{a}) IS NOT NULL)
 Source materialize.public.bar
   filter=((#0{a}) IS NOT NULL)
 
@@ -71,11 +74,13 @@ foo_raw left join bar on foo_raw.a = bar.a;
 Explained Query:
   With
     cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        Filter (#0{a}) IS NOT NULL
+          ReadStorage materialize.public.foo_raw
+    cte l1 =
       Project (#0{a}..=#2{u}, #4{v})
         Join on=(#0{a} = #3{a}) type=differential
-          ArrangeBy keys=[[#0{a}]]
-            Filter (#0{a}) IS NOT NULL
-              ReadStorage materialize.public.foo_raw
+          Get l0
           ArrangeBy keys=[[#0{a}]]
             Filter (#0{a}) IS NOT NULL
               ReadStorage materialize.public.bar
@@ -85,10 +90,15 @@ Explained Query:
         Union
           Negate
             Project (#0{a}..=#2{u})
-              Get l0
+              Join on=(#0{a} = #3{a}) type=differential
+                Get l0
+                ArrangeBy keys=[[#0{a}]]
+                  Distinct project=[#0{a}]
+                    Project (#0{a})
+                      Get l1
           ReadStorage materialize.public.foo_raw
       Project (#0{a}..=#2{u}, #0{a}, #3{v})
-        Get l0
+        Get l1
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -112,8 +122,12 @@ Explained Query:
         Filter (#0{a}) IS NOT NULL
           ReadStorage materialize.public.foo_raw
     cte l1 =
-      Filter (#0{a}) IS NOT NULL
-        ReadStorage materialize.public.bar
+      Project (#0{a}, #1{v}, #3{b}, #4{u})
+        Join on=(#0{a} = #2{a}) type=differential
+          ArrangeBy keys=[[#0{a}]]
+            Filter (#0{a}) IS NOT NULL
+              ReadStorage materialize.public.bar
+          Get l0
   Return
     Union
       Project (#3, #4, #0{a}..=#2{u})
@@ -124,14 +138,12 @@ Explained Query:
                 Join on=(#0{a} = #3{a}) type=differential
                   Get l0
                   ArrangeBy keys=[[#0{a}]]
-                    Project (#0{a})
-                      Get l1
+                    Distinct project=[#0{a}]
+                      Project (#0{a})
+                        Get l1
             ReadStorage materialize.public.foo_raw
-      Project (#0{a}, #1{v}, #0{a}, #3{b}, #4{u})
-        Join on=(#0{a} = #2{a}) type=differential
-          ArrangeBy keys=[[#0{a}]]
-            Get l1
-          Get l0
+      Project (#0{a}, #1{v}, #0{a}, #2{b}, #3{u})
+        Get l1
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -150,61 +162,74 @@ foo left join bar on foo.a = bar.a
     left join quux on baz.c = quux.c;
 ----
 Explained Query:
-  Project (#0{a}..=#2{u}, #14, #15, #17..=#19, #21, #22)
-    Map ((#5) IS NULL, case when #13 then null else #0{a} end, case when #13 then null else #4{v} end, (#9) IS NULL, case when #16 then null else #1{b} end, case when #16 then null else #7{c} end, case when #16 then null else #8{w} end, (#12) IS NULL, case when #20 then null else #10{c} end, case when #20 then null else #11{x} end)
-      Join on=(#0{a} = #3{a} AND #1{b} = #6{b} AND #10{c} = case when (#9) IS NULL then null else #7{c} end) type=delta
-        ArrangeBy keys=[[#0{a}], [#1{b}]]
+  With
+    cte l0 =
+      Union
+        Project (#0{a}, #1{b})
           ReadStorage materialize.public.foo
-        ArrangeBy keys=[[#0{a}]]
-          Union
-            Filter (#0{a}) IS NOT NULL
-              Map (true)
-                ReadStorage materialize.public.bar
-            Map (null, null)
-              Threshold
-                Union
-                  Negate
-                    Project (#0{a})
-                      Filter (#0{a}) IS NOT NULL
-                        ReadStorage materialize.public.bar
-                  Distinct project=[#0{a}]
-                    Project (#0{a})
-                      ReadStorage materialize.public.foo
-        ArrangeBy keys=[[#0{b}], [case when (#3) IS NULL then null else #1{c} end]]
-          Union
-            Map (true)
-              ReadStorage materialize.public.baz
-            Map (null, null, null)
-              Threshold
-                Union
-                  Negate
-                    Project (#0{b})
-                      ReadStorage materialize.public.baz
-                  Distinct project=[#0{b}]
-                    Project (#1{b})
-                      ReadStorage materialize.public.foo
-        ArrangeBy keys=[[#0{c}]]
-          Union
-            Map (true)
-              ReadStorage materialize.public.quux
-            Map (null, null)
-              Threshold
-                Union
-                  Negate
-                    Project (#0{c})
-                      ReadStorage materialize.public.quux
-                  Distinct project=[#0{c}]
-                    Union
-                      Project (#1{c})
-                        ReadStorage materialize.public.baz
-                      Constant
-                        - (null)
+        Constant
+          - (null, null)
+  Return
+    Project (#0{a}..=#2{u}, #14, #15, #17..=#19, #21, #22)
+      Map ((#5) IS NULL, case when #13 then null else #0{a} end, case when #13 then null else #4{v} end, (#9) IS NULL, case when #16 then null else #1{b} end, case when #16 then null else #7{c} end, case when #16 then null else #8{w} end, (#12) IS NULL, case when #20 then null else #10{c} end, case when #20 then null else #11{x} end)
+        Join on=(#0{a} = #3{a} AND #1{b} = #6{b} AND #10{c} = case when (#9) IS NULL then null else #7{c} end) type=delta
+          ArrangeBy keys=[[#0{a}], [#1{b}]]
+            ReadStorage materialize.public.foo
+          ArrangeBy keys=[[#0{a}]]
+            Union
+              Filter (#0{a}) IS NOT NULL
+                Map (true)
+                  ReadStorage materialize.public.bar
+              Map (null, null)
+                Threshold
+                  Union
+                    Negate
+                      Project (#0{a})
+                        Filter (#0{a}) IS NOT NULL
+                          ReadStorage materialize.public.bar
+                    Distinct project=[#0{a}]
+                      Project (#0{a})
+                        Get l0
+          ArrangeBy keys=[[#0{b}], [case when (#3) IS NULL then null else #1{c} end]]
+            Union
+              Filter (#0{b}) IS NOT NULL
+                Map (true)
+                  ReadStorage materialize.public.baz
+              Map (null, null, null)
+                Threshold
+                  Union
+                    Negate
+                      Project (#0{b})
+                        Filter (#0{b}) IS NOT NULL
+                          ReadStorage materialize.public.baz
+                    Distinct project=[#0{b}]
+                      Project (#1{b})
+                        Get l0
+          ArrangeBy keys=[[#0{c}]]
+            Union
+              Filter (#0{c}) IS NOT NULL
+                Map (true)
+                  ReadStorage materialize.public.quux
+              Map (null, null)
+                Threshold
+                  Union
+                    Negate
+                      Project (#0{c})
+                        Filter (#0{c}) IS NOT NULL
+                          ReadStorage materialize.public.quux
+                    Distinct project=[#0{c}]
+                      Union
+                        Project (#1{c})
+                          ReadStorage materialize.public.baz
+                        Constant
+                          - (null)
 
 Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0{a}) IS NOT NULL)
 Source materialize.public.baz
 Source materialize.public.quux
+  filter=((#0{c}) IS NOT NULL)
 
 Target cluster: quickstart
 
@@ -222,50 +247,60 @@ foo left join bar on foo.a = bar.a
 Explained Query:
   With
     cte l0 =
+      Project (#0{a}, #1{b})
+        ReadStorage materialize.public.foo
+    cte l1 =
+      Union
+        Get l0
+        Constant
+          - (null, null)
+    cte l2 =
       Project (#0{a})
         Filter (#0{a}) IS NOT NULL
           ReadStorage materialize.public.bar
-    cte l1 =
+    cte l3 =
       Project (#0{c})
-        ReadStorage materialize.public.quux
-    cte l2 =
+        Filter (#0{c}) IS NOT NULL
+          ReadStorage materialize.public.quux
+    cte l4 =
       Reduce aggregates=[count(*)]
         Project ()
           Join on=(#0{a} = #2{a} AND #1{b} = #3{b} AND #6{c} = case when (#5) IS NULL then null else #4{c} end) type=delta
             ArrangeBy keys=[[#0{a}], [#1{b}]]
-              Project (#0{a}, #1{b})
-                ReadStorage materialize.public.foo
+              Get l0
             ArrangeBy keys=[[#0{a}]]
               Union
-                Get l0
+                Get l2
                 Threshold
                   Union
                     Negate
-                      Get l0
+                      Get l2
                     Distinct project=[#0{a}]
                       Project (#0{a})
-                        ReadStorage materialize.public.foo
+                        Get l1
             ArrangeBy keys=[[#0{b}], [case when (#2) IS NULL then null else #1{c} end]]
               Union
                 Project (#0{b}, #1{c}, #3)
-                  Map (true)
-                    ReadStorage materialize.public.baz
+                  Filter (#0{b}) IS NOT NULL
+                    Map (true)
+                      ReadStorage materialize.public.baz
                 Map (null, null)
                   Threshold
                     Union
                       Negate
                         Project (#0{b})
-                          ReadStorage materialize.public.baz
+                          Filter (#0{b}) IS NOT NULL
+                            ReadStorage materialize.public.baz
                       Distinct project=[#0{b}]
                         Project (#1{b})
-                          ReadStorage materialize.public.foo
+                          Get l1
             ArrangeBy keys=[[#0{c}]]
               Union
-                Get l1
+                Get l3
                 Threshold
                   Union
                     Negate
-                      Get l1
+                      Get l3
                     Distinct project=[#0{c}]
                       Union
                         Project (#1{c})
@@ -274,12 +309,12 @@ Explained Query:
                           - (null)
   Return
     Union
-      Get l2
+      Get l4
       Map (0)
         Union
           Negate
             Project ()
-              Get l2
+              Get l4
           Constant
             - ()
 
@@ -288,6 +323,7 @@ Source materialize.public.bar
   filter=((#0{a}) IS NOT NULL)
 Source materialize.public.baz
 Source materialize.public.quux
+  filter=((#0{c}) IS NOT NULL)
 
 Target cluster: quickstart
 
@@ -310,27 +346,34 @@ Explained Query:
             ReadStorage materialize.public.foo
         ArrangeBy keys=[[#0{b}], [case when (#3) IS NULL then null else #1{c} end]]
           Union
-            Map (true)
-              ReadStorage materialize.public.baz
+            Filter (#0{b}) IS NOT NULL
+              Map (true)
+                ReadStorage materialize.public.baz
             Map (null, null, null)
               Threshold
                 Union
                   Negate
                     Project (#0{b})
-                      ReadStorage materialize.public.baz
+                      Filter (#0{b}) IS NOT NULL
+                        ReadStorage materialize.public.baz
                   Distinct project=[#0{b}]
-                    Project (#1{b})
-                      ReadStorage materialize.public.foo
+                    Union
+                      Project (#1{b})
+                        ReadStorage materialize.public.foo
+                      Constant
+                        - (null)
         ArrangeBy keys=[[#0{c}]]
           Union
-            Map (true)
-              ReadStorage materialize.public.quux
+            Filter (#0{c}) IS NOT NULL
+              Map (true)
+                ReadStorage materialize.public.quux
             Map (null, null)
               Threshold
                 Union
                   Negate
                     Project (#0{c})
-                      ReadStorage materialize.public.quux
+                      Filter (#0{c}) IS NOT NULL
+                        ReadStorage materialize.public.quux
                   Distinct project=[#0{c}]
                     Union
                       Project (#1{c})
@@ -341,6 +384,7 @@ Explained Query:
 Source materialize.public.foo
 Source materialize.public.baz
 Source materialize.public.quux
+  filter=((#0{c}) IS NOT NULL)
 
 Target cluster: quickstart
 
@@ -375,16 +419,19 @@ Explained Query:
           Project (#0{a}..=#2{u}, #0{a})
             Join on=(#0{a} = #3{a}) type=differential
               ArrangeBy keys=[[#0{a}]]
-                ReadStorage materialize.public.foo
+                Filter (#0{a}) IS NOT NULL
+                  ReadStorage materialize.public.foo
               ArrangeBy keys=[[#0{a}]]
-                Project (#0{a})
-                  Filter (#0{a}) IS NOT NULL
-                    ReadStorage materialize.public.bar
+                Distinct project=[#0{a}]
+                  Project (#0{a})
+                    Filter (#0{a}) IS NOT NULL
+                      ReadStorage materialize.public.bar
           Get l0
   Return
     Get l0
 
 Source materialize.public.foo
+  filter=((#0{a}) IS NOT NULL)
 Source materialize.public.bar
   filter=((#0{a}) IS NOT NULL)
 
@@ -564,7 +611,8 @@ select a, -2, 'keys', a from keys;
 Explained Query:
   Project (#0{a}, #2, #1{v}, #0{a})
     Map (-1)
-      ReadStorage materialize.public.bar
+      Distinct project=[#0{a}, #1{v}]
+        ReadStorage materialize.public.bar
 
 Source materialize.public.bar
 
@@ -641,31 +689,38 @@ select * from c0
 Explained Query:
   With Mutually Recursive
     cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        Project (#0..=#2)
+          Filter (#0{a}) IS NOT NULL
+            Get l2
+    cte l1 =
       Project (#0..=#2, #4{v})
         Join on=(#0{a} = #3{a}) type=differential
-          ArrangeBy keys=[[#0{a}]]
-            Project (#0..=#2)
-              Filter (#0{a}) IS NOT NULL
-                Get l1
+          Get l0
           ArrangeBy keys=[[#0{a}]]
             Filter (#0{a}) IS NOT NULL
               ReadStorage materialize.public.bar
-    cte l1 =
+    cte l2 =
       Distinct project=[#0{a}..=#4{v}]
         Union
           Map (null, null)
             Union
               Negate
                 Project (#0..=#2)
-                  Get l0
+                  Join on=(#0{a} = #3) type=differential
+                    Get l0
+                    ArrangeBy keys=[[#0]]
+                      Distinct project=[#0]
+                        Project (#0)
+                          Get l1
               Project (#0{a}..=#2{u})
-                Get l1
+                Get l2
           Project (#0..=#2, #0, #3{v})
-            Get l0
+            Get l1
           Project (#0{a}..=#2{u}, #0{a}, #2{u})
             ReadStorage materialize.public.foo_raw
   Return
-    Get l1
+    Get l2
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -693,30 +748,37 @@ select * from c0
 Explained Query:
   With
     cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        Filter (#0{a}) IS NOT NULL
+          ReadStorage materialize.public.foo_raw
+    cte l1 =
       Project (#0{a}..=#2{u}, #4{v})
         Join on=(#0{a} = #3{a}) type=differential
-          ArrangeBy keys=[[#0{a}]]
-            Filter (#0{a}) IS NOT NULL
-              ReadStorage materialize.public.foo_raw
+          Get l0
           ArrangeBy keys=[[#0{a}]]
             Filter (#0{a}) IS NOT NULL
               ReadStorage materialize.public.bar
   Return
     With Mutually Recursive
-      cte l1 =
+      cte l2 =
         Distinct project=[#0{a}..=#4{v}]
           Union
             Map (null, null)
               Union
                 Negate
                   Project (#0{a}..=#2{u})
-                    Get l0
+                    Join on=(#0{a} = #3{a}) type=differential
+                      Get l0
+                      ArrangeBy keys=[[#0{a}]]
+                        Distinct project=[#0{a}]
+                          Project (#0{a})
+                            Get l1
                 ReadStorage materialize.public.foo_raw
             Project (#0{a}..=#2{u}, #0{a}, #3{v})
-              Get l0
-            Get l1
+              Get l1
+            Get l2
     Return
-      Get l1
+      Get l2
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -777,28 +839,32 @@ Explained Query:
                 ArrangeBy keys=[[#0{b}], [case when (#2) IS NULL then null else #1{c} end]]
                   Union
                     Project (#0{b}, #1{c}, #3)
-                      Map (true)
-                        ReadStorage materialize.public.baz
+                      Filter (#0{b}) IS NOT NULL
+                        Map (true)
+                          ReadStorage materialize.public.baz
                     Map (null, null)
                       Threshold
                         Union
                           Negate
                             Project (#0{b})
-                              ReadStorage materialize.public.baz
+                              Filter (#0{b}) IS NOT NULL
+                                ReadStorage materialize.public.baz
                           Distinct project=[#0]
                             Project (#1)
                               Get l0
                 ArrangeBy keys=[[#0{c}]]
                   Union
                     Project (#0{c}, #2)
-                      Map (true)
-                        ReadStorage materialize.public.quux
+                      Filter (#0{c}) IS NOT NULL
+                        Map (true)
+                          ReadStorage materialize.public.quux
                     Map (null)
                       Threshold
                         Union
                           Negate
                             Project (#0{c})
-                              ReadStorage materialize.public.quux
+                              Filter (#0{c}) IS NOT NULL
+                                ReadStorage materialize.public.quux
                           Distinct project=[#0{c}]
                             Union
                               Project (#1{c})
@@ -814,6 +880,7 @@ Source materialize.public.bar
   filter=((#0{a}) IS NOT NULL)
 Source materialize.public.baz
 Source materialize.public.quux
+  filter=((#0{c}) IS NOT NULL)
 
 Target cluster: quickstart
 
@@ -845,16 +912,23 @@ Explained Query:
           ReadStorage materialize.public.bar // { arity: 2 }
     cte l1 =
       Project (#0{c}) // { arity: 1 }
-        ReadStorage materialize.public.quux // { arity: 2 }
+        Filter (#0{c}) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.quux // { arity: 2 }
   Return // { arity: 3 }
     With Mutually Recursive
       cte l2 =
+        Union // { arity: 2 }
+          Project (#0{a}, #1{b}) // { arity: 2 }
+            Get l3 // { arity: 3 }
+          Constant // { arity: 2 }
+            - (null, null)
+      cte l3 =
         Distinct project=[#0{a}..=#2{u}] // { arity: 3 }
           Union // { arity: 3 }
             Project (#0..=#2) // { arity: 3 }
               Join on=(#0 = #3{a} AND #1 = #4{b} AND #7{c} = case when (#6) IS NULL then null else #5{c} end) type=delta // { arity: 8 }
                 ArrangeBy keys=[[#0{a}], [#1{b}]] // { arity: 3 }
-                  Get l2 // { arity: 3 }
+                  Get l3 // { arity: 3 }
                 ArrangeBy keys=[[#0{a}]] // { arity: 1 }
                   Union // { arity: 1 }
                     Get l0 // { arity: 1 }
@@ -863,22 +937,24 @@ Explained Query:
                         Negate // { arity: 1 }
                           Get l0 // { arity: 1 }
                         Distinct project=[#0] // { arity: 1 }
-                          Project (#0{a}) // { arity: 1 }
-                            Get l2 // { arity: 3 }
+                          Project (#0) // { arity: 1 }
+                            Get l2 // { arity: 2 }
                 ArrangeBy keys=[[#0{b}], [case when (#2) IS NULL then null else #1{c} end]] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#0{b}, #1{c}, #3) // { arity: 3 }
-                      Map (true) // { arity: 4 }
-                        ReadStorage materialize.public.baz // { arity: 3 }
+                      Filter (#0{b}) IS NOT NULL // { arity: 4 }
+                        Map (true) // { arity: 4 }
+                          ReadStorage materialize.public.baz // { arity: 3 }
                     Map (null, null) // { arity: 3 }
                       Threshold // { arity: 1 }
                         Union // { arity: 1 }
                           Negate // { arity: 1 }
                             Project (#0{b}) // { arity: 1 }
-                              ReadStorage materialize.public.baz // { arity: 3 }
+                              Filter (#0{b}) IS NOT NULL // { arity: 3 }
+                                ReadStorage materialize.public.baz // { arity: 3 }
                           Distinct project=[#0] // { arity: 1 }
-                            Project (#1{b}) // { arity: 1 }
-                              Get l2 // { arity: 3 }
+                            Project (#1) // { arity: 1 }
+                              Get l2 // { arity: 2 }
                 ArrangeBy keys=[[#0{c}]] // { arity: 1 }
                   Union // { arity: 1 }
                     Get l1 // { arity: 1 }
@@ -894,13 +970,14 @@ Explained Query:
                               - (null)
             ReadStorage materialize.public.foo // { arity: 3 }
     Return // { arity: 3 }
-      Get l2 // { arity: 3 }
+      Get l3 // { arity: 3 }
 
 Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0{a}) IS NOT NULL)
 Source materialize.public.baz
 Source materialize.public.quux
+  filter=((#0{c}) IS NOT NULL)
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -50,6 +50,28 @@ g2  true
 g3  false
 g4  true
 
+# The exported desc of a *materialized* view is canonicalized: persisted
+# history could contradict optimizer-inferred constraints, so inferred
+# non-nullability (and unique keys) are dropped and all columns report as
+# nullable.
+statement ok
+CREATE MATERIALIZED VIEW regex_nullability_mv AS
+SELECT r.* FROM data, regexp_extract('(?P<g1>a)(?P<g2>b)?(?P<g3>(?P<g4>c)|d)', data.input) AS r
+
+query TT
+SELECT c.name, c.nullable::text
+FROM mz_columns c JOIN mz_materialized_views v ON c.id = v.id
+WHERE v.name = 'regex_nullability_mv'
+ORDER BY c.position
+----
+g1  true
+g2  true
+g3  true
+g4  true
+
+statement ok
+DROP MATERIALIZED VIEW regex_nullability_mv
+
 # Standard regex matching.
 query TTT
 SELECT 'foo' ~ 'foo?', 'fo' ~ 'foo?', 'f' ~ 'foo?'

--- a/test/sqllogictest/replacement-materialized-views.slt
+++ b/test/sqllogictest/replacement-materialized-views.slt
@@ -126,29 +126,29 @@ CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT a::text, b FROM t
 db error: ERROR: replacement schema differs from target schema
 DETAIL: column "a" at position 1: type mismatch (target: Int32, replacement: String)
 
-# nullability mismatch
-simple
+# Inferred nullability is not part of the exported schema of a materialized
+# view (the desc is canonicalized: all columns nullable, no unique keys), so a
+# replacement whose plan infers tighter nullability is accepted.
+statement ok
 CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT a, b FROM t WHERE a IS NOT NULL
-----
-db error: ERROR: replacement schema differs from target schema
-DETAIL: column "a" at position 1: nullability mismatch (target: NULL, replacement: NOT NULL)
 
-# key mismatch
-simple
+statement ok
+DROP MATERIALIZED VIEW rp
+
+# Likewise for inferred unique keys.
+statement ok
 CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT DISTINCT a, b FROM t
-----
-db error: ERROR: replacement schema differs from target schema
-DETAIL: keys differ (target: (none), replacement: {a, b})
+
+statement ok
+DROP MATERIALIZED VIEW rp
 
 # multiple mismatches
 simple
 CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT DISTINCT a, b AS c, 1 AS d FROM t WHERE a IS NOT NULL
 ----
 db error: ERROR: replacement schema differs from target schema
-DETAIL: column "a" at position 1: nullability mismatch (target: NULL, replacement: NOT NULL)
-column at position 2: name mismatch (target: "b", replacement: "c")
+DETAIL: column at position 2: name mismatch (target: "b", replacement: "c")
 extra column "d" at position 3
-keys differ (target: (none), replacement: {a, c})
 
 
 statement ok

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -58,13 +58,19 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * FROM v1 CROSS JOIN LATERAL (SELECT * FROM v2 WHERE counter < f1 ORDER BY counter DESC LIMIT 3);
 ----
 Explained Query:
-  TopK group_by=[#0{f1}] order_by=[#1{counter} desc nulls_first] limit=3
-    Filter (#1{counter} < #0{f1})
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          ReadStorage materialize.public.v1
-        ArrangeBy keys=[[]]
-          ReadStorage materialize.public.v2
+  Project (#0{f1}, #2{counter})
+    Join on=(#0{f1} = #1{f1}) type=differential
+      ArrangeBy keys=[[#0{f1}]]
+        ReadStorage materialize.public.v1
+      ArrangeBy keys=[[#0{f1}]]
+        TopK group_by=[#0{f1}] order_by=[#1{counter} desc nulls_first] limit=3
+          Filter (#1{counter} < #0{f1})
+            CrossJoin type=differential
+              ArrangeBy keys=[[]]
+                Distinct project=[#0{f1}]
+                  ReadStorage materialize.public.v1
+              ArrangeBy keys=[[]]
+                ReadStorage materialize.public.v2
 
 Source materialize.public.v1
 Source materialize.public.v2

--- a/test/sqllogictest/transform/reduction_pushdown.slt
+++ b/test/sqllogictest/transform/reduction_pushdown.slt
@@ -186,27 +186,34 @@ GROUP BY 1, 2, 3;
 Explained Query:
   With
     cte l0 =
-      Filter (#0{f2} = (#0{f2} + #1{f2})) // { arity: 2 }
+      Filter (#0{f2}) IS NOT NULL // { arity: 2 }
         TopK order_by=[#0{f2} asc nulls_last, #1 asc nulls_last] limit=1 offset=1 // { arity: 2 }
           Project (#1{f2}, #2) // { arity: 2 }
             Map ((#1{f2} + #0{f1})) // { arity: 3 }
               ReadStorage materialize.public.pk1 // { arity: 2 }
   Return // { arity: 3 }
-    Project (#0{f2}, #3, #2) // { arity: 3 }
-      Map (null) // { arity: 4 }
-        Distinct project=[#0{f2}, (#0{f2} + #1{f2}), #1] // { arity: 3 }
-          Union // { arity: 2 }
-            Negate // { arity: 2 }
-              CrossJoin type=differential // { arity: 2 }
-                ArrangeBy keys=[[]] // { arity: 2 }
-                  Filter (#1{f2} != 4) // { arity: 2 }
+    Project (#0{f2}, #4, #1) // { arity: 3 }
+      Map (null) // { arity: 5 }
+        Join on=(#0{f2} = #2{f2} AND #1 = #3) type=differential // { arity: 4 }
+          ArrangeBy keys=[[#0{f2}, #1]] // { arity: 2 }
+            Project (#0{f2}, #2) // { arity: 2 }
+              Distinct project=[#0{f2}, (#0{f2} + #1{f2}), #1] // { arity: 3 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    CrossJoin type=differential // { arity: 2 }
+                      ArrangeBy keys=[[]] // { arity: 2 }
+                        Filter (#1{f2} != 4) AND (#0{f2} = (#0{f2} + #1{f2})) // { arity: 2 }
+                          Get l0 // { arity: 2 }
+                      ArrangeBy keys=[[]] // { arity: 0 }
+                        Project () // { arity: 0 }
+                          TopK order_by=[#0{f2} asc nulls_last] limit=1 offset=7 // { arity: 1 }
+                            Project (#1{f2}) // { arity: 1 }
+                              ReadStorage materialize.public.t2 // { arity: 2 }
+                  Filter (#0{f2} = (#0{f2} + #1{f2})) // { arity: 2 }
                     Get l0 // { arity: 2 }
-                ArrangeBy keys=[[]] // { arity: 0 }
-                  Project () // { arity: 0 }
-                    TopK order_by=[#0{f2} asc nulls_last] limit=1 offset=7 // { arity: 1 }
-                      Project (#1{f2}) // { arity: 1 }
-                        ReadStorage materialize.public.t2 // { arity: 2 }
-            Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0{f2}, #1]] // { arity: 2 }
+            Filter (#1) IS NOT NULL // { arity: 2 }
+              Get l0 // { arity: 2 }
 
 Source materialize.public.t2
 Source materialize.public.pk1

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -75,11 +75,13 @@ b  sum
 1  6
 2  1
 
+# The exported desc of a materialized view is canonicalized: inferred
+# non-nullability is dropped, so all columns report as nullable.
 > SHOW COLUMNS FROM test1
 name nullable type     comment
 ------------------------------
-b     false   bigint   ""
-sum   false   numeric  ""
+b     true    bigint   ""
+sum   true    numeric  ""
 
 > SHOW VIEWS LIKE '%data%'
 data_view  ""


### PR DESCRIPTION
### Motivation

The RelationDesc recorded in the catalog and registered with persist for a materialized view carries optimizer-inferred column nullability and unique keys.<br>The desc is re-derived from the `create_sql` on every boot, so an optimizer improvement (e.g. [#36848](<https://github.com/MaterializeInc/materialize/issues/36848>)) or a replacement definition can tighten it while persist retains history written under the looser desc.<br>A time-traveling consumer (`AS OF`, retained history, replicas catching up) can then observe data contradicting the advertised constraints, and the write path's exact-equality schema-id lookup misses, which surfaced as the [PER-22](https://linear.app/materializeinc/issue/PER-22) panic (mitigated symptomatically in MaterializeInc/materialize#36896).

### Description

Canonicalize the exported desc at construction (`RelationDesc::canonicalize_for_persisted_export`): mark every column nullable and drop all unique keys, keeping only write-time-enforced constraints (`ASSERT NOT NULL` columns).<br>The two construction sites (`optimize::materialized_view` and the catalog item parse path) apply the same helper, so created and booted descs are identical and stable across optimizer changes.<br>Internal optimization of the MV's own dataflow keeps the precise types; views, tables, sources, and indexes are unchanged.

The precise inferred desc (nullability and unique keys) is kept as an in-memory-only advisory field on the catalog item, consulted solely by DDL planning: sink planning (validation, natural-key message keying, and the encoded Avro/Iceberg schemas) and default index key selection.<br>Sinks therefore keep today's schema behavior.

User-visible consequences:

* `mz_columns`/`SHOW COLUMNS` report inferred MV columns as nullable; `ASSERT NOT NULL` columns stay non-nullable.
* Replacement materialized views no longer reject nullability- or key-only schema differences.
* Downstream plans over materialized views lose unique-key and non-nullability based optimizations (accepted tradeoff; golden plans updated — including some delta-join index lookups degrading to full scans in the LDBC tests).

### Follow-up work (not in this PR, no issues filed yet)

* **Sink schema stability.** Sink descs are re-derived from `create_sql` at every boot, so inference drift across versions can change a sink's encoded Avro/Iceberg schema (and trip schema-registry compatibility checks) — a pre-existing hazard this PR deliberately leaves unchanged. Candidate fixes: freeze the sink's desc/schema at creation time, or canonicalize sink schemas too (breaking for consumers; needs product sign-off).
* **Sources.** Inferred source desc nullability (`FORMAT REGEX`, also tightened by [#36848](<https://github.com/MaterializeInc/materialize/issues/36848>)) has the same time-travel hazard and is not covered by `evolve_nullability_for_bootstrap`.

### Verification

Adds unit tests for the canonicalization helper (including desc stability across differently-inferred inputs) and an MV nullability assertion in `regex.slt`.<br>Updates the `RegexpExtractNonNullable` platform check to assert the canonical (all-nullable) desc across restart/upgrade, replacement-MV tests for the now-accepted nullability/key differences, a `SHOW COLUMNS` expectation in `materializations.td`, and golden plans (`ldbc_bi*.slt`, `outer_join_simplification.slt`, transform and explain tests).<br>Note: `RestartEntireMz` platform-check scenarios currently fail on `main` with a catalog migration parse panic unrelated to this change (reproduced on a pristine checkout).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)