### PR TITLE
RD-1207558 | Binary Build Requirements Compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,6 +3553,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "fivetran_destination"
+version = "0.0.0"
+dependencies = [
+ "async-compression",
+ "bytes",
+ "clap",
+ "csv-async",
+ "futures",
+ "insta",
+ "itertools 0.14.0",
+ "mz-build-tools",
+ "mz-ore",
+ "mz-pgrepr",
+ "mz-sql-parser",
+ "openssl",
+ "postgres-openssl",
+ "postgres-protocol",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-postgres",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6903,45 +6942,6 @@ dependencies = [
  "proc-macro2",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "mz-fivetran-destination"
-version = "0.0.0"
-dependencies = [
- "async-compression",
- "bytes",
- "clap",
- "csv-async",
- "futures",
- "insta",
- "itertools 0.14.0",
- "mz-build-tools",
- "mz-ore",
- "mz-pgrepr",
- "mz-sql-parser",
- "openssl",
- "postgres-openssl",
- "postgres-protocol",
- "prost",
- "prost-build",
- "prost-types",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sha2",
- "socket2 0.6.4",
- "thiserror 2.0.18",
- "tokio",
- "tokio-postgres",
- "tokio-stream",
- "tokio-util",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mz-fivetran-destination"
+name = "fivetran_destination"
 description = "Fivetran destination for Materialize."
 version = "0.0.0"
 edition.workspace = true

--- a/src/fivetran-destination/README.md
+++ b/src/fivetran-destination/README.md
@@ -23,18 +23,18 @@ for instructions.
 To build the destination into a static Rust binary, run:
 
 ```shell
-cargo build --release -p mz-fivetran-destination
+cargo build --release -p fivetran_destination
 ```
 
 > **Note:** If you already have [`protoc`](https://grpc.io/docs/protoc-installation/) installed
 and in your PATH, you can skip building the vendored version with:
 
 ```shell
-cargo build --release -p mz-fivetran-destination --no-default-features
+cargo build --release -p fivetran_destination --no-default-features
 ```
 
 Cargo will emit the built binary at
-`ROOT/target/release/mz-fivetran-destination.`
+`ROOT/target/release/fivetran_destination.`
 
 ### Docker image distribution
 

--- a/src/fivetran-destination/README.md
+++ b/src/fivetran-destination/README.md
@@ -34,7 +34,7 @@ cargo build --release -p fivetran_destination --no-default-features
 ```
 
 Cargo will emit the built binary at
-`ROOT/target/release/fivetran_destination.`
+`ROOT/target/release/mz-fivetran-destination.`
 
 ### Docker image distribution
 

--- a/src/fivetran-destination/ci/mzbuild.yml
+++ b/src/fivetran-destination/ci/mzbuild.yml
@@ -10,4 +10,4 @@
 name: fivetran-destination
 pre-image:
   - type: cargo-build
-    bin: fivetran-destination
+    bin: mz-fivetran-destination

--- a/src/fivetran-destination/ci/mzbuild.yml
+++ b/src/fivetran-destination/ci/mzbuild.yml
@@ -10,4 +10,4 @@
 name: fivetran-destination
 pre-image:
   - type: cargo-build
-    bin: mz-fivetran-destination
+    bin: fivetran-destination

--- a/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
+++ b/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
@@ -9,8 +9,8 @@
 
 //! Fivetran destination for Materialize.
 
-use mz_fivetran_destination::logging::FivetranLoggingFormat;
-use mz_fivetran_destination::{DestinationConnectorServer, MaterializeDestination};
+use fivetran_destination::logging::FivetranLoggingFormat;
+use fivetran_destination::{DestinationConnectorServer, MaterializeDestination};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
 use socket2::{Domain, Protocol, Socket, Type};


### PR DESCRIPTION
### Description

Standardize Rust package naming to comply with Fivetran binary build pipeline
  

- Renamed library crate from mz-fivetran-destination to fivetran-destination in Cargo.toml, as the Fivetran binary build pipeline requires the package name to be exactly fivetran_destination and builds via
cargo build --release -p fivetran_destination.
- Updated binary entry point (mz-fivetran-destination.rs) to import from the correctly named crate (fivetran_destination:: instead of mz_fivetran_destination::).
- Updated README to reflect the correct binary output path produced by the pipeline (target/release/mz-fivetran-destination).

The changes have been made as per this requirements page published by Fivetran:
https://github.com/fivetran/fivetran_partner_sdk/blob/main/development-guide/binary-build-requirements.md

### Verification
Verified with using the current branch to build the binary using pipeline and it succeeded. 
<img width="470" height="426" alt="Screenshot 2026-06-07 at 8 48 17 PM" src="https://github.com/user-attachments/assets/8ac4b06c-8d07-4d1a-8ed7-5c077a1eedf6" />
