### PR TITLE
Scoped feature flags: resolution and gating

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -229,6 +229,11 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "enable_scoped_system_parameters",
+            "false",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_upsert_v2",
             "false",
             ["true", "false"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1518,6 +1518,7 @@ class FlipFlagsAction(Action):
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_scoped_system_parameters"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",
             "1",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -277,6 +277,17 @@ pub const PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT: Config<Duration> = Config::new(
     Postgres/CRDB timestamp oracle. A value of zero leaves the statement timeout unset.",
 );
 
+/// Whether per-cluster and per-replica scoped system parameters are evaluated.
+/// Off by default: the parameter sync loop evaluates no cluster/replica
+/// contexts and resolution falls back to the environment-wide value everywhere
+/// (the pre-scoped behavior). Enabling it (e.g. from LaunchDarkly) turns on
+/// scoped evaluation without a deploy.
+pub const ENABLE_SCOPED_SYSTEM_PARAMETERS: Config<bool> = Config::new(
+    "enable_scoped_system_parameters",
+    false,
+    "Whether per-cluster and per-replica scoped system parameters are evaluated and applied.",
+);
+
 /// Adds the full set of all adapter `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -315,4 +326,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ARRANGEMENT_SIZE_HISTORY_RETENTION_PERIOD)
         .add(&CATALOG_INFO_METRICS_RECONCILE_INTERVAL)
         .add(&PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT)
+        .add(&ENABLE_SCOPED_SYSTEM_PARAMETERS)
 }

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -73,7 +73,7 @@ use crate::catalog::{
     is_reserved_role_name, object_type_to_audit_object_type,
     system_object_type_to_audit_object_type,
 };
-use crate::config::ScopedParameters;
+use crate::config::{ScopedParameters, ScopedParametersScope};
 use crate::coord::ConnMeta;
 use crate::coord::catalog_implications::parsed_state_updates::ParsedStateUpdate;
 use crate::coord::cluster_scheduling::SchedulingDecision;
@@ -247,14 +247,19 @@ pub enum Op {
     },
     ResetAllSystemConfiguration,
     /// Persists the durable cache of scoped (per-cluster and per-replica)
-    /// system parameters to match `scoped`, the complete desired state computed
-    /// by the system-parameter sync loop (the sole writer). The handler diffs
-    /// against the current durable contents: it upserts changed/added entries
-    /// and removes entries the sync loop no longer serves, and lazily prunes
-    /// entries whose owning object id is absent from the catalog. See the
-    /// scoped feature flags design.
+    /// system parameters towards `scoped`. The handler diffs against the current
+    /// durable contents: it upserts changed/added entries and removes entries
+    /// the update no longer serves.
+    ///
+    /// `prune_scope` bounds removals to the objects the update was evaluated
+    /// for. `Some(scope)` removes a row only when its owning object is in
+    /// `scope`, so an object created after the update's evaluation snapshot, and
+    /// the override it folded into its own create transaction, survives a
+    /// concurrent full-state reconcile. `None` is an unscoped full replace, used
+    /// only by the disabled-feature clear path where no create-time writes race.
     UpdateScopedSystemParameters {
         scoped: ScopedParameters,
+        prune_scope: Option<ScopedParametersScope>,
     },
     /// Injects audit events into the catalog.
     ///
@@ -2712,18 +2717,38 @@ impl Catalog {
                     EventDetails::ResetAllV1,
                 )?;
             }
-            Op::UpdateScopedSystemParameters { scoped } => {
-                // The sync loop pushes the *complete* desired state each tick;
-                // diff it against the durable cache and persist only the delta.
-                // Entries whose owning object id is absent from the catalog are
-                // pruned (lazy GC); object ids are never reused, so such entries
-                // are inert and pruning is hygiene only.
+            Op::UpdateScopedSystemParameters {
+                scoped,
+                prune_scope,
+            } => {
+                // Diff `scoped` against the durable cache and persist only the
+                // delta: upsert changed/added entries, then remove entries the
+                // update no longer serves. A removal for a still-live object is
+                // bounded by `prune_scope` so this update does not delete a row
+                // for an object it was not evaluated for (e.g. one created after
+                // the update's snapshot, whose override rode its own create
+                // transaction). `None` prunes unconditionally (the
+                // disabled-feature clear path). Rows whose owning object is no
+                // longer live are always pruned regardless of `prune_scope`,
+                // because nothing else garbage collects them and ids are never
+                // reused, so this lazily reclaims orphans left by dropped
+                // objects.
                 let live_clusters: BTreeSet<ClusterId> =
                     tx.get_clusters().map(|cluster| cluster.id).collect();
                 let live_replicas: BTreeSet<ReplicaId> = tx
                     .get_cluster_replicas()
                     .map(|replica| replica.replica_id)
                     .collect();
+                let prune_cluster = |id: &ClusterId| {
+                    prune_scope
+                        .as_ref()
+                        .map_or(true, |s| s.clusters.contains(id))
+                };
+                let prune_replica = |id: &ReplicaId| {
+                    prune_scope
+                        .as_ref()
+                        .map_or(true, |s| s.replicas.contains(id))
+                };
 
                 // Cluster-coherent scope.
                 let existing_cluster: BTreeMap<(ClusterId, String), String> = tx
@@ -2742,10 +2767,10 @@ impl Catalog {
                         }
                     }
                 }
-                // Non-live clusters never enter `desired_cluster` (they `continue`
-                // above), so a missing entry already covers dropped clusters.
                 for (cluster_id, name) in existing_cluster.into_keys() {
-                    if !desired_cluster.contains(&(cluster_id, name.clone())) {
+                    if (!live_clusters.contains(&cluster_id) || prune_cluster(&cluster_id))
+                        && !desired_cluster.contains(&(cluster_id, name.clone()))
+                    {
                         tx.remove_cluster_system_config(cluster_id, &name);
                     }
                 }
@@ -2768,7 +2793,9 @@ impl Catalog {
                     }
                 }
                 for (replica_id, name) in existing_replica.into_keys() {
-                    if !desired_replica.contains(&(replica_id, name.clone())) {
+                    if (!live_replicas.contains(&replica_id) || prune_replica(&replica_id))
+                        && !desired_replica.contains(&(replica_id, name.clone()))
+                    {
                         tx.remove_replica_system_config(replica_id, &name);
                     }
                 }
@@ -3399,6 +3426,245 @@ mod tests {
             let all_t2 = state_all_at_once.try_get_entry(&id_t2).expect("all t2");
             assert_eq!(inc_t2.name(), all_t2.name());
             assert_eq!(inc_t2.owner_id, all_t2.owner_id);
+
+            catalog.expire().await;
+        })
+        .await
+    }
+
+    /// Exercises the diff-and-prune semantics of the
+    /// `Op::UpdateScopedSystemParameters` apply handler over the cluster scope.
+    /// Covers four behaviors: upsert of a desired row, the bounded-prune
+    /// protection that spares a live cluster outside `prune_scope`, removal of a
+    /// stale in-scope row, and the orphan-prune that reclaims a row whose owning
+    /// cluster was dropped even though that id is absent from `prune_scope`.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
+    async fn test_transact_update_scoped_system_parameters_prune() {
+        use std::collections::{BTreeMap, BTreeSet};
+
+        use mz_catalog::memory::objects::{ClusterConfig, ClusterVariant};
+        use mz_controller_types::ClusterId;
+
+        use crate::catalog::DropObjectInfo;
+        use crate::config::{ScopedParameters, ScopedParametersScope};
+
+        Catalog::with_debug(|mut catalog| async move {
+            let param = "max_query_result_size".to_string();
+            let value = "1MB".to_string();
+
+            // Allocate and create two live clusters, A and B, the same way
+            // production code does.
+            let commit_ts = catalog.current_upper().await;
+            let cluster_a = catalog
+                .allocate_user_cluster_id(commit_ts)
+                .await
+                .expect("allocate cluster A");
+            let commit_ts = catalog.current_upper().await;
+            let cluster_b = catalog
+                .allocate_user_cluster_id(commit_ts)
+                .await
+                .expect("allocate cluster B");
+
+            let make_cluster_op = |id: ClusterId, name: &str| Op::CreateCluster {
+                id,
+                name: name.to_string(),
+                introspection_sources: Vec::new(),
+                owner_id: MZ_SYSTEM_ROLE_ID,
+                config: ClusterConfig {
+                    variant: ClusterVariant::Unmanaged,
+                    workload_class: None,
+                },
+            };
+
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![
+                        make_cluster_op(cluster_a, "test_cluster_a"),
+                        make_cluster_op(cluster_b, "test_cluster_b"),
+                    ],
+                )
+                .await
+                .expect("create clusters");
+
+            // Reads the durable cluster system configuration rows.
+            async fn rows(catalog: &Catalog) -> BTreeSet<(ClusterId, String, String)> {
+                let mut storage = catalog.storage().await;
+                let tx = storage.transaction().await.expect("open transaction");
+                tx.get_cluster_system_configurations()
+                    .map(|c| (c.cluster_id, c.name, c.value))
+                    .collect()
+            }
+
+            let scope_with = |ids: &[ClusterId]| ScopedParametersScope {
+                clusters: ids.iter().copied().collect(),
+                replicas: BTreeSet::new(),
+            };
+            let cluster_scoped = |id: ClusterId| {
+                let mut cluster = BTreeMap::new();
+                let mut overrides = BTreeMap::new();
+                overrides.insert(param.clone(), value.clone());
+                cluster.insert(id, overrides);
+                ScopedParameters {
+                    cluster,
+                    replica: BTreeMap::new(),
+                }
+            };
+            let empty_scoped = || ScopedParameters {
+                cluster: BTreeMap::new(),
+                replica: BTreeMap::new(),
+            };
+
+            // Behavior 1: upsert. A is live and in scope, so the row is created.
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![Op::UpdateScopedSystemParameters {
+                        scoped: cluster_scoped(cluster_a),
+                        prune_scope: Some(scope_with(&[cluster_a])),
+                    }],
+                )
+                .await
+                .expect("upsert A");
+            assert!(
+                rows(&catalog)
+                    .await
+                    .contains(&(cluster_a, param.clone(), value.clone())),
+                "upsert must create the row for A"
+            );
+
+            // Set up an additional row for B so the prune cases have something to
+            // act on.
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![Op::UpdateScopedSystemParameters {
+                        scoped: cluster_scoped(cluster_b),
+                        prune_scope: Some(scope_with(&[cluster_b])),
+                    }],
+                )
+                .await
+                .expect("upsert B");
+            assert!(
+                rows(&catalog)
+                    .await
+                    .contains(&(cluster_b, param.clone(), value.clone())),
+                "setup must create the row for B"
+            );
+
+            // Behavior 2: bounded prune. Running with empty `scoped` and a scope
+            // that excludes the live cluster B must leave B's row intact, because
+            // the update was not authoritative for B.
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![Op::UpdateScopedSystemParameters {
+                        scoped: empty_scoped(),
+                        prune_scope: Some(scope_with(&[cluster_a])),
+                    }],
+                )
+                .await
+                .expect("bounded prune");
+            assert!(
+                rows(&catalog)
+                    .await
+                    .contains(&(cluster_b, param.clone(), value.clone())),
+                "a live cluster outside prune_scope must keep its row"
+            );
+
+            // Behavior 3: stale in-scope prune. A is live and in scope but not
+            // desired, so its row is removed.
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![Op::UpdateScopedSystemParameters {
+                        scoped: empty_scoped(),
+                        prune_scope: Some(scope_with(&[cluster_a])),
+                    }],
+                )
+                .await
+                .expect("stale in-scope prune");
+            assert!(
+                !rows(&catalog)
+                    .await
+                    .iter()
+                    .any(|(id, _, _)| *id == cluster_a),
+                "a live in-scope undesired row must be removed"
+            );
+
+            // Behavior 4: orphan prune. Re-create A's row, drop cluster A, then run
+            // the update with a scope that does NOT contain A. The sync loop only
+            // ever places live ids in prune_scope, so the orphan must still be
+            // reclaimed because its owning cluster is no longer live.
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![Op::UpdateScopedSystemParameters {
+                        scoped: cluster_scoped(cluster_a),
+                        prune_scope: Some(scope_with(&[cluster_a])),
+                    }],
+                )
+                .await
+                .expect("re-create A row");
+            assert!(
+                rows(&catalog)
+                    .await
+                    .contains(&(cluster_a, param.clone(), value.clone())),
+                "re-created row for A must exist"
+            );
+
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![Op::DropObjects(vec![DropObjectInfo::Cluster(cluster_a)])],
+                )
+                .await
+                .expect("drop cluster A");
+
+            // B is the only live cluster the sync loop would have evaluated, so
+            // only B appears in prune_scope. A's id is deliberately absent.
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![Op::UpdateScopedSystemParameters {
+                        scoped: cluster_scoped(cluster_b),
+                        prune_scope: Some(scope_with(&[cluster_b])),
+                    }],
+                )
+                .await
+                .expect("orphan prune");
+            assert!(
+                !rows(&catalog)
+                    .await
+                    .iter()
+                    .any(|(id, _, _)| *id == cluster_a),
+                "orphan row for a dropped cluster must be removed even when absent from prune_scope"
+            );
 
             catalog.expire().await;
         })

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -56,6 +56,7 @@ use crate::command::{
     CatalogDump, CatalogSnapshot, Command, CopyFromStdinWriter, ExecuteResponse, Response,
     SASLChallengeResponse, SASLVerifyProofResponse, SuperuserAttribute,
 };
+use crate::config::{ScopedParameters, ScopedParametersScope, SystemParameterFrontend};
 use crate::coord::{Coordinator, ExecuteContextGuard};
 use crate::error::AdapterError;
 use crate::metrics::{self, Metrics};
@@ -553,6 +554,45 @@ Issue a SQL query to get started. Need help?
         let (tx, rx) = oneshot::channel();
         self.send(Command::GetSystemVars { tx });
         rx.await.expect("coordinator unexpectedly gone")
+    }
+
+    /// Returns a snapshot of the catalog.
+    pub async fn catalog_snapshot(&self) -> Arc<Catalog> {
+        let (tx, rx) = oneshot::channel();
+        self.send(Command::CatalogSnapshot { tx });
+        let CatalogSnapshot { catalog } = rx.await.expect("coordinator unexpectedly gone");
+        catalog
+    }
+
+    /// Reconciles the coordinator's scoped feature-flag working copy towards
+    /// `overrides`. Used by the system-parameter sync loop from continuous
+    /// LaunchDarkly evaluation.
+    ///
+    /// `prune_scope` bounds which objects' rows the reconcile may remove (the
+    /// objects `overrides` was evaluated for). The sync loop passes the live
+    /// objects from its snapshot; `None` is a full replace, used by the
+    /// disabled-feature clear path. See
+    /// [`crate::catalog::Op::UpdateScopedSystemParameters`].
+    pub async fn update_scoped_system_parameters(
+        &self,
+        overrides: ScopedParameters,
+        prune_scope: Option<ScopedParametersScope>,
+    ) {
+        let (tx, rx) = oneshot::channel();
+        self.send(Command::UpdateScopedSystemParameters {
+            overrides,
+            prune_scope,
+            tx,
+        });
+        let _ = rx.await;
+    }
+
+    /// Installs (or replaces) the shared system-parameter frontend on the
+    /// coordinator, letting the create-cluster / create-replica paths resolve a
+    /// new object's scoped overrides synchronously. Sent by the sync loop each
+    /// time it (re)initializes the frontend. Fire-and-forget.
+    pub fn install_scoped_system_parameter_frontend(&self, frontend: Arc<SystemParameterFrontend>) {
+        self.send(Command::InstallScopedSystemParameterFrontend { frontend });
     }
 
     #[instrument(level = "debug")]
@@ -1320,6 +1360,8 @@ impl SessionClient {
                 | Command::PrivilegedCancelRequest { .. }
                 | Command::GetSystemVars { .. }
                 | Command::SetSystemVars { .. }
+                | Command::UpdateScopedSystemParameters { .. }
+                | Command::InstallScopedSystemParameterFrontend { .. }
                 | Command::Terminate { .. }
                 | Command::RetireExecute { .. }
                 | Command::CheckConsistency { .. }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -46,6 +46,7 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::catalog::Catalog;
+use crate::config::{ScopedParameters, ScopedParametersScope, SystemParameterFrontend};
 use crate::coord::appends::BuiltinTableAppendNotify;
 use crate::coord::consistency::CoordinatorInconsistencies;
 use crate::coord::peek::{PeekDataflowPlan, PeekResponseUnary};
@@ -166,6 +167,30 @@ pub enum Command {
         vars: BTreeMap<String, String>,
         conn_id: ConnectionId,
         tx: oneshot::Sender<Result<(), AdapterError>>,
+    },
+
+    /// Replace the scoped feature-flag overrides (the complete desired state).
+    /// Computed by the system-parameter sync loop from continuous LaunchDarkly
+    /// evaluation. The coordinator stores this working copy and reconciles it
+    /// into the per-scope resolution boundaries (the compute controller's
+    /// per-replica dyncfg layer for `replica`-scoped parameters). See the
+    /// scoped feature flags design.
+    UpdateScopedSystemParameters {
+        overrides: ScopedParameters,
+        /// Bounds which objects' durable rows the reconcile may prune. See
+        /// [`crate::catalog::Op::UpdateScopedSystemParameters`].
+        prune_scope: Option<ScopedParametersScope>,
+        tx: oneshot::Sender<()>,
+    },
+
+    /// Install (or replace) the shared system-parameter frontend on the
+    /// coordinator, so the create-cluster / create-replica paths can resolve a
+    /// new object's scoped overrides synchronously, before the controller
+    /// installs it or its first dataflow is planned, rather than waiting for
+    /// the next sync tick. Sent by the sync loop whenever it (re)initializes the
+    /// frontend. See the scoped feature flags design.
+    InstallScopedSystemParameterFrontend {
+        frontend: Arc<SystemParameterFrontend>,
     },
 
     InjectAuditEvents {
@@ -369,6 +394,8 @@ impl Command {
             | Command::Terminate { .. }
             | Command::GetSystemVars { .. }
             | Command::SetSystemVars { .. }
+            | Command::UpdateScopedSystemParameters { .. }
+            | Command::InstallScopedSystemParameterFrontend { .. }
             | Command::RetireExecute { .. }
             | Command::CheckConsistency { .. }
             | Command::Dump { .. }
@@ -407,6 +434,8 @@ impl Command {
             | Command::Terminate { .. }
             | Command::GetSystemVars { .. }
             | Command::SetSystemVars { .. }
+            | Command::UpdateScopedSystemParameters { .. }
+            | Command::InstallScopedSystemParameterFrontend { .. }
             | Command::RetireExecute { .. }
             | Command::CheckConsistency { .. }
             | Command::Dump { .. }

--- a/src/adapter/src/config.rs
+++ b/src/adapter/src/config.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use mz_build_info::BuildInfo;
@@ -25,8 +25,12 @@ mod params;
 mod sync;
 
 pub use backend::SystemParameterBackend;
-pub use frontend::SystemParameterFrontend;
+pub use frontend::{
+    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
+    SystemParameterFrontend,
+};
 pub use params::{ModifiedParameter, SynchronizedParameters};
+pub(crate) use sync::evaluate_scoped_parameters;
 pub use sync::system_parameter_sync;
 
 /// Scoped (per-cluster and per-replica) system-parameter overrides, keyed by
@@ -42,6 +46,22 @@ pub struct ScopedParameters {
     pub cluster: BTreeMap<ClusterId, BTreeMap<String, String>>,
     /// Replica-local overrides, keyed by replica id.
     pub replica: BTreeMap<ReplicaId, BTreeMap<String, String>>,
+}
+
+/// The set of objects a [`ScopedParameters`] update was evaluated for, used to
+/// bound which durable override rows the update may prune.
+///
+/// The update is authoritative only for objects in this set. The durable apply
+/// removes a row only when its owning object is in scope and the update no
+/// longer carries that override, so an object created after the update's
+/// evaluation snapshot, and the override it folded into its own create
+/// transaction, is not wiped by a concurrent full-state reconcile.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ScopedParametersScope {
+    /// Cluster ids whose rows the update may prune.
+    pub clusters: BTreeSet<ClusterId>,
+    /// Replica ids whose rows the update may prune.
+    pub replicas: BTreeSet<ReplicaId>,
 }
 
 impl ScopedParameters {

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -18,6 +18,8 @@ use hyper_tls::HttpsConnector;
 use launchdarkly_server_sdk as ld;
 use mz_build_info::BuildInfo;
 use mz_cloud_provider::CloudProvider;
+use mz_cluster_client::ReplicaId;
+use mz_controller_types::ClusterId;
 use mz_ore::now::NowFn;
 use mz_sql::catalog::EnvironmentId;
 use serde_json::Value as JsonValue;
@@ -38,6 +40,11 @@ pub struct SystemParameterFrontend {
     /// to use when populating the [SynchronizedParameters]
     /// instance in [SystemParameterFrontend::pull].
     key_map: BTreeMap<String, String>,
+    /// The environment ID, used to build scoped (`cluster` / `replica`)
+    /// evaluation contexts.
+    env_id: EnvironmentId,
+    /// Build info, used to build scoped evaluation contexts.
+    build_info: &'static BuildInfo,
     /// Frontend metrics.
     metrics: Metrics,
 }
@@ -71,13 +78,20 @@ impl SystemParameterFrontend {
             super::SystemParameterSyncClientConfig::File { path } => Ok(Self {
                 client: SystemParameterFrontendClient::File { path: path.clone() },
                 key_map: sync_config.key_map.clone(),
+                env_id: sync_config.env_id.clone(),
+                build_info: sync_config.build_info,
                 metrics: sync_config.metrics.clone(),
             }),
             SystemParameterSyncClientConfig::LaunchDarkly { sdk_key, now_fn } => Ok(Self {
                 client: SystemParameterFrontendClient::LaunchDarkly {
                     client: ld_client(sdk_key, &sync_config.metrics, now_fn).await?,
-                    ctx: ld_ctx(&sync_config.env_id, sync_config.build_info)?,
+                    // The environment-wide context carries no cluster/replica
+                    // scope. Scoped evaluation passes a `cluster` or `replica`
+                    // context per pass via [`ld_ctx`].
+                    ctx: ld_ctx(&sync_config.env_id, sync_config.build_info, None, None)?,
                 },
+                env_id: sync_config.env_id.clone(),
+                build_info: sync_config.build_info,
                 metrics: sync_config.metrics.clone(),
                 key_map: sync_config.key_map.clone(),
             }),
@@ -144,6 +158,193 @@ impl SystemParameterFrontend {
 
         changed
     }
+
+    /// Evaluates the replica-local scoped parameters for each given replica and
+    /// returns, per cluster and replica, the parameter values that differ from
+    /// the environment-wide value held in `params`.
+    ///
+    /// Only the LaunchDarkly client performs scoped evaluation. The file
+    /// client returns an empty map (replicas fall back to the environment-wide value).
+    /// The returned map is sparse: replicas (and clusters) with no overriding
+    /// value are omitted.
+    pub fn pull_replica_overrides(
+        &self,
+        params: &SynchronizedParameters,
+        param_names: &[&'static str],
+        replicas: &[ReplicaEvalContext],
+    ) -> BTreeMap<ReplicaId, BTreeMap<String, String>> {
+        let mut out: BTreeMap<ReplicaId, BTreeMap<String, String>> = BTreeMap::new();
+
+        let SystemParameterFrontendClient::LaunchDarkly { client, .. } = &self.client else {
+            // The file client has no notion of scoped evaluation.
+            return out;
+        };
+
+        if param_names.is_empty() {
+            return out;
+        }
+
+        for replica in replicas {
+            let ctx = match ld_ctx(
+                &self.env_id,
+                self.build_info,
+                Some(&replica.cluster),
+                Some(&replica.replica),
+            ) {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    warn!(
+                        replica_id = %replica.replica.id,
+                        "could not build scoped LD context: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            let overrides = self.evaluate_scoped_overrides(client, &ctx, params, param_names);
+            if !overrides.is_empty() {
+                out.insert(replica.replica_id, overrides);
+            }
+        }
+
+        out
+    }
+
+    /// Evaluates the cluster-coherent scoped parameters for each given cluster
+    /// and returns, per cluster, the parameter values that differ from the
+    /// environment-wide value held in `params`. Evaluated replica-free (the
+    /// `cluster` context kind), so the value cannot vary by replica.
+    ///
+    /// Only the LaunchDarkly client performs scoped evaluation. The file
+    /// client returns an empty map. The returned map is sparse.
+    pub fn pull_cluster_overrides(
+        &self,
+        params: &SynchronizedParameters,
+        param_names: &[&'static str],
+        clusters: &[ClusterEvalContext],
+    ) -> BTreeMap<ClusterId, BTreeMap<String, String>> {
+        let mut out: BTreeMap<ClusterId, BTreeMap<String, String>> = BTreeMap::new();
+
+        let SystemParameterFrontendClient::LaunchDarkly { client, .. } = &self.client else {
+            // The file client has no notion of scoped evaluation.
+            return out;
+        };
+
+        if param_names.is_empty() {
+            return out;
+        }
+
+        for cluster in clusters {
+            let ctx = match ld_ctx(&self.env_id, self.build_info, Some(&cluster.cluster), None) {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    warn!(
+                        cluster_id = %cluster.cluster.id,
+                        "could not build scoped LD context: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            let overrides = self.evaluate_scoped_overrides(client, &ctx, params, param_names);
+            if !overrides.is_empty() {
+                out.insert(cluster.cluster_id, overrides);
+            }
+        }
+
+        out
+    }
+
+    /// Evaluates each of `param_names` against `ctx`, returning only the values
+    /// that differ from the environment-wide value held in `params`. Shared by
+    /// the cluster and replica passes, so the returned map is sparse.
+    ///
+    /// We record on the differs-from-env test, not the `variation_detail`
+    /// reason. The inline comment at the recording decision explains why.
+    fn evaluate_scoped_overrides(
+        &self,
+        client: &ld::Client,
+        ctx: &ld::Context,
+        params: &SynchronizedParameters,
+        param_names: &[&'static str],
+    ) -> BTreeMap<String, String> {
+        let mut overrides = BTreeMap::new();
+        for &param_name in param_names {
+            let flag_name = self
+                .key_map
+                .get(param_name)
+                .map(|flag_name| flag_name.as_str())
+                .unwrap_or(param_name);
+
+            let base = params.get(param_name);
+            // Evaluate with `base` as the default, so a silent LD (flag absent,
+            // off, error, failed prerequisite) resolves back to the env-wide
+            // value and is dropped by the difference test below.
+            let flag_var = client.variation(ctx, flag_name, base.clone());
+            let value = match flag_var {
+                ld::FlagValue::Bool(v) => v.to_string(),
+                ld::FlagValue::Str(v) => v,
+                ld::FlagValue::Number(v) => v.to_string(),
+                ld::FlagValue::Json(v) => v.to_string(),
+            };
+
+            // Record iff the scoped evaluation *differs* from the env-wide value.
+            // The `variation_detail` reason is the wrong signal: it cannot say
+            // which context kind's clause matched (an env-level rule and a
+            // cluster-specific rule both report `RuleMatch`), and `Fallthrough`
+            // serves the env-wide value to every object. Comparing against the
+            // env-wide baseline is the only signal that means "this scope context
+            // changed the answer", which is what must beat a manual `FEATURES`
+            // pin and what keeps the durable collections sparse. See the scoped
+            // feature flags design, §Resolution.
+            //
+            // Compare in the parameter's canonical encoding. `base` is the
+            // var-formatted env-wide value (a `bool` is `"on"`/`"off"`), whereas
+            // the raw LaunchDarkly value spells a boolean `"true"`/`"false"`, so a
+            // direct string compare would treat every boolean flag as differing,
+            // even on `Fallthrough`. We still *store* the raw `value` (downstream
+            // consumers parse `"true"`/`"false"`). Only the decision is canonical.
+            let differs = match params.canonicalize(param_name, &value) {
+                Some(canonical) => canonical != base,
+                // LaunchDarkly served a value that does not parse for this
+                // parameter's type (e.g. a malformed boolean like `"maybe"`).
+                // Never record it: storing an unparseable value would poison
+                // resolution. The optimizer's `bool` decode, for one, panics on
+                // every plan for a cluster-coherent override it cannot parse.
+                // Treat it as "no scoped opinion" and fall back to the env-wide
+                // value.
+                None => false,
+            };
+            if differs {
+                overrides.insert(param_name.to_string(), value);
+            }
+        }
+        overrides
+    }
+}
+
+/// The identity of a single live replica, used to evaluate replica-local scoped
+/// parameters in [`SystemParameterFrontend::pull_replica_overrides`].
+#[derive(Clone, Debug)]
+pub struct ReplicaEvalContext {
+    /// The owning cluster's id.
+    pub cluster_id: ClusterId,
+    /// The replica's id.
+    pub replica_id: ReplicaId,
+    /// The owning cluster's scope context (for the replica-free, cluster pass).
+    pub cluster: ClusterScopeContext,
+    /// The replica's scope context.
+    pub replica: ReplicaScopeContext,
+}
+
+/// The identity of a single live cluster, used to evaluate cluster-coherent
+/// scoped parameters in [`SystemParameterFrontend::pull_cluster_overrides`].
+#[derive(Clone, Debug)]
+pub struct ClusterEvalContext {
+    /// The cluster's id.
+    pub cluster_id: ClusterId,
+    /// The cluster's scope context (replica-free).
+    pub cluster: ClusterScopeContext,
 }
 
 fn ld_config(api_key: &str, metrics: &Metrics) -> ld::Config {
@@ -209,9 +410,101 @@ async fn ld_client(
     Ok(ld_client)
 }
 
+/// Identity of a cluster, used to build a `cluster` context kind for
+/// cluster-coherent scoped feature flags.
+///
+/// Exposes both `id` and `name`: an LD rule that targets `cluster_id` is an
+/// incarnation pin that dies on drop/recreate (ids are never reused), while a
+/// rule targeting `cluster_name` / `is_builtin` is a durable role predicate
+/// that re-applies to any matching cluster. See the scoped feature flags
+/// design.
+#[derive(Clone, Debug)]
+pub struct ClusterScopeContext {
+    /// The cluster's catalog id, e.g. `s2` or `u1`.
+    pub id: String,
+    /// The cluster's name, e.g. `mz_catalog_server`.
+    pub name: String,
+    /// Whether the cluster is a builtin (system) cluster.
+    pub is_builtin: bool,
+}
+
+/// Identity of a replica, used to build a `replica` context kind for
+/// replica-local scoped feature flags.
+///
+/// Carries the owning cluster's identity as attributes so that replica-local
+/// flags can be cluster-targeted without a second evaluation, and the replica
+/// size and size *family* so flags can be keyed by size family (e.g. legacy
+/// sizes keep `lgalloc`). See the scoped feature flags design.
+#[derive(Clone, Debug)]
+pub struct ReplicaScopeContext {
+    /// The replica's catalog id.
+    pub id: String,
+    /// The replica's name.
+    pub name: String,
+    /// Whether the replica belongs to a builtin (system) cluster.
+    pub is_builtin: bool,
+    /// The replica's full size name, e.g. `D.1-xsmall` or a legacy t-shirt size
+    /// like `xsmall`. This is the fine-grained targeting axis. The coarse axis
+    /// is [`Self::size_family`]. The two are distinct: `D.1-xsmall` is a size,
+    /// `D` is its family.
+    pub size: String,
+    /// The replica's size family, e.g. `D` or `legacy`. The coarse targeting
+    /// axis, derived from the size map rather than the size name (see
+    /// [`Self::size`]).
+    pub size_family: String,
+    /// The owning cluster's catalog id.
+    pub cluster_id: String,
+    /// The owning cluster's name.
+    pub cluster_name: String,
+}
+
+/// Builds a single `cluster` context kind from a [`ClusterScopeContext`].
+///
+/// Deliberately replica-free: cluster-coherent flags must resolve identically
+/// across a cluster's replicas, so no replica/size attributes appear here.
+fn cluster_context(cluster: &ClusterScopeContext) -> Result<ld::Context, anyhow::Error> {
+    ld::ContextBuilder::new(cluster.id.as_str())
+        .anonymous(true) // keep the LD dashboard Contexts list clean
+        .kind("cluster")
+        .set_string("cluster_id", cluster.id.clone())
+        .set_string("cluster_name", cluster.name.clone())
+        .set_string("is_builtin", cluster.is_builtin.to_string())
+        .build()
+        .map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Builds a single `replica` context kind from a [`ReplicaScopeContext`].
+///
+/// Includes the owning cluster's identity so a rule can combine both axes,
+/// e.g. "size family `D` *and* cluster `foo`".
+fn replica_context(replica: &ReplicaScopeContext) -> Result<ld::Context, anyhow::Error> {
+    ld::ContextBuilder::new(replica.id.as_str())
+        .anonymous(true) // keep the LD dashboard Contexts list clean
+        .kind("replica")
+        .set_string("replica_id", replica.id.clone())
+        .set_string("replica_name", replica.name.clone())
+        .set_string("is_builtin", replica.is_builtin.to_string())
+        .set_string("replica_size", replica.size.clone())
+        .set_string("replica_size_family", replica.size_family.clone())
+        .set_string("cluster_id", replica.cluster_id.clone())
+        .set_string("cluster_name", replica.cluster_name.clone())
+        .build()
+        .map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Builds a multi-context for evaluating scoped feature flags.
+///
+/// Composes the base contexts (`environment` + `organization` + `build`) with:
+/// - a `cluster` context for cluster-coherent (replica-free) resolution, and/or
+/// - a `replica` context for replica-local resolution.
+///
+/// The environment-wide pass passes `None` for both. This is the single entry
+/// point the sync loop uses to evaluate each scoped pass.
 fn ld_ctx(
     env_id: &EnvironmentId,
     build_info: &'static BuildInfo,
+    cluster: Option<&ClusterScopeContext>,
+    replica: Option<&ReplicaScopeContext>,
 ) -> Result<ld::Context, anyhow::Error> {
     // Register multiple contexts for this client.
     //
@@ -271,5 +564,66 @@ fn ld_ctx(
             .map_err(|e| anyhow::anyhow!(e))?,
     );
 
+    // Cluster-coherent resolution evaluates with a `cluster` context (no
+    // replica attributes). Replica-local resolution additionally carries a
+    // `replica` context. The environment-wide pass carries neither.
+    if let Some(cluster) = cluster {
+        ctx_builder.add_context(cluster_context(cluster)?);
+    }
+    if let Some(replica) = replica {
+        ctx_builder.add_context(replica_context(replica)?);
+    }
+
     ctx_builder.build().map_err(|e| anyhow::anyhow!(e))
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_build_info::DUMMY_BUILD_INFO;
+
+    use super::*;
+
+    fn env_id() -> EnvironmentId {
+        EnvironmentId::for_tests()
+    }
+
+    #[mz_ore::test]
+    fn builds_cluster_scoped_context() {
+        // Cluster-coherent resolution evaluates with a replica-free `cluster`
+        // context.
+        let cluster = ClusterScopeContext {
+            id: "s2".into(),
+            name: "mz_catalog_server".into(),
+            is_builtin: true,
+        };
+        ld_ctx(&env_id(), &DUMMY_BUILD_INFO, Some(&cluster), None)
+            .expect("cluster-scoped context builds");
+    }
+
+    #[mz_ore::test]
+    fn builds_replica_scoped_context() {
+        // Replica-local resolution carries both a `cluster` and a `replica`
+        // context so a rule can combine size family and cluster.
+        let cluster = ClusterScopeContext {
+            id: "u1".into(),
+            name: "quickstart".into(),
+            is_builtin: false,
+        };
+        let replica = ReplicaScopeContext {
+            id: "u1-replica-1".into(),
+            name: "r1".into(),
+            is_builtin: false,
+            size: "D.1-xsmall".into(),
+            size_family: "D".into(),
+            cluster_id: "u1".into(),
+            cluster_name: "quickstart".into(),
+        };
+        ld_ctx(&env_id(), &DUMMY_BUILD_INFO, Some(&cluster), Some(&replica))
+            .expect("replica-scoped context builds");
+    }
+
+    #[mz_ore::test]
+    fn environment_wide_context_is_unscoped() {
+        ld_ctx(&env_id(), &DUMMY_BUILD_INFO, None, None).expect("environment-wide context builds");
+    }
 }

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -9,6 +9,7 @@
 
 use std::collections::BTreeSet;
 
+use mz_adapter_types::dyncfgs::ENABLE_SCOPED_SYSTEM_PARAMETERS;
 use mz_sql::session::vars::{ENABLE_LAUNCHDARKLY, SystemVars, Value, Var, VarInput};
 
 /// A struct that defines the system parameters that should be synchronized
@@ -96,6 +97,21 @@ impl SynchronizedParameters {
             .value()
     }
 
+    /// Canonicalize a raw `value` for the parameter `name` to the same formatted
+    /// form [`SynchronizedParameters::get`] returns, by parsing it through the
+    /// system var and re-formatting.
+    ///
+    /// This lets values that are equal but differently encoded compare equal.
+    /// For example LaunchDarkly serves a boolean as `"true"`, while the canonical
+    /// formatting of a `bool` system var is `"on"`. Returns `None` if `name` is
+    /// not a valid parameter or `value` does not parse for it.
+    pub fn canonicalize(&self, name: &str, value: &str) -> Option<String> {
+        self.system_vars
+            .parse(name, VarInput::Flat(value))
+            .ok()
+            .map(|value| value.format())
+    }
+
     /// Try to modify the in-memory entry for `name` in the SystemVars backing
     /// this [SynchronizedParameters] instance.
     ///
@@ -143,6 +159,15 @@ impl SynchronizedParameters {
         let var_input = VarInput::Flat(&var_name);
         bool::parse(var_input).expect("This is known to be a bool")
     }
+
+    /// Whether scoped (per-cluster and per-replica) system parameters are
+    /// evaluated. Read from this working copy so the sync loop can gate the
+    /// scoped reconcile without taking a catalog snapshot.
+    pub fn enable_scoped_system_parameters(&self) -> bool {
+        let var_name = self.get(ENABLE_SCOPED_SYSTEM_PARAMETERS.name());
+        let var_input = VarInput::Flat(&var_name);
+        bool::parse(var_input).expect("This is known to be a bool")
+    }
 }
 
 pub struct ModifiedParameter {
@@ -166,6 +191,49 @@ mod tests {
         assert_eq!(sync.get("allowed_cluster_replica_sizes"), r#""1", "2""#);
         assert!(sync.modify("allowed_cluster_replica_sizes", ""));
         assert_eq!(sync.get("allowed_cluster_replica_sizes"), "");
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    fn test_canonicalize_bridges_bool_encodings() {
+        let vars = SystemVars::default();
+        let sync = SynchronizedParameters::new(vars);
+
+        // A `bool` system var formats canonically as "on"/"off", while
+        // LaunchDarkly serves booleans as "true"/"false". The scoped
+        // differs-from-env test compares a raw LD value against `get()`, so
+        // canonicalization must bridge the two spellings, otherwise every
+        // boolean flag would register as differing, even on a FALLTHROUGH that
+        // serves the env-wide value. (`enable_eager_delta_joins` is a scoped
+        // `bool` feature flag, default off.)
+        let name = "enable_eager_delta_joins";
+        let off = sync.get(name);
+        assert_eq!(off, "off");
+
+        // The LD spellings canonicalize to the same form as the var's own.
+        assert_eq!(sync.canonicalize(name, "false").as_deref(), Some("off"));
+        assert_eq!(sync.canonicalize(name, "true").as_deref(), Some("on"));
+        assert_eq!(
+            sync.canonicalize(name, "off"),
+            sync.canonicalize(name, "false")
+        );
+        assert_eq!(
+            sync.canonicalize(name, "on"),
+            sync.canonicalize(name, "true")
+        );
+
+        // The crux: a scoped "false" must match the env-wide "off" baseline, so
+        // it is dropped rather than recorded as a spurious override.
+        assert_eq!(
+            sync.canonicalize(name, "false").as_deref(),
+            Some(off.as_str())
+        );
+
+        // An unparseable value yields `None`. The scoped recording path relies
+        // on this to *skip* such values rather than store them: a stored
+        // unparseable bool would later panic the optimizer's decode on every
+        // plan. See `SystemParameterFrontend::evaluate_scoped_overrides`.
+        assert_eq!(sync.canonicalize(name, "not-a-bool"), None);
     }
 
     #[mz_ore::test]

--- a/src/adapter/src/config/sync.rs
+++ b/src/adapter/src/config/sync.rs
@@ -7,14 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeSet;
+use std::sync::Arc;
 use std::time::Duration;
 
+use mz_controller::clusters::ReplicaLocation;
+use mz_controller_types::{ClusterId, ReplicaId};
+use mz_dyncfg::ParameterScope;
 use tokio::time;
 
 use crate::Client;
+use crate::catalog::Catalog;
 use crate::config::{
-    SynchronizedParameters, SystemParameterBackend, SystemParameterFrontend,
-    SystemParameterSyncConfig,
+    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
+    ScopedParameters, ScopedParametersScope, SynchronizedParameters, SystemParameterBackend,
+    SystemParameterFrontend, SystemParameterSyncConfig,
 };
 
 /// Run a loop that periodically pulls system parameters defined in the
@@ -30,8 +37,14 @@ pub async fn system_parameter_sync(
         return Ok(());
     };
 
-    // Ensure the frontend client is initialized.
-    let mut frontend = Option::<SystemParameterFrontend>::None; // lazy initialize the frontend below
+    // Keep a client handle for catalog snapshots and the per-replica scoped
+    // config push, since the backend consumes its own clone.
+    let scoped_client = adapter_client.clone();
+
+    // Ensure the frontend client is initialized. Wrapped in `Arc` so a clone can
+    // be shared with the coordinator for synchronous create-time scoped
+    // resolution.
+    let mut frontend = Option::<Arc<SystemParameterFrontend>>::None; // lazy initialize the frontend below
     let mut backend = SystemParameterBackend::new(adapter_client).await?;
 
     // Tick every `tick_duration` ms, skipping missed ticks.
@@ -43,6 +56,13 @@ pub async fn system_parameter_sync(
         "synchronizing system parameter values every {} seconds",
         tick_interval.as_secs()
     );
+
+    // Whether the scoped overrides may carry state that needs clearing once the
+    // feature is disabled. True at startup, since a prior run (this process or
+    // an earlier one) may have left overrides behind. While the feature stays
+    // disabled this lets the scoped reconcile do no per-tick work after the
+    // single clearing push.
+    let mut scoped_overrides_maybe_dirty = true;
 
     let mut params = SynchronizedParameters::default();
     loop {
@@ -66,7 +86,12 @@ pub async fn system_parameter_sync(
 
         if frontend.is_none() {
             tracing::info!("initializing system parameter frontend");
-            frontend = Some(SystemParameterFrontend::from(&sync_config).await?);
+            let new_frontend = Arc::new(SystemParameterFrontend::from(&sync_config).await?);
+            // Share the frontend with the coordinator so the create-cluster /
+            // create-replica paths can resolve a new object's scoped overrides
+            // synchronously, instead of waiting for the next tick.
+            scoped_client.install_scoped_system_parameter_frontend(Arc::clone(&new_frontend));
+            frontend = Some(new_frontend);
         }
 
         // Pull latest state from frontend and push changes to backend.
@@ -74,5 +99,185 @@ pub async fn system_parameter_sync(
         if frontend.pull(&mut params) {
             backend.push(&mut params).await;
         }
+
+        // Reconcile the scoped (per-cluster and per-replica) parameters. We do
+        // this every tick (independent of whether the environment-wide values
+        // changed) so the overrides track the current set of live objects.
+        sync_scoped_params(
+            &scoped_client,
+            frontend,
+            &params,
+            &mut scoped_overrides_maybe_dirty,
+        )
+        .await;
     }
+}
+
+/// Evaluate the scoped parameters (cluster-coherent and replica-local) for the
+/// currently live clusters and replicas and push the resulting overrides to the
+/// coordinator's working copy.
+async fn sync_scoped_params(
+    client: &Client,
+    frontend: &SystemParameterFrontend,
+    params: &SynchronizedParameters,
+    maybe_dirty: &mut bool,
+) {
+    // Read the feature gate from the working copy rather than a catalog
+    // snapshot. The gate is an environment-wide synced parameter, so `params`
+    // already carries its current value. This keeps a disabled environment, the
+    // default, from paying a coordinator round-trip every tick.
+    //
+    // Scoped (per-cluster and per-replica) overrides are off by default,
+    // leaving the environment-wide behavior unchanged. While disabled we
+    // evaluate no scoped contexts. If a prior run left overrides behind we clear
+    // them once so resolution falls back to the environment-wide value
+    // everywhere, then do no per-tick work until the feature is enabled again.
+    if !params.enable_scoped_system_parameters() {
+        if *maybe_dirty {
+            // Full replace with an empty desired state clears every override.
+            // No create-time write races here: it is gated off too.
+            client
+                .update_scoped_system_parameters(ScopedParameters::default(), None)
+                .await;
+            *maybe_dirty = false;
+        }
+        return;
+    }
+    *maybe_dirty = true;
+
+    let catalog = client.catalog_snapshot().await;
+
+    // Push the desired state to the coordinator, which holds the working copy
+    // and resolves each layer at its boundary: the controller's per-replica
+    // dyncfg push for `replica`, plan-time `OptimizerFeatureOverrides` for
+    // `cluster`. Scope removals to the live objects in this snapshot, so an
+    // object created between this snapshot and the apply (folding its override
+    // into its own create transaction) is not wiped by this reconcile.
+    let prune_scope = ScopedParametersScope {
+        clusters: catalog.clusters().map(|cluster| cluster.id).collect(),
+        replicas: catalog
+            .clusters()
+            .flat_map(|cluster| cluster.replicas().map(|replica| replica.replica_id))
+            .collect(),
+    };
+    let scoped = evaluate_scoped_parameters(frontend, params, &catalog, None, None);
+    client
+        .update_scoped_system_parameters(scoped, Some(prune_scope))
+        .await;
+}
+
+/// Evaluate the scoped parameters (cluster-coherent and replica-local) for the
+/// live objects, optionally restricted to a subset of cluster or replica ids.
+///
+/// The full pass (both filters `None`) is the sync loop's per-tick reconcile.
+/// The create path passes `Some(..)` to resolve just the newly-created objects
+/// synchronously, so they observe their overrides in their first controller
+/// configuration or first plan rather than after the next tick. Returns the
+/// sparse desired overrides for the evaluated objects.
+pub(crate) fn evaluate_scoped_parameters(
+    frontend: &SystemParameterFrontend,
+    params: &SynchronizedParameters,
+    catalog: &Catalog,
+    cluster_filter: Option<&BTreeSet<ClusterId>>,
+    replica_filter: Option<&BTreeSet<ReplicaId>>,
+) -> ScopedParameters {
+    let system_config = catalog.system_config();
+
+    // The synced parameters, partitioned by scope class. The scope declaration
+    // bounds evaluation to exactly the flags in use: an environment with no
+    // scoped flags evaluates neither pass.
+    let replica_param_names: Vec<&'static str> = system_config
+        .iter_synced()
+        .filter(|var| var.scope() == ParameterScope::Replica)
+        .map(|var| var.name())
+        .collect();
+    let cluster_param_names: Vec<&'static str> = system_config
+        .iter_synced()
+        .filter(|var| var.scope() == ParameterScope::Cluster)
+        .map(|var| var.name())
+        .collect();
+
+    let replica = if replica_param_names.is_empty() {
+        Default::default()
+    } else {
+        let replicas = build_replica_eval_contexts(catalog, replica_filter);
+        frontend.pull_replica_overrides(params, &replica_param_names, &replicas)
+    };
+    let cluster = if cluster_param_names.is_empty() {
+        Default::default()
+    } else {
+        let clusters = build_cluster_eval_contexts(catalog, cluster_filter);
+        frontend.pull_cluster_overrides(params, &cluster_param_names, &clusters)
+    };
+
+    ScopedParameters { cluster, replica }
+}
+
+/// Build a [`ClusterEvalContext`] for each live cluster in the catalog, skipping
+/// clusters absent from `filter` when one is given.
+fn build_cluster_eval_contexts(
+    catalog: &Catalog,
+    filter: Option<&BTreeSet<ClusterId>>,
+) -> Vec<ClusterEvalContext> {
+    catalog
+        .clusters()
+        .filter(|cluster| filter.is_none_or(|f| f.contains(&cluster.id)))
+        .map(|cluster| ClusterEvalContext {
+            cluster_id: cluster.id,
+            cluster: ClusterScopeContext {
+                id: cluster.id.to_string(),
+                name: cluster.name.clone(),
+                is_builtin: cluster.id.is_system(),
+            },
+        })
+        .collect()
+}
+
+/// Build a [`ReplicaEvalContext`] for each live managed replica in the catalog,
+/// skipping replicas absent from `filter` when one is given.
+fn build_replica_eval_contexts(
+    catalog: &Catalog,
+    filter: Option<&BTreeSet<ReplicaId>>,
+) -> Vec<ReplicaEvalContext> {
+    // An empty filter cannot match any replica, so skip the per-cluster scan.
+    // The create-cluster path passes an empty set to resolve only the cluster
+    // scope.
+    if filter.is_some_and(|f| f.is_empty()) {
+        return Vec::new();
+    }
+
+    let mut contexts = Vec::new();
+    for cluster in catalog.clusters() {
+        let is_builtin = cluster.id.is_system();
+        let cluster_ctx = ClusterScopeContext {
+            id: cluster.id.to_string(),
+            name: cluster.name.clone(),
+            is_builtin,
+        };
+        for replica in cluster.replicas() {
+            if filter.is_some_and(|f| !f.contains(&replica.replica_id)) {
+                continue;
+            }
+            // Only managed replicas have a size (and therefore a size family).
+            let ReplicaLocation::Managed(location) = &replica.config.location else {
+                continue;
+            };
+            let replica_ctx = ReplicaScopeContext {
+                id: replica.replica_id.to_string(),
+                name: replica.name.clone(),
+                is_builtin,
+                size: location.size.clone(),
+                size_family: location.allocation.family().to_string(),
+                cluster_id: cluster.id.to_string(),
+                cluster_name: cluster.name.clone(),
+            };
+            contexts.push(ReplicaEvalContext {
+                cluster_id: cluster.id,
+                replica_id: replica.replica_id,
+                cluster: cluster_ctx.clone(),
+                replica: replica_ctx,
+            });
+        }
+    }
+    contexts
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -92,7 +92,8 @@ use mz_adapter_types::bootstrap_builtin_cluster_config::BootstrapBuiltinClusterC
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_adapter_types::dyncfgs::{
-    USER_ID_POOL_BATCH_SIZE, WITH_0DT_DEPLOYMENT_CAUGHT_UP_CHECK_INTERVAL,
+    ENABLE_SCOPED_SYSTEM_PARAMETERS, USER_ID_POOL_BATCH_SIZE,
+    WITH_0DT_DEPLOYMENT_CAUGHT_UP_CHECK_INTERVAL,
 };
 use mz_auth::password::Password;
 use mz_build_info::BuildInfo;
@@ -139,7 +140,7 @@ use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::global_id::TransientIdGen;
-use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::{OptimizerFeatureOverrides, OptimizerFeatures, OverrideFrom};
 use mz_repr::role_id::RoleId;
 use mz_repr::{CatalogItemId, Diff, GlobalId, RelationDesc, SqlRelationType, Timestamp};
 use mz_secrets::cache::CachingSecretsReader;
@@ -183,7 +184,10 @@ use crate::active_compute_sink::{ActiveComputeSink, ActiveCopyFrom};
 use crate::catalog::{BuiltinTableUpdate, Catalog, OpenCatalogResult};
 use crate::client::{Client, Handle};
 use crate::command::{Command, ExecuteResponse};
-use crate::config::{SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig};
+use crate::config::{
+    ScopedParameters, ScopedParametersScope, SynchronizedParameters, SystemParameterFrontend,
+    SystemParameterSyncConfig, evaluate_scoped_parameters,
+};
 use crate::coord::appends::{
     BuiltinTableAppendNotify, DeferredOp, GroupCommitPermit, PendingWriteTxn,
 };
@@ -436,6 +440,12 @@ impl Message {
                 Command::GetWebhook { .. } => "command-get_webhook",
                 Command::GetSystemVars { .. } => "command-get_system_vars",
                 Command::SetSystemVars { .. } => "command-set_system_vars",
+                Command::UpdateScopedSystemParameters { .. } => {
+                    "command-update_scoped_system_parameters"
+                }
+                Command::InstallScopedSystemParameterFrontend { .. } => {
+                    "command-install_scoped_system_parameter_frontend"
+                }
                 Command::Terminate { .. } => "command-terminate",
                 Command::RetireExecute { .. } => "command-retire_execute",
                 Command::CheckConsistency { .. } => "command-check_consistency",
@@ -1984,6 +1994,16 @@ pub struct Coordinator {
     /// so it can register and own its `*_info` series.
     catalog_info_metrics_registry: MetricsRegistry,
 
+    /// The shared system-parameter frontend, installed by the sync loop once it
+    /// initializes (and re-installed on reconnect). `None` until then, for
+    /// example before LaunchDarkly connects, where a newly-created object
+    /// resolves to the environment-wide value (the cold-cache fallback). Used to
+    /// resolve a new cluster's or replica's scoped overrides synchronously at
+    /// create time, so its first plan or first controller configuration is
+    /// correct rather than waiting for the next sync tick. See the scoped
+    /// feature flags design.
+    scoped_frontend: Option<Arc<SystemParameterFrontend>>,
+
     /// Tracks the state associated with the currently installed watchsets.
     installed_watch_sets: BTreeMap<WatchSetId, (ConnectionId, WatchSetResponse)>,
 
@@ -2014,6 +2034,103 @@ pub struct Coordinator {
 }
 
 impl Coordinator {
+    /// Persists the scoped system-parameter working copy and reconciles it into
+    /// the per-scope resolution boundaries.
+    ///
+    /// The system-parameter sync loop and the create-time resolve
+    /// (`resolve_scoped_for_new_objects`) are the only writers, both serialized
+    /// on the coordinator loop. The diff is persisted to the
+    /// durable cache (so values survive an `environmentd` restart and an LD
+    /// outage) via `Op::UpdateScopedSystemParameters`, which also updates the
+    /// in-memory working copy in [`CatalogState`] and the
+    /// `mz_cluster_system_parameters` / `mz_replica_system_parameters`
+    /// introspection relations. The `replica`-scoped overrides reach the compute
+    /// controller's per-replica dyncfg layer through the catalog implication for
+    /// the persisted change. The `cluster`-scoped layer is resolved at plan time
+    /// via [`CatalogState::cluster_scoped_optimizer_overrides`].
+    ///
+    /// [`CatalogState`]: crate::catalog::CatalogState
+    /// [`CatalogState::cluster_scoped_optimizer_overrides`]: crate::catalog::CatalogState::cluster_scoped_optimizer_overrides
+    pub(crate) async fn reconcile_scoped_system_parameters(
+        &mut self,
+        scoped: ScopedParameters,
+        prune_scope: Option<ScopedParametersScope>,
+    ) {
+        // Nothing changed: skip the durable write. This is the common case on
+        // most sync ticks.
+        if self.catalog().state().scoped_system_parameters() == &scoped {
+            return;
+        }
+
+        // Persist the diff and update the in-memory working copy + introspection
+        // through the catalog transaction, serialized on the coordinator loop
+        // with the create-time resolve. The replica-scoped
+        // controller push is derived from this transaction's diff by the catalog
+        // implication. `prune_scope` bounds removals to the evaluated objects, so
+        // a concurrently-created object's override is not wiped. Best-effort: a
+        // failure here is logged and retried on the next sync tick.
+        if let Err(e) = self
+            .catalog_transact(
+                None,
+                vec![crate::catalog::Op::UpdateScopedSystemParameters {
+                    scoped,
+                    prune_scope,
+                }],
+            )
+            .await
+        {
+            tracing::warn!("failed to persist scoped system parameters: {e}");
+        }
+    }
+
+    /// Synchronously resolves the scoped overrides for the given freshly-created
+    /// clusters and replicas and folds them into the working copy, so a new
+    /// object observes its overrides immediately, before its first plan
+    /// (cluster-coherent) or first controller configuration (replica-local),
+    /// rather than after the next sync tick. Render-frozen flags (optimizer
+    /// features baked into an immutable dataflow) make the tick-latency window a
+    /// correctness problem, not just a delay, which is why this exists.
+    ///
+    /// No-op when the feature is gated off or the shared frontend is not yet
+    /// installed (e.g. before LaunchDarkly connects), in which case the object
+    /// resolves to the environment-wide value, the cold-cache fallback. The
+    /// periodic sync loop remains the authoritative full-state reconciler.
+    pub(crate) async fn resolve_scoped_for_new_objects(
+        &mut self,
+        clusters: &BTreeSet<ClusterId>,
+        replicas: &BTreeSet<ReplicaId>,
+    ) {
+        if clusters.is_empty() && replicas.is_empty() {
+            return;
+        }
+        let Some(frontend) = self.scoped_frontend.clone() else {
+            return;
+        };
+        let catalog = self.catalog();
+        if !ENABLE_SCOPED_SYSTEM_PARAMETERS.get(catalog.system_config().dyncfgs()) {
+            return;
+        }
+
+        // Evaluate only the new objects, then merge onto the current working copy
+        // so reconcile keeps the overrides of objects it did not re-evaluate.
+        let params = SynchronizedParameters::new(catalog.system_config().clone());
+        let evaluated =
+            evaluate_scoped_parameters(&frontend, &params, catalog, Some(clusters), Some(replicas));
+        let merged = catalog.state().scoped_system_parameters().merge(&evaluated);
+        // This runs synchronously after the create transaction, so the catalog
+        // already reflects the new objects. The merged state is authoritative
+        // for all live objects, so prune within them.
+        let prune_scope = ScopedParametersScope {
+            clusters: catalog.clusters().map(|cluster| cluster.id).collect(),
+            replicas: catalog
+                .clusters()
+                .flat_map(|cluster| cluster.replicas().map(|replica| replica.replica_id))
+                .collect(),
+        };
+        self.reconcile_scoped_system_parameters(merged, Some(prune_scope))
+            .await;
+    }
+
     /// Resolves the replica-local scoped overrides from the catalog working copy
     /// into the compute controller's per-replica dyncfg layer, then re-pushes
     /// the environment-wide compute configuration so replicas observe the new
@@ -2082,6 +2199,18 @@ impl Coordinator {
         // renders the full dyncfg set.
         let compute_config = crate::flags::compute_config(self.catalog().system_config());
         self.controller.compute.update_configuration(compute_config);
+    }
+
+    /// Returns the cluster-coherent scoped optimizer-feature overrides for
+    /// `cluster_id`. See
+    /// [`CatalogState::cluster_scoped_optimizer_overrides`](crate::catalog::CatalogState::cluster_scoped_optimizer_overrides).
+    pub(crate) fn cluster_scoped_optimizer_overrides(
+        &self,
+        cluster_id: ClusterId,
+    ) -> OptimizerFeatureOverrides {
+        self.catalog()
+            .state()
+            .cluster_scoped_optimizer_overrides(cluster_id)
     }
 
     /// Initializes coordinator state based on the contained catalog. Must be
@@ -3298,7 +3427,15 @@ impl Coordinator {
         let optimizer_config = |catalog: &Catalog, cluster_id| {
             let system_config = catalog.system_config();
             let overrides = catalog.get_cluster(cluster_id).config.features();
-            OptimizerConfig::from(system_config).override_from(&overrides)
+            OptimizerConfig::from(system_config)
+                .override_from(&overrides)
+                // A cluster-scoped LaunchDarkly rule beats a manual `FEATURES`
+                // pin.
+                .override_from(
+                    &catalog
+                        .state()
+                        .cluster_scoped_optimizer_overrides(cluster_id),
+                )
         };
 
         for entry in ordered_catalog_entries {
@@ -4817,6 +4954,7 @@ pub fn serve(
                     segment_client,
                     metrics,
                     catalog_info_metrics_registry: metrics_registry.clone(),
+                    scoped_frontend: None,
                     optimizer_metrics,
                     tracing_handle,
                     statement_logging: StatementLogging::new(coord_now.clone()),

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -1598,6 +1598,12 @@ impl Coordinator {
             .system_config()
             .enable_storage_introspection_logs();
 
+        // This replica's scoped (replica-local) overrides were pushed into the
+        // controller's per-replica layer before this loop, by the
+        // replica-scoped-configuration implication, so the replica's first
+        // configuration replays with them. Render-frozen flags make a later push
+        // too late, which is why the push precedes `create_replica`.
+
         self.controller
             .create_replica(
                 cluster_id,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -272,6 +272,24 @@ impl Coordinator {
                     let _ = tx.send(result);
                 }
 
+                Command::UpdateScopedSystemParameters {
+                    overrides,
+                    prune_scope,
+                    tx,
+                } => {
+                    // Store the new working copy, persist it durably, and
+                    // reconcile it into the per-scope resolution boundaries.
+                    self.reconcile_scoped_system_parameters(overrides, prune_scope)
+                        .await;
+                    let _ = tx.send(());
+                }
+
+                Command::InstallScopedSystemParameterFrontend { frontend } => {
+                    // Keep the shared frontend so create-cluster / create-replica
+                    // can resolve scoped overrides synchronously at create time.
+                    self.scoped_frontend = Some(frontend);
+                }
+
                 Command::InjectAuditEvents {
                     events,
                     conn_id,

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -203,7 +203,9 @@ impl Coordinator {
 
         let vars = self.catalog().system_config();
         let overrides = self.catalog.get_cluster(cluster_id).config.features();
-        let optimizer_config = optimize::OptimizerConfig::from(vars).override_from(&overrides);
+        let optimizer_config = optimize::OptimizerConfig::from(vars)
+            .override_from(&overrides)
+            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
 
         let mut optimizer = optimize::subscribe::Optimizer::new(
             self.owned_catalog(),

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -740,6 +740,19 @@ impl Coordinator {
 
         self.catalog_transact(Some(session), ops).await?;
 
+        // Resolve the new cluster's cluster-scoped overrides now, so its first
+        // plan uses them rather than the env-wide values. Optimizer features are
+        // baked into immutable dataflows, so a value applied on a later sync tick
+        // cannot retrofit an already planned dataflow.
+        //
+        // TODO: this resolves only the cluster-scoped overrides. Replicas created
+        // in this same transaction reach the controller with env-wide config and
+        // pick up their replica-local overrides on the next sync tick, which is
+        // too late for render-frozen flags. The follow-up materialize#37158 folds
+        // replica resolution into the create transaction.
+        self.resolve_scoped_for_new_objects(&BTreeSet::from([cluster_id]), &BTreeSet::new())
+            .await;
+
         Ok(ExecuteResponse::CreatedCluster)
     }
 
@@ -941,6 +954,11 @@ impl Coordinator {
         }
 
         self.catalog_transact(Some(session), ops).await?;
+
+        // Resolve the new cluster's cluster-coherent scoped overrides now (see
+        // the managed path for rationale).
+        self.resolve_scoped_for_new_objects(&BTreeSet::from([id]), &BTreeSet::new())
+            .await;
 
         Ok(ExecuteResponse::CreatedCluster)
     }

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -219,6 +219,7 @@ impl Coordinator {
 
         let features = OptimizerFeatures::from(self.catalog().system_config())
             .override_from(&target_cluster.config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(index.cluster_id))
             .override_from(&config.features);
 
         // TODO(mgree): calculate statistics (need a timestamp)
@@ -331,6 +332,7 @@ impl Coordinator {
 
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&self.catalog.get_cluster(*cluster_id).config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(*cluster_id))
             .override_from(&explain_ctx);
         let optimizer_features = optimizer_config.features.clone();
 
@@ -644,6 +646,7 @@ impl Coordinator {
 
         let features = OptimizerFeatures::from(self.catalog().system_config())
             .override_from(&target_cluster.config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(index.cluster_id))
             .override_from(&config.features);
 
         let rows = optimizer_trace

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -249,6 +249,7 @@ impl Coordinator {
 
         let features = OptimizerFeatures::from(self.catalog().system_config())
             .override_from(&target_cluster.config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(view.cluster_id))
             .override_from(&config.features);
 
         let cardinality_stats = BTreeMap::new();
@@ -453,6 +454,7 @@ impl Coordinator {
         let debug_name = self.catalog().resolve_full_name(name, None).to_string();
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&self.catalog.get_cluster(*cluster_id).config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(*cluster_id))
             .override_from(&explain_ctx);
         let optimizer_features = optimizer_config.features.clone();
 
@@ -964,6 +966,7 @@ impl Coordinator {
 
         let features = OptimizerFeatures::from(self.catalog().system_config())
             .override_from(&target_cluster.config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id))
             .override_from(&config.features);
 
         let rows = optimizer_trace

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -257,6 +257,7 @@ impl Coordinator {
             .expect("compute instance does not exist");
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&self.catalog.get_cluster(cluster.id()).config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(cluster.id()))
             .override_from(&explain_ctx);
 
         if cluster.replicas().next().is_none() && explain_ctx.needs_cluster() {
@@ -800,7 +801,8 @@ impl Coordinator {
         if let Some(trace) = plan_insights_optimizer_trace {
             let target_cluster = self.catalog().get_cluster(cluster_id);
             let features = OptimizerFeatures::from(self.catalog().system_config())
-                .override_from(&target_cluster.config.features());
+                .override_from(&target_cluster.config.features())
+                .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
             let insights = trace
                 .into_plan_insights(
                     &features,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -268,6 +268,7 @@ impl Coordinator {
         let debug_name = format!("subscribe-{}", sink_id);
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&self.catalog.get_cluster(cluster_id).config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id))
             .override_from(&explain_ctx);
 
         // Build an optimizer for this SUBSCRIBE.
@@ -574,6 +575,7 @@ impl Coordinator {
 
         let features = OptimizerFeatures::from(self.catalog().system_config())
             .override_from(&target_cluster.config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id))
             .override_from(&config.features);
 
         let rows = optimizer_trace

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -519,6 +519,12 @@ impl PeekClient {
 
         let optimizer_config = optimize::OptimizerConfig::from(catalog.system_config())
             .override_from(&catalog.get_cluster(cluster.id()).config.features())
+            // A cluster-scoped LaunchDarkly rule beats a manual `FEATURES` pin.
+            .override_from(
+                &catalog
+                    .state()
+                    .cluster_scoped_optimizer_overrides(cluster.id()),
+            )
             .override_from(&explain_ctx);
 
         if cluster.replicas().next().is_none() && explain_ctx.needs_cluster() {
@@ -1242,7 +1248,14 @@ impl PeekClient {
                 if let Some(trace) = plan_insights_optimizer_trace {
                     let target_cluster = catalog.get_cluster(target_cluster_id);
                     let features = OptimizerFeatures::from(catalog.system_config())
-                        .override_from(&target_cluster.config.features());
+                        .override_from(&target_cluster.config.features())
+                        // A cluster-scoped LaunchDarkly rule beats a manual
+                        // `FEATURES` pin.
+                        .override_from(
+                            &catalog
+                                .state()
+                                .cluster_scoped_optimizer_overrides(target_cluster_id),
+                        );
                     let insights = trace
                         .into_plan_insights(
                             &features,

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -188,4 +188,54 @@ macro_rules! impl_optimizer_feature_type {
 
 // Implement `OptimizerFeatureType` for all types used in the
 // `optimizer_feature_flags!(...)`  call above.
-impl_optimizer_feature_type![bool, usize];
+impl_optimizer_feature_type![usize];
+
+impl OptimizerFeatureType for bool {
+    fn encode(self) -> String {
+        self.to_string()
+    }
+
+    fn decode(v: &str) -> Self {
+        // Accept both the Rust spelling (`true`/`false`, what `encode` and
+        // `CREATE CLUSTER ... FEATURES` produce) and the canonical system-var /
+        // PostgreSQL spellings (`on`/`off`, ...). A cluster-coherent scoped
+        // override may arrive as the var's canonical `on`/`off`.
+        match v.trim().to_lowercase().as_str() {
+            "t" | "true" | "on" | "1" | "y" | "yes" => true,
+            "f" | "false" | "off" | "0" | "n" | "no" => false,
+            // The writer only stores values that passed `canonicalize`, so this
+            // arm is unreachable in practice. Log rather than panic anyway: a
+            // stored bad value reaching the plan path would otherwise crash the
+            // optimizer on every query for the affected cluster. Fall back to
+            // `false`.
+            other => {
+                mz_ore::soft_panic_or_log!("invalid boolean optimizer feature override: {other:?}");
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::OptimizerFeatureOverrides;
+
+    #[mz_ore::test]
+    fn bool_override_decodes_lenient_spellings() {
+        for (stored, want) in [
+            ("true", true),
+            ("false", false),
+            ("on", true),
+            ("off", false),
+        ] {
+            let map =
+                BTreeMap::from([("enable_eager_delta_joins".to_string(), stored.to_string())]);
+            assert_eq!(
+                OptimizerFeatureOverrides::from(map).enable_eager_delta_joins,
+                Some(want),
+            );
+        }
+    }
+}

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -50,6 +50,39 @@ BUILDKITE_PULL_REQUEST = environ.get("BUILDKITE_PULL_REQUEST")
 LD_CONTEXT_KEY = DEFAULT_MZ_ENVIRONMENT_ID
 # A unique feature flag key to use for this test.
 LD_FEATURE_FLAG_KEY = f"ci-test-{BUILDKITE_JOB_ID}"
+# Unique feature flag keys for the scoped (per-cluster / per-replica) cases.
+LD_OPTIMIZER_FLAG_KEY = f"ci-test-optimizer-{BUILDKITE_JOB_ID}"
+LD_LGALLOC_FLAG_KEY = f"ci-test-lgalloc-{BUILDKITE_JOB_ID}"
+# A cluster-coherent (optimizer) parameter and a replica-local parameter, both
+# declared scoped in their definitions.
+OPTIMIZER_PARAM = "enable_eager_delta_joins"
+LGALLOC_PARAM = "enable_lgalloc"
+
+
+def context_rule(
+    context_kind: str, attribute: str, values: list[str], variation: int
+) -> dict[str, Any]:
+    """Builds a LaunchDarkly targeting rule that serves `variation` to contexts
+    of `context_kind` whose `attribute` is in `values`."""
+    return {
+        "variation": variation,
+        "clauses": [
+            {
+                "contextKind": context_kind,
+                "attribute": attribute,
+                "op": "in",
+                "values": values,
+                "negate": False,
+            }
+        ],
+    }
+
+
+# Boolean flag variations: index 0 is `false`, index 1 is `true`.
+BOOL_VARIATIONS: list[Any] = [
+    Variation(value=False, name="false"),
+    Variation(value=True, name="true"),
+]
 
 SERVICES = [
     Materialized(
@@ -79,8 +112,8 @@ def workflow_default(c: Composition) -> None:
         configuration=launchdarkly_api.Configuration(
             api_key=dict(ApiKey=LAUNCHDARKLY_API_TOKEN),
         ),
-        project_key="default",
-        environment_key="ci-cd",
+        project_key=environ.get("LAUNCHDARKLY_PROJECT_KEY", "default"),
+        environment_key=environ.get("LAUNCHDARKLY_ENVIRONMENT_KEY", "ci-cd"),
     )
 
     try:
@@ -229,6 +262,9 @@ def workflow_default(c: Composition) -> None:
         # turned off).
         c.testdrive("\n".join(["> SHOW max_result_size", "1GB"]))
         c.stop("materialized")
+
+        # Exercise the scoped (per-cluster / per-replica) feature flags.
+        run_scoped_feature_flag_cases(c, ld_client)
     except launchdarkly_api.ApiException as e:
         raise UIError(dedent(f"""
                 Error when calling the Launch Darkly API.
@@ -240,6 +276,306 @@ def workflow_default(c: Composition) -> None:
             ld_client.delete_flag(LD_FEATURE_FLAG_KEY)
         except:
             pass  # ignore exceptions on cleanup
+
+
+def run_scoped_feature_flag_cases(
+    c: Composition, ld_client: "LaunchDarklyClient"
+) -> None:
+    """Demonstrates per-cluster (cluster-coherent) and per-replica
+    (replica-local) LaunchDarkly overrides, plus their durability across a
+    restart.
+
+    Cluster case: a cluster-coherent optimizer feature is served `true` to the
+    builtin clusters (e.g. `mz_catalog_server`) and `false` to user clusters,
+    targeted by the `cluster` context's `is_builtin` attribute.
+
+    Replica case: the replica-local `enable_lgalloc` flag is served `false` only
+    to replicas whose `replica_size_family` is `legacy`, while modern (`cc`)
+    replicas keep the environment-wide value, targeted by the `replica`
+    context's `replica_size_family` attribute.
+    """
+    # A materialized that syncs the scoped flags. The key map ties the
+    # cluster-coherent optimizer parameter and the replica-local lgalloc
+    # parameter to their LD flags, alongside the original max_result_size flag.
+    # MZ_LAUNCHDARKLY_KEY_MAP entries are `;`-separated (the CLI arg's value
+    # delimiter), not comma-separated.
+    key_map = ";".join(
+        [
+            f"max_result_size={LD_FEATURE_FLAG_KEY}",
+            f"{OPTIMIZER_PARAM}={LD_OPTIMIZER_FLAG_KEY}",
+            f"{LGALLOC_PARAM}={LD_LGALLOC_FLAG_KEY}",
+        ]
+    )
+    scoped_mz = Materialized(
+        environment_extra=[
+            f"MZ_LAUNCHDARKLY_SDK_KEY={LAUNCHDARKLY_SDK_KEY}",
+            f"MZ_LAUNCHDARKLY_KEY_MAP={key_map}",
+            "MZ_CONFIG_SYNC_LOOP_INTERVAL=1s",
+        ],
+        additional_system_parameter_defaults={
+            "log_filter": "mz_adapter::catalog=debug,mz_adapter::config=debug",
+            # Scoped overrides are gated off by default. Opt in for these cases.
+            "enable_scoped_system_parameters": "true",
+        },
+        external_metadata_store=True,
+    )
+
+    try:
+        # Cluster-coherent optimizer flag. Fallthrough serves the env-wide
+        # `false`. The rules carve out per-cluster opinions:
+        #   * builtin clusters (`is_builtin`) and a same-named user cluster
+        #     (`ld_role`, by name) are served `true`, which differs from env-wide,
+        #     so it is recorded.
+        #   * `quickstart` is served the env-wide `false`. That rule *matches*
+        #     but the served value does not differ from env-wide, so it must NOT
+        #     record a row. This guards the recording rule: a bare LD match is
+        #     not, by itself, a cluster opinion. Only a *differing* value is.
+        optimizer_rules = [
+            context_rule("cluster", "is_builtin", ["true"], 1),
+            context_rule("cluster", "cluster_name", ["ld_role", "ld_sync"], 1),
+            context_rule("cluster", "cluster_name", ["quickstart"], 0),
+        ]
+        ld_client.create_flag(
+            LD_OPTIMIZER_FLAG_KEY,
+            tags=["ci-test"],
+            variations=BOOL_VARIATIONS,
+            off_variation=0,
+            on_variation=0,
+        )
+        ld_client.update_targeting(
+            LD_OPTIMIZER_FLAG_KEY,
+            on=True,
+            rules=optimizer_rules,
+        )
+
+        # Replica-local lgalloc flag: fallthrough serves `true` (the env-wide
+        # default), a rule serves `false` to the legacy size family.
+        ld_client.create_flag(
+            LD_LGALLOC_FLAG_KEY,
+            tags=["ci-test"],
+            variations=BOOL_VARIATIONS,
+            off_variation=0,
+            on_variation=1,
+        )
+        ld_client.update_targeting(
+            LD_LGALLOC_FLAG_KEY,
+            on=True,
+            rules=[context_rule("replica", "replica_size_family", ["legacy"], 0)],
+        )
+
+        with c.override(scoped_mz):
+            c.up("materialized")
+
+            # A user cluster with a legacy-family replica (to contrast with the
+            # builtin / `cc` defaults), plus `ld_role`, targeted by name to
+            # exercise recreate semantics below.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "CREATE CLUSTER ld_legacy SIZE 'scale=1,workers=1,legacy'",
+                        "CREATE CLUSTER ld_role SIZE 'scale=1,workers=1,legacy'",
+                    ]
+                )
+            )
+
+            # Allow a few sync ticks to evaluate the new clusters/replicas.
+            sleep(5)
+
+            # Cluster case + differs-from-env guard. Recorded rows are sparse:
+            # `mz_catalog_server` (is_builtin rule) and `ld_role` (name rule)
+            # differ from the env-wide `false` and are recorded. `quickstart`
+            # (rule serves the env-wide `false`) and `ld_legacy` (fallthrough)
+            # carry no differing value, so they have no row. If either appears,
+            # the recording rule has regressed to keying on the LD match.
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT c.name, p.value FROM mz_internal.mz_cluster_system_parameters p JOIN mz_clusters c ON c.id = p.cluster_id WHERE p.name = '{OPTIMIZER_PARAM}' AND c.name IN ('mz_catalog_server', 'quickstart', 'ld_legacy', 'ld_role') ORDER BY c.name",
+                        "ld_role true",
+                        "mz_catalog_server true",
+                    ]
+                )
+            )
+
+            # Replica case: the legacy-family replica's `false` differs from the
+            # env-wide `true` and is recorded. The `cc`-family quickstart replica
+            # falls through to the env-wide value, so it has no override row.
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT cr.name, p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name IN ('ld_legacy', 'quickstart') ORDER BY c.name",
+                        "r1 false",
+                    ]
+                )
+            )
+
+            # Recreate semantics: a `cluster_name` rule is a *role* predicate, so
+            # it must re-apply to a recreated same-named cluster (which gets a
+            # fresh id, never the old one). Drop and recreate `ld_role`. The
+            # override returns under the new id.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "DROP CLUSTER ld_role",
+                        "CREATE CLUSTER ld_role SIZE 'scale=1,workers=1,legacy'",
+                    ]
+                )
+            )
+            sleep(5)
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT c.name, p.value FROM mz_internal.mz_cluster_system_parameters p JOIN mz_clusters c ON c.id = p.cluster_id WHERE p.name = '{OPTIMIZER_PARAM}' AND c.name = 'ld_role'",
+                        "ld_role true",
+                    ]
+                )
+            )
+
+            # Bidirectional reconcile: the sync loop is the sole writer and must
+            # *remove* an override once LD no longer serves a differing value.
+            # Clear the rules so every cluster falls through to env-wide. All
+            # rows for the parameter disappear. Restoring the rules brings them
+            # back, exercising propagation in both directions.
+            ld_client.update_targeting(LD_OPTIMIZER_FLAG_KEY, rules=[])
+            sleep(5)
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT count(*) FROM mz_internal.mz_cluster_system_parameters WHERE name = '{OPTIMIZER_PARAM}'",
+                        "0",
+                    ]
+                )
+            )
+            ld_client.update_targeting(
+                LD_OPTIMIZER_FLAG_KEY,
+                rules=optimizer_rules,
+            )
+            sleep(5)
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT c.name, p.value FROM mz_internal.mz_cluster_system_parameters p JOIN mz_clusters c ON c.id = p.cluster_id WHERE p.name = '{OPTIMIZER_PARAM}' AND c.name IN ('mz_catalog_server', 'ld_role') ORDER BY c.name",
+                        "ld_role true",
+                        "mz_catalog_server true",
+                    ]
+                )
+            )
+
+            # Feature gate. Turning `enable_scoped_system_parameters` off makes
+            # the sync loop evaluate no scoped contexts and clear what it
+            # previously persisted, so both collections empty out and resolution
+            # reverts to env-wide. Turning it back on re-evaluates and restores.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "ALTER SYSTEM SET enable_scoped_system_parameters = false",
+                    ]
+                )
+            )
+            sleep(5)
+            c.testdrive(
+                "\n".join(
+                    [
+                        "> SELECT count(*) FROM mz_internal.mz_cluster_system_parameters",
+                        "0",
+                        "> SELECT count(*) FROM mz_internal.mz_replica_system_parameters",
+                        "0",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "ALTER SYSTEM SET enable_scoped_system_parameters = true",
+                    ]
+                )
+            )
+            sleep(5)
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT c.name, p.value FROM mz_internal.mz_cluster_system_parameters p JOIN mz_clusters c ON c.id = p.cluster_id WHERE p.name = '{OPTIMIZER_PARAM}' AND c.name IN ('mz_catalog_server', 'ld_role') ORDER BY c.name",
+                        "ld_role true",
+                        "mz_catalog_server true",
+                        f"> SELECT cr.name, p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_legacy'",
+                        "r1 false",
+                    ]
+                )
+            )
+            c.stop("materialized")
+
+        # Durability: restart without the sync loop and assert the scoped values
+        # are restored from the durable cache, including the recreated
+        # `ld_role` cluster override and the legacy replica override.
+        with c.override(Materialized(external_metadata_store=True)):
+            c.up("materialized")
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT c.name, p.value FROM mz_internal.mz_cluster_system_parameters p JOIN mz_clusters c ON c.id = p.cluster_id WHERE p.name = '{OPTIMIZER_PARAM}' AND c.name IN ('mz_catalog_server', 'ld_role') ORDER BY c.name",
+                        "ld_role true",
+                        "mz_catalog_server true",
+                        f"> SELECT cr.name, p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name IN ('ld_legacy', 'quickstart') ORDER BY c.name",
+                        "r1 false",
+                    ]
+                )
+            )
+            c.stop("materialized")
+
+        # Create-time resolution: a cluster created between sync ticks must
+        # resolve its cluster-coherent overrides synchronously, before its first
+        # plan, since optimizer features are baked into immutable dataflows. We
+        # isolate this from the periodic loop by running with a very long sync
+        # interval: the frontend is still installed on the first (immediate)
+        # tick, but no further reconcile happens during the test, so a row that
+        # appears right after `CREATE CLUSTER` can only come from create-time
+        # resolution. (testdrive `>` retries, but the periodic loop cannot fire
+        # within the retry window at this interval.)
+        slow_mz = Materialized(
+            environment_extra=[
+                f"MZ_LAUNCHDARKLY_SDK_KEY={LAUNCHDARKLY_SDK_KEY}",
+                f"MZ_LAUNCHDARKLY_KEY_MAP={key_map}",
+                "MZ_CONFIG_SYNC_LOOP_INTERVAL=3600s",
+            ],
+            additional_system_parameter_defaults={
+                "enable_scoped_system_parameters": "true",
+            },
+            external_metadata_store=True,
+        )
+        with c.override(slow_mz):
+            c.up("materialized")
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "CREATE CLUSTER ld_sync SIZE 'scale=1,workers=1,legacy'",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT c.name, p.value FROM mz_internal.mz_cluster_system_parameters p JOIN mz_clusters c ON c.id = p.cluster_id WHERE p.name = '{OPTIMIZER_PARAM}' AND c.name = 'ld_sync'",
+                        "ld_sync true",
+                    ]
+                )
+            )
+            c.stop("materialized")
+    finally:
+        for flag in (LD_OPTIMIZER_FLAG_KEY, LD_LGALLOC_FLAG_KEY):
+            try:
+                ld_client.delete_flag(flag)
+            except:
+                pass  # ignore exceptions on cleanup
 
 
 class LaunchDarklyClient:
@@ -258,7 +594,21 @@ class LaunchDarklyClient:
         self.project_key = project_key
         self.environment_key = environment_key
 
-    def create_flag(self, feature_flag_key: str, tags: list[str] = []) -> Any:
+    def create_flag(
+        self,
+        feature_flag_key: str,
+        tags: list[str] = [],
+        variations: list[Any] | None = None,
+        off_variation: int = 0,
+        on_variation: int = 1,
+    ) -> Any:
+        if variations is None:
+            variations = [
+                Variation(value=1073741824, name="1 GiB"),
+                Variation(value=2147483648, name="2 GiB"),
+                Variation(value=3221225472, name="3 GiB"),
+                Variation(value=4294967295, name="4 GiB - 1 (max size)"),
+            ]
         with launchdarkly_api.ApiClient(self.configuration) as api_client:
             api = feature_flags_api.FeatureFlagsApi(api_client)
             return api.post_feature_flag(
@@ -270,17 +620,12 @@ class LaunchDarklyClient:
                         using_environment_id=True,
                         using_mobile_key=True,
                     ),
-                    variations=[
-                        Variation(value=1073741824, name="1 GiB"),
-                        Variation(value=2147483648, name="2 GiB"),
-                        Variation(value=3221225472, name="3 GiB"),
-                        Variation(value=4294967295, name="4 GiB - 1 (max size)"),
-                    ],
+                    variations=variations,
                     temporary=False,
                     tags=tags,
                     defaults=Defaults(
-                        off_variation=0,
-                        on_variation=1,
+                        off_variation=off_variation,
+                        on_variation=on_variation,
                     ),
                 ),
             )
@@ -290,6 +635,7 @@ class LaunchDarklyClient:
         feature_flag_key: str,
         on: bool | None = None,
         contextTargets: list[Any] | None = None,
+        rules: list[Any] | None = None,
     ) -> Any:
         with launchdarkly_api.ApiClient(self.configuration) as api_client:
             api = feature_flags_api.FeatureFlagsApi(api_client)
@@ -320,6 +666,17 @@ class LaunchDarklyClient:
                                         ),
                                     ]
                                     if contextTargets is not None
+                                    else []
+                                ),
+                                (
+                                    [
+                                        PatchOperation(
+                                            op="replace",
+                                            path=f"/environments/{self.environment_key}/rules",
+                                            value=rules,
+                                        ),
+                                    ]
+                                    if rules is not None
                                     else []
                                 ),
                             )


### PR DESCRIPTION
### Motivation

The resolution layer for scoped feature flags. The foundation (#37079), the
durable persistence and introspection (#37080), and the catalog-implications
foundation (#37151, which derives the replica-scoped controller push from the
committed catalog diff) have all merged. Create-time render-frozen correctness
is completed in the follow-up #37158. Design:
doc/developer/design/20260609_scoped_feature_flags.md (#36947).

Behind the `enable_scoped_system_parameters` dyncfg (off by default), this PR
consumes the durable scoped overrides and resolves them at the per-scope
boundaries.

### Description

* The sync loop evaluates the `cluster` (replica-free) and `replica` (size, size
  family, owning cluster) LaunchDarkly contexts and records an override only when
  the scoped value **differs from the environment-wide value**, compared in
  canonical encoding so bool spellings (`on`/`off` vs `true`/`false`) match. LD
  multi-context evaluation cannot reveal which context produced a value, so the
  differs-from-env test, not the `variation_detail` reason, is the recording
  rule. The evaluation is skipped while the gate is off, and the gate is read
  from the sync working copy so a disabled environment takes no catalog snapshot
  per tick.
* Resolution boundaries: cluster-coherent overrides feed plan-time
  `OptimizerFeatureOverrides` (with a lenient bool decode so `on`/`off` cannot
  panic the optimizer). Replica-local overrides reach the compute controller
  through the catalog implication from #37151.
* Create-time: a post-transact resolve folds a freshly created object's overrides
  into the working copy so it need not wait for the next sync tick. The follow-up
  #37158 moves this into the create transaction so render-frozen replica flags are
  set before `create_replica`.

### Verification

Canonical bool bridging, lenient optimizer decode, and frontend context unit
tests, plus the `test/launchdarkly` mzcompose workflow extended with
cluster/replica/durability/gating/create-time cases, validated end-to-end
against a live LaunchDarkly project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUorxx5m6B8TT2VAek2STo