### PR TITLE
sql: redact passwd in pg_catalog.pg_user

### DIFF
--- a/src/catalog/src/builtin/pg_catalog.rs
+++ b/src/catalog/src/builtin/pg_catalog.rs
@@ -2081,7 +2081,7 @@ pub static PG_USER: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {
         .with_column("usesuper", SqlScalarType::Bool.nullable(true))
         .with_column("userepl", SqlScalarType::Bool.nullable(false))
         .with_column("usebypassrls", SqlScalarType::Bool.nullable(false))
-        .with_column("passwd", SqlScalarType::String.nullable(true))
+        .with_column("passwd", SqlScalarType::String.nullable(false))
         .with_column(
             "valuntil",
             SqlScalarType::TimestampTz { precision: None }.nullable(true),
@@ -2100,7 +2100,7 @@ SELECT
     rolsuper AS usesuper,
     rolreplication AS userepl,
     rolbypassrls AS usebypassrls,
-    rolpassword as passwd,
+    '********' as passwd,
     rolvaliduntil as valuntil,
     (
         SELECT array_agg(parameter_name || '=' || parameter_value)

--- a/test/sqllogictest/pg_catalog_user.slt
+++ b/test/sqllogictest/pg_catalog_user.slt
@@ -27,9 +27,9 @@ CREATE ROLE "materialize@foocorp.io" WITH LOGIN
 query TIBBBBTTT rowsort
 SELECT usename, usesysid, usecreatedb, usesuper, userepl, usebypassrls, passwd, valuntil, useconfig FROM pg_user;
 ----
-materialize@foocorp.io  20196  false  NULL  false  false  NULL  NULL  NULL
-mz_support  16662  false  true  false  false  NULL  NULL  NULL
-mz_system  16661  true  true  false  false  NULL  NULL  NULL
+materialize@foocorp.io  20196  false  NULL  false  false  ********  NULL  NULL
+mz_support  16662  false  true  false  false  ********  NULL  NULL
+mz_system  16661  true  true  false  false  ********  NULL  NULL
 
 statement ok
 ALTER USER "materialize@foocorp.io" SET search_path = 'abc,def';

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -317,3 +317,16 @@ name                nullable    type    comment
  indexname          false       text    ""
  tablespace         true        text    ""
  indexdef           true        text    ""
+
+# pg_user.passwd is redacted, like pg_roles.rolpassword.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_password_auth = true
+DROP ROLE IF EXISTS passwd_redaction_role
+CREATE ROLE passwd_redaction_role WITH LOGIN PASSWORD 'pw_123'
+
+> SELECT passwd FROM pg_catalog.pg_user WHERE usename = 'passwd_redaction_role'
+"********"
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+DROP ROLE passwd_redaction_role
+ALTER SYSTEM RESET enable_password_auth


### PR DESCRIPTION
Make pg_catalog.pg_user.passwd return the constant '********', matching pg_catalog.pg_roles.rolpassword as well as PostgreSQL and CockroachDB, which always render this column as '********'. The column is now non-nullable to match, mirroring pg_roles.rolpassword.

Adds a testdrive case in pg-catalog.td and updates the pg_catalog_user.slt expectations.

Remove these sections if your commit already has a good description!

### Motivation

Closes SQL-312
