### PR TITLE
ci: fix nightly package-isolation and Miri correction_v2 timeouts

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -118,8 +118,8 @@ steps:
         label: Package-isolated cargo check
         command: bin/ci-builder run stable bin/check-package-isolation
         depends_on: []
-        timeout_in_minutes: 45
-        parallelism: 5
+        timeout_in_minutes: 60
+        parallelism: 8
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         sanitizer: skip

--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -1466,6 +1466,7 @@ mod tests {
     /// structure exists to support), and assert `iter()` roundtrips values, order,
     /// and diffs across the spill boundary.
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow: crossing the ~2 MiB mint boundary needs ~200k updates
     fn chain_builder_roundtrips_across_mint_boundary() {
         // A single `mint()` fires near the ~2 MiB (`SHIP_WORDS`) serialized boundary. With
         // three 8-byte columns per update that's tens of thousands of updates; pushing 200k


### PR DESCRIPTION
Fixes two nightly failures.

### `bin/check-package-isolation` timeout

The job was timing out at 45 minutes. With 119 workspace packages and `parallelism: 5`, each shard checks ~24 packages, each with two `cargo check` invocations (`--all-targets`, then lib+bins under `-D warnings`).

- Bump `parallelism` 5 → 8 (~15 packages/shard, the dominant lever on wall-clock).
- Raise `timeout_in_minutes` 45 → 60 for headroom.

The script already round-robins by `BUILDKITE_PARALLEL_JOB`, so no script change is needed for the parallelism bump.

### Miri timeout in `correction_v2`

`sink::correction_v2::tests::chain_builder_roundtrips_across_mint_boundary` was timing out under Miri (`TIMEOUT [2400s]`). The test deliberately pushes 200k updates to cross the ~2 MiB (`SHIP_WORDS`) mint/spill boundary; that count can't be reduced without defeating the test's purpose, and it is far too slow under the Miri interpreter.

- Add `#[cfg_attr(miri, ignore)] // too slow`, matching the existing convention used elsewhere in the tree (`persist-types`, `environmentd`, …). Correctness is still covered by native test runs.

https://claude.ai/code/session_01SbKGnuokAA1C4wJM5AitK7

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbKGnuokAA1C4wJM5AitK7)_