### PR TITLE
timely-util: serialize resident merge-batcher chunks into a fitting buffer

### DIFF
--- a/src/timely-util/src/column_pager.rs
+++ b/src/timely-util/src/column_pager.rs
@@ -369,7 +369,29 @@ impl ColumnPager {
                     bytes: len_bytes,
                     policy: Arc::clone(&self.policy),
                 };
-                return PagedColumn::Resident(std::mem::take(col), ticket);
+                // A resident chunk joins a merge chain and may live there
+                // across many merge rounds. A `Column::Typed` body arrives
+                // carrying `Column::merge_from`'s worst-case `reserve_for`
+                // capacity — sized for the unconsolidated union of both merge
+                // inputs — and parking that slack in the chain is the dominant
+                // source of merge-batcher resident memory. Serialize the body
+                // into a `Vec<u64>` sized exactly to its content and store the
+                // fitting `Column::Align` instead, clearing `col` in place (as
+                // the codec paths below do) so the high-capacity typed buffer
+                // stays with the caller for recycling. `Align` / `Bytes`
+                // bodies are already fitting (or refcounted), so move them
+                // through unchanged.
+                let resident = if matches!(col, Column::Typed(_)) {
+                    debug_assert_eq!(len_bytes % 8, 0);
+                    let mut buf = Vec::with_capacity(len_bytes);
+                    col.into_bytes(&mut buf);
+                    debug_assert_eq!(buf.len() % 8, 0);
+                    col.clear();
+                    Column::Align(bytemuck::allocation::pod_collect_to_vec::<u8, u64>(&buf))
+                } else {
+                    std::mem::take(col)
+                };
+                return PagedColumn::Resident(resident, ticket);
             }
             PageDecision::Page { backend, codec } => (backend, codec),
         };

--- a/src/timely-util/src/columnar/merge_batcher.rs
+++ b/src/timely-util/src/columnar/merge_batcher.rs
@@ -856,6 +856,58 @@ mod tests {
         assert_eq!(out, vec![((0, 0), 0, 1), ((5, 0), 0, 2), ((10, 0), 0, 1)]);
     }
 
+    /// Regression: under the disabled (always-resident) pager, shipped chunks
+    /// must be serialized into a fitting `Column::Align`, never parked as
+    /// `Column::Typed`. A `Typed` result carries `Column::merge_from`'s
+    /// worst-case `reserve_for` capacity; leaving it in the chain across merge
+    /// rounds was the dominant source of merge-batcher resident memory. Only
+    /// the live accumulator (`result`) and not-yet-shipped heads may be
+    /// `Typed` — every entry that reaches the sink should be `Align`.
+    #[mz_ore::test]
+    fn merge_chains_ships_fitting_align() {
+        let pager = ColumnPager::disabled();
+        // Interleaved keys force the per-record merge path: records flow
+        // through the `result` accumulator and ship as a merged chunk rather
+        // than passing a head through wholesale.
+        let q1 = to_chain(vec![col(&[((0, 0), 0, 1), ((2, 0), 0, 1)])], &pager);
+        let q2 = to_chain(vec![col(&[((1, 0), 0, 1), ((3, 0), 0, 1)])], &pager);
+
+        let mut output: Vec<PagedColumn<KvUpdate>> = Vec::new();
+        let mut stash: Vec<Column<KvUpdate>> = Vec::new();
+        merge_chains(
+            FetchIter::new(q1, &pager),
+            FetchIter::new(q2, &pager),
+            |paged| output.push(paged),
+            &mut stash,
+        );
+
+        assert!(!output.is_empty(), "merge produced no chunks");
+        for entry in &output {
+            match entry {
+                PagedColumn::Resident(col, _) => assert!(
+                    matches!(col, Column::Align(_)),
+                    "shipped chunk parked as non-Align resident: {:?}",
+                    std::mem::discriminant(col),
+                ),
+                other => panic!(
+                    "disabled pager should ship Resident, got a paged variant: {:?}",
+                    std::mem::discriminant(other)
+                ),
+            }
+        }
+
+        // Sanity: data round-trips through the fitting Align buffers.
+        assert_eq!(
+            collect_pc(&output, &pager),
+            vec![
+                ((0, 0), 0, 1),
+                ((1, 0), 0, 1),
+                ((2, 0), 0, 1),
+                ((3, 0), 0, 1)
+            ],
+        );
+    }
+
     /// Same merge, force-paged: chains stay in `Paged` form throughout, and
     /// the consolidated result still matches.
     #[mz_ore::test]


### PR DESCRIPTION
### Motivation

The column-paged merge batcher routes every shipped chunk through `ColumnPager::page`.
With paged spill gated off in production the pager is the disabled (always-resident) policy, so `page`'s `Skip` arm took the whole `Column::Typed` body into the merge chain.
That body arrives carrying `Column::merge_from`'s worst-case `reserve_for` capacity, sized for the unconsolidated union of both merge inputs.
Heavy consolidation collapses the record count but leaves the surplus capacity live in the chain across merge rounds.

Production heap profiles showed this as ~146 GB resident on a single replica, localized to `ColumnMergeBatcher::merge_by → Column::merge_from → reserve_for → RawVec<u64>::reserve`.
A before/after comparison across the live flag flip (same replica) put the arrange merge batcher at sub-2 GB under the columnation merger versus 146 GB under the columnar one — essentially all of the ~160 GB total heap growth.

### Description

In `page`'s `Skip` arm, serialize a `Typed` body into a `Vec<u64>` sized exactly to its content and store the fitting `Column::Align` instead of moving the over-reserved typed buffer into the chain.
The source column is cleared in place (matching the codec paths) so the high-capacity typed buffer stays with the caller for stash recycling.
`Align` / `Bytes` bodies are already fitting (or refcounted) and pass through unchanged.

Only the live accumulator and not-yet-shipped heads remain `Typed`; every chunk that reaches the chain is now serialized to a fitting buffer.
This only affects the resident path — when real paging is enabled, chunks already serialize on pageout.

### Verification

Adds `merge_chains_ships_fitting_align`, which asserts that under the disabled pager every shipped chain entry is `Resident(Column::Align)` (never `Typed`) and that the data round-trips.
Existing `column_pager` and `merge_batcher` unit tests continue to pass.