### PR TITLE
Add mz-aws-glue-schema-registry crate with basic client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-glue"
+version = "1.142.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc77647907307c70ffd751db85653804552e4a3c27f054d3af7a0874ef4dfe22"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-kms"
 version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,6 +5704,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mz-aws-glue-schema-registry"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "aws-sdk-glue",
+ "aws-smithy-runtime-api",
+ "aws-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "mz-aws-secrets-controller"
 version = "0.1.0"
 dependencies = [
@@ -8240,6 +8277,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "mysql_async",
+ "mz-aws-glue-schema-registry",
  "mz-aws-util",
  "mz-build-tools",
  "mz-ccsr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "src/auth",
     "src/authenticator",
     "src/avro",
+    "src/aws-glue-schema-registry",
     "src/aws-secrets-controller",
     "src/aws-util",
     "src/balancerd",
@@ -136,6 +137,7 @@ default-members = [
     "src/auth",
     "src/authenticator",
     "src/avro",
+    "src/aws-glue-schema-registry",
     "src/aws-secrets-controller",
     "src/aws-util",
     "src/balancerd",
@@ -279,6 +281,7 @@ async-trait = "0.1.89"
 aws-config = { version = "1.8.15", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.10", features = ["hardcoded-credentials"] }
 aws-lc-rs = "1"
+aws-sdk-glue = { version = "1.104.0", default-features = false, features = ["rt-tokio"] }
 aws-sdk-kms = { version = "1.104.0", default-features = false, features = ["rt-tokio"] }
 aws-sdk-s3 = { version = "1.129.0", default-features = false, features = ["rt-tokio"] }
 aws-sdk-secretsmanager = { version = "1.103.0", default-features = false, features = ["rt-tokio"] }

--- a/src/aws-glue-schema-registry/Cargo.toml
+++ b/src/aws-glue-schema-registry/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mz-aws-glue-schema-registry"
+description = "AWS Glue Schema Registry API client."
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+aws-sdk-glue.workspace = true
+aws-smithy-runtime-api.workspace = true
+aws-types.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+uuid.workspace = true

--- a/src/aws-glue-schema-registry/src/client.rs
+++ b/src/aws-glue-schema-registry/src/client.rs
@@ -1,0 +1,295 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! The Glue Schema Registry client.
+
+use aws_sdk_glue::error::{DisplayErrorContext, SdkError};
+use aws_sdk_glue::operation::get_registry::GetRegistryError as SdkGetRegistryError;
+use aws_sdk_glue::operation::get_schema_version::{
+    GetSchemaVersionError as SdkGetSchemaVersionError, GetSchemaVersionOutput,
+};
+use aws_sdk_glue::types::{
+    DataFormat as SdkDataFormat, RegistryId, RegistryStatus as SdkRegistryStatus, SchemaId,
+    SchemaVersionNumber, SchemaVersionStatus as SdkSchemaVersionStatus,
+};
+use aws_types::SdkConfig;
+use thiserror::Error;
+use uuid::Uuid;
+
+/// An API client for the AWS Glue Schema Registry.
+///
+/// `Client` is cheap to clone — internally it wraps an [`aws_sdk_glue::Client`],
+/// which is itself a clone-friendly handle backed by a shared connection pool.
+#[derive(Clone, Debug)]
+pub struct Client {
+    inner: aws_sdk_glue::Client,
+}
+
+impl Client {
+    pub(crate) fn from_sdk_config(sdk_config: SdkConfig) -> Self {
+        Client {
+            inner: aws_sdk_glue::Client::new(&sdk_config),
+        }
+    }
+
+    /// Look up a registry by name.
+    ///
+    /// Returns [`GetRegistryError::NotFound`] if the registry does not exist
+    /// in the configured account and region. Other errors (auth failures,
+    /// throttling, transport) surface as [`GetRegistryError::Other`].
+    pub async fn get_registry(&self, name: &str) -> Result<Registry, GetRegistryError> {
+        let id = RegistryId::builder().registry_name(name).build();
+        let output = self
+            .inner
+            .get_registry()
+            .registry_id(id)
+            .send()
+            .await
+            .map_err(classify_get_registry_error)?;
+        Ok(Registry {
+            name: output.registry_name,
+            arn: output.registry_arn,
+            description: output.description,
+            lifecycle_status: output.status.map(RegistryLifecycleStatus::from_sdk),
+        })
+    }
+
+    /// Fetch a schema version by its UUID.
+    ///
+    /// This is the source-decode path: the UUID is read from the Glue
+    /// wire-format header, and the returned `SchemaVersion::definition`
+    /// carries the writer schema (Avro JSON, for our usage).
+    ///
+    /// Glue schema-version UUIDs are globally unique within an AWS account
+    /// and this call does **not** scope to any registry — it returns the
+    /// matching version from anywhere the configured credentials can read.
+    /// Returns [`GetSchemaVersionError::NotFound`] only when no schema
+    /// version with this UUID exists in any visible registry. Callers that
+    /// need to enforce a specific registry must check the returned
+    /// `SchemaArn` themselves.
+    ///
+    /// The AWS `GetSchemaVersion` API accepts *either* a `SchemaVersionId`
+    /// (the UUID, registry-agnostic) *or* `SchemaId + SchemaVersionNumber`,
+    /// never both — which is why looking up by name is a separate method,
+    /// [`Client::get_schema_version_latest_by_name`].
+    pub async fn get_schema_version_by_id(
+        &self,
+        id: Uuid,
+    ) -> Result<SchemaVersion, GetSchemaVersionError> {
+        let output = self
+            .inner
+            .get_schema_version()
+            .schema_version_id(id.to_string())
+            .send()
+            .await
+            .map_err(classify_get_schema_version_error)?;
+        Ok(SchemaVersion::from_sdk(output))
+    }
+
+    /// Fetch the latest version of a schema by `(registry_name, schema_name)`.
+    ///
+    /// This is the DDL-planning path: at `CREATE SOURCE` time we don't yet
+    /// know any per-record UUIDs, so we pin the reader schema to whatever
+    /// the registry currently calls "latest". Runtime schema resolution
+    /// for individual records still goes through
+    /// [`Client::get_schema_version_by_id`] using the UUID in each Kafka
+    /// payload's Glue header.
+    pub async fn get_schema_version_latest_by_name(
+        &self,
+        registry_name: &str,
+        schema_name: &str,
+    ) -> Result<SchemaVersion, GetSchemaVersionError> {
+        let schema_id = SchemaId::builder()
+            .registry_name(registry_name)
+            .schema_name(schema_name)
+            .build();
+        let version_number = SchemaVersionNumber::builder().latest_version(true).build();
+        let output = self
+            .inner
+            .get_schema_version()
+            .schema_id(schema_id)
+            .schema_version_number(version_number)
+            .send()
+            .await
+            .map_err(classify_get_schema_version_error)?;
+        Ok(SchemaVersion::from_sdk(output))
+    }
+}
+
+/// A Glue Schema Registry, as returned by [`Client::get_registry`].
+///
+/// Only the fields Materialize currently cares about are surfaced; the full
+/// SDK type carries a few additional timestamps that we ignore.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Registry {
+    pub name: Option<String>,
+    pub arn: Option<String>,
+    pub description: Option<String>,
+    pub lifecycle_status: Option<RegistryLifecycleStatus>,
+}
+
+/// Lifecycle status of a Glue registry.
+///
+/// Mirrors `aws_sdk_glue::types::RegistryStatus`, with `Unknown(String)` as
+/// the forward-compat escape hatch for variants AWS may add later. Keeping
+/// our own enum means callers get exhaustive matching without taking a
+/// direct dependency on the SDK type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryLifecycleStatus {
+    Available,
+    Deleting,
+    /// A value the SDK reported that this crate does not yet know about.
+    Unknown(String),
+}
+
+impl RegistryLifecycleStatus {
+    fn from_sdk(status: SdkRegistryStatus) -> Self {
+        match &status {
+            SdkRegistryStatus::Available => RegistryLifecycleStatus::Available,
+            SdkRegistryStatus::Deleting => RegistryLifecycleStatus::Deleting,
+            _ => RegistryLifecycleStatus::Unknown(status.as_str().to_string()),
+        }
+    }
+}
+
+/// Errors returned by [`Client::get_registry`].
+#[derive(Debug, Error)]
+pub enum GetRegistryError {
+    /// The named registry does not exist in the configured account/region.
+    /// Maps from Glue's `EntityNotFoundException`.
+    #[error("registry not found")]
+    NotFound,
+    /// Anything else: auth failure, throttling, transport error, etc.
+    /// The wrapped message preserves the upstream SDK's diagnostic.
+    #[error("AWS Glue error: {0}")]
+    Other(String),
+}
+
+fn classify_get_registry_error(err: SdkError<SdkGetRegistryError>) -> GetRegistryError {
+    if let SdkError::ServiceError(service_err) = &err
+        && matches!(
+            service_err.err(),
+            SdkGetRegistryError::EntityNotFoundException(_)
+        )
+    {
+        return GetRegistryError::NotFound;
+    }
+    GetRegistryError::Other(DisplayErrorContext(&err).to_string())
+}
+
+/// A Glue schema version, as returned by [`Client::get_schema_version_by_id`]
+/// and [`Client::get_schema_version_latest_by_name`].
+///
+/// `definition` is the format-specific schema text; for Avro it is a JSON
+/// document the Avro parser can ingest directly. The remaining fields are
+/// informational and exist for debug logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaVersion {
+    pub schema_version_id: Option<String>,
+    pub schema_arn: Option<String>,
+    /// The format-specific schema text (Avro JSON, JSON Schema, etc.).
+    pub definition: Option<String>,
+    /// Glue's data-format tag — `AVRO`, `JSON`, or `PROTOBUF`. Mirrors the
+    /// SDK enum so callers get exhaustive matching without depending on the
+    /// SDK type directly.
+    pub data_format: Option<DataFormat>,
+    pub version_number: Option<i64>,
+    pub lifecycle_status: Option<SchemaVersionLifecycleStatus>,
+}
+
+impl SchemaVersion {
+    fn from_sdk(output: GetSchemaVersionOutput) -> Self {
+        SchemaVersion {
+            schema_version_id: output.schema_version_id,
+            schema_arn: output.schema_arn,
+            definition: output.schema_definition,
+            data_format: output.data_format.map(DataFormat::from_sdk),
+            version_number: output.version_number,
+            lifecycle_status: output.status.map(SchemaVersionLifecycleStatus::from_sdk),
+        }
+    }
+}
+
+/// Data format of a Glue schema.
+///
+/// Mirrors `aws_sdk_glue::types::DataFormat`, with `Unknown(String)` as the
+/// forward-compat escape hatch for variants AWS may add later. See
+/// [`RegistryLifecycleStatus`] for the rationale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataFormat {
+    Avro,
+    Json,
+    Protobuf,
+    /// A value the SDK reported that this crate does not yet know about.
+    Unknown(String),
+}
+
+impl DataFormat {
+    fn from_sdk(format: SdkDataFormat) -> Self {
+        match &format {
+            SdkDataFormat::Avro => DataFormat::Avro,
+            SdkDataFormat::Json => DataFormat::Json,
+            SdkDataFormat::Protobuf => DataFormat::Protobuf,
+            _ => DataFormat::Unknown(format.as_str().to_string()),
+        }
+    }
+}
+
+/// Lifecycle status of a Glue schema version.
+///
+/// Mirrors `aws_sdk_glue::types::SchemaVersionStatus`. See
+/// [`RegistryLifecycleStatus`] for the rationale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaVersionLifecycleStatus {
+    Available,
+    Pending,
+    Failure,
+    Deleting,
+    /// A value the SDK reported that this crate does not yet know about.
+    Unknown(String),
+}
+
+impl SchemaVersionLifecycleStatus {
+    fn from_sdk(status: SdkSchemaVersionStatus) -> Self {
+        match &status {
+            SdkSchemaVersionStatus::Available => SchemaVersionLifecycleStatus::Available,
+            SdkSchemaVersionStatus::Pending => SchemaVersionLifecycleStatus::Pending,
+            SdkSchemaVersionStatus::Failure => SchemaVersionLifecycleStatus::Failure,
+            SdkSchemaVersionStatus::Deleting => SchemaVersionLifecycleStatus::Deleting,
+            _ => SchemaVersionLifecycleStatus::Unknown(status.as_str().to_string()),
+        }
+    }
+}
+
+/// Errors returned by [`Client::get_schema_version_by_id`] and
+/// [`Client::get_schema_version_latest_by_name`].
+#[derive(Debug, Error)]
+pub enum GetSchemaVersionError {
+    /// No matching schema version exists in the configured account/region.
+    /// Maps from Glue's `EntityNotFoundException`.
+    #[error("schema version not found")]
+    NotFound,
+    /// Anything else: auth failure, throttling, transport error, etc.
+    #[error("AWS Glue error: {0}")]
+    Other(String),
+}
+
+fn classify_get_schema_version_error(
+    err: SdkError<SdkGetSchemaVersionError>,
+) -> GetSchemaVersionError {
+    if let SdkError::ServiceError(service_err) = &err
+        && matches!(
+            service_err.err(),
+            SdkGetSchemaVersionError::EntityNotFoundException(_)
+        )
+    {
+        return GetSchemaVersionError::NotFound;
+    }
+    GetSchemaVersionError::Other(DisplayErrorContext(&err).to_string())
+}

--- a/src/aws-glue-schema-registry/src/config.rs
+++ b/src/aws-glue-schema-registry/src/config.rs
@@ -1,0 +1,41 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Builder for [`Client`].
+//!
+//! The Glue Schema Registry client is configured from an
+//! [`aws_types::SdkConfig`]. In Materialize, this `SdkConfig` is produced by
+//! `AwsConnection::load_sdk_config`, which threads the region, endpoint
+//! override (used in tests/LocalStack), and credential provider derived from
+//! the user's `AWS CONNECTION`. The Glue client does not need any
+//! Materialize-specific config beyond what `SdkConfig` already carries —
+//! unlike CCSR there is no separate URL or basic-auth.
+
+use aws_types::SdkConfig;
+
+use crate::client::Client;
+
+/// Builder for [`Client`].
+#[derive(Debug, Clone)]
+pub struct ClientConfig {
+    sdk_config: SdkConfig,
+}
+
+impl ClientConfig {
+    /// Construct a new client config from an AWS SDK config.
+    pub fn new(sdk_config: SdkConfig) -> ClientConfig {
+        ClientConfig { sdk_config }
+    }
+
+    /// Build the client. Infallible — the underlying `aws_sdk_glue::Client`
+    /// constructor validates lazily on first request.
+    pub fn build(self) -> Client {
+        Client::from_sdk_config(self.sdk_config)
+    }
+}

--- a/src/aws-glue-schema-registry/src/lib.rs
+++ b/src/aws-glue-schema-registry/src/lib.rs
@@ -1,0 +1,57 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![warn(missing_debug_implementations)]
+
+//! An API client for the [AWS Glue Schema Registry][gsr].
+//!
+//! This crate is the Glue analogue of [`mz-ccsr`], the Confluent Schema
+//! Registry client. It is intentionally narrow: only the surface needed by
+//! the current Materialize integration is implemented.
+//!
+//! Currently implemented:
+//!
+//! * [`Client::get_registry`] — used by `GlueSchemaRegistryConnection::validate`
+//!   to verify a registry exists at `CREATE CONNECTION` time.
+//! * [`Client::get_schema_version_by_id`] — source decode: fetch a writer
+//!   schema by the UUID embedded in each record's Glue wire-format header.
+//! * [`Client::get_schema_version_latest_by_name`] — DDL planning: pin a
+//!   reader schema to the registry's current "latest" version.
+//!
+//! Future work will add:
+//!
+//! * `register_schema_version`, `get_schema_version_by_definition`,
+//!   `get_compatibility`, `update_compatibility` — sink encode.
+//!
+//! ## Example usage
+//!
+//! ```no_run
+//! # async {
+//! use mz_aws_glue_schema_registry::{Client, ClientConfig};
+//! use aws_types::SdkConfig;
+//!
+//! let sdk_config: SdkConfig = unimplemented!("from AwsConnection::load_sdk_config");
+//! let client = ClientConfig::new(sdk_config).build();
+//! let registry = client.get_registry("my-registry").await?;
+//! # let _ = registry;
+//! # Ok::<_, mz_aws_glue_schema_registry::GetRegistryError>(())
+//! # };
+//! ```
+//!
+//! [gsr]: https://docs.aws.amazon.com/glue/latest/dg/schema-registry.html
+//! [`mz-ccsr`]: https://docs.rs/mz-ccsr
+
+mod client;
+mod config;
+
+pub use client::{
+    Client, GetRegistryError, GetSchemaVersionError, Registry, RegistryLifecycleStatus,
+    SchemaVersion, SchemaVersionLifecycleStatus,
+};
+pub use config::ClientConfig;

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -30,6 +30,7 @@ hex.workspace = true
 http.workspace = true
 itertools.workspace = true
 mysql_async.workspace = true
+mz-aws-glue-schema-registry = { path = "../aws-glue-schema-registry" }
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-resources = { path = "../cloud-resources" }

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1606,12 +1606,6 @@ impl<C: ConnectionAccess> AlterCompatible for CsrConnection<C> {
 ///
 /// AWS credentials, region, and endpoint are inherited from the referenced
 /// [`AwsConnection`]; this struct only carries the per-registry settings.
-///
-/// NOTE: Stage 1 of the GSR rollout. The client crate
-/// (`mz-aws-glue-schema-registry`) does not exist yet; `validate` is a
-/// no-op until Stage 3 retrofits a real `GetRegistry` ping. The connection
-/// can be created and inspected, but cannot yet be attached to a source or
-/// sink.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct GlueSchemaRegistryConnection<C: ConnectionAccess = InlinedConnection> {
     /// The referenced AWS connection that supplies credentials, region, and
@@ -1638,11 +1632,9 @@ impl<R: ConnectionResolver> IntoInlineConnection<GlueSchemaRegistryConnection, R
 
 impl<C: ConnectionAccess> GlueSchemaRegistryConnection<C> {
     fn validate_by_default(&self) -> bool {
-        // Stage 1 of the AWS Glue Schema Registry rollout: the client crate
-        // does not exist yet, and the no-op `validate` below succeeds
-        // unconditionally. Default-validating preserves the API contract so
-        // that Stage 3's real `GetRegistry` ping slots in without
-        // behavioral change.
+        // Matches CSR: default-validate so a bad registry name fails at
+        // `CREATE CONNECTION` rather than surfacing later on first use.
+        // Users can still opt out with `WITH (VALIDATE = false)`.
         true
     }
 }
@@ -1651,14 +1643,33 @@ impl GlueSchemaRegistryConnection {
     async fn validate(
         &self,
         _id: CatalogItemId,
-        _storage_configuration: &StorageConfiguration,
+        storage_configuration: &StorageConfiguration,
     ) -> Result<(), anyhow::Error> {
-        // Stage 1: no-op. Real validation arrives in Stage 3 when the
-        // Glue client crate exists. Until then a `CREATE CONNECTION`
-        // succeeds even against a registry that doesn't exist; the
-        // failure will surface on first use (which is itself gated until
-        // source/sink integration lands in Stages 4/5).
-        std::future::ready(Ok(())).await
+        let enforce_external_addresses =
+            crate::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES.get(storage_configuration.config_set());
+        let sdk_config = self
+            .aws_connection
+            .connection
+            .load_sdk_config(
+                &storage_configuration.connection_context,
+                self.aws_connection.connection_id,
+                // We are in a normal tokio context during validation.
+                InTask::No,
+                enforce_external_addresses,
+            )
+            .await?;
+        let client = mz_aws_glue_schema_registry::ClientConfig::new(sdk_config).build();
+        match client.get_registry(&self.registry_name).await {
+            Ok(_) => Ok(()),
+            Err(mz_aws_glue_schema_registry::GetRegistryError::NotFound) => Err(anyhow!(
+                "AWS Glue Schema Registry {:?} does not exist in the configured account/region",
+                self.registry_name
+            )),
+            Err(err) => Err(anyhow::Error::new(err).context(format!(
+                "failed to validate AWS Glue Schema Registry connection (registry={:?})",
+                self.registry_name
+            ))),
+        }
     }
 }
 

--- a/test/sqllogictest/glue_schema_registry.slt
+++ b/test/sqllogictest/glue_schema_registry.slt
@@ -7,11 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Stage 1 tests for AWS Glue Schema Registry connections.
+# Tests for AWS Glue Schema Registry connections.
 #
-# Validates parsing, planning, catalog round-trip, ALTER compatibility, and
-# the `enable_glue_schema_registry` feature flag. No client crate exists in
-# this stage; `validate()` is a no-op (Stage 3 retrofits real validation).
+# Covers parsing, planning, catalog round-trip, ALTER compatibility, and the
+# `enable_glue_schema_registry` feature flag.
+#
+# `validate()` performs a real `GetRegistry` call against AWS.
+# Sqllogictest has no AWS credentials, so every CREATE CONNECTION here uses
+# `WITH (VALIDATE = false)`. End-to-end validation coverage lives in the
+# LocalStack-backed mzcompose tests.
 #
 # See doc/developer/design/20260512_aws_glue_schema_registry.md.
 
@@ -35,12 +39,13 @@ CREATE CONNECTION aws_conn TO AWS (
     ASSUME ROLE ARN 'arn:aws:iam::123456789000:role/my-role'
 ) WITH (VALIDATE = false)
 
-# Happy path: GSR connection with both required options.
+# Happy path: GSR connection with both required options. Validation is
+# skipped because we have no AWS account to call against.
 statement ok
 CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
     AWS CONNECTION = aws_conn,
     REGISTRY = 'my-registry'
-)
+) WITH (VALIDATE = false)
 
 # SHOW CREATE CONNECTION round-trip (pretty-printed multiline form).
 query T multiline
@@ -107,7 +112,7 @@ statement error CREATE CONNECTION \.\.\. TO AWS GLUE SCHEMA REGISTRY is not avai
 CREATE CONNECTION gated_glue TO AWS GLUE SCHEMA REGISTRY (
     AWS CONNECTION = aws_conn,
     REGISTRY = 'my-registry'
-)
+) WITH (VALIDATE = false)
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_glue_schema_registry TO true;
@@ -119,7 +124,7 @@ statement ok
 CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
     AWS CONNECTION = aws_conn,
     REGISTRY = 'my-registry'
-)
+) WITH (VALIDATE = false)
 
 statement ok
 DROP CONNECTION glue_conn


### PR DESCRIPTION
Adds an AWS Glue schema registry client and create. Follows a pattern similar to the existing Confluent schema registry client.

This PR implements the following APIs that will be used during the setup of a GSR connection and a kafka source using GSR:
* `Client::get_registry`
  * used to verify a registry exists at `CREATE CONNECTION` time.
* `Client::get_schema_version_by_id`
  * source decode: fetch a writer schema by the UUID embedded in each record's Glue wire-format header.
* `Client::get_schema_version_latest_by_name`
  * DDL planning: lookup and pin a reader schema to the registry's current "latest" version.