### PR TITLE
mzcompose: Service companions wiring the metadata store, FoundationDB storage_engine

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -201,17 +201,32 @@ class Composition:
                     name = name[len("workflow_") :].replace("_", "-")
                     self.workflows[name] = fn
 
-            def _register(python_service: Any) -> None:
+            def _register_companion(python_service: Any) -> None:
+                # Companions never override an explicit declaration (or an
+                # already-registered companion). A customized service listed
+                # in SERVICES therefore wins over the default companion of the
+                # same name, and identical companions of sibling services
+                # (e.g. the metadata store of both Materialized and Testdrive)
+                # collapse to a single registration.
+                if python_service.name in self.compose["services"]:
+                    return
+                self.compose["services"][python_service.name] = python_service.config
+                for companion in getattr(python_service, "companions", []):
+                    _register_companion(companion)
+
+            services = list(getattr(module, "SERVICES", []))
+            # First register all explicit services, keeping the guard against
+            # the same name being spelled out twice. Companions are registered
+            # afterwards so that explicit declarations always take precedence.
+            for python_service in services:
                 if python_service.name in self.compose["services"]:
                     raise UIError(
                         f"service {python_service.name!r} specified more than once"
                     )
                 self.compose["services"][python_service.name] = python_service.config
+            for python_service in services:
                 for companion in getattr(python_service, "companions", []):
-                    _register(companion)
-
-            for python_service in getattr(module, "SERVICES", []):
-                _register(python_service)
+                    _register_companion(companion)
 
             for volume_name, volume_def in getattr(module, "VOLUMES", {}).items():
                 if volume_name in self.compose["volumes"]:

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -201,11 +201,17 @@ class Composition:
                     name = name[len("workflow_") :].replace("_", "-")
                     self.workflows[name] = fn
 
+            def _register(python_service: Any) -> None:
+                if python_service.name in self.compose["services"]:
+                    raise UIError(
+                        f"service {python_service.name!r} specified more than once"
+                    )
+                self.compose["services"][python_service.name] = python_service.config
+                for companion in getattr(python_service, "companions", []):
+                    _register(companion)
+
             for python_service in getattr(module, "SERVICES", []):
-                name = python_service.name
-                if name in self.compose["services"]:
-                    raise UIError(f"service {name!r} specified more than once")
-                self.compose["services"][name] = python_service.config
+                _register(python_service)
 
             for volume_name, volume_def in getattr(module, "VOLUMES", {}).items():
                 if volume_name in self.compose["volumes"]:

--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -198,8 +198,13 @@ class Service:
     Attributes:
         name: The name of the service.
         config: The definition of the service.
+        companions: Sibling services that should be registered in the
+            composition alongside this one. Lets a service pull in dependent
+            sidecar containers without each composition having to spell them
+            out.
     """
 
     def __init__(self, name: str, config: ServiceConfig) -> None:
         self.name = name
         self.config = config
+        self.companions: list["Service"] = []

--- a/misc/python/materialize/mzcompose/services/foundationdb.py
+++ b/misc/python/materialize/mzcompose/services/foundationdb.py
@@ -116,6 +116,7 @@ class FoundationDBCluster(Service):
         image: str | None = None,
         node_names: list[str] | None = None,
         cluster_file_contents: str | None = None,
+        storage_engine: str = "ssd",
     ) -> None:
         """
         Create a FoundationDB cluster initialization service.
@@ -126,6 +127,8 @@ class FoundationDBCluster(Service):
         :param name: Service name (typically "foundationdb" for dependency compatibility).
         :param node_names: List of FDB server node service names to depend on.
         :param cluster_file_contents: Contents of the FDB cluster file.
+        :param storage_engine: FDB storage engine ("ssd" for durable, "memory"
+                               for a RAM-backed store with no on-disk data).
         """
         node_names = node_names or []
 
@@ -147,7 +150,7 @@ class FoundationDBCluster(Service):
             "fi; "
             # Not configured - configure it now
             "echo 'Configuring new database...'; "
-            "fdbcli -C /var/fdb/fdb.cluster --exec 'configure new single ssd' --timeout 30; "
+            f"fdbcli -C /var/fdb/fdb.cluster --exec 'configure new single {storage_engine}' --timeout 30; "
             "echo 'Database configured successfully'; "
             "exec sleep infinity"
         )
@@ -187,6 +190,7 @@ def foundationdb_services(
         "FDB_NETWORKING_MODE=container",
     ],
     restart: str = "no",
+    storage_engine: str = "ssd",
 ) -> list[Service]:
     """
     Create a list of FoundationDB services forming a cluster.
@@ -234,6 +238,7 @@ def foundationdb_services(
             image=image,
             node_names=node_names,
             cluster_file_contents=cluster_file_contents,
+            storage_engine=storage_engine,
         )
     )
 

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -35,6 +35,7 @@ from materialize.mzcompose.services.azurite import azure_blob_uri
 from materialize.mzcompose.services.metadata_store import (
     EXTERNAL_METADATA_STORE_ADDRESS,
     METADATA_STORE,
+    metadata_store_companions,
 )
 from materialize.mzcompose.services.minio import minio_blob_uri
 
@@ -410,6 +411,12 @@ class Materialized(Service):
             )
 
         super().__init__(name=name, config=config)
+
+        # Pull the external metadata store container(s) into the composition
+        # automatically, so compositions don't have to spell them out.
+        self.companions = metadata_store_companions(
+            metadata_store, external_metadata_store
+        )
 
 
 class DeploymentStatus(Enum):

--- a/misc/python/materialize/mzcompose/services/metadata_store.py
+++ b/misc/python/materialize/mzcompose/services/metadata_store.py
@@ -126,20 +126,35 @@ EXTERNAL_METADATA_STORE_ADDRESS: str | bool = external_metadata_store()
 """ The external_metadata_store value to use for Materialized/Testdrive. """
 
 
-def metadata_store_services(*args, **kwargs) -> list[Service]:
+def metadata_store_companions(
+    metadata_store: str = METADATA_STORE,
+    external_metadata_store: str | bool = EXTERNAL_METADATA_STORE_ADDRESS,
+    *args,
+    **kwargs,
+) -> list[Service]:
     """
-    Returns a list containing the metadata store service instance if an external metadata store is used,
-    otherwise returns an empty list. Useful to construct a `SERVICES` list in a composition.
-    :param args: Passed through to the metadata store service constructor.
-    :param kwargs: Passed through to the metadata store service constructor.
+    Returns the sibling services that back the given external metadata store,
+    suitable for use as `Service.companions`. A service declaring these
+    companions pulls the store container(s) into the composition automatically,
+    so compositions no longer have to spell out the metadata store themselves.
+
+    Returns an empty list when the store is internal or disabled.
 
     For FoundationDB, returns multiple services (server nodes + cluster service).
+    :param metadata_store: The metadata store backend name.
+    :param external_metadata_store: The resolved `external_metadata_store` value;
+        a falsy value means an internal store and yields no companions.
+    :param args: Passed through to the metadata store service constructor.
+    :param kwargs: Passed through to the metadata store service constructor.
     """
-    if not METADATA_STORE_SERVICE:
+    if not external_metadata_store:
         return []
-    if METADATA_STORE == "foundationdb":
+    service = metadata_store_service(metadata_store)
+    if service is None:
+        return []
+    if metadata_store == "foundationdb":
         return foundationdb_services(num_nodes=FDB_NUM_NODES, **kwargs)
-    return [METADATA_STORE_SERVICE(*args, **kwargs)]
+    return [service(*args, **kwargs)]
 
 
 # Legacy switch to select between CockroachDB and Postgres for metadata storage.

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -22,6 +22,7 @@ from materialize.mzcompose.services.azurite import azure_blob_uri
 from materialize.mzcompose.services.metadata_store import (
     EXTERNAL_METADATA_STORE_ADDRESS,
     METADATA_STORE,
+    metadata_store_companions,
 )
 from materialize.mzcompose.services.minio import minio_blob_uri
 
@@ -225,4 +226,10 @@ class Testdrive(Service):
         super().__init__(
             name=name,
             config=config,
+        )
+
+        # Pull the external metadata store container(s) into the composition
+        # automatically, so compositions don't have to spell them out.
+        self.companions = metadata_store_companions(
+            metadata_store, external_metadata_store
         )

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -31,7 +31,6 @@ from materialize.mzcompose.services.materialized import (
     DeploymentStatus,
     Materialized,
 )
-from materialize.mzcompose.services.metadata_store import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
@@ -53,7 +52,6 @@ SERVICES = [
     SqlServer(),
     Kafka(),
     SchemaRegistry(),
-    CockroachOrPostgresMetadata(),
     Mz(app_password=""),
     Materialized(
         name="mz_old",

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -34,7 +34,6 @@ from materialize.mzcompose.composition import (
     WorkflowArgumentParser,
 )
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.redpanda_cloud import RedpandaCloud
@@ -197,7 +196,6 @@ class Redpanda:
 
 
 SERVICES = [
-    CockroachOrPostgresMetadata(),
     Materialized(
         # We use materialize/environmentd and not materialize/materialized here
         # in order to ensure a perfect match to the container that should be

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -40,7 +40,6 @@ from materialize.mzcompose.composition import (
 )
 from materialize.mzcompose.service import Service as MzComposeService
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import metadata_store_services
 from materialize.mzcompose.services.mz import Mz
 from materialize.test_analytics.config.test_analytics_db_config import (
     create_test_analytics_config,
@@ -85,7 +84,6 @@ def staging_version() -> str:
 SERVICES = [
     # Overridden below
     Mz(app_password=""),
-    *metadata_store_services(),
     Materialized(
         propagate_crashes=True,
         additional_system_parameter_defaults=MATERIALIZED_ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -44,7 +44,6 @@ from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.localstack import Localstack
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
@@ -74,7 +73,6 @@ SERVICES = [
         },
         support_external_clusterd=True,
     ),
-    CockroachOrPostgresMetadata(),
     Postgres(),
     Redpanda(),
     Toxiproxy(),

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -33,7 +33,6 @@ from launchdarkly_api.model.variation import Variation  # type: ignore
 from materialize.mzcompose import DEFAULT_MZ_ENVIRONMENT_ID, DEFAULT_ORG_ID
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.ui import UIError
 
@@ -53,7 +52,6 @@ LD_CONTEXT_KEY = DEFAULT_MZ_ENVIRONMENT_ID
 LD_FEATURE_FLAG_KEY = f"ci-test-{BUILDKITE_JOB_ID}"
 
 SERVICES = [
-    CockroachOrPostgresMetadata(),
     Materialized(
         environment_extra=[
             f"MZ_LAUNCHDARKLY_SDK_KEY={LAUNCHDARKLY_SDK_KEY}",

--- a/test/output-consistency/mzcompose.py
+++ b/test/output-consistency/mzcompose.py
@@ -14,7 +14,6 @@ dataflow rendering and constant folding).
 
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.test_result import FailedTestExecutionError
 from materialize.output_consistency.execution.query_output_mode import QueryOutputMode
@@ -24,7 +23,6 @@ from materialize.output_consistency.output_consistency_test import (
 )
 
 SERVICES = [
-    CockroachOrPostgresMetadata(),
     Materialized(propagate_crashes=True, external_metadata_store=True),
     Mz(app_password=""),
 ]

--- a/test/postgres-consistency/mzcompose.py
+++ b/test/postgres-consistency/mzcompose.py
@@ -13,7 +13,6 @@ Test the consistency of Materialize against Postgres as an oracle.
 
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.test_result import FailedTestExecutionError
@@ -26,7 +25,6 @@ from materialize.postgres_consistency.postgres_consistency_test import (
 )
 
 SERVICES = [
-    CockroachOrPostgresMetadata(),
     Materialized(propagate_crashes=True, external_metadata_store=True),
     Postgres(),
     Mz(app_password=""),

--- a/test/retain-history/mzcompose.py
+++ b/test/retain-history/mzcompose.py
@@ -15,11 +15,9 @@ from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.testdrive import Testdrive
 
 SERVICES = [
-    CockroachOrPostgresMetadata(),
     Materialized(propagate_crashes=True, external_metadata_store=True),
     Testdrive(no_reset=True, default_timeout="5s"),
 ]

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -24,7 +24,6 @@ from materialize.mzcompose.composition import (
 from materialize.mzcompose.services.azurite import Azurite
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.metadata_store import metadata_store_services
 from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.mz import Mz
@@ -61,7 +60,6 @@ SERVICES = [
         sanity_restart=False,
     ),
     Testdrive(external_blob_store=True),
-    *metadata_store_services(),
 ]
 
 


### PR DESCRIPTION
### Motivation

Test-harness groundwork.
Generic mzcompose additions that upcoming work (and FoundationDB tests in particular) build on.

### Description

* `Service.companions`: a generic list of sibling services.
  The Composition `SERVICES` loop registers explicit services first (keeping the duplicate-name guard), then walks companions recursively with skip-if-present, so a service can pull in dependent sidecar containers without each composition spelling them out.
  Explicit declarations win over a companion of the same name, and identical companions of sibling services collapse to a single registration.
* Metadata store as the first consumer: `metadata_store_services()` is replaced by `metadata_store_companions(metadata_store, external_metadata_store)`, and `Materialized`/`Testdrive` populate `self.companions` from their resolved params.
  Compositions whose `SERVICES`-level Materialized/Testdrive passes a truthy `external_metadata_store` no longer declare the store container themselves.
  Compositions that only enable the external store through runtime `c.override(...)` keep their explicit declaration, since companions register only from module-level `SERVICES`.
* `storage_engine` parameter on the FoundationDB cluster services (`FoundationDBCluster` / `foundationdb_services`), threaded into the `configure new single ` call.
  Defaults to `ssd` (unchanged); `memory` brings up a RAM-backed cluster with no on-disk data, useful for fast, non-durable FoundationDB test runs.

The companion now keys on the resolved `external_metadata_store` value rather than the always-set `METADATA_STORE` global.
A side effect is that compositions using the internal store (env `EXTERNAL_METADATA_STORE` unset) no longer spin up an unused external store container.

### Verification

Loaded the migrated and the kept compositions and confirmed the store container is registered exactly once, including the dedup case where an explicit declaration and a companion coincide.
Confirmed companions resolve to `postgres-metadata`, to the FoundationDB cluster services, or to nothing for an internal store, and that the `storage_engine="memory"` init script is emitted.