### PR TITLE
[sql] fix REVOKE/GRANT ALL on TABLE <view/mv/source> losing non-SELECT privileges

### DIFF
--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -17,6 +17,14 @@ The syntax supports the `ALL [PRIVILEGES]` shorthand to refer to all
 [*applicable* privileges](/sql/grant-privilege/#available-privileges) for the
 object type.
 
+For PostgreSQL compatibility, you can reference views, materialized views,
+and sources with the `TABLE` keyword. With `ON TABLE`, the `ALL [PRIVILEGES]`
+shorthand expands to the full table privilege set
+(`SELECT, INSERT, UPDATE, DELETE`), even if some of those privileges aren't
+meaningful for the object type. The non-applicable privileges have no
+runtime effect. They're stored so that a later `REVOKE ALL ON TABLE` can
+clear every privilege previously granted through the same shorthand.
+
 {{</note>}}
 
 {{< tabs >}}
@@ -99,7 +107,19 @@ For specific materialized view(s)/view(s)/source(s):
 
 ```mzsql
 GRANT <SELECT | ALL [PRIVILEGES]>
-ON [TABLE] <name> [, <name> ...] -- For PostgreSQL compatibility, if specifying type, use TABLE
+ON <name> [, <name> ...]
+TO <role_name> [, ... ];
+```
+
+For PostgreSQL compatibility, the `TABLE` keyword is also accepted. With the
+`TABLE` syntax, you can name `INSERT`, `UPDATE`, and `DELETE` explicitly, and
+`ALL [PRIVILEGES]` expands to the full table privilege set
+(`SELECT, INSERT, UPDATE, DELETE`). The non-applicable privileges have no
+runtime effect, but they're stored so a matching `REVOKE ALL` can clear them.
+
+```mzsql
+GRANT <SELECT | INSERT | UPDATE | DELETE | ALL [PRIVILEGES]> [, ...]
+ON TABLE <name> [, <name> ...]
 TO <role_name> [, ... ];
 ```
 

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -18,6 +18,13 @@ The syntax supports the `ALL [PRIVILEGES]` shorthand to refer to all
 [*applicable* privileges](#applicable-privileges-to-revoke) for the
 object type.
 
+For PostgreSQL compatibility, you can reference views, materialized views,
+and sources with the `TABLE` keyword. With `ON TABLE`, the `ALL [PRIVILEGES]`
+shorthand expands to the full table privilege set
+(`SELECT, INSERT, UPDATE, DELETE`). This clears every privilege previously
+granted through the same shorthand, including the non-applicable ones that
+have no runtime effect.
+
 {{</note>}}
 
 
@@ -103,7 +110,19 @@ For specific materialized view(s)/view(s)/source(s):
 
 ```mzsql
 REVOKE <SELECT | ALL [PRIVILEGES]>
-ON [TABLE] <name> [, <name> ...] -- For PostgreSQL compatibility, if specifying type, use TABLE
+ON <name> [, <name> ...]
+FROM <role_name> [, ... ];
+```
+
+For PostgreSQL compatibility, the `TABLE` keyword is also accepted. With the
+`TABLE` syntax, you can name `INSERT`, `UPDATE`, and `DELETE` explicitly, and
+`ALL [PRIVILEGES]` expands to the full table privilege set
+(`SELECT, INSERT, UPDATE, DELETE`). This clears every privilege previously
+granted through the matching `GRANT ALL ON TABLE` shorthand.
+
+```mzsql
+REVOKE <SELECT | INSERT | UPDATE | DELETE | ALL [PRIVILEGES]> [, ...]
+ON TABLE <name> [, <name> ...]
 FROM <role_name> [, ... ];
 ```
 

--- a/misc/python/materialize/checks/all_checks/privileges.py
+++ b/misc/python/materialize/checks/all_checks/privileges.py
@@ -39,6 +39,13 @@ class Privileges(Check):
         return s
 
     def _grant_privileges(self, role: str, i: int, expensive: bool = False) -> str:
+        # For views, materialized views, and sources, the explicit privilege
+        # list is intentional. SQL-232 fixed `GRANT/REVOKE ALL ON TABLE
+        # <view/mv/source>` to expand to the full TABLE set (arwd) instead of
+        # only SELECT. Using `ALL PRIVILEGES` here would yield different
+        # `SHOW GRANTS` output across pre- and post-fix versions, breaking
+        # upgrade checks. Spelling out the privileges keeps the check
+        # version-stable.
         s = dedent(f"""
             $ postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
             GRANT ALL PRIVILEGES ON DATABASE privilege_db{i} TO {role}
@@ -47,19 +54,22 @@ class Privileges(Check):
             GRANT ALL PRIVILEGES ON CONNECTION privilege_csr_conn{i} TO {role}
             GRANT ALL PRIVILEGES ON TYPE privilege_type{i} TO {role}
             GRANT ALL PRIVILEGES ON TABLE privilege_t{i} TO {role}
-            GRANT ALL PRIVILEGES ON TABLE privilege_v{i} TO {role}
-            GRANT ALL PRIVILEGES ON TABLE privilege_mv{i} TO {role}
+            GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE privilege_v{i} TO {role}
+            GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE privilege_mv{i} TO {role}
             GRANT ALL PRIVILEGES ON SECRET privilege_secret{i} TO {role}
             """)
         if expensive:
             s += dedent(f"""
-                GRANT ALL PRIVILEGES ON TABLE privilege_source{i} TO {role}
+                GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE privilege_source{i} TO {role}
                 GRANT ALL PRIVILEGES ON CLUSTER privilege_cluster{i} TO {role}
                 """)
 
         return s
 
     def _revoke_privileges(self, role: str, i: int, expensive: bool = False) -> str:
+        # Explicit privilege list for view/mv/source for the same reason as
+        # in `_grant_privileges` — keeps upgrade checks version-stable across
+        # the SQL-232 fix.
         s = dedent(f"""
                 $ postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
                 REVOKE ALL PRIVILEGES ON DATABASE privilege_db{i} FROM {role}
@@ -68,13 +78,13 @@ class Privileges(Check):
                 REVOKE ALL PRIVILEGES ON CONNECTION privilege_csr_conn{i} FROM {role}
                 REVOKE ALL PRIVILEGES ON TYPE privilege_type{i} FROM {role}
                 REVOKE ALL PRIVILEGES ON TABLE privilege_t{i} FROM {role}
-                REVOKE ALL PRIVILEGES ON TABLE privilege_v{i} FROM {role}
-                REVOKE ALL PRIVILEGES ON TABLE privilege_mv{i} FROM {role}
+                REVOKE INSERT, SELECT, UPDATE, DELETE ON TABLE privilege_v{i} FROM {role}
+                REVOKE INSERT, SELECT, UPDATE, DELETE ON TABLE privilege_mv{i} FROM {role}
                 REVOKE ALL PRIVILEGES ON SECRET privilege_secret{i} FROM {role}
                 """)
         if expensive:
             s += dedent(f"""
-                    REVOKE ALL PRIVILEGES ON TABLE privilege_source{i} FROM {role}
+                    REVOKE INSERT, SELECT, UPDATE, DELETE ON TABLE privilege_source{i} FROM {role}
                     REVOKE ALL PRIVILEGES ON CLUSTER privilege_cluster{i} FROM {role}
                     """)
 
@@ -197,20 +207,20 @@ class Privileges(Check):
                 privilege_v2  materialize=r/materialize
                 privilege_v3  materialize=r/materialize
                 privilege_v4  materialize=r/materialize
-                privilege_v1  role_1=r/materialize
-                privilege_v2  role_1=r/materialize
-                privilege_v3  role_1=r/materialize
-                privilege_v4  role_1=r/materialize
+                privilege_v1  role_1=arwd/materialize
+                privilege_v2  role_1=arwd/materialize
+                privilege_v3  role_1=arwd/materialize
+                privilege_v4  role_1=arwd/materialize
 
                 > SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name LIKE 'privilege_mv%'
                 privilege_mv1  materialize=r/materialize
                 privilege_mv2  materialize=r/materialize
                 privilege_mv3  materialize=r/materialize
                 privilege_mv4  materialize=r/materialize
-                privilege_mv1  role_1=r/materialize
-                privilege_mv2  role_1=r/materialize
-                privilege_mv3  role_1=r/materialize
-                privilege_mv4  role_1=r/materialize
+                privilege_mv1  role_1=arwd/materialize
+                privilege_mv2  role_1=arwd/materialize
+                privilege_mv3  role_1=arwd/materialize
+                privilege_mv4  role_1=arwd/materialize
 
                 > SELECT name, unnest(privileges)::text FROM mz_types WHERE name LIKE 'privilege_type%'
                 privilege_type1  =U/materialize
@@ -238,7 +248,7 @@ class Privileges(Check):
 
                 > SELECT name, unnest(privileges)::text FROM mz_sources WHERE name LIKE 'privilege_source%' AND type = 'load-generator'
                 privilege_source1 materialize=r/materialize
-                privilege_source1 role_1=r/materialize
+                privilege_source1 role_1=arwd/materialize
 
                 ! SELECT name, unnest(privileges)::text FROM mz_sinks WHERE name LIKE 'privilege_sink%'
                 contains: column "privileges" does not exist

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4350,12 +4350,16 @@ impl Coordinator {
             acl_mode,
             target_id,
             grantor,
+            acl_from_all,
         } in update_privileges
         {
             let actual_object_type = catalog.get_system_object_type(&target_id);
             // For all relations we allow all applicable table privileges, but send a warning if the
-            // privilege isn't actually applicable to the object type.
-            if actual_object_type.is_relation() {
+            // privilege isn't actually applicable to the object type. We skip the warning when the
+            // user used the `ALL [PRIVILEGES]` shorthand: the user did not explicitly name a
+            // non-applicable privilege, and via PostgreSQL-compatible `ON TABLE <view>` syntax
+            // `ALL` deliberately expands to the full table set.
+            if actual_object_type.is_relation() && !acl_from_all {
                 let applicable_privileges = rbac::all_object_privileges(actual_object_type);
                 let non_applicable_privileges = acl_mode.difference(applicable_privileges);
                 if !non_applicable_privileges.is_empty() {

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -4043,3 +4043,64 @@ async fn test_serialized_ddl_cancel() {
     // run, because spawn_blocking (used by optimization) are waited upon during Drop. Thus, don't
     // pass very high durations to mz_sleep so that we aren't waiting for long.
 }
+
+// Regression test for SQL-232: `GRANT ALL ON TABLE <view>` must not emit the
+// non-applicable-privilege-types notice. The shorthand expands to the full
+// table privilege set for PostgreSQL compatibility, but the user did not
+// explicitly request a non-applicable privilege, so warning is noisy. The
+// notice still fires when the user explicitly names a non-applicable
+// privilege like `GRANT INSERT, UPDATE ON TABLE <view>`.
+#[test] // allow(test-attribute)
+#[allow(clippy::disallowed_methods)]
+fn test_grant_all_on_view_suppresses_non_applicable_notice() {
+    let server = test_util::TestHarness::default().start_blocking();
+
+    let (tx, mut rx) = futures::channel::mpsc::unbounded();
+    let mut client = server
+        .pg_config()
+        .notice_callback(move |notice| {
+            tx.unbounded_send(notice).unwrap();
+        })
+        .connect(postgres::NoTls)
+        .unwrap();
+
+    client.batch_execute("CREATE VIEW v AS SELECT 1").unwrap();
+    client.batch_execute("CREATE ROLE joe").unwrap();
+
+    // Drain any notices accumulated during setup.
+    while rx.try_recv().is_ok() {}
+
+    let non_applicable = |msg: &str| msg.contains("non-applicable privilege types");
+
+    // Explicit non-applicable privileges: the notice MUST fire.
+    client
+        .batch_execute("GRANT INSERT, UPDATE ON TABLE v TO joe")
+        .unwrap();
+    let saw_notice = Retry::default()
+        .max_duration(Duration::from_secs(5))
+        .retry(|_| match rx.try_recv() {
+            Ok(msg) if non_applicable(msg.message()) => Ok(()),
+            Ok(_) => Err("other notice, keep looking"),
+            Err(_) => Err("no notice yet"),
+        });
+    assert!(
+        saw_notice.is_ok(),
+        "expected non-applicable privilege types notice for explicit GRANT INSERT, UPDATE",
+    );
+
+    // `ALL` shorthand: the notice MUST NOT fire.
+    client.batch_execute("GRANT ALL ON TABLE v TO joe").unwrap();
+    client
+        .batch_execute("REVOKE ALL ON TABLE v FROM joe")
+        .unwrap();
+    client
+        .batch_execute("GRANT ALL PRIVILEGES ON TABLE v TO joe")
+        .unwrap();
+    while let Ok(msg) = rx.try_recv() {
+        assert!(
+            !non_applicable(msg.message()),
+            "unexpected non-applicable privilege types notice for `ALL` shorthand: {}",
+            msg.message(),
+        );
+    }
+}

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1440,6 +1440,11 @@ pub struct UpdatePrivilege {
     pub target_id: SystemObjectId,
     /// The role that is granting the privileges.
     pub grantor: RoleId,
+    /// Whether `acl_mode` was derived from the `ALL [PRIVILEGES]` shorthand.
+    /// Used to suppress the `NonApplicablePrivilegeTypes` notice in that
+    /// case: the shorthand is not the user explicitly naming a privilege
+    /// that doesn't apply to the object type, so warning would be noisy.
+    pub acl_from_all: bool,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -545,8 +545,6 @@ fn plan_update_privilege(
         // type is table.
         let mut reference_object_type = actual_object_type.clone();
 
-        let acl_mode = privilege_spec_to_acl_mode(scx, &privileges, actual_object_type);
-
         if let SystemObjectId::Object(ObjectId::Item(id)) = &target_id {
             let item = scx.get_item(id);
             let item_type: ObjectType = item.item_type().into();
@@ -566,6 +564,13 @@ fn plan_update_privilege(
                 });
             }
         }
+
+        // Compute the ACL mode against the reference type so that, for example,
+        // `REVOKE ALL ON TABLE <view>` expands to the full TABLE privilege set
+        // (SELECT|INSERT|UPDATE|DELETE) rather than only the privileges valid
+        // for a view on its own (SELECT).
+        let acl_mode = privilege_spec_to_acl_mode(scx, &privileges, reference_object_type);
+        let acl_from_all = matches!(privileges, PrivilegeSpecification::All);
 
         let all_object_privileges = scx.catalog.all_object_privileges(reference_object_type);
         let invalid_privileges = acl_mode.difference(all_object_privileges);
@@ -596,6 +601,7 @@ fn plan_update_privilege(
             acl_mode,
             target_id,
             grantor,
+            acl_from_all,
         });
     }
 

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -1131,6 +1131,167 @@ false
 statement error invalid privilege types USAGE, CREATE for SOURCE
 GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE s TO joe
 
+## Regression test for SQL-232:
+## `REVOKE ALL ON TABLE <view/mv/source>` must revoke every privilege the role
+## holds via the TABLE syntax, not just SELECT. Same goes for `GRANT ALL`.
+
+### Exact reproducer from SQL-232: granting an asymmetric subset
+### (INSERT + SELECT) then REVOKE ALL must clear both, not just SELECT.
+statement ok
+GRANT INSERT, SELECT ON TABLE v TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v' AND privilege LIKE 'joe=%'
+----
+v  joe=ar/materialize
+
+statement ok
+REVOKE ALL ON TABLE v FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v' AND privilege LIKE 'joe=%'
+----
+
+### View
+statement ok
+GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE v TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v' AND privilege LIKE 'joe=%'
+----
+v  joe=arwd/materialize
+
+statement ok
+REVOKE ALL ON TABLE v FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v' AND privilege LIKE 'joe=%'
+----
+
+statement ok
+GRANT ALL ON TABLE v TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v' AND privilege LIKE 'joe=%'
+----
+v  joe=arwd/materialize
+
+statement ok
+REVOKE ALL PRIVILEGES ON TABLE v FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v' AND privilege LIKE 'joe=%'
+----
+
+### Materialized view
+statement ok
+GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE mv TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv' AND privilege LIKE 'joe=%'
+----
+mv  joe=arwd/materialize
+
+statement ok
+REVOKE ALL ON TABLE mv FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv' AND privilege LIKE 'joe=%'
+----
+
+statement ok
+GRANT ALL ON TABLE mv TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv' AND privilege LIKE 'joe=%'
+----
+mv  joe=arwd/materialize
+
+statement ok
+REVOKE ALL PRIVILEGES ON TABLE mv FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv' AND privilege LIKE 'joe=%'
+----
+
+### Source
+statement ok
+GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE s TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's' AND privilege LIKE 'joe=%'
+----
+s  joe=arwd/materialize
+
+statement ok
+REVOKE ALL ON TABLE s FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's' AND privilege LIKE 'joe=%'
+----
+
+statement ok
+GRANT ALL ON TABLE s TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's' AND privilege LIKE 'joe=%'
+----
+s  joe=arwd/materialize
+
+statement ok
+REVOKE ALL PRIVILEGES ON TABLE s FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's' AND privilege LIKE 'joe=%'
+----
+
+### GRANT/REVOKE ALL ON ALL TABLES IN SCHEMA must also expand to the full
+### TABLE set for views/MVs/sources, not just real tables. The schema-scoped
+### iteration uses the same plan path as per-object grants, so this guards
+### against future regressions that split the two paths.
+statement ok
+CREATE ROLE schema_grant_role
+
+statement ok
+GRANT ALL ON ALL TABLES IN SCHEMA public TO schema_grant_role
+
+query TT rowsort
+SELECT name, privilege FROM item_privileges WHERE privilege LIKE 'schema_grant_role=%' AND name IN ('t', 'v', 'mv', 's')
+----
+mv  schema_grant_role=arwd/materialize
+s  schema_grant_role=arwd/materialize
+t  schema_grant_role=arwd/materialize
+v  schema_grant_role=arwd/materialize
+
+statement ok
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM schema_grant_role
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE privilege LIKE 'schema_grant_role=%'
+----
+
+### Asymmetric per-privilege grant via schema-scoped path, then REVOKE ALL
+### via the same path must clear everything, not just SELECT.
+statement ok
+GRANT INSERT, SELECT ON ALL TABLES IN SCHEMA public TO schema_grant_role
+
+query TT rowsort
+SELECT name, privilege FROM item_privileges WHERE privilege LIKE 'schema_grant_role=%' AND name IN ('v', 'mv', 's')
+----
+mv  schema_grant_role=ar/materialize
+s  schema_grant_role=ar/materialize
+v  schema_grant_role=ar/materialize
+
+statement ok
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM schema_grant_role
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE privilege LIKE 'schema_grant_role=%'
+----
+
+statement ok
+DROP ROLE schema_grant_role
+
 ## Type
 
 statement ok
@@ -2519,10 +2680,12 @@ GRANT ALL ON v1 TO joe
 ----
 COMPLETE 0
 
+# `GRANT ALL ON <view>` (which parses as TABLE by default) grants the full TABLE
+# privilege set, matching PostgreSQL semantics. See SQL-232.
 query TT rowsort
 SELECT name, privilege FROM item_privileges WHERE name = 'v1'
 ----
-v1  joe=r/mz_system
+v1  joe=arwd/mz_system
 v1  mz_system=r/mz_system
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
plan_update_privilege computed the ACL mode against the object's actual type (View/MaterializedView/Source) before remapping the reference type to TABLE.

Compute the ACL mode against the (post-remap) reference type so that the TABLE syntax expands `ALL` to the full TABLE privilege set (SELECT|INSERT|UPDATE| DELETE), matching PostgreSQL semantics. Update the SLT case that previously encoded the buggy behavior, and add a regression block exercising view/mv/ source × GRANT ALL / REVOKE ALL / REVOKE ALL PRIVILEGES.

Update the Privileges platform check to spell out the privileges explicitly (`INSERT, SELECT, UPDATE, DELETE`) for views, materialized views, and sources instead of `ALL PRIVILEGES`. The check previously used `GRANT ALL ON TABLE` against those object types and expected only SELECT to be granted, i.e. it encoded the bug.

Fixes SQL-232
