### PR TITLE
compute: cache per-batch heap size in ArrangementSize operator

### DIFF
--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
@@ -272,14 +272,19 @@ where
             ));
 
             // Weak references to batches, so we can observe batches outside the trace.
-            let mut batches = BTreeMap::new();
+            // Batches are immutable once sealed, so we compute their size exactly
+            // once (when first observed) and cache it alongside the weak reference.
+            // Subsequent activations only sum the cached values for live batches,
+            // avoiding a repeated walk of every batch's backing regions.
+            let mut batches: BTreeMap<*const B, (Weak<B>, (usize, usize, usize))> = BTreeMap::new();
 
             move |input, output| {
                 input.for_each(|time, data| {
-                    batches.extend(
-                        data.iter()
-                            .map(|batch| (Rc::as_ptr(batch), Rc::downgrade(batch))),
-                    );
+                    for batch in data.iter() {
+                        batches
+                            .entry(Rc::as_ptr(batch))
+                            .or_insert_with(|| (Rc::downgrade(batch), logic(batch)));
+                    }
                     output.session(&time).give_container(data);
                 });
                 let Some(trace) = trace.upgrade() else {
@@ -287,13 +292,15 @@ where
                 };
 
                 trace.borrow().trace().map_batches(|batch| {
-                    batches.insert(Rc::as_ptr(batch), Rc::downgrade(batch));
+                    batches
+                        .entry(Rc::as_ptr(batch))
+                        .or_insert_with(|| (Rc::downgrade(batch), logic(batch)));
                 });
 
                 let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-                batches.retain(|_, weak| {
-                    if let Some(batch) = weak.upgrade() {
-                        let (sz, c, a) = logic(&batch);
+                batches.retain(|_, (weak, cached)| {
+                    if weak.strong_count() > 0 {
+                        let (sz, c, a) = *cached;
                         (size += sz, capacity += c, allocations += a);
                         true
                     } else {


### PR DESCRIPTION
### Motivation

The arrangement-size logging operator (`log_arrangement_size`) is sometimes slow.
On every activation it recomputed the heap size of every live batch by walking each batch's backing regions, even when nothing changed and the operator fired for unrelated reasons.
For large arrangements this repeated walk dominates.

### Description

Batches are immutable once sealed, so their heap size never changes after creation.
The operator already keys its batch map on `Rc::as_ptr`, relying on stable pointer identity.
This change caches the computed `(size, capacity, allocations)` tuple alongside the weak reference when a batch is first observed (via the input stream or `map_batches`), and only sums the cached values on subsequent activations.
Dead batches are still dropped, now via `Weak::strong_count` instead of an `upgrade` that cloned the `Rc`.

Per-activation cost drops from `O(batches * columns * regions)` to `O(new batches * regions)` plus an `O(batches)` sum, eliminating the repeated region walk.
Logged deltas are unchanged: because batches are immutable, the cached size equals what a re-walk would produce.

### Verification

Behavior-preserving change covered by existing arrangement-size logging tests and the `mz_arrangement_sizes` introspection views.
`cargo clippy -p mz-compute` and `cargo fmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)