### PR TITLE
[environmentd] skip group_claim lookup for non-Frontegg auth

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -1227,13 +1227,22 @@ async fn http_auth(
     )
     .await;
 
-    let group_claim = group_claim_for(&adapter_client_rx).await;
+    // Only the Frontegg arm consumes `group_claim`; resolving it requires a
+    // coordinator round-trip (`Command::GetSystemVars`), so skip it for
+    // None/Password/OIDC paths. Otherwise unauth'd probes like `/api/livez`,
+    // `/api/readyz`, and `/metrics` on a `None`-auth listener would couple
+    // liveness to coordinator health. Mirrors the pgwire path.
+    let group_claim = if matches!(authenticator, Authenticator::Frontegg(_)) {
+        Some(group_claim_for(&adapter_client_rx).await)
+    } else {
+        None
+    };
     let user = auth(
         &authenticator,
         creds,
         allowed_roles,
         &challenges,
-        Some(&group_claim),
+        group_claim.as_deref(),
     )
     .await?;
 
@@ -1328,13 +1337,19 @@ async fn init_ws(
             // client is reading WS frames, not parsing HTTP headers, so
             // we just suppress challenge emission entirely.
             let no_challenges = WwwAuthenticateChallenges::default();
-            let group_claim = group_claim_for(&adapter_client_rx).await;
+            // See `http_auth`: only Frontegg uses `group_claim`, and the
+            // fetch costs a coordinator round-trip.
+            let group_claim = if matches!(authenticator, Authenticator::Frontegg(_)) {
+                Some(group_claim_for(&adapter_client_rx).await)
+            } else {
+                None
+            };
             let user = auth(
                 &authenticator,
                 Some(creds),
                 allowed_roles,
                 &no_challenges,
-                Some(&group_claim),
+                group_claim.as_deref(),
             )
             .await?;
             user

--- a/test/http-auth/mzcompose.py
+++ b/test/http-auth/mzcompose.py
@@ -98,3 +98,33 @@ def workflow_default(c: Composition) -> None:
                 "permission denied"
                 in r.json()["results"][0]["error"]["message"].lower()
             )
+
+    check_livez_coordinator_coupling(c)
+
+
+def check_livez_coordinator_coupling(c: Composition) -> None:
+    """Regression test for SQL-343: previously having group_claim_for above
+    the authenticator match in http_auth, so unauthenticated internal
+    endpoints (/api/livez, /api/readyz, /metrics) began round-tripping
+    the coordinator (`Command::GetSystemVars`) on every request for a value
+    only the Frontegg arm uses.
+    """
+    c.up("materialized")
+    base = f"http://localhost:{c.port('materialized', 6878)}"
+
+    # Coordinator-side count of GetSystemVars commands, scraped from /metrics.
+    def get_system_vars_count() -> int:
+        for line in requests.get(f"{base}/metrics").text.splitlines():
+            if (
+                line.startswith("mz_slow_message_handling_count{")
+                and "get_system_vars" in line
+            ):
+                return int(float(line.split()[-1]))
+        return 0
+
+    with c.test_case("livez_does_not_round_trip_coordinator"):
+        before = get_system_vars_count()
+        for _ in range(100):
+            assert requests.get(f"{base}/api/livez").status_code == 200
+        delta = get_system_vars_count() - before
+        assert delta < 50, f"100 liveness probes caused {delta} coordinator round-trips"


### PR DESCRIPTION
The HTTP auth path unconditionally called group_claim_for, which issues a round-trip to the coordinator.

Only the Frontegg arm consumes the result, so unauthenticated probes like `/api/livez`, `/api/readyz`, and `/metrics` coupled liveness to coordinator health. Gate the fetch on `Authenticator::Frontegg` to mirror the pgwire path.

Add a regression test in `test/http-auth` that asserts liveness probes do not round-trip the coordinator.

Remove these sections if your commit already has a good description!

Closes SQL-343
