### PR TITLE
docs: draft enterprise SSO via Ory section DEP-139

### DIFF
--- a/doc/user/content/security/self-managed/sso-ory.md
+++ b/doc/user/content/security/self-managed/sso-ory.md
@@ -1,0 +1,128 @@
+---
+title: "Single sign-on via Ory"
+description: "User-facing reference for SSO into Self-Managed Materialize via the Ory stack."
+menu:
+  main:
+    parent: "authentication-sm"
+    name: "SSO via Ory"
+    identifier: "sso-ory-sm"
+    weight: 2
+---
+
+{{< public-preview />}}
+
+This page covers the SSO usage and configuration that's specific to the
+Ory-based deployment. If you're using the direct-OIDC path (Kratos not
+in the picture), see the [SSO](/security/self-managed/sso/) page
+instead.
+
+The Ory stack adds three capabilities on top of the direct-OIDC path:
+
+- **SAML SSO** via Polis, for IdPs that don't speak OIDC natively
+- **SCIM provisioning** via Polis, so users are pushed automatically
+  from your IdP into Polis (and onward into Materialize on first login)
+- **Federation across multiple IdPs** through a single proxy, so
+  Materialize sees one issuer regardless of which IdP the user came
+  from
+
+## How sign-in works
+
+When a user opens the Materialize console:
+
+1. The console redirects to Hydra (the OAuth2 / OIDC provider deployed
+   with the Ory stack).
+2. Hydra delegates login to the Kratos selfservice UI.
+3. The user sees the login screen with a button per configured upstream
+   provider (e.g. "Sign in with Okta", "Sign in via SAML").
+4. Clicking a button kicks off the federated flow:
+   - For an OIDC provider: Kratos bounces the user to the IdP's
+     authorization endpoint and back.
+   - For SAML via Polis: Kratos bounces to Polis, Polis bounces to the
+     SAML IdP, the IdP posts the SAML assertion back to Polis, Polis
+     issues an OIDC token to Kratos.
+5. Kratos creates a federated identity tied to the user's email on first
+   login (a Kratos record, not yet a Materialize SQL role).
+6. Kratos returns to Hydra, which issues an OAuth2 access token and
+   ID token to the console.
+7. The console attaches the token to its API calls into Materialize
+   (the SQL HTTP endpoint via balancerd, the operator API, etc.).
+8. Materialize validates the token against Hydra's JWKS, reads the
+   `email` claim, and either uses the existing SQL role of that name or
+   creates one if it doesn't exist (JIT role creation).
+
+The user is now logged in. The role has no privileges by default; an
+admin runs `GRANT` statements separately. See
+[Auto-provisioning roles](/security/self-managed/sso/#auto-provisioning-roles)
+for the JIT behaviour (it's identical to the direct-OIDC path).
+
+## Configuring authentication on the Materialize side
+
+The deployment example wires the OIDC system parameters automatically.
+For reference, what gets set:
+
+```hcl
+system_parameters = {
+  oidc_issuer               = "https://<your-hydra-hostname>"
+  oidc_audience             = jsonencode([<oauth2-client-id>])
+  oidc_authentication_claim = "email"
+  console_oidc_client_id    = <oauth2-client-id>
+  console_oidc_scopes       = "openid email"
+}
+```
+
+Where `<oauth2-client-id>` is the `client_id` Hydra Maester generates
+for the OAuth2Client CRD that the example creates.
+
+You can override:
+
+- `oidc_authentication_claim` if you want to use a different JWT claim
+  than `email` for the SQL role name. Most customers stick with `email`.
+- `console_oidc_scopes` if you want to request additional scopes from
+  the user during sign-in. The defaults (`openid email`) are the
+  minimum needed for the JIT role creation to work.
+
+Anything beyond this is handled by the deployment example. You don't
+need to manage these parameters by hand unless you're deviating from
+the example's default setup.
+
+## Configuring identity providers
+
+The IdP-side setup (creating OIDC clients, registering SAML connections
+in Polis, enabling SCIM) is covered in [Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/).
+
+## What the Ory stack does NOT change
+
+This part is identical to the direct-OIDC path; see the
+[SSO](/security/self-managed/sso/) page for the canonical docs on each:
+
+- How SQL clients connect using JWT tokens (`psql` with a token
+  password, the Materialize CLI, application connection strings)
+- How service accounts authenticate (the SQL password authentication
+  path and the OAuth2 Client Credentials flow)
+- How role privileges are managed (RBAC via `GRANT` and `REVOKE`, plus
+  pre-provisioning if needed)
+- How to retrieve a token from the Materialize console for SQL access
+
+## Limitations
+
+| Feature | Status |
+|---|---|
+| SAML SSO | Supported via Polis |
+| SCIM user provisioning | Supported via Polis |
+| SCIM group → SQL role mapping | Not supported. Groups push to Polis but don't translate to Materialize SQL grants. Admins still run `GRANT` manually. |
+| Automatic role deprovisioning | Partial. SCIM-driven IdP deactivation marks the user inactive in Polis, but the Materialize SQL role isn't dropped automatically. |
+| API key management for service accounts (beyond OAuth2 client_credentials) | Tracked as future work via Ory Talos. |
+| Multiple IdPs on a single Polis tenant | Supported but not documented end-to-end in the example. |
+
+## See also
+
+- [Deploying the Ory stack](/self-managed-deployments/enterprise-sso/) --
+  architecture and per-cloud install guides
+- [Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/) --
+  OIDC, SAML via Polis, SCIM
+- [Operations](/self-managed-deployments/enterprise-sso/operations/) --
+  day-2 tasks for the Ory stack
+- [SSO (direct OIDC)](/security/self-managed/sso/) -- the simpler path
+  when you don't need SAML, SCIM, or federation
+- [RBAC](/security/self-managed/access-control/) -- granting
+  privileges to SSO-authenticated users

--- a/doc/user/content/self-managed-deployments/enterprise-sso/_index.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/_index.md
@@ -1,0 +1,104 @@
+---
+title: "Enterprise SSO (Ory)"
+description: "Deploy Materialize Self-Managed with the Ory stack for SAML, SCIM, and federated SSO."
+disable_list: true
+menu:
+  main:
+    parent: "sm-deployments"
+    identifier: "enterprise-sso"
+    weight: 60
+---
+
+{{< public-preview />}}
+
+Self-Managed Materialize ships with a built-in OIDC authentication path
+documented at [SSO](/security/self-managed/sso/). For customers who need
+**SAML**, **SCIM provisioning**, or **federation through an IdP-agnostic
+proxy**, Materialize provides an additional Terraform-managed Ory stack
+that sits in front of the Materialize console and acts as the OIDC issuer.
+
+This section walks through deploying that stack, configuring it against
+your identity provider, and operating it day to day.
+
+## When to use the Ory-based stack
+
+| You need... | Use |
+|---|---|
+| OIDC against an OIDC-capable IdP (Okta OIDC, Google Workspace, Auth0 OIDC) | [Direct OIDC SSO](/security/self-managed/sso/) |
+| SAML against a SAML-only IdP (Entra SAML, ADFS, Auth0 SAML, Okta SAML) | Ory stack with Polis enabled |
+| SCIM provisioning from your IdP into Materialize | Ory stack with Polis enabled |
+| One IdP-agnostic SSO endpoint so you can swap IdPs without changing Materialize config | Ory stack |
+| API key management for service accounts beyond OAuth2 client credentials | Ory stack (future) |
+
+The Ory-based stack is a superset of the direct-OIDC path. If you start
+with direct OIDC and later need SAML or SCIM, you can migrate without
+rebuilding your Materialize deployment.
+
+## Architecture
+
+```
+Your IdP (Okta / Entra / Auth0 / ...)
+       |
+       |-- SAML auth + SCIM provisioning   (Polis path)
+       v
+   Polis (SAML-to-OIDC bridge, optional)
+       |-- OIDC
+       v
+   Kratos (identity management)
+       |
+       v
+   Selfservice UI  ----- consent flow -----> Hydra (OAuth2 / OIDC provider)
+                                              |
+                                              v
+                                       Materialize console
+                                       (validates Hydra JWTs)
+```
+
+| Component | Role |
+|---|---|
+| **Kratos** | Stores identities, runs the login flow, federates upstream OIDC providers |
+| **Hydra** | OAuth2 + OIDC authorization server that Materialize talks to; issues JWTs |
+| **Selfservice UI** | Renders login and consent pages, mediates between the browser and Kratos/Hydra |
+| **Polis** | Optional SAML-to-OIDC translator and SCIM endpoint for customers whose IdPs don't speak OIDC natively |
+| **Materialize** | The protected application; trusts Hydra's JWTs and JIT-creates SQL roles from the `email` claim |
+
+Each component is deployed and managed by the Terraform modules in
+[`materialize-terraform-self-managed`](https://github.com/MaterializeInc/materialize-terraform-self-managed).
+The composite `ory-stack` module wires them together and exposes the
+integration with your Materialize instance (OAuth2 client registration,
+network policies, console TLS).
+
+## What gets deployed
+
+When you apply one of the enterprise examples, Terraform stands up:
+
+- A Kubernetes cluster (AKS / GKE / EKS) sized for both Materialize and Ory
+- A Materialize Postgres instance (Cloud SQL / Flexible Server / RDS)
+- A separate Postgres instance (or set of databases on a shared instance,
+  depending on cloud) for Kratos, Hydra, and Polis
+- Object storage for Materialize's persistence backend
+- The Materialize operator and a Materialize instance CR
+- Kratos, Hydra, and the selfservice UI in the `ory` namespace
+- Optional: Polis in the same namespace, with its own TLS termination
+  proxy
+- cert-manager, with either a self-signed or BYO ClusterIssuer for the
+  browser-facing TLS certificates
+- Optional: Prometheus and Grafana for observability
+
+## Reading order
+
+If you're planning a deployment for the first time, work through these
+pages in order:
+
+1. **[Prerequisites](/self-managed-deployments/enterprise-sso/prerequisites/)** -- license key, DNS, cert-manager, Polis-specific requirements
+2. **Install on [Azure](/self-managed-deployments/enterprise-sso/install-on-azure/) / GCP / AWS** -- pick your cloud, walk through the example (GCP and AWS guides coming as those examples land)
+3. **[Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/)** -- direct OIDC, SAML via Polis, SCIM provisioning
+4. **[Operations](/self-managed-deployments/enterprise-sso/operations/)** -- day-2 tasks: rotating credentials, adding OAuth2 clients, managing identities
+5. **[Troubleshooting](/self-managed-deployments/enterprise-sso/troubleshooting/)** -- common errors and fixes
+
+## See also
+
+- [SSO (direct OIDC)](/security/self-managed/sso/) -- the simpler path
+  when your IdP speaks OIDC
+- [Ory documentation](https://www.ory.sh/docs/) -- upstream component
+  reference

--- a/doc/user/content/self-managed-deployments/enterprise-sso/_index.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/_index.md
@@ -91,7 +91,7 @@ If you're planning a deployment for the first time, work through these
 pages in order:
 
 1. **[Prerequisites](/self-managed-deployments/enterprise-sso/prerequisites/)** -- license key, DNS, cert-manager, Polis-specific requirements
-2. **Install on [Azure](/self-managed-deployments/enterprise-sso/install-on-azure/) / GCP / AWS** -- pick your cloud, walk through the example (GCP and AWS guides coming as those examples land)
+2. **Install on [Azure](/self-managed-deployments/enterprise-sso/install-on-azure/), [GCP](/self-managed-deployments/enterprise-sso/install-on-gcp/), or [AWS](/self-managed-deployments/enterprise-sso/install-on-aws/)** -- pick your cloud and walk through the example
 3. **[Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/)** -- direct OIDC, SAML via Polis, SCIM provisioning
 4. **[Operations](/self-managed-deployments/enterprise-sso/operations/)** -- day-2 tasks: rotating credentials, adding OAuth2 clients, managing identities
 5. **[Troubleshooting](/self-managed-deployments/enterprise-sso/troubleshooting/)** -- common errors and fixes

--- a/doc/user/content/self-managed-deployments/enterprise-sso/identity-providers.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/identity-providers.md
@@ -1,0 +1,286 @@
+---
+title: "Configure identity providers"
+description: "Wire your IdP into the Ory-based enterprise SSO stack via OIDC, SAML, or SCIM."
+menu:
+  main:
+    parent: "enterprise-sso"
+    identifier: "enterprise-sso-identity-providers"
+    weight: 40
+---
+
+Once the Ory stack is deployed, you connect it to your identity
+provider. There are three paths, depending on what your IdP supports
+and what you need.
+
+| Path | Use when |
+|---|---|
+| [Direct OIDC](#direct-oidc) | Your IdP speaks OIDC and you only need authentication |
+| [SAML via Polis](#saml-via-polis) | Your IdP only speaks SAML, or you want a single proxy in front of multiple IdPs |
+| [SCIM via Polis](#scim-via-polis) | You want users provisioned and deactivated automatically from your IdP |
+
+The SAML and SCIM paths require `enable_polis = true` in your tfvars.
+SCIM is layered on top of SAML; you need the SAML connection registered
+in Polis first.
+
+## Direct OIDC
+
+The simplest path. Kratos federates upstream OIDC providers directly,
+no Polis required. Use this when your IdP supports OIDC and you don't
+need SCIM provisioning.
+
+### Step 1. Create an OIDC application in your IdP
+
+Create a new application with these settings:
+
+- **Sign-in redirect URI**: `https://<your-kratos-hostname>/self-service/methods/oidc/callback/<id>`
+  where `<id>` matches the entry you'll add to tfvars (e.g. `okta`,
+  `entra`, `google`).
+- **Grant types**: Authorization Code
+- **Scopes**: `openid`, `email`, `profile`
+
+For Okta specifically: Applications → Create App Integration → OIDC →
+Web Application → set the redirect URI as above.
+
+Grab the **Issuer URL**, **Client ID**, and **Client Secret** from the
+app's settings.
+
+### Step 2. Add the provider to tfvars
+
+Add an entry to `upstream_oidc_providers` in your `terraform.tfvars`:
+
+```hcl
+upstream_oidc_providers = [
+  {
+    id            = "okta"
+    provider      = "generic"
+    client_id     = "<from Okta>"
+    client_secret = "<from Okta>"
+    issuer_url    = "https://your-org.okta.com/oauth2/default"
+    scope         = ["openid", "email", "profile"]
+    label         = "Sign in with Okta"
+  },
+]
+```
+
+Run `terraform apply`. Kratos will reload its config and pick up the new
+provider. The label text becomes the button on the login screen.
+
+### Step 3. Test the login
+
+Open the Materialize console in an incognito window:
+`https://<your-console-hostname>`. You should see the Kratos login
+screen with a "Sign in with Okta" button. Click it; you'll bounce
+through your IdP and land in the Materialize console signed in.
+
+## SAML via Polis
+
+Use this when your IdP only supports SAML (Entra SAML, ADFS, Okta SAML,
+Auth0 SAML), or when you want a single SSO proxy in front of multiple
+IdPs.
+
+The flow at runtime: console → Hydra → Kratos UI → "Sign in via SAML"
+button → Polis → your IdP SAML → back through Polis → Kratos issues a
+federated identity → Hydra issues an OAuth2 token → console.
+
+### Step 1. Create a SAML application in your IdP
+
+In your IdP, create a SAML 2.0 application with:
+
+- **ACS URL / Assertion consumer URL**:
+  `https://<your-polis-hostname>/api/oauth/saml`
+- **Audience URI / Entity ID**: `https://saml.boxyhq.com`
+- **NameID format**: EmailAddress
+- **Attribute statements**: at minimum, `firstName`, `lastName`, `email`
+  mapped from the IdP user profile fields.
+
+Save and grab the SAML metadata URL (or download the metadata XML).
+Assign users (or groups) to the app so they can authenticate through it.
+
+### Step 2. Get the Polis admin API key
+
+```bash
+POLIS_API_KEY=$(kubectl get secret -n ory polis-config \
+  -o jsonpath='{.data.API_KEYS}' | base64 -d)
+```
+
+### Step 3. Register the SAML connection in Polis
+
+If the IdP exposes a publicly-fetchable metadata URL:
+
+```bash
+curl -X POST https://<your-polis-hostname>/api/v1/sso \
+  -H "Authorization: Api-Key $POLIS_API_KEY" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "tenant=<customer-name>" \
+  --data-urlencode "product=materialize" \
+  --data-urlencode "name=<idp-name>-saml" \
+  --data-urlencode "redirectUrl=https://<your-kratos-hostname>/self-service/methods/oidc/callback/polis" \
+  --data-urlencode "defaultRedirectUrl=https://<your-console-hostname>" \
+  --data-urlencode "metadataUrl=https://<idp-metadata-url>"
+```
+
+If the metadata URL is gated by API auth (Okta integrator orgs, for
+example), POST the raw XML instead:
+
+```bash
+curl -X POST https://<your-polis-hostname>/api/v1/sso \
+  -H "Authorization: Api-Key $POLIS_API_KEY" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "tenant=<customer-name>" \
+  --data-urlencode "product=materialize" \
+  --data-urlencode "name=<idp-name>-saml" \
+  --data-urlencode "redirectUrl=https://<your-kratos-hostname>/self-service/methods/oidc/callback/polis" \
+  --data-urlencode "defaultRedirectUrl=https://<your-console-hostname>" \
+  --data-urlencode "rawMetadata=$(cat saml-metadata.xml)"
+```
+
+The response contains a `clientID` and `clientSecret`. Save them for the
+next step.
+
+Verify the connection landed:
+
+```bash
+curl -s -H "Authorization: Api-Key $POLIS_API_KEY" \
+  "https://<your-polis-hostname>/api/v1/sso?tenant=<customer-name>&product=materialize" | jq .
+```
+
+### Step 4. Wire Polis into Kratos as an upstream OIDC provider
+
+Polis acts as an OIDC provider to Kratos. Add an entry to
+`upstream_oidc_providers` in tfvars, alongside any direct OIDC entries:
+
+```hcl
+upstream_oidc_providers = [
+  {
+    id            = "polis"
+    provider      = "generic"
+    client_id     = "<clientID from Step 3>"
+    client_secret = "<clientSecret from Step 3>"
+    issuer_url    = "https://<your-polis-hostname>"
+    scope         = ["openid", "email", "profile"]
+    label         = "Sign in via SAML"
+  },
+]
+```
+
+Run `terraform apply`. The "Sign in via SAML" button will appear on the
+Kratos login screen.
+
+### Step 5. Test the SAML login
+
+Open the Materialize console in an incognito window. Click **Sign in via
+SAML**. You'll bounce through Polis to your IdP, authenticate, and land
+in the Materialize console. The federated identity is created in Kratos
+on first login, and Materialize JIT-creates the SQL role from your email
+claim.
+
+## SCIM via Polis
+
+Adds automatic user provisioning and deactivation from your IdP to
+Materialize. Build on top of the SAML setup above.
+
+### Step 1. Create a SCIM directory in Polis
+
+```bash
+curl -X POST https://<your-polis-hostname>/api/v1/dsync \
+  -H "Authorization: Api-Key $POLIS_API_KEY" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "tenant=<customer-name>" \
+  --data-urlencode "product=materialize" \
+  --data-urlencode "name=<idp-name>-scim" \
+  --data-urlencode "type=okta-scim-v2"
+```
+
+For other IdPs, change `type` to `azure-scim-v2`, `onelogin-scim-v2`,
+or `generic-scim-v2`.
+
+Save the `scim.endpoint` URL and `scim.secret` bearer token from the
+response. Both go into your IdP's SCIM configuration.
+
+### Step 2. Enable SCIM provisioning in your IdP
+
+Steps for Okta (other IdPs vary in wording but follow the same shape):
+
+1. Open the SAML application you created above.
+2. **General** tab → Provisioning → switch to "SCIM" → Save.
+3. A **Provisioning** tab appears. Click into it → **Integration**:
+   - SCIM connector base URL: paste `scim.endpoint`
+   - Unique identifier for users: `email`
+   - Supported provisioning actions: Push New Users, Push Profile
+     Updates, Push Groups
+   - Authentication Mode: HTTP Header
+   - Authorization: paste `scim.secret`
+   - **Test Connector Configuration** -- expect green checks
+4. **Provisioning** → **To App** → Edit → enable Create Users, Update
+   User Attributes, Deactivate Users. Save.
+
+### Step 3. Verify the push
+
+Currently-assigned users push immediately. New users push on assignment.
+
+```bash
+DIRECTORY_ID=<id from the Step 1 response>
+curl -s -H "Authorization: Api-Key $POLIS_API_KEY" \
+  "https://<your-polis-hostname>/api/v1/dsync/users?tenant=<customer-name>&product=materialize&directoryId=$DIRECTORY_ID" | jq .
+```
+
+You should see the assigned users with their email, name, and external
+ID populated.
+
+{{< note >}}
+**Existing assignments don't backfill on enable.** If a user was
+assigned to the SAML app before SCIM was turned on, Okta doesn't
+re-push them. Either unassign and reassign the user (the cleanest
+trigger), or push manually via Okta admin → Directory → People → the
+user → Applications → "..." → Push profile updates.
+{{</ note >}}
+
+### Step 4. (Optional) Sync groups
+
+Group memberships also push to Polis, but currently **don't translate
+to Materialize SQL role grants**. The OIDC token Polis issues to Kratos
+doesn't include a group claim today, and Materialize has no setting that
+maps OIDC groups to SQL role memberships.
+
+If you want group push to land in Polis:
+
+1. Create a group in your IdP and add users to it.
+2. Open the SAML app → **Push Groups** tab → "Push Groups" → "by name"
+   → search and add the group → save.
+
+Polis will SCIM-sync the group entity. Confirm:
+
+```bash
+curl -s -H "Authorization: Api-Key $POLIS_API_KEY" \
+  "https://<your-polis-hostname>/api/v1/dsync/groups?tenant=<customer-name>&product=materialize&directoryId=$DIRECTORY_ID" | jq .
+```
+
+Mapping these groups to Materialize SQL grants currently has to be done
+manually with `GRANT role_name TO "user@email"`. Tracking the
+end-to-end automation as future work.
+
+## What happens when users sign in
+
+The Ory stack issues OIDC tokens with the user's email as the `email`
+claim. Materialize is configured with `oidc_authentication_claim =
+"email"`, so:
+
+- **First login**: Materialize creates a SQL role named after the user's
+  email (JIT role creation). The role has no privileges by default.
+- **Subsequent logins**: Same role is reused.
+- **Deprovisioned in IdP**: SCIM deactivates the user in Polis, but the
+  Materialize SQL role isn't dropped automatically. You'll need to
+  `DROP ROLE "user@email"` separately or let it become a stale (but
+  inactive) record.
+
+To grant privileges, see the role / permission management docs at
+[RBAC](/security/self-managed/access-control/).
+
+## See also
+
+- [SSO (direct OIDC)](/security/self-managed/sso/) -- the simpler path
+  for OIDC-only deployments
+- [Operations](/self-managed-deployments/enterprise-sso/operations/) -- day-2: rotating credentials, adding
+  OAuth2 clients
+- [Troubleshooting](/self-managed-deployments/enterprise-sso/troubleshooting/) -- common errors during the
+  IdP-side setup

--- a/doc/user/content/self-managed-deployments/enterprise-sso/install-on-aws.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/install-on-aws.md
@@ -1,20 +1,20 @@
 ---
-title: "Install on Azure"
-description: "Deploy the Ory-based enterprise SSO stack on Azure with Materialize."
+title: "Install on AWS"
+description: "Deploy the Ory-based enterprise SSO stack on AWS with Materialize."
 menu:
   main:
     parent: "enterprise-sso"
-    identifier: "enterprise-sso-azure"
-    weight: 20
+    identifier: "enterprise-sso-aws"
+    weight: 40
 ---
 
 This guide walks through the
-[`azure/examples/enterprise`](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/azure/examples/enterprise)
+[`aws/examples/enterprise`](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/aws/examples/enterprise)
 example in the [Materialize Terraform
 repository](https://github.com/MaterializeInc/materialize-terraform-self-managed),
 which extends the base [Install on
-Azure](/self-managed-deployments/installation/install-on-azure/) walkthrough
-with the Ory-based enterprise SSO stack on AKS.
+AWS](/self-managed-deployments/installation/install-on-aws/) walkthrough with
+the Ory-based enterprise SSO stack on EKS.
 
 {{% self-managed/materialize-components-sentence %}} This example layers the
 Ory stack (Kratos, Hydra, the selfservice UI, and optional Polis) on top so
@@ -35,23 +35,28 @@ hostnames, and a cert-manager strategy.
 ## What Gets Created
 
 This example provisions everything from the base [Install on
-Azure](/self-managed-deployments/installation/install-on-azure/) guide, plus
-the additions below.
+AWS](/self-managed-deployments/installation/install-on-aws/) guide, plus the
+additions below.
 
 ### Networking
 
 | Resource | Description |
 |----------|-------------|
 | Public Hostnames | Six browser-facing hostnames (Hydra, Kratos, the selfservice UI, optional Polis, the Materialize console, balancerd). DNS records are created by you after `terraform apply`. |
-| LoadBalancer Services | One per browser-facing service in the `ory` and `materialize-environment` namespaces. Backed by Azure standard load balancers. |
+| LoadBalancer Services | One per browser-facing service in the `ory` and `materialize-environment` namespaces. Backed by AWS Network Load Balancers via the AWS Load Balancer Controller, target type `ip`. |
 
 ### Database
 
 | Resource | Description |
 |----------|-------------|
-| Ory Azure PostgreSQL Flexible Server | Separate instance from the Materialize backend. PostgreSQL 18, `Standard_B1ms` SKU, 32GB storage, private endpoint only. |
-| Databases | `kratos`, `hydra`, plus `polis` when `enable_polis = true`. |
-| User | `oryadmin` with auto-generated password. |
+| Ory Kratos RDS | Dedicated RDS instance for the `kratos` database. PostgreSQL 18, `db.t3.small`. |
+| Ory Hydra RDS | Dedicated RDS instance for the `hydra` database. PostgreSQL 18, `db.t3.small`. |
+| Ory Polis RDS (optional) | Dedicated RDS instance for the `polis` database when `enable_polis = true`. PostgreSQL 18, `db.t3.small`. |
+| User | `oryadmin` shared across instances, with auto-generated password. |
+
+AWS RDS is one-database-per-instance, so each Ory component gets its own RDS
+instance. (GCP Cloud SQL, in contrast, hosts them as separate databases on a
+single shared instance.)
 
 ### Kubernetes Add-ons
 
@@ -72,22 +77,21 @@ the additions below.
 
 ## Prerequisites
 
-### Azure Account Requirements
+### AWS Account Requirements
 
-An active Azure subscription with permission to create:
+An active AWS account with permission to create:
 
-- Resource groups
-- Virtual networks, subnets, and NAT gateways
-- AKS clusters and node pools
-- Azure Database for PostgreSQL Flexible Servers
-- Storage accounts
-- Managed identities and role assignments
+- EKS clusters and Karpenter nodepools
+- RDS instances
+- S3 buckets
+- VPCs and networking resources
+- IAM roles and policies
 
 ### Required Tools
 
 - [Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform)
-- [Azure CLI (`az`)](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+- [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html)
 - [Helm 3.2.0+](https://helm.sh/docs/intro/install/)
 
 ### License Key
@@ -112,39 +116,37 @@ key](/self-managed-deployments/enterprise-sso/prerequisites/#license-key-with-th
 1. Open a terminal window.
 
 1. Clone the Materialize Terraform repository and go to the
-   `azure/examples/enterprise` directory:
+   `aws/examples/enterprise` directory:
 
    ```bash
    git clone https://github.com/MaterializeInc/materialize-terraform-self-managed.git
-   cd materialize-terraform-self-managed/azure/examples/enterprise
+   cd materialize-terraform-self-managed/aws/examples/enterprise
    ```
 
-1. Sign in to Azure and select the subscription you'll deploy into:
+1. Ensure your AWS CLI is configured with the appropriate profile, substituting
+   `<your-aws-profile>` with the profile to use:
 
    ```bash
-   az login
-   az account set --subscription <your-subscription-id>
+   export AWS_PROFILE=<your-aws-profile>
    ```
 
 ### Step 2: Configure Terraform Variables
 
 1. Create a `terraform.tfvars` file with the required variables:
 
-   - `subscription_id`: Azure subscription ID
-   - `resource_group_name`: Name of the resource group to create
+   - `aws_region`: AWS region (defaults to `us-east-1`)
+   - `aws_profile`: AWS CLI profile to use
    - `name_prefix`: Prefix for all resource names
-   - `location`: Azure region
    - `license_key`: Materialize license key JWT with the `ory` entitlement
-   - `k8s_apiserver_authorized_networks`: CIDRs allowed to reach the AKS API server (required, no default)
+   - `k8s_apiserver_authorized_networks`: CIDRs allowed to reach the EKS API server (required, no default)
    - `ory_hydra_fqdn`, `ory_ui_fqdn`, `ory_kratos_fqdn`, `materialize_console_fqdn`, `materialize_balancerd_fqdn`: Public hostnames for the browser-facing services
    - `tags`: Map of tags to apply to resources
 
    ```hcl
-   subscription_id     = "12345678-1234-1234-1234-123456789012"
-   resource_group_name = "materialize-enterprise-rg"
-   name_prefix         = "mz-enterprise"
-   location            = "westus2"
-   license_key         = "your-materialize-license-key"
+   aws_region  = "us-east-1"
+   aws_profile = "default"
+   name_prefix = "mz-enterprise"
+   license_key = "your-materialize-license-key"
 
    k8s_apiserver_authorized_networks = ["0.0.0.0/0"]   # tighten for production
 
@@ -179,16 +181,16 @@ key](/self-managed-deployments/enterprise-sso/prerequisites/#license-key-with-th
    terraform apply
    ```
 
-   Expect 30 to 45 minutes for the full apply. The slowest parts are AKS
-   provisioning, the two Flexible Server instances, and the Materialize
-   instance reaching ready.
+   Expect 30 to 45 minutes for the full apply. The slowest parts are EKS
+   provisioning, the RDS instances, and the Materialize instance reaching
+   ready.
 
 1. Configure `kubectl` against the new cluster:
 
    ```bash
-   az aks get-credentials \
-     --resource-group $(terraform output -raw resource_group_name) \
-     --name $(terraform output -raw aks_cluster_name)
+   aws eks update-kubeconfig \
+     --name $(terraform output -raw eks_cluster_name) \
+     --region <your-aws-region>
    ```
 
 ### Step 4: Create DNS Records
@@ -208,26 +210,39 @@ providers](/self-managed-deployments/enterprise-sso/identity-providers/).
 You can override module inputs independently. For details on the per-cloud
 modules, see the [top-level
 README](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main)
-and the [Azure-specific
-README](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/azure).
+and the [AWS-specific
+README](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/aws).
 
-Notes specific to Azure:
+Notes specific to AWS:
 
-- **PostgreSQL version**: The example targets PostgreSQL 18 on Azure
-  Database for PostgreSQL Flexible Server. The `azurerm` provider declaration
-  in `versions.tf` is pinned at `>= 4.55.0` to support PG 18.
-- **AKS API server access**: `k8s_apiserver_authorized_networks` has no
+- **One RDS per Ory component**: AWS RDS is one-database-per-instance, so
+  Kratos, Hydra, and Polis (when enabled) each get their own `db.t3.small`
+  RDS instance. GCP Cloud SQL hosts them as separate databases on a single
+  shared instance.
+- **EKS API server access**: `k8s_apiserver_authorized_networks` has no
   default. Production deployments should pin a tight allowlist instead of
   `0.0.0.0/0`.
-- **VM sizes**: Default node pool uses `Standard_D4ps_v6` (arm64). The
-  Materialize node pool uses `Standard_E*` instances. Adjust via
-  `materialize_nodepool` and the default pool size variables.
+- **Karpenter nodepools**: The generic nodepool defaults to `t4g.xlarge`
+  (arm64 Graviton); the Materialize nodepool uses `r7gd.2xlarge`. Both use
+  Bottlerocket. Override via the `instance_types_*` locals in `main.tf`.
+- **NLB target type `ip`**: Ory and console Services are exposed via Network
+  Load Balancers with the `ip` target type, so traffic goes directly to pod
+  IPs without an intermediate node hop.
 
 ## Cleanup
 
 ```bash
 terraform destroy
 ```
+
+{{< note >}}
+**AWS-specific teardown gotchas:** the AWS Load Balancer Controller and
+Karpenter can deadlock each other on destroy. If `terraform destroy` hangs,
+you may need to manually delete Karpenter-managed nodes and the LBC-created
+NLB target groups before the destroy can finish. See the example
+[README](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/aws/examples/enterprise#destroy)
+for the exact cleanup commands.
+{{</ note >}}
 
 {{< include-md file="shared-content/self-managed/enterprise-sso/destroy-finalizer-note.md" >}}
 
@@ -236,4 +251,4 @@ terraform destroy
 - [Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/)
 - [Operations](/self-managed-deployments/enterprise-sso/operations/)
 - [Troubleshooting](/self-managed-deployments/enterprise-sso/troubleshooting/)
-- [Install on Azure (base Materialize stack)](/self-managed-deployments/installation/install-on-azure/)
+- [Install on AWS (base Materialize stack)](/self-managed-deployments/installation/install-on-aws/)

--- a/doc/user/content/self-managed-deployments/enterprise-sso/install-on-azure.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/install-on-azure.md
@@ -1,0 +1,267 @@
+---
+title: "Install on Azure"
+description: "Deploy the Ory-based enterprise SSO stack on Azure with Materialize."
+menu:
+  main:
+    parent: "enterprise-sso"
+    identifier: "enterprise-sso-azure"
+    weight: 20
+---
+
+This guide walks through the Azure enterprise example in
+[`materialize-terraform-self-managed`](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/azure/examples/enterprise),
+which provisions a full Materialize + Ory deployment on AKS.
+
+{{< note >}}
+Before starting, work through the [prerequisites](/self-managed-deployments/enterprise-sso/prerequisites/):
+license key with the `ory` entitlement, DNS hostnames, cert-manager
+strategy, and (if you're deploying Polis on arm64 nodes) the amd64 node
+pool and Polis chart key file.
+{{</ note >}}
+
+## What gets created
+
+The Azure enterprise example provisions:
+
+- A resource group
+- A virtual network with AKS, Postgres, and API server subnets
+- An AKS cluster with two node pools: a default pool for system + Ory
+  workloads, and a dedicated `Standard_E*` pool for Materialize
+  (tainted so only Materialize pods land there)
+- Two Azure Database for PostgreSQL Flexible Server instances (one for
+  Materialize, one shared by Kratos + Hydra + optional Polis)
+- An Azure Storage account for Materialize's persistence backend
+- The Materialize operator and a Materialize instance CR
+- The Ory stack (Kratos, Hydra, selfservice UI) and optionally Polis,
+  all in the `ory` namespace
+- cert-manager, plus an optional Let's Encrypt + Cloudflare DNS-01
+  ClusterIssuer if you drop in the `letsencrypt.tf` snippet
+- Optional Prometheus and Grafana (`enable_observability = true` by
+  default)
+
+## Step 1. Configure required variables
+
+Create `terraform.tfvars` in the example directory:
+
+```hcl
+subscription_id     = "12345678-1234-1234-1234-123456789012"
+resource_group_name = "materialize-enterprise-rg"
+name_prefix         = "mz-enterprise"
+location            = "westus2"
+license_key         = "<Materialize license key JWT with ory entitlement>"
+
+k8s_apiserver_authorized_networks = ["0.0.0.0/0"]   # tighten for production
+
+ory_hydra_hostname             = "hydra.example.com"
+ory_ui_hostname                = "auth.example.com"
+ory_kratos_hostname            = "kratos.example.com"
+materialize_console_hostname   = "console.example.com"
+materialize_balancerd_hostname = "balancerd.example.com"
+
+tags = {
+  environment = "demo"
+}
+```
+
+To enable Polis (SAML + SCIM):
+
+```hcl
+enable_polis                 = true
+ory_polis_hostname           = "polis.example.com"
+ory_polis_oci_chart_key_file = "/path/to/ory-artifacts-sa-key.json"
+
+# Pin Polis to amd64 nodes (skip if your default node pool is amd64)
+polis_helm_values = {
+  deployment = { nodeSelector = { workload = "polis-amd64" } }
+  job        = { nodeSelector = { workload = "polis-amd64" } }
+}
+```
+
+To bring your own cert-manager issuer:
+
+```hcl
+cert_issuer_ref = {
+  name = "letsencrypt-prod"
+  kind = "ClusterIssuer"
+}
+```
+
+If you're using Let's Encrypt, drop in a `letsencrypt.tf` next to
+`main.tf` with the Cloudflare DNS-01 ClusterIssuer. A starter snippet is
+in the example's README.
+
+To federate logins through an OIDC IdP (Okta OIDC, Google Workspace,
+Auth0 OIDC, Entra OIDC):
+
+```hcl
+upstream_oidc_providers = [
+  {
+    id            = "okta"
+    provider      = "generic"
+    client_id     = "<from Okta>"
+    client_secret = "<from Okta>"
+    issuer_url    = "https://your-org.okta.com/oauth2/default"
+    scope         = ["openid", "email", "profile"]
+    label         = "Sign in with Okta"
+  },
+]
+```
+
+See [Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/) for SAML and
+SCIM setup once the stack is up.
+
+## Step 2. Add the amd64 node pool (only when Polis is enabled)
+
+If your default AKS node pool is arm64 (it's recommended for cost on
+Azure), Polis needs a small amd64 node pool. Add one with the label that
+matches your `polis_helm_values` selector:
+
+```bash
+az aks nodepool add \
+  --resource-group materialize-enterprise-rg \
+  --cluster-name mz-enterprise-aks \
+  --name polisamd \
+  --node-vm-size Standard_B2s \
+  --node-count 1 \
+  --labels workload=polis-amd64
+```
+
+One small VM is enough. Both the Polis Deployment and its pre-install
+migration Job will schedule there.
+
+This step goes away when Ory ships a multi-arch `polis-oel` image.
+
+## Step 3. Apply
+
+```bash
+terraform init
+terraform apply
+```
+
+Expect 30 to 45 minutes for the full apply. The slowest parts are AKS
+provisioning, the two Flexible Server instances, and the Materialize
+instance reaching ready.
+
+## Step 4. Create DNS records
+
+After apply finishes, grab the LoadBalancer IPs:
+
+```bash
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}/{.metadata.name}{"\t"}{.status.loadBalancer.ingress[0].ip}{"\n"}{end}'
+```
+
+Create A records (DNS-only, not proxied if you're on Cloudflare):
+
+| Hostname | Backed by |
+|---|---|
+| `hydra.example.com` | `ory/hydra-public-lb` |
+| `kratos.example.com` | `ory/kratos-public-lb` |
+| `auth.example.com` | `ory/ory-selfservice-ui-lb` |
+| `polis.example.com` | `ory/polis-public-lb` (only when `enable_polis = true`) |
+| `console.example.com` | `materialize-environment/main-console-https` |
+| `balancerd.example.com` | `materialize-environment/<release-id>-balancerd-lb` |
+
+cert-manager will start issuing TLS certs as soon as the records
+resolve. Wait for all Certificates to report `READY=True`:
+
+```bash
+kubectl get certificate -A -w
+```
+
+Typically 1-3 minutes per cert via Let's Encrypt DNS-01.
+
+## Step 5. Verify
+
+Smoke-test each component:
+
+```bash
+# Hydra OIDC discovery (should return JSON with issuer matching ory_hydra_hostname)
+curl -fsSL https://hydra.example.com/.well-known/openid-configuration | jq .issuer
+
+# Kratos health
+curl -fsSL https://kratos.example.com/health/ready
+
+# Selfservice UI health
+curl -fsSL https://auth.example.com/health/alive
+
+# Polis health (when enabled)
+curl -fsSL https://polis.example.com/api/health
+
+# Materialize console
+curl -fsSL -o /dev/null -w "%{http_code}\n" https://console.example.com
+```
+
+All should return 200 or a valid health response.
+
+Open the Materialize console in a browser:
+
+```
+https://console.example.com
+```
+
+You should see the Kratos login screen. If you wired an
+`upstream_oidc_providers` entry, you'll see a "Sign in with X" button.
+If you have Polis enabled and registered a SAML connection, you'll see
+a "Sign in via SAML" button too.
+
+If you haven't configured an IdP yet, see
+[Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/) next.
+
+## Step 6. Tear down
+
+```bash
+terraform destroy
+```
+
+{{< note >}}
+**Known destroy issue:** `terraform destroy` can hang on the `ory`
+namespace because the OAuth2Client CRD has a Hydra Maester finalizer
+that's not always cleared before Maester itself is torn down. If the
+destroy stalls on the namespace, run:
+
+```bash
+kubectl patch oauth2client materialize-oauth2-client -n ory \
+  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
+```
+
+Then re-run `terraform destroy`. We're tracking a cleaner fix.
+{{</ note >}}
+
+If you provisioned the amd64 node pool for Polis out of band (Step 2),
+delete it separately:
+
+```bash
+az aks nodepool delete \
+  --resource-group materialize-enterprise-rg \
+  --cluster-name mz-enterprise-aks \
+  --name polisamd
+```
+
+Or just delete the whole resource group if you're sure nothing else
+lives in it.
+
+## Notes specific to Azure
+
+- **PostgreSQL version**: The example targets PostgreSQL 18 on Azure
+  Database for PostgreSQL Flexible Server. The `azurerm` provider
+  declaration in `versions.tf` is pinned at >= 4.55.0 to support PG 18
+  as a valid version.
+- **Balancerd hostname**: required input (no default). The Materialize
+  console's browser-side JS calls balancerd directly, so it needs both
+  a public hostname and a trusted TLS cert. The cert is provisioned
+  automatically once the DNS record resolves.
+- **AKS API server access**: `k8s_apiserver_authorized_networks` is a
+  required input with no default; production deployments should pin a
+  tight allowlist instead of `0.0.0.0/0`.
+- **VM sizes**: Default node pool uses `Standard_D4ps_v6` (4 vCPU,
+  16 GiB, arm64). Materialize node pool uses `Standard_E*` instances.
+  Adjust via `materialize_nodepool` and the default pool size variables
+  if you need different sizing.
+
+## Next steps
+
+- [Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/) -- wire up
+  Okta, Entra, Auth0, or another IdP
+- [Operations](/self-managed-deployments/enterprise-sso/operations/) -- day-2 tasks: rotating credentials,
+  adding OAuth2 clients, managing identities
+- [Troubleshooting](/self-managed-deployments/enterprise-sso/troubleshooting/) -- common errors and fixes

--- a/doc/user/content/self-managed-deployments/enterprise-sso/install-on-azure.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/install-on-azure.md
@@ -52,11 +52,11 @@ license_key         = "<Materialize license key JWT with ory entitlement>"
 
 k8s_apiserver_authorized_networks = ["0.0.0.0/0"]   # tighten for production
 
-ory_hydra_hostname             = "hydra.example.com"
-ory_ui_hostname                = "auth.example.com"
-ory_kratos_hostname            = "kratos.example.com"
-materialize_console_hostname   = "console.example.com"
-materialize_balancerd_hostname = "balancerd.example.com"
+ory_hydra_fqdn             = "hydra.example.com"
+ory_ui_fqdn                = "auth.example.com"
+ory_kratos_fqdn            = "kratos.example.com"
+materialize_console_fqdn   = "console.example.com"
+materialize_balancerd_fqdn = "balancerd.example.com"
 
 tags = {
   environment = "demo"
@@ -67,7 +67,7 @@ To enable Polis (SAML + SCIM):
 
 ```hcl
 enable_polis                 = true
-ory_polis_hostname           = "polis.example.com"
+ory_polis_fqdn           = "polis.example.com"
 ory_polis_oci_chart_key_file = "/path/to/ory-artifacts-sa-key.json"
 
 # Pin Polis to amd64 nodes (skip if your default node pool is amd64)
@@ -175,7 +175,7 @@ Typically 1-3 minutes per cert via Let's Encrypt DNS-01.
 Smoke-test each component:
 
 ```bash
-# Hydra OIDC discovery (should return JSON with issuer matching ory_hydra_hostname)
+# Hydra OIDC discovery (should return JSON with issuer matching ory_hydra_fqdn)
 curl -fsSL https://hydra.example.com/.well-known/openid-configuration | jq .issuer
 
 # Kratos health

--- a/doc/user/content/self-managed-deployments/enterprise-sso/install-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/install-on-gcp.md
@@ -1,20 +1,20 @@
 ---
-title: "Install on Azure"
-description: "Deploy the Ory-based enterprise SSO stack on Azure with Materialize."
+title: "Install on GCP"
+description: "Deploy the Ory-based enterprise SSO stack on GCP with Materialize."
 menu:
   main:
     parent: "enterprise-sso"
-    identifier: "enterprise-sso-azure"
-    weight: 20
+    identifier: "enterprise-sso-gcp"
+    weight: 30
 ---
 
 This guide walks through the
-[`azure/examples/enterprise`](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/azure/examples/enterprise)
+[`gcp/examples/enterprise`](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/gcp/examples/enterprise)
 example in the [Materialize Terraform
 repository](https://github.com/MaterializeInc/materialize-terraform-self-managed),
 which extends the base [Install on
-Azure](/self-managed-deployments/installation/install-on-azure/) walkthrough
-with the Ory-based enterprise SSO stack on AKS.
+GCP](/self-managed-deployments/installation/install-on-gcp/) walkthrough with
+the Ory-based enterprise SSO stack on GKE.
 
 {{% self-managed/materialize-components-sentence %}} This example layers the
 Ory stack (Kratos, Hydra, the selfservice UI, and optional Polis) on top so
@@ -35,22 +35,22 @@ hostnames, and a cert-manager strategy.
 ## What Gets Created
 
 This example provisions everything from the base [Install on
-Azure](/self-managed-deployments/installation/install-on-azure/) guide, plus
-the additions below.
+GCP](/self-managed-deployments/installation/install-on-gcp/) guide, plus the
+additions below.
 
 ### Networking
 
 | Resource | Description |
 |----------|-------------|
 | Public Hostnames | Six browser-facing hostnames (Hydra, Kratos, the selfservice UI, optional Polis, the Materialize console, balancerd). DNS records are created by you after `terraform apply`. |
-| LoadBalancer Services | One per browser-facing service in the `ory` and `materialize-environment` namespaces. Backed by Azure standard load balancers. |
+| LoadBalancer Services | One per browser-facing service in the `ory` and `materialize-environment` namespaces. Backed by GCP network load balancers. |
 
 ### Database
 
 | Resource | Description |
 |----------|-------------|
-| Ory Azure PostgreSQL Flexible Server | Separate instance from the Materialize backend. PostgreSQL 18, `Standard_B1ms` SKU, 32GB storage, private endpoint only. |
-| Databases | `kratos`, `hydra`, plus `polis` when `enable_polis = true`. |
+| Ory Cloud SQL for PostgreSQL | Separate instance from the Materialize backend. PostgreSQL 18, `db-f1-micro` tier, private IP only. |
+| Databases | `kratos`, `hydra`, plus `polis` when `enable_polis = true`. Cloud SQL supports multiple databases on a single instance, so all three Ory components share this instance. |
 | User | `oryadmin` with auto-generated password. |
 
 ### Kubernetes Add-ons
@@ -72,23 +72,23 @@ the additions below.
 
 ## Prerequisites
 
-### Azure Account Requirements
+### GCP Account Requirements
 
-An active Azure subscription with permission to create:
+A Google account with permission to enable the required APIs on your project and to create:
 
-- Resource groups
-- Virtual networks, subnets, and NAT gateways
-- AKS clusters and node pools
-- Azure Database for PostgreSQL Flexible Servers
-- Storage accounts
-- Managed identities and role assignments
+- GKE clusters and node pools
+- Cloud SQL instances and VPC peering
+- Cloud Storage buckets
+- VPC networks, subnets, Cloud Router, Cloud NAT
+- Service accounts and IAM bindings
 
 ### Required Tools
 
 - [Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform)
-- [Azure CLI (`az`)](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Helm 3.2.0+](https://helm.sh/docs/intro/install/)
+- [GKE auth plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin)
 
 ### License Key
 
@@ -112,41 +112,44 @@ key](/self-managed-deployments/enterprise-sso/prerequisites/#license-key-with-th
 1. Open a terminal window.
 
 1. Clone the Materialize Terraform repository and go to the
-   `azure/examples/enterprise` directory:
+   `gcp/examples/enterprise` directory:
 
    ```bash
    git clone https://github.com/MaterializeInc/materialize-terraform-self-managed.git
-   cd materialize-terraform-self-managed/azure/examples/enterprise
+   cd materialize-terraform-self-managed/gcp/examples/enterprise
    ```
 
-1. Sign in to Azure and select the subscription you'll deploy into:
+1. Authenticate with Google Cloud and select your project:
 
    ```bash
-   az login
-   az account set --subscription <your-subscription-id>
+   gcloud auth application-default login
+   gcloud config set project <your-project-id>
    ```
 
 ### Step 2: Configure Terraform Variables
 
 1. Create a `terraform.tfvars` file with the required variables:
 
-   - `subscription_id`: Azure subscription ID
-   - `resource_group_name`: Name of the resource group to create
+   - `project_id`: GCP project ID
+   - `region`: GCP region (defaults to `us-central1`)
    - `name_prefix`: Prefix for all resource names
-   - `location`: Azure region
    - `license_key`: Materialize license key JWT with the `ory` entitlement
-   - `k8s_apiserver_authorized_networks`: CIDRs allowed to reach the AKS API server (required, no default)
+   - `k8s_apiserver_authorized_networks`: CIDRs allowed to reach the GKE master endpoint (required, no default)
    - `ory_hydra_fqdn`, `ory_ui_fqdn`, `ory_kratos_fqdn`, `materialize_console_fqdn`, `materialize_balancerd_fqdn`: Public hostnames for the browser-facing services
-   - `tags`: Map of tags to apply to resources
+   - `labels`: Map of labels to apply to resources
 
    ```hcl
-   subscription_id     = "12345678-1234-1234-1234-123456789012"
-   resource_group_name = "materialize-enterprise-rg"
-   name_prefix         = "mz-enterprise"
-   location            = "westus2"
-   license_key         = "your-materialize-license-key"
+   project_id  = "my-gcp-project-id"
+   region      = "us-central1"
+   name_prefix = "mz-enterprise"
+   license_key = "your-materialize-license-key"
 
-   k8s_apiserver_authorized_networks = ["0.0.0.0/0"]   # tighten for production
+   k8s_apiserver_authorized_networks = [
+     {
+       cidr_block   = "0.0.0.0/0"   # tighten for production
+       display_name = "lab"
+     },
+   ]
 
    ory_hydra_fqdn             = "hydra.example.com"
    ory_ui_fqdn                = "auth.example.com"
@@ -154,7 +157,7 @@ key](/self-managed-deployments/enterprise-sso/prerequisites/#license-key-with-th
    materialize_console_fqdn   = "console.example.com"
    materialize_balancerd_fqdn = "balancerd.example.com"
 
-   tags = {
+   labels = {
      environment = "demo"
    }
    ```
@@ -179,16 +182,16 @@ key](/self-managed-deployments/enterprise-sso/prerequisites/#license-key-with-th
    terraform apply
    ```
 
-   Expect 30 to 45 minutes for the full apply. The slowest parts are AKS
-   provisioning, the two Flexible Server instances, and the Materialize
-   instance reaching ready.
+   Expect 30 to 45 minutes for the full apply. The slowest parts are GKE
+   provisioning, the two Cloud SQL instances, and the Materialize instance
+   reaching ready.
 
 1. Configure `kubectl` against the new cluster:
 
    ```bash
-   az aks get-credentials \
-     --resource-group $(terraform output -raw resource_group_name) \
-     --name $(terraform output -raw aks_cluster_name)
+   gcloud container clusters get-credentials \
+     $(terraform output -raw gke_cluster_name) \
+     --region $(terraform output -raw gke_cluster_location)
    ```
 
 ### Step 4: Create DNS Records
@@ -208,20 +211,25 @@ providers](/self-managed-deployments/enterprise-sso/identity-providers/).
 You can override module inputs independently. For details on the per-cloud
 modules, see the [top-level
 README](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main)
-and the [Azure-specific
-README](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/azure).
+and the [GCP-specific
+README](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/gcp).
 
-Notes specific to Azure:
+Notes specific to GCP:
 
-- **PostgreSQL version**: The example targets PostgreSQL 18 on Azure
-  Database for PostgreSQL Flexible Server. The `azurerm` provider declaration
-  in `versions.tf` is pinned at `>= 4.55.0` to support PG 18.
-- **AKS API server access**: `k8s_apiserver_authorized_networks` has no
-  default. Production deployments should pin a tight allowlist instead of
-  `0.0.0.0/0`.
-- **VM sizes**: Default node pool uses `Standard_D4ps_v6` (arm64). The
-  Materialize node pool uses `Standard_E*` instances. Adjust via
-  `materialize_nodepool` and the default pool size variables.
+- **Shared Cloud SQL instance for Ory**: Cloud SQL supports multiple databases
+  on a single instance, so Kratos, Hydra, and optional Polis share one
+  `db-f1-micro` instance with separate databases. (AWS, in contrast,
+  provisions one RDS instance per Ory component.)
+- **GKE master access**: `k8s_apiserver_authorized_networks` has no default.
+  Production deployments should pin a tight allowlist instead of `0.0.0.0/0`.
+- **Egress to the OEL proxy**: GKE nodes need outbound access to
+  `ory.registry.cloud.materialize.com` and `storage.googleapis.com`. The proxy
+  returns HTTP 307 redirects to signed GCS URLs for blob layers, which the
+  kubelet follows directly. Adjust your VPC firewall and Cloud NAT egress
+  rules accordingly.
+- **Node pools**: Default `e2-standard-8` for the generic pool;
+  `n2-highmem-8` with one local SSD for the Materialize pool. Override via the
+  `generic_nodepool` and `materialize_nodepool` variables.
 
 ## Cleanup
 
@@ -236,4 +244,4 @@ terraform destroy
 - [Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/)
 - [Operations](/self-managed-deployments/enterprise-sso/operations/)
 - [Troubleshooting](/self-managed-deployments/enterprise-sso/troubleshooting/)
-- [Install on Azure (base Materialize stack)](/self-managed-deployments/installation/install-on-azure/)
+- [Install on GCP (base Materialize stack)](/self-managed-deployments/installation/install-on-gcp/)

--- a/doc/user/content/self-managed-deployments/enterprise-sso/operations.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/operations.md
@@ -1,0 +1,241 @@
+---
+title: "Operations"
+description: "Day-2 tasks for the Ory-based enterprise SSO stack."
+menu:
+  main:
+    parent: "enterprise-sso"
+    identifier: "enterprise-sso-operations"
+    weight: 50
+---
+
+This page covers ongoing operations once the Ory stack is deployed and
+your IdP is connected.
+
+## Add additional OAuth2 clients
+
+By default the example registers a single OAuth2Client in Hydra for the
+Materialize console. If you have other internal applications that
+should authenticate through the same Hydra instance, you can register
+additional clients using Hydra Maester's `OAuth2Client` CRDs.
+
+Apply a manifest like:
+
+```yaml
+apiVersion: hydra.ory.sh/v1alpha1
+kind: OAuth2Client
+metadata:
+  name: my-internal-app
+  namespace: ory
+spec:
+  clientName: My Internal App
+  grantTypes: ["authorization_code", "refresh_token"]
+  responseTypes: ["code", "id_token"]
+  scope: "openid profile email offline"
+  redirectUris:
+    - "https://my-app.example.com/auth/callback"
+  secretName: my-internal-app-credentials
+  tokenEndpointAuthMethod: "client_secret_basic"
+  # Set skipConsent: true for first-party apps to bypass the consent screen.
+  skipConsent: true
+```
+
+Hydra Maester watches for these resources and registers the client with
+Hydra. The generated client_id and client_secret are written to the
+`secretName` Kubernetes Secret in the same namespace.
+
+To read the credentials:
+
+```bash
+kubectl get secret my-internal-app-credentials -n ory \
+  -o jsonpath='{.data.CLIENT_ID}' | base64 -d
+kubectl get secret my-internal-app-credentials -n ory \
+  -o jsonpath='{.data.CLIENT_SECRET}' | base64 -d
+```
+
+## Rotate the license key
+
+When your Materialize license key approaches expiry or you receive a
+new one with updated entitlements:
+
+1. Update `license_key` in `terraform.tfvars`.
+2. Run `terraform apply`.
+
+The `imagePullSecret` in the `ory` namespace gets updated with the new
+JWT. Pods don't roll automatically, but the next time they restart (or
+the next image pull) they'll use the new credentials. To force an
+immediate roll:
+
+```bash
+kubectl rollout restart deployment kratos hydra ory-selfservice-ui -n ory
+kubectl rollout restart deployment polis -n ory   # only if enable_polis
+```
+
+The Materialize side also picks up the new key on the next operator
+reconcile.
+
+## Manage Kratos identities
+
+Kratos stores user identities in its own Postgres database. You can
+inspect and manage them via Kratos's admin API.
+
+Get the in-cluster admin URL:
+
+```bash
+kubectl port-forward -n ory svc/kratos-admin 4434:4434
+```
+
+List identities:
+
+```bash
+curl -s http://localhost:4434/admin/identities | jq .
+```
+
+Get a specific identity:
+
+```bash
+curl -s http://localhost:4434/admin/identities/<id> | jq .
+```
+
+Lock a user out (disable login):
+
+```bash
+curl -X PATCH http://localhost:4434/admin/identities/<id> \
+  -H "Content-Type: application/json-patch+json" \
+  -d '[{"op": "replace", "path": "/state", "value": "inactive"}]'
+```
+
+See the [Kratos admin API
+reference](https://www.ory.sh/docs/kratos/reference/api) for the full
+set of operations.
+
+## Manage Polis SAML connections and SCIM directories
+
+Polis admin operations go through its admin API. The Polis admin web UI
+is not exposed by default (the module sets `hosted = false`).
+
+Get the admin API key:
+
+```bash
+POLIS_API_KEY=$(kubectl get secret -n ory polis-config \
+  -o jsonpath='{.data.API_KEYS}' | base64 -d)
+```
+
+List SAML connections:
+
+```bash
+curl -s -H "Authorization: Api-Key $POLIS_API_KEY" \
+  "https://<your-polis-hostname>/api/v1/sso?tenant=<customer-name>&product=materialize" | jq .
+```
+
+Update a SAML connection (for example, to refresh the IdP metadata XML
+after a certificate rotation):
+
+```bash
+curl -X PATCH "https://<your-polis-hostname>/api/v1/sso?tenant=<customer-name>&product=materialize&name=okta-saml" \
+  -H "Authorization: Api-Key $POLIS_API_KEY" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "rawMetadata=$(cat new-saml-metadata.xml)"
+```
+
+List SCIM directories:
+
+```bash
+curl -s -H "Authorization: Api-Key $POLIS_API_KEY" \
+  "https://<your-polis-hostname>/api/v1/dsync?tenant=<customer-name>&product=materialize" | jq .
+```
+
+Delete a SCIM directory (use cautiously, this disconnects the IdP push
+target):
+
+```bash
+curl -X DELETE -H "Authorization: Api-Key $POLIS_API_KEY" \
+  "https://<your-polis-hostname>/api/v1/dsync?tenant=<customer-name>&product=materialize&directoryId=<id>"
+```
+
+If you want to enable the multi-tenant admin UI for hands-on
+management instead of the API, set in tfvars:
+
+```hcl
+polis_helm_values = {
+  polis = { hosted = true }
+}
+```
+
+and re-apply. The UI is then available at
+`https://<your-polis-hostname>/admin/auth/login`. You'll need to
+configure a NextAuth provider for login (see
+[Polis hosted-mode docs](https://www.ory.sh/docs/polis/deploy/env-variables)).
+
+## Disable registration in Kratos
+
+By default Kratos allows users to register new identities through the
+selfservice UI. For production deployments where users come exclusively
+from your IdP, disable registration via Helm values in tfvars:
+
+```hcl
+kratos_helm_values = {
+  kratos = {
+    config = {
+      selfservice = {
+        flows = {
+          registration = {
+            enabled = false
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Apply. The "Sign up" link disappears from the login screen.
+
+## Back up the Ory Postgres database
+
+The Ory components (Kratos, Hydra, Polis) store identities, OAuth2
+clients, sessions, SAML connections, and SCIM directory state in a
+Postgres database. Loss of this database means:
+
+- All Kratos identities are gone (users will need to re-register / be
+  re-provisioned via SCIM on next login)
+- All issued Hydra tokens are invalidated
+- All Polis SAML connections and SCIM directories have to be re-created
+
+Each cloud's database module enables managed automated backups by
+default (`backup_retained_backups = 35` on Cloud SQL,
+`backup_retention_days = 35` on Flexible Server and RDS). For
+production deployments, verify the retention period matches your DR
+requirements and consider running periodic restore drills to confirm
+the backups are usable.
+
+## Monitor the stack
+
+If you deployed with `enable_observability = true` (the default), the
+example provisions Prometheus and Grafana scraping Materialize and the
+Ory pods. The Ory Helm charts emit standard metrics including request
+counts and latencies per endpoint, which you can wire into your
+existing alerting.
+
+Key signals to alert on:
+
+- Hydra `/oauth2/token` 5xx rate (token issuance failing)
+- Kratos `/sessions/whoami` 5xx rate (session validation failing)
+- Polis OIDC callback errors (SAML assertions failing)
+- Pod restart counts on any Ory component
+- Postgres connection failures from any Ory component (suggests DB
+  saturation or networking issues)
+
+## Future work
+
+Items tracked but not yet shipped:
+
+- **API key management for service accounts** via Ory Talos
+  (tracked as DEP-143). When this lands, this page will gain a section
+  on issuing and revoking API keys for non-interactive clients.
+- **IdP group to SQL role mapping**. Today, group memberships push to
+  Polis but don't translate to Materialize SQL role grants. The
+  end-to-end automation is open product work.
+- **Multi-IdP support on a single Polis tenant**. Polis supports
+  multiple SAML connections per tenant, but the example doesn't
+  document the multi-tenant Polis setup yet. Useful for customers with
+  parallel IdPs (e.g., one for employees, one for contractors).

--- a/doc/user/content/self-managed-deployments/enterprise-sso/prerequisites.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/prerequisites.md
@@ -1,0 +1,174 @@
+---
+title: "Prerequisites"
+description: "Requirements to deploy the Ory-based enterprise SSO stack."
+menu:
+  main:
+    parent: "enterprise-sso"
+    identifier: "enterprise-sso-prerequisites"
+    weight: 10
+---
+
+Before running the enterprise example for your cloud, you'll need:
+
+## Materialize license key with the `ory` entitlement
+
+The Ory components ship as private OEL (Ory Enterprise License) images.
+Materialize hosts a registry proxy at `ory.registry.cloud.materialize.com`
+that pulls these images on behalf of customers. Authentication to the
+proxy uses your Materialize license key JWT (passed as the password in a
+Kubernetes `imagePullSecret`), so you don't need a separate Ory
+credential.
+
+The license key has to carry the `ory` entitlement. Contact Materialize
+sales or support to have one issued.
+
+{{< note >}}
+The license key is also used by Materialize itself; the same JWT covers
+both. There's no separate "Ory key" you have to manage.
+{{</ note >}}
+
+## Cluster egress
+
+The Ory pods need network egress to two hosts:
+
+- `ory.registry.cloud.materialize.com` (the registry proxy)
+- `storage.googleapis.com` (the proxy returns HTTP 307 redirects to
+  signed GCS URLs for blob layers, which the kubelet follows directly)
+
+If your cluster has egress restrictions or a NAT gateway with allowlist
+rules, both hosts must be reachable.
+
+## DNS hostnames
+
+You need DNS hostnames you control for each browser-facing service.
+With Polis enabled, that's six hostnames:
+
+| Hostname | Purpose |
+|---|---|
+| `hydra.example.com` | OAuth2 / OIDC issuer that Materialize trusts |
+| `kratos.example.com` | Kratos public API; browser-side redirect target |
+| `auth.example.com` | Selfservice UI (login, consent, registration pages) |
+| `polis.example.com` | Polis (SAML ACS, SCIM endpoint, OIDC token endpoint). Only when Polis is enabled. |
+| `console.example.com` | Materialize console |
+| `balancerd.example.com` | Materialize's SQL-over-HTTP endpoint. The console JS calls this from the browser, so it needs a public hostname and a trusted TLS cert. |
+
+You'll create A records pointing at the LoadBalancer IPs after the first
+`terraform apply`. The example deployment doesn't create the DNS records
+for you; the per-cloud install pages show the exact commands to grab the
+LB IPs.
+
+## cert-manager and a ClusterIssuer
+
+The example deploys cert-manager into the cluster and uses it to
+provision TLS certificates for each browser-facing hostname. You can
+choose one of three modes:
+
+### In-cluster self-signed (demos and air-gapped clusters)
+
+Default behaviour if you don't override `cert_issuer_ref`. cert-manager
+generates an in-cluster CA and signs all browser-facing certs from it.
+Browsers will not trust the certs out of the box.
+
+Suitable for offline demos or proof-of-concept clusters where no public
+DNS / ACME path is available. Production deployments should use a real
+issuer.
+
+### Bring your own ClusterIssuer
+
+Set `cert_issuer_ref` in tfvars to point at an existing ClusterIssuer
+managed outside of the example. Typical sources: a corporate CA, an
+ACME issuer (Let's Encrypt) already configured for other workloads, or
+a managed cloud issuer.
+
+```hcl
+cert_issuer_ref = {
+  name = "letsencrypt-prod"
+  kind = "ClusterIssuer"
+}
+```
+
+The browser-facing certs use this issuer. The internal mTLS cert
+between Materialize components continues to use the in-cluster
+self-signed cluster issuer because it includes `*.cluster.local` SANs
+that public ACME issuers cannot sign.
+
+### Let's Encrypt with cert-manager DNS-01
+
+For new deployments where you want browser-trusted certs without a
+managed cloud cert service, the example supports a Let's Encrypt
+ClusterIssuer backed by cert-manager's DNS-01 solver. Cloudflare,
+Route 53, Azure DNS, and Google Cloud DNS are all supported by
+cert-manager out of the box.
+
+A starter `letsencrypt.tf` block is documented in the README of each
+per-cloud enterprise example. Drop it into your root module, set your
+DNS provider API token, and set `cert_issuer_ref` to
+`{ name = "letsencrypt-prod", kind = "ClusterIssuer" }`.
+
+## Polis-specific prerequisites (only when `enable_polis = true`)
+
+Polis has two upstream issues that the example works around with extra
+configuration. These are temporary and tracked with Ory; the
+requirements below will go away when Ory ships the fixes.
+
+### Dedicated amd64 node pool
+
+The Polis OEL image (`polis-oel`) is currently published as `amd64` only.
+Kratos, Hydra, and the selfservice UI all ship multi-arch images and
+can run on any cluster, but Polis cannot run on `arm64` nodes.
+
+If your cluster's default node pool runs on `arm64` instances (Azure
+ARM, AWS Graviton, GCP Tau, Ampere), you need to add a small `amd64`
+node pool and pin Polis to it via Helm values:
+
+```hcl
+polis_helm_values = {
+  deployment = {
+    nodeSelector = { workload = "polis-amd64" }
+  }
+  job = {
+    nodeSelector = { workload = "polis-amd64" }
+  }
+}
+```
+
+One `Standard_B2s` (Azure) / `t3.small` (AWS) / `e2-small` (GCP)
+instance is enough. Both the Polis Deployment and the chart's
+pre-install migration Job need the selector, hence the two blocks.
+
+### GCP service-account JSON key for the chart pull
+
+The Polis Helm chart is published as a private OCI artifact on GCP
+Artifact Registry. The OEL registry proxy currently handles image pulls
+but doesn't yet serve OCI Helm chart manifests, so the chart needs to
+be pulled directly from GCP with a service account key.
+
+Set the path to the key file in tfvars:
+
+```hcl
+ory_polis_oci_chart_key_file = "/path/to/ory-artifacts-sa-key.json"
+```
+
+Contact Materialize sales or support to be issued a key. This will go
+away once the chart is published publicly or the OEL registry proxy
+gains OCI chart support.
+
+## Tooling
+
+Local tools you'll need:
+
+- `terraform` (>= 1.8)
+- `kubectl`
+- `helm` (only if you want to inspect chart values)
+- The cloud CLI for the cloud you're deploying to (`az`, `gcloud`, or
+  `aws`)
+- `jq` (optional, helpful when piping through admin API responses)
+
+## Next steps
+
+Once you have the license key, DNS plan, and cert-manager strategy
+sorted, pick your cloud and follow the install guide:
+
+- [Install on Azure](/self-managed-deployments/enterprise-sso/install-on-azure/)
+- [Install on GCP](/self-managed-deployments/enterprise-sso/install-on-gcp/)
+- [Install on AWS](/self-managed-deployments/enterprise-sso/install-on-aws/)

--- a/doc/user/content/self-managed-deployments/enterprise-sso/prerequisites.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/prerequisites.md
@@ -8,77 +8,78 @@ menu:
     weight: 10
 ---
 
-Before running the enterprise example for your cloud, you'll need:
+Before running the enterprise example for your cloud, gather the items
+below.
 
-## Materialize license key with the `ory` entitlement
+## License Key with the `ory` Entitlement
+
+{{< yaml-table data="self_managed/license_key" >}}
 
 The Ory components ship as private OEL (Ory Enterprise License) images.
 Materialize hosts a registry proxy at `ory.registry.cloud.materialize.com`
-that pulls these images on behalf of customers. Authentication to the
-proxy uses your Materialize license key JWT (passed as the password in a
-Kubernetes `imagePullSecret`), so you don't need a separate Ory
-credential.
+that pulls these images on behalf of customers. Authentication to the proxy
+uses your Materialize license key JWT (passed as the password in a Kubernetes
+`imagePullSecret`), so there is no separate Ory credential to manage.
 
-The license key has to carry the `ory` entitlement. Contact Materialize
-sales or support to have one issued.
+The license key must carry the `ory` entitlement. Contact Materialize sales
+or support to have one issued.
 
 {{< note >}}
-The license key is also used by Materialize itself; the same JWT covers
-both. There's no separate "Ory key" you have to manage.
+The license key is also used by Materialize itself; the same JWT covers both.
+There is no separate "Ory key" to manage.
 {{</ note >}}
 
-## Cluster egress
+## Cluster Egress
 
 The Ory pods need network egress to two hosts:
 
-- `ory.registry.cloud.materialize.com` (the registry proxy)
-- `storage.googleapis.com` (the proxy returns HTTP 307 redirects to
-  signed GCS URLs for blob layers, which the kubelet follows directly)
+| Host | Purpose |
+|------|---------|
+| `ory.registry.cloud.materialize.com` | The Materialize-hosted Ory registry proxy. |
+| `storage.googleapis.com` | The proxy returns HTTP 307 redirects to signed GCS URLs for blob layers, which the kubelet follows directly. |
 
 If your cluster has egress restrictions or a NAT gateway with allowlist
 rules, both hosts must be reachable.
 
-## DNS hostnames
+## DNS Hostnames
 
-You need DNS hostnames you control for each browser-facing service.
-With Polis enabled, that's six hostnames:
+You need DNS hostnames you control for each browser-facing service. With
+Polis enabled, that is six hostnames:
 
 | Hostname | Purpose |
-|---|---|
+|----------|---------|
 | `hydra.example.com` | OAuth2 / OIDC issuer that Materialize trusts |
 | `kratos.example.com` | Kratos public API; browser-side redirect target |
 | `auth.example.com` | Selfservice UI (login, consent, registration pages) |
 | `polis.example.com` | Polis (SAML ACS, SCIM endpoint, OIDC token endpoint). Only when Polis is enabled. |
 | `console.example.com` | Materialize console |
-| `balancerd.example.com` | Materialize's SQL-over-HTTP endpoint. The console JS calls this from the browser, so it needs a public hostname and a trusted TLS cert. |
+| `balancerd.example.com` | Materialize's SQL-over-HTTP endpoint. The console's browser-side JS calls this directly, so it needs a public hostname and a trusted TLS cert. |
 
-You'll create A records pointing at the LoadBalancer IPs after the first
-`terraform apply`. The example deployment doesn't create the DNS records
-for you; the per-cloud install pages show the exact commands to grab the
-LB IPs.
+You will create DNS records pointing at the LoadBalancer IPs (or hostnames,
+on AWS) after the first `terraform apply`. The example does not create the
+DNS records for you; the per-cloud install pages show the exact commands to
+look up each LB.
 
-## cert-manager and a ClusterIssuer
+## cert-manager and a `ClusterIssuer`
 
-The example deploys cert-manager into the cluster and uses it to
-provision TLS certificates for each browser-facing hostname. You can
-choose one of three modes:
+The example deploys cert-manager into the cluster and uses it to provision
+TLS certificates for each browser-facing hostname. Pick one of three modes:
 
-### In-cluster self-signed (demos and air-gapped clusters)
+### In-Cluster Self-Signed (Demos and Air-Gapped Clusters)
 
-Default behaviour if you don't override `cert_issuer_ref`. cert-manager
-generates an in-cluster CA and signs all browser-facing certs from it.
-Browsers will not trust the certs out of the box.
+Default behaviour when `cert_issuer_ref` is not set. cert-manager generates
+an in-cluster CA and signs all browser-facing certs from it. Browsers will
+not trust the certs out of the box.
 
-Suitable for offline demos or proof-of-concept clusters where no public
-DNS / ACME path is available. Production deployments should use a real
-issuer.
+Suitable for offline demos or proof-of-concept clusters where no public DNS
+or ACME path is available. Production deployments should use a real issuer.
 
-### Bring your own ClusterIssuer
+### Bring Your Own `ClusterIssuer`
 
-Set `cert_issuer_ref` in tfvars to point at an existing ClusterIssuer
-managed outside of the example. Typical sources: a corporate CA, an
-ACME issuer (Let's Encrypt) already configured for other workloads, or
-a managed cloud issuer.
+Set `cert_issuer_ref` in tfvars to point at an existing `ClusterIssuer`
+managed outside of the example. Typical sources: a corporate CA, an ACME
+issuer (Let's Encrypt) already configured for other workloads, or a managed
+cloud issuer.
 
 ```hcl
 cert_issuer_ref = {
@@ -87,87 +88,48 @@ cert_issuer_ref = {
 }
 ```
 
-The browser-facing certs use this issuer. The internal mTLS cert
-between Materialize components continues to use the in-cluster
-self-signed cluster issuer because it includes `*.cluster.local` SANs
-that public ACME issuers cannot sign.
+The browser-facing certs use this issuer. The internal mTLS cert between
+Materialize components continues to use the in-cluster self-signed cluster
+issuer because it includes `*.cluster.local` SANs that public ACME issuers
+cannot sign.
 
 ### Let's Encrypt with cert-manager DNS-01
 
-For new deployments where you want browser-trusted certs without a
-managed cloud cert service, the example supports a Let's Encrypt
-ClusterIssuer backed by cert-manager's DNS-01 solver. Cloudflare,
-Route 53, Azure DNS, and Google Cloud DNS are all supported by
-cert-manager out of the box.
+For new deployments that want browser-trusted certs without a managed cloud
+cert service, the example supports a Let's Encrypt `ClusterIssuer` backed by
+cert-manager's DNS-01 solver. Cloudflare, Route 53, Azure DNS, and Google
+Cloud DNS are all supported by cert-manager out of the box.
 
 A starter `letsencrypt.tf` block is documented in the README of each
-per-cloud enterprise example. Drop it into your root module, set your
-DNS provider API token, and set `cert_issuer_ref` to
-`{ name = "letsencrypt-prod", kind = "ClusterIssuer" }`.
+per-cloud enterprise example. Drop it into your root module, set your DNS
+provider API token, and point `cert_issuer_ref` at it.
 
-## Polis-specific prerequisites (only when `enable_polis = true`)
+## Polis (Optional, SAML and SCIM)
 
-Polis has two upstream issues that the example works around with extra
-configuration. These are temporary and tracked with Ory; the
-requirements below will go away when Ory ships the fixes.
+Polis is the SAML-to-OIDC bridge that lets Kratos consume a SAML IdP as an
+upstream OIDC provider, and exposes a SCIM endpoint for IdP-driven user
+provisioning. It is off by default; opt in by setting `enable_polis = true`
+and supplying `ory_polis_fqdn` in the per-cloud install.
 
-### Dedicated amd64 node pool
+The Polis Helm chart and image are pulled through the same OEL registry
+proxy as the rest of the Ory stack, authenticated with the same license key
+JWT.
 
-The Polis OEL image (`polis-oel`) is currently published as `amd64` only.
-Kratos, Hydra, and the selfservice UI all ship multi-arch images and
-can run on any cluster, but Polis cannot run on `arm64` nodes.
+## Required Tools
 
-If your cluster's default node pool runs on `arm64` instances (Azure
-ARM, AWS Graviton, GCP Tau, Ampere), you need to add a small `amd64`
-node pool and pin Polis to it via Helm values:
-
-```hcl
-polis_helm_values = {
-  deployment = {
-    nodeSelector = { workload = "polis-amd64" }
-  }
-  job = {
-    nodeSelector = { workload = "polis-amd64" }
-  }
-}
-```
-
-One `Standard_B2s` (Azure) / `t3.small` (AWS) / `e2-small` (GCP)
-instance is enough. Both the Polis Deployment and the chart's
-pre-install migration Job need the selector, hence the two blocks.
-
-### GCP service-account JSON key for the chart pull
-
-The Polis Helm chart is published as a private OCI artifact on GCP
-Artifact Registry. The OEL registry proxy currently handles image pulls
-but doesn't yet serve OCI Helm chart manifests, so the chart needs to
-be pulled directly from GCP with a service account key.
-
-Set the path to the key file in tfvars:
-
-```hcl
-ory_polis_oci_chart_key_file = "/path/to/ory-artifacts-sa-key.json"
-```
-
-Contact Materialize sales or support to be issued a key. This will go
-away once the chart is published publicly or the OEL registry proxy
-gains OCI chart support.
-
-## Tooling
-
-Local tools you'll need:
-
-- `terraform` (>= 1.8)
-- `kubectl`
-- `helm` (only if you want to inspect chart values)
-- The cloud CLI for the cloud you're deploying to (`az`, `gcloud`, or
-  `aws`)
+- [Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform) (>= 1.8)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [Helm 3.2.0+](https://helm.sh/docs/intro/install/) (only required if you want to inspect chart values)
+- The cloud CLI for your target cloud:
+  [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli),
+  [gcloud CLI](https://cloud.google.com/sdk/docs/install), or
+  [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 - `jq` (optional, helpful when piping through admin API responses)
 
-## Next steps
+## Next Steps
 
-Once you have the license key, DNS plan, and cert-manager strategy
-sorted, pick your cloud and follow the install guide:
+Once you have the license key, DNS plan, and cert-manager strategy sorted,
+pick your cloud and follow the install guide:
 
 - [Install on Azure](/self-managed-deployments/enterprise-sso/install-on-azure/)
 - [Install on GCP](/self-managed-deployments/enterprise-sso/install-on-gcp/)

--- a/doc/user/content/self-managed-deployments/enterprise-sso/troubleshooting.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/troubleshooting.md
@@ -36,9 +36,7 @@ you can see which component rejected the flow.
 |---|---|---|
 | Pods stuck in `ImagePullBackOff` | License key JWT missing the `ory` entitlement, or expired | Update `license_key` in tfvars, re-apply, restart the Ory pods |
 | `curl https://polis.example.com` times out, LB has zero endpoints | Service selector doesn't match polis pod labels | Confirm the LoadBalancer Service selector targets `app.kubernetes.io/name=polis, instance=polis` |
-| TLS handshake fails on polis hostname | Polis doesn't terminate TLS, the LB target is plain HTTP | The example deploys an nginx TLS proxy in front of Polis automatically; check that the `polis-tls-proxy` Deployment is running |
-| Helm chart pull fails with `403 Forbidden` on `helm-oel-polis` | OEL registry proxy doesn't serve OCI chart manifests | Set `ory_polis_oci_chart_key_file` to a GCP service-account key with read access on `helm-oel-polis` |
-| `exec /bin/sh: exec format error` in `polis-migration` pod | Migration job scheduled on an arm64 node, polis image is amd64-only | Add `polis_helm_values = { job = { nodeSelector = { workload = "polis-amd64" } } }` and ensure an amd64 node pool exists |
+| TLS handshake fails on polis hostname | Polis doesn't terminate TLS, the LB target is plain HTTP | The example deploys a pingap TLS proxy in front of Polis automatically; check that the `polis-tls-proxy` Deployment is running |
 | Polis SCIM endpoint URLs return `http://localhost:5225/...` | `EXTERNAL_URL` env var not set on Polis | Module sets it automatically from `external_url`; re-run `terraform apply` |
 | Polis logs `OAuth server not configured correctly for openid flow, check if JWT signing keys are loaded` | `OPENID_RSA_PRIVATE_KEY` and `OPENID_RSA_PUBLIC_KEY` missing | Module auto-generates and injects them; re-run `terraform apply` |
 | Polis logs `"pkcs8" must be PKCS#8 formatted string` | RSA private key was PKCS#1 | Module uses the PKCS#8 form; re-run `terraform apply` |

--- a/doc/user/content/self-managed-deployments/enterprise-sso/troubleshooting.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/troubleshooting.md
@@ -138,7 +138,7 @@ See the cloud-specific notes:
 - **Azure**: usually the OAuth2Client finalizer (see the symptom table
   above)
 - **AWS**: the AWS Load Balancer Controller can race with namespace
-  deletion. See [AWS-specific notes](/self-managed-deployments/enterprise-sso/install-on-aws/#destroy)
+  deletion. See [AWS-specific notes](/self-managed-deployments/enterprise-sso/install-on-aws/#cleanup)
 - **GCP**: the GKE master IP allocator can be slow; usually patience is
   the fix
 

--- a/doc/user/content/self-managed-deployments/enterprise-sso/troubleshooting.md
+++ b/doc/user/content/self-managed-deployments/enterprise-sso/troubleshooting.md
@@ -1,0 +1,164 @@
+---
+title: "Troubleshooting"
+description: "Diagnose and fix common issues with the Ory-based enterprise SSO stack."
+menu:
+  main:
+    parent: "enterprise-sso"
+    identifier: "enterprise-sso-troubleshooting"
+    weight: 60
+---
+
+Common errors and fixes when deploying or operating the Ory stack.
+
+## Where to look first
+
+For most failures, the right place to start is the Ory pod logs:
+
+```bash
+kubectl logs -n ory deploy/kratos -f
+kubectl logs -n ory deploy/hydra -f
+kubectl logs -n ory deploy/ory-selfservice-ui -f
+kubectl logs -n ory deploy/polis -f          # when enable_polis = true
+```
+
+Hydra Maester (responsible for managing OAuth2Client CRDs):
+
+```bash
+kubectl logs -n ory deploy/hydra-hydra-maester -f
+```
+
+For login-time issues, tail Kratos, Hydra, and Polis simultaneously so
+you can see which component rejected the flow.
+
+## Symptom table
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Pods stuck in `ImagePullBackOff` | License key JWT missing the `ory` entitlement, or expired | Update `license_key` in tfvars, re-apply, restart the Ory pods |
+| `curl https://polis.example.com` times out, LB has zero endpoints | Service selector doesn't match polis pod labels | Confirm the LoadBalancer Service selector targets `app.kubernetes.io/name=polis, instance=polis` |
+| TLS handshake fails on polis hostname | Polis doesn't terminate TLS, the LB target is plain HTTP | The example deploys an nginx TLS proxy in front of Polis automatically; check that the `polis-tls-proxy` Deployment is running |
+| Helm chart pull fails with `403 Forbidden` on `helm-oel-polis` | OEL registry proxy doesn't serve OCI chart manifests | Set `ory_polis_oci_chart_key_file` to a GCP service-account key with read access on `helm-oel-polis` |
+| `exec /bin/sh: exec format error` in `polis-migration` pod | Migration job scheduled on an arm64 node, polis image is amd64-only | Add `polis_helm_values = { job = { nodeSelector = { workload = "polis-amd64" } } }` and ensure an amd64 node pool exists |
+| Polis SCIM endpoint URLs return `http://localhost:5225/...` | `EXTERNAL_URL` env var not set on Polis | Module sets it automatically from `external_url`; re-run `terraform apply` |
+| Polis logs `OAuth server not configured correctly for openid flow, check if JWT signing keys are loaded` | `OPENID_RSA_PRIVATE_KEY` and `OPENID_RSA_PUBLIC_KEY` missing | Module auto-generates and injects them; re-run `terraform apply` |
+| Polis logs `"pkcs8" must be PKCS#8 formatted string` | RSA private key was PKCS#1 | Module uses the PKCS#8 form; re-run `terraform apply` |
+| First login fails with `no matching authentication claim found in the JWT` | User clicked Allow on the consent screen without ticking the `email` scope | Module sets `skipConsent: true` on the OAuth2Client which bypasses the consent screen for the Materialize client; re-run `terraform apply` |
+| `"Couldn't fetch XML data"` when registering a Polis SAML connection | The IdP's metadata URL is gated by API auth | Post `rawMetadata=<XML>` to Polis instead of `metadataUrl=...` |
+| "Sign in via SAML" button missing on Kratos login | Cached login flow from before the polis provider was added | Hard refresh or open a new incognito session |
+| Materialize console reaches the login screen but balancerd times out | DNS or cert SAN mismatch | Confirm the balancerd hostname A record resolves and is in the cert SAN list (`balancerd_extra_dns_names`) |
+| User logs in but can't run any SQL | JIT role created with no privileges | Run `GRANT <role> TO "user@email"` as `mz_system` |
+| SCIM "Test Connector Configuration" passes but no users push | Existing assignments don't backfill when SCIM is enabled after-the-fact | In Okta, unassign + reassign the user, or push profile updates from the people side |
+| `terraform destroy` hangs on `kubernetes_namespace.ory` | OAuth2Client finalizer not cleared because Hydra Maester is torn down before processing it | `kubectl patch oauth2client materialize-oauth2-client -n ory --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'` then re-run destroy |
+
+## Detailed walkthroughs
+
+### Hydra returns `invalid_client` on the token endpoint
+
+Usually means the OAuth2Client CRD didn't reconcile against Hydra (so
+the `client_id` Materialize is using doesn't exist in Hydra's
+database).
+
+Check the CRD:
+
+```bash
+kubectl get oauth2client -n ory materialize-oauth2-client -o yaml
+```
+
+Look for the `status.reconciliationError` field. Common errors:
+
+- "Hydra admin unreachable" -- Hydra Maester can't connect to Hydra's
+  admin port. Confirm `hydra-admin.ory.svc.cluster.local:4445` resolves
+  from inside the cluster.
+- "duplicate client name" -- a stale OAuth2Client from a previous apply
+  exists in Hydra's DB. Delete the CRD, wait for Hydra Maester to drop
+  the Hydra-side record, then re-apply.
+
+Check Hydra Maester logs:
+
+```bash
+kubectl logs -n ory deploy/hydra-hydra-maester --tail=100
+```
+
+### Kratos selfservice UI shows a blank login page
+
+Almost always a TLS or DNS issue between the browser and Kratos. Open
+your browser's network tab and inspect the requests:
+
+- 502/504 on `/self-service/login/browser` → Kratos isn't reachable
+  from the UI pod. Check Kratos pod status.
+- TLS error on the redirect target → cert not provisioned yet, or the
+  hostname DNS record isn't propagated. Run `kubectl get certificate -A`
+  and confirm `kratos-tls` is `READY=True`.
+- `CORS` error → the Hydra `cors_allowed_origins` doesn't include the
+  console hostname. Check the `hydra` Helm release values.
+
+### Polis SAML flow returns `server_error: <random-name>`
+
+Polis encodes errors with a random nickname for the log entry (e.g.
+`curve_tourist_bean`). The real error is in the Polis pod logs:
+
+```bash
+kubectl logs -n ory deploy/polis --tail=200 | grep -B2 -A5 "error\|Error"
+```
+
+Common causes:
+
+- `"pkcs8" must be PKCS#8 formatted string` → see symptom table
+- IdP metadata doesn't include the SAML signing cert → re-export the
+  metadata XML from the IdP and update the Polis connection with
+  `rawMetadata`
+- Audience mismatch → confirm the IdP's SAML app audience is set to
+  `https://saml.boxyhq.com`
+
+### Console login loops back to the IdP indefinitely
+
+Usually a redirect URI mismatch. The redirect URI registered with your
+IdP must exactly match what Kratos sends:
+
+```
+https://<your-kratos-hostname>/self-service/methods/oidc/callback/<id>
+```
+
+where `<id>` is the entry in `upstream_oidc_providers`. Trailing slashes
+matter. Update the redirect URI in the IdP to match.
+
+If the redirect URI is correct, check the `oidc_audience` system
+parameter on the Materialize side. It must include the OAuth2 client_id
+Hydra Maester generated:
+
+```bash
+kubectl get secret -n ory materialize-oauth2-client \
+  -o jsonpath='{.data.CLIENT_ID}' | base64 -d
+```
+
+Compare with the Materialize CR's `system_parameters.oidc_audience`.
+
+### A specific cloud is hanging during destroy
+
+See the cloud-specific notes:
+
+- **Azure**: usually the OAuth2Client finalizer (see the symptom table
+  above)
+- **AWS**: the AWS Load Balancer Controller can race with namespace
+  deletion. See [AWS-specific notes](/self-managed-deployments/enterprise-sso/install-on-aws/#destroy)
+- **GCP**: the GKE master IP allocator can be slow; usually patience is
+  the fix
+
+## When to escalate
+
+If the failure doesn't match any of the above and the Ory pod logs
+don't surface a clear cause, file an issue with:
+
+- The pod logs (`kubectl logs -n ory deploy/<component>`) from the
+  affected component plus the two it talks to
+- The Hydra OAuth2Client CRD YAML (`kubectl get oauth2client -n ory
+  materialize-oauth2-client -o yaml`)
+- The output of `kubectl get all,certificate,oauth2client -n ory`
+- The cloud (Azure / GCP / AWS), Materialize version, and Ory chart
+  version pinned in your tfvars
+
+## See also
+
+- [Ory Kratos troubleshooting](https://www.ory.sh/docs/kratos/troubleshooting)
+- [Ory Hydra debugging](https://www.ory.sh/docs/hydra/debug)
+- [Ory Polis docs](https://www.ory.sh/docs/polis)

--- a/doc/user/shared-content/self-managed/enterprise-sso/cert-issuer-tfvars.md
+++ b/doc/user/shared-content/self-managed/enterprise-sso/cert-issuer-tfvars.md
@@ -1,0 +1,10 @@
+To bring your own cert-manager `ClusterIssuer` for the browser-facing TLS certs (Hydra, Kratos, the selfservice UI, Polis, the Materialize console, and balancerd):
+
+```hcl
+cert_issuer_ref = {
+  name = "letsencrypt-prod"
+  kind = "ClusterIssuer"
+}
+```
+
+If you want a Let's Encrypt issuer signed via DNS-01, the example's README ships a starter `letsencrypt.tf` snippet for Cloudflare, Route 53, Azure DNS, and Google Cloud DNS. Drop it next to `main.tf`, set your DNS provider API token, and point `cert_issuer_ref` at it.

--- a/doc/user/shared-content/self-managed/enterprise-sso/destroy-finalizer-note.md
+++ b/doc/user/shared-content/self-managed/enterprise-sso/destroy-finalizer-note.md
@@ -1,0 +1,10 @@
+{{< note >}}
+`terraform destroy` can hang on the `ory` namespace because the `OAuth2Client` CRD has a Hydra Maester finalizer that is not always cleared before Maester itself is torn down. If the destroy stalls on the namespace, patch the finalizer off:
+
+```bash
+kubectl patch oauth2client materialize-oauth2-client -n ory \
+  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
+```
+
+Then re-run `terraform destroy`. A cleaner fix is tracked upstream.
+{{</ note >}}

--- a/doc/user/shared-content/self-managed/enterprise-sso/dns-records.md
+++ b/doc/user/shared-content/self-managed/enterprise-sso/dns-records.md
@@ -1,0 +1,24 @@
+After `terraform apply`, list the LoadBalancer ingress addresses:
+
+```bash
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}/{.metadata.name}{"\t"}{.status.loadBalancer.ingress[0].ip}{"\t"}{.status.loadBalancer.ingress[0].hostname}{"\n"}{end}'
+```
+
+Create DNS records pointing the six browser-facing hostnames at the corresponding LB IP (Azure, GCP) or hostname (AWS):
+
+| Hostname | Backed by Service |
+|----------|-------------------|
+| `hydra.example.com` | `ory/hydra-public-lb` |
+| `kratos.example.com` | `ory/kratos-public-lb` |
+| `auth.example.com` | `ory/ory-selfservice-ui-lb` |
+| `polis.example.com` | `ory/polis-public-lb` (only when `enable_polis = true`) |
+| `console.example.com` | `materialize-environment/main-console-https` |
+| `balancerd.example.com` | `materialize-environment/<release-id>-balancerd-lb` |
+
+cert-manager issues TLS certs as soon as DNS resolves. Wait for all Certificates to report `READY=True`:
+
+```bash
+kubectl get certificate -A -w
+```
+
+The first issuance via Let's Encrypt DNS-01 typically takes 1 to 3 minutes per cert.

--- a/doc/user/shared-content/self-managed/enterprise-sso/polis-tfvars.md
+++ b/doc/user/shared-content/self-managed/enterprise-sso/polis-tfvars.md
@@ -1,0 +1,6 @@
+To enable Polis (SAML and SCIM):
+
+```hcl
+enable_polis   = true
+ory_polis_fqdn = "polis.example.com"
+```

--- a/doc/user/shared-content/self-managed/enterprise-sso/upstream-oidc-tfvars.md
+++ b/doc/user/shared-content/self-managed/enterprise-sso/upstream-oidc-tfvars.md
@@ -1,0 +1,17 @@
+To federate logins through one or more upstream OIDC providers (Okta, Google Workspace, Auth0, Entra), add an `upstream_oidc_providers` list. Each entry renders as a "Sign in with ..." button on the selfservice UI:
+
+```hcl
+upstream_oidc_providers = [
+  {
+    id            = "okta"
+    provider      = "generic"
+    client_id     = "<from your IdP>"
+    client_secret = "<from your IdP>"
+    issuer_url    = "https://your-org.okta.com/oauth2/default"
+    scope         = ["openid", "email", "profile"]
+    label         = "Sign in with Okta"
+  },
+]
+```
+
+Register the redirect URI `https://<ory_kratos_fqdn>/self-service/methods/oidc/callback/<id>` at the upstream IdP. See [Configure identity providers](/self-managed-deployments/enterprise-sso/identity-providers/) for SAML and SCIM setup once the stack is up.

--- a/doc/user/shared-content/self-managed/enterprise-sso/verify.md
+++ b/doc/user/shared-content/self-managed/enterprise-sso/verify.md
@@ -1,0 +1,20 @@
+Smoke-test each browser-facing endpoint:
+
+```bash
+# Hydra OIDC discovery (issuer should match ory_hydra_fqdn)
+curl -fsSL https://hydra.example.com/.well-known/openid-configuration | jq .issuer
+
+# Kratos health
+curl -fsSL https://kratos.example.com/health/ready
+
+# Selfservice UI health
+curl -fsSL https://auth.example.com/health/alive
+
+# Polis health (only when enable_polis = true)
+curl -fsSL https://polis.example.com/api/health
+
+# Materialize console (expect HTTP 200)
+curl -fsSL -o /dev/null -w "%{http_code}\n" https://console.example.com
+```
+
+Open `https://console.example.com` in a browser. You should land on the Kratos login screen. If you configured `upstream_oidc_providers`, a "Sign in with ..." button is rendered per provider. With Polis enabled and a SAML connection registered, a "Sign in via SAML" button is rendered as well.


### PR DESCRIPTION
Draft of the user-facing docs for the Ory-based enterprise SSO stack. Covers Azure, GCP, and AWS installs in the canonical install-on-* style, with shared snippets factored into shared-content for the bits that repeat. Linear: DEP-139.