### PR TITLE
docs/mcp: document developer query tool

### DIFF
--- a/doc/user/content/integrations/mcp-server/mcp-developer-config.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer-config.md
@@ -18,6 +18,7 @@ endpoint:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `enable_mcp_developer` | `true` | Enable or disable the `/api/mcp/developer` endpoint. When the endpoint is disabled, requests return HTTP 503 (Service Unavailable). |
+| `enable_mcp_developer_query_tool` | `true` | Enable or disable the `query` tool on the developer endpoint. When disabled, the tool is hidden from `tools/list` and calls return an error. `query_system_catalog` remains available. |
 | `mcp_max_response_size` | `1000000` | Maximum response size in bytes. Queries exceeding this limit return an error. |
 
 ## Disabling the endpoint

--- a/doc/user/content/integrations/mcp-server/mcp-developer-config.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer-config.md
@@ -18,7 +18,7 @@ endpoint:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `enable_mcp_developer` | `true` | Enable or disable the `/api/mcp/developer` endpoint. When the endpoint is disabled, requests return HTTP 503 (Service Unavailable). |
-| `enable_mcp_developer_query_tool` | `true` | Enable or disable the `query` tool on the developer endpoint. When disabled, the tool is hidden from `tools/list` and calls return an error. `query_system_catalog` remains available. |
+| `enable_mcp_developer_query_tool` | `true` | Available starting in v26.30. Enable or disable the `query` tool on the developer endpoint. When disabled, the tool is hidden from `tools/list` and calls return an error. `query_system_catalog` remains available. |
 | `mcp_max_response_size` | `1000000` | Maximum response size in bytes. Queries exceeding this limit return an error. |
 
 ## Disabling the endpoint

--- a/doc/user/content/integrations/mcp-server/mcp-developer-tools.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer-tools.md
@@ -14,8 +14,14 @@ menu:
 ### `query_system_catalog`
 
 Execute a read-only SQL query restricted to system catalog tables (`mz_*`,
-`pg_catalog`, `information_schema`). No cluster argument; prefer this for
-catalog lookups that do not need a cluster to run on.
+`pg_catalog`, `information_schema`). The tool does not take a cluster argument;
+the request runs on the catalog server cluster (`mz_catalog_server`).
+
+{{< tip >}}
+For system catalog lookups that can run on the `mz_catalog_server` cluster,
+prefer `query_system_catalog` over the
+[`query`](#query) tool.
+{{</ tip >}}
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -44,10 +50,10 @@ Only one statement per call is allowed. Write operations (`INSERT`, `UPDATE`,
 
 ### `query`
 
-Execute a read-only SQL query (`SELECT`, `SHOW`, or `EXPLAIN`) against any
-object the role can access, including system catalog and user objects. A
-cluster is required, which is what enables `EXPLAIN ANALYZE` and queries
-against indexed user objects.
+Available starting in v26.30. Execute a read-only SQL query (`SELECT`, `SHOW`,
+or `EXPLAIN`) against any object the role can access, including system catalog
+and user objects. You must specify a cluster to run `EXPLAIN ANALYZE` and
+queries against user objects.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -55,11 +61,13 @@ against indexed user objects.
 | `sql_query` | string | Yes | `SELECT`, `SHOW`, or `EXPLAIN` statement. |
 
 Only one statement per call is allowed. Write operations (`INSERT`, `UPDATE`,
-`CREATE`, etc.) are rejected. The tool is hidden when the operator has
-disabled it via [`enable_mcp_developer_query_tool`](/integrations/mcp-server/mcp-developer-config/).
+`CREATE`, etc.) are rejected. To disable the tool, see
+[`enable_mcp_developer_query_tool`](/integrations/mcp-server/mcp-developer-config/).
 
-For pure system catalog lookups that do not need a cluster, prefer
-[`query_system_catalog`](#query_system_catalog).
+{{< tip >}}
+For system catalog lookups that can run on the `mz_catalog_server` cluster,
+prefer [`query_system_catalog`](#query_system_catalog) over `query`.
+{{</ tip >}}
 
 **Example response:**
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer-tools.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer-tools.md
@@ -14,7 +14,8 @@ menu:
 ### `query_system_catalog`
 
 Execute a read-only SQL query restricted to system catalog tables (`mz_*`,
-`pg_catalog`, `information_schema`).
+`pg_catalog`, `information_schema`). No cluster argument; prefer this for
+catalog lookups that do not need a cluster to run on.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -34,6 +35,43 @@ Only one statement per call is allowed. Write operations (`INSERT`, `UPDATE`,
       {
         "type": "text",
         "text": "[\n  [\n    \"quickstart\",\n    \"ready\"\n  ],\n  [\n    \"mcp_cluster\",\n    \"ready\"\n  ]\n]"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+### `query`
+
+Execute a read-only SQL query (`SELECT`, `SHOW`, or `EXPLAIN`) against any
+object the role can access, including system catalog and user objects. A
+cluster is required, which is what enables `EXPLAIN ANALYZE` and queries
+against indexed user objects.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `cluster` | string | Yes | Exact cluster name the query should run on. |
+| `sql_query` | string | Yes | `SELECT`, `SHOW`, or `EXPLAIN` statement. |
+
+Only one statement per call is allowed. Write operations (`INSERT`, `UPDATE`,
+`CREATE`, etc.) are rejected. The tool is hidden when the operator has
+disabled it via [`enable_mcp_developer_query_tool`](/integrations/mcp-server/mcp-developer-config/).
+
+For pure system catalog lookups that do not need a cluster, prefer
+[`query_system_catalog`](#query_system_catalog).
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[\n  [\n    \"Explained Query (fast path):\\n  →Constant (1 rows)\\n\\nTarget cluster: quickstart\\n\"\n  ]\n]"
       }
     ],
     "isError": false

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -18,10 +18,18 @@ process or external server is required.
 
 ## Overview
 
-The `materialize-developer` MCP server provides read-only access to the system
-catalog (`mz_*` tables). You can connect an MCP-compatible client (such as
-Claude Code, Claude Desktop, or Cursor) to the MCP server and ask natural
-language questions like:
+The `materialize-developer` MCP server exposes two read-only tools:
+
+- [`query_system_catalog`](/integrations/mcp-server/mcp-developer-tools/#query_system_catalog)
+  for system catalog (`mz_*`, `pg_catalog`, `information_schema`) lookups. Runs
+  on the catalog server cluster (`mz_catalog_server`); does not take a cluster
+  argument.
+- [`query`](/integrations/mcp-server/mcp-developer-tools/#query) for `SELECT`,
+  `SHOW`, and `EXPLAIN` (including `EXPLAIN ANALYZE`) against any object the
+  role can access. You must specify a cluster. Available starting in v26.30.
+
+You can connect an MCP-compatible client (such as Claude Code, Claude Desktop,
+or Cursor) to the MCP server and ask natural language questions like:
 
 - *Why is my materialized view stale?*
 - *How much memory is my cluster using?*
@@ -256,22 +264,21 @@ curl -X POST <baseURL>/api/mcp/developer \
 
 Once connected to the MCP server, you can ask natural language questions like:
 
-| Question | What the agent does |
-|----------|---------------------|
-| **Why is my materialized view stale?** | Checks materialization lag, hydration status, replica health, and source errors. |
-| **Why is my cluster running out of memory?** | Checks replica utilization, identifies the largest dataflows, and finds optimization opportunities via the built-in index advisor. |
-| **Has my source finished snapshotting yet?** | Checks source statistics and status. |
-| **How much memory is my cluster using?** | Checks replica utilization metrics across all clusters. |
-| **What's the health of my environment?** | Checks replica statuses, source and sink health, and resource utilization. |
-| **What can I optimize to save costs?** | Queries the index advisor for materialized views that can be dematerialized and indexes that can be dropped. |
+| Question | What the agent does | Tool |
+|----------|---------------------|------|
+| **Why is my materialized view stale?** | Checks materialization lag, hydration status, replica health, and source errors. Optionally runs `EXPLAIN ANALYZE MEMORY` on the materialized view. | `query_system_catalog`, plus `query` if the agent needs `EXPLAIN ANALYZE` |
+| **Why is my cluster running out of memory?** | Checks replica utilization, identifies the largest dataflows, and finds optimization opportunities via the built-in index advisor. | `query_system_catalog`, plus `query` for `EXPLAIN ANALYZE MEMORY` |
+| **Has my source finished snapshotting yet?** | Checks source statistics and status. | `query_system_catalog` |
+| **How much memory is my cluster using?** | Checks replica utilization metrics across all clusters. | `query_system_catalog` |
+| **What's the health of my environment?** | Checks replica statuses, source and sink health, and resource utilization. | `query_system_catalog` |
+| **What can I optimize to save costs?** | Queries the index advisor for materialized views that can be dematerialized and indexes that can be dropped. | `query_system_catalog` |
 
-The agent translates natural language questions into the appropriate system
-catalog queries and runs them via either the
-[`query_system_catalog`](/integrations/mcp-server/mcp-developer-tools/#query_system_catalog)
-tool (catalog lookups with no cluster needed) or the
-[`query`](/integrations/mcp-server/mcp-developer-tools/#query) tool
-(`EXPLAIN ANALYZE` and read-only queries against user objects, both of which
-require a cluster), then synthesizes the results.
+The agent picks the appropriate tool for each question. Most catalog lookups
+run on the catalog server cluster via
+[`query_system_catalog`](/integrations/mcp-server/mcp-developer-tools/#query_system_catalog);
+[`query`](/integrations/mcp-server/mcp-developer-tools/#query) is used when the
+question needs a specific cluster (for example, `EXPLAIN ANALYZE` against a
+materialized view or index, or reading user objects).
 
 ## Privileges
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -266,9 +266,12 @@ Once connected to the MCP server, you can ask natural language questions like:
 | **What can I optimize to save costs?** | Queries the index advisor for materialized views that can be dematerialized and indexes that can be dropped. |
 
 The agent translates natural language questions into the appropriate system
-catalog queries, uses the [`query_system_catalog`
-tool](/integrations/mcp-server/mcp-developer-tools/#query_system_catalog) to run
-those queries, and synthesizes the results.
+catalog queries and runs them via either the
+[`query_system_catalog`](/integrations/mcp-server/mcp-developer-tools/#query_system_catalog)
+tool (catalog lookups with no cluster needed) or the
+[`query`](/integrations/mcp-server/mcp-developer-tools/#query) tool
+(`EXPLAIN ANALYZE` and read-only queries against user objects, both of which
+require a cluster), then synthesizes the results.
 
 ## Privileges
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -18,21 +18,15 @@ process or external server is required.
 
 ## Overview
 
-The `materialize-developer` MCP server exposes two read-only tools:
-
-- [`query_system_catalog`](/integrations/mcp-server/mcp-developer-tools/#query_system_catalog)
-  for system catalog (`mz_*`, `pg_catalog`, `information_schema`) lookups. Runs
-  on the catalog server cluster (`mz_catalog_server`); does not take a cluster
-  argument.
-- [`query`](/integrations/mcp-server/mcp-developer-tools/#query) for `SELECT`,
-  `SHOW`, and `EXPLAIN` (including `EXPLAIN ANALYZE`) against any object the
-  role can access. You must specify a cluster. Available starting in v26.30.
-
 You can connect an MCP-compatible client (such as Claude Code, Claude Desktop,
-or Cursor) to the MCP server and ask natural language questions like:
+or Cursor) to the MCP server to:
 
-- *Why is my materialized view stale?*
-- *How much memory is my cluster using?*
+- Ask questions about the Materialize system
+  - *Why is my materialized view stale?*
+  - *How much memory is my cluster using?*
+- Run queries on your objects (Available starting in v26.30)
+  - *Using the quickstart cluster, SELECT * from my_mat_view;*
+  - *Using the quickstart cluster, examine the memory usage of my_mat_view with skew.*
 
 ## Connect to the MCP server
 
@@ -272,13 +266,15 @@ Once connected to the MCP server, you can ask natural language questions like:
 | **How much memory is my cluster using?** | Checks replica utilization metrics across all clusters. | `query_system_catalog` |
 | **What's the health of my environment?** | Checks replica statuses, source and sink health, and resource utilization. | `query_system_catalog` |
 | **What can I optimize to save costs?** | Queries the index advisor for materialized views that can be dematerialized and indexes that can be dropped. | `query_system_catalog` |
+| **Using the `quickstart` cluster, examine the memory usage of `my_mat_view` with skew.** | Runs `EXPLAIN ANALYZE MEMORY WITH SKEW` on the materialized view to report its memory usage and highlight data skew across workers. | `query` for `EXPLAIN ANALYZE MEMORY WITH SKEW` |
 
-The agent picks the appropriate tool for each question. Most catalog lookups
-run on the catalog server cluster via
+The agent picks the appropriate tool for each question. Most catalog lookups run
+on the catalog server cluster via
 [`query_system_catalog`](/integrations/mcp-server/mcp-developer-tools/#query_system_catalog);
-[`query`](/integrations/mcp-server/mcp-developer-tools/#query) is used when the
-question needs a specific cluster (for example, `EXPLAIN ANALYZE` against a
-materialized view or index, or reading user objects).
+[`query`](/integrations/mcp-server/mcp-developer-tools/#query) (available
+starting in v26.30) is used when the question needs a specific cluster (for
+example, `EXPLAIN ANALYZE` against a materialized view or index, or reading user
+objects).
 
 ## Privileges
 


### PR DESCRIPTION
Follow-up to #36949: documents the new `query` tool on the developer MCP endpoint and the `enable_mcp_developer_query_tool` dyncfg. Held as a draft so it can land the week after the binary change ships.
