### PR TITLE
doc: Add design for scoped feature flags (per-cluster and per-replica)

### DIFF
--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -227,8 +227,35 @@ overrides at plan time, at the (already cluster-aware) sequencing sites in
 
 Precedence for replica-local flags, lowest to highest:
 `Global < ReplicaSizeFamily < Replica(id)` (a specific replica pin beats a size
-family rule). Cluster-coherent flags resolve `Global < Cluster`. Interaction with
-manually-set `CREATE CLUSTER ... FEATURES` is covered in Open Questions.
+family rule).
+
+For cluster-coherent flags the ordering is **specificity-then-source**, lowest
+to highest:
+
+```
+env-wide LD  <  manual CREATE CLUSTER ... FEATURES  <  cluster-scoped LD
+```
+
+i.e. a more specific scope wins, and at equal specificity **LD beats manual**.
+This is consistent with the existing global behavior — LD already overrides a
+manual `ALTER SYSTEM SET` wherever LD serves a value (the sync loop rewrites the
+param every tick), and `FEATURES` is likewise a system-only operator knob, so it
+gets the same treatment. It also *preserves* today's behavior that a manual
+`FEATURES` override beats the env-wide defaults (confirmed by `override_from` in
+`src/repr/src/optimize.rs`): env-wide LD is not cluster-specific, so a deliberate
+per-cluster manual pin still beats it, while a cluster-specific *LD* rule beats
+the manual pin.
+
+Crucially this is decided **per feature, only where LD actually serves a value**,
+mirroring the global case (where a manual value survives exactly when LD is
+silent). The implementation uses the LD evaluation *reason* from
+`variation_detail` to distinguish "LD has an opinion" (`RULE_MATCH` /
+`TARGET_MATCH` / `FALLTHROUGH`) from "LD is silent" (`FLAG_NOT_FOUND` / error);
+where LD is silent, the manual `FEATURES` value stands.
+
+The accepted trade-off, stated plainly: an operator's manual `FEATURES` pin can
+be overridden by a cluster-scoped LD rule. That is the same bargain operators
+already accept for `ALTER SYSTEM`, so it is consistent rather than novel.
 
 ### Worked examples
 
@@ -297,11 +324,6 @@ with `contextKind = "cluster"` and `"replica"` cases.
 
 ## Open questions
 
-- **Manual `FEATURES` vs LD-driven cluster overrides.** A cluster can already
-  carry manual `OptimizerFeatureOverrides` via `CREATE CLUSTER ... FEATURES`. When
-  both exist for the same feature, which wins? Proposed: manual DDL wins (explicit
-  operator intent), with the LD layer applying only where no manual override is
-  set. Confirm.
 - **Opt-in surface.** Should every synced parameter be scopable, or should
   parameters declare whether they are cluster-coherent, replica-local, or neither
   (e.g. on the `Var` / dyncfg definition)? Declaring it bounds the evaluation

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -108,8 +108,9 @@ populate the LD *Contexts list* in the dashboard. (That, not billing, is why the
 existing dev-mode path uses `anonymous(true)` + fixed keys.) We mark the
 cluster/replica contexts `anonymous` for the same dashboard-cleanliness reason.
 
-> Action item: confirm with the LD account owner that we are on the standard
-> service-connections model and not a custom contract with per-context metering.
+> **Pre-launch checkbox (must be confirmed before enabling the gate):** confirm
+> with the LD account owner that we are on the standard service-connections model
+> and not a custom contract with per-context metering.
 
 ## Solution Proposal
 

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -1,0 +1,344 @@
+# Scoped feature flags: per-cluster and per-replica-size LaunchDarkly overrides
+
+- Associated:
+  - `doc/developer/design/20240205_cluster_specific_optimization.md` (prior art, rejected the per-cluster LD approach "for now")
+
+## The Problem
+
+We distribute feature flags / system parameters through LaunchDarkly (LD). The
+finest granularity we can currently target is the **environment**: every flag is
+evaluated exactly once, against a single fixed `ld::Context`, and the resulting
+value is applied globally to the environment's `SystemVars`. There is no way to
+say "this flag has value X on cluster A but value Y everywhere else", or "this
+flag is on for replicas of size family D but off for the legacy t-shirt sizes".
+
+Two concrete use cases motivate finer granularity:
+
+1. **Per-cluster overrides.** We want the `mz_catalog_server` cluster (the
+   builtin cluster known internally as `s2`) to run with a different set of
+   flags than the rest of the environment, independent of the environment-wide
+   values. For example, we may want to turn an optimizer feature or a persist
+   read tuning on for the catalog server without affecting user clusters (or
+   vice-versa).
+
+2. **Per-replica-size-family overrides.** We are introducing replica *size
+   families* — `cc`, the legacy t-shirt sizes, `M.1`, and soon `D.1` — and
+   different families should ship with different flags. Concretely: the legacy
+   t-shirt sizes should keep using `lgalloc`, while `D.1` might enable the
+   persist pager and LZ4 compression. The override is keyed by the replica's
+   *size*, not by the cluster it belongs to.
+
+Today, the only knob we have that resembles this is the manually-set, optimizer-
+only `CREATE CLUSTER ... FEATURES (...)` override
+(`src/sql/src/plan/statement/ddl.rs`, stored as `OptimizerFeatureOverrides` on
+the cluster's `ClusterConfig`). It is not wired to LaunchDarkly, and it only
+covers optimizer features.
+
+## Success Criteria
+
+- A flag can be assigned a value scoped to (a) a specific cluster and (b) a
+  specific replica size family, with a well-defined precedence relative to the
+  environment-wide value.
+- Those scoped values are driven from LaunchDarkly using LD's existing targeting
+  primitives, so they can be rolled out / rolled back without a deploy, exactly
+  like environment-wide flags today.
+- The consumers that already know which cluster / replica they are acting on
+  (the optimizer, the compute & storage controllers, `clusterd`) observe the
+  correctly resolved value.
+- Adding scoped targeting does not blow up LaunchDarkly context cardinality
+  (LD bills per context), and does not regress the environment-wide path.
+- Behaviour is well-defined when LaunchDarkly is unreachable (same fallback
+  story as today's global flags).
+
+## Out of Scope
+
+- Per-session, per-database, or per-role flag scoping (PostgreSQL-style
+  `system < database < role < session`). We only add `cluster` and
+  `replica size family` scopes here, though the mechanism is designed so a third
+  scope could be added later.
+- Per-individual-replica overrides (i.e. two replicas of the *same* size in the
+  same cluster getting different flags). The scope is the size family, not the
+  replica.
+- Arbitrary user-defined targeting in the product surface (e.g. exposing this to
+  customers). This is an internal operability mechanism, driven by LD on the
+  Materialize side.
+- Switching feature-flag vendors. LaunchDarkly already supports everything we
+  need on the distribution side (see "LaunchDarkly capabilities"); the work is
+  almost entirely on the Materialize side.
+
+## LaunchDarkly capabilities (why this is mostly a Materialize-side change)
+
+The environment-only granularity is **not** an LD limitation. LD already
+supports:
+
+- **Custom context kinds.** Beyond `user`, you can define arbitrary kinds such
+  as `cluster` and `replica_size`, each with custom attributes. We already use
+  this: `ld_ctx` in `src/adapter/src/config/frontend.rs` builds a multi-context
+  with kinds `environment`, `organization`, and `build`.
+- **Multi-contexts.** A single evaluation can carry `environment` +
+  `organization` + `cluster` + `replica_size` at once, and targeting rules can
+  combine conditions across kinds.
+- **Per-evaluation context with one SDK client.** `client.variation(ctx, flag,
+  default)` takes the context per call, so we can evaluate the same flag against
+  different contexts from the same `ld::Client` — no extra clients needed.
+- **Rule-based segments and percentage rollouts** on any attribute, e.g.
+  `replica_size_family in {legacy, cc}` or `cluster_name = "mz_catalog_server"`.
+
+So the LD-facing change is: add `cluster` / `replica_size` context kinds to the
+evaluation, and author targeting rules against them. The hard part is on our
+side: **where do scoped values live, and how does each consumer resolve the
+value for the cluster/replica it is operating on.**
+
+## Solution Proposal
+
+High-level: introduce **scoped system parameters**. A synced parameter can carry,
+in addition to its environment-wide value, a set of overrides keyed by a *scope*:
+
+```
+scope := Global | Cluster(cluster) | ReplicaSizeFamily(family)
+```
+
+with resolution precedence, from lowest to highest:
+
+```
+Global  <  ReplicaSizeFamily  <  Cluster
+```
+
+(Cluster wins over size family because cluster targeting is the more specific,
+operator-driven decision; see Open Questions for whether this ordering is right
+for every parameter.)
+
+The design has three parts: **distribution** (LD), **storage** (catalog), and
+**resolution** (consumers). We keep the existing data flow shape —
+`LaunchDarkly -> sync loop -> ALTER SYSTEM -> catalog -> consumers` — and extend
+each stage to be scope-aware, rather than inventing a parallel path.
+
+### 1. Distribution: evaluate LaunchDarkly per scope
+
+Today `SystemParameterFrontend::pull` (`frontend.rs`) loops over parameters and
+calls `client.variation(&self.ctx, flag, default)` with one fixed context. The
+sync loop (`sync.rs`) calls `pull` once per tick.
+
+Changes:
+
+- **Extend `ld_ctx`** to accept optional scope attributes and emit additional
+  context kinds:
+  - `cluster` — `key = <cluster name>`, attrs: `cluster_name`,
+    `is_builtin` (bool), `cluster_id`.
+  - `replica_size` — `key = <size family>`, attrs: `size_family`
+    (`cc` / `legacy` / `M` / `D`), `size_name` (e.g. `D.1`).
+- **Evaluate per scope.** The frontend gains
+  `pull_scoped(scope, params)` which builds the appropriate multi-context
+  (always including the existing `environment` / `organization` / `build`
+  contexts, plus the scope's context) and evaluates the synced flags against it.
+  The sync loop now does, per tick:
+  1. `pull` with the base context → environment-wide values (unchanged).
+  2. For each *scope of interest*, `pull_scoped` → that scope's values.
+  The diff between a scope's evaluation and the base evaluation is the scope's
+  *override set* (we only store a scoped value when it actually differs from the
+  environment-wide value, to keep overrides sparse).
+
+- **Bounding context cardinality (important — LD bills per context).** We do
+  **not** create an LD context per user cluster or per replica. Instead:
+  - For clusters, the sync loop only evaluates the **builtin system clusters**
+    (`mz_catalog_server`, `mz_system`, `mz_probe`, …) by their stable names.
+    These are a fixed, tiny, low-cardinality set, and use case 1 only needs
+    `mz_catalog_server`. (Targeting arbitrary user clusters is left as future
+    work precisely because of cardinality; see Open Questions.)
+  - For replica sizes, the loop evaluates one context per **distinct size
+    family currently in use** (~4 today), discovered from the cluster replica
+    size configuration. Keying by family (not by individual replica) keeps this
+    at a handful of contexts regardless of replica count.
+  - All scope contexts can be marked `anonymous` so they don't pollute the LD
+    Contexts dashboard, mirroring the existing `Local` dev handling in
+    `ld_ctx`.
+
+The sync loop already holds a `SystemParameterBackend` with a `SessionClient`,
+so it can query the catalog for the list of builtin clusters and the in-use size
+families to decide which scopes to evaluate.
+
+### 2. Storage: scoped `ALTER SYSTEM` in the catalog
+
+Today the backend (`backend.rs`) pushes each modified value via
+`set_system_vars`, i.e. `ALTER SYSTEM SET <name> = <value>`, and the catalog
+persists it. We keep this and add scoped variants:
+
+- New SQL surface (system-only, like `FEATURES`):
+  - `ALTER SYSTEM SET <name> = <value> FOR CLUSTER <name>`
+  - `ALTER SYSTEM SET <name> = <value> FOR REPLICA SIZE FAMILY <family>`
+  - plus `RESET` counterparts.
+- New catalog state: a scoped-overrides table/collection mapping
+  `(scope, parameter_name) -> value`, durably stored next to the existing system
+  configuration. The backend's `push` writes the override set computed by the
+  sync loop into this collection (and resets entries that no longer differ).
+
+Persisting (rather than keeping overrides only in environmentd memory) buys us
+the same properties the global path already has: values survive an environmentd
+restart and an LD outage, and they are introspectable. We expose the resolved
+and the raw scoped values through new `mz_internal` relations (e.g.
+`mz_cluster_system_parameters`) for debugging.
+
+This is the concrete realization of the extension the cluster-specific
+optimization design doc hinted at: "use the `CLUSTER`-specific `ALTER SYSTEM`
+extensions in `SystemVars` in the `backend.push(...)` call."
+
+### 3. Resolution: consumers read the scoped value
+
+This is the most invasive part, but it factors into two existing per-scope
+boundaries, so we do **not** need a universal rewrite of `SystemVars`.
+
+`SystemVars` (`mz_sql::session::vars`) gains a layered lookup:
+
+```rust
+// pseudocode
+fn get_for(&self, name: &str, scope: ResolveScope) -> &VarValue {
+    // ReplicaSizeFamily and Cluster overrides shadow the global value,
+    // Cluster winning over ReplicaSizeFamily.
+}
+```
+
+where `ResolveScope { cluster: Option<ClusterId>, size_family: Option<Family> }`.
+The default `get` (no scope) returns the global value, so every existing call
+site is unchanged.
+
+The two boundaries that need to pass a scope:
+
+**(a) The compute & storage controllers' per-replica config push — handles use
+case 2 and the cluster-scoped dyncfg part of use case 1.**
+
+The flags in use case 2 (`lgalloc`, persist pager, LZ4 compression) are
+`mz_dyncfg` parameters consumed inside `clusterd`, and environmentd already
+pushes a `ConfigSet` / `ConfigUpdates` to each replica through the controllers.
+environmentd knows each replica's cluster *and* size at push time. So we resolve
+there: when building the `ConfigUpdates` for a replica, layer
+`global ⊕ size_family_override ⊕ cluster_override` and send the effective value.
+
+Crucially, **`clusterd` needs no changes** — it keeps reading its dyncfg
+`ConfigSet`; it just receives size/cluster-appropriate values. This makes
+use case 2 almost entirely a matter of resolving at the push site.
+
+**(b) The optimizer's per-cluster feature set — handles the optimizer part of
+use case 1.**
+
+The optimizer already takes an `OptimizerFeatures` derived from `SystemVars`
+*plus* the per-cluster `OptimizerFeatureOverrides` stored on `ClusterConfig`.
+We generalize the source of those overrides: instead of only the manually-set
+`CREATE CLUSTER ... FEATURES`, the cluster's resolved layer (from §2) feeds the
+overrides. Any place that already plumbs a "which cluster am I optimizing for"
+context (peek/index/MV sequencing in
+`src/adapter/src/coord/sequencer/inner/*`) resolves the cluster scope.
+
+For SystemVars consumed in environmentd that are neither dyncfg nor optimizer
+features but are still cluster-dependent, the same `get_for(name, scope)` lookup
+is used at the (already cluster-aware) call site. We expect this set to be small;
+each such parameter is opted in explicitly (see Open Questions on opt-in).
+
+### Worked examples
+
+**Use case 1 — `mz_catalog_server` gets a different optimizer feature.**
+
+1. In LD, add a targeting rule on the synced flag: `cluster_name =
+   "mz_catalog_server"` → variation X.
+2. Sync loop evaluates the base context (→ env-wide value) and a
+   `cluster:mz_catalog_server` context (→ X). They differ, so it writes
+   `Cluster(mz_catalog_server) -> X` via `ALTER SYSTEM SET ... FOR CLUSTER
+   mz_catalog_server`.
+3. When the coordinator optimizes a dataflow on `mz_catalog_server`, the cluster
+   layer feeds `OptimizerFeatureOverrides`, so X is used. Other clusters keep the
+   env-wide value.
+
+**Use case 2 — legacy sizes keep `lgalloc`, `D.1` gets pager + LZ4.**
+
+1. In LD, target the `lgalloc` dyncfg flag with `size_family = "legacy"` → on,
+   and the pager / LZ4 flags with `size_family = "D"` → on.
+2. Sync loop evaluates one context per in-use family (`cc`, `legacy`, `M`, `D`)
+   and records the per-family override sets.
+3. When the controller pushes dyncfg to a replica, it resolves by that replica's
+   size family: a `D.1` replica receives pager+LZ4 enabled; a legacy-sized
+   replica receives `lgalloc` enabled. No `clusterd` change required.
+
+## Minimal Viable Prototype
+
+Smallest end-to-end slice that de-risks the design, ordered:
+
+1. **Replica-size dyncfg push (use case 2 first — it's the cleaner boundary).**
+   - Add the `replica_size` context kind to `ld_ctx` and `pull_scoped`.
+   - Compute per-size-family override sets in the sync loop (held in
+     environmentd memory for the prototype, no catalog persistence yet).
+   - Resolve at the controller's per-replica dyncfg push.
+   - Demonstrate: LD rule `size_family = "legacy"` toggles `lgalloc` only on
+     legacy replicas, verified via the replica's effective config.
+   This proves the LD-per-scope evaluation and the push-site resolution with
+   zero catalog/SQL/`clusterd` changes.
+
+2. **Cluster scope for `mz_catalog_server` (use case 1).**
+   - Add the `cluster` context kind (builtin clusters only).
+   - Feed the resolved cluster layer into `OptimizerFeatureOverrides`.
+   - Demonstrate a flag that differs on `mz_catalog_server` vs. user clusters.
+
+3. **Catalog persistence + `ALTER SYSTEM ... FOR ...` SQL** and the
+   `mz_internal` introspection relations, once the in-memory prototype validates
+   the resolution model.
+
+Test surface to extend: `test/launchdarkly/mzcompose.py` already targets by
+`contextKind`; add cases for `contextKind = "cluster"` and `"replica_size"`.
+
+## Alternatives
+
+- **Universal `SystemVars` layering (`system < cluster < session`).** Teach
+  `SystemVars` to be fully scope-aware for *every* read site, as the prior design
+  doc sketched. More general, but a large, risky change touching every consumer
+  and the session-var resolution path. Rejected as the starting point in favour
+  of resolving at the two existing per-scope boundaries (controller push,
+  optimizer overrides), which covers both use cases with far less blast radius.
+  The `get_for` lookup proposed here is a stepping stone toward this if we later
+  need broader scoping.
+
+- **In-memory-only overrides (no catalog persistence).** Keep scoped values only
+  in environmentd, re-derived from LD each tick and pushed to consumers. Simpler
+  (no SQL/catalog work), and fine for the prototype, but loses the
+  survive-restart / survive-LD-outage / introspectable properties the global
+  path has today. We adopt it for the MVP but recommend persistence for GA.
+
+- **Per-individual-replica targeting (LD context per replica).** Maximum
+  flexibility, but explodes LD context cardinality (billing) and gives no
+  benefit over size-family targeting for the stated use cases. Rejected.
+
+- **Switch / add a different feature-flag tool.** Surveyed Unleash, Flagsmith,
+  Statsig, and the OpenFeature standard. None removes the Materialize-side
+  storage/resolution work, and several (Unleash, Flagsmith) are *less* expressive
+  than LD's multi-context model — they would force flattening cluster/size into
+  context fields. The only structural reason to consider OpenFeature is backend
+  portability (wrap the integration behind its API and keep LD as the provider).
+  Rejected as a prerequisite; orthogonal to this design.
+
+## Open questions
+
+- **Precedence.** Is `Global < ReplicaSizeFamily < Cluster` always right? A
+  cluster-level override would shadow a size-family override even for a replica
+  whose size family was explicitly targeted. Do we need per-parameter precedence,
+  or is a single global ordering acceptable?
+- **Opt-in surface.** Should *every* synced parameter be scopable, or should
+  parameters opt into being cluster-/size-scopable (e.g. a flag on the `Var`
+  definition)? Opting in keeps the resolution surface and the LD evaluation cost
+  bounded and avoids surprising interactions for params that are meaningless
+  per-cluster.
+- **User clusters.** Use case 1 only needs builtin clusters, which keeps LD
+  context cardinality trivial. Is there a near-term need to target arbitrary user
+  clusters, and if so, how do we bound the context count (e.g. only clusters that
+  have an active scoped rule, anonymous contexts, or a server-side evaluation
+  proxy)?
+- **Size family taxonomy.** Where is the authoritative `size name -> size
+  family` mapping (`D.1 -> D`, t-shirt sizes -> `legacy`)? It must be available
+  both to the sync loop (to know which families to evaluate) and to the
+  controller (to resolve per replica). Likely the cluster replica size
+  configuration; confirm.
+- **Interaction with `CREATE CLUSTER ... FEATURES`.** A cluster can already carry
+  manual `OptimizerFeatureOverrides`. When both a manual override and an
+  LD-driven cluster override exist for the same feature, which wins? Proposed:
+  manual DDL override wins over LD (operator intent is explicit), but this needs
+  confirmation.
+- **Sync cost.** Per-tick evaluation count grows from 1 to `1 + |builtin
+  clusters| + |size families|`. With the bounds above this is ~10 evaluations;
+  confirm this is acceptable for the LD SDK and tick interval, and whether scoped
+  evaluation should run on a slower cadence than the base pull.

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -54,8 +54,11 @@ not wired to LaunchDarkly.
   silently inherit an override that was meant for the previous incarnation,
   unless the override was authored as a durable predicate (e.g. by name or size
   family) that intentionally applies to the new object too.
-- Behaviour is well-defined when LaunchDarkly is unreachable (same fallback
-  story as today's global flags: fall back to the environment-wide value).
+- Scoped values are **durable**: they survive an `environmentd` restart and
+  remain in effect while LaunchDarkly is slow to sync or unavailable. Resolution
+  falls back to the environment-wide value only on a *cold cache* — i.e. an
+  object we have never successfully evaluated against LD. This matches how
+  environment-wide flags already persist and survive an LD outage.
 
 ## Out of Scope
 
@@ -282,29 +285,53 @@ accidentally carry over; because predicates key on stable names/families, role
 intent survives recreate by design. The operator picks the behavior by choosing
 the attribute. This is why we expose **both** identifiers on each context.
 
-### Storage: in-memory, reconciled from LD — not `ALTER SYSTEM ... FOR CLUSTER`
+### Storage: a durable cache, written solely by the sync loop
 
-The source of truth is the LD ruleset (which targets by name/attributes), and
-the sync loop re-evaluates every tick. So the scoped layer is best modeled as a
-**cache of a continuous LD evaluation**, not durable user-authored state:
+Scoped overrides are **persisted**, so they survive an `environmentd` restart and
+stay in effect while LaunchDarkly is slow to sync or unavailable. This is
+required: LD may take a while to connect/stream after a restart, or be
+unreachable, and during that window we must serve the last-known scoped values
+rather than reverting to environment-wide defaults. It also removes an asymmetry
+— environment-wide flags already persist in the catalog (via the existing
+`ALTER SYSTEM` path) and survive an LD outage; the scoped layer should too.
 
-- The scoped layer is a `BTreeMap<ClusterId, Overrides>` and
-  `BTreeMap<ReplicaId, Overrides>` held in `environmentd`, rebuilt each sync tick
-  by evaluating LD (with the appropriate contexts) for each live cluster/replica
-  in the catalog. We store only values that differ from the environment-wide
-  value, keeping the maps sparse.
-- Drop a cluster/replica → it leaves the catalog → it is no longer evaluated →
-  it falls out of the map. Nothing durable lingers, so nothing can bind a stale
-  override to a recreated object.
-- On `environmentd` restart or LD outage, the maps are simply empty until
-  re-derived, and resolution falls back to the environment-wide value — the same
-  fallback story global flags have today.
+The scoped layer is a durable catalog collection, keyed by **object id**, with an
+in-memory working copy used for resolution:
 
-We deliberately **reject** persisting scoped overrides as `ALTER SYSTEM SET ...
-FOR CLUSTER <name>` DDL (see Alternatives): it would force a name-vs-id binding
-decision, tempt a second (human) writer that the sync loop would overwrite, and
-require explicit GC of dangling entries — reintroducing exactly the recreate
-ambiguity the in-memory model avoids.
+```
+(Cluster(ClusterId) | Replica(ReplicaId), parameter_name) -> value
+```
+
+The **sync loop is the sole writer**; there is no user-facing
+`ALTER SYSTEM ... FOR CLUSTER` DDL (see Alternatives). We store only values that
+differ from the environment-wide value, keeping the collection sparse.
+
+Lifecycle:
+
+- **Startup:** load the persisted collection into the working maps, so scoped
+  values are in effect immediately — no waiting for the first LD sync.
+- **LD reachable:** each successful tick reconciles the collection to LD's current
+  evaluation, *including removals* — an entry is dropped when LD no longer serves
+  a non-default value for it (distinguished via the `variation_detail` reason, as
+  on the global path), so removing an LD rule propagates.
+- **LD slow / unavailable:** keep serving the last persisted values; do **not**
+  revert to the environment-wide value. This is the case that motivates
+  persistence.
+- **Cold cache + LD unavailable** (first-ever startup, object never yet
+  evaluated): fall back to the environment-wide value — unavoidable, since we
+  have never observed LD for it.
+
+Crucially, persisting does **not** reintroduce the recreate ambiguity that sank
+the `ALTER SYSTEM ... FOR CLUSTER` DDL alternative, because of the monotonic id
+allocator (`USER_CLUSTER_ID_ALLOC_KEY`): ids are **never reused**, so a persisted
+entry keyed by a dropped object's id is **inert** — it can never match a future
+object. A recreated same-named cluster (new id) starts with no cached overrides;
+a name-targeting LD rule re-applies on the next sync under the new id, while an
+incarnation pin keyed by the old id never resurfaces. GC is therefore *not* a
+correctness concern, only hygiene: entries for object ids absent from the catalog
+are pruned lazily (on startup and on each successful reconcile). This is the same
+non-reuse property the dual-identity scheme already relies on (§Identity &
+recreate semantics).
 
 ### Resolution: two existing per-scope boundaries
 
@@ -387,16 +414,22 @@ Ordered to de-risk the cleaner boundary first:
    Annotate the parameters the two use cases need (the target optimizer features
    as `Cluster`; `lgalloc` / pager / LZ4 as `Replica`). This is a prerequisite
    for the evaluation steps below, since the sync loop keys off the class.
-1. **Replica-local dyncfg push (use case 2).** Add the `replica` context kind and
-   per-replica evaluation; compute per-replica/size override maps in
-   `environmentd` (in-memory); resolve at the controller's dyncfg push.
-   Demonstrate `replica_size_family = "legacy"` toggling `lgalloc` only on legacy
-   replicas. Zero SQL / catalog / `clusterd` changes.
-2. **Cluster-coherent optimizer flags (use case 1).** Add the `cluster` context
+1. **Replica-local dyncfg push (use case 2), in-memory first.** Add the `replica`
+   context kind and per-replica evaluation; compute per-replica/size override maps
+   in `environmentd` (in-memory, not yet persisted); resolve at the controller's
+   dyncfg push. Demonstrate `replica_size_family = "legacy"` toggling `lgalloc`
+   only on legacy replicas. This validates the eval + push path cheaply, with no
+   catalog/`clusterd` changes; persistence follows next.
+2. **Persist the scoped cache.** Add the durable catalog collection keyed by
+   object id, load it into the working maps on startup, and have the sync loop
+   reconcile it (incl. removals + lazy prune). Demonstrate that scoped values
+   survive an `environmentd` restart and an LD outage, falling back to
+   environment-wide only on a cold cache.
+3. **Cluster-coherent optimizer flags (use case 1).** Add the `cluster` context
    kind (replica-free evaluation); feed the resolved cluster layer into
    `OptimizerFeatureOverrides`. Demonstrate an optimizer feature differing on
    `mz_catalog_server` vs. user clusters.
-3. **Introspection.** Expose resolved scoped values via `mz_internal` relations
+4. **Introspection.** Expose resolved scoped values via `mz_internal` relations
    for debugging (e.g. `mz_cluster_system_parameters`,
    `mz_replica_system_parameters`).
 
@@ -411,11 +444,17 @@ with `contextKind = "cluster"` and `"replica"` cases.
   resolved replica-free; a replica-only model cannot express "evaluate
   independent of any replica" and would permit incoherent per-replica plan
   divergence.
-- **Persisted `ALTER SYSTEM ... FOR CLUSTER` DDL.** Durable and introspectable,
-  but forces a name-vs-id binding choice, invites a human writer the sync loop
-  overwrites, and needs explicit dangling-entry GC on drop. The in-memory
-  reconciled model sidesteps all three. (We can revisit durable persistence later
-  if surviving an LD outage with non-default scoped values becomes a requirement.)
+- **User-facing `ALTER SYSTEM ... FOR CLUSTER` DDL.** Note that *persistence
+  itself is adopted* (see Storage) — what we reject is exposing it as **user
+  DDL**. A human-writable scoped setting would force a name-vs-id binding choice,
+  invite a second writer the sync loop overwrites, and need eager dangling-entry
+  GC. The internal, id-keyed, sync-loop-only durable cache gets the durability
+  without any of these: keying by id avoids the binding choice, a sole writer
+  avoids the conflict, and non-reused ids make stale entries inert (lazy GC).
+- **Pure in-memory cache (no persistence).** Simpler, but loses the last-known
+  values across an `environmentd` restart and during an LD outage — exactly when
+  we most need them — so resolution would wrongly revert to environment-wide
+  defaults until LD re-syncs. Rejected for that reason.
 - **Universal `SystemVars` layering (`system < cluster < session`).** General but
   large/risky, touching every read site. Resolving at the two existing boundaries
   covers both use cases with far less blast radius; this can evolve toward general

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -118,6 +118,16 @@ Introduce **scoped system parameters**: a synced parameter can carry, in
 addition to its environment-wide value, overrides resolved per cluster and per
 replica. We keep the existing data-flow shape and extend it to be scope-aware.
 
+### Feature gate
+
+The entire scoped-parameter mechanism is gated behind a new `enable_scoped_system_parameters` dyncfg defined in `mz_adapter_types::dyncfgs`, default `false`.
+The default behavior is therefore exactly today's environment-wide-only resolution, and the feature is strictly opt-in.
+The gate is checked at the single sync-loop chokepoint, `sync_scoped_params`.
+When off, no cluster or replica contexts are evaluated, and any overrides a previously-enabled run persisted are cleared once, so resolution falls back to the environment-wide value everywhere.
+This clearing is conditional on the sync loop running with the gate off: if the frontend is disabled entirely (self-managed, or no LD), those persisted overrides are not actively cleared, so a one-time prune on the gate-off path (independent of LD reachability) is needed to make the guarantee unconditional.
+When on, evaluation begins with no deploy, since every dyncfg is mirrored as a LaunchDarkly-synced, `ALTER SYSTEM`-settable system var.
+It is a dyncfg rather than a `feature_flags!` entry because the latter carries the catalog item-parsing rehydration contract for SQL/syntax features, which this runtime subsystem toggle has no part in.
+
 ### Two context kinds, because there are two scopes of coherence
 
 Not every flag can be resolved at the same granularity. There are two distinct
@@ -351,14 +361,8 @@ Lifecycle:
 - **Cold cache + LD unavailable** (first-ever startup, object never yet
   evaluated): fall back to the environment-wide value — unavoidable, since we
   have never observed LD for it.
-- **Newly-created object:** a cluster/replica created mid-interval runs with
-  environment-wide values until the next sync tick evaluates it (an
-  eventual-consistency window). This interacts with the plan-time consumption of
-  cluster-coherent flags (§Resolution): a freshly created cluster may plan its
-  first dataflows under environment-wide optimizer features and only pick up its
-  intended cluster-scoped features on later replanning. If first-plan correctness
-  for a known cluster matters, evaluate its scope synchronously at creation rather
-  than waiting for the tick.
+- **Newly-created object:** a cluster or replica created between ticks does **not** wait for the next tick — it resolves its scoped overrides synchronously at creation.
+  See §Resolution, "Synchronous create-time resolution", for why (render-frozen flags make the window a correctness problem, not just a delay) and how (inline `variation` evaluation at the two scope boundaries), including the sub-tick restart residual for replica-local persistence.
 
 Crucially, persisting does **not** reintroduce the recreate ambiguity that sank
 the `ALTER SYSTEM ... FOR CLUSTER` DDL alternative, because of the monotonic id
@@ -373,29 +377,17 @@ reconcile after startup**, and on each successful reconcile thereafter — there
 no separate startup-time prune pass. This is the same non-reuse property the
 dual-identity scheme already relies on (§Identity & recreate semantics).
 
-#### Feature gate
-
-The entire scoped-parameter mechanism is gated behind a new
-`enable_scoped_system_parameters` dyncfg (defined in `mz_adapter_types::dyncfgs`, default `false`).
-With the gate off, behavior is exactly today's environment-wide-only resolution, so the feature is strictly opt-in.
-The gate is checked at the single sync-loop chokepoint, `sync_scoped_params`.
-When off, no cluster or replica contexts are evaluated, and any overrides that a previously-enabled run persisted are cleared once, so resolution falls back to the environment-wide value everywhere.
-This clearing is conditional on the sync loop running with the gate off: if the frontend is disabled entirely (self-managed, or no LD), a previously-enabled run's persisted overrides are not actively cleared, so a one-time prune on the gate-off path (independent of LD reachability) is needed to make the guarantee unconditional.
-When on, cluster/replica evaluation begins with no deploy, since every dyncfg is mirrored as an LD-synced, `ALTER SYSTEM`-settable system var.
-It is a dyncfg rather than a `feature_flags!` entry because the latter carries the catalog item-parsing rehydration contract for SQL/syntax features, which this runtime subsystem toggle has no part in.
-
 ### Resolution: two existing per-scope boundaries
 
 We do **not** rewrite `SystemVars` into a universally scope-aware store. Both use
 cases resolve at boundaries that already carry the right context:
 
-**(a) The compute & storage controllers' per-replica config push — replica-local
-flags (use case 2).** environmentd already pushes a dyncfg `ConfigSet` /
-`ConfigUpdates` to each replica through the controllers, and knows each replica's
-cluster, size, and size family at push time. We resolve there:
-`effective = global ⊕ replica_local_override` for that replica. **`clusterd`
-needs no changes** — it keeps reading its dyncfg set and simply receives
-size/replica-appropriate values.
+**(a) The compute controller's per-replica config push — replica-local flags (use case 2).**
+environmentd already pushes a dyncfg `ConfigSet` / `ConfigUpdates` to each replica through the controller, and knows each replica's cluster, size, and size family at push time.
+We resolve there: `effective = global ⊕ replica_local_override` for that replica, and **`clusterd` needs no changes** — it keeps reading its dyncfg set and simply receives size/replica-appropriate values.
+Only the *compute* controller's per-replica dyncfg layer is pushed, but on `clusterd` that reaches storage too: compute and storage share one process, and the compute worker's configuration handler applies the pushed updates both to compute's worker `ConfigSet` and to the shared persist client `ConfigSet` that the co-located storage server reads.
+So the replica-local examples (persist pager, LZ4, persist client tuning, `lgalloc`) take effect on storage as well.
+The only thing this would miss is a future `Replica`-scoped config realized solely in the storage worker's own `ConfigSet` (applied only via the storage controller), which does not exist today.
 
 **(b) The optimizer's per-cluster feature set — cluster-coherent flags (use case
 1).** The optimizer already takes `OptimizerFeatures` derived from `SystemVars`
@@ -433,6 +425,21 @@ does **not** retroactively change installed dataflows. An operator who needs the
 change to apply to existing objects must trigger replanning (recreate the object,
 or reboot the environment). The doc calls this out explicitly because the two
 paths read as symmetric ("resolution at existing boundaries") but are not.
+
+#### Synchronous create-time resolution
+
+A cluster or replica created between sync ticks must resolve its scoped overrides synchronously at creation, not on the next tick.
+This is a correctness requirement, not a latency nicety: render-frozen flags — optimizer features baked into immutable dataflows, and any replica-local flag consumed only at dataflow-render time — turn the tick-latency window into a window in which the object renders permanently under the wrong values.
+It is feasible at no cost on the DDL path because `launchdarkly_server_sdk::Client::variation` is a synchronous, local evaluation against the SDK's streamed flag cache, with no network call, so an arbitrary new-object context evaluates correctly inline.
+The frontend is shared with the coordinator, and resolution happens at the two boundaries that match the two scopes:
+
+* Replica-local overrides are pushed into the compute controller's per-replica layer *before* the controller installs the replica, so the replica's first configuration already carries them.
+* Cluster-coherent overrides are resolved right after the create transaction — the cluster id is known pre-transaction — so the cluster's first plan, a later and separately sequenced command, uses them.
+
+The periodic sync loop remains the authoritative full-state writer.
+Replica-local persistence still lands on the next reconcile (≤ 1 tick), so an `environmentd` restart in that sub-tick window re-hydrates a just-created replica under environment-wide values until the first post-restart tick — an acknowledged, self-healing residual.
+Cluster-coherent overrides are persisted synchronously through reconcile and so do not have this gap.
+Both paths no-op when the gate is off or before the frontend is installed (the cold-cache environment-wide fallback).
 
 Precedence for replica-local flags, lowest to highest:
 `Global < ReplicaSizeFamily < Replica(id)` (a specific replica pin beats a size

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -209,29 +209,16 @@ the controller (to resolve a given replica's family at dyncfg-push time), and it
 versions and deploys with the rest of the size configuration rather than living
 in a second place that could drift.
 
-The `family` field need not be populated for every size up front, but the
-fallback must **fail safe**. A family should be assigned only when *positively
-identified* — `cc` via `is_cc`, `legacy` via membership in the known legacy set —
-and a size that matches neither (an unannotated new size, or an operator-defined
-one) must default to a **neutral family string** such as `other` that matches *no*
-curated rule. The tempting `is_cc ? "cc" : "legacy"` fallback is a footgun: it
-makes `legacy` the catch-all, so a brand-new size would silently match the
-motivating `replica_size_family = "legacy"` rule (e.g. "legacy keeps lgalloc") and
-inherit behavior it was never meant to have. Defaulting unknowns to a
-no-rule-matches `other` means an unannotated size gets only the environment-wide
-value until someone deliberately assigns its family.
+The `family` field need not be populated for every size up front.
+`ReplicaAllocation::family()` (`src/controller/src/clusters.rs`) returns the explicit `family` when set, and otherwise falls back to a value derived from `is_cc`: `cc` for modern sizes and `legacy` as the catch-all.
+This keeps the `cc` and `legacy` families targetable before every size gains an explicit `family` in the size configuration, which covers the motivating "legacy keeps lgalloc" rule on day one.
+A consequence worth noting: `legacy` is the default for any size that is neither explicitly annotated nor `is_cc`, so a brand-new, unannotated, non-cc size is reported as `legacy` and would match a `replica_size_family = "legacy"` rule.
+The mitigation is to give such sizes an explicit `family` when they are introduced, rather than relying on the fallback.
 
-The default must always yield a well-defined string, never fail or leave the
-attribute unset, because we do not control size (or cluster) naming everywhere. In
-**self-managed**, operators define their own replica sizes via
-`--cluster-replica-sizes`, with names we have never seen; `family()` must still
-return a string for them (`other`, per the above) so the `replica` context is
-always complete. In practice this is harmless there: the scoped mechanism is
-LD-driven, and self-managed deployments use the file-based system-parameter
-frontend (`SystemParameterFrontendClient::File`) or none — so they produce no
-scoped overrides and resolve to environment-wide defaults regardless of how sizes
-are named. The feature is effectively a cloud-fleet operability mechanism that
-degrades gracefully to env-wide elsewhere.
+The fallback always yields a well-defined string, never failing or leaving the attribute unset, because we do not control size (or cluster) naming everywhere.
+In **self-managed**, operators define their own replica sizes via `--cluster-replica-sizes`, with names we have never seen; `family()` still returns a string for them (`cc` or `legacy` per the fallback) so the `replica` context is always complete.
+In practice this is harmless there: the scoped mechanism is LD-driven, and self-managed deployments use the file-based system-parameter frontend (`SystemParameterFrontendClient::File`) or none — so they produce no scoped overrides and resolve to environment-wide defaults regardless of how sizes are named.
+The feature is effectively a cloud-fleet operability mechanism that degrades gracefully to env-wide elsewhere.
 
 We deliberately do **not** ask LD rule authors to derive the family from the
 size string with `startsWith` / `endsWith` operators. The family is a *curated
@@ -362,7 +349,7 @@ Lifecycle:
   evaluated): fall back to the environment-wide value — unavoidable, since we
   have never observed LD for it.
 - **Newly-created object:** a cluster or replica created between ticks does **not** wait for the next tick — it resolves its scoped overrides synchronously at creation.
-  See §Resolution, "Synchronous create-time resolution", for why (render-frozen flags make the window a correctness problem, not just a delay) and how (inline `variation` evaluation at the two scope boundaries), including the sub-tick restart residual for replica-local persistence.
+  See §Resolution, "Synchronous create-time resolution", for why (render-frozen flags make the window a correctness problem, not just a delay) and how (the overrides are evaluated inline and folded into the create transaction, so they are also persisted synchronously with no restart gap).
 
 Crucially, persisting does **not** reintroduce the recreate ambiguity that sank
 the `ALTER SYSTEM ... FOR CLUSTER` DDL alternative, because of the monotonic id
@@ -385,6 +372,7 @@ cases resolve at boundaries that already carry the right context:
 **(a) The compute controller's per-replica config push — replica-local flags (use case 2).**
 environmentd already pushes a dyncfg `ConfigSet` / `ConfigUpdates` to each replica through the controller, and knows each replica's cluster, size, and size family at push time.
 We resolve there: `effective = global ⊕ replica_local_override` for that replica, and **`clusterd` needs no changes** — it keeps reading its dyncfg set and simply receives size/replica-appropriate values.
+The push is not a direct controller call from the sync loop: the replica-local overrides are persisted through `Op::UpdateScopedSystemParameters`, and the per-replica controller push is derived from that committed diff as a *catalog implication* (`src/adapter/src/coord/catalog_implications`), which is also what carries a freshly-created replica's overrides before `create_replica`.
 Only the *compute* controller's per-replica dyncfg layer is pushed, but on `clusterd` that reaches storage too: compute and storage share one process, and the compute worker's configuration handler applies the pushed updates both to compute's worker `ConfigSet` and to the shared persist client `ConfigSet` that the co-located storage server reads.
 So the replica-local examples (persist pager, LZ4, persist client tuning, `lgalloc`) take effect on storage as well.
 The only thing this would miss is a future `Replica`-scoped config realized solely in the storage worker's own `ConfigSet` (applied only via the storage controller), which does not exist today.
@@ -431,14 +419,15 @@ paths read as symmetric ("resolution at existing boundaries") but are not.
 A cluster or replica created between sync ticks must resolve its scoped overrides synchronously at creation, not on the next tick.
 This is a correctness requirement, not a latency nicety: render-frozen flags — optimizer features baked into immutable dataflows, and any replica-local flag consumed only at dataflow-render time — turn the tick-latency window into a window in which the object renders permanently under the wrong values.
 It is feasible at no cost on the DDL path because `launchdarkly_server_sdk::Client::variation` is a synchronous, local evaluation against the SDK's streamed flag cache, with no network call, so an arbitrary new-object context evaluates correctly inline.
-The frontend is shared with the coordinator, and resolution happens at the two boundaries that match the two scopes:
+The frontend is shared with the coordinator.
+Both the new cluster's cluster-coherent and the new replicas' replica-local overrides are evaluated from the pre-allocated ids and *folded into the create transaction itself* (`scoped_overrides_create_op` appends an `Op::UpdateScopedSystemParameters` to the create ops in `src/adapter/src/coord/sequencer/inner/cluster.rs`).
+Folding into the create transaction, rather than resolving after it, means the committed diff drives both boundaries:
 
-* Replica-local overrides are pushed into the compute controller's per-replica layer *before* the controller installs the replica, so the replica's first configuration already carries them.
-* Cluster-coherent overrides are resolved right after the create transaction — the cluster id is known pre-transaction — so the cluster's first plan, a later and separately sequenced command, uses them.
+* The replica-local overrides reach the compute controller's per-replica dyncfg layer through the catalog implication derived from that diff, *before* `create_replica`, so the replica's first configuration already carries them.
+* The cluster-coherent overrides are in `CatalogState` as soon as the transaction commits, so the cluster's first plan — a later, separately sequenced command — uses them.
 
-The periodic sync loop remains the authoritative full-state writer.
-Replica-local persistence still lands on the next reconcile (≤ 1 tick), so an `environmentd` restart in that sub-tick window re-hydrates a just-created replica under environment-wide values until the first post-restart tick — an acknowledged, self-healing residual.
-Cluster-coherent overrides are persisted synchronously through reconcile and so do not have this gap.
+Because the overrides are committed in the create transaction, they are persisted synchronously: a just-created object's overrides survive an `environmentd` restart with no re-hydration gap.
+The periodic sync loop remains the authoritative full-state writer (`reconcile_scoped_system_parameters`), and the create-time fold and the loop are the only writers, both serialized on the coordinator loop and both persisting through the same `Op::UpdateScopedSystemParameters`.
 Both paths no-op when the gate is off or before the frontend is installed (the cold-cache environment-wide fallback).
 
 Precedence for replica-local flags, lowest to highest:

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -199,24 +199,29 @@ the controller (to resolve a given replica's family at dyncfg-push time), and it
 versions and deploys with the rest of the size configuration rather than living
 in a second place that could drift.
 
-The `family` field need not be populated for every size up front:
-`ReplicaAllocation::family()` falls back to deriving `cc` (via `is_cc`) or
-`legacy` when no explicit family is set, so the `legacy` and `cc` families are
-targetable immediately, before the new families (`M`, `D`) get explicit `family`
-entries. Explicit values are required only where the fallback is wrong.
+The `family` field need not be populated for every size up front, but the
+fallback must **fail safe**. A family should be assigned only when *positively
+identified* — `cc` via `is_cc`, `legacy` via membership in the known legacy set —
+and a size that matches neither (an unannotated new size, or an operator-defined
+one) must default to a **neutral family string** such as `other` that matches *no*
+curated rule. The tempting `is_cc ? "cc" : "legacy"` fallback is a footgun: it
+makes `legacy` the catch-all, so a brand-new size would silently match the
+motivating `replica_size_family = "legacy"` rule (e.g. "legacy keeps lgalloc") and
+inherit behavior it was never meant to have. Defaulting unknowns to a
+no-rule-matches `other` means an unannotated size gets only the environment-wide
+value until someone deliberately assigns its family.
 
-This fallback must always yield a **sensible default family string**, never fail
-or leave the attribute unset, because we do not control size (or cluster) naming
-everywhere. In **self-managed**, operators define their own replica sizes via
+The default must always yield a well-defined string, never fail or leave the
+attribute unset, because we do not control size (or cluster) naming everywhere. In
+**self-managed**, operators define their own replica sizes via
 `--cluster-replica-sizes`, with names we have never seen; `family()` must still
-return a well-defined string for them so the `replica` context is always
-complete. In practice this is harmless there: the scoped mechanism is LD-driven,
-and self-managed deployments use the file-based system-parameter frontend
-(`SystemParameterFrontendClient::File`) or none — so they produce no scoped
-overrides and resolve to environment-wide defaults regardless of how sizes are
-named. The feature is effectively a cloud-fleet operability mechanism that
-degrades gracefully to env-wide elsewhere; the only hard requirement self-managed
-imposes is that the family derivation has a sensible default for unknown names.
+return a string for them (`other`, per the above) so the `replica` context is
+always complete. In practice this is harmless there: the scoped mechanism is
+LD-driven, and self-managed deployments use the file-based system-parameter
+frontend (`SystemParameterFrontendClient::File`) or none — so they produce no
+scoped overrides and resolve to environment-wide defaults regardless of how sizes
+are named. The feature is effectively a cloud-fleet operability mechanism that
+degrades gracefully to env-wide elsewhere.
 
 We deliberately do **not** ask LD rule authors to derive the family from the
 size string with `startsWith` / `endsWith` operators. The family is a *curated
@@ -346,6 +351,14 @@ Lifecycle:
 - **Cold cache + LD unavailable** (first-ever startup, object never yet
   evaluated): fall back to the environment-wide value — unavoidable, since we
   have never observed LD for it.
+- **Newly-created object:** a cluster/replica created mid-interval runs with
+  environment-wide values until the next sync tick evaluates it (an
+  eventual-consistency window). This interacts with the plan-time consumption of
+  cluster-coherent flags (§Resolution): a freshly created cluster may plan its
+  first dataflows under environment-wide optimizer features and only pick up its
+  intended cluster-scoped features on later replanning. If first-plan correctness
+  for a known cluster matters, evaluate its scope synchronously at creation rather
+  than waiting for the tick.
 
 Crucially, persisting does **not** reintroduce the recreate ambiguity that sank
 the `ALTER SYSTEM ... FOR CLUSTER` DDL alternative, because of the monotonic id
@@ -367,6 +380,7 @@ The entire scoped-parameter mechanism is gated behind a new
 With the gate off, behavior is exactly today's environment-wide-only resolution, so the feature is strictly opt-in.
 The gate is checked at the single sync-loop chokepoint, `sync_scoped_params`.
 When off, no cluster or replica contexts are evaluated, and any overrides that a previously-enabled run persisted are cleared once, so resolution falls back to the environment-wide value everywhere.
+This clearing is conditional on the sync loop running with the gate off: if the frontend is disabled entirely (self-managed, or no LD), a previously-enabled run's persisted overrides are not actively cleared, so a one-time prune on the gate-off path (independent of LD reachability) is needed to make the guarantee unconditional.
 When on, cluster/replica evaluation begins with no deploy, since every dyncfg is mirrored as an LD-synced, `ALTER SYSTEM`-settable system var.
 It is a dyncfg rather than a `feature_flags!` entry because the latter carries the catalog item-parsing rehydration contract for SQL/syntax features, which this runtime subsystem toggle has no part in.
 
@@ -405,6 +419,20 @@ re-optimization closure, and both of those hold only a catalog snapshot, not the
 coordinator. Threading the working copy through the catalog is what makes it
 visible at *every* cluster-aware resolution site rather than just the sequencing
 path.
+
+**Timing: the two boundaries are not symmetric, and this is operationally
+significant.** Replica-local flags take effect **live** — a changed value is
+pushed to running replicas via dyncfg on the next sync tick, no recreation
+needed. Cluster-coherent (optimizer) flags are consumed **at plan time**, so
+changing one in LD affects only *subsequent* planning: existing indexes,
+materialized views, and subscribes keep their already-optimized plans until they
+are recreated or the environment reboots and re-optimizes. This is the same
+behavior as `ALTER SYSTEM` not re-optimizing existing objects, and it is
+defensible — but it means "flip an optimizer flag on `mz_catalog_server` from LD"
+does **not** retroactively change installed dataflows. An operator who needs the
+change to apply to existing objects must trigger replanning (recreate the object,
+or reboot the environment). The doc calls this out explicitly because the two
+paths read as symmetric ("resolution at existing boundaries") but are not.
 
 Precedence for replica-local flags, lowest to highest:
 `Global < ReplicaSizeFamily < Replica(id)` (a specific replica pin beats a size
@@ -454,6 +482,13 @@ opinion and the manual `FEATURES` pin stands. This is the same `differs from
 env-wide` test used at replica scope (which has no manual layer), so the recording
 rule is **uniform across both scopes** — there is no need to special-case
 `FALLTHROUGH` per scope.
+
+The comparison must be on the **resolved, typed value**, not the raw serialized
+form: both the env-wide and scoped values must be run through the *identical*
+evaluation-and-parse path before comparing, so that LD's raw `"true"` and the
+var-formatted `"on"` (or `100ms` vs `"100ms"`, etc.) are recognized as equal. A
+naive comparison of LD's raw string against the formatted system-var value will
+spuriously report a difference and record a no-op override for every object.
 
 The one behavior this does *not* support is reasserting the env-wide value on a
 cluster purely to clear a `FEATURES` pin (LD value equal to env-wide cannot
@@ -510,9 +545,13 @@ Ordered to de-risk the cleaner boundary first:
    kind (replica-free evaluation); feed the resolved cluster layer into
    `OptimizerFeatureOverrides`. Demonstrate an optimizer feature differing on
    `mz_catalog_server` vs. user clusters.
-4. **Introspection.** Expose resolved scoped values via `mz_internal` relations
-   for debugging (e.g. `mz_cluster_system_parameters`,
-   `mz_replica_system_parameters`).
+4. **Introspection.** Expose scoped values via `mz_internal` relations (e.g.
+   `mz_cluster_system_parameters`, `mz_replica_system_parameters`). These expose
+   the **raw stored override** per scope, not the effective value after precedence
+   (manual `FEATURES`, `EXPLAIN WITH`). That is a deliberate choice for a first
+   cut, but note that for debugging "why is this cluster behaving this way?" an
+   operator usually wants the *effective* value; surfacing the resolved value
+   (or both) is a worthwhile follow-up.
 
 Extend `test/launchdarkly/mzcompose.py` (which already targets by `contextKind`)
 with `contextKind = "cluster"` and `"replica"` cases.
@@ -551,10 +590,19 @@ with `contextKind = "cluster"` and `"replica"` cases.
 
 ## Open questions
 
-Both remaining items are **deferrable** — they are operational tuning concerns,
-not design decisions, and neither blocks the MVP. Both can be revisited once the
-mechanism is in use and we have real numbers.
+One pre-launch checkbox, one operational guardrail, and two deferrable tuning
+concerns. None is a design decision that blocks the MVP.
 
+- **LD billing/contract model (pre-launch checkbox).** Confirm with the LD account
+  owner that we are on the standard service-connections model, not a custom
+  contract with per-context metering, before the gate is enabled (see §Billing).
+  Not deferrable — it gates turning the feature on.
+- **Blast radius of builtin-targeted optimizer rules.** `mz_catalog_server` is the
+  headline target and is critical infrastructure; a bad `is_builtin = true`
+  optimizer rule degrades the catalog-server fleet environment-wide. Worth
+  rollout discipline (narrow targeting, staged rollout, a quick disable path) for
+  builtin-cluster-scoped flags — the gate is the coarse kill-switch, but a bad
+  *rule* under an enabled gate still needs an operational guardrail.
 - **User-cluster context-list growth (deferred).** Billing is unaffected, but
   keying cluster contexts by id means resized/recreated objects accumulate in the
   dashboard Contexts list over time. `anonymous` contexts are likely enough; if

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -162,6 +162,20 @@ Evaluation composes these into the existing multi-context per pass:
   `environment + organization + build + cluster + replica`. Including the cluster
   lets a rule combine both axes, e.g. *"size family `D` **and** cluster `foo`."*
 
+LD contexts in a multi-context are **siblings, not a hierarchy** — there is no
+attribute inheritance between kinds, but a targeting rule can reference
+attributes from *any* kind present in the evaluated multi-context (each rule
+clause is a `(kind, attribute)` pair). This is why every scoped evaluation must
+keep the `environment` / `organization` / `build` contexts in the bundle
+*alongside* the scope context, rather than evaluating the `cluster` / `replica`
+context standalone: it is what lets rules cross axes (e.g.
+`environment.cloud_provider = "aws" AND cluster.cluster_name = "..."`). We do
+**not** copy environment attributes onto the cluster/replica contexts — that
+would be redundant and risk drift; the environment context simply rides along.
+Concretely, `pull_scoped` adds the scope context to the *same*
+`MultiContextBuilder` that `ld_ctx` already populates with
+environment/organization/build, rather than replacing it.
+
 The `replica` context carries the owning cluster's identity as attributes so that
 replica-local flags can still be cluster-targeted without a second evaluation;
 the standalone `cluster` kind exists specifically for the replica-free,

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -359,6 +359,16 @@ reconcile after startup**, and on each successful reconcile thereafter — there
 no separate startup-time prune pass. This is the same non-reuse property the
 dual-identity scheme already relies on (§Identity & recreate semantics).
 
+#### Feature gate
+
+The entire scoped-parameter mechanism is gated behind a new
+`enable_scoped_system_parameters` dyncfg (defined in `mz_adapter_types::dyncfgs`, default `false`).
+With the gate off, behavior is exactly today's environment-wide-only resolution, so the feature is strictly opt-in.
+The gate is checked at the single sync-loop chokepoint, `sync_scoped_params`.
+When off, no cluster or replica contexts are evaluated, and any overrides that a previously-enabled run persisted are cleared once, so resolution falls back to the environment-wide value everywhere.
+When on, cluster/replica evaluation begins with no deploy, since every dyncfg is mirrored as an LD-synced, `ALTER SYSTEM`-settable system var.
+It is a dyncfg rather than a `feature_flags!` entry because the latter carries the catalog item-parsing rehydration contract for SQL/syntax features, which this runtime subsystem toggle has no part in.
+
 ### Resolution: two existing per-scope boundaries
 
 We do **not** rewrite `SystemVars` into a universally scope-aware store. Both use
@@ -483,6 +493,7 @@ Ordered to de-risk the cleaner boundary first:
    Annotate the parameters the two use cases need (the target optimizer features
    as `Cluster`; `lgalloc` / pager / LZ4 as `Replica`). This is a prerequisite
    for the evaluation steps below, since the sync loop keys off the class.
+   - **Kill-switch (step 0's companion).** Add the `enable_scoped_system_parameters` dyncfg (default `false`) and gate `sync_scoped_params` on it, so the mechanism ships dark and the default behavior stays environment-wide-only until it is turned on with no deploy.
 1. **Replica-local dyncfg push (use case 2), in-memory first.** Add the `replica`
    context kind and per-replica evaluation; compute per-replica/size override maps
    in `environmentd` (in-memory, not yet persisted); resolve at the controller's

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -39,6 +39,11 @@ not wired to LaunchDarkly.
 - A flag can be assigned a value scoped to (a) a specific cluster and (b) a
   specific replica / replica size family, with a well-defined precedence
   relative to the environment-wide value.
+- Every synced parameter **declares its scope class** (environment-only,
+  cluster-coherent, or replica-local) at its definition. The declaration is
+  required, is surfaced in documentation / introspection, and is the single
+  source of truth for which contexts the sync loop evaluates and where the value
+  may be overridden.
 - Those scoped values are driven from LaunchDarkly using LD's existing targeting
   primitives, so they can be rolled out / rolled back without a deploy, exactly
   like environment-wide flags today.
@@ -162,6 +167,66 @@ replica-local flags can still be cluster-targeted without a second evaluation;
 the standalone `cluster` kind exists specifically for the replica-free,
 cluster-coherent case.
 
+### Size family taxonomy
+
+The `replica_size_family` attribute needs a `size name -> family` mapping
+(`D.1 -> D`, t-shirt sizes -> `legacy`, …) that **does not exist today and must
+be introduced**. It belongs in the **cluster replica size map**
+(`ClusterReplicaSizeMap` in `mz_catalog::config`, parsed from the
+`--cluster-replica-sizes` configuration that already defines each named size's
+allocation), as a new per-size `family` field. That makes the size definitions
+the single authoritative source: it is available both to the sync loop (to
+enumerate the in-use families and which `replica` contexts to evaluate) and to
+the controller (to resolve a given replica's family at dyncfg-push time), and it
+versions and deploys with the rest of the size configuration rather than living
+in a second place that could drift.
+
+### Scope declaration is required, per parameter
+
+Every synced parameter must declare its scope class as part of its definition.
+This is a hard requirement, not an opt-in convenience: it is what lets the sync
+loop know which contexts to build, lets resolution know where a value may be
+overridden, gives us a basis to reject nonsensical targeting, and documents the
+surface area of each flag.
+
+```rust
+enum ParameterScope {
+    /// Environment-wide only; no cluster/replica overrides. The default, so all
+    /// existing synced parameters are unchanged.
+    Environment,
+    /// Cluster-coherent: env-wide base + per-cluster overrides. Evaluated with
+    /// the `cluster` context (replica-free) and resolved at plan time via
+    /// `OptimizerFeatureOverrides`. e.g. optimizer features.
+    Cluster,
+    /// Replica-local: env-wide base + per-replica / per-size-family overrides.
+    /// Evaluated with the `replica` context and resolved at the controller's
+    /// per-replica dyncfg push. e.g. `lgalloc`, persist pager, LZ4.
+    Replica,
+}
+```
+
+The class is declared where the parameter is defined — on the `Var` builder for
+system vars and on the dyncfg `Config` definition — defaulting to `Environment`.
+The scope class is a property of the parameter's **consumption site / coherence**,
+not of any targeting attribute, so a single class per parameter is sufficient
+(`Replica` already covers both size-family and per-replica targeting).
+
+The declaration drives three things:
+
+1. **Documentation.** Surfaced in the generated parameter docs and in an
+   introspection relation, so the scope of every flag is discoverable.
+2. **Evaluation.** The sync loop only builds and evaluates a `cluster` context
+   for `Cluster` parameters, and a `replica` context for `Replica` parameters.
+   This bounds the per-tick evaluation work to exactly what is in use and is the
+   answer to the sync-cadence/cardinality concern: an environment with no
+   `Replica`-scoped flags pays nothing for replica evaluation.
+3. **Validation.** Because we know a parameter's class, we can detect and warn on
+   an LD rule that targets an out-of-class dimension (e.g. an `Environment` or
+   `Cluster` parameter targeted by `replica_size_family`). Such a rule would
+   simply never match (we never build that context for that parameter), so the
+   behavior is safe-by-construction; the declaration lets us surface it as a lint
+   rather than a silent no-op.
+
 ### Identity & recreate semantics: dual id/name attributes
 
 Catalog object ids are allocated from a monotonic counter
@@ -280,6 +345,11 @@ env-wide value automatically.
 
 Ordered to de-risk the cleaner boundary first:
 
+0. **Scope declaration.** Add the `ParameterScope` enum and the declaration hook
+   on the `Var` / dyncfg `Config` definitions, defaulting to `Environment`.
+   Annotate the parameters the two use cases need (the target optimizer features
+   as `Cluster`; `lgalloc` / pager / LZ4 as `Replica`). This is a prerequisite
+   for the evaluation steps below, since the sync loop keys off the class.
 1. **Replica-local dyncfg push (use case 2).** Add the `replica` context kind and
    per-replica evaluation; compute per-replica/size override maps in
    `environmentd` (in-memory); resolve at the controller's dyncfg push.
@@ -324,20 +394,19 @@ with `contextKind = "cluster"` and `"replica"` cases.
 
 ## Open questions
 
-- **Opt-in surface.** Should every synced parameter be scopable, or should
-  parameters declare whether they are cluster-coherent, replica-local, or neither
-  (e.g. on the `Var` / dyncfg definition)? Declaring it bounds the evaluation
-  surface and prevents nonsensical scoping (e.g. an optimizer flag targeted by
-  size family).
-- **Size family taxonomy.** Where is the authoritative `size name -> size family`
-  mapping (`D.1 -> D`, t-shirt -> `legacy`)? It must be available to the sync loop
-  (which families to evaluate) and the controller (resolve per replica). Likely
-  the cluster replica size configuration; confirm.
-- **User-cluster context-list growth.** Billing is unaffected, but keying cluster
-  contexts by id means resized/recreated objects accumulate in the dashboard
-  Contexts list over time. Is `anonymous` enough, or do we want a periodic prune /
-  to only emit contexts for objects matching an active rule?
-- **Sync cadence.** Per-tick evaluation grows from 1 to roughly
-  `1 + |clusters| + |live replicas|`. With anonymous server-side contexts this is
-  free billing-wise, but confirm the SDK evaluation cost is acceptable, and
-  whether scoped evaluation should run on a slower cadence than the base pull.
+Both remaining items are **deferrable** — they are operational tuning concerns,
+not design decisions, and neither blocks the MVP. Both can be revisited once the
+mechanism is in use and we have real numbers.
+
+- **User-cluster context-list growth (deferred).** Billing is unaffected, but
+  keying cluster contexts by id means resized/recreated objects accumulate in the
+  dashboard Contexts list over time. `anonymous` contexts are likely enough; if
+  the list becomes unwieldy we can add a periodic prune or only emit contexts for
+  objects matching an active rule. Not a blocker — for the MVP (builtin clusters
+  + a handful of size families) the list stays small.
+- **Sync cadence (deferred).** Per-tick evaluation grows from 1 to roughly
+  `1 + |Cluster-scoped objects| + |live replicas with Replica-scoped flags|`.
+  The scope-declaration requirement already bounds this to parameters actually in
+  use, and on the server SDK it is free billing-wise. If the per-tick cost ever
+  matters, scoped evaluation can run on a slower cadence than the base pull. Defer
+  until we have evaluation-cost numbers.

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -204,6 +204,19 @@ The `family` field need not be populated for every size up front:
 targetable immediately, before the new families (`M`, `D`) get explicit `family`
 entries. Explicit values are required only where the fallback is wrong.
 
+This fallback must always yield a **sensible default family string**, never fail
+or leave the attribute unset, because we do not control size (or cluster) naming
+everywhere. In **self-managed**, operators define their own replica sizes via
+`--cluster-replica-sizes`, with names we have never seen; `family()` must still
+return a well-defined string for them so the `replica` context is always
+complete. In practice this is harmless there: the scoped mechanism is LD-driven,
+and self-managed deployments use the file-based system-parameter frontend
+(`SystemParameterFrontendClient::File`) or none — so they produce no scoped
+overrides and resolve to environment-wide defaults regardless of how sizes are
+named. The feature is effectively a cloud-fleet operability mechanism that
+degrades gracefully to env-wide elsewhere; the only hard requirement self-managed
+imposes is that the family derivation has a sensible default for unknown names.
+
 We deliberately do **not** ask LD rule authors to derive the family from the
 size string with `startsWith` / `endsWith` operators. The family is a *curated
 mapping*, not a stable encoding: the new families follow `<family>.<version>`
@@ -367,6 +380,13 @@ overrides at plan time, at the (already cluster-aware) sequencing sites in
 `src/adapter/src/coord/sequencer/inner/*`. This is the direct path to
 "optimizer flags in LD per cluster."
 
+The cluster-scoped layer **feeds** `OptimizerFeatureOverrides`; it does **not**
+replace the mechanism. The overrides struct stays as the composition point and
+simply gains LD as one input. It is still needed independently for per-statement,
+what-if overrides — notably `EXPLAIN WITH (<flag>)`, which previews how a plan
+*would* look with a flag flipped. That per-statement override is the most specific
+scope of all and sits above the cluster layer (see precedence below).
+
 The cluster-scoped working copy must live in `CatalogState` (behind
 `Arc<Catalog>`), **not** on the coordinator. Cluster-coherent overrides must also
 apply on the fast-path peek route (`frontend_peek`) and inside the bootstrap
@@ -383,10 +403,13 @@ For cluster-coherent flags the ordering is **specificity-then-source**, lowest
 to highest:
 
 ```
-env-wide LD  <  manual CREATE CLUSTER ... FEATURES  <  cluster-scoped LD
+env-wide LD  <  manual CREATE CLUSTER ... FEATURES  <  cluster-scoped LD  <  EXPLAIN WITH (per-statement)
 ```
 
 i.e. a more specific scope wins, and at equal specificity **LD beats manual**.
+The per-statement `EXPLAIN WITH (<flag>)` override is the most specific and wins
+for that one statement's preview, which is why the `OptimizerFeatureOverrides`
+mechanism is retained rather than replaced by the cluster-scoped layer.
 This is consistent with the existing global behavior — LD already overrides a
 manual `ALTER SYSTEM SET` wherever LD serves a value (the sync loop rewrites the
 param every tick), and `FEATURES` is likewise a system-only operator knob, so it

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -1,4 +1,4 @@
-# Scoped feature flags: per-cluster and per-replica-size LaunchDarkly overrides
+# Scoped feature flags: per-cluster and per-replica LaunchDarkly overrides
 
 - Associated:
   - `doc/developer/design/20240205_cluster_specific_optimization.md` (prior art, rejected the per-cluster LD approach "for now")
@@ -14,54 +14,51 @@ flag is on for replicas of size family D but off for the legacy t-shirt sizes".
 
 Two concrete use cases motivate finer granularity:
 
-1. **Per-cluster overrides.** We want the `mz_catalog_server` cluster (the
-   builtin cluster known internally as `s2`) to run with a different set of
-   flags than the rest of the environment, independent of the environment-wide
-   values. For example, we may want to turn an optimizer feature or a persist
-   read tuning on for the catalog server without affecting user clusters (or
-   vice-versa).
+1. **Per-cluster overrides (cluster-coherent flags).** We want the
+   `mz_catalog_server` cluster (the builtin cluster known internally as `s2`) to
+   run with a different set of flags than the rest of the environment,
+   independent of the environment-wide values. The motivating class here is
+   **optimizer flags**: there is broad interest in being able to flip optimizer
+   features per cluster from LD, e.g. enabling a feature on the catalog server
+   (or a specific user cluster) without affecting everyone else.
 
-2. **Per-replica-size-family overrides.** We are introducing replica *size
-   families* — `cc`, the legacy t-shirt sizes, `M.1`, and soon `D.1` — and
-   different families should ship with different flags. Concretely: the legacy
-   t-shirt sizes should keep using `lgalloc`, while `D.1` might enable the
-   persist pager and LZ4 compression. The override is keyed by the replica's
-   *size*, not by the cluster it belongs to.
+2. **Per-replica overrides (replica-local flags), keyed by size family.** We are
+   introducing replica *size families* — `cc`, the legacy t-shirt sizes, `M.1`,
+   and soon `D.1` — and different families should ship with different flags.
+   Concretely: the legacy t-shirt sizes should keep using `lgalloc`, while `D.1`
+   might enable the persist pager and LZ4 compression. The override is keyed by
+   the replica's *size*, not by the cluster it belongs to.
 
-Today, the only knob we have that resembles this is the manually-set, optimizer-
-only `CREATE CLUSTER ... FEATURES (...)` override
-(`src/sql/src/plan/statement/ddl.rs`, stored as `OptimizerFeatureOverrides` on
-the cluster's `ClusterConfig`). It is not wired to LaunchDarkly, and it only
-covers optimizer features.
+Today the only knob that resembles this is the manually-set, optimizer-only
+`CREATE CLUSTER ... FEATURES (...)` override (`src/sql/src/plan/statement/ddl.rs`,
+stored as `OptimizerFeatureOverrides` on the cluster's `ClusterConfig`). It is
+not wired to LaunchDarkly.
 
 ## Success Criteria
 
 - A flag can be assigned a value scoped to (a) a specific cluster and (b) a
-  specific replica size family, with a well-defined precedence relative to the
-  environment-wide value.
+  specific replica / replica size family, with a well-defined precedence
+  relative to the environment-wide value.
 - Those scoped values are driven from LaunchDarkly using LD's existing targeting
   primitives, so they can be rolled out / rolled back without a deploy, exactly
   like environment-wide flags today.
 - The consumers that already know which cluster / replica they are acting on
   (the optimizer, the compute & storage controllers, `clusterd`) observe the
   correctly resolved value.
-- Adding scoped targeting does not blow up LaunchDarkly context cardinality
-  (LD bills per context), and does not regress the environment-wide path.
+- Recreating an object (drop + recreate, or a replica resize) does **not**
+  silently inherit an override that was meant for the previous incarnation,
+  unless the override was authored as a durable predicate (e.g. by name or size
+  family) that intentionally applies to the new object too.
 - Behaviour is well-defined when LaunchDarkly is unreachable (same fallback
-  story as today's global flags).
+  story as today's global flags: fall back to the environment-wide value).
 
 ## Out of Scope
 
 - Per-session, per-database, or per-role flag scoping (PostgreSQL-style
-  `system < database < role < session`). We only add `cluster` and
-  `replica size family` scopes here, though the mechanism is designed so a third
-  scope could be added later.
-- Per-individual-replica overrides (i.e. two replicas of the *same* size in the
-  same cluster getting different flags). The scope is the size family, not the
-  replica.
-- Arbitrary user-defined targeting in the product surface (e.g. exposing this to
-  customers). This is an internal operability mechanism, driven by LD on the
-  Materialize side.
+  `system < database < role < session`). We only add `cluster` and `replica`
+  scopes here, though the mechanism is designed so a third scope could be added.
+- Exposing this targeting to customers as a product surface. This is an internal
+  operability mechanism, driven by LD on the Materialize side.
 - Switching feature-flag vendors. LaunchDarkly already supports everything we
   need on the distribution side (see "LaunchDarkly capabilities"); the work is
   almost entirely on the Materialize side.
@@ -69,276 +66,256 @@ covers optimizer features.
 ## LaunchDarkly capabilities (why this is mostly a Materialize-side change)
 
 The environment-only granularity is **not** an LD limitation. LD already
-supports:
+supports custom context kinds, multi-contexts (one evaluation carrying several
+kinds at once), per-evaluation contexts on a single SDK client
+(`client.variation(ctx, flag, default)`), and rule-based segments / percentage
+rollouts on any attribute. We already use a multi-context of kinds `environment`,
+`organization`, and `build` in `ld_ctx` (`src/adapter/src/config/frontend.rs`).
 
-- **Custom context kinds.** Beyond `user`, you can define arbitrary kinds such
-  as `cluster` and `replica_size`, each with custom attributes. We already use
-  this: `ld_ctx` in `src/adapter/src/config/frontend.rs` builds a multi-context
-  with kinds `environment`, `organization`, and `build`.
-- **Multi-contexts.** A single evaluation can carry `environment` +
-  `organization` + `cluster` + `replica_size` at once, and targeting rules can
-  combine conditions across kinds.
-- **Per-evaluation context with one SDK client.** `client.variation(ctx, flag,
-  default)` takes the context per call, so we can evaluate the same flag against
-  different contexts from the same `ld::Client` — no extra clients needed.
-- **Rule-based segments and percentage rollouts** on any attribute, e.g.
-  `replica_size_family in {legacy, cc}` or `cluster_name = "mz_catalog_server"`.
+So the LD-facing change is small: add `cluster` and `replica` context kinds to
+the evaluation and author rules against them. The substantive work is on our
+side — where scoped values live and how each consumer resolves the value for the
+cluster/replica it is operating on.
 
-So the LD-facing change is: add `cluster` / `replica_size` context kinds to the
-evaluation, and author targeting rules against them. The hard part is on our
-side: **where do scoped values live, and how does each consumer resolve the
-value for the cluster/replica it is operating on.**
+### Billing note: server-side SDKs are billed by connections, not contexts
+
+A natural worry is that minting a context per cluster/replica explodes LD
+billing. It does not, because of how LD meters the two SDK families:
+
+- **Client-side / edge SDKs** are billed by **MAU** = unique context keys per
+  month. This is what the Materialize **Console** consumes (the JS client-side
+  SDK in `console/src/hooks/useLaunchDarklyClient.ts`, keyed by user/org).
+- **Server-side SDKs** are billed by **service connections** = one SDK instance
+  connected to one environment, measured in connection-minutes. **Context count
+  is irrelevant to this metric.**
+
+`environmentd` uses the **server-side** SDK (`launchdarkly_server_sdk`). Whether
+it evaluates 4 contexts or 4,000 from its single client, the billing is the same
+— it is driven by how many `environmentd` / `balancerd` instances connect, not
+by how many cluster/replica contexts we mint. The MAU bucket visible on the
+usage page is therefore not the relevant constraint for this work.
+
+The only residual cost of many distinct context keys is **cosmetic**: they
+populate the LD *Contexts list* in the dashboard. (That, not billing, is why the
+existing dev-mode path uses `anonymous(true)` + fixed keys.) We mark the
+cluster/replica contexts `anonymous` for the same dashboard-cleanliness reason.
+
+> Action item: confirm with the LD account owner that we are on the standard
+> service-connections model and not a custom contract with per-context metering.
 
 ## Solution Proposal
 
-High-level: introduce **scoped system parameters**. A synced parameter can carry,
-in addition to its environment-wide value, a set of overrides keyed by a *scope*:
+Introduce **scoped system parameters**: a synced parameter can carry, in
+addition to its environment-wide value, overrides resolved per cluster and per
+replica. We keep the existing data-flow shape and extend it to be scope-aware.
+
+### Two context kinds, because there are two scopes of coherence
+
+Not every flag can be resolved at the same granularity. There are two distinct
+classes:
+
+- **Replica-local flags** — realized inside a `clusterd` process (e.g.
+  `lgalloc`, the allocator, persist client tuning, the persist pager, LZ4
+  compression). Each replica applies its own value independently, so the
+  **replica is the unit of control**, and the value may legitimately differ per
+  replica (e.g. by size family). This is use case 2.
+
+- **Cluster-coherent flags** — change a **shared artifact across the cluster's
+  replicas**, chiefly the **optimized dataflow** (optimizer features). Replicas
+  of a managed cluster are interchangeable and run the *same* installed plan; the
+  feature set is consumed once, in `environmentd`, at plan time, and stored on
+  the cluster (`OptimizerFeatureOverrides` on `ClusterConfig`). There is **no
+  replica in scope** when that value is read. This is use case 1.
+
+A cluster-coherent flag must be **replica-independent**: you cannot have two
+replicas of one cluster running plans optimized under different feature sets. To
+*enforce* that, cluster-coherent flags are evaluated against a context that
+deliberately carries no replica/size attributes — which is exactly what a
+separate `cluster` context kind provides. Folding cluster identity into replica
+attributes only would make it possible to write a rule that resolves a
+plan-level flag differently per replica (incoherent, or nondeterministic if we
+picked a "representative" replica). Hence two kinds:
 
 ```
-scope := Global | Cluster(cluster) | ReplicaSizeFamily(family)
+context kind = "cluster"
+  key:  <cluster id>
+  attrs: cluster_id, cluster_name, is_builtin
+
+context kind = "replica"
+  key:  <replica id>
+  attrs: replica_id, replica_name, is_builtin,
+         replica_size, replica_size_family,
+         cluster_id, cluster_name        # the owning cluster, for combined rules
 ```
 
-with resolution precedence, from lowest to highest:
+Evaluation composes these into the existing multi-context per pass:
 
-```
-Global  <  ReplicaSizeFamily  <  Cluster
-```
+- **Cluster-coherent resolution** (optimizer features): evaluate with
+  `environment + organization + build + cluster`. Replica-free, so the value
+  cannot vary by replica.
+- **Replica-local resolution** (dyncfg to `clusterd`): evaluate with
+  `environment + organization + build + cluster + replica`. Including the cluster
+  lets a rule combine both axes, e.g. *"size family `D` **and** cluster `foo`."*
 
-(Cluster wins over size family because cluster targeting is the more specific,
-operator-driven decision; see Open Questions for whether this ordering is right
-for every parameter.)
+The `replica` context carries the owning cluster's identity as attributes so that
+replica-local flags can still be cluster-targeted without a second evaluation;
+the standalone `cluster` kind exists specifically for the replica-free,
+cluster-coherent case.
 
-The design has three parts: **distribution** (LD), **storage** (catalog), and
-**resolution** (consumers). We keep the existing data flow shape —
-`LaunchDarkly -> sync loop -> ALTER SYSTEM -> catalog -> consumers` — and extend
-each stage to be scope-aware, rather than inventing a parallel path.
+### Identity & recreate semantics: dual id/name attributes
 
-### 1. Distribution: evaluate LaunchDarkly per scope
+Catalog object ids are allocated from a monotonic counter
+(`USER_CLUSTER_ID_ALLOC_KEY`, `src/catalog/src/durable.rs`), so a dropped or
+**resized** object's id is **never reused** — a recreated cluster, or a resized
+replica, gets a fresh id. We exploit this to support two opposite intents from
+the *same* mechanism, selected by which attribute an LD rule matches:
 
-Today `SystemParameterFrontend::pull` (`frontend.rs`) loops over parameters and
-calls `client.variation(&self.ctx, flag, default)` with one fixed context. The
-sync loop (`sync.rs`) calls `pull` once per tick.
+| Intent | Target attribute | On drop / recreate / resize |
+|---|---|---|
+| **Role / identity** ("the catalog server should always behave this way"; "the legacy size family keeps lgalloc") | `cluster_name`, `is_builtin`, `replica_size_family`, `replica_size` | predicate — re-applies to any matching object, including future ones (intended) |
+| **Incarnation patch** ("this specific cluster/replica is hitting a bug right now, pin a flag for it") | `cluster_id`, `replica_id` | dies with the incarnation — the recreated/resized object has a new id and matches no rule (intended) |
 
-Changes:
+Because ids are never reused, an incarnation pin keyed by `*_id` cannot
+accidentally carry over; because predicates key on stable names/families, role
+intent survives recreate by design. The operator picks the behavior by choosing
+the attribute. This is why we expose **both** identifiers on each context.
 
-- **Extend `ld_ctx`** to accept optional scope attributes and emit additional
-  context kinds:
-  - `cluster` — `key = <cluster name>`, attrs: `cluster_name`,
-    `is_builtin` (bool), `cluster_id`.
-  - `replica_size` — `key = <size family>`, attrs: `size_family`
-    (`cc` / `legacy` / `M` / `D`), `size_name` (e.g. `D.1`).
-- **Evaluate per scope.** The frontend gains
-  `pull_scoped(scope, params)` which builds the appropriate multi-context
-  (always including the existing `environment` / `organization` / `build`
-  contexts, plus the scope's context) and evaluates the synced flags against it.
-  The sync loop now does, per tick:
-  1. `pull` with the base context → environment-wide values (unchanged).
-  2. For each *scope of interest*, `pull_scoped` → that scope's values.
-  The diff between a scope's evaluation and the base evaluation is the scope's
-  *override set* (we only store a scoped value when it actually differs from the
-  environment-wide value, to keep overrides sparse).
+### Storage: in-memory, reconciled from LD — not `ALTER SYSTEM ... FOR CLUSTER`
 
-- **Bounding context cardinality (important — LD bills per context).** We do
-  **not** create an LD context per user cluster or per replica. Instead:
-  - For clusters, the sync loop only evaluates the **builtin system clusters**
-    (`mz_catalog_server`, `mz_system`, `mz_probe`, …) by their stable names.
-    These are a fixed, tiny, low-cardinality set, and use case 1 only needs
-    `mz_catalog_server`. (Targeting arbitrary user clusters is left as future
-    work precisely because of cardinality; see Open Questions.)
-  - For replica sizes, the loop evaluates one context per **distinct size
-    family currently in use** (~4 today), discovered from the cluster replica
-    size configuration. Keying by family (not by individual replica) keeps this
-    at a handful of contexts regardless of replica count.
-  - All scope contexts can be marked `anonymous` so they don't pollute the LD
-    Contexts dashboard, mirroring the existing `Local` dev handling in
-    `ld_ctx`.
+The source of truth is the LD ruleset (which targets by name/attributes), and
+the sync loop re-evaluates every tick. So the scoped layer is best modeled as a
+**cache of a continuous LD evaluation**, not durable user-authored state:
 
-The sync loop already holds a `SystemParameterBackend` with a `SessionClient`,
-so it can query the catalog for the list of builtin clusters and the in-use size
-families to decide which scopes to evaluate.
+- The scoped layer is a `BTreeMap<ClusterId, Overrides>` and
+  `BTreeMap<ReplicaId, Overrides>` held in `environmentd`, rebuilt each sync tick
+  by evaluating LD (with the appropriate contexts) for each live cluster/replica
+  in the catalog. We store only values that differ from the environment-wide
+  value, keeping the maps sparse.
+- Drop a cluster/replica → it leaves the catalog → it is no longer evaluated →
+  it falls out of the map. Nothing durable lingers, so nothing can bind a stale
+  override to a recreated object.
+- On `environmentd` restart or LD outage, the maps are simply empty until
+  re-derived, and resolution falls back to the environment-wide value — the same
+  fallback story global flags have today.
 
-### 2. Storage: scoped `ALTER SYSTEM` in the catalog
+We deliberately **reject** persisting scoped overrides as `ALTER SYSTEM SET ...
+FOR CLUSTER <name>` DDL (see Alternatives): it would force a name-vs-id binding
+decision, tempt a second (human) writer that the sync loop would overwrite, and
+require explicit GC of dangling entries — reintroducing exactly the recreate
+ambiguity the in-memory model avoids.
 
-Today the backend (`backend.rs`) pushes each modified value via
-`set_system_vars`, i.e. `ALTER SYSTEM SET <name> = <value>`, and the catalog
-persists it. We keep this and add scoped variants:
+### Resolution: two existing per-scope boundaries
 
-- New SQL surface (system-only, like `FEATURES`):
-  - `ALTER SYSTEM SET <name> = <value> FOR CLUSTER <name>`
-  - `ALTER SYSTEM SET <name> = <value> FOR REPLICA SIZE FAMILY <family>`
-  - plus `RESET` counterparts.
-- New catalog state: a scoped-overrides table/collection mapping
-  `(scope, parameter_name) -> value`, durably stored next to the existing system
-  configuration. The backend's `push` writes the override set computed by the
-  sync loop into this collection (and resets entries that no longer differ).
+We do **not** rewrite `SystemVars` into a universally scope-aware store. Both use
+cases resolve at boundaries that already carry the right context:
 
-Persisting (rather than keeping overrides only in environmentd memory) buys us
-the same properties the global path already has: values survive an environmentd
-restart and an LD outage, and they are introspectable. We expose the resolved
-and the raw scoped values through new `mz_internal` relations (e.g.
-`mz_cluster_system_parameters`) for debugging.
+**(a) The compute & storage controllers' per-replica config push — replica-local
+flags (use case 2).** environmentd already pushes a dyncfg `ConfigSet` /
+`ConfigUpdates` to each replica through the controllers, and knows each replica's
+cluster, size, and size family at push time. We resolve there:
+`effective = global ⊕ replica_local_override` for that replica. **`clusterd`
+needs no changes** — it keeps reading its dyncfg set and simply receives
+size/replica-appropriate values.
 
-This is the concrete realization of the extension the cluster-specific
-optimization design doc hinted at: "use the `CLUSTER`-specific `ALTER SYSTEM`
-extensions in `SystemVars` in the `backend.push(...)` call."
+**(b) The optimizer's per-cluster feature set — cluster-coherent flags (use case
+1).** The optimizer already takes `OptimizerFeatures` derived from `SystemVars`
+plus the per-cluster `OptimizerFeatureOverrides` on `ClusterConfig`. We add a
+second source of those overrides: the cluster's resolved scoped layer feeds the
+overrides at plan time, at the (already cluster-aware) sequencing sites in
+`src/adapter/src/coord/sequencer/inner/*`. This is the direct path to
+"optimizer flags in LD per cluster."
 
-### 3. Resolution: consumers read the scoped value
-
-This is the most invasive part, but it factors into two existing per-scope
-boundaries, so we do **not** need a universal rewrite of `SystemVars`.
-
-`SystemVars` (`mz_sql::session::vars`) gains a layered lookup:
-
-```rust
-// pseudocode
-fn get_for(&self, name: &str, scope: ResolveScope) -> &VarValue {
-    // ReplicaSizeFamily and Cluster overrides shadow the global value,
-    // Cluster winning over ReplicaSizeFamily.
-}
-```
-
-where `ResolveScope { cluster: Option<ClusterId>, size_family: Option<Family> }`.
-The default `get` (no scope) returns the global value, so every existing call
-site is unchanged.
-
-The two boundaries that need to pass a scope:
-
-**(a) The compute & storage controllers' per-replica config push — handles use
-case 2 and the cluster-scoped dyncfg part of use case 1.**
-
-The flags in use case 2 (`lgalloc`, persist pager, LZ4 compression) are
-`mz_dyncfg` parameters consumed inside `clusterd`, and environmentd already
-pushes a `ConfigSet` / `ConfigUpdates` to each replica through the controllers.
-environmentd knows each replica's cluster *and* size at push time. So we resolve
-there: when building the `ConfigUpdates` for a replica, layer
-`global ⊕ size_family_override ⊕ cluster_override` and send the effective value.
-
-Crucially, **`clusterd` needs no changes** — it keeps reading its dyncfg
-`ConfigSet`; it just receives size/cluster-appropriate values. This makes
-use case 2 almost entirely a matter of resolving at the push site.
-
-**(b) The optimizer's per-cluster feature set — handles the optimizer part of
-use case 1.**
-
-The optimizer already takes an `OptimizerFeatures` derived from `SystemVars`
-*plus* the per-cluster `OptimizerFeatureOverrides` stored on `ClusterConfig`.
-We generalize the source of those overrides: instead of only the manually-set
-`CREATE CLUSTER ... FEATURES`, the cluster's resolved layer (from §2) feeds the
-overrides. Any place that already plumbs a "which cluster am I optimizing for"
-context (peek/index/MV sequencing in
-`src/adapter/src/coord/sequencer/inner/*`) resolves the cluster scope.
-
-For SystemVars consumed in environmentd that are neither dyncfg nor optimizer
-features but are still cluster-dependent, the same `get_for(name, scope)` lookup
-is used at the (already cluster-aware) call site. We expect this set to be small;
-each such parameter is opted in explicitly (see Open Questions on opt-in).
+Precedence for replica-local flags, lowest to highest:
+`Global < ReplicaSizeFamily < Replica(id)` (a specific replica pin beats a size
+family rule). Cluster-coherent flags resolve `Global < Cluster`. Interaction with
+manually-set `CREATE CLUSTER ... FEATURES` is covered in Open Questions.
 
 ### Worked examples
 
-**Use case 1 — `mz_catalog_server` gets a different optimizer feature.**
-
-1. In LD, add a targeting rule on the synced flag: `cluster_name =
-   "mz_catalog_server"` → variation X.
-2. Sync loop evaluates the base context (→ env-wide value) and a
-   `cluster:mz_catalog_server` context (→ X). They differ, so it writes
-   `Cluster(mz_catalog_server) -> X` via `ALTER SYSTEM SET ... FOR CLUSTER
-   mz_catalog_server`.
-3. When the coordinator optimizes a dataflow on `mz_catalog_server`, the cluster
-   layer feeds `OptimizerFeatureOverrides`, so X is used. Other clusters keep the
-   env-wide value.
+**Use case 1 — an optimizer feature on `mz_catalog_server` only.**
+LD rule: `cluster_name = "mz_catalog_server"` → variation X. Each tick the sync
+loop evaluates the `cluster` context for the catalog server (replica-free), sees
+X differ from the env-wide value, and records `Cluster(s2) -> {feature: X}`. At
+plan time the coordinator feeds that into `OptimizerFeatureOverrides` for the
+catalog server; other clusters are unaffected.
 
 **Use case 2 — legacy sizes keep `lgalloc`, `D.1` gets pager + LZ4.**
+LD rules: `replica_size_family = "legacy"` → `lgalloc` on; `replica_size_family =
+"D"` → pager + LZ4 on. The sync loop evaluates the `replica` context per live
+replica; the controller resolves per replica at dyncfg push: a `D.1` replica
+gets pager+LZ4, a legacy replica gets `lgalloc`. No `clusterd` change.
 
-1. In LD, target the `lgalloc` dyncfg flag with `size_family = "legacy"` → on,
-   and the pager / LZ4 flags with `size_family = "D"` → on.
-2. Sync loop evaluates one context per in-use family (`cc`, `legacy`, `M`, `D`)
-   and records the per-family override sets.
-3. When the controller pushes dyncfg to a replica, it resolves by that replica's
-   size family: a `D.1` replica receives pager+LZ4 enabled; a legacy-sized
-   replica receives `lgalloc` enabled. No `clusterd` change required.
+**Incident pin.** LD rule: `replica_id = "u42-replica-3"` → flag Y. Applies to
+exactly that replica; if it is resized or recreated (new id) it reverts to the
+env-wide value automatically.
 
 ## Minimal Viable Prototype
 
-Smallest end-to-end slice that de-risks the design, ordered:
+Ordered to de-risk the cleaner boundary first:
 
-1. **Replica-size dyncfg push (use case 2 first — it's the cleaner boundary).**
-   - Add the `replica_size` context kind to `ld_ctx` and `pull_scoped`.
-   - Compute per-size-family override sets in the sync loop (held in
-     environmentd memory for the prototype, no catalog persistence yet).
-   - Resolve at the controller's per-replica dyncfg push.
-   - Demonstrate: LD rule `size_family = "legacy"` toggles `lgalloc` only on
-     legacy replicas, verified via the replica's effective config.
-   This proves the LD-per-scope evaluation and the push-site resolution with
-   zero catalog/SQL/`clusterd` changes.
+1. **Replica-local dyncfg push (use case 2).** Add the `replica` context kind and
+   per-replica evaluation; compute per-replica/size override maps in
+   `environmentd` (in-memory); resolve at the controller's dyncfg push.
+   Demonstrate `replica_size_family = "legacy"` toggling `lgalloc` only on legacy
+   replicas. Zero SQL / catalog / `clusterd` changes.
+2. **Cluster-coherent optimizer flags (use case 1).** Add the `cluster` context
+   kind (replica-free evaluation); feed the resolved cluster layer into
+   `OptimizerFeatureOverrides`. Demonstrate an optimizer feature differing on
+   `mz_catalog_server` vs. user clusters.
+3. **Introspection.** Expose resolved scoped values via `mz_internal` relations
+   for debugging (e.g. `mz_cluster_system_parameters`,
+   `mz_replica_system_parameters`).
 
-2. **Cluster scope for `mz_catalog_server` (use case 1).**
-   - Add the `cluster` context kind (builtin clusters only).
-   - Feed the resolved cluster layer into `OptimizerFeatureOverrides`.
-   - Demonstrate a flag that differs on `mz_catalog_server` vs. user clusters.
-
-3. **Catalog persistence + `ALTER SYSTEM ... FOR ...` SQL** and the
-   `mz_internal` introspection relations, once the in-memory prototype validates
-   the resolution model.
-
-Test surface to extend: `test/launchdarkly/mzcompose.py` already targets by
-`contextKind`; add cases for `contextKind = "cluster"` and `"replica_size"`.
+Extend `test/launchdarkly/mzcompose.py` (which already targets by `contextKind`)
+with `contextKind = "cluster"` and `"replica"` cases.
 
 ## Alternatives
 
-- **Universal `SystemVars` layering (`system < cluster < session`).** Teach
-  `SystemVars` to be fully scope-aware for *every* read site, as the prior design
-  doc sketched. More general, but a large, risky change touching every consumer
-  and the session-var resolution path. Rejected as the starting point in favour
-  of resolving at the two existing per-scope boundaries (controller push,
-  optimizer overrides), which covers both use cases with far less blast radius.
-  The `get_for` lookup proposed here is a stepping stone toward this if we later
-  need broader scoping.
-
-- **In-memory-only overrides (no catalog persistence).** Keep scoped values only
-  in environmentd, re-derived from LD each tick and pushed to consumers. Simpler
-  (no SQL/catalog work), and fine for the prototype, but loses the
-  survive-restart / survive-LD-outage / introspectable properties the global
-  path has today. We adopt it for the MVP but recommend persistence for GA.
-
-- **Per-individual-replica targeting (LD context per replica).** Maximum
-  flexibility, but explodes LD context cardinality (billing) and gives no
-  benefit over size-family targeting for the stated use cases. Rejected.
-
-- **Switch / add a different feature-flag tool.** Surveyed Unleash, Flagsmith,
-  Statsig, and the OpenFeature standard. None removes the Materialize-side
-  storage/resolution work, and several (Unleash, Flagsmith) are *less* expressive
-  than LD's multi-context model — they would force flattening cluster/size into
-  context fields. The only structural reason to consider OpenFeature is backend
-  portability (wrap the integration behind its API and keep LD as the provider).
-  Rejected as a prerequisite; orthogonal to this design.
+- **Single `replica` context kind, cluster as attributes only.** Simpler, and
+  sufficient *if* this mechanism only drove replica-local flags. Rejected because
+  cluster-coherent flags (optimizer features — an explicit near-term goal) must be
+  resolved replica-free; a replica-only model cannot express "evaluate
+  independent of any replica" and would permit incoherent per-replica plan
+  divergence.
+- **Persisted `ALTER SYSTEM ... FOR CLUSTER` DDL.** Durable and introspectable,
+  but forces a name-vs-id binding choice, invites a human writer the sync loop
+  overwrites, and needs explicit dangling-entry GC on drop. The in-memory
+  reconciled model sidesteps all three. (We can revisit durable persistence later
+  if surviving an LD outage with non-default scoped values becomes a requirement.)
+- **Universal `SystemVars` layering (`system < cluster < session`).** General but
+  large/risky, touching every read site. Resolving at the two existing boundaries
+  covers both use cases with far less blast radius; this can evolve toward general
+  layering later if needed.
+- **Per-individual-replica LD contexts for everything.** Unnecessary; size-family
+  predicates cover the durable cases and incarnation pins cover the rest, and
+  (per the billing note) cardinality is not a cost driver on the server SDK
+  anyway.
+- **Switch / add another flag tool (Unleash, Flagsmith, Statsig, OpenFeature).**
+  None removes the Materialize-side storage/resolution work, and several are less
+  expressive than LD's multi-context model. OpenFeature is the only one worth
+  considering, purely for backend portability; orthogonal to this design.
 
 ## Open questions
 
-- **Precedence.** Is `Global < ReplicaSizeFamily < Cluster` always right? A
-  cluster-level override would shadow a size-family override even for a replica
-  whose size family was explicitly targeted. Do we need per-parameter precedence,
-  or is a single global ordering acceptable?
-- **Opt-in surface.** Should *every* synced parameter be scopable, or should
-  parameters opt into being cluster-/size-scopable (e.g. a flag on the `Var`
-  definition)? Opting in keeps the resolution surface and the LD evaluation cost
-  bounded and avoids surprising interactions for params that are meaningless
-  per-cluster.
-- **User clusters.** Use case 1 only needs builtin clusters, which keeps LD
-  context cardinality trivial. Is there a near-term need to target arbitrary user
-  clusters, and if so, how do we bound the context count (e.g. only clusters that
-  have an active scoped rule, anonymous contexts, or a server-side evaluation
-  proxy)?
-- **Size family taxonomy.** Where is the authoritative `size name -> size
-  family` mapping (`D.1 -> D`, t-shirt sizes -> `legacy`)? It must be available
-  both to the sync loop (to know which families to evaluate) and to the
-  controller (to resolve per replica). Likely the cluster replica size
-  configuration; confirm.
-- **Interaction with `CREATE CLUSTER ... FEATURES`.** A cluster can already carry
-  manual `OptimizerFeatureOverrides`. When both a manual override and an
-  LD-driven cluster override exist for the same feature, which wins? Proposed:
-  manual DDL override wins over LD (operator intent is explicit), but this needs
-  confirmation.
-- **Sync cost.** Per-tick evaluation count grows from 1 to `1 + |builtin
-  clusters| + |size families|`. With the bounds above this is ~10 evaluations;
-  confirm this is acceptable for the LD SDK and tick interval, and whether scoped
-  evaluation should run on a slower cadence than the base pull.
+- **Manual `FEATURES` vs LD-driven cluster overrides.** A cluster can already
+  carry manual `OptimizerFeatureOverrides` via `CREATE CLUSTER ... FEATURES`. When
+  both exist for the same feature, which wins? Proposed: manual DDL wins (explicit
+  operator intent), with the LD layer applying only where no manual override is
+  set. Confirm.
+- **Opt-in surface.** Should every synced parameter be scopable, or should
+  parameters declare whether they are cluster-coherent, replica-local, or neither
+  (e.g. on the `Var` / dyncfg definition)? Declaring it bounds the evaluation
+  surface and prevents nonsensical scoping (e.g. an optimizer flag targeted by
+  size family).
+- **Size family taxonomy.** Where is the authoritative `size name -> size family`
+  mapping (`D.1 -> D`, t-shirt -> `legacy`)? It must be available to the sync loop
+  (which families to evaluate) and the controller (resolve per replica). Likely
+  the cluster replica size configuration; confirm.
+- **User-cluster context-list growth.** Billing is unaffected, but keying cluster
+  contexts by id means resized/recreated objects accumulate in the dashboard
+  Contexts list over time. Is `anonymous` enough, or do we want a periodic prune /
+  to only emit contexts for objects matching an active rule?
+- **Sync cadence.** Per-tick evaluation grows from 1 to roughly
+  `1 + |clusters| + |live replicas|`. With anonymous server-side contexts this is
+  free billing-wise, but confirm the SDK evaluation cost is acceptable, and
+  whether scoped evaluation should run on a slower cadence than the base pull.

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -195,6 +195,29 @@ the controller (to resolve a given replica's family at dyncfg-push time), and it
 versions and deploys with the rest of the size configuration rather than living
 in a second place that could drift.
 
+We deliberately do **not** ask LD rule authors to derive the family from the
+size string with `startsWith` / `endsWith` operators. The family is a *curated
+mapping*, not a stable encoding: the new families follow `<family>.<version>`
+(`M.1`, `D.1`) and would prefix-match, but `cc` and the legacy t-shirt sizes
+(`xsmall`, `2xlarge`, numeric `1`/`2`/`4`, …) share no clean affix, and `legacy`
+is effectively *"everything not in another family"* — which cannot be expressed
+as a positive affix clause at all. Affix matching would also scatter the taxonomy
+across every rule and break whenever a new size is added that does not fit the
+assumed pattern. The explicit attribute, sourced from the size map, avoids all of
+this. We also keep the raw `replica_size` attribute for fine-grained targeting
+(exactly `D.1` vs all of `D`): family is the coarse axis, size the fine one.
+
+This is the opposite call from `is_builtin`, and the distinction is worth stating
+because the two look similar ("can't we just derive it from the id / size
+string?"). `is_builtin` *is* a clean invariant we fully control —
+`matches!(id, ClusterId::System(_))`, equivalently the rendered id starting with
+`s` — so the attribute is semantic sugar: derivable, but kept because
+`is_builtin = true` is more readable in rules and does not bake the id-rendering
+convention into every rule (it must be computed from the enum variant, **not** by
+string-prefixing the rendered id). The rule of thumb: derive-from-string is fine
+for a clean invariant we own (`is_builtin`); it is a trap for a curated product
+mapping (`replica_size_family`).
+
 ### Scope declaration is required, per parameter
 
 Every synced parameter must declare its scope class as part of its definition.

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -198,6 +198,12 @@ the controller (to resolve a given replica's family at dyncfg-push time), and it
 versions and deploys with the rest of the size configuration rather than living
 in a second place that could drift.
 
+The `family` field need not be populated for every size up front:
+`ReplicaAllocation::family()` falls back to deriving `cc` (via `is_cc`) or
+`legacy` when no explicit family is set, so the `legacy` and `cc` families are
+targetable immediately, before the new families (`M`, `D`) get explicit `family`
+entries. Explicit values are required only where the fallback is wrong.
+
 We deliberately do **not** ask LD rule authors to derive the family from the
 size string with `startsWith` / `endsWith` operators. The family is a *curated
 mapping*, not a stable encoding: the new families follow `<family>.<version>`
@@ -295,25 +301,31 @@ rather than reverting to environment-wide defaults. It also removes an asymmetry
 — environment-wide flags already persist in the catalog (via the existing
 `ALTER SYSTEM` path) and survive an LD outage; the scoped layer should too.
 
-The scoped layer is a durable catalog collection, keyed by **object id**, with an
-in-memory working copy used for resolution:
+The scoped layer is **two** durable catalog collections — one per scope, mirroring
+the existing flat `system_configurations` collection rather than a single
+sum-typed key — each keyed by **object id**, with an in-memory working copy used
+for resolution:
 
 ```
-(Cluster(ClusterId) | Replica(ReplicaId), parameter_name) -> value
+cluster_system_configurations:  (ClusterId, parameter_name) -> value
+replica_system_configurations:  (ReplicaId, parameter_name) -> value
 ```
 
 The **sync loop is the sole writer**; there is no user-facing
-`ALTER SYSTEM ... FOR CLUSTER` DDL (see Alternatives). We store only values that
-differ from the environment-wide value, keeping the collection sparse.
+`ALTER SYSTEM ... FOR CLUSTER` DDL (see Alternatives). A row is written **only
+when the scoped evaluation differs from the environment-wide value** (see
+Resolution for why *difference* — not the raw LD evaluation reason — is the
+correct signal), so the collections are sparse: only objects that LD targets to a
+scope-specific value get a row.
 
 Lifecycle:
 
 - **Startup:** load the persisted collection into the working maps, so scoped
   values are in effect immediately — no waiting for the first LD sync.
-- **LD reachable:** each successful tick reconciles the collection to LD's current
-  evaluation, *including removals* — an entry is dropped when LD no longer serves
-  a non-default value for it (distinguished via the `variation_detail` reason, as
-  on the global path), so removing an LD rule propagates.
+- **LD reachable:** each successful tick reconciles the collections to LD's
+  current evaluation, *including removals* — an entry is dropped once the scoped
+  evaluation no longer differs from the environment-wide value (e.g. its LD rule
+  was removed), so changes propagate in both directions.
 - **LD slow / unavailable:** keep serving the last persisted values; do **not**
   revert to the environment-wide value. This is the case that motivates
   persistence.
@@ -328,10 +340,11 @@ entry keyed by a dropped object's id is **inert** — it can never match a futur
 object. A recreated same-named cluster (new id) starts with no cached overrides;
 a name-targeting LD rule re-applies on the next sync under the new id, while an
 incarnation pin keyed by the old id never resurfaces. GC is therefore *not* a
-correctness concern, only hygiene: entries for object ids absent from the catalog
-are pruned lazily (on startup and on each successful reconcile). This is the same
-non-reuse property the dual-identity scheme already relies on (§Identity &
-recreate semantics).
+correctness concern, only hygiene: dead-object entries load into the in-memory
+copy **inert** (they can never match a live object) and are removed on the **first
+reconcile after startup**, and on each successful reconcile thereafter — there is
+no separate startup-time prune pass. This is the same non-reuse property the
+dual-identity scheme already relies on (§Identity & recreate semantics).
 
 ### Resolution: two existing per-scope boundaries
 
@@ -354,6 +367,14 @@ overrides at plan time, at the (already cluster-aware) sequencing sites in
 `src/adapter/src/coord/sequencer/inner/*`. This is the direct path to
 "optimizer flags in LD per cluster."
 
+The cluster-scoped working copy must live in `CatalogState` (behind
+`Arc<Catalog>`), **not** on the coordinator. Cluster-coherent overrides must also
+apply on the fast-path peek route (`frontend_peek`) and inside the bootstrap
+re-optimization closure, and both of those hold only a catalog snapshot, not the
+coordinator. Threading the working copy through the catalog is what makes it
+visible at *every* cluster-aware resolution site rather than just the sequencing
+path.
+
 Precedence for replica-local flags, lowest to highest:
 `Global < ReplicaSizeFamily < Replica(id)` (a specific replica pin beats a size
 family rule).
@@ -375,16 +396,41 @@ gets the same treatment. It also *preserves* today's behavior that a manual
 per-cluster manual pin still beats it, while a cluster-specific *LD* rule beats
 the manual pin.
 
-Crucially this is decided **per feature, only where LD actually serves a value**,
-mirroring the global case (where a manual value survives exactly when LD is
-silent). The implementation uses the LD evaluation *reason* from
-`variation_detail` to distinguish "LD has an opinion" (`RULE_MATCH` /
-`TARGET_MATCH` / `FALLTHROUGH`) from "LD is silent" (`FLAG_NOT_FOUND` / error);
-where LD is silent, the manual `FEATURES` value stands.
+Crucially, whether a cluster-scoped LD value beats a manual `FEATURES` pin is
+decided by **whether LD assigns the cluster a value that differs from the
+environment-wide value** — not by the raw `variation_detail` reason. The reason is
+the wrong signal, in two ways:
 
-The accepted trade-off, stated plainly: an operator's manual `FEATURES` pin can
-be overridden by a cluster-scoped LD rule. That is the same bargain operators
-already accept for `ALTER SYSTEM`, so it is consistent rather than novel.
+- `FALLTHROUGH` *is* the environment-wide value (it is what every context gets
+  absent a specific match). Treating it as a cluster opinion would let any
+  globally-on flag silently override a deliberate per-cluster `FEATURES` pin —
+  coarse scope beating fine scope, the opposite of "more specific wins" — and
+  would record a row for *every* live object, making the collections dense rather
+  than sparse.
+- A `RULE_MATCH` does not say *which* context kind's attributes matched. An
+  environment-level rollout rule (`environment.cloud_provider = "aws"`) also
+  reports `RULE_MATCH`, indistinguishable from a cluster-specific rule without
+  inspecting the rule's clauses — which the SDK does not expose.
+
+Comparing the scoped evaluation to the baseline (env-only) evaluation captures
+exactly *"LD has a **cluster-specific** opinion"*: the cluster context changed the
+result. So `cluster-scoped LD` in the ordering above means **the cluster-scoped
+evaluation differs from env-wide**; where it does not differ, there is no cluster
+opinion and the manual `FEATURES` pin stands. This is the same `differs from
+env-wide` test used at replica scope (which has no manual layer), so the recording
+rule is **uniform across both scopes** — there is no need to special-case
+`FALLTHROUGH` per scope.
+
+The one behavior this does *not* support is reasserting the env-wide value on a
+cluster purely to clear a `FEATURES` pin (LD value equal to env-wide cannot
+override the pin, because it is indistinguishable from "no cluster opinion").
+That is handled by removing the pin, not via LD — an acceptable trade for a simple,
+introspection-free rule.
+
+The accepted trade-off, stated plainly: an operator's manual `FEATURES` pin can be
+overridden by a cluster-scoped LD rule (whenever LD targets the cluster to a
+*different* value). That is the same bargain operators already accept for
+`ALTER SYSTEM`, so it is consistent rather than novel.
 
 ### Worked examples
 


### PR DESCRIPTION
### Motivation

This design document describes scoped feature flags in Materialize: per-cluster and per-replica LaunchDarkly overrides. It addresses two concrete use cases:

1. **Per-cluster optimizer flags**: clusters such as `mz_catalog_server` should be able to run with a different optimizer feature set without affecting the rest of the environment.
2. **Per-replica flags by size family**: replica size families (legacy t-shirt sizes, `D.1`, etc.) should support different configurations (e.g. legacy sizes keep `lgalloc`, while `D.1` enables the persist pager and LZ4 compression).

Today feature flags are evaluated once per environment, with no way to target a specific cluster or replica.

### Description

The design extends the existing LaunchDarkly integration with two new scope classes, resolved at boundaries that already carry the right context:

- **Cluster-coherent flags** — evaluated replica-free via a `cluster` context kind and applied at plan time, feeding `OptimizerFeatureOverrides` (not replacing it; `EXPLAIN WITH` still needs per-statement overrides). Replica-free evaluation makes incoherent per-replica plan divergence unrepresentable by construction.
- **Replica-local flags** — evaluated per replica via a `replica` context kind (carrying size, size family, and owning-cluster attributes), pushed to the compute controller's per-replica dyncfg layer (which reaches storage on `clusterd` via the shared persist client `ConfigSet`).

Key design decisions:

1. **Dual context kinds** (`cluster`, `replica`) to enforce the coherence boundary.
2. **Required scope declaration** on every synced parameter (`ParameterScope::{Environment,Cluster,Replica}`), driving evaluation, validation, and docs.
3. **Durable, id-keyed cache** written solely by the sync loop — two catalog collections (`cluster_system_configurations`, `replica_system_configurations`), so scoped values survive an `environmentd` restart and an LD outage. There is no user-facing `ALTER SYSTEM ... FOR CLUSTER` DDL. Because catalog ids are never reused, stale entries are inert and GC is hygiene, not correctness.
4. **Dual id/name attributes** on contexts: name/family predicates survive recreate (role intent), `*_id` pins die with the incarnation (patch intent).
5. **Differs-from-env-wide recording** (compared on the resolved/typed value, not the `variation_detail` reason), which keeps the collections sparse and lets a cluster-scoped LD value beat a manual `CREATE CLUSTER ... FEATURES` pin.
6. **Feature gate** `enable_scoped_system_parameters` (dyncfg, default `false`): strictly opt-in, checked at the single `sync_scoped_params` chokepoint, so default behavior is exactly today's environment-wide-only resolution.
7. **Synchronous create-time resolution**: a newly created cluster/replica's overrides are folded into the create transaction (so they persist synchronously and a fresh object's first configuration/plan already carries them), because render-frozen flags make the next-tick window a correctness problem.

The document also covers LaunchDarkly's billing model (server-side service connections, not MAU), self-managed behavior, worked examples, alternatives, and open questions.

### Status

The design has been **implemented and merged** across #37079, #37080, #36959, #37151, #37159, and #37158. This document has been verified against the merged implementation and reconciled with it (durable persistence, the catalog-implication-driven replica push, synchronous create-time persistence, and the shipped `ReplicaAllocation::family()` fallback), so it now serves as the up-to-date design record rather than a pre-implementation proposal.

https://claude.ai/code/session_01S9fiehWEbC4BEXEq8p7LP9