### PR TITLE
prototype: RECORDER / DELTA TABLE surface over CHANGES

### DIFF
--- a/demo2_driver.sh
+++ b/demo2_driver.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Driver for the second recorder-prototype asciinema demo: arrival-time
+# stamping for Postgres CDC data, replacing a Kafka loopback.
+#
+# Expects: bin/environmentd running; Postgres on 25432 with table
+# public.orders (one seed row) in publication mz_source; secret pgpass and
+# connection pg_conn already created in Materialize.
+set -euo pipefail
+
+HOST=127.0.0.1
+
+type_out() {
+    local s=$1
+    local i
+    for ((i = 0; i < ${#s}; i++)); do
+        printf '%s' "${s:i:1}"
+        sleep 0.012
+    done
+    printf '\n'
+}
+
+say() {
+    printf '\n'
+    type_out "-- $1"
+    sleep 0.4
+}
+
+run() { # run <port> <user> <sql> [password]
+    local port=$1 user=$2 sql=$3 pass=${4:-}
+    printf '\n'
+    type_out "$user> $sql"
+    sleep 0.3
+    local db=materialize opts="-c welcome_message=off"
+    if [ "$port" = 25432 ]; then
+        db=postgres
+        opts=""
+    fi
+    PGPASSWORD="$pass" PGOPTIONS="$opts" psql -P pager=off -h "$HOST" -p "$port" -U "$user" \
+        "$db" -c "$sql"
+    sleep 1.0
+}
+
+sys() { run 6877 mz_system "$1"; }
+usr() { run 6875 materialize "$1"; }
+pg()  { run 25432 postgres "$1" postgres; }
+
+clear
+type_out '# RECORDERS (prototype): stamp CDC data with its arrival time -- as data.'
+type_out '# Today this customer loops data through Kafka just to add an ingestion'
+type_out '# timestamp, then reingests it. A recorder does it in one hop.'
+sleep 1.5
+
+say 'The external system: a Postgres database with an orders table.'
+pg "SELECT * FROM orders;"
+
+say 'Ingest it with a regular Postgres CDC source.'
+usr "CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg_conn (PUBLICATION 'mz_source');"
+usr "CREATE TABLE orders FROM SOURCE pg_src (REFERENCE orders) WITH (RETAIN HISTORY = FOR '1 hour');"
+sleep 3
+usr "SELECT * FROM orders;"
+
+say 'A DELTA TABLE for the stamped changelog, and a RECORDER that records each'
+say 'change with now() frozen at processing time: the arrival timestamp.'
+usr "CREATE DELTA TABLE orders_log (id int, item text, qty int, arrived_at timestamptz) WITH (RETAIN HISTORY = FOR '1 hour');"
+sys "CREATE RECORDER order_arrivals AS RECORD (SELECT c.id, c.item, c.qty, now() AS arrived_at, c.mz_timestamp, c.mz_diff FROM CHANGES(orders AS OF AT LEAST 0) c) INTO orders_log;"
+sleep 3
+usr "SELECT * FROM orders_log;"
+
+say 'A new order lands in Postgres ...'
+pg "INSERT INTO orders VALUES (2, 'monitor', 1);"
+sleep 5
+say '... and arrives stamped. No Kafka, no reingestion.'
+usr "SELECT * FROM orders_log ORDER BY mz_timestamp;"
+
+say 'Updates are stamped too: retract old version, record new version.'
+pg "UPDATE orders SET qty = 5 WHERE id = 2;"
+sleep 5
+usr "SELECT * FROM orders_log ORDER BY mz_timestamp;"
+
+say 'Present it as data: the current orders, each with its arrival time.'
+usr "CREATE VIEW orders_with_arrival AS SELECT DISTINCT ON (id) id, item, qty, arrived_at FROM (SELECT id FROM orders_log GROUP BY id HAVING SUM(mz_diff) > 0) live JOIN orders_log USING (id) WHERE mz_diff > 0 ORDER BY id, mz_timestamp DESC;"
+usr "SELECT * FROM orders_with_arrival ORDER BY id;"
+
+say 'The arrival time is recorded once, at ingestion -- never recomputed,'
+say 'stable across restarts and replicas. The Kafka loopback is gone.'
+sleep 2

--- a/demo2_driver.sh
+++ b/demo2_driver.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 # Driver for the second recorder-prototype asciinema demo: arrival-time
 # stamping for Postgres CDC data, replacing a Kafka loopback.
 #

--- a/demo3_driver.sh
+++ b/demo3_driver.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Driver for the third recorder-prototype asciinema demo: Seth's multi-action
+# recorder — record (key, a) changes with b frozen at processing time,
+# maintain a latest-per-key view, prune superseded log rows.
+set -euo pipefail
+
+HOST=127.0.0.1
+
+type_out() {
+    local s=$1
+    local i
+    for ((i = 0; i < ${#s}; i++)); do
+        printf '%s' "${s:i:1}"
+        sleep 0.010
+    done
+    printf '\n'
+}
+
+say() {
+    printf '\n'
+    type_out "-- $1"
+    sleep 0.4
+}
+
+run() { # run <port> <user> <sql>
+    local port=$1 user=$2 sql=$3
+    printf '\n'
+    type_out "$user> $sql"
+    sleep 0.3
+    PGOPTIONS="-c welcome_message=off" psql -P pager=off -h "$HOST" -p "$port" -U "$user" \
+        materialize -c "$sql"
+    sleep 1.0
+}
+
+run_file() { # run_file <port> <user> <file>: type and run a multi-line statement
+    local port=$1 user=$2 file=$3
+    printf '\n'
+    printf '%s> ' "$user"
+    printf '\n'
+    while IFS= read -r line; do
+        type_out "$line"
+    done <"$file"
+    sleep 0.3
+    PGOPTIONS="-c welcome_message=off" psql -P pager=off -h "$HOST" -p "$port" -U "$user" \
+        materialize -f "$file"
+    sleep 1.0
+}
+
+sys() { run 6877 mz_system "$1"; }
+usr() { run 6875 materialize "$1"; }
+
+clear
+type_out '# RECORDERS (prototype): a multi-action recorder.'
+type_out '# Record (key, a) changes with b frozen at processing time, maintain a'
+type_out '# latest-per-key view, and prune superseded log rows -- one object,'
+type_out '# three composed actions: RECORD / INTEGRATE / DELETE.'
+sleep 1.5
+
+say 'The base table, and the driver: differentiate the projection that drops b,'
+say 'so a b-only edit consolidates to zero and produces no delta.'
+usr "CREATE TABLE foo (key bigint, a bigint, b bigint) WITH (RETAIN HISTORY = FOR '1 hour');"
+usr "CREATE MATERIALIZED VIEW foo_ka WITH (RETAIN HISTORY = FOR '1 hour') AS SELECT key, a FROM foo;"
+
+say 'The durable log of (key, a) changes, with the frozen b.'
+usr "CREATE DELTA TABLE a_log (key bigint, a bigint, b bigint) WITH (RETAIN HISTORY = FOR '1 hour');"
+
+say 'The recorder: three named relations, three actions, one object.'
+cat >/tmp/recorder3.sql <<'SQL'
+CREATE RECORDER foo_a_recorder WITH
+  -- Driver: fires only when (key, a) changes. Joining foo back as a bare
+  -- TVC reference freezes the current b at processing time.
+  recorded AS (
+    SELECT c.key, c.a, f.b, c.mz_timestamp, c.mz_diff
+    FROM CHANGES(foo_ka AS OF AT LEAST 0) c
+    JOIN foo f ON c.key = f.key
+    WHERE c.mz_diff > 0
+  ),
+  -- Most recent recorded row per key.
+  latest AS (
+    SELECT DISTINCT ON (key) key, a, b
+    FROM a_log
+    WHERE mz_diff > 0
+    ORDER BY key, mz_timestamp DESC
+  ),
+  -- Rows that are NOT the per-key latest: a newer recorded row exists.
+  superseded AS (
+    SELECT l.*
+    FROM a_log l
+    WHERE l.mz_diff > 0
+      AND EXISTS (
+        SELECT 1 FROM a_log l2
+        WHERE l2.key = l.key
+          AND l2.mz_diff > 0
+          AND l2.mz_timestamp > l.mz_timestamp
+      )
+  )
+AS
+  RECORD    recorded   INTO a_log,             -- append frozen (key, a, b) deltas
+  INTEGRATE latest     AS   foo_with_frozen_b, -- the maintained view you want
+  DELETE    superseded FROM a_log;             -- bound the log: one row per key
+SQL
+run_file 6877 mz_system /tmp/recorder3.sql
+
+say 'Two rows arrive.'
+usr "INSERT INTO foo VALUES (1, 10, 100), (2, 20, 200);"
+sleep 4
+usr "SELECT * FROM a_log ORDER BY key;"
+usr "SELECT * FROM foo_with_frozen_b ORDER BY key;"
+
+say 'A b-only edit: the projection consolidates to zero deltas -- the recorder'
+say 'does not fire, and the frozen b stays exactly as recorded.'
+usr "UPDATE foo SET b = 999 WHERE key = 1;"
+sleep 4
+usr "SELECT * FROM a_log ORDER BY key;"
+usr "SELECT * FROM foo_with_frozen_b ORDER BY key;"
+
+say 'An edit to a DOES fire, freezing the b of *now* (999).'
+usr "UPDATE foo SET a = 11 WHERE key = 1;"
+sleep 4
+usr "SELECT * FROM a_log ORDER BY key, mz_timestamp;"
+usr "SELECT * FROM foo_with_frozen_b ORDER BY key;"
+
+say 'And the DELETE action prunes the superseded row: the log stays bounded,'
+say 'one row per key.'
+sleep 4
+usr "SELECT * FROM a_log ORDER BY key;"
+
+say 'RECORD, INTEGRATE, DELETE: compositions of one calculus, not three features.'
+sleep 2

--- a/demo4_driver.sh
+++ b/demo4_driver.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Driver for the fourth recorder-prototype asciinema demo: the progress
+# watermark — how the targets' frontier advances with the recorder's inputs.
+# Expects the demo-3 objects (foo, foo_ka, a_log) to exist and no recorder
+# running.
+set -euo pipefail
+
+HOST=127.0.0.1
+
+type_out() {
+    local s=$1
+    local i
+    for ((i = 0; i < ${#s}; i++)); do
+        printf '%s' "${s:i:1}"
+        sleep 0.010
+    done
+    printf '\n'
+}
+
+say() {
+    printf '\n'
+    type_out "-- $1"
+    sleep 0.4
+}
+
+run() { # run <port> <user> <sql>
+    local port=$1 user=$2 sql=$3
+    printf '\n'
+    type_out "$user> $sql"
+    sleep 0.3
+    PGOPTIONS="-c welcome_message=off" psql -P pager=off -h "$HOST" -p "$port" -U "$user" \
+        materialize -c "$sql"
+    sleep 1.0
+}
+
+sys() { run 6877 mz_system "$1"; }
+usr() { run 6875 materialize "$1"; }
+
+clear
+type_out '# RECORDERS (prototype): the progress watermark.'
+type_out '# The recorded data carries timestamps, but a reader also needs to know how'
+type_out '# far the recorder has CONSUMED its inputs -- the frontier of the targets.'
+type_out '# In the full design the commit at T advances the output uppers, including'
+type_out '# empty commits. The prototype expresses that frontier as data instead.'
+sleep 2
+
+say 'A recorder is running (demo 3). Its watermark advances every tick,'
+say 'even though the input is completely idle:'
+usr "SELECT * FROM mz_recorder_progress;"
+sleep 2
+usr "SELECT * FROM mz_recorder_progress;"
+
+say 'The frontier is AHEAD of the newest recorded delta: "no delta at t" is a'
+say 'statement about the input, not about the recorder lagging.'
+usr "SELECT p.consumed_through > max(l.mz_timestamp) AS nothing_new_through_frontier FROM mz_recorder_progress p, a_log l GROUP BY p.consumed_through;"
+
+say 'Now the recorder disappears ...'
+sys "DROP RECORDER foo_a_recorder;"
+sleep 3
+
+say '... and the frontier STALLS while wall clock moves on. The targets still'
+say 'serve, but a reader can see exactly through when they are complete.'
+usr "SELECT consumed_through, mz_now() AS wall_clock, consumed_through < mz_now() AS stalled FROM mz_recorder_progress;"
+sleep 2
+usr "SELECT consumed_through, mz_now() AS wall_clock, consumed_through < mz_now() AS stalled FROM mz_recorder_progress;"
+
+say 'Without the watermark, a dead recorder is indistinguishable from a quiet'
+say 'input. With it, completeness-through-F is part of the recorded state.'
+sleep 2

--- a/demo_driver.sh
+++ b/demo_driver.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Driver for the recorder-prototype asciinema demo.
+set -euo pipefail
+
+export PGOPTIONS="-c welcome_message=off"
+HOST=127.0.0.1
+
+type_out() {
+    local s=$1
+    local i
+    for ((i = 0; i < ${#s}; i++)); do
+        printf '%s' "${s:i:1}"
+        sleep 0.012
+    done
+    printf '\n'
+}
+
+say() {
+    printf '\n'
+    type_out "-- $1"
+    sleep 0.4
+}
+
+run() { # run <port> <user> <sql>
+    local port=$1 user=$2 sql=$3
+    printf '\n'
+    type_out "$user> $sql"
+    sleep 0.3
+    psql -P pager=off -h "$HOST" -p "$port" -U "$user" materialize -c "$sql"
+    sleep 1.0
+}
+
+sys() { run 6877 mz_system "$1"; }
+usr() { run 6875 materialize "$1"; }
+
+clear
+type_out '# RECORDERS (prototype) -- record processing-time decisions, never recompute them'
+type_out '# Design: doc/developer/design/20260604_recorders.md (PR #36909)'
+sleep 1
+
+say 'An event stream and a dimension table.'
+usr "CREATE TABLE events (id int, fk text) WITH (RETAIN HISTORY = FOR '1 hour');"
+usr "CREATE TABLE dim (key text, val text) WITH (RETAIN HISTORY = FOR '1 hour');"
+usr "INSERT INTO dim VALUES ('a', 'EUR 0.92');"
+
+say 'A DELTA TABLE: a durable changelog, with implicit mz_timestamp / mz_diff columns.'
+usr "CREATE DELTA TABLE enriched (id int, fk text, val text) WITH (RETAIN HISTORY = FOR '1 hour');"
+usr "SHOW COLUMNS FROM enriched;"
+
+say 'A RECORDER: on each event delta, look up dim AT PROCESSING TIME and record the result.'
+say 'The bare "dim" reference is a frozen lookup -- freeze is typing, not a keyword.'
+sys "CREATE RECORDER rec AS RECORD (SELECT e.id, e.fk, d.val, e.mz_timestamp, e.mz_diff FROM CHANGES(events AS OF AT LEAST 0) e JOIN dim d ON e.fk = d.key) INTO enriched;"
+
+say 'An event arrives ...'
+usr "INSERT INTO events VALUES (1, 'a');"
+sleep 2.5
+say '... and is recorded with the dim value of *now*.'
+usr "SELECT * FROM enriched;"
+
+say 'The dimension changes ...'
+usr "UPDATE dim SET val = 'EUR 0.95' WHERE key = 'a';"
+sleep 2.5
+say '... but the recorded row does NOT: the value is frozen. No backfill, ever.'
+usr "SELECT * FROM enriched;"
+
+say 'A new event freezes the new value.'
+usr "INSERT INTO events VALUES (2, 'a');"
+sleep 2.5
+usr "SELECT * FROM enriched ORDER BY mz_timestamp;"
+
+say 'Deletes are recorded too, as retraction deltas (mz_diff = -1).'
+usr "DELETE FROM events WHERE id = 1;"
+sleep 2.5
+usr "SELECT * FROM enriched ORDER BY mz_timestamp;"
+
+say 'INTEGRATE by hand: the current state is the integral of the recorded deltas.'
+usr "CREATE VIEW current_enriched AS SELECT DISTINCT ON (id, fk) id, fk, val FROM (SELECT id, fk FROM enriched GROUP BY id, fk HAVING SUM(mz_diff) > 0) live JOIN enriched USING (id, fk) WHERE mz_diff > 0 ORDER BY id, fk, mz_timestamp DESC;"
+usr "SELECT * FROM current_enriched;"
+
+say 'Only the live event remains -- with its frozen, never-recomputed value.'
+sleep 2

--- a/demo_driver.sh
+++ b/demo_driver.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 # Driver for the recorder-prototype asciinema demo.
 set -euo pipefail
 

--- a/recorder_demo.sql
+++ b/recorder_demo.sql
@@ -1,3 +1,12 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
 -- Recorder prototype demo (design doc 20260604_recorders.md, PR #36909).
 --
 -- Run against bin/environmentd:

--- a/recorder_demo.sql
+++ b/recorder_demo.sql
@@ -1,0 +1,64 @@
+-- Recorder prototype demo (design doc 20260604_recorders.md, PR #36909).
+--
+-- Run against bin/environmentd:
+--   as mz_system (psql -h 127.0.0.1 -p 6877 -U mz_system materialize):
+--     the ALTER SYSTEM statements and CREATE/DROP RECORDER;
+--   the rest as materialize (psql -h 127.0.0.1 -p 6875 -U materialize materialize).
+--
+-- Note: all collections read by a recorder body need RETAIN HISTORY for now;
+-- the AT LEAST clamp uses the dataflow-wide since, so a 1s-compacting input
+-- (default) drags the changelog start forward and re-emits the snapshot.
+
+-- 1. Setup (mz_system).
+ALTER SYSTEM SET enable_changes_table_function = true;
+ALTER SYSTEM SET enable_logical_compaction_window = true;
+
+-- 2. Inputs: an event stream and a dimension table.
+CREATE TABLE events (id int, fk text) WITH (RETAIN HISTORY = FOR '1 hour');
+CREATE TABLE dim (key text, val text) WITH (RETAIN HISTORY = FOR '1 hour');
+INSERT INTO dim VALUES ('a', 'EUR 0.92');
+
+-- 3. A DELTA TABLE: implicit mz_timestamp / mz_diff columns.
+CREATE DELTA TABLE enriched (id int, fk text, val text)
+  WITH (RETAIN HISTORY = FOR '1 hour');
+SHOW COLUMNS FROM enriched;
+
+-- 4. The recorder (mz_system): records enriched event deltas. The bare `dim`
+--    reference is a frozen lookup (freeze-by-typing): evaluated at processing
+--    time, recorded once, never recomputed.
+CREATE RECORDER rec AS RECORD (
+  SELECT e.id, e.fk, d.val, e.mz_timestamp, e.mz_diff
+  FROM CHANGES(events AS OF AT LEAST 0) e
+  JOIN dim d ON e.fk = d.key
+) INTO enriched;
+
+-- 5. An event arrives and is recorded with the dim value of *now*.
+INSERT INTO events VALUES (1, 'a');
+SELECT * FROM enriched;          -- 1 | a | EUR 0.92 | <ts> | 1
+
+-- 6. The dimension changes; the recorded row does NOT (frozen).
+UPDATE dim SET val = 'EUR 0.95' WHERE key = 'a';
+SELECT * FROM enriched;          -- unchanged
+
+-- 7. A new event freezes the new value.
+INSERT INTO events VALUES (2, 'a');
+SELECT * FROM enriched;          -- second row with EUR 0.95
+
+-- 8. Deletes are recorded as retraction deltas (mz_diff = -1).
+DELETE FROM events WHERE id = 1;
+SELECT * FROM enriched ORDER BY mz_timestamp;
+
+-- 9. "INTEGRATE" by hand: the current state is the integral of the deltas.
+--    (Liveness from SUM(mz_diff) per key; value from the latest insert. The
+--    frozen value makes whole-row retraction non-exact when the dim changed
+--    in between -- the design doc's documented consolidation hazard.)
+CREATE VIEW current_enriched AS
+  SELECT DISTINCT ON (id, fk) id, fk, val
+  FROM (SELECT id, fk FROM enriched GROUP BY id, fk HAVING SUM(mz_diff) > 0) live
+  JOIN enriched USING (id, fk)
+  WHERE mz_diff > 0
+  ORDER BY id, fk, mz_timestamp DESC;
+SELECT * FROM current_enriched;  -- only event 2, with its frozen EUR 0.95
+
+-- 10. Cleanup (mz_system).
+-- DROP RECORDER rec;

--- a/recorder_demo2.sql
+++ b/recorder_demo2.sql
@@ -1,0 +1,49 @@
+-- Recorder prototype demo 2: arrival-time stamping for CDC data.
+--
+-- Customer story: data is ingested from an external Postgres system, and the
+-- time it entered Materialize must be available *as data*. Today that is
+-- emulated by looping the data through Kafka to attach a timestamp and
+-- reingesting it. A recorder stamps it on ingestion instead.
+--
+-- Setup outside this script:
+--   docker run --name demo-pg -d -p 25432:5432 -e POSTGRES_PASSWORD=postgres \
+--     postgres:16 -c wal_level=logical
+--   In Postgres: CREATE TABLE orders (id int PRIMARY KEY, item text, qty int);
+--     ALTER TABLE orders REPLICA IDENTITY FULL;
+--     CREATE PUBLICATION mz_source FOR TABLE orders;
+--   In Materialize (flags as in recorder_demo.sql), plus:
+--     CREATE SECRET pgpass AS 'postgres';
+--     CREATE CONNECTION pg_conn TO POSTGRES (HOST '127.0.0.1', PORT 25432,
+--       USER postgres, PASSWORD SECRET pgpass, DATABASE postgres,
+--       SSL MODE disable);
+--
+-- Note: requires the prototype's relaxed read-then-write dependency check
+-- (sources readable in INSERT ... SELECT); see coord/read_then_write.rs.
+
+-- 1. Ingest via a regular Postgres CDC source.
+CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg_conn (PUBLICATION 'mz_source');
+CREATE TABLE orders FROM SOURCE pg_src (REFERENCE orders)
+  WITH (RETAIN HISTORY = FOR '1 hour');
+
+-- 2. The stamped changelog and the recorder. `now()` is frozen at processing
+--    time: the arrival timestamp, recorded once, never recomputed.
+CREATE DELTA TABLE orders_log (id int, item text, qty int, arrived_at timestamptz)
+  WITH (RETAIN HISTORY = FOR '1 hour');
+CREATE RECORDER order_arrivals AS RECORD (  -- as mz_system
+  SELECT c.id, c.item, c.qty, now() AS arrived_at, c.mz_timestamp, c.mz_diff
+  FROM CHANGES(orders AS OF AT LEAST 0) c
+) INTO orders_log;
+
+-- 3. Insert / update rows in Postgres; each change arrives stamped:
+--    inserts as +1 deltas, updates as retract/insert pairs, all with
+--    arrived_at = when the change entered Materialize.
+SELECT * FROM orders_log ORDER BY mz_timestamp;
+
+-- 4. Present it as data: current orders, each with its arrival time.
+CREATE VIEW orders_with_arrival AS
+  SELECT DISTINCT ON (id) id, item, qty, arrived_at
+  FROM (SELECT id FROM orders_log GROUP BY id HAVING SUM(mz_diff) > 0) live
+  JOIN orders_log USING (id)
+  WHERE mz_diff > 0
+  ORDER BY id, mz_timestamp DESC;
+SELECT * FROM orders_with_arrival ORDER BY id;

--- a/recorder_demo2.sql
+++ b/recorder_demo2.sql
@@ -1,3 +1,12 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
 -- Recorder prototype demo 2: arrival-time stamping for CDC data.
 --
 -- Customer story: data is ingested from an external Postgres system, and the

--- a/recorder_demo3.sql
+++ b/recorder_demo3.sql
@@ -1,0 +1,41 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE RECORDER foo_a_recorder WITH
+  -- Driver: fires only when (key, a) changes. Joining foo back as a bare
+  -- TVC reference freezes the current b at processing time.
+  recorded AS (
+    SELECT c.key, c.a, f.b, c.mz_timestamp, c.mz_diff
+    FROM CHANGES(foo_ka AS OF AT LEAST 0) c
+    JOIN foo f ON c.key = f.key
+    WHERE c.mz_diff > 0
+  ),
+  -- Most recent recorded row per key.
+  latest AS (
+    SELECT DISTINCT ON (key) key, a, b
+    FROM a_log
+    WHERE mz_diff > 0
+    ORDER BY key, mz_timestamp DESC
+  ),
+  -- Rows that are NOT the per-key latest: a newer recorded row exists.
+  superseded AS (
+    SELECT l.*
+    FROM a_log l
+    WHERE l.mz_diff > 0
+      AND EXISTS (
+        SELECT 1 FROM a_log l2
+        WHERE l2.key = l.key
+          AND l2.mz_diff > 0
+          AND l2.mz_timestamp > l.mz_timestamp
+      )
+  )
+AS
+  RECORD    recorded   INTO a_log,             -- append frozen (key, a, b) deltas
+  INTEGRATE latest     AS   foo_with_frozen_b, -- the maintained view you want
+  DELETE    superseded FROM a_log;             -- bound the log: one row per key

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -583,6 +583,10 @@ pub enum ExecuteResponse {
     CreatedType,
     /// The requested network policy was created.
     CreatedNetworkPolicy,
+    /// The requested recorder was created (prototype).
+    CreatedRecorder,
+    /// The requested recorder was dropped (prototype).
+    DroppedRecorder,
     /// The requested prepared statement was removed.
     Deallocate { all: bool },
     /// The requested cursor was declared.
@@ -749,6 +753,8 @@ impl TryInto<ExecuteResponse> for ExecuteResponseKind {
                 Ok(ExecuteResponse::CreatedMaterializedView)
             }
             ExecuteResponseKind::CreatedNetworkPolicy => Ok(ExecuteResponse::CreatedNetworkPolicy),
+            ExecuteResponseKind::CreatedRecorder => Ok(ExecuteResponse::CreatedRecorder),
+            ExecuteResponseKind::DroppedRecorder => Ok(ExecuteResponse::DroppedRecorder),
             ExecuteResponseKind::CreatedType => Ok(ExecuteResponse::CreatedType),
             ExecuteResponseKind::Deallocate => Err(()),
             ExecuteResponseKind::DeclaredCursor => Ok(ExecuteResponse::DeclaredCursor),
@@ -812,6 +818,8 @@ impl ExecuteResponse {
             CreatedMaterializedView { .. } => Some("CREATE MATERIALIZED VIEW".into()),
             CreatedType => Some("CREATE TYPE".into()),
             CreatedNetworkPolicy => Some("CREATE NETWORKPOLICY".into()),
+            CreatedRecorder => Some("CREATE RECORDER".into()),
+            DroppedRecorder => Some("DROP RECORDER".into()),
             Deallocate { all } => Some(format!("DEALLOCATE{}", if *all { " ALL" } else { "" })),
             DeclaredCursor => Some("DECLARE CURSOR".into()),
             Deleted(n) => Some(format!("DELETE {}", n)),
@@ -940,6 +948,8 @@ impl ExecuteResponse {
             StartTransaction => &[StartedTransaction],
             SideEffectingFunc => &[SendingRowsStreaming, SendingRowsImmediate],
             ValidateConnection => &[ExecuteResponseKind::ValidatedConnection],
+            CreateRecorder => &[ExecuteResponseKind::CreatedRecorder],
+            DropRecorder => &[ExecuteResponseKind::DroppedRecorder],
         }
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -218,6 +218,7 @@ pub(crate) mod in_memory_oracle;
 pub(crate) mod peek;
 pub(crate) mod read_policy;
 pub(crate) mod read_then_write;
+pub(crate) mod recorder;
 pub(crate) mod sequencer;
 pub(crate) mod statement_logging;
 pub(crate) mod timeline;
@@ -1881,6 +1882,9 @@ pub struct Coordinator {
     active_compute_sinks: BTreeMap<GlobalId, ActiveComputeSink>,
     /// A map from active webhooks to their invalidation handle.
     active_webhooks: BTreeMap<CatalogItemId, WebhookAppenderInvalidator>,
+    /// Active recorders (prototype): name to polling-task handle; dropping a
+    /// handle aborts the task. Not catalog-backed, lost on restart.
+    recorders: BTreeMap<String, mz_ore::task::AbortOnDropHandle<()>>,
     /// A map of active `COPY FROM` statements. The Coordinator waits for `clusterd`
     /// to stage Batches in Persist that we will then link into the shard.
     active_copies: BTreeMap<ConnectionId, ActiveCopyFrom>,
@@ -4712,6 +4716,7 @@ pub fn serve(
                     serialized_ddl: LockedVecDeque::new(),
                     active_compute_sinks: BTreeMap::new(),
                     active_webhooks: BTreeMap::new(),
+                    recorders: BTreeMap::new(),
                     active_copies: BTreeMap::new(),
                     connection_cancel_watches: BTreeMap::new(),
                     introspection_subscribes: BTreeMap::new(),

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -1006,6 +1006,8 @@ pub(crate) fn waiting_on_startup_appends(
         | Plan::Insert(_)
         | Plan::AlterNetworkPolicy(_)
         | Plan::AlterNoop(_)
+        | Plan::CreateRecorder(_)
+        | Plan::DropRecorder(_)
         | Plan::AlterClusterRename(_)
         | Plan::AlterClusterSwap(_)
         | Plan::AlterClusterReplicaRename(_)

--- a/src/adapter/src/coord/catalog_serving.rs
+++ b/src/adapter/src/coord/catalog_serving.rs
@@ -164,6 +164,8 @@ pub fn auto_run_on_catalog_server<'a, 's, 'p>(
         | Plan::AlterDefaultPrivileges(_)
         | Plan::ReassignOwned(_)
         | Plan::ValidateConnection(_)
+        | Plan::CreateRecorder(_)
+        | Plan::DropRecorder(_)
         | Plan::SideEffectingFunc(_) => return TargetCluster::Active,
     };
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1324,6 +1324,8 @@ impl Coordinator {
                     | Statement::Update(_)
                     | Statement::ValidateConnection(_)
                     | Statement::Comment(_)
+                    | Statement::CreateRecorder(_)
+                    | Statement::DropRecorder(_)
                     | Statement::ExecuteUnitTest(_) => {
                         let txn_status = ctx.session_mut().transaction_mut();
 

--- a/src/adapter/src/coord/read_then_write.rs
+++ b/src/adapter/src/coord/read_then_write.rs
@@ -55,17 +55,21 @@ pub(crate) fn validate_read_then_write_dependencies(
                     let valid_id = id.is_user() || matches!(typ, Func);
                     valid_id
                 }
-                Source | Secret | Connection => false,
+                // Recorder prototype: sources (and source-export tables,
+                // below) are readable in read-then-write. Their frontiers move
+                // independently of the write timestamp, so the read may block
+                // until the source catches up and writes may land between the
+                // read and the write — the at-least-once semantics the
+                // recorder design accepts. Restore `false` outside the
+                // prototype.
+                Source => true,
+                Secret | Connection => false,
                 // Cannot select from sinks or indexes.
                 Sink | Index => unreachable!(),
                 Table => {
-                    if !id.is_user() {
-                        // We can't read from non-user tables
-                        false
-                    } else {
-                        // We can't read from tables that are source-exports
-                        entry.source_export_details().is_none()
-                    }
+                    // We can't read from non-user tables, but (recorder
+                    // prototype) source-export tables are allowed; see above.
+                    id.is_user()
                 }
                 Type => true,
             }

--- a/src/adapter/src/coord/recorder.rs
+++ b/src/adapter/src/coord/recorder.rs
@@ -9,45 +9,57 @@
 
 //! Prototype runtime for `RECORDER`s (design doc `20260604_recorders.md`).
 //!
-//! A recorder runs a body query (a dTVC, typically over `CHANGES(...)`) and
-//! records its deltas into a `DELTA TABLE`. This prototype takes the largest
-//! shortcut available: instead of a standing dataflow plus an OCC commit at a
-//! target `T`, the coordinator spawns a task that periodically re-executes the
-//! body through an internal SQL self-connection as
+//! A recorder binds named relations (dTVCs, typically over `CHANGES(...)`)
+//! and a set of actions over them. This prototype takes the largest shortcut
+//! available: instead of a standing dataflow plus an OCC commit at a target
+//! `T`, the coordinator spawns a task that periodically re-executes the
+//! actions through an internal SQL self-connection.
 //!
-//! ```sql
-//! INSERT INTO <target>
-//! SELECT * FROM (<body>) AS __record
-//! WHERE COALESCE(__record.mz_timestamp >
-//!     (SELECT MAX(mz_timestamp) FROM <target>), TRUE);
-//! ```
+//! Per tick, each action becomes one SQL statement (named relations are
+//! prefixed as CTEs):
 //!
-//! The `max(mz_timestamp)` filter is the recorder's "consumed-through" frontier
-//! (the design's "resume from the output's upper"): a one-off `CHANGES` read at
-//! time `T` returns all deltas `<= T`, so every poll records exactly the deltas
-//! that arrived since the previous poll, idempotently and restart-safe.
-//! Freeze-by-typing falls out: a bare TVC reference joined in the body is
-//! evaluated at the poll's processing time, and re-evaluations of old driver
-//! deltas (after the reference changed) are discarded by the frontier filter.
+//! * `RECORD r INTO t` —
+//!   ```sql
+//!   INSERT INTO t WITH <rels...>, __record AS (SELECT * FROM r)
+//!   SELECT * FROM __record
+//!   WHERE COALESCE(__record.mz_timestamp >
+//!       (SELECT MAX(mz_timestamp) FROM t), TRUE);
+//!   ```
+//!   The `max(mz_timestamp)` filter is the recorder's "consumed-through"
+//!   frontier (the design's "resume from the output's upper"): a one-off
+//!   `CHANGES` read at time `T` returns all deltas `<= T`, so every poll
+//!   records exactly the deltas that arrived since the previous poll,
+//!   idempotently and restart-safe. Freeze-by-typing falls out: a bare TVC
+//!   reference joined in the body is evaluated at the poll's processing time,
+//!   and re-evaluations of old driver deltas (after the reference changed)
+//!   are discarded by the frontier filter.
+//! * `INTEGRATE r AS v` — a one-time `CREATE VIEW v AS WITH <rels...>
+//!   SELECT * FROM r` (a maintained view over the durable delta table; the
+//!   design's "recomputes and self-corrects" restart behavior for free).
+//! * `DELETE r FROM t` — `DELETE FROM t WHERE (<cols>) IN (SELECT <cols>
+//!   FROM ...)`, with `t`'s column list fetched from the catalog. `r` must
+//!   select full rows of `t`.
 //!
 //! Shortcuts taken (prototype only):
-//! * Recorders are in-memory coordinator state, not catalog items; they do not
-//!   survive a restart (the recorded data does, and a re-created recorder
+//! * Recorders are in-memory coordinator state, not catalog items; they do
+//!   not survive a restart (the recorded data does, and a re-created recorder
 //!   resumes from the target's contents).
-//! * Commits ride the ordinary table write path at an oracle-chosen timestamp;
-//!   there is no atomic multi-action bundle commit at a chosen `T`.
-//! * One action (`RECORD ... INTO`); no `INTEGRATE`/`DELETE` actions.
+//! * Actions run sequentially per tick, not as one atomic bundle at a chosen
+//!   `T`; cross-action consistency is eventual (the design's `T+1` visibility
+//!   rule, stretched to one tick).
+//! * Reads of the recorder's own outputs observe the previously committed
+//!   state (the design's pre-commit snapshot rule, for free).
 
 use std::time::Duration;
 
-use mz_sql::plan::{CreateRecorderPlan, DropRecorderPlan};
+use mz_sql::plan::{CreateRecorderPlan, DropRecorderPlan, RecorderActionPlan};
 use tracing::{info, warn};
 
 use crate::ExecuteResponse;
 use crate::coord::Coordinator;
 use crate::error::AdapterError;
 
-/// How often a recorder re-executes its body.
+/// How often a recorder re-executes its actions.
 const TICK_INTERVAL: Duration = Duration::from_secs(1);
 
 impl Coordinator {
@@ -58,26 +70,18 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         let CreateRecorderPlan {
             name,
-            body_sql,
-            target,
+            rels,
+            actions,
         } = plan;
         if self.recorders.contains_key(&name) {
             return Err(AdapterError::Unstructured(anyhow::anyhow!(
                 "recorder {name} already exists"
             )));
         }
-        // The COALESCE makes the empty-target case (MAX is NULL) record
-        // everything, without needing a literal of type mz_timestamp.
-        let insert_sql = format!(
-            "INSERT INTO {target} \
-             SELECT * FROM ({body_sql}) AS __record \
-             WHERE COALESCE(__record.mz_timestamp > \
-             (SELECT MAX(mz_timestamp) FROM {target}), TRUE)"
-        );
         let task_name = format!("recorder-{name}");
         let recorder_name = name.clone();
         let handle = mz_ore::task::spawn(|| task_name, async move {
-            recorder_loop(recorder_name, insert_sql).await;
+            recorder_loop(recorder_name, rels, actions).await;
         });
         self.recorders.insert(name, handle.abort_on_drop());
         Ok(ExecuteResponse::CreatedRecorder)
@@ -99,13 +103,98 @@ impl Coordinator {
     }
 }
 
-/// The recorder's polling loop: (re)connect to the internal SQL listener and
-/// re-execute the record statement every [`TICK_INTERVAL`].
-async fn recorder_loop(name: String, insert_sql: String) {
-    let addr = std::env::var("MZ_RECORDER_SQL_ADDR")
-        .unwrap_or_else(|_| "postgres://mz_system@127.0.0.1:6877/materialize".into());
-    info!(recorder = %name, sql = %insert_sql, "recorder starting");
+/// Builds the `WITH <name> AS (<body>), ...` prefix containing the relations
+/// the relation `root` (transitively) references, in declaration order.
+///
+/// References are detected textually (word match) — fine for the prototype,
+/// where relation names are simple identifiers.
+fn cte_prefix(rels: &[(String, String)], root: &str) -> String {
+    let references = |sql: &str, name: &str| {
+        sql.split(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .any(|word| word == name)
+    };
+    // Iterate to a fixpoint: a relation is needed if the root or any needed
+    // relation references it.
+    let mut needed = vec![false; rels.len()];
     loop {
+        let mut changed = false;
+        for (i, (name, _)) in rels.iter().enumerate() {
+            if needed[i] {
+                continue;
+            }
+            let root_refs = root == name;
+            let rel_refs = rels
+                .iter()
+                .zip(needed.iter())
+                .any(|((_, sql), n)| *n && references(sql, name));
+            if root_refs || rel_refs {
+                needed[i] = true;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    let ctes: Vec<String> = rels
+        .iter()
+        .zip(needed.iter())
+        .filter(|(_, n)| **n)
+        .map(|((name, sql), _)| format!("{name} AS ({sql})"))
+        .collect();
+    if ctes.is_empty() {
+        String::new()
+    } else {
+        format!("WITH {} ", ctes.join(", "))
+    }
+}
+
+/// The SQL for one tick of a `RECORD` action.
+fn record_sql(rels: &[(String, String)], action: &RecorderActionPlan) -> Option<String> {
+    let RecorderActionPlan::Record {
+        rel,
+        query_sql,
+        into,
+    } = action
+    else {
+        return None;
+    };
+    let (mut prefix, body) = match (rel, query_sql) {
+        (Some(rel), _) => (cte_prefix(rels, rel), format!("SELECT * FROM {rel}")),
+        (None, Some(sql)) => (String::new(), sql.clone()),
+        (None, None) => return None,
+    };
+    if prefix.is_empty() {
+        prefix = "WITH ".into();
+    } else {
+        prefix.truncate(prefix.len() - 1);
+        prefix.push_str(", ");
+    }
+    // The COALESCE makes the empty-target case (MAX is NULL) record
+    // everything, without needing a literal of type mz_timestamp.
+    Some(format!(
+        "INSERT INTO {into} {prefix}__record AS ({body}) \
+         SELECT * FROM __record \
+         WHERE COALESCE(__record.mz_timestamp > \
+         (SELECT MAX(mz_timestamp) FROM {into}), TRUE)"
+    ))
+}
+
+/// The recorder's polling loop: (re)connect to the internal SQL listener,
+/// perform one-time setup (`INTEGRATE` views, `DELETE` column lists), and
+/// re-execute the `RECORD`/`DELETE` actions every [`TICK_INTERVAL`].
+async fn recorder_loop(
+    name: String,
+    rels: Vec<(String, String)>,
+    actions: Vec<RecorderActionPlan>,
+) {
+    // Run as the default user on the external listener, so objects the
+    // recorder creates (INTEGRATE views) and reads share ownership with the
+    // user's objects. (Local bin/environmentd has no authentication.)
+    let addr = std::env::var("MZ_RECORDER_SQL_ADDR")
+        .unwrap_or_else(|_| "postgres://materialize@127.0.0.1:6875/materialize".into());
+    info!(recorder = %name, "recorder starting");
+    'reconnect: loop {
         let client = match tokio_postgres::connect(&addr, tokio_postgres::NoTls).await {
             Ok((client, conn)) => {
                 let conn_task = format!("recorder-{name}-conn");
@@ -122,17 +211,74 @@ async fn recorder_loop(name: String, insert_sql: String) {
                 continue;
             }
         };
+
+        // One-time setup, idempotent across reconnects: INTEGRATE views and
+        // the per-tick statements for RECORD/DELETE actions.
+        let mut tick_sqls = Vec::new();
+        for action in &actions {
+            match action {
+                RecorderActionPlan::Record { .. } => {
+                    tick_sqls.extend(record_sql(&rels, action));
+                }
+                RecorderActionPlan::Integrate { rel, view } => {
+                    let prefix = cte_prefix(&rels, rel);
+                    let sql = format!("CREATE VIEW {view} AS {prefix}SELECT * FROM {rel}");
+                    match client.execute(&sql, &[]).await {
+                        Ok(_) => info!(recorder = %name, view, "recorder created integrate view"),
+                        // "already exists" is fine (re-create or reconnect).
+                        Err(err) if err.to_string().contains("already exists") => {}
+                        Err(err) => {
+                            warn!(recorder = %name, "recorder integrate failed: {err}");
+                            tokio::time::sleep(TICK_INTERVAL).await;
+                            continue 'reconnect;
+                        }
+                    }
+                }
+                RecorderActionPlan::Delete { rel, from } => {
+                    // Fetch the target's column list; `rel` must select full
+                    // rows of `from`.
+                    let bare = from.rsplit('.').next().unwrap_or(from).replace('"', "");
+                    let cols_query = "SELECT column_name FROM information_schema.columns \
+                         WHERE table_name = $1 ORDER BY ordinal_position";
+                    let cols: Vec<String> = match client.query(cols_query, &[&bare]).await {
+                        Ok(rows) => rows.iter().map(|r| r.get::<_, String>(0)).collect(),
+                        Err(err) => {
+                            warn!(recorder = %name, "recorder column fetch failed: {err}");
+                            tokio::time::sleep(TICK_INTERVAL).await;
+                            continue 'reconnect;
+                        }
+                    };
+                    if cols.is_empty() {
+                        warn!(recorder = %name, from, "recorder delete target has no columns");
+                        tokio::time::sleep(TICK_INTERVAL).await;
+                        continue 'reconnect;
+                    }
+                    let col_list = cols.join(", ");
+                    let prefix = cte_prefix(&rels, rel);
+                    tick_sqls.push(format!(
+                        "DELETE FROM {from} WHERE ({col_list}) IN \
+                         (SELECT {col_list} FROM ({prefix}SELECT * FROM {rel}) AS __delete)"
+                    ));
+                }
+            }
+        }
+        for sql in &tick_sqls {
+            info!(recorder = %name, sql = %sql, "recorder tick statement");
+        }
+
         loop {
             tokio::time::sleep(TICK_INTERVAL).await;
-            match client.execute(&insert_sql, &[]).await {
-                Ok(rows) if rows > 0 => {
-                    info!(recorder = %name, rows, "recorder recorded deltas");
-                }
-                Ok(_) => {}
-                Err(err) => {
-                    warn!(recorder = %name, "recorder tick failed: {err}");
-                    if client.is_closed() {
-                        break;
+            for sql in &tick_sqls {
+                match client.execute(sql.as_str(), &[]).await {
+                    Ok(rows) if rows > 0 => {
+                        info!(recorder = %name, rows, "recorder applied action");
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        warn!(recorder = %name, "recorder tick failed: {err}");
+                        if client.is_closed() {
+                            continue 'reconnect;
+                        }
                     }
                 }
             }

--- a/src/adapter/src/coord/recorder.rs
+++ b/src/adapter/src/coord/recorder.rs
@@ -1,0 +1,141 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Prototype runtime for `RECORDER`s (design doc `20260604_recorders.md`).
+//!
+//! A recorder runs a body query (a dTVC, typically over `CHANGES(...)`) and
+//! records its deltas into a `DELTA TABLE`. This prototype takes the largest
+//! shortcut available: instead of a standing dataflow plus an OCC commit at a
+//! target `T`, the coordinator spawns a task that periodically re-executes the
+//! body through an internal SQL self-connection as
+//!
+//! ```sql
+//! INSERT INTO <target>
+//! SELECT * FROM (<body>) AS __record
+//! WHERE COALESCE(__record.mz_timestamp >
+//!     (SELECT MAX(mz_timestamp) FROM <target>), TRUE);
+//! ```
+//!
+//! The `max(mz_timestamp)` filter is the recorder's "consumed-through" frontier
+//! (the design's "resume from the output's upper"): a one-off `CHANGES` read at
+//! time `T` returns all deltas `<= T`, so every poll records exactly the deltas
+//! that arrived since the previous poll, idempotently and restart-safe.
+//! Freeze-by-typing falls out: a bare TVC reference joined in the body is
+//! evaluated at the poll's processing time, and re-evaluations of old driver
+//! deltas (after the reference changed) are discarded by the frontier filter.
+//!
+//! Shortcuts taken (prototype only):
+//! * Recorders are in-memory coordinator state, not catalog items; they do not
+//!   survive a restart (the recorded data does, and a re-created recorder
+//!   resumes from the target's contents).
+//! * Commits ride the ordinary table write path at an oracle-chosen timestamp;
+//!   there is no atomic multi-action bundle commit at a chosen `T`.
+//! * One action (`RECORD ... INTO`); no `INTEGRATE`/`DELETE` actions.
+
+use std::time::Duration;
+
+use mz_sql::plan::{CreateRecorderPlan, DropRecorderPlan};
+use tracing::{info, warn};
+
+use crate::ExecuteResponse;
+use crate::coord::Coordinator;
+use crate::error::AdapterError;
+
+/// How often a recorder re-executes its body.
+const TICK_INTERVAL: Duration = Duration::from_secs(1);
+
+impl Coordinator {
+    /// Creates a recorder: spawns its polling task and registers it.
+    pub(crate) fn sequence_create_recorder(
+        &mut self,
+        plan: CreateRecorderPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let CreateRecorderPlan {
+            name,
+            body_sql,
+            target,
+        } = plan;
+        if self.recorders.contains_key(&name) {
+            return Err(AdapterError::Unstructured(anyhow::anyhow!(
+                "recorder {name} already exists"
+            )));
+        }
+        // The COALESCE makes the empty-target case (MAX is NULL) record
+        // everything, without needing a literal of type mz_timestamp.
+        let insert_sql = format!(
+            "INSERT INTO {target} \
+             SELECT * FROM ({body_sql}) AS __record \
+             WHERE COALESCE(__record.mz_timestamp > \
+             (SELECT MAX(mz_timestamp) FROM {target}), TRUE)"
+        );
+        let task_name = format!("recorder-{name}");
+        let recorder_name = name.clone();
+        let handle = mz_ore::task::spawn(|| task_name, async move {
+            recorder_loop(recorder_name, insert_sql).await;
+        });
+        self.recorders.insert(name, handle.abort_on_drop());
+        Ok(ExecuteResponse::CreatedRecorder)
+    }
+
+    /// Drops a recorder: deregisters it, aborting its task.
+    pub(crate) fn sequence_drop_recorder(
+        &mut self,
+        plan: DropRecorderPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        match self.recorders.remove(&plan.name) {
+            // Dropping the handle aborts the task.
+            Some(_handle) => Ok(ExecuteResponse::DroppedRecorder),
+            None => Err(AdapterError::Unstructured(anyhow::anyhow!(
+                "unknown recorder {}",
+                plan.name
+            ))),
+        }
+    }
+}
+
+/// The recorder's polling loop: (re)connect to the internal SQL listener and
+/// re-execute the record statement every [`TICK_INTERVAL`].
+async fn recorder_loop(name: String, insert_sql: String) {
+    let addr = std::env::var("MZ_RECORDER_SQL_ADDR")
+        .unwrap_or_else(|_| "postgres://mz_system@127.0.0.1:6877/materialize".into());
+    info!(recorder = %name, sql = %insert_sql, "recorder starting");
+    loop {
+        let client = match tokio_postgres::connect(&addr, tokio_postgres::NoTls).await {
+            Ok((client, conn)) => {
+                let conn_task = format!("recorder-{name}-conn");
+                mz_ore::task::spawn(|| conn_task, async move {
+                    // Terminates when the client is dropped; an error here
+                    // surfaces as a failed query in the tick loop.
+                    let _ = conn.await;
+                });
+                client
+            }
+            Err(err) => {
+                warn!(recorder = %name, "recorder connect failed: {err}");
+                tokio::time::sleep(TICK_INTERVAL).await;
+                continue;
+            }
+        };
+        loop {
+            tokio::time::sleep(TICK_INTERVAL).await;
+            match client.execute(&insert_sql, &[]).await {
+                Ok(rows) if rows > 0 => {
+                    info!(recorder = %name, rows, "recorder recorded deltas");
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    warn!(recorder = %name, "recorder tick failed: {err}");
+                    if client.is_closed() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/adapter/src/coord/recorder.rs
+++ b/src/adapter/src/coord/recorder.rs
@@ -59,6 +59,14 @@ use crate::ExecuteResponse;
 use crate::coord::Coordinator;
 use crate::error::AdapterError;
 
+/// The detailed message of a tokio-postgres error (its `Display` is just
+/// "db error").
+fn err_msg(err: &tokio_postgres::Error) -> String {
+    err.as_db_error()
+        .map(|e| e.message().to_string())
+        .unwrap_or_else(|| err.to_string())
+}
+
 /// How often a recorder re-executes its actions.
 const TICK_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -226,9 +234,9 @@ async fn recorder_loop(
                     match client.execute(&sql, &[]).await {
                         Ok(_) => info!(recorder = %name, view, "recorder created integrate view"),
                         // "already exists" is fine (re-create or reconnect).
-                        Err(err) if err.to_string().contains("already exists") => {}
+                        Err(err) if err_msg(&err).contains("already exists") => {}
                         Err(err) => {
-                            warn!(recorder = %name, "recorder integrate failed: {err}");
+                            warn!(recorder = %name, "recorder integrate failed: {}", err_msg(&err));
                             tokio::time::sleep(TICK_INTERVAL).await;
                             continue 'reconnect;
                         }
@@ -243,7 +251,7 @@ async fn recorder_loop(
                     let cols: Vec<String> = match client.query(cols_query, &[&bare]).await {
                         Ok(rows) => rows.iter().map(|r| r.get::<_, String>(0)).collect(),
                         Err(err) => {
-                            warn!(recorder = %name, "recorder column fetch failed: {err}");
+                            warn!(recorder = %name, "recorder column fetch failed: {}", err_msg(&err));
                             tokio::time::sleep(TICK_INTERVAL).await;
                             continue 'reconnect;
                         }
@@ -266,8 +274,57 @@ async fn recorder_loop(
             info!(recorder = %name, sql = %sql, "recorder tick statement");
         }
 
+        // The progress watermark: in the real design the RECORD commit at `T`
+        // advances the targets' physical uppers in lockstep with input
+        // consumption (including empty commits — "nothing to record through
+        // `F`" is information). The prototype's targets are plain tables whose
+        // uppers free-run with wall clock, so the consumed-through frontier is
+        // instead expressed *as data*: one row per recorder, advanced every
+        // tick even when no deltas flow. Without it, a reader cannot
+        // distinguish "no delta at `t`" from "the recorder has not gotten
+        // there" (or is gone).
+        // Separate statements: DDL and writes cannot share an implicit
+        // multi-statement transaction.
+        let progress_setup = [
+            "CREATE TABLE IF NOT EXISTS mz_recorder_progress \
+             (recorder text, consumed_through mz_timestamp)"
+                .to_string(),
+            format!("DELETE FROM mz_recorder_progress WHERE recorder = '{name}'"),
+            format!("INSERT INTO mz_recorder_progress VALUES ('{name}', 0)"),
+        ];
+        for sql in &progress_setup {
+            if let Err(err) = client.execute(sql.as_str(), &[]).await {
+                warn!(recorder = %name, sql = %sql, "recorder progress setup failed: {}", err_msg(&err));
+                tokio::time::sleep(TICK_INTERVAL).await;
+                continue 'reconnect;
+            }
+        }
+        // The frontier is inlined as a literal: tokio-postgres would serialize
+        // a text parameter against the server-inferred mz_timestamp type.
+        let progress_sql = |frontier: &str| {
+            format!(
+                "UPDATE mz_recorder_progress SET consumed_through = '{frontier}'::mz_timestamp \
+                 WHERE recorder = '{name}'"
+            )
+        };
+
         loop {
             tokio::time::sleep(TICK_INTERVAL).await;
+            // Sample the frontier before running the actions: the actions'
+            // reads happen at later timestamps, so every input delta with
+            // `mz_timestamp <= frontier` is reflected in the targets once they
+            // all succeed. Conservative by up to one tick.
+            let frontier: String = match client.query_one("SELECT mz_now()::text", &[]).await {
+                Ok(row) => row.get(0),
+                Err(err) => {
+                    warn!(recorder = %name, "recorder frontier read failed: {}", err_msg(&err));
+                    if client.is_closed() {
+                        continue 'reconnect;
+                    }
+                    continue;
+                }
+            };
+            let mut all_ok = true;
             for sql in &tick_sqls {
                 match client.execute(sql.as_str(), &[]).await {
                     Ok(rows) if rows > 0 => {
@@ -275,10 +332,20 @@ async fn recorder_loop(
                     }
                     Ok(_) => {}
                     Err(err) => {
-                        warn!(recorder = %name, "recorder tick failed: {err}");
+                        warn!(recorder = %name, "recorder tick failed: {}", err_msg(&err));
+                        all_ok = false;
                         if client.is_closed() {
                             continue 'reconnect;
                         }
+                    }
+                }
+            }
+            // Advance the watermark only if the whole tick applied.
+            if all_ok {
+                if let Err(err) = client.execute(&progress_sql(&frontier), &[]).await {
+                    warn!(recorder = %name, "recorder progress write failed: {}", err_msg(&err));
+                    if client.is_closed() {
+                        continue 'reconnect;
                     }
                 }
             }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -704,6 +704,14 @@ impl Coordinator {
                         ctx.retire(res);
                     });
                 }
+                Plan::CreateRecorder(plan) => {
+                    let result = self.sequence_create_recorder(plan);
+                    ctx.retire(result);
+                }
+                Plan::DropRecorder(plan) => {
+                    let result = self.sequence_drop_recorder(plan);
+                    ctx.retire(result);
+                }
             }
         }
         .instrument(tracing::debug_span!("coord::sequencer::sequence_plan"))

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -75,12 +75,12 @@ use mz_ore::stack::RecursionLimitError;
 use mz_repr::adt::timestamp::TimestampError;
 use mz_repr::optimize::{OptimizerFeatureOverrides, OptimizerFeatures, OverrideFrom};
 use mz_repr::{CatalogItemId, GlobalId};
-use timely::progress::Antichain;
 use mz_sql::names::{FullItemName, QualifiedItemName};
 use mz_sql::plan::{HirRelationExpr, PlanError};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::SystemVars;
 use mz_transform::{MaybeShouldPanic, StatisticsOracle, TransformCtx, TransformError};
+use timely::progress::Antichain;
 
 use crate::TimestampContext;
 

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -235,6 +235,8 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
             | ExecuteResponse::CreatedMaterializedView
             | ExecuteResponse::CreatedType
             | ExecuteResponse::CreatedNetworkPolicy
+            | ExecuteResponse::CreatedRecorder
+            | ExecuteResponse::DroppedRecorder
             | ExecuteResponse::Deallocate { .. }
             | ExecuteResponse::DeclaredCursor
             | ExecuteResponse::Deleted(_)

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1503,6 +1503,8 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::CreatedView { .. }
         | ExecuteResponse::CreatedViews { .. }
         | ExecuteResponse::CreatedMaterializedView { .. }
+        | ExecuteResponse::CreatedRecorder
+        | ExecuteResponse::DroppedRecorder
         | ExecuteResponse::CreatedType
         | ExecuteResponse::CreatedNetworkPolicy
         | ExecuteResponse::Comment

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -2272,6 +2272,8 @@ where
             | ExecuteResponse::CreatedView { .. }
             | ExecuteResponse::CreatedViews { .. }
             | ExecuteResponse::CreatedNetworkPolicy
+            | ExecuteResponse::CreatedRecorder
+            | ExecuteResponse::DroppedRecorder
             | ExecuteResponse::Comment
             | ExecuteResponse::Deallocate { .. }
             | ExecuteResponse::Deleted(..)

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -381,6 +381,8 @@ Read
 Ready
 Real
 Reassign
+Record
+Recorder
 Recursion
 Recursive
 Redacted

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -242,6 +242,7 @@ Inspect
 Instance
 Int
 Integer
+Integrate
 Internal
 Intersect
 Interval

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -817,32 +817,119 @@ impl<T: AstInfo> AstDisplay for ValidateConnectionStatement<T> {
 }
 impl_display_t!(ValidateConnectionStatement);
 
-/// `CREATE RECORDER <name> AS RECORD (<query>) INTO <table>` (prototype)
+/// `CREATE RECORDER <name> [WITH <rel> AS (<query>), ...] AS <action>, ...`
+/// (prototype)
 ///
-/// The body is kept as raw SQL text: the prototype recorder re-executes it
-/// verbatim through an internal SQL connection, so no name resolution or
-/// planning of the body happens at DDL time.
+/// Relation bodies are kept as raw SQL text: the prototype recorder
+/// re-executes them verbatim through an internal SQL connection, so no name
+/// resolution or planning of the bodies happens at DDL time.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateRecorderStatement {
     /// Name of the recorder.
     pub name: UnresolvedItemName,
-    /// The raw SQL text of the body query (a dTVC over `CHANGES(...)`).
-    pub body_sql: String,
-    /// The `DELTA TABLE` the body's deltas are recorded into.
-    pub into: UnresolvedItemName,
+    /// Named relations the actions may reference (`WITH r AS (...)`).
+    pub rels: Vec<RecorderRelation>,
+    /// The actions, committed (sequentially, in this prototype) per tick.
+    pub actions: Vec<RecorderAction>,
 }
 
 impl AstDisplay for CreateRecorderStatement {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE RECORDER ");
         f.write_node(&self.name);
-        f.write_str(" AS RECORD (");
-        f.write_str(&self.body_sql);
-        f.write_str(") INTO ");
-        f.write_node(&self.into);
+        if !self.rels.is_empty() {
+            f.write_str(" WITH ");
+            f.write_node(&display::comma_separated(&self.rels));
+        }
+        f.write_str(" AS ");
+        f.write_node(&display::comma_separated(&self.actions));
     }
 }
 impl_display!(CreateRecorderStatement);
+
+/// A named relation in a `CREATE RECORDER` statement (prototype).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RecorderRelation {
+    /// The relation's name, referenced by actions and other relations.
+    pub name: Ident,
+    /// The raw SQL text of the relation's body.
+    pub body_sql: String,
+}
+
+impl AstDisplay for RecorderRelation {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        f.write_str(" AS (");
+        f.write_str(&self.body_sql);
+        f.write_str(")");
+    }
+}
+impl_display!(RecorderRelation);
+
+/// An action of a `CREATE RECORDER` statement (prototype).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RecorderAction {
+    /// `RECORD <rel | (query)> INTO <delta table>`: append the relation's
+    /// deltas to a delta table.
+    Record {
+        /// A named relation (`rels` entry), ...
+        rel: Option<Ident>,
+        /// ... or an inline query (raw SQL).
+        query_sql: Option<String>,
+        /// The target delta table.
+        into: UnresolvedItemName,
+    },
+    /// `INTEGRATE <rel> AS <view>`: maintain the relation as a TVC.
+    Integrate {
+        /// The named relation to integrate.
+        rel: Ident,
+        /// The name of the maintained view.
+        view: UnresolvedItemName,
+    },
+    /// `DELETE <rel> FROM <delta table>`: prune the relation's rows.
+    Delete {
+        /// The named relation selecting the rows to delete.
+        rel: Ident,
+        /// The delta table to delete from.
+        from: UnresolvedItemName,
+    },
+}
+
+impl AstDisplay for RecorderAction {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            RecorderAction::Record {
+                rel,
+                query_sql,
+                into,
+            } => {
+                f.write_str("RECORD ");
+                if let Some(rel) = rel {
+                    f.write_node(rel);
+                } else if let Some(query_sql) = query_sql {
+                    f.write_str("(");
+                    f.write_str(query_sql);
+                    f.write_str(")");
+                }
+                f.write_str(" INTO ");
+                f.write_node(into);
+            }
+            RecorderAction::Integrate { rel, view } => {
+                f.write_str("INTEGRATE ");
+                f.write_node(rel);
+                f.write_str(" AS ");
+                f.write_node(view);
+            }
+            RecorderAction::Delete { rel, from } => {
+                f.write_str("DELETE ");
+                f.write_node(rel);
+                f.write_str(" FROM ");
+                f.write_node(from);
+            }
+        }
+    }
+}
+impl_display!(RecorderAction);
 
 /// `DROP RECORDER <name>` (prototype)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -115,6 +115,8 @@ pub enum Statement<T: AstInfo> {
     ReassignOwned(ReassignOwnedStatement<T>),
     ValidateConnection(ValidateConnectionStatement<T>),
     Comment(CommentStatement<T>),
+    CreateRecorder(CreateRecorderStatement),
+    DropRecorder(DropRecorderStatement),
 }
 
 impl<T: AstInfo> AstDisplay for Statement<T> {
@@ -194,6 +196,8 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::ReassignOwned(stmt) => f.write_node(stmt),
             Statement::ValidateConnection(stmt) => f.write_node(stmt),
             Statement::Comment(stmt) => f.write_node(stmt),
+            Statement::CreateRecorder(stmt) => f.write_node(stmt),
+            Statement::DropRecorder(stmt) => f.write_node(stmt),
         }
     }
 }
@@ -278,6 +282,8 @@ pub fn statement_kind_label_value(kind: StatementKind) -> &'static str {
         StatementKind::ReassignOwned => "reassign_owned",
         StatementKind::ValidateConnection => "validate_connection",
         StatementKind::Comment => "comment",
+        StatementKind::CreateRecorder => "create_recorder",
+        StatementKind::DropRecorder => "drop_recorder",
     }
 }
 
@@ -810,6 +816,48 @@ impl<T: AstInfo> AstDisplay for ValidateConnectionStatement<T> {
     }
 }
 impl_display_t!(ValidateConnectionStatement);
+
+/// `CREATE RECORDER <name> AS RECORD (<query>) INTO <table>` (prototype)
+///
+/// The body is kept as raw SQL text: the prototype recorder re-executes it
+/// verbatim through an internal SQL connection, so no name resolution or
+/// planning of the body happens at DDL time.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateRecorderStatement {
+    /// Name of the recorder.
+    pub name: UnresolvedItemName,
+    /// The raw SQL text of the body query (a dTVC over `CHANGES(...)`).
+    pub body_sql: String,
+    /// The `DELTA TABLE` the body's deltas are recorded into.
+    pub into: UnresolvedItemName,
+}
+
+impl AstDisplay for CreateRecorderStatement {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("CREATE RECORDER ");
+        f.write_node(&self.name);
+        f.write_str(" AS RECORD (");
+        f.write_str(&self.body_sql);
+        f.write_str(") INTO ");
+        f.write_node(&self.into);
+    }
+}
+impl_display!(CreateRecorderStatement);
+
+/// `DROP RECORDER <name>` (prototype)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DropRecorderStatement {
+    /// Name of the recorder to drop.
+    pub name: UnresolvedItemName,
+}
+
+impl AstDisplay for DropRecorderStatement {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("DROP RECORDER ");
+        f.write_node(&self.name);
+    }
+}
+impl_display!(DropRecorderStatement);
 
 /// `CREATE (SOURCE | TABLE) <name> FROM WEBHOOK`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4988,25 +4988,81 @@ impl<'a> Parser<'a> {
         Ok(Statement::CreateTable(stmt))
     }
 
-    /// Parses `CREATE RECORDER <name> AS RECORD (<query>) INTO <table>`
-    /// (recorder prototype). The body query is captured as raw SQL text.
-    fn parse_create_recorder(&mut self) -> Result<Statement<Raw>, ParserError> {
-        self.expect_keyword(RECORDER)?;
-        let name = self.parse_item_name()?;
-        self.expect_keywords(&[AS, RECORD])?;
+    /// Parses a parenthesized query, returning its raw SQL text (recorder
+    /// prototype). The query is parsed for syntax validation only.
+    fn parse_recorder_query_sql(&mut self) -> Result<String, ParserError> {
         self.expect_token(&Token::LParen)?;
         let body_start = self.peek_pos();
-        // Parse the query for syntax validation, but keep only the raw text.
         let _ = self.parse_query()?;
         let body_end = self.peek_pos();
         let body_sql = self.sql[body_start..body_end].trim().to_string();
         self.expect_token(&Token::RParen)?;
-        self.expect_keyword(INTO)?;
-        let into = self.parse_item_name()?;
+        Ok(body_sql)
+    }
+
+    /// Parses `CREATE RECORDER <name> [WITH <rel> AS (<query>), ...] AS
+    /// <action>, ...` (recorder prototype), where an action is one of
+    /// `RECORD <rel | (query)> INTO <table>`, `INTEGRATE <rel> AS <view>`, or
+    /// `DELETE <rel> FROM <table>`. Queries are captured as raw SQL text.
+    fn parse_create_recorder(&mut self) -> Result<Statement<Raw>, ParserError> {
+        self.expect_keyword(RECORDER)?;
+        let name = self.parse_item_name()?;
+        let mut rels = Vec::new();
+        if self.parse_keyword(WITH) {
+            loop {
+                let rel_name = self.parse_identifier()?;
+                self.expect_keyword(AS)?;
+                let body_sql = self.parse_recorder_query_sql()?;
+                rels.push(RecorderRelation {
+                    name: rel_name,
+                    body_sql,
+                });
+                if !self.consume_token(&Token::Comma) {
+                    break;
+                }
+            }
+        }
+        self.expect_keyword(AS)?;
+        let mut actions = Vec::new();
+        loop {
+            let action = match self.expect_one_of_keywords(&[RECORD, INTEGRATE, DELETE])? {
+                RECORD => {
+                    let (rel, query_sql) = if self.peek_token() == Some(Token::LParen) {
+                        (None, Some(self.parse_recorder_query_sql()?))
+                    } else {
+                        (Some(self.parse_identifier()?), None)
+                    };
+                    self.expect_keyword(INTO)?;
+                    let into = self.parse_item_name()?;
+                    RecorderAction::Record {
+                        rel,
+                        query_sql,
+                        into,
+                    }
+                }
+                INTEGRATE => {
+                    let rel = self.parse_identifier()?;
+                    self.expect_keyword(AS)?;
+                    let view = self.parse_item_name()?;
+                    RecorderAction::Integrate { rel, view }
+                }
+                DELETE => {
+                    let rel = self.parse_identifier()?;
+                    self.expect_keyword(FROM)?;
+                    let from = self.parse_item_name()?;
+                    RecorderAction::Delete { rel, from }
+                }
+                _ => unreachable!(),
+            };
+            actions.push(action);
+            if !self.consume_token(&Token::Comma) {
+                break;
+            }
+        }
         Ok(Statement::CreateRecorder(CreateRecorderStatement {
             name,
-            body_sql,
-            into,
+            rels,
+            actions,
         }))
     }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1988,6 +1988,12 @@ impl<'a> Parser<'a> {
                 self.parse_create_table()
                     .map_parser_err(StatementKind::CreateTable)
             }
+        } else if self.peek_keywords(&[DELTA, TABLE]) {
+            self.parse_create_delta_table()
+                .map_parser_err(StatementKind::CreateTable)
+        } else if self.peek_keyword(RECORDER) {
+            self.parse_create_recorder()
+                .map_parser_err(StatementKind::CreateRecorder)
         } else if self.peek_keyword(SECRET) {
             self.parse_create_secret()
                 .map_parser_err(StatementKind::CreateSecret)
@@ -4696,6 +4702,11 @@ impl<'a> Parser<'a> {
         if self.parse_keyword(OWNED) {
             self.parse_drop_owned()
                 .map_parser_err(StatementKind::DropOwned)
+        } else if self.parse_keyword(RECORDER) {
+            // Recorder prototype: not a catalog object, bespoke drop path.
+            self.parse_item_name()
+                .map(|name| Statement::DropRecorder(DropRecorderStatement { name }))
+                .map_parser_err(StatementKind::DropRecorder)
         } else {
             self.parse_drop_objects()
                 .map_parser_err(StatementKind::DropObjects)
@@ -4947,6 +4958,55 @@ impl<'a> Parser<'a> {
             if_not_exists,
             temporary,
             with_options,
+        }))
+    }
+
+    /// Parses `CREATE DELTA TABLE <name> (<cols>)` (recorder prototype).
+    ///
+    /// Desugars at parse time into a plain `CREATE TABLE` with implicit
+    /// `mz_timestamp mz_timestamp` and `mz_diff int8` columns appended, so the
+    /// rest of the system needs no new collection kind.
+    fn parse_create_delta_table(&mut self) -> Result<Statement<Raw>, ParserError> {
+        self.expect_keyword(DELTA)?;
+        let stmt = self.parse_create_table()?;
+        let Statement::CreateTable(mut stmt) = stmt else {
+            unreachable!("parse_create_table returns CreateTable")
+        };
+        for (name, type_name) in [("mz_timestamp", "mz_timestamp"), ("mz_diff", "int8")] {
+            stmt.columns.push(ColumnDef {
+                name: Ident::new_unchecked(name),
+                data_type: RawDataType::Other {
+                    name: RawItemName::Name(UnresolvedItemName::unqualified(Ident::new_unchecked(
+                        type_name,
+                    ))),
+                    typ_mod: vec![],
+                },
+                collation: None,
+                options: vec![],
+            });
+        }
+        Ok(Statement::CreateTable(stmt))
+    }
+
+    /// Parses `CREATE RECORDER <name> AS RECORD (<query>) INTO <table>`
+    /// (recorder prototype). The body query is captured as raw SQL text.
+    fn parse_create_recorder(&mut self) -> Result<Statement<Raw>, ParserError> {
+        self.expect_keyword(RECORDER)?;
+        let name = self.parse_item_name()?;
+        self.expect_keywords(&[AS, RECORD])?;
+        self.expect_token(&Token::LParen)?;
+        let body_start = self.peek_pos();
+        // Parse the query for syntax validation, but keep only the raw text.
+        let _ = self.parse_query()?;
+        let body_end = self.peek_pos();
+        let body_sql = self.sql[body_start..body_end].trim().to_string();
+        self.expect_token(&Token::RParen)?;
+        self.expect_keyword(INTO)?;
+        let into = self.parse_item_name()?;
+        Ok(Statement::CreateRecorder(CreateRecorderStatement {
+            name,
+            body_sql,
+            into,
         }))
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -212,6 +212,8 @@ pub enum Plan {
     ValidateConnection(ValidateConnectionPlan),
     AlterRetainHistory(AlterRetainHistoryPlan),
     AlterSourceTimestampInterval(AlterSourceTimestampIntervalPlan),
+    CreateRecorder(CreateRecorderPlan),
+    DropRecorder(DropRecorderPlan),
 }
 
 impl Plan {
@@ -261,6 +263,8 @@ impl Plan {
             ],
             StatementKind::Close => &[PlanKind::Close],
             StatementKind::Comment => &[PlanKind::Comment],
+            StatementKind::CreateRecorder => &[PlanKind::CreateRecorder],
+            StatementKind::DropRecorder => &[PlanKind::DropRecorder],
             StatementKind::Commit => &[PlanKind::CommitTransaction],
             StatementKind::Copy => &[
                 PlanKind::CopyFrom,
@@ -472,6 +476,8 @@ impl Plan {
             Plan::ValidateConnection(_) => "validate connection",
             Plan::AlterRetainHistory(_) => "alter retain history",
             Plan::AlterSourceTimestampInterval(_) => "alter source timestamp interval",
+            Plan::CreateRecorder(_) => "create recorder",
+            Plan::DropRecorder(_) => "drop recorder",
         }
     }
 
@@ -700,6 +706,26 @@ pub struct CreateConnectionPlan {
     pub if_not_exists: bool,
     pub connection: Connection,
     pub validate: bool,
+}
+
+/// Prototype: a recorder periodically re-executes its body through an
+/// internal SQL connection and records the resulting deltas into the target
+/// delta table. Both are carried as raw SQL strings.
+#[derive(Debug)]
+pub struct CreateRecorderPlan {
+    /// Name of the recorder.
+    pub name: String,
+    /// Raw SQL text of the body query.
+    pub body_sql: String,
+    /// Raw SQL name of the target delta table.
+    pub target: String,
+}
+
+/// Prototype: drop an in-memory recorder by name.
+#[derive(Debug)]
+pub struct DropRecorderPlan {
+    /// Name of the recorder.
+    pub name: String,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -708,17 +708,45 @@ pub struct CreateConnectionPlan {
     pub validate: bool,
 }
 
-/// Prototype: a recorder periodically re-executes its body through an
-/// internal SQL connection and records the resulting deltas into the target
-/// delta table. Both are carried as raw SQL strings.
+/// Prototype: a recorder periodically re-executes its actions through an
+/// internal SQL connection. Relations and names are carried as raw SQL
+/// strings.
 #[derive(Debug)]
 pub struct CreateRecorderPlan {
     /// Name of the recorder.
     pub name: String,
-    /// Raw SQL text of the body query.
-    pub body_sql: String,
-    /// Raw SQL name of the target delta table.
-    pub target: String,
+    /// Named relations: `(name, raw SQL body)`, in declaration order.
+    pub rels: Vec<(String, String)>,
+    /// The actions, executed sequentially per tick.
+    pub actions: Vec<RecorderActionPlan>,
+}
+
+/// Prototype: one action of a recorder.
+#[derive(Debug, Clone)]
+pub enum RecorderActionPlan {
+    /// Append the relation's deltas to a delta table.
+    Record {
+        /// A named relation, or ...
+        rel: Option<String>,
+        /// ... an inline query (raw SQL).
+        query_sql: Option<String>,
+        /// The target delta table (raw SQL name).
+        into: String,
+    },
+    /// Maintain the relation as a view.
+    Integrate {
+        /// The named relation to integrate.
+        rel: String,
+        /// The view name (raw SQL name).
+        view: String,
+    },
+    /// Delete the relation's rows from a delta table.
+    Delete {
+        /// The named relation selecting rows to delete.
+        rel: String,
+        /// The delta table to delete from (raw SQL name).
+        from: String,
+    },
 }
 
 /// Prototype: drop an in-memory recorder by name.

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -256,6 +256,8 @@ pub fn describe(
             scl::describe_inspect_shard(&scx, stmt)?
         }
         Statement::ValidateConnection(stmt) => validate::describe_validate_connection(&scx, stmt)?,
+        Statement::CreateRecorder(stmt) => ddl::describe_create_recorder(&scx, stmt)?,
+        Statement::DropRecorder(stmt) => ddl::describe_drop_recorder(&scx, stmt)?,
         Statement::ExecuteUnitTest(_) => {
             return Err(PlanError::Unsupported {
                 feature: "EXECUTE UNIT TEST statement".to_string(),
@@ -449,6 +451,8 @@ pub fn plan(
         Statement::Raise(stmt) => raise::plan_raise(scx, stmt),
         Statement::Show(ShowStatement::InspectShard(stmt)) => scl::plan_inspect_shard(scx, stmt),
         Statement::ValidateConnection(stmt) => validate::plan_validate_connection(scx, stmt),
+        Statement::CreateRecorder(stmt) => ddl::plan_create_recorder(scx, stmt),
+        Statement::DropRecorder(stmt) => ddl::plan_drop_recorder(scx, stmt),
         Statement::ExecuteUnitTest(_) => {
             return Err(PlanError::Unsupported {
                 feature: "EXECUTE UNIT TEST statement".to_string(),
@@ -1083,6 +1087,7 @@ impl<T: mz_sql_parser::ast::AstInfo> From<&Statement<T>> for StatementClassifica
             Statement::CreateWebhookSource(_) => DDL,
             Statement::CreateSource(_) => DDL,
             Statement::CreateSubsource(_) => DDL,
+            Statement::CreateRecorder(_) => DDL,
             Statement::CreateTable(_) => DDL,
             Statement::CreateTableFromSource(_) => DDL,
             Statement::CreateType(_) => DDL,
@@ -1091,6 +1096,7 @@ impl<T: mz_sql_parser::ast::AstInfo> From<&Statement<T>> for StatementClassifica
             Statement::CreateNetworkPolicy(_) => DDL,
             Statement::DropObjects(_) => DDL,
             Statement::DropOwned(_) => DDL,
+            Statement::DropRecorder(_) => DDL,
 
             // `ACL` statements.
             Statement::AlterOwner(_) => ACL,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -73,12 +73,12 @@ use mz_sql_parser::ast::{
     LoadGeneratorOptionName, MaterializedViewOption, MaterializedViewOptionName, MySqlConfigOption,
     MySqlConfigOptionName, NetworkPolicyOption, NetworkPolicyOptionName,
     NetworkPolicyRuleDefinition, NetworkPolicyRuleOption, NetworkPolicyRuleOptionName,
-    PgConfigOption, PgConfigOptionName, ProtobufSchema, QualifiedReplica, RefreshAtOptionValue,
-    RefreshEveryOptionValue, RefreshOptionValue, ReplicaDefinition, ReplicaOption,
-    ReplicaOptionName, RoleAttribute, SetRoleVar, SourceErrorPolicy, SourceIncludeMetadata,
-    SqlServerConfigOption, SqlServerConfigOptionName, Statement, TableConstraint,
-    TableFromSourceColumns, TableFromSourceOption, TableFromSourceOptionName, TableOption,
-    TableOptionName, UnresolvedDatabaseName, UnresolvedItemName, UnresolvedObjectName,
+    PgConfigOption, PgConfigOptionName, ProtobufSchema, QualifiedReplica, RecorderAction,
+    RefreshAtOptionValue, RefreshEveryOptionValue, RefreshOptionValue, ReplicaDefinition,
+    ReplicaOption, ReplicaOptionName, RoleAttribute, SetRoleVar, SourceErrorPolicy,
+    SourceIncludeMetadata, SqlServerConfigOption, SqlServerConfigOptionName, Statement,
+    TableConstraint, TableFromSourceColumns, TableFromSourceOption, TableFromSourceOptionName,
+    TableOption, TableOptionName, UnresolvedDatabaseName, UnresolvedItemName, UnresolvedObjectName,
     UnresolvedSchemaName, Value, ViewDefinition, WithOptionValue,
 };
 use mz_sql_parser::ident;
@@ -159,9 +159,9 @@ use crate::plan::{
     CreateViewPlan, DataSourceDesc, DropObjectsPlan, DropOwnedPlan, DropRecorderPlan,
     HirRelationExpr, Index, MaterializedView, NetworkPolicyRule, NetworkPolicyRuleAction,
     NetworkPolicyRuleDirection, Plan, PlanClusterOption, PlanNotice, PolicyAddress, QueryContext,
-    ReplicaConfig, Secret, Sink, Source, Table, TableDataSource, Type, VariableValue, View,
-    WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders, WebhookValidation, literal,
-    plan_utils, query, transform_ast,
+    RecorderActionPlan, ReplicaConfig, Secret, Sink, Source, Table, TableDataSource, Type,
+    VariableValue, View, WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders,
+    WebhookValidation, literal, plan_utils, query, transform_ast,
 };
 use crate::session::vars::{
     self, ENABLE_CLUSTER_SCHEDULE_REFRESH, ENABLE_COLLECTION_PARTITION_BY,
@@ -5208,13 +5208,39 @@ pub fn plan_create_recorder(
 ) -> Result<Plan, PlanError> {
     let CreateRecorderStatement {
         name,
-        body_sql,
-        into,
+        rels,
+        actions,
     } = stmt;
+    let rels = rels
+        .into_iter()
+        .map(|r| (r.name.to_ast_string_simple(), r.body_sql))
+        .collect();
+    let actions = actions
+        .into_iter()
+        .map(|a| match a {
+            RecorderAction::Record {
+                rel,
+                query_sql,
+                into,
+            } => RecorderActionPlan::Record {
+                rel: rel.map(|r| r.to_ast_string_simple()),
+                query_sql,
+                into: into.to_ast_string_simple(),
+            },
+            RecorderAction::Integrate { rel, view } => RecorderActionPlan::Integrate {
+                rel: rel.to_ast_string_simple(),
+                view: view.to_ast_string_simple(),
+            },
+            RecorderAction::Delete { rel, from } => RecorderActionPlan::Delete {
+                rel: rel.to_ast_string_simple(),
+                from: from.to_ast_string_simple(),
+            },
+        })
+        .collect();
     Ok(Plan::CreateRecorder(CreateRecorderPlan {
         name: name.to_ast_string_simple(),
-        body_sql,
-        target: into.to_ast_string_simple(),
+        rels,
+        actions,
     }))
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -58,17 +58,17 @@ use mz_sql_parser::ast::{
     ConnectionOption, ConnectionOptionName, CreateClusterReplicaStatement, CreateClusterStatement,
     CreateConnectionOption, CreateConnectionOptionName, CreateConnectionStatement,
     CreateConnectionType, CreateDatabaseStatement, CreateIndexStatement,
-    CreateMaterializedViewStatement, CreateNetworkPolicyStatement, CreateRoleStatement,
-    CreateSchemaStatement, CreateSecretStatement, CreateSinkConnection, CreateSinkOption,
-    CreateSinkOptionName, CreateSinkStatement, CreateSourceConnection, CreateSourceOption,
-    CreateSourceOptionName, CreateSourceStatement, CreateSubsourceOption,
+    CreateMaterializedViewStatement, CreateNetworkPolicyStatement, CreateRecorderStatement,
+    CreateRoleStatement, CreateSchemaStatement, CreateSecretStatement, CreateSinkConnection,
+    CreateSinkOption, CreateSinkOptionName, CreateSinkStatement, CreateSourceConnection,
+    CreateSourceOption, CreateSourceOptionName, CreateSourceStatement, CreateSubsourceOption,
     CreateSubsourceOptionName, CreateSubsourceStatement, CreateTableFromSourceStatement,
     CreateTableStatement, CreateTypeAs, CreateTypeListOption, CreateTypeListOptionName,
     CreateTypeMapOption, CreateTypeMapOptionName, CreateTypeStatement, CreateViewStatement,
     CreateWebhookSourceStatement, CsrConfigOption, CsrConfigOptionName, CsrConnection,
     CsrConnectionAvro, CsrConnectionProtobuf, CsrSeedProtobuf, CsvColumns, DeferredItemName,
-    DocOnIdentifier, DocOnSchema, DropObjectsStatement, DropOwnedStatement, Expr, Format,
-    FormatSpecifier, IcebergSinkConfigOption, Ident, IfExistsBehavior, IndexOption,
+    DocOnIdentifier, DocOnSchema, DropObjectsStatement, DropOwnedStatement, DropRecorderStatement,
+    Expr, Format, FormatSpecifier, IcebergSinkConfigOption, Ident, IfExistsBehavior, IndexOption,
     IndexOptionName, KafkaSinkConfigOption, KeyConstraint, LoadGeneratorOption,
     LoadGeneratorOptionName, MaterializedViewOption, MaterializedViewOptionName, MySqlConfigOption,
     MySqlConfigOptionName, NetworkPolicyOption, NetworkPolicyOptionName,
@@ -154,13 +154,14 @@ use crate::plan::{
     ComputeReplicaIntrospectionConfig, ConnectionDetails, CreateClusterManagedPlan,
     CreateClusterPlan, CreateClusterReplicaPlan, CreateClusterUnmanagedPlan, CreateClusterVariant,
     CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan, CreateMaterializedViewPlan,
-    CreateNetworkPolicyPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan,
-    CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, DataSourceDesc,
-    DropObjectsPlan, DropOwnedPlan, HirRelationExpr, Index, MaterializedView, NetworkPolicyRule,
-    NetworkPolicyRuleAction, NetworkPolicyRuleDirection, Plan, PlanClusterOption, PlanNotice,
-    PolicyAddress, QueryContext, ReplicaConfig, Secret, Sink, Source, Table, TableDataSource, Type,
-    VariableValue, View, WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders,
-    WebhookValidation, literal, plan_utils, query, transform_ast,
+    CreateNetworkPolicyPlan, CreateRecorderPlan, CreateRolePlan, CreateSchemaPlan,
+    CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan,
+    CreateViewPlan, DataSourceDesc, DropObjectsPlan, DropOwnedPlan, DropRecorderPlan,
+    HirRelationExpr, Index, MaterializedView, NetworkPolicyRule, NetworkPolicyRuleAction,
+    NetworkPolicyRuleDirection, Plan, PlanClusterOption, PlanNotice, PolicyAddress, QueryContext,
+    ReplicaConfig, Secret, Sink, Source, Table, TableDataSource, Type, VariableValue, View,
+    WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders, WebhookValidation, literal,
+    plan_utils, query, transform_ast,
 };
 use crate::session::vars::{
     self, ENABLE_CLUSTER_SCHEDULE_REFRESH, ENABLE_COLLECTION_PARTITION_BY,
@@ -5189,6 +5190,48 @@ pub fn describe_create_secret(
     _: CreateSecretStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(None))
+}
+
+// Recorder prototype: the recorder is not a catalog item; the body and target
+// are carried as raw SQL for re-execution by the coordinator's recorder task.
+
+pub fn describe_create_recorder(
+    _: &StatementContext,
+    _: CreateRecorderStatement,
+) -> Result<StatementDesc, PlanError> {
+    Ok(StatementDesc::new(None))
+}
+
+pub fn plan_create_recorder(
+    _scx: &StatementContext,
+    stmt: CreateRecorderStatement,
+) -> Result<Plan, PlanError> {
+    let CreateRecorderStatement {
+        name,
+        body_sql,
+        into,
+    } = stmt;
+    Ok(Plan::CreateRecorder(CreateRecorderPlan {
+        name: name.to_ast_string_simple(),
+        body_sql,
+        target: into.to_ast_string_simple(),
+    }))
+}
+
+pub fn describe_drop_recorder(
+    _: &StatementContext,
+    _: DropRecorderStatement,
+) -> Result<StatementDesc, PlanError> {
+    Ok(StatementDesc::new(None))
+}
+
+pub fn plan_drop_recorder(
+    _scx: &StatementContext,
+    stmt: DropRecorderStatement,
+) -> Result<Plan, PlanError> {
+    Ok(Plan::DropRecorder(DropRecorderPlan {
+        name: stmt.name.to_ast_string_simple(),
+    }))
 }
 
 pub fn plan_create_secret(

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -456,6 +456,11 @@ fn generate_rbac_requirements(
     role_id: RoleId,
 ) -> RbacRequirements {
     match plan {
+        // Recorder prototype: superuser only.
+        Plan::CreateRecorder(_) | Plan::DropRecorder(_) => RbacRequirements {
+            superuser_action: Some("create or drop recorders (prototype)".to_string()),
+            ..Default::default()
+        },
         Plan::CreateConnection(plan::CreateConnectionPlan {
             name,
             if_not_exists: _,


### PR DESCRIPTION
### Motivation

Demo prototype for the recorders design (#36909), validating the MVP described there: `RECORD` / `INTEGRATE` / `DELETE` actions over `CHANGES(input)` writing `DELTA TABLE`s, with frozen (processing-time) lookups.
Based on the `CHANGES` branch (#36869); the PR diff is against it.

### Description

Deliberately minimal, demo-only shortcuts:

* `CREATE DELTA TABLE t (cols)` desugars at parse time into a plain table with implicit `mz_timestamp mz_timestamp, mz_diff bigint` columns — no new collection kind.
* `CREATE RECORDER r [WITH rel AS (query), ...] AS RECORD rel INTO t, INTEGRATE rel AS v, DELETE rel FROM t` keeps the relation bodies as raw SQL and spawns an in-memory coordinator task (`coord/recorder.rs`), not a catalog item.
  The task polls every 1s through a SQL self-connection; named relations become CTE prefixes on each action's statement.
  `RECORD` generates:

  ```sql
  INSERT INTO t WITH rels..., __record AS (SELECT * FROM rel)
  SELECT * FROM __record
  WHERE COALESCE(__record.mz_timestamp > (SELECT MAX(mz_timestamp) FROM t), TRUE);
  ```

  The `max(mz_timestamp)` filter is the consumed-through resume point (the design's "resume from the output's upper"): a one-shot `CHANGES` read at `T` returns all deltas `<= T`, so each poll records exactly the new deltas — exactly-once per delta, idempotent, restart-safe.
  Freeze-by-typing falls out: a bare TVC reference joined in the body is evaluated at the poll's processing time, and re-evaluations of old driver deltas are discarded by the frontier filter.
  `INTEGRATE` desugars to a one-time `CREATE VIEW` over the durable delta table (the design's self-correcting restart behavior for free); `DELETE` prunes via a column-tuple `IN` subquery.
  Actions run sequentially per tick — eventual cross-action consistency, the design's `T+1` rule stretched to one tick.
* **Progress watermark.** The recorded data carries timestamps, but that alone does not express how far the recorder has consumed its inputs — the frontier of the targets.
  In the full design the commit at `T` advances the output uppers in lockstep with input consumption, *including empty commits* ("nothing to record through `F`" is information; CT's sink did this, and `append_table`'s `advance_to` is the hook).
  The prototype's targets are plain tables whose uppers free-run with wall clock, so the consumed-through frontier is expressed *as data* instead: `mz_recorder_progress(recorder, consumed_through)`, advanced every tick (sampled before the tick's actions, written only if they all succeed — conservative by at most one tick).
  The watermark advances while inputs are idle, sits ahead of the newest recorded delta ("no delta at `t`" is a statement about the input, not recorder lag), and stalls when the recorder dies.
* `DROP RECORDER` aborts the task.
  Recorders die on `environmentd` restart; the recorded data survives, and a re-created recorder resumes from the target's contents.
* The read-then-write dependency check is relaxed to allow sources and source-export tables in the selection — the at-least-once relaxation the design accepts, needed so a recorder can read `CHANGES` over CDC data.

### Demos

1. **Frozen enrichment** (`recorder_demo.sql`, `demo_driver.sh`): a stream-table join frozen at processing time — a dimension update does not touch recorded rows, a later event freezes the new value, deletes are recorded as `-1` deltas, and a hand-written `INTEGRATE` view derives the current state.
2. **CDC arrival-time stamping** (`recorder_demo2.sql`, `demo2_driver.sh`): data ingested from Postgres CDC is recorded with `now()` frozen at processing time — the time the data entered the system, as data.
   Replaces the Kafka-loopback-and-reingest pattern customers use today.
3. **Multi-action recorder** (`recorder_demo3.sql`, `demo3_driver.sh`, Seth's test): record `(key, a)` changes with `b` frozen at processing time — driving on a projection MV so `b`-only edits consolidate away — `INTEGRATE` a latest-per-key view, and `DELETE` superseded log rows to keep the log bounded at one row per key.
   Deviations from the original sketch: `CHANGES` over a projection is not supported on the base branch, so the driver differentiates a materialized view of the projection (same consolidation semantics); the recorded relation lists `mz_timestamp`/`mz_diff` explicitly.
4. **Progress watermark** (`demo4_driver.sh`): the consumed-through frontier advancing on an idle input, sitting ahead of the newest recorded delta, and stalling after `DROP RECORDER` — completeness-through-`F` as part of the recorded state.

Findings worth feeding back into the design docs:

1. The `AT LEAST` clamp in `optimize/peek.rs` uses the dataflow-wide `since` rather than the changelog input's own, so any default-compaction collection in the query drags the changelog start to ~now and re-emits the snapshot every poll ([CLU-107](https://linear.app/materializeinc/issue/CLU-107)).
   Workaround here: `RETAIN HISTORY` on all body inputs; proper fix is per-input sinces.
2. Frozen retractions are non-exact when the dimension changed in between (the recorded `-1` carries the *current* dim value) — the design doc's consolidation hazard, visible in the demo.
3. `ALTER TABLE ... SET (RETAIN HISTORY ...)` on a source-export table fails with an internal error ("planner should have rejected invalid alter retain history item type"); setting it at `CREATE TABLE ... FROM SOURCE` time works ([SQL-335](https://linear.app/materializeinc/issue/SQL-335)).
4. The target-frontier question deserves first-class treatment in the design: `RECORD`'s "resume from the output's upper" doubles as the consumed-through frontier only if the recorder owns the output's upper and advances it on empty commits; `INTEGRATE`'s view inherits its frontier from the delta table.
   The design doc states this for `RECORD` restart but does not spell out the upper-advancement contract or how readers observe recorder lag.

### Verification

No automated tests (demo prototype).
Verified manually end-to-end against `bin/environmentd`; see the demo recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)