### PR TITLE
adapter: fix statement-logging double-end panics on concurrent DROP CLUSTER

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -328,11 +328,16 @@ pub enum Command {
 
     /// Unregister a pending peek that was registered but failed to issue.
     /// This is used for cleanup when `client.peek()` fails after `RegisterFrontendPeek` succeeds.
-    /// The `ExecuteContextExtra` is dropped without logging the statement retirement, because the
-    /// frontend will log the error.
+    ///
+    /// Sends back whether the peek was still registered. If it was, its
+    /// `ExecuteContextExtra` is dropped without logging the statement
+    /// retirement, because the frontend will log the error. If it was *not*
+    /// still registered, then a concurrent teardown (e.g. a `DROP CLUSTER`)
+    /// already removed and retired it, which logged the end of execution; the
+    /// frontend uses this to avoid logging the end a second time.
     UnregisterFrontendPeek {
         uuid: Uuid,
-        tx: oneshot::Sender<()>,
+        tx: oneshot::Sender<bool>,
     },
 
     /// Generate a timestamp explanation.

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -2109,12 +2109,24 @@ impl Coordinator {
 
     /// Handle unregistration of a frontend peek that was registered but failed to issue.
     /// This is used for cleanup when `client.peek()` fails after `RegisterFrontendPeek` succeeds.
-    fn handle_unregister_frontend_peek(&mut self, uuid: Uuid, tx: oneshot::Sender<()>) {
-        // Remove from pending_peeks (this also removes from client_pending_peeks)
-        if let Some(pending_peek) = self.remove_pending_peek(&uuid) {
-            // Retire `ExecuteContextExtra`, because the frontend will log the peek's error result.
-            let _ = pending_peek.ctx_extra.defuse();
-        }
-        let _ = tx.send(());
+    ///
+    /// Sends back whether the peek was still registered (`true`) or had already
+    /// been removed and retired by a concurrent teardown (`false`). In the
+    /// latter case the end of execution was already logged, so the frontend
+    /// must not log it again.
+    fn handle_unregister_frontend_peek(&mut self, uuid: Uuid, tx: oneshot::Sender<bool>) {
+        // Remove from pending_peeks (this also removes from client_pending_peeks).
+        let still_registered = match self.remove_pending_peek(&uuid) {
+            Some(pending_peek) => {
+                // Retire `ExecuteContextExtra` without logging the end, because
+                // the frontend will log the peek's error result.
+                let _ = pending_peek.ctx_extra.defuse();
+                true
+            }
+            // A concurrent teardown already removed and retired this peek, so
+            // the end of execution has already been logged.
+            None => false,
+        };
+        let _ = tx.send(still_registered);
     }
 }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -694,6 +694,16 @@ impl FastPathPlan {
 
 impl crate::coord::Coordinator {
     /// Implements a peek plan produced by `create_plan` above.
+    ///
+    /// Ownership of `ctx_extra` (the statement-logging guard): on success its
+    /// contents are taken and end-of-execution logging is handed off — retired
+    /// immediately for a constant peek, or moved into `pending_peeks` for
+    /// `handle_peek_notification` to retire on a streaming peek. On an early error
+    /// return (e.g. a concurrent dependency drop before the peek is registered) the
+    /// contents are left intact, so the caller must take ownership: `retire` it if
+    /// the caller is the sole end-logger, or `defuse` it if something else logs the
+    /// end on error (as the frontend does via `implement_slow_path_peek`). Otherwise
+    /// the guard's `Drop` emits a spurious `Aborted`, double-ending the statement.
     #[mz_ore::instrument(level = "debug")]
     pub async fn implement_peek_plan(
         &mut self,
@@ -1378,16 +1388,29 @@ impl crate::coord::Coordinator {
         // TODO(peek-seq): After the old peek sequencing is completely removed, we should merge the
         // relevant parts of the old `implement_peek_plan` into this method, and remove the old
         // `implement_peek_plan`.
-        self.implement_peek_plan(
-            &mut ExecuteContextGuard::new(statement_logging_id, self.internal_cmd_tx.clone()),
-            planned_peek,
-            finishing,
-            compute_instance,
-            target_replica,
-            max_result_size,
-            max_query_result_size,
-        )
-        .await
+        //
+        // `implement_peek_plan` leaves the guard's contents intact on an error
+        // return (see its doc comment). Defuse on error so the frontend stays the
+        // sole end-logger: letting the guard's `Drop` also emit `Aborted` would
+        // double-end the `Errored` and panic in `end_statement_execution`. Matches
+        // the watch-set invariant noted above.
+        let mut ctx_guard =
+            ExecuteContextGuard::new(statement_logging_id, self.internal_cmd_tx.clone());
+        let result = self
+            .implement_peek_plan(
+                &mut ctx_guard,
+                planned_peek,
+                finishing,
+                compute_instance,
+                target_replica,
+                max_result_size,
+                max_query_result_size,
+            )
+            .await;
+        if result.is_err() {
+            let _ = ctx_guard.defuse();
+        }
+        result
     }
 
     /// Implements a `COPY TO` command by installing peek watch sets,

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -218,8 +218,16 @@ impl PeekClient {
         // emitting; non-streaming arms emit via `log_ended_execution`.
         logging_guard.defuse();
 
+        let mut end_already_logged = false;
         let result = self
-            .try_frontend_peek_inner(session, catalog, stmt, params, statement_logging_id)
+            .try_frontend_peek_inner(
+                session,
+                catalog,
+                stmt,
+                params,
+                statement_logging_id,
+                &mut end_already_logged,
+            )
             .await;
 
         // Log the end of execution if we are logging this statement and
@@ -268,6 +276,12 @@ impl PeekClient {
                 // can adjust the `From` impl to do exactly what we need here,
                 // so the special cases above won't be needed.
                 Ok(Some(resp)) => resp.into(),
+                // A concurrent teardown (e.g. a `DROP CLUSTER`) already retired
+                // and logged the end of this peek on the coordinator; logging
+                // again would double-end and panic in `end_statement_execution`.
+                Err(_) if end_already_logged => {
+                    return result;
+                }
                 Err(e) => StatementEndedExecutionReason::Errored {
                     error: e.to_string(),
                 },
@@ -288,6 +302,7 @@ impl PeekClient {
         stmt: Option<Arc<Statement<Raw>>>,
         params: Params,
         statement_logging_id: Option<crate::statement_logging::StatementLoggingId>,
+        end_already_logged: &mut bool,
     ) -> Result<Option<ExecuteResponse>, AdapterError> {
         let stmt = match stmt {
             Some(stmt) => stmt,
@@ -1327,6 +1342,7 @@ impl PeekClient {
                             session.conn_id().clone(),
                             source_ids,
                             watch_set,
+                            end_already_logged,
                         )
                         .await?
                     }

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -223,6 +223,11 @@ impl PeekClient {
     /// Note: `input_read_holds` has holds for all inputs. For fast-path peeks, this includes the
     /// peek target. For slow-path peeks (to be implemented later), we'll need to additionally call
     /// into the Controller to acquire a hold on the peek target after we create the dataflow.
+    ///
+    /// `end_already_logged` is an out-parameter. It is set to `true` if the peek
+    /// failed to issue *and* a concurrent teardown (e.g. a `DROP CLUSTER`) had
+    /// already retired the statement on the coordinator, which logged the end of
+    /// execution. The caller uses this to avoid logging the end a second time.
     pub async fn implement_fast_path_peek_plan(
         &mut self,
         fast_path: FastPathPlan,
@@ -240,6 +245,7 @@ impl PeekClient {
         conn_id: mz_adapter_types::connection::ConnectionId,
         depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
         watch_set: Option<WatchSetCreation>,
+        end_already_logged: &mut bool,
     ) -> Result<crate::ExecuteResponse, AdapterError> {
         // If the dataflow optimizes to a constant expression, we can immediately return the result.
         if let FastPathPlan::Constant(rows_res, _) = fast_path {
@@ -371,6 +377,16 @@ impl PeekClient {
         })
         .await?;
 
+        // Test-only synchronization point. The peek is now registered with the
+        // coordinator but not yet issued; a `pause` failpoint here lets a test
+        // deterministically land a concurrent `DROP CLUSTER` in this window, so
+        // the coordinator retires (and logs the end of) this peek before
+        // `client.peek()` below fails. See the
+        // `workflow_test_drop_cluster_during_registered_peeks_fast_path` test.
+        // Negligible cost when not configured (a registry lookup miss), which
+        // is the only case outside of tests.
+        fail::fail_point!("peek_after_register_before_issue");
+
         let finishing_for_instance = finishing.clone();
         let peek_result = client
             .peek(
@@ -389,9 +405,16 @@ impl PeekClient {
 
         if let Err(err) = peek_result {
             // Clean up the registered peek since the peek failed to issue.
-            // The frontend will handle statement logging for the error.
-            self.call_coordinator(|tx| Command::UnregisterFrontendPeek { uuid, tx })
+            let still_registered = self
+                .call_coordinator(|tx| Command::UnregisterFrontendPeek { uuid, tx })
                 .await;
+            // If the peek was no longer registered, then a concurrent teardown
+            // (e.g. a `DROP CLUSTER`) already removed and retired it, which
+            // logged the end of execution. Signal this to the caller so it
+            // doesn't log the end a second time (which would double-end and
+            // panic in `end_statement_execution`). Otherwise, the frontend will
+            // log the error end itself.
+            *end_already_logged = !still_registered;
             return Err(
                 AdapterError::concurrent_dependency_drop_from_instance_peek_error(
                     err,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -21,7 +21,7 @@ from copy import copy
 from datetime import datetime, timedelta
 from statistics import quantiles
 from textwrap import dedent
-from threading import Thread
+from threading import Event, Thread
 
 import psycopg
 import requests
@@ -4300,6 +4300,111 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
         # process (src/ore/src/panic.rs). With no restart policy the container
         # then stays down, so this fresh connection raises. (An unrelated clusterd
         # crash propagates to environmentd too, and is also worth failing on.)
+        with c.sql_cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone() == (1,)
+
+
+def workflow_test_drop_cluster_during_registered_peeks_fast_path(
+    c: Composition,
+) -> None:
+    """Deterministically reproduce the *fast-path* variant of the registered-peek
+    double-end (see `workflow_test_drop_cluster_during_registered_peeks` for the
+    slow-path variant and the shared symptom).
+
+    A `PeekExisting` fast-path peek registers with the coordinator
+    (`RegisterFrontendPeek`) and only *then* issues `client.peek()`. If a
+    `DROP CLUSTER` lands in that window, the coordinator retires the pending peek
+    (logging its end) while `client.peek()` fails and the frontend ends the
+    statement too — a double `end_statement_execution` that panics with "matched
+    `begin_statement_execution` and `end_statement_execution` invocations".
+
+    That window is a sub-millisecond cross-thread gap, hopeless to hit by brute
+    force (unlike the slow-path variant, whose error window spans a whole
+    `ExecuteSlowPathPeek` command). So we make it deterministic with the
+    `peek_after_register_before_issue` failpoint: pause a peek right after it
+    registers, drop its cluster while it's parked (coordinator logs end #1), then
+    resume so `client.peek()` fails (frontend logs end #2). With the fix the
+    frontend learns the coordinator already ended the statement and stays silent;
+    without it, environmentd panics.
+    """
+
+    failpoint = "peek_after_register_before_issue"
+
+    with c.override(Materialized()):
+        c.up("materialized")
+
+        c.sql(
+            """
+            ALTER SYSTEM SET statement_logging_max_sample_rate = 1.0;
+            ALTER SYSTEM SET statement_logging_default_sample_rate = 1.0;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        c.sql("CREATE TABLE t (a int); INSERT INTO t SELECT generate_series(1, 10);")
+        c.sql("CREATE CLUSTER victim SIZE 'scale=1,workers=1'")
+        # The index makes `SELECT * FROM t` on `victim` a `PeekExisting` fast path
+        # (without it the bare scan would be a `standard` slow-path dataflow).
+        c.sql("CREATE INDEX victim_idx IN CLUSTER victim ON t (a)")
+
+        peeker_ready = Event()
+        failpoint_armed = Event()
+        peek_outcome: list[str] = []
+
+        def peeker() -> None:
+            try:
+                with c.sql_cursor() as cur:
+                    cur.execute("SET auto_route_catalog_queries = false")
+                    cur.execute("SET cluster = victim")
+                    # We connect and configure *before* the failpoint is armed so
+                    # that connection-setup peeks aren't caught by it.
+                    peeker_ready.set()
+                    failpoint_armed.wait()
+                    # `PeekExisting` fast path: this registers with the
+                    # coordinator and then parks at the failpoint before issuing
+                    # `client.peek()`. It fails once `victim` is dropped.
+                    cur.execute("SELECT * FROM t")
+                    cur.fetchall()
+                    peek_outcome.append("ok")
+            except Exception as e:
+                peek_outcome.append(f"error: {e}")
+
+        peek_thread = PropagatingThread(target=peeker, name="peeker")
+        peek_thread.start()
+
+        # Drive the race from a single control connection opened *before* the
+        # failpoint is armed — so its own connection-setup peeks don't park, which
+        # would otherwise deadlock it against the very failpoint it must turn off.
+        with c.sql_cursor() as control:
+            assert peeker_ready.wait(timeout=30), "peeker failed to connect"
+            # Arm: every fast-path peek now parks right after registering.
+            control.execute(f"SET failpoints = '{failpoint}=pause'")
+            failpoint_armed.set()
+            # Give the peeker time to issue its SELECT and park. It stays parked
+            # until we turn the failpoint off, so this only has to outlast plan +
+            # `RegisterFrontendPeek`, not race a narrow window.
+            time.sleep(5)
+            # Drop the cluster while the peek is parked: the coordinator retires
+            # the pending peek and logs its end (#1).
+            control.execute("DROP CLUSTER victim CASCADE")
+            # Resume the peek: `client.peek()` now fails (cluster gone) and the
+            # frontend logs the end (#2). Without the fix this double-ends and
+            # panics the coordinator.
+            control.execute(f"SET failpoints = '{failpoint}=off'")
+
+        peek_thread.join(timeout=30)
+
+        # The parked peek must actually have failed on the dropped cluster;
+        # otherwise the race didn't happen and the test is silently vacuous.
+        assert peek_outcome, "peeker thread did not finish"
+        assert peek_outcome[0].startswith(
+            "error"
+        ), f"expected the peek to fail on the dropped cluster, got: {peek_outcome[0]}"
+
+        # If the double-end bug is present, the coordinator thread panics, which
+        # aborts the entire environmentd process (src/ore/src/panic.rs). With no
+        # restart policy the container stays down, so this fresh connection raises.
         with c.sql_cursor() as cur:
             cur.execute("SELECT 1")
             assert cur.fetchone() == (1,)

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4176,6 +4176,135 @@ def workflow_test_drop_cluster_during_peeks(c: Composition) -> None:
             assert cur.fetchone() == (1,)
 
 
+def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
+    """Race registered *slow-path* peeks against DROP/CREATE of their target
+    cluster; environmentd must not panic with a statement-logging begin/end
+    mismatch in `end_statement_execution`.
+
+    Unlike `workflow_test_drop_cluster_during_peeks`, which runs `SELECT 1` (a
+    *constant* fast path that is handled inline and never registered with the
+    coordinator), this reads a real table with no usable index, so the optimizer
+    produces a `standard` slow-path dataflow peek (`ExecuteSlowPathPeek`) that
+    registers a pending peek with the coordinator. When a concurrent
+    `DROP CLUSTER` makes the peek fail, `implement_peek_plan` returns an error
+    before taking ownership of its `ExecuteContextExtra`, so the throwaway
+    `ExecuteContextGuard` auto-emits an `Aborted` end (the coordinator's end of
+    the statement) while the frontend *also* ends it via `log_ended_execution`.
+    That double `end_statement_execution` panics with "matched
+    `begin_statement_execution` and `end_statement_execution` invocations". The
+    fix defuses the guard on error.
+
+    The narrow fast-path variant of this race (a `PeekExisting` peek retired by
+    the teardown in the window between `RegisterFrontendPeek` and `client.peek()`)
+    is too timing-sensitive to hit by brute force; it is covered deterministically
+    by `workflow_test_drop_cluster_during_registered_peeks_fast_path`.
+
+    The race window is narrow, so we hammer several clusters in parallel — each
+    churned by its own thread, to get the DROP rate past the CREATE-CLUSTER
+    provisioning bottleneck — with many peekers each.
+    """
+
+    num_clusters = 4
+    peekers_per_cluster = 8
+    duration_s = 60
+
+    with c.override(Materialized()):
+        c.up("materialized")
+
+        c.sql(
+            """
+            ALTER SYSTEM SET statement_logging_max_sample_rate = 1.0;
+            ALTER SYSTEM SET statement_logging_default_sample_rate = 1.0;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        c.sql("CREATE TABLE t (a int); INSERT INTO t SELECT generate_series(1, 10);")
+        for i in range(num_clusters):
+            c.sql(f"CREATE CLUSTER victim{i} SIZE 'scale=1,workers=1'")
+
+        stop = [False]
+
+        def make_peek_loop(cluster: str) -> Callable[[], None]:
+            def peek_loop() -> None:
+                while not stop[0]:
+                    try:
+                        with c.sql_cursor() as cur:
+                            cur.execute("SET auto_route_catalog_queries = false")
+                            # `.encode()`: psycopg types `execute`'s query as
+                            # `LiteralString`; an f-string with a runtime value is
+                            # a plain `str`, and passing `bytes` sidesteps that.
+                            cur.execute(f"SET cluster = {cluster}".encode())
+                            while not stop[0]:
+                                # A bare table scan with no usable index: a
+                                # registered `standard` slow-path peek (not an
+                                # inlined constant), dispatched on cluster
+                                # `{cluster}`.
+                                cur.execute("SELECT * FROM t")
+                                cur.fetchall()
+                    except Exception:
+                        # The target cluster vanishing out from under us is the
+                        # whole point; once environmentd is down `c.sql_cursor()`
+                        # raises a `UIError` rather than a `DatabaseError`, so
+                        # catch broadly (these are chaos threads — the real
+                        # signal is whether environmentd survived, asserted below).
+                        time.sleep(0.05)
+
+            return peek_loop
+
+        def make_churn_loop(cluster: str) -> Callable[[], None]:
+            def churn_loop() -> None:
+                while not stop[0]:
+                    try:
+                        with c.sql_cursor() as cur:
+                            cur.execute(
+                                f"DROP CLUSTER IF EXISTS {cluster} CASCADE".encode()
+                            )
+                            cur.execute(
+                                f"CREATE CLUSTER {cluster} SIZE 'scale=1,workers=1'".encode()
+                            )
+                    except Exception:
+                        # The target cluster vanishing out from under us is the
+                        # whole point; once environmentd is down `c.sql_cursor()`
+                        # raises a `UIError` rather than a `DatabaseError`, so
+                        # catch broadly (these are chaos threads — the real
+                        # signal is whether environmentd survived, asserted below).
+                        time.sleep(0.05)
+
+            return churn_loop
+
+        threads = []
+        for i in range(num_clusters):
+            cluster = f"victim{i}"
+            threads.append(
+                PropagatingThread(target=make_churn_loop(cluster), name=f"churn-{i}")
+            )
+            for j in range(peekers_per_cluster):
+                threads.append(
+                    PropagatingThread(
+                        target=make_peek_loop(cluster), name=f"peek-{i}-{j}"
+                    )
+                )
+        for t in threads:
+            t.start()
+
+        try:
+            time.sleep(duration_s)
+        finally:
+            stop[0] = True
+            for t in threads:
+                t.join(timeout=30)
+
+        # The whole point: if the double-end bug is present, the coordinator
+        # thread panics during the race, which aborts the entire environmentd
+        # process (src/ore/src/panic.rs). With no restart policy the container
+        # then stays down, so this fresh connection raises. (An unrelated clusterd
+        # crash propagates to environmentd too, and is also worth failing on.)
+        with c.sql_cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone() == (1,)
+
+
 def workflow_test_refresh_mv_warmup(
     c: Composition, parser: WorkflowArgumentParser
 ) -> None:


### PR DESCRIPTION
### Motivation

A frontend-sequenced peek whose cluster is dropped concurrently could log its
statement-execution end twice, panicking the coordinator at
`end_statement_execution` and aborting environmentd. Two distinct races hit the
identical panic — one fast-path, one slow-path — both fixed here.

This seems to have happened in [#incident-1070](https://materializeinc.slack.com/archives/C0B8QU8FGCR).

<!-- Link a database-issues ticket here if one exists. -->

### Description

Two commits, one per path — reviewable independently, apart from the two tests'
cross-references to each other.

A frontend peek must be the sole end-logger unless the coordinator already has a
genuine end of its own. The fast and slow paths break this differently — in one
the coordinator's extra end is real, in the other it is spurious — so each is
fixed differently:

- **Fast path**: `DROP CLUSTER` in the `RegisterFrontendPeek`→`client.peek()`
  window makes the coordinator retire the peek with a *real* end (`Canceled`)
  while the frontend also logs `Errored`. Fix: `UnregisterFrontendPeek` reports
  whether the peek was still registered; if already retired, the frontend skips
  logging (`end_already_logged`).
- **Slow path**: `implement_peek_plan` errors before taking its
  `ExecuteContextGuard`, so the guard's `Drop` emits a *spurious* `Aborted` on
  top of the frontend's `Errored`. Fix: defuse the guard on error.

Also documents `implement_peek_plan`'s `ctx_extra` ownership contract.

### Verification

Two new `test/cluster` workflows that fail on any environmentd abort: a
slow-path stress test, and a deterministic fast-path test using a new
`peek_after_register_before_issue` failpoint. Both pass with the fixes;
reverting the fast-path fix makes its workflow fail as expected.

Nightly: https://buildkite.com/materialize/nightly/builds/16727

🤖 Generated with [Claude Code](https://claude.com/claude-code)