### PR TITLE
adapter: route COPY FROM stdin through sequence_copy_from

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -35,9 +35,8 @@ use mz_repr::{CatalogItemId, Datum, Diff, GlobalId, IntoRowIterator, Row, RowAre
 use mz_sql::catalog::{CatalogError, SessionCatalog};
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{
-    self, AbortTransactionPlan, CommitTransactionPlan, CopyFromSource, CreateRolePlan,
-    CreateSourcePlanBundle, FetchPlan, HirScalarExpr, MutationKind, Params, Plan, PlanKind,
-    RaisePlan,
+    self, AbortTransactionPlan, CommitTransactionPlan, CreateRolePlan, CreateSourcePlanBundle,
+    FetchPlan, HirScalarExpr, MutationKind, Params, Plan, PlanKind, RaisePlan,
 };
 use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
@@ -424,24 +423,9 @@ impl Coordinator {
                     self.sequence_peek(ctx, show_columns_plan.select_plan, target_cluster, max)
                         .await;
                 }
-                Plan::CopyFrom(plan) => match plan.source {
-                    CopyFromSource::Stdin => {
-                        let (tx, _, session, ctx_extra) = ctx.into_parts();
-                        tx.send(
-                            Ok(ExecuteResponse::CopyFrom {
-                                target_id: plan.target_id,
-                                target_name: plan.target_name,
-                                columns: plan.columns,
-                                params: plan.params,
-                                ctx_extra,
-                            }),
-                            session,
-                        );
-                    }
-                    CopyFromSource::Url(_) | CopyFromSource::AwsS3 { .. } => {
-                        self.sequence_copy_from(ctx, plan, target_cluster).await;
-                    }
-                },
+                Plan::CopyFrom(plan) => {
+                    self.sequence_copy_from(ctx, plan, target_cluster).await;
+                }
                 Plan::ExplainPlan(plan) => {
                     self.sequence_explain_plan(ctx, plan, target_cluster).await;
                 }

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -50,6 +50,24 @@ impl Coordinator {
         plan: plan::CopyFromPlan,
         target_cluster: TargetCluster,
     ) {
+        // STDIN is sequenced by handing control back to pgwire, which drives the
+        // CopyData/CopyDone exchange. URL/S3 sources stage a one-shot ingestion
+        // server-side and fall through to the rest of this function.
+        if let CopyFromSource::Stdin = plan.source {
+            let (tx, _, session, ctx_extra) = ctx.into_parts();
+            tx.send(
+                Ok(ExecuteResponse::CopyFrom {
+                    target_id: plan.target_id,
+                    target_name: plan.target_name,
+                    columns: plan.columns,
+                    params: plan.params,
+                    ctx_extra,
+                }),
+                session,
+            );
+            return;
+        }
+
         let plan::CopyFromPlan {
             target_name: _,
             target_id,
@@ -182,7 +200,7 @@ impl Coordinator {
                 }
             }
             CopyFromSource::Stdin => {
-                unreachable!("COPY FROM STDIN should be handled elsewhere")
+                unreachable!("STDIN handled by the early return above")
             }
         };
 


### PR DESCRIPTION
### Motivation

Preparation for #36328, which adds an isolation-level check that must apply to every `COPY FROM` variant. Today the stdin case is dispatched directly in the sequencer's plan match, so any such check would have to live in two places.

### Description

Moves the stdin dispatch from the sequencer's plan match into `sequence_copy_from` itself, so all `COPY FROM` sequencing decisions live in one place. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)