### PR TITLE
compute/repr: add `ToDatumIter::extend_datums` and port fill sites

### DIFF
--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -214,16 +214,14 @@ where
         let arena = RowArena::new();
 
         let key_item = self.cursor.key(&self.storage);
-        let key = key_item.to_datum_iter();
         let row_item = self.cursor.val(&self.storage);
-        let row = row_item.to_datum_iter();
 
         // An optional literal that we might have added to the borrow. Needs to be declared
         // before the borrow to ensure correct drop order.
         let maybe_literal;
         let mut borrow = self.datum_vec.borrow();
-        borrow.extend(key);
-        borrow.extend(row);
+        key_item.extend_datums(&mut borrow, None);
+        row_item.extend_datums(&mut borrow, None);
 
         if let Some(literals) = &mut self.literals
             && let Some(literal) = literals.peek()
@@ -231,7 +229,7 @@ where
             // The peek was created from an IndexedFilter join. We have to add those columns
             // here that the join would add in a dataflow.
             maybe_literal = literal;
-            borrow.extend(maybe_literal.to_datum_iter());
+            maybe_literal.extend_datums(&mut borrow, None);
         }
         if let Some(result) = self
             .map_filter_project

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -324,9 +324,9 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                           ok_session: &mut Session<T, DCB>,
                           err_session: &mut Session<T, ECB<T>>| {
             let mut datums_borrow = datums.borrow();
-            datums_borrow.extend(k.to_datum_iter().take(max_demand));
+            k.extend_datums(&mut datums_borrow, Some(max_demand));
             let max_demand = max_demand.saturating_sub(datums_borrow.len());
-            datums_borrow.extend(v.to_datum_iter().take(max_demand));
+            v.extend_datums(&mut datums_borrow, Some(max_demand));
             logic(&mut datums_borrow, t, d, ok_session, err_session)
         };
 
@@ -378,9 +378,9 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         let mut datums = DatumVec::new();
         let logic = move |k: DatumSeq, v: DatumSeq, t, d, ok_session: &mut Session<T, DCB>| {
             let mut datums_borrow = datums.borrow();
-            datums_borrow.extend(k.to_datum_iter().take(max_demand));
+            k.extend_datums(&mut datums_borrow, Some(max_demand));
             let max_demand = max_demand.saturating_sub(datums_borrow.len());
-            datums_borrow.extend(v.to_datum_iter().take(max_demand));
+            v.extend_datums(&mut datums_borrow, Some(max_demand));
             logic(&mut datums_borrow, t, d, ok_session)
         };
 

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -416,7 +416,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                datums_local.extend(lookup_row.to_datum_iter());
+                lookup_row.extend_datums(&mut datums_local, None);
 
                 let row = closure.apply(&mut datums_local, &temp_storage, &mut row_builder);
 
@@ -464,7 +464,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                datums_local.extend(lookup_row.to_datum_iter());
+                lookup_row.extend_datums(&mut datums_local, None);
 
                 if let Some(row) = closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -527,7 +527,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                datums_local.extend(lookup_row.to_datum_iter());
+                lookup_row.extend_datums(&mut datums_local, None);
 
                 let row = closure.apply(&mut datums_local, &temp_storage, &mut row_builder);
 
@@ -574,7 +574,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                datums_local.extend(lookup_row.to_datum_iter());
+                lookup_row.extend_datums(&mut datums_local, None);
 
                 if let Some(row) = closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -654,8 +654,8 @@ where
                                         let temp_storage = RowArena::new();
 
                                         let mut datums_local = datums.borrow();
-                                        datums_local.extend(key.to_datum_iter());
-                                        datums_local.extend(val.to_datum_iter());
+                                        key.extend_datums(&mut datums_local, None);
+                                        val.extend_datums(&mut datums_local, None);
 
                                         if !initial_closure.is_identity() {
                                             match initial_closure

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -496,9 +496,9 @@ where
                     let temp_storage = RowArena::new();
 
                     let mut datums_local = datums.borrow();
-                    datums_local.extend(key.to_datum_iter());
-                    datums_local.extend(old.to_datum_iter());
-                    datums_local.extend(new.to_datum_iter());
+                    key.extend_datums(&mut datums_local, None);
+                    old.extend_datums(&mut datums_local, None);
+                    new.extend_datums(&mut datums_local, None);
 
                     closure
                         .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -524,9 +524,9 @@ where
                     let temp_storage = RowArena::new();
 
                     let mut datums_local = datums.borrow();
-                    datums_local.extend(key.to_datum_iter());
-                    datums_local.extend(old.to_datum_iter());
-                    datums_local.extend(new.to_datum_iter());
+                    key.extend_datums(&mut datums_local, None);
+                    old.extend_datums(&mut datums_local, None);
+                    new.extend_datums(&mut datums_local, None);
 
                     closure
                         .apply(&mut datums_local, &temp_storage, &mut row_builder)

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -319,7 +319,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 move |key, _input, output| {
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums1.borrow();
-                    datums_local.extend(key.to_datum_iter());
+                    key.extend_datums(&mut datums_local, None);
 
                     // Note that the key contains all the columns in a `Distinct` and that `mfp_after` is
                     // required to preserve the key. Therefore, if `mfp_after` maps, then it must project
@@ -352,9 +352,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 // If `mfp_after` can error, then evaluate it here.
                 let Some(mfp) = &mfp_after2 else { return };
                 let temp_storage = RowArena::new();
-                let datum_iter = key.to_datum_iter();
                 let mut datums_local = datums2.borrow();
-                datums_local.extend(datum_iter);
+                key.extend_datums(&mut datums_local, None);
 
                 if let Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
                     output.push((e.into(), Diff::ONE));
@@ -429,9 +428,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>("ReduceFuseBasic", {
                 move |key, input, output| {
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums1.borrow();
-                    datums_local.extend(datum_iter);
+                    key.extend_datums(&mut datums_local, None);
                     let key_len = datums_local.len();
 
                     for ((_, row), _) in input.iter() {
@@ -458,9 +456,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         // Since negative accumulations are checked in at least one component
                         // aggregate, we only need to look for MFP errors here.
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums2.borrow();
-                        datums_local.extend(datum_iter);
+                        key.extend_datums(&mut datums_local, None);
 
                         for ((_, row), _) in input.iter() {
                             datums_local.push(row.unpack_first());
@@ -594,9 +591,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         });
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums1.borrow();
-                        datums_local.extend(datum_iter);
+                        key.extend_datums(&mut datums_local, None);
                         let key_len = datums_local.len();
                         datums_local.push(
                         // Note that this is not necessarily a window aggregation, in which case
@@ -631,7 +627,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         // This is the part that is specific to the `fused_unnest_list` branch.
                         let temp_storage = RowArena::new();
                         let mut datums_local = datums_key_1.borrow();
-                        datums_local.extend(key.to_datum_iter());
+                        key.extend_datums(&mut datums_local, None);
                         let key_len = datums_local.len();
                         for datum in func
                             .eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(
@@ -696,9 +692,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                             });
 
                             let temp_storage = RowArena::new();
-                            let datum_iter = key.to_datum_iter();
                             let mut datums_local = datums2.borrow();
-                            datums_local.extend(datum_iter);
+                            key.extend_datums(&mut datums_local, None);
                             datums_local.push(
                                 func2.eval_with_fast_window_agg::<
                                     _,
@@ -734,7 +729,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 
                             let temp_storage = RowArena::new();
                             let mut datums_local = datums_key_2.borrow();
-                            datums_local.extend(key.to_datum_iter());
+                            key.extend_datums(&mut datums_local, None);
                             let key_len = datums_local.len();
                             for datum in func2
                                 .eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(
@@ -968,9 +963,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                                 // We know that `mfp_after` can error if it exists, so try to evaluate it here.
                                 let Some(mfp) = &mfp_after2 else { return };
                                 let temp_storage = RowArena::new();
-                                let datum_iter = key.to_datum_iter();
                                 let mut datums_local = datums2.borrow();
-                                datums_local.extend(datum_iter);
+                                key.extend_datums(&mut datums_local, None);
 
                                 let mut source_iters = source
                                     .iter()
@@ -1001,9 +995,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         "ReduceMinsMaxes",
                         move |key, source, target| {
                             let temp_storage = RowArena::new();
-                            let datum_iter = key.to_datum_iter();
                             let mut datums_local = datums1.borrow();
-                            datums_local.extend(datum_iter);
+                            key.extend_datums(&mut datums_local, None);
                             let key_len = datums_local.len();
 
                             let mut source_iters = source
@@ -1264,9 +1257,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>("ReduceMonotonic", {
                 move |key, input, output| {
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums1.borrow();
-                    datums_local.extend(datum_iter);
+                    key.extend_datums(&mut datums_local, None);
                     let key_len = datums_local.len();
                     let accum = &input[0].1;
                     for monoid in accum.iter() {
@@ -1291,9 +1283,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     "ReduceMonotonic Error Check",
                     move |key, input, output| {
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums2.borrow();
-                        datums_local.extend(datum_iter);
+                        key.extend_datums(&mut datums_local, None);
                         let accum = &input[0].1;
                         for monoid in accum.iter() {
                             datums_local.extend(monoid.finalize().iter());
@@ -1461,9 +1452,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     let (ref accums, total) = input[0].1;
 
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums1.borrow();
-                    datums_local.extend(datum_iter);
+                    key.extend_datums(&mut datums_local, None);
                     let key_len = datums_local.len();
                     for (aggr, accum) in full_aggrs.iter().zip_eq(accums) {
                         datums_local.push(finalize_accum(&aggr.func, accum, total));
@@ -1521,9 +1511,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     // If `mfp_after` can error, then evaluate it here.
                     let Some(mfp) = &mfp_after2 else { return };
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums2.borrow();
-                    datums_local.extend(datum_iter);
+                    key.extend_datums(&mut datums_local, None);
                     for (aggr, accum) in full_aggrs2.iter().zip_eq(accums) {
                         datums_local.push(finalize_accum(&aggr.func, accum, total));
                     }

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -23,6 +23,23 @@ pub trait ToDatumIter: Sized {
 
     /// Obtains an iterator of datums out of an instance of `&Self`.
     fn to_datum_iter(&self) -> Self::DatumIter<'_>;
+
+    /// Append datums to `target` — all of them (`max == None`) or at most
+    /// `max` (`Some`) — branching on representation ONCE rather than once per
+    /// datum.
+    ///
+    /// The default extends via `to_datum_iter`, identical to the prior
+    /// `target.extend(x.to_datum_iter()[.take(max)])` call sites. Implementors
+    /// backed by packed bytes (e.g. row-spine's `DatumSeq`) should override this
+    /// with a tight loop that pushes directly, avoiding the `Iterator::extend` /
+    /// `take` per-datum machinery.
+    #[inline]
+    fn extend_datums<'a>(&'a self, target: &mut Vec<Datum<'a>>, max: Option<usize>) {
+        match max {
+            Some(max) => target.extend(self.to_datum_iter().into_iter().take(max)),
+            None => target.extend(self.to_datum_iter()),
+        }
+    }
 }
 
 impl<'b, T: ToDatumIter> ToDatumIter for &'b T {
@@ -32,6 +49,11 @@ impl<'b, T: ToDatumIter> ToDatumIter for &'b T {
         Self: 'a;
     fn to_datum_iter(&self) -> Self::DatumIter<'_> {
         (**self).to_datum_iter()
+    }
+    #[inline]
+    fn extend_datums<'a>(&'a self, target: &mut Vec<Datum<'a>>, max: Option<usize>) {
+        // Forward to T's impl so an override isn't lost behind a reference.
+        (**self).extend_datums(target, max)
     }
 }
 

--- a/src/row-spine/src/lib.rs
+++ b/src/row-spine/src/lib.rs
@@ -353,6 +353,26 @@ mod container {
         fn to_datum_iter<'short>(&'short self) -> Self::DatumIter<'short> {
             *self
         }
+        #[inline]
+        fn extend_datums<'a>(&'a self, target: &mut Vec<Datum<'a>>, max: Option<usize>) {
+            // Tight loop over packed row bytes: push directly instead of going
+            // through `Iterator::extend`/`take`, branching on the bound once.
+            let mut bytes = self.bytes;
+            match max {
+                Some(max) => {
+                    let mut n = 0;
+                    while n < max && !bytes.is_empty() {
+                        target.push(unsafe { read_datum(&mut bytes) });
+                        n += 1;
+                    }
+                }
+                None => {
+                    while !bytes.is_empty() {
+                        target.push(unsafe { read_datum(&mut bytes) });
+                    }
+                }
+            }
+        }
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Add `ToDatumIter::extend_datums(&self, target, max: Option<usize>)` with a default that matches the existing `target.extend(x.to_datum_iter()[.take(n)])` pattern (zero behavior change for `Row` and the `&T` blanket forwards through to the inner impl). Override it on row-spine's `DatumSeq` with a tight `read_datum` push loop, so the read-item representation is branched on once per row rather than once per datum (the `Iterator::extend`/`take` machinery).

Port the fitting fill sites to `extend_datums`: render context (key/val, with the `max_demand` cap), linear- and delta-join, reduce, and the peek-result iterator. Genuine non-fits left as-is: `reduce.rs`'s repeat-first-datum, `encode.rs`'s collect-for-assert.

Independent of dictionary compression; the dictionary-arrangements PR will add a codec-aware `DatumSeq` override on top.

Remove these sections if your commit already has a good description!

### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
