### PR TITLE
mcp: advertise Frontegg authorization server via RFC 9728

### DIFF
--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -748,6 +748,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
 
     // Configure connections.
     let tls = args.tls.into_config()?;
+    let frontegg_oauth_issuer_url = args.frontegg.oauth_issuer_url().map(str::to_string);
     let frontegg = FronteggAuthenticator::from_args(args.frontegg, &metrics_registry)?;
     let listeners_config: ListenersConfig = {
         let f = File::open(args.listeners_config_path)?;
@@ -1090,6 +1091,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 tls_reload_certs: mz_server_core::default_cert_reload_ticker(),
                 external_login_password_mz_system: args.external_login_password_mz_system,
                 frontegg,
+                frontegg_oauth_issuer_url,
                 cors_allowed_origin,
                 cors_allowed_origin_list,
                 egress_addresses: args.announce_egress_address,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -172,6 +172,7 @@ pub struct HttpConfig {
     /// today, and an attacker reaching the server directly can otherwise
     /// poison the published metadata URLs.
     pub http_host_name: Option<String>,
+    pub frontegg_oauth_issuer_url: Option<String>,
     pub concurrent_webhook_req: Arc<tokio::sync::Semaphore>,
     pub metrics: Metrics,
     pub metrics_registry: MetricsRegistry,
@@ -230,6 +231,7 @@ impl HttpServer {
             active_connection_counter,
             helm_chart_version,
             http_host_name,
+            frontegg_oauth_issuer_url,
             concurrent_webhook_req,
             metrics,
             metrics_registry,
@@ -243,6 +245,14 @@ impl HttpServer {
     ) -> HttpServer {
         let tls_enabled = tls.is_some();
         let webhook_cache = WebhookAppenderCache::new();
+
+        // Compute OAuth discovery once per listener so the Bearer challenge
+        // and the discovery handler always agree, and the middleware doesn't
+        // re-derive (and re-allocate the Frontegg issuer) on each request.
+        let oauth_discovery = Arc::new(oauth_metadata::McpOAuthDiscovery::for_authenticator(
+            authenticator_kind,
+            frontegg_oauth_issuer_url.as_deref(),
+        ));
 
         // Create secure session store and manager
         let session_store = TowerSessionMemoryStore::default();
@@ -552,9 +562,7 @@ impl HttpServer {
                 .layer(Extension(adapter_client_rx.clone()))
                 .layer(Extension(oauth_metadata::DiscoveryConfig {
                     http_host_name: http_host_name.clone(),
-                    discovery: oauth_metadata::McpOAuthDiscovery::for_authenticator(
-                        authenticator_kind,
-                    ),
+                    discovery: (*oauth_discovery).clone(),
                 }))
                 .layer(Extension(oauth_metadata_metrics.clone()));
             router = router.merge(oauth_metadata_router);
@@ -589,6 +597,7 @@ impl HttpServer {
                 .layer(auth_middleware.clone())
                 .layer(Extension(BearerChallengeConfig {
                     scope: oauth_metadata::MCP_SCOPE,
+                    discovery: Arc::clone(&oauth_discovery),
                 }))
                 .layer(Extension(adapter_client_rx.clone()))
                 .layer(Extension(active_connection_counter.clone()))
@@ -959,6 +968,9 @@ where
 pub(crate) struct BearerChallengeConfig {
     /// OAuth scope advertised in the `Bearer` challenge's `scope=` parameter.
     pub scope: &'static str,
+    /// Precomputed once at server build time and shared with the discovery
+    /// handler so the two never disagree.
+    pub discovery: Arc<oauth_metadata::McpOAuthDiscovery>,
 }
 
 /// Per-request decision about which `WWW-Authenticate` challenges to emit
@@ -1204,7 +1216,7 @@ async fn http_auth(
             .any(|prefix| path.starts_with(prefix))
         || bearer_config.is_some();
     let (bearer_resource_metadata, bearer_scope) = if let Some(config) = &bearer_config
-        && oauth_metadata::McpOAuthDiscovery::for_authenticator(authenticator_kind).is_enabled()
+        && config.discovery.is_enabled()
     {
         (
             oauth_metadata::metadata_url(&req, http_host_name.as_deref()),

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -266,12 +266,10 @@ impl HttpServer {
         let frontegg_middleware = frontegg.clone();
         let oidc_middleware_rx = oidc_rx.clone();
         let adapter_client_middleware_rx = adapter_client_rx.clone();
-        let http_host_name_middleware = http_host_name.clone();
         let auth_middleware = middleware::from_fn(move |req, next| {
             let frontegg = frontegg_middleware.clone();
             let oidc_rx = oidc_middleware_rx.clone();
             let adapter_client_rx = adapter_client_middleware_rx.clone();
-            let http_host_name = http_host_name_middleware.clone();
             async move {
                 http_auth(
                     req,
@@ -282,7 +280,6 @@ impl HttpServer {
                     oidc_rx,
                     adapter_client_rx,
                     allowed_roles,
-                    http_host_name,
                 )
                 .await
             }
@@ -560,9 +557,9 @@ impl HttpServer {
                     routing::get(oauth_metadata::handle_protected_resource_metadata),
                 )
                 .layer(Extension(adapter_client_rx.clone()))
-                .layer(Extension(oauth_metadata::DiscoveryConfig {
+                .layer(Extension(oauth_metadata::McpOAuthConfig {
                     http_host_name: http_host_name.clone(),
-                    discovery: (*oauth_discovery).clone(),
+                    discovery: Arc::clone(&oauth_discovery),
                 }))
                 .layer(Extension(oauth_metadata_metrics.clone()));
             router = router.merge(oauth_metadata_router);
@@ -595,8 +592,8 @@ impl HttpServer {
             let mcp_allowed_origins = Arc::new(allowed_origin_list.clone());
             mcp_router = mcp_router
                 .layer(auth_middleware.clone())
-                .layer(Extension(BearerChallengeConfig {
-                    scope: oauth_metadata::MCP_SCOPE,
+                .layer(Extension(oauth_metadata::McpOAuthConfig {
+                    http_host_name: http_host_name.clone(),
                     discovery: Arc::clone(&oauth_discovery),
                 }))
                 .layer(Extension(adapter_client_rx.clone()))
@@ -959,28 +956,14 @@ where
     }
 }
 
-/// Route-attached marker that opts a route into OAuth Bearer challenges on a
-/// 401. The auth middleware reads this as a request extension instead of
-/// switching on the URL path, so the middleware stays path-agnostic. Set on
-/// `mcp_router` today; add to other routers if they later want to advertise
-/// OAuth discovery via RFC 9728.
-#[derive(Debug, Clone)]
-pub(crate) struct BearerChallengeConfig {
-    /// OAuth scope advertised in the `Bearer` challenge's `scope=` parameter.
-    pub scope: &'static str,
-    /// Precomputed once at server build time and shared with the discovery
-    /// handler so the two never disagree.
-    pub discovery: Arc<oauth_metadata::McpOAuthDiscovery>,
-}
-
 /// Per-request decision about which `WWW-Authenticate` challenges to emit
 /// on a 401, computed by the auth middleware.
 ///
 /// Carries both the `Basic` toggle (today's behavior, kept for the SQL HTTP
 /// layer and friends) and an optional `Bearer` challenge with a
-/// `resource_metadata` URL per RFC 9728. The Bearer challenge is only set
-/// on routes that attach a [`BearerChallengeConfig`] extension; other routes
-/// emit only `Basic` so their behavior is unchanged.
+/// `resource_metadata` URL per RFC 9728. The Bearer challenge is only set on
+/// routes that attach an [`oauth_metadata::McpOAuthConfig`] extension; other
+/// routes emit only `Basic` so their behavior is unchanged.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct WwwAuthenticateChallenges {
     /// Whether to emit `WWW-Authenticate: Basic realm=Materialize`.
@@ -1143,7 +1126,6 @@ async fn http_auth(
     oidc_rx: Delayed<mz_authenticator::GenericOidcAuthenticator>,
     adapter_client_rx: Delayed<Client>,
     allowed_roles: AllowedRoles,
-    http_host_name: Option<String>,
 ) -> Result<impl IntoResponse, AuthError> {
     let creds = if let Some(basic) = req.headers().typed_get::<Authorization<Basic>>() {
         Some(Credentials::Password {
@@ -1202,25 +1184,28 @@ async fn http_auth(
     }
 
     let path = req.uri().path();
-    // Routes that advertise OAuth opt in via the `BearerChallengeConfig`
+    // Routes that advertise OAuth opt in by attaching an `McpOAuthConfig`
     // extension; the middleware stays path-agnostic. Routes that opt in also
     // get a `Basic` challenge so existing curl/Bearer-already users still see
     // a usable challenge. See `crate::http::oauth_metadata` for the discovery
-    // document; the challenge and the discovery handler share
-    // `McpOAuthDiscovery` so they never disagree about whether OAuth is
-    // advertised on this listener.
-    let bearer_config = req.extensions().get::<BearerChallengeConfig>().cloned();
+    // document; the challenge and the discovery handler read the same
+    // `McpOAuthConfig`, so they emit the same authorization server and the
+    // same host for a given listener.
+    let oauth_config = req
+        .extensions()
+        .get::<oauth_metadata::McpOAuthConfig>()
+        .cloned();
     let include_basic = path == "/"
         || PROFILING_API_ENDPOINTS
             .iter()
             .any(|prefix| path.starts_with(prefix))
-        || bearer_config.is_some();
-    let (bearer_resource_metadata, bearer_scope) = if let Some(config) = &bearer_config
+        || oauth_config.is_some();
+    let (bearer_resource_metadata, bearer_scope) = if let Some(config) = &oauth_config
         && config.discovery.is_enabled()
     {
         (
-            oauth_metadata::metadata_url(&req, http_host_name.as_deref()),
-            Some(config.scope),
+            oauth_metadata::metadata_url(&req, config.http_host_name.as_deref()),
+            Some(config.scope()),
         )
     } else {
         (None, None)

--- a/src/environmentd/src/http/oauth_metadata.rs
+++ b/src/environmentd/src/http/oauth_metadata.rs
@@ -254,6 +254,15 @@ pub(crate) async fn handle_protected_resource_metadata(
     Extension(metrics): Extension<OauthMetadataMetrics>,
     req: Request,
 ) -> Response {
+    // Early-return for listeners that don't advertise OAuth, before we touch
+    // request headers. Keeps the response 404 even when `Host` is malformed,
+    // so probes can't distinguish "Disabled listener" from "non-existent
+    // listener" by the status code.
+    if !config.discovery.is_enabled() {
+        metrics.inc(MetricStatus::Disabled);
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
     let Some(host) = resolve_host(&req, config.http_host_name.as_deref()) else {
         warn!(
             "oauth-protected-resource: no http_host_name configured and request has no Host header"
@@ -264,13 +273,7 @@ pub(crate) async fn handle_protected_resource_metadata(
     let resource = format!("{PUBLISHED_SCHEME}://{host}/api/mcp");
 
     let issuer = match &config.discovery {
-        McpOAuthDiscovery::Disabled => {
-            // Listener validates no OAuth bearer token (None/Password/Sasl,
-            // or Frontegg without an issuer URL), so there is no
-            // authorization flow to advertise.
-            metrics.inc(MetricStatus::Disabled);
-            return StatusCode::NOT_FOUND.into_response();
-        }
+        McpOAuthDiscovery::Disabled => unreachable!("handled above"),
         McpOAuthDiscovery::Frontegg { issuer } => {
             // Validated once at startup in `for_authenticator`; trusted here.
             issuer.clone()

--- a/src/environmentd/src/http/oauth_metadata.rs
+++ b/src/environmentd/src/http/oauth_metadata.rs
@@ -48,6 +48,7 @@
 //!
 //! [RFC 9728]: https://datatracker.ietf.org/doc/html/rfc9728
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Extension;
@@ -225,16 +226,32 @@ impl McpOAuthDiscovery {
     }
 }
 
-/// Per-listener config for the discovery handler. Carried as an axum
-/// `Extension` because one environmentd process can serve listeners with
-/// different authenticators and `http_host_name`s.
+/// Per-listener config shared by the OAuth discovery handler and the auth
+/// middleware's `WWW-Authenticate` builder. Carried as an axum `Extension`
+/// because one environmentd process can serve listeners with different
+/// authenticators and `http_host_name`s.
+///
+/// Wrapping both consumers in one struct keeps them in lockstep: the 401
+/// challenge and the discovery document are computed from the same
+/// `discovery` value and the same `http_host_name`, so a client that
+/// follows the `resource_metadata` URL from a 401 reaches a document with
+/// matching host and matching authorization server.
 #[derive(Debug, Clone)]
-pub(crate) struct DiscoveryConfig {
+pub(crate) struct McpOAuthConfig {
     /// Operator-configured external host (without scheme). Beats the
     /// `Host` header when set.
     pub http_host_name: Option<String>,
     /// How (or whether) this listener advertises OAuth.
-    pub discovery: McpOAuthDiscovery,
+    pub discovery: Arc<McpOAuthDiscovery>,
+}
+
+impl McpOAuthConfig {
+    /// OAuth scope advertised in the `Bearer` challenge's `scope=`
+    /// parameter on 401 responses. Constant today; method-form keeps the
+    /// auth middleware free of [`MCP_SCOPE`] knowledge.
+    pub(crate) fn scope(&self) -> &'static str {
+        MCP_SCOPE
+    }
 }
 
 /// HTTP handler for [`PROTECTED_RESOURCE_METADATA_PATH`].
@@ -250,7 +267,7 @@ pub(crate) struct DiscoveryConfig {
 /// the JSON document otherwise.
 pub(crate) async fn handle_protected_resource_metadata(
     Extension(adapter_client_rx): Extension<Delayed<Client>>,
-    Extension(config): Extension<DiscoveryConfig>,
+    Extension(config): Extension<McpOAuthConfig>,
     Extension(metrics): Extension<OauthMetadataMetrics>,
     req: Request,
 ) -> Response {
@@ -272,7 +289,7 @@ pub(crate) async fn handle_protected_resource_metadata(
     };
     let resource = format!("{PUBLISHED_SCHEME}://{host}/api/mcp");
 
-    let issuer = match &config.discovery {
+    let issuer = match &*config.discovery {
         McpOAuthDiscovery::Disabled => unreachable!("handled above"),
         McpOAuthDiscovery::Frontegg { issuer } => {
             // Validated once at startup in `for_authenticator`; trusted here.

--- a/src/environmentd/src/http/oauth_metadata.rs
+++ b/src/environmentd/src/http/oauth_metadata.rs
@@ -178,32 +178,45 @@ impl OauthMetadataMetrics {
 /// routes. Derived once per listener from its authenticator and consulted
 /// by both the 401 `WWW-Authenticate` challenge and this discovery handler,
 /// so the two never disagree about whether OAuth is on offer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum McpOAuthDiscovery {
     /// The listener validates no OAuth bearer token, so there is no flow to
-    /// advertise. Covers `None`, `Password`, and `Sasl`.
+    /// advertise. Covers `None`, `Password`, and `Sasl`, plus `Frontegg`
+    /// when no issuer URL is configured.
     Disabled,
     /// Self-managed OIDC: the authorization server is the `oidc_issuer`
     /// dyncfg, read at request time so an operator can change it without a
     /// restart.
     Oidc,
-    // Frontegg (cloud) validates tokens against its own pre-shared key
-    // rather than `oidc_issuer`, and its authorization server is the
-    // configured Frontegg URL. Advertising it needs a `Frontegg { issuer }`
-    // arm here plus edge plumbing; tracked in DEX-31.
+    /// Frontegg (cloud): the authorization server is the workspace URL
+    /// supplied at startup via `--frontegg-oauth-issuer-url`.
+    Frontegg { issuer: String },
 }
 
 impl McpOAuthDiscovery {
     /// The single mapping from a listener's authenticator to its OAuth
-    /// advertisement behavior. Only `Oidc` validates bearer tokens against
-    /// `oidc_issuer`, so only `Oidc` advertises today.
-    pub(crate) fn for_authenticator(kind: listeners::AuthenticatorKind) -> Self {
-        match kind {
-            listeners::AuthenticatorKind::Oidc => Self::Oidc,
-            listeners::AuthenticatorKind::Frontegg
-            | listeners::AuthenticatorKind::Password
-            | listeners::AuthenticatorKind::Sasl
-            | listeners::AuthenticatorKind::None => Self::Disabled,
+    /// advertisement behavior. Frontegg requires a valid issuer URL;
+    /// otherwise falls back to `Disabled`.
+    pub(crate) fn for_authenticator(
+        kind: listeners::AuthenticatorKind,
+        frontegg_oauth_issuer_url: Option<&str>,
+    ) -> Self {
+        match (kind, frontegg_oauth_issuer_url) {
+            (listeners::AuthenticatorKind::Oidc, _) => Self::Oidc,
+            (listeners::AuthenticatorKind::Frontegg, Some(issuer)) => {
+                if let Err(err) = validate_issuer_url(issuer) {
+                    warn!(
+                        error = %err,
+                        "frontegg-oauth-issuer-url is invalid; MCP OAuth discovery disabled"
+                    );
+                    Self::Disabled
+                } else {
+                    Self::Frontegg {
+                        issuer: issuer.to_string(),
+                    }
+                }
+            }
+            _ => Self::Disabled,
         }
     }
 
@@ -241,13 +254,6 @@ pub(crate) async fn handle_protected_resource_metadata(
     Extension(metrics): Extension<OauthMetadataMetrics>,
     req: Request,
 ) -> Response {
-    if !config.discovery.is_enabled() {
-        // Listener validates no OAuth bearer token (None/Password/Sasl), so
-        // there is no authorization flow to advertise.
-        metrics.inc(MetricStatus::Disabled);
-        return StatusCode::NOT_FOUND.into_response();
-    }
-
     let Some(host) = resolve_host(&req, config.http_host_name.as_deref()) else {
         warn!(
             "oauth-protected-resource: no http_host_name configured and request has no Host header"
@@ -257,51 +263,68 @@ pub(crate) async fn handle_protected_resource_metadata(
     };
     let resource = format!("{PUBLISHED_SCHEME}://{host}/api/mcp");
 
-    let adapter_client =
-        match tokio::time::timeout(ADAPTER_WAIT_TIMEOUT, adapter_client_rx.clone()).await {
-            Ok(Ok(client)) => client,
-            Ok(Err(_)) | Err(_) => {
-                metrics.inc(MetricStatus::AdapterUnavailable);
-                return (StatusCode::SERVICE_UNAVAILABLE, "adapter not ready").into_response();
+    let issuer = match &config.discovery {
+        McpOAuthDiscovery::Disabled => {
+            // Listener validates no OAuth bearer token (None/Password/Sasl,
+            // or Frontegg without an issuer URL), so there is no
+            // authorization flow to advertise.
+            metrics.inc(MetricStatus::Disabled);
+            return StatusCode::NOT_FOUND.into_response();
+        }
+        McpOAuthDiscovery::Frontegg { issuer } => {
+            // Validated once at startup in `for_authenticator`; trusted here.
+            issuer.clone()
+        }
+        McpOAuthDiscovery::Oidc => {
+            let adapter_client =
+                match tokio::time::timeout(ADAPTER_WAIT_TIMEOUT, adapter_client_rx.clone()).await {
+                    Ok(Ok(client)) => client,
+                    Ok(Err(_)) | Err(_) => {
+                        metrics.inc(MetricStatus::AdapterUnavailable);
+                        return (StatusCode::SERVICE_UNAVAILABLE, "adapter not ready")
+                            .into_response();
+                    }
+                };
+            let system_vars = adapter_client.get_system_vars().await;
+            let Some(issuer) = OIDC_ISSUER.get(system_vars.dyncfgs()) else {
+                // No OAuth authorization server is configured. Per RFC 9728 the
+                // document MUST contain at least one entry in
+                // `authorization_servers`, so the honest response is 404 rather
+                // than an empty document that misleads the client.
+                warn!("oauth-protected-resource: oidc_issuer is unset; cannot publish");
+                metrics.inc(MetricStatus::NoIssuer);
+                return StatusCode::NOT_FOUND.into_response();
+            };
+            if let Err(err) = validate_issuer_url(&issuer) {
+                // Don't echo the issuer into the WARN: a userinfo-bearing value
+                // would turn this log line into a credential dump. The error
+                // reason is specific enough.
+                warn!(error = %err, "oauth-protected-resource: refusing to publish invalid oidc_issuer");
+                metrics.inc(MetricStatus::InvalidIssuer);
+                return (StatusCode::SERVICE_UNAVAILABLE, err).into_response();
             }
-        };
-    let system_vars = adapter_client.get_system_vars().await;
-    let Some(issuer) = OIDC_ISSUER.get(system_vars.dyncfgs()) else {
-        // No OAuth authorization server is configured. Per RFC 9728 the
-        // document MUST contain at least one entry in
-        // `authorization_servers`, so the honest response is 404 rather
-        // than an empty document that misleads the client.
-        warn!("oauth-protected-resource: oidc_issuer is unset; cannot publish");
-        metrics.inc(MetricStatus::NoIssuer);
-        return StatusCode::NOT_FOUND.into_response();
-    };
-    if let Err(err) = validate_issuer_url(&issuer) {
-        // Don't echo the issuer into the WARN: a userinfo-bearing value
-        // would turn this log line into a credential dump. The error
-        // reason is specific enough.
-        warn!(error = %err, "oauth-protected-resource: refusing to publish invalid oidc_issuer");
-        metrics.inc(MetricStatus::InvalidIssuer);
-        return (StatusCode::SERVICE_UNAVAILABLE, err).into_response();
-    }
 
-    // We still publish when no audience is configured (mirroring the
-    // authenticator, which warns and skips `aud` validation), but a resource
-    // server that does not bind tokens to its own audience is exposed to
-    // same-issuer token reuse, so make the gap visible to operators.
-    if OIDC_AUDIENCE
-        .get(system_vars.dyncfgs())
-        .as_array()
-        .is_none_or(|audiences| audiences.is_empty())
-    {
-        warn!(
-            "oauth-protected-resource: publishing with oidc_audience unset; tokens from this \
-             issuer are not audience-bound to this resource"
-        );
-    }
+            // We still publish when no audience is configured (mirroring the
+            // authenticator, which warns and skips `aud` validation), but a resource
+            // server that does not bind tokens to its own audience is exposed to
+            // same-issuer token reuse, so make the gap visible to operators.
+            if OIDC_AUDIENCE
+                .get(system_vars.dyncfgs())
+                .as_array()
+                .is_none_or(|audiences| audiences.is_empty())
+            {
+                warn!(
+                    "oauth-protected-resource: publishing with oidc_audience unset; tokens from \
+                     this issuer are not audience-bound to this resource"
+                );
+            }
+            issuer.to_string()
+        }
+    };
 
     let metadata = ProtectedResourceMetadata {
         resource,
-        authorization_servers: vec![issuer.to_string()],
+        authorization_servers: vec![issuer],
         bearer_methods_supported: vec!["header".to_string()],
         scopes_supported: vec![MCP_SCOPE.to_string()],
     };
@@ -647,31 +670,61 @@ mod tests {
         }
     }
 
-    /// Pin the authenticator-to-discovery mapping. Today only `Oidc`
-    /// advertises OAuth; if Frontegg, Password, Sasl, or None flips to
-    /// enabled by accident, MCP clients would be steered into a flow
-    /// the listener can't honour.
+    /// Pin the authenticator-to-discovery mapping so a refactor doesn't
+    /// silently steer MCP clients into a flow the listener can't honour.
     #[mz_ore::test]
     fn test_mcp_oauth_discovery_for_authenticator() {
         use listeners::AuthenticatorKind;
+        // Oidc always advertises, regardless of the Frontegg issuer URL.
+        for issuer in [None, Some("https://ignored.example.com")] {
+            assert_eq!(
+                McpOAuthDiscovery::for_authenticator(AuthenticatorKind::Oidc, issuer),
+                McpOAuthDiscovery::Oidc,
+            );
+        }
+        // Frontegg requires a valid issuer URL; absent or invalid → Disabled.
         assert_eq!(
-            McpOAuthDiscovery::for_authenticator(AuthenticatorKind::Oidc),
-            McpOAuthDiscovery::Oidc,
+            McpOAuthDiscovery::for_authenticator(AuthenticatorKind::Frontegg, None),
+            McpOAuthDiscovery::Disabled,
         );
+        assert_eq!(
+            McpOAuthDiscovery::for_authenticator(
+                AuthenticatorKind::Frontegg,
+                Some("not a url"),
+            ),
+            McpOAuthDiscovery::Disabled,
+        );
+        assert_eq!(
+            McpOAuthDiscovery::for_authenticator(
+                AuthenticatorKind::Frontegg,
+                Some("https://acme.frontegg.com"),
+            ),
+            McpOAuthDiscovery::Frontegg {
+                issuer: "https://acme.frontegg.com".to_string(),
+            },
+        );
+        // Non-token authenticators stay disabled even with an issuer URL set.
         for kind in [
             AuthenticatorKind::None,
             AuthenticatorKind::Password,
-            AuthenticatorKind::Frontegg,
             AuthenticatorKind::Sasl,
         ] {
-            assert_eq!(
-                McpOAuthDiscovery::for_authenticator(kind),
-                McpOAuthDiscovery::Disabled,
-                "{kind:?} must not advertise OAuth until explicitly wired up",
-            );
+            for issuer in [None, Some("https://acme.frontegg.com")] {
+                assert_eq!(
+                    McpOAuthDiscovery::for_authenticator(kind, issuer),
+                    McpOAuthDiscovery::Disabled,
+                    "{kind:?} must not advertise OAuth",
+                );
+            }
         }
         assert!(McpOAuthDiscovery::Oidc.is_enabled());
         assert!(!McpOAuthDiscovery::Disabled.is_enabled());
+        assert!(
+            McpOAuthDiscovery::Frontegg {
+                issuer: "https://acme.frontegg.com".to_string(),
+            }
+            .is_enabled()
+        );
     }
 
     /// Rejects values that would confuse clients downstream or leak

--- a/src/environmentd/src/http/oauth_metadata.rs
+++ b/src/environmentd/src/http/oauth_metadata.rs
@@ -691,10 +691,7 @@ mod tests {
             McpOAuthDiscovery::Disabled,
         );
         assert_eq!(
-            McpOAuthDiscovery::for_authenticator(
-                AuthenticatorKind::Frontegg,
-                Some("not a url"),
-            ),
+            McpOAuthDiscovery::for_authenticator(AuthenticatorKind::Frontegg, Some("not a url"),),
             McpOAuthDiscovery::Disabled,
         );
         assert_eq!(

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -107,6 +107,8 @@ pub struct Config {
     pub external_login_password_mz_system: Option<Password>,
     /// Frontegg JWT authenticator.
     pub frontegg: Option<FronteggAuthenticator>,
+    /// Frontegg workspace URL advertised in MCP OAuth discovery.
+    pub frontegg_oauth_issuer_url: Option<String>,
     /// Origins for which cross-origin resource sharing (CORS) for HTTP requests
     /// is permitted.
     pub cors_allowed_origin: AllowOrigin,
@@ -401,6 +403,7 @@ impl Listeners {
                 active_connection_counter: active_connection_counter.clone(),
                 helm_chart_version: config.helm_chart_version.clone(),
                 http_host_name: config.http_host_name.clone(),
+                frontegg_oauth_issuer_url: config.frontegg_oauth_issuer_url.clone(),
                 source,
                 tls,
                 authenticator_kind,

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -886,6 +886,7 @@ impl Listeners {
                 cloud_resource_controller: None,
                 tls: config.tls,
                 frontegg: config.frontegg,
+                frontegg_oauth_issuer_url: None,
                 unsafe_mode: config.unsafe_mode,
                 all_features: false,
                 metrics_registry: metrics_registry.clone(),

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -51,4 +51,13 @@ pub struct FronteggCliArgs {
     /// The name of the admin role in Frontegg.
     #[clap(long, env = "FRONTEGG_ADMIN_ROLE", requires = "frontegg_tenant")]
     frontegg_admin_role: Option<String>,
+    /// Issuer URL of the Frontegg workspace, advertised in MCP OAuth discovery.
+    #[clap(long, env = "FRONTEGG_OAUTH_ISSUER_URL")]
+    frontegg_oauth_issuer_url: Option<String>,
+}
+
+impl FronteggCliArgs {
+    pub fn oauth_issuer_url(&self) -> Option<&str> {
+        self.frontegg_oauth_issuer_url.as_deref()
+    }
 }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1229,6 +1229,7 @@ impl<'a> RunnerInner<'a> {
             cloud_resource_controller: None,
             tls: None,
             frontegg: None,
+            frontegg_oauth_issuer_url: None,
             cors_allowed_origin: AllowOrigin::list([]),
             cors_allowed_origin_list: Vec::new(),
             unsafe_mode: true,


### PR DESCRIPTION
Follow-up to #36669 that adds the Frontegg arm of MCP OAuth discovery. Introduces `--frontegg-oauth-issuer-url` (env `FRONTEGG_OAUTH_ISSUER_URL`) on environmentd; when set on a Frontegg listener, `/.well-known/oauth-protected-resource` advertises that URL as the authorization server and 401 Bearer challenges point clients at it. Cloud-side plumbing in MaterializeInc/cloud#12773.

