### PR TITLE
adapter: reuse optimize_oneshot in frontend_peek pipelines

### DIFF
--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -889,19 +889,18 @@ impl PeekClient {
                         span.in_scope(|| {
                             let _dispatch_guard = explain_ctx.dispatch_guard();
 
-                            // COPY TO path
-                            // HIR ⇒ MIR lowering and MIR optimization (local)
-                            let local_mir_plan =
-                                optimizer.catch_unwind_optimize(raw_expr.clone())?;
-                            // Attach resolved context required to continue the pipeline.
-                            let local_mir_plan = local_mir_plan.resolve(
-                                timestamp_context.clone(),
-                                &session_meta,
-                                stats,
-                            );
-                            // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
-                            let global_lir_plan =
-                                optimizer.catch_unwind_optimize(local_mir_plan)?;
+                            // COPY TO path: HIR ⇒ local MIR ⇒ resolve ⇒ global LIR.
+                            let global_lir_plan = optimize::optimize_oneshot(
+                                &mut optimizer,
+                                raw_expr.clone(),
+                                |local_mir_plan| {
+                                    local_mir_plan.resolve(
+                                        timestamp_context.clone(),
+                                        &session_meta,
+                                        stats,
+                                    )
+                                },
+                            )?;
                             Ok(Execution::CopyToS3 {
                                 global_lir_plan,
                                 source_ids: source_ids_for_closure,
@@ -931,28 +930,22 @@ impl PeekClient {
                         span.in_scope(|| {
                             let _dispatch_guard = explain_ctx.dispatch_guard();
 
-                            // SELECT/EXPLAIN path
-                            // HIR ⇒ MIR lowering and MIR optimization (local)
-
-                            // The purpose of wrapping the following in a closure is to control where the
-                            // `?`s return from, so that even when a `catch_unwind_optimize` call fails,
-                            // we can still handle `EXPLAIN BROKEN`.
-                            let pipeline = || {
-                                let local_mir_plan =
-                                    optimizer.catch_unwind_optimize(raw_expr.clone())?;
-                                // Attach resolved context required to continue the pipeline.
-                                let local_mir_plan = local_mir_plan.resolve(
-                                    timestamp_context.clone(),
-                                    &session_meta,
-                                    stats,
-                                );
-                                // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
-                                let global_lir_plan =
-                                    optimizer.catch_unwind_optimize(local_mir_plan)?;
-                                Ok::<_, AdapterError>(global_lir_plan)
-                            };
-
-                            let global_lir_plan_result = pipeline();
+                            // SELECT/EXPLAIN path: HIR ⇒ local MIR ⇒ resolve ⇒
+                            // global LIR. We capture the result (rather than
+                            // propagating with `?`) so that a failure can still be
+                            // routed to `EXPLAIN BROKEN` below.
+                            let global_lir_plan_result = optimize::optimize_oneshot(
+                                &mut optimizer,
+                                raw_expr.clone(),
+                                |local_mir_plan| {
+                                    local_mir_plan.resolve(
+                                        timestamp_context.clone(),
+                                        &session_meta,
+                                        stats,
+                                    )
+                                },
+                            )
+                            .map_err(AdapterError::from);
                             let optimization_finished_at = now();
 
                             let create_insights_ctx =

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -223,7 +223,7 @@ impl PeekOptimizer {
 /// paths. The `resolve` closure attaches the timestamp/session/stats context to
 /// the local plan; it is path-specific only in the concrete plan type it
 /// operates on.
-fn optimize_oneshot<O, LocalPlan, ResolvedPlan, GlobalPlan>(
+pub(crate) fn optimize_oneshot<O, LocalPlan, ResolvedPlan, GlobalPlan>(
     optimizer: &mut O,
     raw_expr: HirRelationExpr,
     resolve: impl FnOnce(LocalPlan) -> ResolvedPlan,


### PR DESCRIPTION
### Motivation

Follow-up to #36895, which introduced `optimize::PeekOptimizer` and factored
the shared one-shot optimization pipeline into `optimize::optimize_oneshot`.

The frontend peek path (`frontend_peek.rs`) still hand-rolled the same
`HIR -> local MIR -> resolve -> global LIR` sequence in both its `COPY TO`
and `SELECT`/`EXPLAIN` arms — the exact sequence now encapsulated by
`optimize_oneshot`. This makes that helper `pub(crate)` and calls it from
both arms.

I deliberately did **not** push the `PeekOptimizer` enum into this file: its
dispatch is a three-way `match` that also includes `Subscribe` (a different
pipeline shape), and the `Select`/`CopyTo` arms each need the concrete
optimizer downstream. The right shared unit here is the pipeline helper, not
the dispatch wrapper.

### Tips for reviewer

As a side effect, the `SELECT` arm's `pipeline` closure disappears. It only
existed to corral multiple `?` operators into a local `Result` so a failure
could still be routed to `EXPLAIN BROKEN`; that is now a single fallible call
whose result we capture with `.map_err(AdapterError::from)`, preserving the
broken-explain handling.

No behavior change — pure refactor. `cargo check -p mz-adapter` is clean.

### Checklist

- [x] This PR has adequate test coverage (no behavior change; covered by existing peek/copy-to tests).
- [x] This PR does not need a release note.

https://claude.ai/code/session_018q73DM2B1dQAb6MQbqTHHk

---
_Generated by [Claude Code](https://claude.ai/code/session_018q73DM2B1dQAb6MQbqTHHk)_