### PR TITLE
pgwire: match PostgreSQL's diagnostic for missing binary output functions

### DIFF
--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -593,6 +593,11 @@ impl Value {
     /// types) supports binary encoding, or `Err(reason)` describing the first
     /// unsupported type encountered. Container types are checked recursively, so
     /// e.g. a record or array that contains a `list` is rejected.
+    ///
+    /// The error messages mirror PostgreSQL's `no binary output function
+    /// available for type <t>` so that drivers and users see a familiar
+    /// diagnostic. Callers should report these errors with the SQLSTATE
+    /// PostgreSQL uses for the same condition, `42883` (undefined_function).
     pub fn binary_encoding_error(typ: &SqlScalarType) -> Result<(), &'static str> {
         match typ {
             SqlScalarType::Bool => Ok(()),
@@ -612,7 +617,7 @@ impl Value {
             SqlScalarType::Numeric { .. } => Ok(()),
             SqlScalarType::MzTimestamp => Ok(()),
             SqlScalarType::MzAclItem => Ok(()),
-            SqlScalarType::AclItem => Err("binary encoding of aclitem type does not exist"),
+            SqlScalarType::AclItem => Err("no binary output function available for type aclitem"),
             SqlScalarType::Date => Ok(()),
             SqlScalarType::Time => Ok(()),
             SqlScalarType::Timestamp { .. } => Ok(()),
@@ -627,8 +632,8 @@ impl Value {
             SqlScalarType::Uuid => Ok(()),
             SqlScalarType::Array(elem_type) => Self::binary_encoding_error(elem_type),
             SqlScalarType::Int2Vector => Ok(()),
-            SqlScalarType::List { .. } => Err("binary encoding of list types is not implemented"),
-            SqlScalarType::Map { .. } => Err("binary encoding of map types is not implemented"),
+            SqlScalarType::List { .. } => Err("no binary output function available for type list"),
+            SqlScalarType::Map { .. } => Err("no binary output function available for type map"),
             SqlScalarType::Record { fields, .. } => fields
                 .iter()
                 .try_for_each(|(_, ty)| Self::binary_encoding_error(&ty.scalar_type)),

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1461,7 +1461,7 @@ where
                         if let Err(msg) = mz_pgrepr::Value::binary_encoding_error(&ty.scalar_type) {
                             return self
                                 .send_error_and_get_state(ErrorResponse::error(
-                                    SqlState::PROTOCOL_VIOLATION,
+                                    SqlState::UNDEFINED_FUNCTION,
                                     msg,
                                 ))
                                 .await;
@@ -2617,7 +2617,7 @@ where
             {
                 return self
                     .send_error_and_get_state(ErrorResponse::error(
-                        SqlState::PROTOCOL_VIOLATION,
+                        SqlState::UNDEFINED_FUNCTION,
                         msg,
                     ))
                     .await

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -36,17 +36,19 @@ class SmokeTest(unittest.TestCase):
                 row = cur.fetchone()
                 self.assertEqual(row, ("{a=>1,b=>2}",))
 
-            # ...but binary encoding is not.
+            # ...but binary encoding is not. As in PostgreSQL, the absence of a
+            # binary output function is reported as an undefined_function error
+            # (SQLSTATE 42883).
             with conn.cursor(binary=True) as cur:
                 with self.assertRaisesRegex(
-                    psycopg.errors.ProtocolViolation,
-                    "binary encoding of list types is not implemented",
+                    psycopg.errors.UndefinedFunction,
+                    "no binary output function available for type list",
                 ):
                     cur.execute("SELECT LIST[1, 2, 3]")
 
                 with self.assertRaisesRegex(
-                    psycopg.errors.ProtocolViolation,
-                    "binary encoding of map types is not implemented",
+                    psycopg.errors.UndefinedFunction,
+                    "no binary output function available for type map",
                 ):
                     cur.execute("SELECT '{a => 1, b => 2}'::map[text => int]")
 

--- a/test/pgtest-mz/copy-binary-unsupported.pt
+++ b/test/pgtest-mz/copy-binary-unsupported.pt
@@ -1,9 +1,9 @@
-# Binary encoding is not implemented for list, map, and aclitem types. COPY ...
-# TO STDOUT WITH (FORMAT binary) must return a clean error rather than panicking
-# (SQL-323). This is Materialize-specific behavior: list/map don't exist in
-# PostgreSQL, and our aclitem error message/SQLSTATE differs from PostgreSQL's
-# "no binary output function available for type aclitem" (42883), so this lives
-# in pgtest-mz rather than pgtest.
+# Binary encoding is not available for list, map, and aclitem types. COPY ... TO
+# STDOUT WITH (FORMAT binary) must return a clean error rather than panicking
+# (SQL-323). The error matches PostgreSQL's diagnostic for the same condition:
+# `no binary output function available for type <t>` with SQLSTATE 42883
+# (undefined_function). This lives in pgtest-mz rather than pgtest because
+# list/map don't exist in PostgreSQL (so the queries don't parse there).
 
 send
 Query {"query": "COPY (SELECT LIST[1, 2, 3]) TO STDOUT WITH (FORMAT binary)"}
@@ -12,7 +12,7 @@ Query {"query": "COPY (SELECT LIST[1, 2, 3]) TO STDOUT WITH (FORMAT binary)"}
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of list types is not implemented"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42883"},{"typ":"M","value":"no binary output function available for type list"}]}
 ReadyForQuery {"status":"I"}
 
 send
@@ -22,7 +22,7 @@ Query {"query": "COPY (SELECT '{a=>b}'::map[text=>text]) TO STDOUT WITH (FORMAT 
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of map types is not implemented"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42883"},{"typ":"M","value":"no binary output function available for type map"}]}
 ReadyForQuery {"status":"I"}
 
 # aclitem also has no binary encoding.
@@ -33,7 +33,7 @@ Query {"query": "COPY (SELECT makeaclitem(1, 2, 'CREATE', false)) TO STDOUT WITH
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of aclitem type does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42883"},{"typ":"M","value":"no binary output function available for type aclitem"}]}
 ReadyForQuery {"status":"I"}
 
 # Container types are checked recursively: a record containing a list is also
@@ -45,7 +45,7 @@ Query {"query": "COPY (SELECT ROW(1, LIST[1, 2])) TO STDOUT WITH (FORMAT binary)
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"08P01"},{"typ":"M","value":"binary encoding of list types is not implemented"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42883"},{"typ":"M","value":"no binary output function available for type list"}]}
 ReadyForQuery {"status":"I"}
 
 # The text format still works for these types.

--- a/test/sqllogictest/aclitem.slt
+++ b/test/sqllogictest/aclitem.slt
@@ -195,7 +195,7 @@ SELECT a::text from t
 statement ok
 DROP TABLE t
 
-query error binary encoding of aclitem type does not exist
+query error no binary output function available for type aclitem
 SELECT makeaclitem(1, 2, 'CREATE', false)
 
 query T

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -81,15 +81,15 @@ Target cluster: quickstart
 
 EOF
 
-# Binary encoding is not implemented for list, map, and aclitem types, and this
-# is checked recursively for container types. A record containing such a type
-# must return a clean error over the binary result format rather than panicking
-# the server (SQL-323). Casting the offending field to text avoids the error.
+# Binary encoding is not available for list, map, and aclitem types, and this is
+# checked recursively for container types. A record containing such a type must
+# return a clean error over the binary result format rather than panicking the
+# server (SQL-323). Casting the offending field to text avoids the error.
 
-query error binary encoding of list types is not implemented
+query error no binary output function available for type list
 SELECT ROW(1, LIST[1, 2])
 
-query error binary encoding of aclitem type does not exist
+query error no binary output function available for type aclitem
 SELECT ROW(1, makeaclitem(1, 2, 'CREATE', false))
 
 query T

--- a/test/sqllogictest/web-console.slt
+++ b/test/sqllogictest/web-console.slt
@@ -43,7 +43,7 @@ LEFT JOIN mz_introspection.mz_dataflow_operator_parents AS mdop ON mdod.id = mdo
 LEFT JOIN mz_introspection.mz_dataflow_addresses AS mda ON mdod.id = mda.id;
 
 # Note(parkmycar): This suceeds on web, but fails because of pg_repr using binary encoding.
-statement error binary encoding of list types is not implemented
+statement error no binary output function available for type list
 SELECT mdco.id, from_operator_id, from_operator_address, from_port, to_operator_id, to_operator_address, to_port, COALESCE(sum(sent), 0) AS sent
 FROM mz_introspection.mz_dataflow_channel_operators AS mdco
 JOIN mz_introspection.mz_dataflow_channels AS mdc ON mdc.id = mdco.id
@@ -53,7 +53,7 @@ WHERE mce.export_id = 'does_not_exist'
 GROUP BY mdco.id, from_operator_id, from_operator_address, to_operator_id, to_operator_address, from_port, to_port;
 
 # Note(parkmycar): This suceeds on web, but fails because of pg_repr using binary encoding.
-statement error binary encoding of list types is not implemented
+statement error no binary output function available for type list
 SELECT id, address, name, parent_id, arrangement_records, elapsed_ns FROM all_ops WHERE export_id = 'does_not_exist';
 
 # Ensure indexes are used where expected.

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -133,7 +133,7 @@ $ webhook-append database=materialize schema=public name=webhook_json_with_heade
 "\"Hellö String\""
 
 ! SELECT * FROM webhook_json_with_headers;
-contains: binary encoding of map types is not implemented
+contains: no binary output function available for type map
 
 # An invalid body should return a 400.
 $ webhook-append database=materialize schema=public name=webhook_json_with_headers status=400 content-type=application/json


### PR DESCRIPTION
When a client requests a binary result or COPY binary format for a type that has no binary output function, Materialize now reports the same diagnostic as PostgreSQL: SQLSTATE 42883 (undefined_function) with the message `no binary output function available for type <t>`. Verified against postgres:16:

    COPY (SELECT '=r/postgres'::aclitem) TO STDOUT WITH (FORMAT binary);
    ERROR:  42883: no binary output function available for type aclitem

PostgreSQL reports this recursively too, e.g. for aclitem[] and records, which our recursive check mirrors.

08P01 (protocol_violation) would be the wrong code here: protocol_violation means the client sent something malformed, but the client did nothing wrong -- it legitimately requested a binary result or COPY format and the server simply has no binary output function for the type. Adopting PostgreSQL's message and SQLSTATE means drivers and tools that branch on the standard error code -- and users who already know the PostgreSQL diagnostic -- behave consistently against Materialize.

list and map don't exist in PostgreSQL, so there's no upstream wording to copy for them; we use the same phrasing with the type name ("type list" / "type map") for consistency.

Only the user-facing diagnostics returned by `binary_encoding_error` and the SQLSTATE at the two pgwire call sites change. The "should never happen" backstop strings inside `encode_binary` itself are left as-is: they are unreachable because every caller validates first, and they sit next to the comments explaining why a binary encoding isn't implemented.