### PR TITLE
adapter: make statement-logging end ownership linear, tolerate duplicate ends

### DIFF
--- a/doc/developer/generated/adapter/frontend_peek.md
+++ b/doc/developer/generated/adapter/frontend_peek.md
@@ -6,7 +6,7 @@ revision: e926ec3a86
 # adapter::frontend_peek
 
 Implements the "frontend peek" sequencing path, where SELECT query optimization and fast-path execution are performed in the pgwire connection task rather than the coordinator's main loop.
-`PeekClient::try_frontend_peek` is the main entry point; it verifies the portal, delegates statement logging setup to `PeekClient::begin_statement_logging` (which returns a `StatementLoggingGuard`), immediately defuses the guard, and then calls `try_frontend_peek_inner`.
+`PeekClient::try_frontend_peek` is the main entry point; it verifies the portal, delegates statement logging setup to `PeekClient::begin_statement_logging` (which returns a `StatementLoggingGuard` owning end-of-execution logging), threads the guard through `try_frontend_peek_inner` — dispatch sites that hand a statement to the coordinator for asynchronous completion defuse it — and retires any still-armed guard with the execution's outcome.
 `try_frontend_peek_inner` sequences the full pipeline — name resolution, planning, cluster selection, RBAC checks, timeline context determination, timestamp determination with read-hold acquisition, optimization (in a `spawn_blocking` task), and finally execution — handling `SELECT`, `EXPLAIN` (plan and pushdown), `COPY TO S3`, and `SUBSCRIBE` statement types.
 Fast-path peeks (constant, arrangement, or persist) are executed directly via `implement_fast_path_peek_plan`; slow-path dataflow plans are dispatched to the coordinator via `Command::ExecuteSlowPathPeek`.
 SUBSCRIBE statements are dispatched via `Command::ExecuteSubscribe`; COPY TO S3 performs an S3 preflight check via `Command::CopyToPreflight` before dispatching `Command::ExecuteCopyTo`.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -351,18 +351,19 @@ pub enum Command {
         tx: oneshot::Sender<Result<(), AdapterError>>,
     },
 
-    /// Unregister a pending peek that was registered but failed to issue.
-    /// This is used for cleanup when `client.peek()` fails after `RegisterFrontendPeek` succeeds.
+    /// Unregister and retire a pending peek that was registered but failed to
+    /// issue. This is used for cleanup when `client.peek()` fails after
+    /// `RegisterFrontendPeek` succeeds.
     ///
-    /// Sends back whether the peek was still registered. If it was, its
-    /// `ExecuteContextExtra` is dropped without logging the statement
-    /// retirement, because the frontend will log the error. If it was *not*
-    /// still registered, then a concurrent teardown (e.g. a `DROP CLUSTER`)
-    /// already removed and retired it, which logged the end of execution; the
-    /// frontend uses this to avoid logging the end a second time.
+    /// Registration handed ownership of end-of-execution logging to the
+    /// coordinator, so the coordinator retires the peek and logs the given end
+    /// reason. If a concurrent teardown (e.g. a `DROP CLUSTER`) already
+    /// retired the peek and logged its end, this is a no-op. The frontend
+    /// must not log the end in either case.
     UnregisterFrontendPeek {
         uuid: Uuid,
-        tx: oneshot::Sender<bool>,
+        reason: StatementEndedExecutionReason,
+        tx: oneshot::Sender<()>,
     },
 
     /// Generate a timestamp explanation.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -353,11 +353,16 @@ pub enum Command {
 
     /// Unregister a pending peek that was registered but failed to issue.
     /// This is used for cleanup when `client.peek()` fails after `RegisterFrontendPeek` succeeds.
-    /// The `ExecuteContextExtra` is dropped without logging the statement retirement, because the
-    /// frontend will log the error.
+    ///
+    /// Sends back whether the peek was still registered. If it was, its
+    /// `ExecuteContextExtra` is dropped without logging the statement
+    /// retirement, because the frontend will log the error. If it was *not*
+    /// still registered, then a concurrent teardown (e.g. a `DROP CLUSTER`)
+    /// already removed and retired it, which logged the end of execution; the
+    /// frontend uses this to avoid logging the end a second time.
     UnregisterFrontendPeek {
         uuid: Uuid,
-        tx: oneshot::Sender<()>,
+        tx: oneshot::Sender<bool>,
     },
 
     /// Generate a timestamp explanation.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -351,15 +351,14 @@ pub enum Command {
         tx: oneshot::Sender<Result<(), AdapterError>>,
     },
 
-    /// Unregister and retire a pending peek that was registered but failed to
-    /// issue. This is used for cleanup when `client.peek()` fails after
-    /// `RegisterFrontendPeek` succeeds.
+    /// Unregister and retire a pending peek that was registered but then
+    /// failed to issue, ending its statement-logging execution with the given
+    /// reason.
     ///
     /// Registration handed ownership of end-of-execution logging to the
-    /// coordinator, so the coordinator retires the peek and logs the given end
-    /// reason. If a concurrent teardown (e.g. a `DROP CLUSTER`) already
-    /// retired the peek and logged its end, this is a no-op. The frontend
-    /// must not log the end in either case.
+    /// coordinator, so the frontend must not log the end itself. If a
+    /// concurrent teardown (e.g. a `DROP CLUSTER`) already retired the peek
+    /// and logged its end, this is a no-op.
     UnregisterFrontendPeek {
         uuid: Uuid,
         reason: StatementEndedExecutionReason,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -2187,12 +2187,24 @@ impl Coordinator {
 
     /// Handle unregistration of a frontend peek that was registered but failed to issue.
     /// This is used for cleanup when `client.peek()` fails after `RegisterFrontendPeek` succeeds.
-    fn handle_unregister_frontend_peek(&mut self, uuid: Uuid, tx: oneshot::Sender<()>) {
-        // Remove from pending_peeks (this also removes from client_pending_peeks)
-        if let Some(pending_peek) = self.remove_pending_peek(&uuid) {
-            // Retire `ExecuteContextExtra`, because the frontend will log the peek's error result.
-            let _ = pending_peek.ctx_extra.defuse();
-        }
-        let _ = tx.send(());
+    ///
+    /// Sends back whether the peek was still registered (`true`) or had already
+    /// been removed and retired by a concurrent teardown (`false`). In the
+    /// latter case the end of execution was already logged, so the frontend
+    /// must not log it again.
+    fn handle_unregister_frontend_peek(&mut self, uuid: Uuid, tx: oneshot::Sender<bool>) {
+        // Remove from pending_peeks (this also removes from client_pending_peeks).
+        let still_registered = match self.remove_pending_peek(&uuid) {
+            Some(pending_peek) => {
+                // Retire `ExecuteContextExtra` without logging the end, because
+                // the frontend will log the peek's error result.
+                let _ = pending_peek.ctx_extra.defuse();
+                true
+            }
+            // A concurrent teardown already removed and retired this peek, so
+            // the end of execution has already been logged.
+            None => false,
+        };
+        let _ = tx.send(still_registered);
     }
 }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -500,8 +500,8 @@ impl Coordinator {
                         Err(e) => {
                             // On success the guard's contents moved into the
                             // `Subscribing` response. On error the frontend
-                            // logs the error end, so defuse rather than
-                            // letting the guard's `Drop` emit a spurious
+                            // logs the error end, so we defuse rather than
+                            // let the guard's `Drop` emit a spurious
                             // `Aborted`.
                             let _ = ctx_extra.defuse();
                             let _ = tx.send(Err(e));

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -2191,20 +2191,16 @@ impl Coordinator {
         let _ = tx.send(Ok(()));
     }
 
-    /// Handle unregistration of a frontend peek that was registered but failed to issue.
-    /// This is used for cleanup when `client.peek()` fails after `RegisterFrontendPeek` succeeds.
-    ///
-    /// Registration made the coordinator the owner of end-of-execution
-    /// logging, so the peek is retired with the given reason. If a concurrent
-    /// teardown (e.g. a `DROP CLUSTER`) already removed and retired the peek,
-    /// its end has already been logged and there is nothing left to do.
+    /// Handles [`Command::UnregisterFrontendPeek`]; see its documentation for
+    /// the end-of-execution ownership contract.
     fn handle_unregister_frontend_peek(
         &mut self,
         uuid: Uuid,
         reason: StatementEndedExecutionReason,
         tx: oneshot::Sender<()>,
     ) {
-        // Remove from pending_peeks (this also removes from client_pending_peeks).
+        // A peek missing from `pending_peeks` was already retired, and its end
+        // logged, by a concurrent teardown.
         if let Some(pending_peek) = self.remove_pending_peek(&uuid) {
             self.retire_execution(reason, pending_peek.ctx_extra.defuse());
         }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -80,7 +80,7 @@ use crate::coord::{
 use crate::error::{AdapterError, AuthenticationError};
 use crate::notice::AdapterNotice;
 use crate::session::{Session, TransactionOps, TransactionStatus};
-use crate::statement_logging::WatchSetCreation;
+use crate::statement_logging::{StatementEndedExecutionReason, WatchSetCreation};
 use crate::util::{ClientTransmitter, ResultExt};
 use crate::webhook::{
     AppendWebhookResponse, AppendWebhookValidator, WebhookAppender, WebhookAppenderInvalidator,
@@ -498,6 +498,12 @@ impl Coordinator {
                             });
                         }
                         Err(e) => {
+                            // On success the guard's contents moved into the
+                            // `Subscribing` response. On error the frontend
+                            // logs the error end, so defuse rather than
+                            // letting the guard's `Drop` emit a spurious
+                            // `Aborted`.
+                            let _ = ctx_extra.defuse();
                             let _ = tx.send(Err(e));
                         }
                     }
@@ -583,8 +589,8 @@ impl Coordinator {
                         tx,
                     );
                 }
-                Command::UnregisterFrontendPeek { uuid, tx } => {
-                    self.handle_unregister_frontend_peek(uuid, tx);
+                Command::UnregisterFrontendPeek { uuid, reason, tx } => {
+                    self.handle_unregister_frontend_peek(uuid, reason, tx);
                 }
                 Command::ExplainTimestamp {
                     conn_id,
@@ -2188,23 +2194,20 @@ impl Coordinator {
     /// Handle unregistration of a frontend peek that was registered but failed to issue.
     /// This is used for cleanup when `client.peek()` fails after `RegisterFrontendPeek` succeeds.
     ///
-    /// Sends back whether the peek was still registered (`true`) or had already
-    /// been removed and retired by a concurrent teardown (`false`). In the
-    /// latter case the end of execution was already logged, so the frontend
-    /// must not log it again.
-    fn handle_unregister_frontend_peek(&mut self, uuid: Uuid, tx: oneshot::Sender<bool>) {
+    /// Registration made the coordinator the owner of end-of-execution
+    /// logging, so the peek is retired with the given reason. If a concurrent
+    /// teardown (e.g. a `DROP CLUSTER`) already removed and retired the peek,
+    /// its end has already been logged and there is nothing left to do.
+    fn handle_unregister_frontend_peek(
+        &mut self,
+        uuid: Uuid,
+        reason: StatementEndedExecutionReason,
+        tx: oneshot::Sender<()>,
+    ) {
         // Remove from pending_peeks (this also removes from client_pending_peeks).
-        let still_registered = match self.remove_pending_peek(&uuid) {
-            Some(pending_peek) => {
-                // Retire `ExecuteContextExtra` without logging the end, because
-                // the frontend will log the peek's error result.
-                let _ = pending_peek.ctx_extra.defuse();
-                true
-            }
-            // A concurrent teardown already removed and retired this peek, so
-            // the end of execution has already been logged.
-            None => false,
-        };
-        let _ = tx.send(still_registered);
+        if let Some(pending_peek) = self.remove_pending_peek(&uuid) {
+            self.retire_execution(reason, pending_peek.ctx_extra.defuse());
+        }
+        let _ = tx.send(());
     }
 }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -694,6 +694,16 @@ impl FastPathPlan {
 
 impl crate::coord::Coordinator {
     /// Implements a peek plan produced by `create_plan` above.
+    ///
+    /// Ownership of `ctx_extra` (the statement-logging guard): on success its
+    /// contents are taken and end-of-execution logging is handed off — retired
+    /// immediately for a constant peek, or moved into `pending_peeks` for
+    /// `handle_peek_notification` to retire on a streaming peek. On an early error
+    /// return (e.g. a concurrent dependency drop before the peek is registered) the
+    /// contents are left intact, so the caller must take ownership: `retire` it if
+    /// the caller is the sole end-logger, or `defuse` it if something else logs the
+    /// end on error (as the frontend does via `implement_slow_path_peek`). Otherwise
+    /// the guard's `Drop` emits a spurious `Aborted`, double-ending the statement.
     #[mz_ore::instrument(level = "debug")]
     pub async fn implement_peek_plan(
         &mut self,
@@ -1378,16 +1388,29 @@ impl crate::coord::Coordinator {
         // TODO(peek-seq): After the old peek sequencing is completely removed, we should merge the
         // relevant parts of the old `implement_peek_plan` into this method, and remove the old
         // `implement_peek_plan`.
-        self.implement_peek_plan(
-            &mut ExecuteContextGuard::new(statement_logging_id, self.internal_cmd_tx.clone()),
-            planned_peek,
-            finishing,
-            compute_instance,
-            target_replica,
-            max_result_size,
-            max_query_result_size,
-        )
-        .await
+        //
+        // `implement_peek_plan` leaves the guard's contents intact on an error
+        // return (see its doc comment). Defuse on error so the frontend stays the
+        // sole end-logger: letting the guard's `Drop` also emit `Aborted` would
+        // double-end the `Errored` and panic in `end_statement_execution`. Matches
+        // the watch-set invariant noted above.
+        let mut ctx_guard =
+            ExecuteContextGuard::new(statement_logging_id, self.internal_cmd_tx.clone());
+        let result = self
+            .implement_peek_plan(
+                &mut ctx_guard,
+                planned_peek,
+                finishing,
+                compute_instance,
+                target_replica,
+                max_result_size,
+                max_query_result_size,
+            )
+            .await;
+        if result.is_err() {
+            let _ = ctx_guard.defuse();
+        }
+        result
     }
 
     /// Implements a `COPY TO` command by installing peek watch sets,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -695,15 +695,14 @@ impl FastPathPlan {
 impl crate::coord::Coordinator {
     /// Implements a peek plan produced by `create_plan` above.
     ///
-    /// Ownership of `ctx_extra` (the statement-logging guard): on success its
-    /// contents are taken and end-of-execution logging is handed off — retired
-    /// immediately for a constant peek, or moved into `pending_peeks` for
-    /// `handle_peek_notification` to retire on a streaming peek. On an early error
-    /// return (e.g. a concurrent dependency drop before the peek is registered) the
-    /// contents are left intact, so the caller must take ownership: `retire` it if
-    /// the caller is the sole end-logger, or `defuse` it if something else logs the
-    /// end on error (as the frontend does via `implement_slow_path_peek`). Otherwise
-    /// the guard's `Drop` emits a spurious `Aborted`, double-ending the statement.
+    /// On success this takes the contents of `ctx_extra`, the
+    /// statement-logging guard: a constant peek is retired immediately, and a
+    /// streaming peek moves them into `pending_peeks` for
+    /// `handle_peek_notification` to retire. On an error return the contents
+    /// are left intact and the caller must take ownership of them: `retire`
+    /// if the caller is the sole end-logger, `defuse` if something else logs
+    /// the error end. Dropping the guard armed emits a spurious `Aborted`,
+    /// double-ending the statement.
     #[mz_ore::instrument(level = "debug")]
     pub async fn implement_peek_plan(
         &mut self,
@@ -1384,16 +1383,9 @@ impl crate::coord::Coordinator {
             source_ids,
         };
 
-        // Call the old peek sequencing's implement_peek_plan for now.
         // TODO(peek-seq): After the old peek sequencing is completely removed, we should merge the
         // relevant parts of the old `implement_peek_plan` into this method, and remove the old
         // `implement_peek_plan`.
-        //
-        // `implement_peek_plan` leaves the guard's contents intact on an error
-        // return (see its doc comment). Defuse on error so the frontend stays the
-        // sole end-logger: letting the guard's `Drop` also emit `Aborted` would
-        // double-end the `Errored` and panic in `end_statement_execution`. Matches
-        // the watch-set invariant noted above.
         let mut ctx_guard =
             ExecuteContextGuard::new(statement_logging_id, self.internal_cmd_tx.clone());
         let result = self
@@ -1407,6 +1399,9 @@ impl crate::coord::Coordinator {
                 max_query_result_size,
             )
             .await;
+        // On error `implement_peek_plan` left the guard's contents intact (see
+        // its doc comment) and the frontend logs the error end, so we defuse
+        // rather than let the guard's `Drop` emit a spurious `Aborted`.
         if result.is_err() {
             let _ = ctx_guard.defuse();
         }

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -16,7 +16,7 @@ use mz_compute_client::controller::error::CollectionLookupError;
 use mz_controller_types::ClusterId;
 use mz_ore::now::{EpochMillis, NowFn, epoch_to_uuid_v7, to_datetime};
 use mz_ore::task::spawn;
-use mz_ore::{cast::CastFrom, cast::CastInto, soft_panic_or_log};
+use mz_ore::{cast::CastFrom, cast::CastInto};
 use mz_repr::adt::timestamp::TimestampLike;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_sql::plan::Params;
@@ -392,13 +392,13 @@ impl Coordinator {
     }
 
     /// Record the end of statement execution for a statement whose beginning was logged.
-    /// It is an error to call this function for a statement whose beginning was not logged
-    /// (because it was not sampled). Requiring the opaque `StatementLoggingId` type,
-    /// which is only instantiated by `begin_statement_execution` if the statement is actually logged,
-    /// should prevent this.
     ///
-    /// It is also an error to end the same execution twice; the duplicate end is
-    /// reported and ignored, keeping the first end.
+    /// Ends are idempotent: the first end wins and any later end for the same
+    /// statement is ignored. While each holder of end-of-execution ownership
+    /// emits at most one end, ownership handoffs between the frontend and the
+    /// coordinator can leave both sides emitting when execution is torn down
+    /// concurrently, so duplicate ends are tolerated here rather than treated
+    /// as an error.
     pub(crate) fn end_statement_execution(
         &mut self,
         id: StatementLoggingId,
@@ -413,13 +413,20 @@ impl Coordinator {
         };
 
         let Some(began_record) = self.statement_logging.executions_begun.remove(&uuid) else {
-            // A `StatementLoggingId` is only minted when a begin is logged, so
-            // a missing entry means this execution was already ended: some bug
-            // ended it twice. That's worth a loud report, but statement
-            // logging must never abort environmentd in production.
-            soft_panic_or_log!(
-                "duplicate end_statement_execution for statement {uuid}, reason: {:?}",
-                ended_record.reason
+            // The statement has already been ended. `StatementLoggingId`s are
+            // only minted when a begin is logged, and every end is processed
+            // after its begin (begins and the commands that hand statements to
+            // the coordinator travel the same command channel, in FIFO order),
+            // so a missing entry can only mean a duplicate end. Duplicates are
+            // legitimate, if rare: ends race when execution is torn down
+            // concurrently — e.g. a frontend that owns the end of a statement
+            // is dropped by a client disconnect just after handing the
+            // statement off to the coordinator, leaving both sides emitting an
+            // end.
+            tracing::warn!(
+                statement_uuid = %uuid,
+                reason = ?ended_record.reason,
+                "duplicate end_statement_execution, keeping the first end",
             );
             return;
         };

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -391,14 +391,9 @@ impl Coordinator {
         }
     }
 
-    /// Record the end of statement execution for a statement whose beginning was logged.
-    ///
-    /// Ends are idempotent: the first end wins and any later end for the same
-    /// statement is ignored. While each holder of end-of-execution ownership
-    /// emits at most one end, ownership handoffs between the frontend and the
-    /// coordinator can leave both sides emitting when execution is torn down
-    /// concurrently, so duplicate ends are tolerated here rather than treated
-    /// as an error.
+    /// Record the end of statement execution for a statement whose beginning
+    /// was logged. Ends are idempotent: the first end wins and later ends for
+    /// the same statement are ignored.
     pub(crate) fn end_statement_execution(
         &mut self,
         id: StatementLoggingId,
@@ -413,16 +408,20 @@ impl Coordinator {
         };
 
         let Some(began_record) = self.statement_logging.executions_begun.remove(&uuid) else {
-            // The statement has already been ended. `StatementLoggingId`s are
-            // only minted when a begin is logged, and every end is processed
-            // after its begin (begins and the commands that hand statements to
-            // the coordinator travel the same command channel, in FIFO order),
-            // so a missing entry can only mean a duplicate end. Duplicates are
-            // legitimate, if rare: ends race when execution is torn down
-            // concurrently — e.g. a frontend that owns the end of a statement
-            // is dropped by a client disconnect just after handing the
-            // statement off to the coordinator, leaving both sides emitting an
-            // end.
+            // The statement was already ended; the first end wins.
+            //
+            // A missing entry can only mean a duplicate end, never an end that
+            // overtook its begin: a StatementLoggingId is only minted when a
+            // begin is logged, and begins travel the same FIFO command channel
+            // as the commands that hand statements to the coordinator, so the
+            // coordinator never ends a statement before processing its begin.
+            //
+            // Duplicate ends are legitimate, if rare. Ownership of the end is
+            // handed from the frontend to the coordinator while a statement is
+            // dispatched, and async cancellation can strike mid-handoff: if a
+            // client disconnect drops the frontend future after the
+            // coordinator registered a peek but before the frontend defused
+            // its logging guard, both sides own the end and both emit one.
             tracing::warn!(
                 statement_uuid = %uuid,
                 reason = ?ended_record.reason,

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -57,6 +57,7 @@ use crate::explain::insights::PlanInsightsContext;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::optimize::Optimize;
 use crate::optimize::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
+use crate::peek_client::StatementLoggingGuard;
 use crate::session::{Session, TransactionOps, TransactionStatus};
 use crate::statement_logging::WatchSetCreation;
 use crate::statement_logging::{StatementEndedExecutionReason, StatementLifecycleEvent};
@@ -110,9 +111,21 @@ impl PeekClient {
         // Extract things from the portal.
         let (stmt, params, logging, lifecycle_timestamps) = {
             if let Err(err) = Coordinator::verify_portal(&*catalog, session, portal_name) {
-                outer_ctx_extra
+                // An inherited outer statement (e.g. EXECUTE) ends here, and
+                // its end is owned here, so log it. Discarding the id instead
+                // would leave the statement "running" forever in
+                // `mz_statement_execution_history`.
+                if let Some(id) = outer_ctx_extra
                     .take()
-                    .and_then(|guard| guard.defuse().retire());
+                    .and_then(|guard| guard.defuse().retire())
+                {
+                    self.log_ended_execution(
+                        id,
+                        StatementEndedExecutionReason::Errored {
+                            error: err.to_string(),
+                        },
+                    );
+                }
                 return Err(err);
             }
             let portal = session
@@ -200,7 +213,7 @@ impl PeekClient {
 
         // Set up statement logging, and log the beginning of execution.
         // (But only if we're not executing in the context of another statement.)
-        let logging_guard = self.begin_statement_logging(
+        let mut logging_guard = self.begin_statement_logging(
             session,
             &params,
             &logging,
@@ -208,53 +221,19 @@ impl PeekClient {
             lifecycle_timestamps,
             outer_ctx_extra,
         );
-        let statement_logging_id = logging_guard.id();
-        // Streaming peek/subscribe/slow-path/copy-to responses hand off the
-        // end-execution event to the coordinator (via
-        // `handle_peek_notification` / `cancel_pending_peeks`), so letting
-        // the RAII guard's `Drop` also emit `Aborted` on mid-flight drop
-        // would double-end and panic at `end_statement_execution`. Defuse
-        // and manage the lifecycle explicitly below: streaming arms skip
-        // emitting; non-streaming arms emit via `log_ended_execution`.
-        logging_guard.defuse();
 
-        let mut end_already_logged = false;
         let result = self
-            .try_frontend_peek_inner(
-                session,
-                catalog,
-                stmt,
-                params,
-                statement_logging_id,
-                &mut end_already_logged,
-            )
+            .try_frontend_peek_inner(session, catalog, stmt, params, &mut logging_guard)
             .await;
 
-        // Log the end of execution if we are logging this statement and
-        // execution has already ended.
-        if let Some(logging_id) = statement_logging_id {
+        // If end-of-execution logging is still owned here, retire it with the
+        // execution's outcome. It is not owned here when a dispatch site in
+        // `try_frontend_peek_inner` handed it off (see the doc comment there):
+        // for streaming responses the end is logged asynchronously — by the
+        // coordinator for registered peeks, by the protocol layer for
+        // subscribes.
+        if logging_guard.id().is_some() {
             let reason = match &result {
-                // Streaming results are handled asynchronously by the
-                // coordinator — it will log the end via
-                // `handle_peek_notification`, so skip emitting here.
-                Ok(Some(
-                    ExecuteResponse::SendingRowsStreaming { .. }
-                    | ExecuteResponse::Subscribing { .. },
-                )) => {
-                    return result;
-                }
-                // COPY TO wrapping a streaming response: same handoff.
-                Ok(Some(resp @ ExecuteResponse::CopyTo { resp: inner, .. })) => {
-                    match inner.as_ref() {
-                        ExecuteResponse::SendingRowsStreaming { .. }
-                        | ExecuteResponse::Subscribing { .. } => {
-                            return result;
-                        }
-                        // For non-streaming COPY TO responses, use the outer
-                        // CopyTo for conversion.
-                        _ => resp.into(),
-                    }
-                }
                 // Bailout case, which should not happen.
                 Ok(None) => {
                     soft_panic_or_log!(
@@ -262,32 +241,21 @@ impl PeekClient {
                     );
                     // The old peek sequencing would start its own statement
                     // logging from scratch; close out this one as errored.
-                    self.log_ended_execution(
-                        logging_id,
-                        StatementEndedExecutionReason::Errored {
-                            error: "Internal error: bailed out from `try_frontend_peek_inner`"
-                                .to_string(),
-                        },
-                    );
-                    return result;
+                    StatementEndedExecutionReason::Errored {
+                        error: "Internal error: bailed out from `try_frontend_peek_inner`"
+                            .to_string(),
+                    }
                 }
-                // All other success responses — use the `From` implementation.
-                // TODO(peek-seq): After we delete the old peek sequencing, we
-                // can adjust the `From` impl to do exactly what we need here,
-                // so the special cases above won't be needed.
+                // Success responses — use the `From` implementation. Streaming
+                // responses cannot reach this: their dispatch sites hand off
+                // the guard (and the `From` impl panics on them).
                 Ok(Some(resp)) => resp.into(),
-                // A concurrent teardown (e.g. a `DROP CLUSTER`) already retired
-                // and logged the end of this peek on the coordinator; logging
-                // again would double-end and panic in `end_statement_execution`.
-                Err(_) if end_already_logged => {
-                    return result;
-                }
                 Err(e) => StatementEndedExecutionReason::Errored {
                     error: e.to_string(),
                 },
             };
 
-            self.log_ended_execution(logging_id, reason);
+            logging_guard.retire(reason);
         }
 
         result
@@ -295,14 +263,20 @@ impl PeekClient {
 
     /// This is encapsulated in an inner function so that the outer function can still do statement
     /// logging after the `?` returns of the inner function.
+    ///
+    /// `logging_guard` owns end-of-execution logging for this statement.
+    /// Dispatch sites that hand the statement to the coordinator for
+    /// asynchronous completion (registered peeks, subscribes) `defuse` the
+    /// guard at the point where the coordinator takes over; everywhere else
+    /// the guard stays armed and the caller logs the end from the returned
+    /// result.
     async fn try_frontend_peek_inner(
         &mut self,
         session: &mut Session,
         catalog: Arc<Catalog>,
         stmt: Option<Arc<Statement<Raw>>>,
         params: Params,
-        statement_logging_id: Option<crate::statement_logging::StatementLoggingId>,
-        end_already_logged: &mut bool,
+        logging_guard: &mut StatementLoggingGuard,
     ) -> Result<Option<ExecuteResponse>, AdapterError> {
         let stmt = match stmt {
             Some(stmt) => stmt,
@@ -495,8 +469,8 @@ impl PeekClient {
         };
 
         // Log cluster selection
-        if let Some(logging_id) = &statement_logging_id {
-            self.log_set_cluster(*logging_id, target_cluster_id, target_cluster_name.clone());
+        if let Some(logging_id) = logging_guard.id() {
+            self.log_set_cluster(logging_id, target_cluster_id, target_cluster_name.clone());
         }
 
         coord::catalog_serving::check_cluster_restrictions(
@@ -1178,8 +1152,8 @@ impl PeekClient {
             };
 
         // Log optimization finished
-        if let Some(logging_id) = &statement_logging_id {
-            self.log_lifecycle_event(*logging_id, StatementLifecycleEvent::OptimizationFinished);
+        if let Some(logging_id) = logging_guard.id() {
+            self.log_lifecycle_event(logging_id, StatementLifecycleEvent::OptimizationFinished);
         }
 
         // Assert that read holds are correct for the execution plan
@@ -1286,7 +1260,7 @@ impl PeekClient {
 
                 // # Now back to peek_finish
 
-                let watch_set = statement_logging_id.map(|logging_id| {
+                let watch_set = logging_guard.id().map(|logging_id| {
                     WatchSetCreation::new(
                         logging_id,
                         catalog.state(),
@@ -1307,7 +1281,7 @@ impl PeekClient {
 
                 let response = match peek_plan {
                     PeekPlan::FastPath(fast_path_plan) => {
-                        if let Some(logging_id) = &statement_logging_id {
+                        if let Some(logging_id) = logging_guard.id() {
                             // TODO(peek-seq): Actually, we should log it also for
                             // FastPathPlan::Constant. The only reason we are not doing so at the
                             // moment is to match the old peek sequencing, so that statement logging
@@ -1323,7 +1297,7 @@ impl PeekClient {
                             //   it here.
                             if !matches!(fast_path_plan, FastPathPlan::Constant(..)) {
                                 self.log_set_timestamp(
-                                    *logging_id,
+                                    logging_id,
                                     determination.timestamp_context.timestamp_or_default(),
                                 );
                             }
@@ -1355,30 +1329,39 @@ impl PeekClient {
                             session.conn_id().clone(),
                             source_ids,
                             watch_set,
-                            end_already_logged,
+                            logging_guard,
                         )
                         .await?
                     }
                     PeekPlan::SlowPath(dataflow_plan) => {
-                        if let Some(logging_id) = &statement_logging_id {
-                            self.log_set_transient_index_id(*logging_id, dataflow_plan.id);
+                        if let Some(logging_id) = logging_guard.id() {
+                            self.log_set_transient_index_id(logging_id, dataflow_plan.id);
                         }
 
-                        self.call_coordinator(|tx| Command::ExecuteSlowPathPeek {
-                            dataflow_plan: Box::new(dataflow_plan),
-                            determination,
-                            finishing,
-                            compute_instance: target_cluster_id,
-                            target_replica,
-                            intermediate_result_type: typ,
-                            source_ids,
-                            conn_id: session.conn_id().clone(),
-                            max_result_size,
-                            max_query_result_size,
-                            watch_set,
-                            tx,
-                        })
-                        .await?
+                        let response = self
+                            .call_coordinator(|tx| Command::ExecuteSlowPathPeek {
+                                dataflow_plan: Box::new(dataflow_plan),
+                                determination,
+                                finishing,
+                                compute_instance: target_cluster_id,
+                                target_replica,
+                                intermediate_result_type: typ,
+                                source_ids,
+                                conn_id: session.conn_id().clone(),
+                                max_result_size,
+                                max_query_result_size,
+                                watch_set,
+                                tx,
+                            })
+                            .await?;
+                        // On success the coordinator has registered the peek in
+                        // `pending_peeks`, which owns end-of-execution logging
+                        // (`handle_peek_notification` or a concurrent teardown
+                        // logs it). On error the coordinator has logged nothing
+                        // (see `implement_slow_path_peek`), the guard stays
+                        // armed, and the caller logs the error.
+                        logging_guard.defuse();
+                        response
                     }
                 };
 
@@ -1433,10 +1416,17 @@ impl PeekClient {
                         session_uuid: session.uuid(),
                         read_holds,
                         plan: subscribe_plan,
-                        statement_logging_id,
+                        statement_logging_id: logging_guard.id(),
                         tx,
                     })
                     .await?;
+                // On success the `Subscribing` response carries the
+                // coordinator-side logging guard, and the protocol layer logs
+                // the end when the subscribe terminates. On error the
+                // coordinator has logged nothing (see the `ExecuteSubscribe`
+                // handler), the guard stays armed, and the caller logs the
+                // error.
+                logging_guard.defuse();
                 Ok(Some(response))
             }
             Execution::CopyToS3 {
@@ -1483,7 +1473,7 @@ impl PeekClient {
                 .await?;
 
                 // Preflight succeeded, now execute the actual COPY TO dataflow
-                let watch_set = statement_logging_id.map(|logging_id| {
+                let watch_set = logging_guard.id().map(|logging_id| {
                     WatchSetCreation::new(
                         logging_id,
                         catalog.state(),
@@ -1492,6 +1482,9 @@ impl PeekClient {
                     )
                 });
 
+                // End-of-execution logging stays owned here: `implement_copy_to`
+                // logs nothing, and the final response (success or error) comes
+                // back through this command and is logged by the caller.
                 let response = self
                     .call_coordinator(|tx| Command::ExecuteCopyTo {
                         df_desc: Box::new(df_desc),

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -111,10 +111,10 @@ impl PeekClient {
         // Extract things from the portal.
         let (stmt, params, logging, lifecycle_timestamps) = {
             if let Err(err) = Coordinator::verify_portal(&*catalog, session, portal_name) {
-                // An inherited outer statement (e.g. EXECUTE) ends here, and
-                // its end is owned here, so log it. Discarding the id instead
-                // would leave the statement "running" forever in
-                // `mz_statement_execution_history`.
+                // An inherited outer statement (e.g. EXECUTE) ends here and we
+                // own its end, so we log it. If we discarded the id instead,
+                // the statement would stay "running" forever in
+                // mz_statement_execution_history.
                 if let Some(id) = outer_ctx_extra
                     .take()
                     .and_then(|guard| guard.defuse().retire())
@@ -226,12 +226,11 @@ impl PeekClient {
             .try_frontend_peek_inner(session, catalog, stmt, params, &mut logging_guard)
             .await;
 
-        // If end-of-execution logging is still owned here, retire it with the
-        // execution's outcome. It is not owned here when a dispatch site in
-        // `try_frontend_peek_inner` handed it off (see the doc comment there):
-        // for streaming responses the end is logged asynchronously — by the
-        // coordinator for registered peeks, by the protocol layer for
-        // subscribes.
+        // If we still own end-of-execution logging, retire it with the
+        // execution's outcome. We don't own it when a dispatch site in
+        // `try_frontend_peek_inner` handed it off: for streaming responses the
+        // end is logged asynchronously, by the coordinator for registered
+        // peeks and by the protocol layer for subscribes.
         if logging_guard.id().is_some() {
             let reason = match &result {
                 // Bailout case, which should not happen.
@@ -246,9 +245,9 @@ impl PeekClient {
                             .to_string(),
                     }
                 }
-                // Success responses — use the `From` implementation. Streaming
-                // responses cannot reach this: their dispatch sites hand off
-                // the guard (and the `From` impl panics on them).
+                // Success responses use the `From` implementation. Streaming
+                // responses cannot reach this arm: their dispatch sites hand
+                // off the guard, and the `From` impl panics on them.
                 Ok(Some(resp)) => resp.into(),
                 Err(e) => StatementEndedExecutionReason::Errored {
                     error: e.to_string(),
@@ -267,7 +266,7 @@ impl PeekClient {
     /// `logging_guard` owns end-of-execution logging for this statement.
     /// Dispatch sites that hand the statement to the coordinator for
     /// asynchronous completion (registered peeks, subscribes) `defuse` the
-    /// guard at the point where the coordinator takes over; everywhere else
+    /// guard at the point where the coordinator takes over. Everywhere else
     /// the guard stays armed and the caller logs the end from the returned
     /// result.
     async fn try_frontend_peek_inner(
@@ -1354,12 +1353,11 @@ impl PeekClient {
                                 tx,
                             })
                             .await?;
-                        // On success the coordinator has registered the peek in
-                        // `pending_peeks`, which owns end-of-execution logging
-                        // (`handle_peek_notification` or a concurrent teardown
-                        // logs it). On error the coordinator has logged nothing
-                        // (see `implement_slow_path_peek`), the guard stays
-                        // armed, and the caller logs the error.
+                        // On success the peek is registered in `pending_peeks`,
+                        // which now owns end-of-execution logging. On error the
+                        // coordinator logs nothing (see
+                        // `implement_slow_path_peek`), so the guard stays armed
+                        // and the caller logs the error.
                         logging_guard.defuse();
                         response
                     }
@@ -1421,10 +1419,10 @@ impl PeekClient {
                     })
                     .await?;
                 // On success the `Subscribing` response carries the
-                // coordinator-side logging guard, and the protocol layer logs
+                // coordinator-side logging guard and the protocol layer logs
                 // the end when the subscribe terminates. On error the
-                // coordinator has logged nothing (see the `ExecuteSubscribe`
-                // handler), the guard stays armed, and the caller logs the
+                // coordinator logs nothing (see the `ExecuteSubscribe`
+                // handler), so the guard stays armed and the caller logs the
                 // error.
                 logging_guard.defuse();
                 Ok(Some(response))
@@ -1482,9 +1480,10 @@ impl PeekClient {
                     )
                 });
 
-                // End-of-execution logging stays owned here: `implement_copy_to`
-                // logs nothing, and the final response (success or error) comes
-                // back through this command and is logged by the caller.
+                // We keep ownership of end-of-execution logging:
+                // `implement_copy_to` logs nothing, and the final response,
+                // success or error, comes back through this command and is
+                // logged by the caller.
                 let response = self
                     .call_coordinator(|tx| Command::ExecuteCopyTo {
                         df_desc: Box::new(df_desc),

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -218,8 +218,16 @@ impl PeekClient {
         // emitting; non-streaming arms emit via `log_ended_execution`.
         logging_guard.defuse();
 
+        let mut end_already_logged = false;
         let result = self
-            .try_frontend_peek_inner(session, catalog, stmt, params, statement_logging_id)
+            .try_frontend_peek_inner(
+                session,
+                catalog,
+                stmt,
+                params,
+                statement_logging_id,
+                &mut end_already_logged,
+            )
             .await;
 
         // Log the end of execution if we are logging this statement and
@@ -268,6 +276,12 @@ impl PeekClient {
                 // can adjust the `From` impl to do exactly what we need here,
                 // so the special cases above won't be needed.
                 Ok(Some(resp)) => resp.into(),
+                // A concurrent teardown (e.g. a `DROP CLUSTER`) already retired
+                // and logged the end of this peek on the coordinator; logging
+                // again would double-end and panic in `end_statement_execution`.
+                Err(_) if end_already_logged => {
+                    return result;
+                }
                 Err(e) => StatementEndedExecutionReason::Errored {
                     error: e.to_string(),
                 },
@@ -288,6 +302,7 @@ impl PeekClient {
         stmt: Option<Arc<Statement<Raw>>>,
         params: Params,
         statement_logging_id: Option<crate::statement_logging::StatementLoggingId>,
+        end_already_logged: &mut bool,
     ) -> Result<Option<ExecuteResponse>, AdapterError> {
         let stmt = match stmt {
             Some(stmt) => stmt,
@@ -1340,6 +1355,7 @@ impl PeekClient {
                             session.conn_id().clone(),
                             source_ids,
                             watch_set,
+                            end_already_logged,
                         )
                         .await?
                     }

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -245,9 +245,8 @@ impl PeekClient {
                             .to_string(),
                     }
                 }
-                // Success responses use the `From` implementation. Streaming
-                // responses cannot reach this arm: their dispatch sites hand
-                // off the guard, and the `From` impl panics on them.
+                // Streaming responses cannot reach this arm: their dispatch
+                // sites hand off the guard. The `From` impl panics on them.
                 Ok(Some(resp)) => resp.into(),
                 Err(e) => StatementEndedExecutionReason::Errored {
                     error: e.to_string(),

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -225,11 +225,11 @@ impl PeekClient {
     /// into the Controller to acquire a hold on the peek target after we create the dataflow.
     ///
     /// `logging_guard` owns end-of-execution logging for this statement. For a
-    /// constant peek it stays armed (the caller logs the end from the returned
-    /// result). For a `PeekExisting`/`PeekPersist` peek, successfully
-    /// registering the peek with the coordinator hands ownership to the
-    /// coordinator's `pending_peeks` entry — including for a `client.peek()`
-    /// that subsequently fails to issue — and the guard is defused here.
+    /// constant peek it stays armed and the caller logs the end from the
+    /// returned result. For a `PeekExisting`/`PeekPersist` peek, successful
+    /// registration with the coordinator hands ownership of the end to the
+    /// coordinator and the guard is defused here. That holds even when the
+    /// subsequent `client.peek()` fails to issue.
     pub(crate) async fn implement_fast_path_peek_plan(
         &mut self,
         fast_path: FastPathPlan,
@@ -379,11 +379,11 @@ impl PeekClient {
         })
         .await?;
 
-        // The peek is registered: ownership of end-of-execution logging has
-        // passed to the coordinator's `pending_peeks` entry, which logs the
-        // end on peek completion, cancellation, concurrent teardown (e.g. a
-        // `DROP CLUSTER`), or the unregistration below. Hand off the guard so
-        // the end is not also logged from the frontend.
+        // The peek is registered: the coordinator's `pending_peeks` entry now
+        // owns end-of-execution logging. It logs the end on peek completion,
+        // cancellation, concurrent teardown (e.g. a DROP CLUSTER), or the
+        // unregistration below. We defuse the guard so the frontend doesn't
+        // also log the end.
         logging_guard.defuse();
 
         // Test-only synchronization point. The peek is now registered with the
@@ -418,11 +418,10 @@ impl PeekClient {
                 compute_instance,
             );
             // The peek failed to issue, so no peek response will ever arrive.
-            // The coordinator owns end-of-execution logging (see above), so
+            // The coordinator owns end-of-execution logging (see above), so we
             // ask it to unregister the peek and retire it with this error. If
-            // a concurrent teardown (e.g. a `DROP CLUSTER`) already retired
-            // the peek, its end has already been logged and the unregistration
-            // is a no-op.
+            // a concurrent teardown already retired the peek, the end is
+            // already logged and the unregistration is a no-op.
             self.call_coordinator(|tx| Command::UnregisterFrontendPeek {
                 uuid,
                 reason: statement_logging::StatementEndedExecutionReason::Errored {
@@ -577,9 +576,9 @@ impl PeekClient {
 
     /// Emit a `FrontendStatementLoggingEvent::EndedExecution` for the given
     /// logging id. Used by the few callers that hold a bare
-    /// [`StatementLoggingId`] rather than a [`StatementLoggingGuard`] — e.g.
-    /// error paths of the EXECUTE unrolling, where the id has not yet been (or
-    /// could not be) wrapped in a guard.
+    /// [`StatementLoggingId`] rather than a [`StatementLoggingGuard`], e.g.
+    /// error paths of the EXECUTE unrolling where the id is not wrapped in a
+    /// guard.
     pub(crate) fn log_ended_execution(
         &self,
         id: StatementLoggingId,

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -386,14 +386,10 @@ impl PeekClient {
         // also log the end.
         logging_guard.defuse();
 
-        // Test-only synchronization point. The peek is now registered with the
-        // coordinator but not yet issued; a `pause` failpoint here lets a test
-        // deterministically land a concurrent `DROP CLUSTER` in this window, so
-        // the coordinator retires (and logs the end of) this peek before
-        // `client.peek()` below fails. See the
-        // `workflow_test_drop_cluster_during_registered_peeks_fast_path` test.
-        // Negligible cost when not configured (a registry lookup miss), which
-        // is the only case outside of tests.
+        // Test-only synchronization point: parks a peek between registration
+        // and issue, so a test can land a concurrent DROP CLUSTER in this
+        // window. Used by
+        // workflow_test_drop_cluster_during_registered_peeks_fast_path.
         fail::fail_point!("peek_after_register_before_issue");
 
         let finishing_for_instance = finishing.clone();
@@ -635,9 +631,7 @@ impl StatementLoggingGuard {
 
     /// Hands off logging responsibility without emitting an end-execution
     /// event. Call this at the point where another component takes over
-    /// end-of-execution logging: once a peek is registered with the
-    /// coordinator, or once the coordinator has installed a slow-path peek or
-    /// subscribe. Afterwards the guard is inert.
+    /// end-of-execution logging. Afterwards the guard is inert.
     pub(crate) fn defuse(&mut self) {
         self.id = None;
     }

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -223,6 +223,11 @@ impl PeekClient {
     /// Note: `input_read_holds` has holds for all inputs. For fast-path peeks, this includes the
     /// peek target. For slow-path peeks (to be implemented later), we'll need to additionally call
     /// into the Controller to acquire a hold on the peek target after we create the dataflow.
+    ///
+    /// `end_already_logged` is an out-parameter. It is set to `true` if the peek
+    /// failed to issue *and* a concurrent teardown (e.g. a `DROP CLUSTER`) had
+    /// already retired the statement on the coordinator, which logged the end of
+    /// execution. The caller uses this to avoid logging the end a second time.
     pub async fn implement_fast_path_peek_plan(
         &mut self,
         fast_path: FastPathPlan,
@@ -240,6 +245,7 @@ impl PeekClient {
         conn_id: mz_adapter_types::connection::ConnectionId,
         depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
         watch_set: Option<WatchSetCreation>,
+        end_already_logged: &mut bool,
     ) -> Result<crate::ExecuteResponse, AdapterError> {
         // If the dataflow optimizes to a constant expression, we can immediately return the result.
         if let FastPathPlan::Constant(rows_res, _) = fast_path {
@@ -371,6 +377,16 @@ impl PeekClient {
         })
         .await?;
 
+        // Test-only synchronization point. The peek is now registered with the
+        // coordinator but not yet issued; a `pause` failpoint here lets a test
+        // deterministically land a concurrent `DROP CLUSTER` in this window, so
+        // the coordinator retires (and logs the end of) this peek before
+        // `client.peek()` below fails. See the
+        // `workflow_test_drop_cluster_during_registered_peeks_fast_path` test.
+        // Negligible cost when not configured (a registry lookup miss), which
+        // is the only case outside of tests.
+        fail::fail_point!("peek_after_register_before_issue");
+
         let finishing_for_instance = finishing.clone();
         let peek_result = client
             .peek(
@@ -389,9 +405,16 @@ impl PeekClient {
 
         if let Err(err) = peek_result {
             // Clean up the registered peek since the peek failed to issue.
-            // The frontend will handle statement logging for the error.
-            self.call_coordinator(|tx| Command::UnregisterFrontendPeek { uuid, tx })
+            let still_registered = self
+                .call_coordinator(|tx| Command::UnregisterFrontendPeek { uuid, tx })
                 .await;
+            // If the peek was no longer registered, then a concurrent teardown
+            // (e.g. a `DROP CLUSTER`) already removed and retired it, which
+            // logged the end of execution. Signal this to the caller so it
+            // doesn't log the end a second time (which would double-end and
+            // panic in `end_statement_execution`). Otherwise, the frontend will
+            // log the error end itself.
+            *end_already_logged = !still_registered;
             return Err(
                 AdapterError::concurrent_dependency_drop_from_instance_peek_error(
                     err,

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -224,11 +224,13 @@ impl PeekClient {
     /// peek target. For slow-path peeks (to be implemented later), we'll need to additionally call
     /// into the Controller to acquire a hold on the peek target after we create the dataflow.
     ///
-    /// `end_already_logged` is an out-parameter. It is set to `true` if the peek
-    /// failed to issue *and* a concurrent teardown (e.g. a `DROP CLUSTER`) had
-    /// already retired the statement on the coordinator, which logged the end of
-    /// execution. The caller uses this to avoid logging the end a second time.
-    pub async fn implement_fast_path_peek_plan(
+    /// `logging_guard` owns end-of-execution logging for this statement. For a
+    /// constant peek it stays armed (the caller logs the end from the returned
+    /// result). For a `PeekExisting`/`PeekPersist` peek, successfully
+    /// registering the peek with the coordinator hands ownership to the
+    /// coordinator's `pending_peeks` entry — including for a `client.peek()`
+    /// that subsequently fails to issue — and the guard is defused here.
+    pub(crate) async fn implement_fast_path_peek_plan(
         &mut self,
         fast_path: FastPathPlan,
         timestamp: Timestamp,
@@ -245,7 +247,7 @@ impl PeekClient {
         conn_id: mz_adapter_types::connection::ConnectionId,
         depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
         watch_set: Option<WatchSetCreation>,
-        end_already_logged: &mut bool,
+        logging_guard: &mut StatementLoggingGuard,
     ) -> Result<crate::ExecuteResponse, AdapterError> {
         // If the dataflow optimizes to a constant expression, we can immediately return the result.
         if let FastPathPlan::Constant(rows_res, _) = fast_path {
@@ -377,6 +379,13 @@ impl PeekClient {
         })
         .await?;
 
+        // The peek is registered: ownership of end-of-execution logging has
+        // passed to the coordinator's `pending_peeks` entry, which logs the
+        // end on peek completion, cancellation, concurrent teardown (e.g. a
+        // `DROP CLUSTER`), or the unregistration below. Hand off the guard so
+        // the end is not also logged from the frontend.
+        logging_guard.defuse();
+
         // Test-only synchronization point. The peek is now registered with the
         // coordinator but not yet issued; a `pause` failpoint here lets a test
         // deterministically land a concurrent `DROP CLUSTER` in this window, so
@@ -404,23 +413,25 @@ impl PeekClient {
             .await;
 
         if let Err(err) = peek_result {
-            // Clean up the registered peek since the peek failed to issue.
-            let still_registered = self
-                .call_coordinator(|tx| Command::UnregisterFrontendPeek { uuid, tx })
-                .await;
-            // If the peek was no longer registered, then a concurrent teardown
-            // (e.g. a `DROP CLUSTER`) already removed and retired it, which
-            // logged the end of execution. Signal this to the caller so it
-            // doesn't log the end a second time (which would double-end and
-            // panic in `end_statement_execution`). Otherwise, the frontend will
-            // log the error end itself.
-            *end_already_logged = !still_registered;
-            return Err(
-                AdapterError::concurrent_dependency_drop_from_instance_peek_error(
-                    err,
-                    compute_instance,
-                ),
+            let err = AdapterError::concurrent_dependency_drop_from_instance_peek_error(
+                err,
+                compute_instance,
             );
+            // The peek failed to issue, so no peek response will ever arrive.
+            // The coordinator owns end-of-execution logging (see above), so
+            // ask it to unregister the peek and retire it with this error. If
+            // a concurrent teardown (e.g. a `DROP CLUSTER`) already retired
+            // the peek, its end has already been logged and the unregistration
+            // is a no-op.
+            self.call_coordinator(|tx| Command::UnregisterFrontendPeek {
+                uuid,
+                reason: statement_logging::StatementEndedExecutionReason::Errored {
+                    error: err.to_string(),
+                },
+                tx,
+            })
+            .await;
+            return Err(err);
         }
 
         let peek_response_stream = Coordinator::create_peek_response_stream(
@@ -447,11 +458,12 @@ impl PeekClient {
     /// entry. If `outer_ctx_extra` is `Some` (e.g. EXECUTE/FETCH), reuses and
     /// retires the existing logging context.
     ///
-    /// Returns a [`StatementLoggingGuard`]. Callers must
-    /// [`defuse`](StatementLoggingGuard::defuse) the guard when handing off
-    /// logging responsibility (or, in future, retire it explicitly on a
-    /// terminal outcome). Dropping the guard without retiring it emits an
-    /// `Aborted` end-execution event.
+    /// Returns a [`StatementLoggingGuard`]. Callers must either
+    /// [`retire`](StatementLoggingGuard::retire) the guard on the execution's
+    /// terminal outcome, or [`defuse`](StatementLoggingGuard::defuse) it at
+    /// the point where end-of-execution logging is handed off to another
+    /// component. Dropping the guard without retiring it emits an `Aborted`
+    /// end-execution event.
     pub(crate) fn begin_statement_logging(
         &self,
         session: &mut Session,
@@ -564,9 +576,10 @@ impl PeekClient {
     }
 
     /// Emit a `FrontendStatementLoggingEvent::EndedExecution` for the given
-    /// logging id. Used by callers that manage the statement-logging
-    /// lifecycle explicitly (see `try_frontend_peek`), rather than via the
-    /// RAII [`StatementLoggingGuard`].
+    /// logging id. Used by the few callers that hold a bare
+    /// [`StatementLoggingId`] rather than a [`StatementLoggingGuard`] — e.g.
+    /// error paths of the EXECUTE unrolling, where the id has not yet been (or
+    /// could not be) wrapped in a guard.
     pub(crate) fn log_ended_execution(
         &self,
         id: StatementLoggingId,
@@ -615,10 +628,18 @@ impl StatementLoggingGuard {
         self.id
     }
 
+    /// Retires the guard with an explicit end-execution reason.
+    /// A no-op if the guard was defused or the statement is not sampled.
+    pub(crate) fn retire(mut self, reason: statement_logging::StatementEndedExecutionReason) {
+        self.emit(reason);
+    }
+
     /// Hands off logging responsibility without emitting an end-execution
-    /// event. Use when another component (e.g. the coordinator, for streaming
-    /// peek / subscribe responses) will log the end asynchronously.
-    pub(crate) fn defuse(mut self) {
+    /// event. Call this at the point where another component takes over
+    /// end-of-execution logging: once a peek is registered with the
+    /// coordinator, or once the coordinator has installed a slow-path peek or
+    /// subscribe. Afterwards the guard is inert.
+    pub(crate) fn defuse(&mut self) {
         self.id = None;
     }
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4293,6 +4293,135 @@ def workflow_test_drop_cluster_during_peeks(c: Composition) -> None:
             assert cur.fetchone() == (1,)
 
 
+def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
+    """Race registered *slow-path* peeks against DROP/CREATE of their target
+    cluster; environmentd must not panic with a statement-logging begin/end
+    mismatch in `end_statement_execution`.
+
+    Unlike `workflow_test_drop_cluster_during_peeks`, which runs `SELECT 1` (a
+    *constant* fast path that is handled inline and never registered with the
+    coordinator), this reads a real table with no usable index, so the optimizer
+    produces a `standard` slow-path dataflow peek (`ExecuteSlowPathPeek`) that
+    registers a pending peek with the coordinator. When a concurrent
+    `DROP CLUSTER` makes the peek fail, `implement_peek_plan` returns an error
+    before taking ownership of its `ExecuteContextExtra`, so the throwaway
+    `ExecuteContextGuard` auto-emits an `Aborted` end (the coordinator's end of
+    the statement) while the frontend *also* ends it via `log_ended_execution`.
+    That double `end_statement_execution` panics with "matched
+    `begin_statement_execution` and `end_statement_execution` invocations". The
+    fix defuses the guard on error.
+
+    The narrow fast-path variant of this race (a `PeekExisting` peek retired by
+    the teardown in the window between `RegisterFrontendPeek` and `client.peek()`)
+    is too timing-sensitive to hit by brute force; it is covered deterministically
+    by `workflow_test_drop_cluster_during_registered_peeks_fast_path`.
+
+    The race window is narrow, so we hammer several clusters in parallel — each
+    churned by its own thread, to get the DROP rate past the CREATE-CLUSTER
+    provisioning bottleneck — with many peekers each.
+    """
+
+    num_clusters = 4
+    peekers_per_cluster = 8
+    duration_s = 60
+
+    with c.override(Materialized()):
+        c.up("materialized")
+
+        c.sql(
+            """
+            ALTER SYSTEM SET statement_logging_max_sample_rate = 1.0;
+            ALTER SYSTEM SET statement_logging_default_sample_rate = 1.0;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        c.sql("CREATE TABLE t (a int); INSERT INTO t SELECT generate_series(1, 10);")
+        for i in range(num_clusters):
+            c.sql(f"CREATE CLUSTER victim{i} SIZE 'scale=1,workers=1'")
+
+        stop = [False]
+
+        def make_peek_loop(cluster: str) -> Callable[[], None]:
+            def peek_loop() -> None:
+                while not stop[0]:
+                    try:
+                        with c.sql_cursor() as cur:
+                            cur.execute("SET auto_route_catalog_queries = false")
+                            # `.encode()`: psycopg types `execute`'s query as
+                            # `LiteralString`; an f-string with a runtime value is
+                            # a plain `str`, and passing `bytes` sidesteps that.
+                            cur.execute(f"SET cluster = {cluster}".encode())
+                            while not stop[0]:
+                                # A bare table scan with no usable index: a
+                                # registered `standard` slow-path peek (not an
+                                # inlined constant), dispatched on cluster
+                                # `{cluster}`.
+                                cur.execute("SELECT * FROM t")
+                                cur.fetchall()
+                    except Exception:
+                        # The target cluster vanishing out from under us is the
+                        # whole point; once environmentd is down `c.sql_cursor()`
+                        # raises a `UIError` rather than a `DatabaseError`, so
+                        # catch broadly (these are chaos threads — the real
+                        # signal is whether environmentd survived, asserted below).
+                        time.sleep(0.05)
+
+            return peek_loop
+
+        def make_churn_loop(cluster: str) -> Callable[[], None]:
+            def churn_loop() -> None:
+                while not stop[0]:
+                    try:
+                        with c.sql_cursor() as cur:
+                            cur.execute(
+                                f"DROP CLUSTER IF EXISTS {cluster} CASCADE".encode()
+                            )
+                            cur.execute(
+                                f"CREATE CLUSTER {cluster} SIZE 'scale=1,workers=1'".encode()
+                            )
+                    except Exception:
+                        # The target cluster vanishing out from under us is the
+                        # whole point; once environmentd is down `c.sql_cursor()`
+                        # raises a `UIError` rather than a `DatabaseError`, so
+                        # catch broadly (these are chaos threads — the real
+                        # signal is whether environmentd survived, asserted below).
+                        time.sleep(0.05)
+
+            return churn_loop
+
+        threads = []
+        for i in range(num_clusters):
+            cluster = f"victim{i}"
+            threads.append(
+                PropagatingThread(target=make_churn_loop(cluster), name=f"churn-{i}")
+            )
+            for j in range(peekers_per_cluster):
+                threads.append(
+                    PropagatingThread(
+                        target=make_peek_loop(cluster), name=f"peek-{i}-{j}"
+                    )
+                )
+        for t in threads:
+            t.start()
+
+        try:
+            time.sleep(duration_s)
+        finally:
+            stop[0] = True
+            for t in threads:
+                t.join(timeout=30)
+
+        # The whole point: if the double-end bug is present, the coordinator
+        # thread panics during the race, which aborts the entire environmentd
+        # process (src/ore/src/panic.rs). With no restart policy the container
+        # then stays down, so this fresh connection raises. (An unrelated clusterd
+        # crash propagates to environmentd too, and is also worth failing on.)
+        with c.sql_cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone() == (1,)
+
+
 def workflow_test_refresh_mv_warmup(
     c: Composition, parser: WorkflowArgumentParser
 ) -> None:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4295,8 +4295,8 @@ def workflow_test_drop_cluster_during_peeks(c: Composition) -> None:
 
 def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
     """Race registered *slow-path* peeks against DROP/CREATE of their target
-    cluster; environmentd must not panic with a statement-logging begin/end
-    mismatch in `end_statement_execution`.
+    cluster; environmentd must survive. (It historically panicked on a
+    statement-logging begin/end mismatch in `end_statement_execution`.)
 
     Unlike `workflow_test_drop_cluster_during_peeks`, which runs `SELECT 1` (a
     *constant* fast path that is handled inline and never registered with the
@@ -4304,12 +4304,12 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
     produces a `standard` slow-path dataflow peek (`ExecuteSlowPathPeek`) that
     registers a pending peek with the coordinator. When a concurrent
     `DROP CLUSTER` makes the peek fail, `implement_peek_plan` returns an error
-    before taking ownership of its `ExecuteContextExtra`, so the throwaway
-    `ExecuteContextGuard` auto-emits an `Aborted` end (the coordinator's end of
-    the statement) while the frontend *also* ends it via `log_ended_execution`.
-    That double `end_statement_execution` panics with "matched
-    `begin_statement_execution` and `end_statement_execution` invocations". The
-    fix defuses the guard on error.
+    before taking ownership of its `ExecuteContextExtra`. The frontend owns
+    end-of-execution logging on the error path, so the `ExecuteSlowPathPeek`
+    handler must defuse its throwaway `ExecuteContextGuard`; letting the
+    guard's `Drop` emit a spurious `Aborted` end on top of the frontend's
+    `Errored` end is the double end that historically panicked and aborted
+    environmentd (it is now also dropped at the sink, with a warning).
 
     The narrow fast-path variant of this race (a `PeekExisting` peek retired by
     the teardown in the window between `RegisterFrontendPeek` and `client.peek()`)
@@ -4412,38 +4412,51 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
             for t in threads:
                 t.join(timeout=30)
 
-        # The whole point: if the double-end bug is present, the coordinator
-        # thread panics during the race, which aborts the entire environmentd
-        # process (src/ore/src/panic.rs). With no restart policy the container
-        # then stays down, so this fresh connection raises. (An unrelated clusterd
-        # crash propagates to environmentd too, and is also worth failing on.)
+        # A panic on the coordinator thread during the race aborts the entire
+        # environmentd process (src/ore/src/panic.rs). With no restart policy
+        # the container then stays down, so this fresh connection raises. (An
+        # unrelated clusterd crash propagates to environmentd too, and is also
+        # worth failing on.)
         with c.sql_cursor() as cur:
             cur.execute("SELECT 1")
             assert cur.fetchone() == (1,)
+
+        # All the raced statements must have been ended exactly once; a
+        # duplicate end is dropped at the sink (so environmentd survives either
+        # way), but it means end-of-execution ownership was held by two parties
+        # at once and the handoff protocol regressed.
+        logs = c.invoke("logs", "materialized", capture=True)
+        assert (
+            "duplicate end_statement_execution" not in logs.stdout
+        ), "statement execution was ended twice; end-of-execution ownership handoff regressed"
 
 
 def workflow_test_drop_cluster_during_registered_peeks_fast_path(
     c: Composition,
 ) -> None:
-    """Deterministically reproduce the *fast-path* variant of the registered-peek
-    double-end (see `workflow_test_drop_cluster_during_registered_peeks` for the
-    slow-path variant and the shared symptom).
+    """Deterministically exercise the *fast-path* variant of the registered-peek
+    teardown race (see `workflow_test_drop_cluster_during_registered_peeks` for
+    the slow-path variant).
 
     A `PeekExisting` fast-path peek registers with the coordinator
-    (`RegisterFrontendPeek`) and only *then* issues `client.peek()`. If a
-    `DROP CLUSTER` lands in that window, the coordinator retires the pending peek
-    (logging its end) while `client.peek()` fails and the frontend ends the
-    statement too — a double `end_statement_execution` that panics with "matched
-    `begin_statement_execution` and `end_statement_execution` invocations".
+    (`RegisterFrontendPeek`) and only *then* issues `client.peek()`. Successful
+    registration hands ownership of end-of-execution logging to the
+    coordinator. If a `DROP CLUSTER` lands in the registration/issue window,
+    the coordinator's teardown retires the pending peek and logs its end, while
+    `client.peek()` fails on the frontend; the frontend's subsequent
+    `UnregisterFrontendPeek` finds the peek already retired and must be a
+    no-op. (Historically the frontend ended the statement itself here, a
+    double `end_statement_execution` that panicked and aborted environmentd.)
 
     That window is a sub-millisecond cross-thread gap, hopeless to hit by brute
     force (unlike the slow-path variant, whose error window spans a whole
     `ExecuteSlowPathPeek` command). So we make it deterministic with the
     `peek_after_register_before_issue` failpoint: pause a peek right after it
-    registers, drop its cluster while it's parked (coordinator logs end #1), then
-    resume so `client.peek()` fails (frontend logs end #2). With the fix the
-    frontend learns the coordinator already ended the statement and stays silent;
-    without it, environmentd panics.
+    registers, drop its cluster while it's parked (the coordinator retires the
+    peek and logs its end), then resume so `client.peek()` fails. The test
+    asserts that environmentd survives *and* that the statement was not ended
+    twice (a duplicate end is dropped at the sink with a warning, which we
+    check the logs for).
     """
 
     failpoint = "peek_after_register_before_issue"
@@ -4503,11 +4516,11 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
             # `RegisterFrontendPeek`, not race a narrow window.
             time.sleep(5)
             # Drop the cluster while the peek is parked: the coordinator retires
-            # the pending peek and logs its end (#1).
+            # the pending peek and logs its end of execution.
             control.execute("DROP CLUSTER victim CASCADE")
             # Resume the peek: `client.peek()` now fails (cluster gone) and the
-            # frontend logs the end (#2). Without the fix this double-ends and
-            # panics the coordinator.
+            # frontend asks the coordinator to retire the already-retired peek,
+            # which must be a no-op.
             control.execute(f"SET failpoints = '{failpoint}=off'")
 
         peek_thread.join(timeout=30)
@@ -4519,12 +4532,21 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
             "error"
         ), f"expected the peek to fail on the dropped cluster, got: {peek_outcome[0]}"
 
-        # If the double-end bug is present, the coordinator thread panics, which
-        # aborts the entire environmentd process (src/ore/src/panic.rs). With no
-        # restart policy the container stays down, so this fresh connection raises.
+        # A panic on the coordinator thread aborts the entire environmentd
+        # process (src/ore/src/panic.rs). With no restart policy the container
+        # stays down, so this fresh connection raises.
         with c.sql_cursor() as cur:
             cur.execute("SELECT 1")
             assert cur.fetchone() == (1,)
+
+        # The race must have been single-ended: registration handed
+        # end-of-execution ownership to the coordinator, whose teardown logged
+        # the only end. A duplicate end is dropped at the sink (so environmentd
+        # survives either way), but it means the ownership handoff regressed.
+        logs = c.invoke("logs", "materialized", capture=True)
+        assert (
+            "duplicate end_statement_execution" not in logs.stdout
+        ), "statement execution was ended twice; end-of-execution ownership handoff regressed"
 
 
 def workflow_test_refresh_mv_warmup(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -23,7 +23,7 @@ from copy import copy
 from datetime import datetime, timedelta
 from statistics import quantiles
 from textwrap import dedent
-from threading import Thread
+from threading import Event, Thread
 
 import psycopg
 import requests
@@ -4417,6 +4417,111 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
         # process (src/ore/src/panic.rs). With no restart policy the container
         # then stays down, so this fresh connection raises. (An unrelated clusterd
         # crash propagates to environmentd too, and is also worth failing on.)
+        with c.sql_cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone() == (1,)
+
+
+def workflow_test_drop_cluster_during_registered_peeks_fast_path(
+    c: Composition,
+) -> None:
+    """Deterministically reproduce the *fast-path* variant of the registered-peek
+    double-end (see `workflow_test_drop_cluster_during_registered_peeks` for the
+    slow-path variant and the shared symptom).
+
+    A `PeekExisting` fast-path peek registers with the coordinator
+    (`RegisterFrontendPeek`) and only *then* issues `client.peek()`. If a
+    `DROP CLUSTER` lands in that window, the coordinator retires the pending peek
+    (logging its end) while `client.peek()` fails and the frontend ends the
+    statement too — a double `end_statement_execution` that panics with "matched
+    `begin_statement_execution` and `end_statement_execution` invocations".
+
+    That window is a sub-millisecond cross-thread gap, hopeless to hit by brute
+    force (unlike the slow-path variant, whose error window spans a whole
+    `ExecuteSlowPathPeek` command). So we make it deterministic with the
+    `peek_after_register_before_issue` failpoint: pause a peek right after it
+    registers, drop its cluster while it's parked (coordinator logs end #1), then
+    resume so `client.peek()` fails (frontend logs end #2). With the fix the
+    frontend learns the coordinator already ended the statement and stays silent;
+    without it, environmentd panics.
+    """
+
+    failpoint = "peek_after_register_before_issue"
+
+    with c.override(Materialized()):
+        c.up("materialized")
+
+        c.sql(
+            """
+            ALTER SYSTEM SET statement_logging_max_sample_rate = 1.0;
+            ALTER SYSTEM SET statement_logging_default_sample_rate = 1.0;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        c.sql("CREATE TABLE t (a int); INSERT INTO t SELECT generate_series(1, 10);")
+        c.sql("CREATE CLUSTER victim SIZE 'scale=1,workers=1'")
+        # The index makes `SELECT * FROM t` on `victim` a `PeekExisting` fast path
+        # (without it the bare scan would be a `standard` slow-path dataflow).
+        c.sql("CREATE INDEX victim_idx IN CLUSTER victim ON t (a)")
+
+        peeker_ready = Event()
+        failpoint_armed = Event()
+        peek_outcome: list[str] = []
+
+        def peeker() -> None:
+            try:
+                with c.sql_cursor() as cur:
+                    cur.execute("SET auto_route_catalog_queries = false")
+                    cur.execute("SET cluster = victim")
+                    # We connect and configure *before* the failpoint is armed so
+                    # that connection-setup peeks aren't caught by it.
+                    peeker_ready.set()
+                    failpoint_armed.wait()
+                    # `PeekExisting` fast path: this registers with the
+                    # coordinator and then parks at the failpoint before issuing
+                    # `client.peek()`. It fails once `victim` is dropped.
+                    cur.execute("SELECT * FROM t")
+                    cur.fetchall()
+                    peek_outcome.append("ok")
+            except Exception as e:
+                peek_outcome.append(f"error: {e}")
+
+        peek_thread = PropagatingThread(target=peeker, name="peeker")
+        peek_thread.start()
+
+        # Drive the race from a single control connection opened *before* the
+        # failpoint is armed — so its own connection-setup peeks don't park, which
+        # would otherwise deadlock it against the very failpoint it must turn off.
+        with c.sql_cursor() as control:
+            assert peeker_ready.wait(timeout=30), "peeker failed to connect"
+            # Arm: every fast-path peek now parks right after registering.
+            control.execute(f"SET failpoints = '{failpoint}=pause'")
+            failpoint_armed.set()
+            # Give the peeker time to issue its SELECT and park. It stays parked
+            # until we turn the failpoint off, so this only has to outlast plan +
+            # `RegisterFrontendPeek`, not race a narrow window.
+            time.sleep(5)
+            # Drop the cluster while the peek is parked: the coordinator retires
+            # the pending peek and logs its end (#1).
+            control.execute("DROP CLUSTER victim CASCADE")
+            # Resume the peek: `client.peek()` now fails (cluster gone) and the
+            # frontend logs the end (#2). Without the fix this double-ends and
+            # panics the coordinator.
+            control.execute(f"SET failpoints = '{failpoint}=off'")
+
+        peek_thread.join(timeout=30)
+
+        # The parked peek must actually have failed on the dropped cluster;
+        # otherwise the race didn't happen and the test is silently vacuous.
+        assert peek_outcome, "peeker thread did not finish"
+        assert peek_outcome[0].startswith(
+            "error"
+        ), f"expected the peek to fail on the dropped cluster, got: {peek_outcome[0]}"
+
+        # If the double-end bug is present, the coordinator thread panics, which
+        # aborts the entire environmentd process (src/ore/src/panic.rs). With no
+        # restart policy the container stays down, so this fresh connection raises.
         with c.sql_cursor() as cur:
             cur.execute("SELECT 1")
             assert cur.fetchone() == (1,)

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4421,10 +4421,10 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
             cur.execute("SELECT 1")
             assert cur.fetchone() == (1,)
 
-        # All the raced statements must have been ended exactly once; a
-        # duplicate end is dropped at the sink (so environmentd survives either
-        # way), but it means end-of-execution ownership was held by two parties
-        # at once and the handoff protocol regressed.
+        # All the raced statements must have been ended exactly once. A
+        # duplicate end is dropped at the sink, so environmentd survives it,
+        # but it means end-of-execution ownership was held by two parties at
+        # once and the handoff protocol regressed.
         logs = c.invoke("logs", "materialized", capture=True)
         assert (
             "duplicate end_statement_execution" not in logs.stdout
@@ -4541,8 +4541,8 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
 
         # The race must have been single-ended: registration handed
         # end-of-execution ownership to the coordinator, whose teardown logged
-        # the only end. A duplicate end is dropped at the sink (so environmentd
-        # survives either way), but it means the ownership handoff regressed.
+        # the only end. A duplicate end is dropped at the sink, so environmentd
+        # survives it, but it means the ownership handoff regressed.
         logs = c.invoke("logs", "materialized", capture=True)
         assert (
             "duplicate end_statement_execution" not in logs.stdout

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4295,30 +4295,25 @@ def workflow_test_drop_cluster_during_peeks(c: Composition) -> None:
 
 def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
     """Race registered *slow-path* peeks against DROP/CREATE of their target
-    cluster; environmentd must survive. (It historically panicked on a
-    statement-logging begin/end mismatch in `end_statement_execution`.)
+    cluster; environmentd must survive and every statement must be ended
+    exactly once.
 
-    Unlike `workflow_test_drop_cluster_during_peeks`, which runs `SELECT 1` (a
-    *constant* fast path that is handled inline and never registered with the
-    coordinator), this reads a real table with no usable index, so the optimizer
-    produces a `standard` slow-path dataflow peek (`ExecuteSlowPathPeek`) that
-    registers a pending peek with the coordinator. When a concurrent
-    `DROP CLUSTER` makes the peek fail, `implement_peek_plan` returns an error
-    before taking ownership of its `ExecuteContextExtra`. The frontend owns
-    end-of-execution logging on the error path, so the `ExecuteSlowPathPeek`
-    handler must defuse its throwaway `ExecuteContextGuard`; letting the
-    guard's `Drop` emit a spurious `Aborted` end on top of the frontend's
-    `Errored` end is the double end that historically panicked and aborted
-    environmentd (it is now also dropped at the sink, with a warning).
+    A bare scan of a table with no usable index becomes a `standard` slow-path
+    peek (`ExecuteSlowPathPeek`) registered with the coordinator; a constant
+    query like `SELECT 1` (exercised by `workflow_test_drop_cluster_during_peeks`)
+    is handled inline and never registered. When a concurrent `DROP CLUSTER`
+    makes the peek fail, the frontend owns the error end of statement logging
+    and the coordinator must defuse its own guard instead of emitting
+    `Aborted`. Two ends for one statement historically panicked and aborted
+    environmentd; today the duplicate is dropped at the sink with the warning
+    we assert on below.
 
-    The narrow fast-path variant of this race (a `PeekExisting` peek retired by
-    the teardown in the window between `RegisterFrontendPeek` and `client.peek()`)
-    is too timing-sensitive to hit by brute force; it is covered deterministically
-    by `workflow_test_drop_cluster_during_registered_peeks_fast_path`.
-
-    The race window is narrow, so we hammer several clusters in parallel — each
-    churned by its own thread, to get the DROP rate past the CREATE-CLUSTER
-    provisioning bottleneck — with many peekers each.
+    The fast-path variant of this race has a sub-millisecond window that brute
+    force can't hit;
+    `workflow_test_drop_cluster_during_registered_peeks_fast_path` covers it
+    deterministically. Here we hammer several clusters in parallel, each
+    churned by its own thread to get the DROP rate past the CREATE-CLUSTER
+    provisioning bottleneck, with many peekers each.
     """
 
     num_clusters = 4
@@ -4353,18 +4348,14 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
                             # a plain `str`, and passing `bytes` sidesteps that.
                             cur.execute(f"SET cluster = {cluster}".encode())
                             while not stop[0]:
-                                # A bare table scan with no usable index: a
-                                # registered `standard` slow-path peek (not an
-                                # inlined constant), dispatched on cluster
-                                # `{cluster}`.
+                                # Bare table scan, no usable index: a
+                                # registered slow-path peek (see docstring).
                                 cur.execute("SELECT * FROM t")
                                 cur.fetchall()
                     except Exception:
-                        # The target cluster vanishing out from under us is the
-                        # whole point; once environmentd is down `c.sql_cursor()`
-                        # raises a `UIError` rather than a `DatabaseError`, so
-                        # catch broadly (these are chaos threads — the real
-                        # signal is whether environmentd survived, asserted below).
+                        # Chaos thread; failures are the point. Catch broadly:
+                        # a downed environmentd raises UIError, not
+                        # DatabaseError. The real signal is asserted below.
                         time.sleep(0.05)
 
             return peek_loop
@@ -4381,11 +4372,9 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
                                 f"CREATE CLUSTER {cluster} SIZE 'scale=1,workers=1'".encode()
                             )
                     except Exception:
-                        # The target cluster vanishing out from under us is the
-                        # whole point; once environmentd is down `c.sql_cursor()`
-                        # raises a `UIError` rather than a `DatabaseError`, so
-                        # catch broadly (these are chaos threads — the real
-                        # signal is whether environmentd survived, asserted below).
+                        # Chaos thread; failures are the point. Catch broadly:
+                        # a downed environmentd raises UIError, not
+                        # DatabaseError. The real signal is asserted below.
                         time.sleep(0.05)
 
             return churn_loop
@@ -4412,19 +4401,16 @@ def workflow_test_drop_cluster_during_registered_peeks(c: Composition) -> None:
             for t in threads:
                 t.join(timeout=30)
 
-        # A panic on the coordinator thread during the race aborts the entire
-        # environmentd process (src/ore/src/panic.rs). With no restart policy
-        # the container then stays down, so this fresh connection raises. (An
-        # unrelated clusterd crash propagates to environmentd too, and is also
-        # worth failing on.)
+        # A panic on the coordinator thread aborts the entire environmentd
+        # process (src/ore/src/panic.rs); with no restart policy the container
+        # stays down and this fresh connection raises.
         with c.sql_cursor() as cur:
             cur.execute("SELECT 1")
             assert cur.fetchone() == (1,)
 
         # All the raced statements must have been ended exactly once. A
         # duplicate end is dropped at the sink, so environmentd survives it,
-        # but it means end-of-execution ownership was held by two parties at
-        # once and the handoff protocol regressed.
+        # but it means the end-of-execution ownership handoff regressed.
         logs = c.invoke("logs", "materialized", capture=True)
         assert (
             "duplicate end_statement_execution" not in logs.stdout
@@ -4435,28 +4421,22 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
     c: Composition,
 ) -> None:
     """Deterministically exercise the *fast-path* variant of the registered-peek
-    teardown race (see `workflow_test_drop_cluster_during_registered_peeks` for
-    the slow-path variant).
+    teardown race (slow-path variant:
+    `workflow_test_drop_cluster_during_registered_peeks`).
 
-    A `PeekExisting` fast-path peek registers with the coordinator
-    (`RegisterFrontendPeek`) and only *then* issues `client.peek()`. Successful
-    registration hands ownership of end-of-execution logging to the
-    coordinator. If a `DROP CLUSTER` lands in the registration/issue window,
-    the coordinator's teardown retires the pending peek and logs its end, while
-    `client.peek()` fails on the frontend; the frontend's subsequent
-    `UnregisterFrontendPeek` finds the peek already retired and must be a
-    no-op. (Historically the frontend ended the statement itself here, a
-    double `end_statement_execution` that panicked and aborted environmentd.)
+    A `PeekExisting` fast-path peek registers with the coordinator and only
+    *then* issues `client.peek()`; registration hands ownership of
+    end-of-execution logging to the coordinator. If a `DROP CLUSTER` lands in
+    that window, the teardown retires the pending peek and logs its end,
+    `client.peek()` fails, and the frontend's `UnregisterFrontendPeek` must be
+    a no-op. Historically the frontend ended the statement itself here, and
+    the double end panicked and aborted environmentd.
 
-    That window is a sub-millisecond cross-thread gap, hopeless to hit by brute
-    force (unlike the slow-path variant, whose error window spans a whole
-    `ExecuteSlowPathPeek` command). So we make it deterministic with the
-    `peek_after_register_before_issue` failpoint: pause a peek right after it
-    registers, drop its cluster while it's parked (the coordinator retires the
-    peek and logs its end), then resume so `client.peek()` fails. The test
-    asserts that environmentd survives *and* that the statement was not ended
-    twice (a duplicate end is dropped at the sink with a warning, which we
-    check the logs for).
+    The window is a sub-millisecond cross-thread gap, so we make it
+    deterministic with the `peek_after_register_before_issue` failpoint: pause
+    a peek right after it registers, drop its cluster while it's parked, then
+    resume so `client.peek()` fails. Assert that environmentd survives and
+    that no duplicate end was logged.
     """
 
     failpoint = "peek_after_register_before_issue"
@@ -4504,8 +4484,8 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
         peek_thread.start()
 
         # Drive the race from a single control connection opened *before* the
-        # failpoint is armed — so its own connection-setup peeks don't park, which
-        # would otherwise deadlock it against the very failpoint it must turn off.
+        # failpoint is armed, so its own connection-setup peeks don't park and
+        # deadlock it against the very failpoint it must turn off.
         with c.sql_cursor() as control:
             assert peeker_ready.wait(timeout=30), "peeker failed to connect"
             # Arm: every fast-path peek now parks right after registering.
@@ -4533,15 +4513,14 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
         ), f"expected the peek to fail on the dropped cluster, got: {peek_outcome[0]}"
 
         # A panic on the coordinator thread aborts the entire environmentd
-        # process (src/ore/src/panic.rs). With no restart policy the container
-        # stays down, so this fresh connection raises.
+        # process (src/ore/src/panic.rs); with no restart policy the container
+        # stays down and this fresh connection raises.
         with c.sql_cursor() as cur:
             cur.execute("SELECT 1")
             assert cur.fetchone() == (1,)
 
-        # The race must have been single-ended: registration handed
-        # end-of-execution ownership to the coordinator, whose teardown logged
-        # the only end. A duplicate end is dropped at the sink, so environmentd
+        # The race must have been single-ended: the teardown logged the only
+        # end. A duplicate would be dropped at the sink, so environmentd
         # survives it, but it means the ownership handoff regressed.
         logs = c.invoke("logs", "materialized", capture=True)
         assert (


### PR DESCRIPTION
### Motivation

Alternative proposal for the statement-logging double-end panics fixed in #36943, put up to gather comments on the approach. It includes both commits of #36943 (the slow-path guard defuse and the tests are kept as-is) and replaces the fast-path mechanism with a design that fixes the *class* of bug rather than the two known instances.

The underlying problem: end-of-execution logging must happen exactly once per begun statement, but the frontend peek sequencing duplicated the capability to end a statement — one copy registered with the coordinator, one retained by the frontend — and decided "who logs the end" by inspecting response shapes after the fact. Every teardown (`DROP CLUSTER`, cancellation) racing a dispatch produced a double end, and the sink turned that into a process abort. Each new frontend-sequenced statement type (subscribes, read-then-write, …) would re-grow these races, window by window.

### Description

Three changes, one commit on top of #36943:

- **Linear, one-way end ownership.** The frontend's `StatementLoggingGuard` owns end-of-execution logging and is threaded through `try_frontend_peek_inner`. Dispatch sites that hand a statement to the coordinator for asynchronous completion (`RegisterFrontendPeek` Ok, `ExecuteSlowPathPeek` Ok, `ExecuteSubscribe` Ok) `defuse` the guard at the point of handoff; after that the frontend never logs the end, even on error. The response-shape matching in `try_frontend_peek` and the `end_already_logged` out-param from #36943 disappear; a still-armed guard at the end is simply retired with the result.
- **`UnregisterFrontendPeek` carries the end reason.** When `client.peek()` fails after registration, the coordinator (as owner) retires the peek with the frontend's error; if a concurrent teardown already retired it, the unregistration is a no-op — the same idempotency the pending-peeks layer already uses everywhere else. The `still_registered` bool reply is gone.
- **`end_statement_execution` tolerates duplicate ends** (first end wins, with a warning) instead of panicking. Exactly-once handoff is unattainable under async cancellation — a frontend future can be dropped between the coordinator registering a peek and the frontend defusing its guard, leaving both sides owning the end — and statement logging is observability: it must never abort environmentd. A missing `executions_begun` entry can only mean a duplicate (begins and the dispatch commands travel the same command channel in FIFO order), so nothing real is masked.

Drive-by fixes that fell out of the model:
- Dropping the frontend future mid-sequencing (client disconnect) used to leak a forever-running entry in `mz_statement_execution_history` (the guard was defused up front); the armed guard now emits an `Aborted` end.
- `verify_portal` failure with an inherited EXECUTE logging id used to discard the id without ending the statement; it now logs an `Errored` end.
- The `ExecuteSubscribe` handler defuses its coordinator-side guard on error, matching the slow-path contract (no error paths currently exist there, but the contract is now uniform).

`doc/developer/guide-adapter.md` gains a section documenting the ownership model and why the sink is tolerant.

Telemetry semantics: in the raced scenarios the recorded reason is the first end to arrive (e.g. `Canceled` from the teardown rather than the frontend's `Errored`); both descriptions are truthful. A pre-existing oddity worth a follow-up: frontend-emitted ends ship an `ended_at` that the coordinator discards and recomputes.

### Verification

The two `test/cluster` workflows from #36943 are kept and extended: since a duplicate end no longer panics, they now also assert that the logs contain no `duplicate end_statement_execution` warning, which keeps them sharp as protocol-regression tests (the deterministic fast-path failpoint test exercises exactly the raced window). `cargo check`/`clippy`/`fmt` pass; the mzcompose workflows and a nightly run have not been re-run on this branch yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
