### PR TITLE
[ss-159] Accept empty exclude columns for consistency with text columns

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -29,7 +29,6 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_ore::iter::IteratorExt;
-use mz_ore::soft_panic_or_log;
 use mz_ore::str::StrExt;
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_proto::RustType;
@@ -2059,14 +2058,9 @@ async fn purify_create_table_from_source(
                 .iter_mut()
                 .find(|option| option.name == TableFromSourceOptionName::ExcludeColumns)
             {
-                match gen_exclude_columns {
-                    Some(gen_exclude_columns) => {
-                        exclude_cols_option.value =
-                            Some(WithOptionValue::Sequence(gen_exclude_columns))
-                    }
-                    None => soft_panic_or_log!(
-                        "exclude_columns should be Some if exclude_cols_option is present"
-                    ),
+                if let Some(gen_exclude_columns) = gen_exclude_columns {
+                    exclude_cols_option.value =
+                        Some(WithOptionValue::Sequence(gen_exclude_columns));
                 }
             }
             match columns {
@@ -2114,14 +2108,9 @@ async fn purify_create_table_from_source(
                 .iter_mut()
                 .find(|option| option.name == TableFromSourceOptionName::ExcludeColumns)
             {
-                match gen_exclude_columns {
-                    Some(gen_exclude_columns) => {
-                        exclude_cols_option.value =
-                            Some(WithOptionValue::Sequence(gen_exclude_columns))
-                    }
-                    None => soft_panic_or_log!(
-                        "exclude_columns should be Some if exclude_cols_option is present"
-                    ),
+                if let Some(gen_exclude_columns) = gen_exclude_columns {
+                    exclude_cols_option.value =
+                        Some(WithOptionValue::Sequence(gen_exclude_columns));
                 }
             }
             match columns {
@@ -2169,14 +2158,8 @@ async fn purify_create_table_from_source(
                 .iter_mut()
                 .find(|opt| opt.name == TableFromSourceOptionName::ExcludeColumns)
             {
-                match gen_excl_columns {
-                    Some(gen_excl_columns) => {
-                        exclude_cols_option.value =
-                            Some(WithOptionValue::Sequence(gen_excl_columns))
-                    }
-                    None => soft_panic_or_log!(
-                        "excl_columns should be Some if excl_cols_option is present"
-                    ),
+                if let Some(gen_excl_columns) = gen_excl_columns {
+                    exclude_cols_option.value = Some(WithOptionValue::Sequence(gen_excl_columns));
                 }
             }
 

--- a/test/mysql-cdc-old-syntax/empty-exclude-columns.td
+++ b/test/mysql-cdc-old-syntax/empty-exclude-columns.td
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Regression test for ss-159: an empty `EXCLUDE COLUMNS ()` on the legacy
+# `CREATE SOURCE .. FOR TABLES` (subsource-creating) syntax is treated as
+# though the option were omitted and must succeed. This differs from the
+# `CREATE TABLE .. FROM SOURCE` syntax, where an empty set is rejected with
+# `invalid EXCLUDE COLUMNS option value: cannot be empty`.
+#
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+> CREATE CONNECTION mysqc TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO t1 VALUES (1, 'one'), (2, 'two');
+
+> CREATE SOURCE mz_source
+  FROM MYSQL CONNECTION mysqc (
+    EXCLUDE COLUMNS ()
+  )
+  FOR TABLES (public.t1);
+
+> SELECT * FROM t1;
+1 one
+2 two

--- a/test/mysql-cdc-old-syntax/empty-exclude-columns.td
+++ b/test/mysql-cdc-old-syntax/empty-exclude-columns.td
@@ -7,13 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `EXCLUDE COLUMNS ()` on the legacy
 # `CREATE SOURCE .. FOR TABLES` (subsource-creating) syntax is treated as
-# though the option were omitted and must succeed. This differs from the
-# `CREATE TABLE .. FROM SOURCE` syntax, where an empty set is rejected with
-# `invalid EXCLUDE COLUMNS option value: cannot be empty`.
-#
+# though the option were omitted and must succeed.
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 

--- a/test/mysql-cdc-old-syntax/empty-text-columns.td
+++ b/test/mysql-cdc-old-syntax/empty-text-columns.td
@@ -7,13 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `TEXT COLUMNS ()` on the legacy
 # `CREATE SOURCE .. FOR TABLES` (subsource-creating) syntax is treated as
-# though the option were omitted and must succeed. This differs from the
-# `CREATE TABLE .. FROM SOURCE` syntax, where an empty set is rejected with
-# `invalid TEXT COLUMNS option value: cannot be empty`.
-#
+# though the option were omitted and must succeed.
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 

--- a/test/pg-cdc-old-syntax/empty-exclude-columns.td
+++ b/test/pg-cdc-old-syntax/empty-exclude-columns.td
@@ -1,0 +1,42 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Regression test for ss-159: an empty `EXCLUDE COLUMNS ()` on the legacy
+# `CREATE SOURCE .. FOR TABLES` (subsource-creating) syntax is treated as
+# though the option were omitted and must succeed. This differs from the
+# `CREATE TABLE .. FROM SOURCE` syntax, where an empty set is rejected with
+# `invalid EXCLUDE COLUMNS option value: cannot be empty`.
+#
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+INSERT INTO t1 VALUES (1, 'one'), (2, 'two');
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source', EXCLUDE COLUMNS ())
+  FOR TABLES (public.t1);
+
+> SELECT * FROM t1;
+1 one
+2 two

--- a/test/pg-cdc-old-syntax/empty-exclude-columns.td
+++ b/test/pg-cdc-old-syntax/empty-exclude-columns.td
@@ -14,6 +14,12 @@
 # `CREATE TABLE .. FROM SOURCE` syntax, where an empty set is rejected with
 # `invalid EXCLUDE COLUMNS option value: cannot be empty`.
 #
+# EXCLUDE COLUMNS on the legacy Postgres source syntax was introduced in
+# v0.162, so skip on older binaries in the multi-version upgrade path that
+# cannot parse the option.
+
+$ skip-if
+SELECT mz_version_num() < 16200;
 
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (

--- a/test/pg-cdc-old-syntax/empty-exclude-columns.td
+++ b/test/pg-cdc-old-syntax/empty-exclude-columns.td
@@ -7,13 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `EXCLUDE COLUMNS ()` on the legacy
 # `CREATE SOURCE .. FOR TABLES` (subsource-creating) syntax is treated as
-# though the option were omitted and must succeed. This differs from the
-# `CREATE TABLE .. FROM SOURCE` syntax, where an empty set is rejected with
-# `invalid EXCLUDE COLUMNS option value: cannot be empty`.
-#
+# though the option were omitted and must succeed.
+
 # EXCLUDE COLUMNS on the legacy Postgres source syntax was introduced in
 # v0.162, so skip on older binaries in the multi-version upgrade path that
 # cannot parse the option.

--- a/test/pg-cdc-old-syntax/empty-text-columns.td
+++ b/test/pg-cdc-old-syntax/empty-text-columns.td
@@ -7,13 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `TEXT COLUMNS ()` on the legacy
 # `CREATE SOURCE .. FOR TABLES` (subsource-creating) syntax is treated as
-# though the option were omitted and must succeed. This differs from the
-# `CREATE TABLE .. FROM SOURCE` syntax, where an empty set is rejected with
-# `invalid TEXT COLUMNS option value: cannot be empty`.
-#
+# though the option were omitted and must succeed.
 
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (

--- a/test/sql-server-cdc/empty-exclude-columns.td
+++ b/test/sql-server-cdc/empty-exclude-columns.td
@@ -7,11 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `EXCLUDE COLUMNS = ()` on a
 # `CREATE TABLE .. FROM SOURCE` statement is treated as though the option
 # were omitted and must succeed.
-#
 
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}

--- a/test/sql-server-cdc/empty-exclude-columns.td
+++ b/test/sql-server-cdc/empty-exclude-columns.td
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Regression test for ss-159: an empty `EXCLUDE COLUMNS = ()` on a
+# `CREATE TABLE .. FROM SOURCE` statement is treated as though the option
+# were omitted and must succeed.
+#
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+USE test;
+CREATE TABLE foo (id INT PRIMARY KEY, name VARCHAR(1024));
+INSERT INTO foo VALUES (1, 'one'), (2, 'two');
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'foo', @role_name = 'SA', @supports_net_changes = 0;
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+> CREATE CONNECTION ssconn TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+> CREATE SOURCE s FROM SQL SERVER CONNECTION ssconn;
+
+> CREATE TABLE foo FROM SOURCE s (REFERENCE dbo.foo) WITH (EXCLUDE COLUMNS = ());
+
+> SELECT * FROM foo;
+1 one
+2 two
+
+> DROP SOURCE s CASCADE;

--- a/test/sql-server-cdc/empty-text-columns.td
+++ b/test/sql-server-cdc/empty-text-columns.td
@@ -7,11 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `TEXT COLUMNS = ()` on a
 # `CREATE TABLE .. FROM SOURCE` statement is treated as though the option
 # were omitted and must succeed.
-#
 
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}

--- a/test/testdrive/empty-exclude-columns.td
+++ b/test/testdrive/empty-exclude-columns.td
@@ -1,0 +1,70 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Regression test for ss-159: an empty `EXCLUDE COLUMNS = ()` on a
+# `CREATE TABLE .. FROM SOURCE` statement is treated as though the option
+# were omitted and must succeed.
+#
+
+# Test Postgres version
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+CREATE TABLE foo (id INT PRIMARY KEY, name TEXT);
+ALTER TABLE foo REPLICA IDENTITY FULL;
+INSERT INTO foo VALUES (1, 'one'), (2, 'two');
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pgconn TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+> CREATE SOURCE s FROM POSTGRES CONNECTION pgconn (PUBLICATION 'mz_source')
+
+> CREATE TABLE foo FROM SOURCE s (REFERENCE = public.foo) WITH (EXCLUDE COLUMNS = ());
+
+> SELECT * FROM foo;
+1 one
+2 two
+
+
+# Test MySql version
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=p@ssw0rd
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+
+CREATE TABLE bar (id INT PRIMARY KEY, name TEXT);
+INSERT INTO bar VALUES (1, 'one'), (2, 'two');
+
+> CREATE SECRET mysqlpass AS 'p@ssw0rd';
+
+> CREATE CONNECTION mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+> CREATE SOURCE s2 FROM MYSQL CONNECTION mysql_conn;
+
+> CREATE TABLE bar FROM SOURCE s2 (REFERENCE = public.bar) WITH (EXCLUDE COLUMNS = ());
+
+> SELECT * FROM bar;
+1 one
+2 two

--- a/test/testdrive/empty-exclude-columns.td
+++ b/test/testdrive/empty-exclude-columns.td
@@ -7,11 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `EXCLUDE COLUMNS = ()` on a
 # `CREATE TABLE .. FROM SOURCE` statement is treated as though the option
 # were omitted and must succeed.
-#
 
 # Test Postgres version
 

--- a/test/testdrive/empty-text-columns.td
+++ b/test/testdrive/empty-text-columns.td
@@ -7,11 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-#
 # Regression test for ss-159: an empty `TEXT COLUMNS = ()` on a
 # `CREATE TABLE .. FROM SOURCE` statement is treated as though the option
 # were omitted and must succeed.
-#
 
 # Test Postgres version
 


### PR DESCRIPTION
### Motivation

While working on https://github.com/MaterializeInc/materialize/pull/36890 I noticed that EXCLUDE COLUMNS has the same behavior as TEXT COLUMNS. For consistency's sake I've implemented the same fix.

### Description

Removes panic/error log for empty exclude columns because we supported and want to support empty exclude columns.

### Verification
Testdrive tests asserting legacy behavior aligns with expectations and new behavior matches it.
