### PR TITLE
ci: Fix nightly failures (2026-06-11)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -165,7 +165,7 @@ steps:
       - id: feature-benchmark
         label: "Feature benchmark against merge base or 'latest'"
         depends_on: build-x86_64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 120
         parallelism: 12
         agents:
           queue: hetzner-x86-64-dedi-16cpu-64gb
@@ -179,7 +179,7 @@ steps:
       - id: scalability-benchmark-dml-dql
         label: "Scalability benchmark (read & write) against merge base or 'latest'"
         depends_on: build-x86_64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 120
         env:
           # Runs against Dockerhub directly
           MZ_GHCR: 0
@@ -204,7 +204,7 @@ steps:
       - id: scalability-benchmark-ddl
         label: "Scalability benchmark (DDL) against merge base or 'latest'"
         depends_on: build-x86_64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 120
         parallelism: 2
         env:
           # Runs against Dockerhub directly
@@ -233,7 +233,7 @@ steps:
       - id: scalability-benchmark-connection
         label: "Scalability benchmark (connection) against merge base or 'latest'"
         depends_on: build-x86_64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 120
         parallelism: 2
         env:
           # Runs against Dockerhub directly
@@ -260,7 +260,7 @@ steps:
       - id: parallel-benchmark
         label: "Parallel Benchmark"
         depends_on: build-x86_64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 120
         parallelism: 5
         agents:
           # Larger instance is more stable in performance
@@ -278,7 +278,7 @@ steps:
       - id: workload-replay
         label: "Workload Replay (1% initial data)"
         depends_on: build-x86_64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 120
         parallelism: 5
         plugins:
           - ./ci/plugins/mzcompose:

--- a/deny.toml
+++ b/deny.toml
@@ -280,6 +280,9 @@ ignore = [
     # rand unsoundness when a custom logger accesses ThreadRng during reseeding.
     # Affects transitive deps (rand 0.7.3 via http-types, rand 0.8.5 via fail/quickcheck/etc).
     "RUSTSEC-2026-0097",
+    # Allows private key leakage through timing information
+    # rsa is required through iceberg-storage-opendal
+    "RUSTSEC-2023-0071",
 ]
 
 # Must be manually kept in sync with about.toml.

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -1009,13 +1009,7 @@ class DifferentialJoinHydration(Dataflow):
     iterations; `v1` stays hydrated throughout.
     """
 
-    # SCALE=8 → 100M rows per side, ~1.6 GiB per side input. The
-    # merge-batcher transient while arranging that input dwarfs the File
-    # variant's spill budget floors (16 MiB per worker + 128 MiB shared),
-    # so nearly all of it spills, while the Baseline holds it in memory.
-    # Note `cluster_default` runs with a single worker, so iterations are
-    # slow; use `--scale` to dial down for quick checks.
-    SCALE = 8
+    SCALE = 6
 
     @classmethod
     def can_run(cls, version: MzVersion) -> bool:

--- a/test/persistence/user-tables/table-persistence-before-large-transaction.td
+++ b/test/persistence/user-tables/table-persistence-before-large-transaction.td
@@ -11,6 +11,11 @@
 # Tests for wide and long transactions
 #
 
+# These transactions are intentionally large, so they can exceed the default
+# timeout on slow CI machines. Raise testdrive's client-side timeout; the
+# server-side statement_timeout (default 60s) is raised separately below.
+$ set-sql-timeout duration=120s
+
 > CREATE TABLE wide_transaction (f1 TEXT);
 
 > INSERT INTO wide_transaction VALUES (REPEAT('x', 100 * 1024 * 1024));

--- a/test/sqlancer/Dockerfile
+++ b/test/sqlancer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
 # ggevay: But in the meantime there have been more changes to our fork, see the `main` branch there.
 RUN git clone https://github.com/MaterializeInc/sqlancer \
     && cd sqlancer \
-    && git checkout 933b9fa077916fa8f431612d6892f6fa4c711a78 \
+    && git checkout 9dedc47f2daa7756a914b01eff329f905c0f8478 \
     && rm -rf .git \
     && mvn package -DskipTests
 # RUN git clone --depth=1 --single-branch https://github.com/sqlancer/sqlancer \

--- a/test/sqlancerplusplus/Dockerfile
+++ b/test/sqlancerplusplus/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
 # Build SQLancer++
 RUN git clone --single-branch --depth=1 https://github.com/MaterializeInc/sqlancerplusplus \
     && cd sqlancerplusplus \
-    && git checkout bc84af4f22f6c2f598d061dd203f45a4ffdaad93 \
+    && git checkout e42267920448183e624123175b7573577e3c6713 \
     && rm -rf .git \
     && mvn package -DskipTests \
     && sed -i "s/MATERIALIZE.host=localhost/MATERIALIZE.host=materialized/g" dbconfigs/jdbc.properties


### PR DESCRIPTION
@ublubu Is it correct that we really require the`rsa` dependency? CC @jasonhernandez 

The benchmark timeouts are required so that we show which scenarios are failing instead of just timing out the entire test when there is a big regression

Test run: https://buildkite.com/materialize/nightly/builds/16763 & https://buildkite.com/materialize/nightly/builds/16767