### PR TITLE
sql/vars: split IsolationLevel as_str into as_variant_str and Display

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1602,7 +1602,11 @@ impl RecordFirstRowStream {
             .inner()
             .metrics()
             .time_to_first_row_seconds
-            .with_label_values(&[instance.as_ref(), isolation_level.as_str(), strategy])
+            .with_label_values(&[
+                instance.as_ref(),
+                isolation_level.as_variant_str(),
+                strategy,
+            ])
     }
 
     /// If you want to match [`RecordFirstRowStream`]'s logic but don't need

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1905,14 +1905,14 @@ impl Coordinator {
                     session.add_notice(AdapterNotice::ClusterDoesNotExist { name });
                 } else if name.as_str() == TRANSACTION_ISOLATION_VAR_NAME {
                     let v = values.into_first().to_lowercase();
-                    if v == IsolationLevel::ReadUncommitted.as_str()
-                        || v == IsolationLevel::ReadCommitted.as_str()
-                        || v == IsolationLevel::RepeatableRead.as_str()
+                    if v == IsolationLevel::ReadUncommitted.as_variant_str()
+                        || v == IsolationLevel::ReadCommitted.as_variant_str()
+                        || v == IsolationLevel::RepeatableRead.as_variant_str()
                     {
                         session.add_notice(AdapterNotice::UnimplementedIsolationLevel {
                             isolation_level: v,
                         });
-                    } else if v == IsolationLevel::StrongSessionSerializable.as_str() {
+                    } else if v == IsolationLevel::StrongSessionSerializable.as_variant_str() {
                         session.add_notice(AdapterNotice::StrongSessionSerializable);
                     }
                 }

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -625,7 +625,7 @@ impl Coordinator {
                     true => "true",
                     false => "false",
                 },
-                isolation_level.as_str(),
+                isolation_level.as_variant_str(),
                 &compute_instance.to_string(),
             ])
             .inc();

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -1535,7 +1535,7 @@ impl PeekClient {
                     true => "true",
                     false => "false",
                 },
-                isolation_level.as_str(),
+                isolation_level.as_variant_str(),
                 &compute_instance.to_string(),
             ])
             .inc();

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -415,7 +415,7 @@ impl fmt::Display for AdapterNotice {
                 write!(
                     f,
                     "transaction isolation level {isolation_level} is unimplemented, the session will be upgraded to {}",
-                    IsolationLevel::Serializable.as_str()
+                    IsolationLevel::Serializable
                 )
             }
             AdapterNotice::StrongSessionSerializable => {

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -54,7 +54,7 @@ pub fn plan_set_variable(
     if let VariableValue::Values(values) = &value {
         if let Some(value) = values.first() {
             if name.as_str() == TRANSACTION_ISOLATION_VAR_NAME
-                && value == IsolationLevel::StrongSessionSerializable.as_str()
+                && value == IsolationLevel::StrongSessionSerializable.as_variant_str()
             {
                 scx.require_feature_flag(&vars::ENABLE_SESSION_TIMELINES)?;
             }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -905,7 +905,7 @@ impl SessionVars {
             .vars
             .get_mut(UncasedStr::new(TRANSACTION_ISOLATION.name()))
             .expect("transaction_isolation variable must exist");
-        var.set(VarInput::Flat(transaction_isolation.as_str()), true)
+        var.set(VarInput::Flat(&transaction_isolation.to_string()), true)
             .expect("setting transaction isolation must succeed");
     }
 

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -910,32 +910,46 @@ pub enum IsolationLevel {
 }
 
 impl IsolationLevel {
-    pub fn as_str(&self) -> &'static str {
+    const READ_UNCOMMITTED: &'static str = "read uncommitted";
+    const READ_COMMITTED: &'static str = "read committed";
+    const REPEATABLE_READ: &'static str = "repeatable read";
+    const SERIALIZABLE: &'static str = "serializable";
+    const STRONG_SESSION_SERIALIZABLE: &'static str = "strong session serializable";
+    const STRICT_SERIALIZABLE: &'static str = "strict serializable";
+
+    /// Unit-cardinality variant identifier, suitable for Prometheus labels,
+    /// equality checks against parsed input, and other contexts where one
+    /// bucket per kind of isolation is wanted.
+    ///
+    /// For the user-facing rendering (which round-trips through
+    /// [`Value::parse`]) use the [`fmt::Display`] impl — that is what
+    /// `SHOW transaction_isolation` returns.
+    pub fn as_variant_str(&self) -> &'static str {
         match self {
-            Self::ReadUncommitted => "read uncommitted",
-            Self::ReadCommitted => "read committed",
-            Self::RepeatableRead => "repeatable read",
-            Self::Serializable => "serializable",
-            Self::StrongSessionSerializable => "strong session serializable",
-            Self::StrictSerializable => "strict serializable",
+            Self::ReadUncommitted => Self::READ_UNCOMMITTED,
+            Self::ReadCommitted => Self::READ_COMMITTED,
+            Self::RepeatableRead => Self::REPEATABLE_READ,
+            Self::Serializable => Self::SERIALIZABLE,
+            Self::StrongSessionSerializable => Self::STRONG_SESSION_SERIALIZABLE,
+            Self::StrictSerializable => Self::STRICT_SERIALIZABLE,
         }
     }
 
     fn valid_values() -> Vec<&'static str> {
         vec![
-            Self::ReadUncommitted.as_str(),
-            Self::ReadCommitted.as_str(),
-            Self::RepeatableRead.as_str(),
-            Self::Serializable.as_str(),
-            // TODO(jkosh44) Add StrongSessionSerializable when it becomes available to users.
-            Self::StrictSerializable.as_str(),
+            Self::READ_UNCOMMITTED,
+            Self::READ_COMMITTED,
+            Self::REPEATABLE_READ,
+            Self::SERIALIZABLE,
+            // TODO(jkosh44) Add STRONG_SESSION_SERIALIZABLE when it becomes available to users.
+            Self::STRICT_SERIALIZABLE,
         ]
     }
 }
 
 impl fmt::Display for IsolationLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.write_str(self.as_variant_str())
     }
 }
 
@@ -956,15 +970,15 @@ impl Value for IsolationLevel {
 
         // We don't have any optimizations for levels below Serializable,
         // so we upgrade them all to Serializable.
-        if s == Self::ReadUncommitted.as_str()
-            || s == Self::ReadCommitted.as_str()
-            || s == Self::RepeatableRead.as_str()
-            || s == Self::Serializable.as_str()
+        if s == Self::READ_UNCOMMITTED
+            || s == Self::READ_COMMITTED
+            || s == Self::REPEATABLE_READ
+            || s == Self::SERIALIZABLE
         {
             Ok(Self::Serializable)
-        } else if s == Self::StrongSessionSerializable.as_str() {
+        } else if s == Self::STRONG_SESSION_SERIALIZABLE {
             Ok(Self::StrongSessionSerializable)
-        } else if s == Self::StrictSerializable.as_str() {
+        } else if s == Self::STRICT_SERIALIZABLE {
             Ok(Self::StrictSerializable)
         } else {
             Err(VarParseError::ConstrainedParameter {
@@ -979,7 +993,7 @@ impl Value for IsolationLevel {
     }
 
     fn format(&self) -> String {
-        self.as_str().into()
+        self.to_string()
     }
 }
 


### PR DESCRIPTION
### Motivation

Preparation for parameterised isolation levels (#36328), where the user-facing rendering carries a payload (a duration) that must not leak into Prometheus metric labels.

### Description

Consolidates the isolation-level strings into constants and splits the single `as_str` accessor into `as_variant_str` (unit-cardinality variant identifier, for metric labels and equality checks) and `Display`/`format` (the user-facing rendering that `SHOW` returns and that round-trips through `Value::parse`). Both render identically today, so this is a pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)