### PR TITLE
repr: Harden proto/Row decoding against malformed input

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -426,7 +426,8 @@ fn eval_error_code(err: &EvalError) -> SqlState {
             | InvalidRangeError::InvalidRangeBoundFlags
             | InvalidRangeError::NullRangeBoundFlags
             | InvalidRangeError::DiscontiguousUnion
-            | InvalidRangeError::DiscontiguousDifference => SqlState::DATA_EXCEPTION,
+            | InvalidRangeError::DiscontiguousDifference
+            | InvalidRangeError::InvalidRangeData => SqlState::DATA_EXCEPTION,
         },
 
         // Cardinality violations from scalar subqueries.

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -725,7 +725,7 @@ impl Value {
             Type::TimeTz { .. } => return Err("input of timetz types is not implemented".into()),
             Type::Timestamp { .. } => Value::Timestamp(strconv::parse_timestamp(s)?),
             Type::TimestampTz { .. } => Value::TimestampTz(strconv::parse_timestamptz(s)?),
-            Type::Uuid => Value::Uuid(Uuid::parse_str(s)?),
+            Type::Uuid => Value::Uuid(strconv::parse_uuid(s)?),
             Type::MzTimestamp => Value::MzTimestamp(strconv::parse_mz_timestamp(s)?),
             Type::Range { element_type } => Value::Range(strconv::parse_range(s, |elem_text| {
                 Value::decode_text(element_type, elem_text.as_bytes()).map(Box::new)
@@ -831,7 +831,7 @@ impl Value {
             Type::TimestampTz { .. } => {
                 packer.push(Datum::TimestampTz(strconv::parse_timestamptz(s)?))
             }
-            Type::Uuid => packer.push(Datum::Uuid(Uuid::parse_str(s)?)),
+            Type::Uuid => packer.push(Datum::Uuid(strconv::parse_uuid(s)?)),
             Type::MzTimestamp => packer.push(Datum::MzTimestamp(strconv::parse_mz_timestamp(s)?)),
             Type::Range { element_type } => {
                 let range = strconv::parse_range(s, |elem_text| {

--- a/src/repr/src/adt/date.rs
+++ b/src/repr/src/adt/date.rs
@@ -54,9 +54,9 @@ impl RustType<ProtoDate> for Date {
     }
 
     fn from_proto(proto: ProtoDate) -> Result<Self, TryFromProtoError> {
-        // Go through `from_pg_epoch` so out-of-range days are rejected
-        // here — pushing them into a `Row` succeeds but `read_datum` would
-        // later panic when reconstructing the date.
+        // Go through `from_pg_epoch` so out-of-range days are rejected here.
+        // Pushing them into a `Row` succeeds, but `read_datum` would later
+        // panic when reconstructing the date.
         Date::from_pg_epoch(proto.days)
             .map_err(|err| TryFromProtoError::InvalidFieldError(err.to_string()))
     }

--- a/src/repr/src/adt/date.rs
+++ b/src/repr/src/adt/date.rs
@@ -54,7 +54,11 @@ impl RustType<ProtoDate> for Date {
     }
 
     fn from_proto(proto: ProtoDate) -> Result<Self, TryFromProtoError> {
-        Ok(Date { days: proto.days })
+        // Go through `from_pg_epoch` so out-of-range days are rejected
+        // here — pushing them into a `Row` succeeds but `read_datum` would
+        // later panic when reconstructing the date.
+        Date::from_pg_epoch(proto.days)
+            .map_err(|err| TryFromProtoError::InvalidFieldError(err.to_string()))
     }
 }
 

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -399,6 +399,14 @@ pub fn twos_complement_be_to_numeric(
 pub fn twos_complement_be_to_numeric_inner<D: Dec<N>, const N: usize>(
     input: &mut [u8],
 ) -> Result<Decimal<N>, anyhow::Error> {
+    if input.is_empty() {
+        // An empty byte string is not a valid two's-complement integer. Our own
+        // encoder never emits one (zero is the single byte `0x00`), so this only
+        // arises from untrusted input — e.g. an Avro `decimal` field whose
+        // unscaled value was encoded as zero-length `bytes`. Reject it rather
+        // than indexing `input[0]` below and panicking.
+        bail!("cannot parse a numeric value from an empty byte string");
+    }
     let is_neg = if (input[0] & 0x80) != 0 {
         // byte-level negate all negative values, guaranteeing all bytes are
         // readable as unsigned.
@@ -467,6 +475,21 @@ fn test_twos_complement_roundtrip() {
     inner("-999999999999999999999999999999999999999");
     inner("-7.2e35");
     inner("-7.2e-35");
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+fn test_twos_complement_empty_is_error() {
+    // An empty byte string is not a valid two's-complement integer and used to
+    // panic with an out-of-bounds index. It only arrives from untrusted input
+    // (e.g. an Avro `decimal` encoded as zero-length `bytes`), so it must be a
+    // clean error, not a panic. Regression test for that fix.
+    for scale in [0u8, 1, 38] {
+        assert!(twos_complement_be_to_numeric(&mut [], scale).is_err());
+    }
+    assert!(
+        twos_complement_be_to_numeric_inner::<Numeric, NUMERIC_DATUM_WIDTH_USIZE>(&mut []).is_err()
+    );
 }
 
 #[mz_ore::test]

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -402,9 +402,9 @@ pub fn twos_complement_be_to_numeric_inner<D: Dec<N>, const N: usize>(
     if input.is_empty() {
         // An empty byte string is not a valid two's-complement integer. Our own
         // encoder never emits one (zero is the single byte `0x00`), so this only
-        // arises from untrusted input — e.g. an Avro `decimal` field whose
-        // unscaled value was encoded as zero-length `bytes`. Reject it rather
-        // than indexing `input[0]` below and panicking.
+        // arises from untrusted input. One example is an Avro `decimal` field
+        // whose unscaled value was encoded as zero-length `bytes`. Reject it
+        // rather than indexing `input[0]` below and panicking.
         bail!("cannot parse a numeric value from an empty byte string");
     }
     let is_neg = if (input[0] & 0x80) != 0 {

--- a/src/repr/src/adt/range.proto
+++ b/src/repr/src/adt/range.proto
@@ -21,5 +21,6 @@ message ProtoInvalidRangeError {
     google.protobuf.Empty discontiguous_union = 4;
     google.protobuf.Empty discontiguous_difference = 5;
     google.protobuf.Empty null_range_bound_flags = 6;
+    google.protobuf.Empty invalid_range_data = 7;
   }
 }

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -796,6 +796,10 @@ pub enum InvalidRangeError {
     DiscontiguousUnion,
     DiscontiguousDifference,
     NullRangeBoundFlags,
+    /// The encoded range data is structurally invalid (e.g. a null bound,
+    /// bounds of inconsistent types, or the wrong number of bounds). Only
+    /// reachable by decoding untrusted/corrupted bytes.
+    InvalidRangeData,
 }
 
 impl Display for InvalidRangeError {
@@ -817,6 +821,7 @@ impl Display for InvalidRangeError {
             InvalidRangeError::NullRangeBoundFlags => {
                 f.write_str("range constructor flags argument must not be null")
             }
+            InvalidRangeError::InvalidRangeData => f.write_str("invalid range data"),
         }
     }
 }
@@ -847,6 +852,7 @@ impl RustType<ProtoInvalidRangeError> for InvalidRangeError {
             InvalidRangeError::DiscontiguousUnion => DiscontiguousUnion(()),
             InvalidRangeError::DiscontiguousDifference => DiscontiguousDifference(()),
             InvalidRangeError::NullRangeBoundFlags => NullRangeBoundFlags(()),
+            InvalidRangeError::InvalidRangeData => InvalidRangeData(()),
         };
         ProtoInvalidRangeError { kind: Some(kind) }
     }
@@ -863,6 +869,7 @@ impl RustType<ProtoInvalidRangeError> for InvalidRangeError {
                 DiscontiguousUnion(()) => InvalidRangeError::DiscontiguousUnion,
                 DiscontiguousDifference(()) => InvalidRangeError::DiscontiguousDifference,
                 NullRangeBoundFlags(()) => InvalidRangeError::NullRangeBoundFlags,
+                InvalidRangeData(()) => InvalidRangeError::InvalidRangeData,
             }),
             None => Err(TryFromProtoError::missing_field(
                 "`ProtoInvalidRangeError::kind`",

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -901,9 +901,11 @@ impl RustType<ProtoNaiveDateTime> for CheckedTimestamp<NaiveDateTime> {
     }
 
     fn from_proto(proto: ProtoNaiveDateTime) -> Result<Self, TryFromProtoError> {
-        Ok(Self {
-            t: NaiveDateTime::from_proto(proto)?,
-        })
+        // Go through `from_timestamplike` so out-of-range values are
+        // rejected here — pushing them into a `Row` succeeds but
+        // `read_datum` would panic when reconstructing the timestamp.
+        CheckedTimestamp::from_timestamplike(NaiveDateTime::from_proto(proto)?)
+            .map_err(|err| TryFromProtoError::InvalidFieldError(err.to_string()))
     }
 }
 
@@ -913,9 +915,8 @@ impl RustType<ProtoNaiveDateTime> for CheckedTimestamp<DateTime<Utc>> {
     }
 
     fn from_proto(proto: ProtoNaiveDateTime) -> Result<Self, TryFromProtoError> {
-        Ok(Self {
-            t: DateTime::<Utc>::from_proto(proto)?,
-        })
+        CheckedTimestamp::from_timestamplike(DateTime::<Utc>::from_proto(proto)?)
+            .map_err(|err| TryFromProtoError::InvalidFieldError(err.to_string()))
     }
 }
 

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -258,25 +258,22 @@ pub trait TimestampLike:
     }
 
     fn truncate_microseconds(&self) -> Self {
-        let time = NaiveTime::from_hms_micro_opt(
-            self.hour(),
-            self.minute(),
-            self.second(),
-            self.nanosecond() / 1_000,
-        )
-        .unwrap();
+        // Use `with_nanosecond` rather than `from_hms_micro_opt`: the latter only
+        // accepts a leap-second sub-second (>= 1s) when `sec == 59`, so a value
+        // carrying chrono's leap representation at any other second (reachable
+        // from a parsed `:60` literal) would be `None` and panic. `with_nanosecond`
+        // accepts the whole [0, 2s) range, preserving the value.
+        let time = NaiveTime::from_hms_opt(self.hour(), self.minute(), self.second())
+            .and_then(|t| t.with_nanosecond((self.nanosecond() / 1_000) * 1_000))
+            .expect("hour/minute/second/nanosecond came from a valid time");
 
         Self::new(self.date(), time)
     }
 
     fn truncate_milliseconds(&self) -> Self {
-        let time = NaiveTime::from_hms_milli_opt(
-            self.hour(),
-            self.minute(),
-            self.second(),
-            self.nanosecond() / 1_000_000,
-        )
-        .unwrap();
+        let time = NaiveTime::from_hms_opt(self.hour(), self.minute(), self.second())
+            .and_then(|t| t.with_nanosecond((self.nanosecond() / 1_000_000) * 1_000_000))
+            .expect("hour/minute/second/nanosecond came from a valid time");
 
         Self::new(self.date(), time)
     }
@@ -1116,6 +1113,27 @@ mod test {
         assert_round_to_precision(high, 4, 8210266790400123500);
         assert_round_to_precision(high, 5, 8210266790400123460);
         assert_round_to_precision(high, 6, 8210266790400123457);
+    }
+
+    #[mz_ore::test]
+    fn test_round_to_precision_leap_second_off_minute() {
+        // Regression: parsing a `:60` literal can leave chrono's leap-second
+        // representation (sub-second >= 1s) on a second other than `:59` (after
+        // time-zone math). Rounding such a value — as the string->timestamp cast
+        // does — must not panic. `truncate_microseconds`/`truncate_milliseconds`
+        // previously rebuilt the time with `from_hms_{micro,milli}_opt`, whose
+        // leap sub-second range is only valid at `:59`, and unwrapped the `None`.
+        let leap = NaiveDate::from_ymd_opt(3, 3, 17)
+            .unwrap()
+            .and_hms_opt(12, 30, 56)
+            .unwrap()
+            .with_nanosecond(1_000_000_000)
+            .unwrap();
+        let ts = CheckedTimestamp::try_from(leap).unwrap();
+        for precision in [None, Some(0), Some(3), Some(6)] {
+            ts.round_to_precision(precision.map(TimestampPrecision))
+                .unwrap();
+        }
     }
 
     #[mz_ore::test]

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -899,7 +899,7 @@ impl RustType<ProtoNaiveDateTime> for CheckedTimestamp<NaiveDateTime> {
 
     fn from_proto(proto: ProtoNaiveDateTime) -> Result<Self, TryFromProtoError> {
         // Go through `from_timestamplike` so out-of-range values are
-        // rejected here — pushing them into a `Row` succeeds but
+        // rejected here. Pushing them into a `Row` succeeds, but
         // `read_datum` would panic when reconstructing the timestamp.
         CheckedTimestamp::from_timestamplike(NaiveDateTime::from_proto(proto)?)
             .map_err(|err| TryFromProtoError::InvalidFieldError(err.to_string()))
@@ -1119,8 +1119,8 @@ mod test {
     fn test_round_to_precision_leap_second_off_minute() {
         // Regression: parsing a `:60` literal can leave chrono's leap-second
         // representation (sub-second >= 1s) on a second other than `:59` (after
-        // time-zone math). Rounding such a value — as the string->timestamp cast
-        // does — must not panic. `truncate_microseconds`/`truncate_milliseconds`
+        // time-zone math). Rounding such a value, as the string->timestamp cast
+        // does, must not panic. `truncate_microseconds`/`truncate_milliseconds`
         // previously rebuilt the time with `from_hms_{micro,milli}_opt`, whose
         // leap sub-second range is only valid at `:59`, and unwrapped the `None`.
         let leap = NaiveDate::from_ymd_opt(3, 3, 17)

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -1034,6 +1034,16 @@ impl RustType<ProtoRelationDesc> for RelationDesc {
             };
             Box::new(itertools::repeat_n(val, proto.names.len()))
         } else {
+            // Reject mismatched lengths explicitly rather than panicking via
+            // `zip_eq` below — this branch is reachable from untrusted proto
+            // bytes.
+            if proto.names.len() != proto.metadata.len() {
+                return Err(TryFromProtoError::InvalidFieldError(format!(
+                    "ProtoRelationDesc: names ({}) and metadata ({}) length mismatch",
+                    proto.names.len(),
+                    proto.metadata.len()
+                )));
+            }
             Box::new(proto.metadata.into_iter())
         };
 

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -1035,8 +1035,8 @@ impl RustType<ProtoRelationDesc> for RelationDesc {
             Box::new(itertools::repeat_n(val, proto.names.len()))
         } else {
             // Reject mismatched lengths explicitly rather than panicking via
-            // `zip_eq` below — this branch is reachable from untrusted proto
-            // bytes.
+            // `zip_eq` below, since this branch is reachable from untrusted
+            // proto bytes.
             if proto.names.len() != proto.metadata.len() {
                 return Err(TryFromProtoError::InvalidFieldError(format!(
                     "ProtoRelationDesc: names ({}) and metadata ({}) length mismatch",

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2808,17 +2808,23 @@ impl RowPacker<'_> {
         let mut dataz = &self.row.data[datum_check..];
         while !dataz.is_empty() {
             let d = unsafe { read_datum(&mut dataz) };
-            assert!(d != Datum::Null, "cannot push Datum::Null into range");
+            // These checks only fail when decoding untrusted/corrupted bytes;
+            // valid callers always push consistent, non-null bounds. Return an
+            // error rather than asserting so a crafted proto doesn't panic.
+            if d == Datum::Null {
+                self.row.data.truncate(start);
+                return Err(InvalidRangeError::InvalidRangeData.into());
+            }
 
             match seen {
                 None => seen = Some(d),
                 Some(seen) => {
                     let seen_kind = DatumKind::from(seen);
                     let d_kind = DatumKind::from(d);
-                    assert!(
-                        seen_kind == d_kind,
-                        "range contains inconsistent data; expected {seen_kind:?} but got {d_kind:?}"
-                    );
+                    if seen_kind != d_kind {
+                        self.row.data.truncate(start);
+                        return Err(InvalidRangeError::InvalidRangeData.into());
+                    }
 
                     if seen > d {
                         self.row.data.truncate(start);
@@ -2829,10 +2835,10 @@ impl RowPacker<'_> {
             actual_datums += 1;
         }
 
-        assert!(
-            actual_datums == expected_datums,
-            "finite values must each push exactly one value; expected {expected_datums} but got {actual_datums}"
-        );
+        if actual_datums != expected_datums {
+            self.row.data.truncate(start);
+            return Err(InvalidRangeError::InvalidRangeData.into());
+        }
 
         Ok(())
     }
@@ -3992,8 +3998,23 @@ mod tests {
             r
         }
 
+        // A finite bound whose closure pushes zero values violates the
+        // `push_range_with` caller contract and still panics. This is
+        // unreachable when decoding a `ProtoRow`: each decoded bound pushes
+        // exactly one datum (or fails), so only an in-process caller can hit it.
         for panicking_case in [
             vec![vec![Datum::Int32(1)], vec![]],
+            vec![vec![Datum::Int32(1), Datum::Int32(2)], vec![]],
+        ] {
+            #[allow(clippy::disallowed_methods)] // not using enhanced panic handler in tests
+            let result = std::panic::catch_unwind(|| test_range_errors_inner(panicking_case));
+            assert_err!(result);
+        }
+
+        // Inconsistent bound counts, mismatched datum kinds, and Null bounds are
+        // all reachable from a crafted/corrupted `ProtoRow`, so they return an
+        // error instead of panicking.
+        for error_case in [
             vec![
                 vec![Datum::Int32(1), Datum::Int32(2)],
                 vec![Datum::Int32(3)],
@@ -4002,14 +4023,14 @@ mod tests {
                 vec![Datum::Int32(1)],
                 vec![Datum::Int32(2), Datum::Int32(3)],
             ],
-            vec![vec![Datum::Int32(1), Datum::Int32(2)], vec![]],
             vec![vec![Datum::Int32(1)], vec![Datum::UInt16(2)]],
             vec![vec![Datum::Null], vec![Datum::Int32(2)]],
             vec![vec![Datum::Int32(1)], vec![Datum::Null]],
         ] {
-            #[allow(clippy::disallowed_methods)] // not using enhanced panic handler in tests
-            let result = std::panic::catch_unwind(|| test_range_errors_inner(panicking_case));
-            assert_err!(result);
+            assert_eq!(
+                test_range_errors_inner(error_case),
+                Err(InvalidRangeError::InvalidRangeData)
+            );
         }
 
         let e = test_range_errors_inner(vec![vec![Datum::Int32(2)], vec![Datum::Int32(1)]]);

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2126,14 +2126,12 @@ impl RowPacker<'_> {
                     // Map keys must be unique and strictly ascending; iterating a
                     // map that violates this trips a debug_assert. A crafted
                     // proto can, so reject it as a decode error here instead.
-                    if let Some(prev) = prev_key {
-                        if e.key.as_str() <= prev {
-                            return Err(format!(
-                                "dict keys must be unique and in ascending order, \
-                                 but {:?} came after {:?}",
-                                e.key, prev,
-                            ));
-                        }
+                    if let Some(prev) = prev_key && e.key.as_str() <= prev {
+                        return Err(format!(
+                            "dict keys must be unique and in ascending order, \
+                             but {:?} came after {:?}",
+                            e.key, prev,
+                        ));
                     }
                     prev_key = Some(e.key.as_str());
                     row.push(Datum::from(e.key.as_str()));

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2126,7 +2126,9 @@ impl RowPacker<'_> {
                     // Map keys must be unique and strictly ascending; iterating a
                     // map that violates this trips a debug_assert. A crafted
                     // proto can, so reject it as a decode error here instead.
-                    if let Some(prev) = prev_key && e.key.as_str() <= prev {
+                    if let Some(prev) = prev_key
+                        && e.key.as_str() <= prev
+                    {
                         return Err(format!(
                             "dict keys must be unique and in ascending order, \
                              but {:?} came after {:?}",
@@ -2148,9 +2150,9 @@ impl RowPacker<'_> {
                 // represented as variants of ProtoDatumOther.
                 //
                 // `decPackedToNumber` (called via `Decimal::from_packed_bcd`)
-                // doesn't bounds-check its input and segfaults on empty bcd —
-                // reachable from untrusted proto bytes, so we reject before
-                // descending into the FFI.
+                // doesn't bounds-check its input and segfaults on empty bcd.
+                // That is reachable from untrusted proto bytes, so we reject
+                // before descending into the FFI.
                 if x.bcd.is_empty() {
                     return Err("ProtoNumeric.bcd is empty".to_string());
                 }
@@ -2170,9 +2172,10 @@ impl RowPacker<'_> {
                             upper,
                         } = &**inner;
 
-                        // Range bounds must not be `Datum::Null` — `push_range_with`
-                        // panics on that invariant. Reject untrusted proto bytes
-                        // that would push a `Null` bound before calling it.
+                        // Range bounds must not be `Datum::Null`, because
+                        // `push_range_with` panics on that invariant. Reject
+                        // untrusted proto bytes that would push a `Null` bound
+                        // before calling it.
                         let is_null_proto = |d: &ProtoDatum| {
                             matches!(
                                 d.datum_type,
@@ -2282,7 +2285,7 @@ mod tests {
     #[mz_ore::test]
     fn proto_row_invalid_range_is_error() {
         // A ProtoRow with a range whose bounds have inconsistent datum kinds
-        // (or a null/extra bound) must decode to an error, not panic — the range
+        // (or a null/extra bound) must decode to an error, not panic. The range
         // packer used to `assert!` these invariants. Regression for the
         // row_proto_roundtrip cargo-fuzz finding.
         use prost::Message;
@@ -2301,7 +2304,7 @@ mod tests {
     #[mz_ore::test]
     fn proto_row_unordered_dict_keys_is_error() {
         // A ProtoRow with a dict whose keys are duplicated or not in ascending
-        // order must decode to an error, not panic — iterating such a map trips
+        // order must decode to an error, not panic. Iterating such a map trips
         // a debug_assert. Regression for the row_proto_roundtrip cargo-fuzz
         // finding.
         use prost::Message;

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2121,7 +2121,21 @@ impl RowPacker<'_> {
                 .map_err(|err| err.to_string())?
             }
             Some(DatumType::Dict(x)) => self.push_dict_with(|row| -> Result<(), String> {
+                let mut prev_key: Option<&str> = None;
                 for e in x.elements.iter() {
+                    // Map keys must be unique and strictly ascending; iterating a
+                    // map that violates this trips a debug_assert. A crafted
+                    // proto can, so reject it as a decode error here instead.
+                    if let Some(prev) = prev_key {
+                        if e.key.as_str() <= prev {
+                            return Err(format!(
+                                "dict keys must be unique and in ascending order, \
+                                 but {:?} came after {:?}",
+                                e.key, prev,
+                            ));
+                        }
+                    }
+                    prev_key = Some(e.key.as_str());
                     row.push(Datum::from(e.key.as_str()));
                     let val = e
                         .val
@@ -2280,6 +2294,24 @@ mod tests {
             0x00, 0x00, 0xaa, 0x01, 0x00, 0x0a, 0x13, 0xf8, 0x01, 0x08, 0xaa, 0x0a, 0x03, 0xba,
             0x01, 0x00, 0x22, 0x03, 0xba, 0x01, 0x00, 0x12, 0x03, 0xaa, 0x01, 0x00, 0x0a, 0x03,
             0xaa, 0x01, 0x00,
+        ];
+        let proto = ProtoRow::decode(bytes).expect("crash input decodes as a proto");
+        let result: Result<Row, _> = proto.into_rust();
+        assert_err!(result);
+    }
+
+    #[mz_ore::test]
+    fn proto_row_unordered_dict_keys_is_error() {
+        // A ProtoRow with a dict whose keys are duplicated or not in ascending
+        // order must decode to an error, not panic — iterating such a map trips
+        // a debug_assert. Regression for the row_proto_roundtrip cargo-fuzz
+        // finding.
+        use prost::Message;
+        let bytes: &[u8] = &[
+            0x0a, 0x32, 0x18, 0x4e, 0x18, 0x18, 0x68, 0x4e, 0xe8, 0x68, 0x57, 0xba, 0x01, 0x0a,
+            0x0a, 0x08, 0x60, 0xff, 0xff, 0x10, 0x12, 0x02, 0x10, 0x10, 0x99, 0x68, 0x0a, 0x18,
+            0x18, 0x4e, 0x18, 0x18, 0x68, 0x4e, 0xe8, 0x5b, 0x18, 0x68, 0x57, 0xba, 0x01, 0x0a,
+            0x0a, 0x08, 0x60, 0xff, 0xff, 0x10, 0x12, 0x02, 0x18, 0x10,
         ];
         let proto = ProtoRow::decode(bytes).expect("crash input decodes as a proto");
         let result: Result<Row, _> = proto.into_rust();

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2158,6 +2158,23 @@ impl RowPacker<'_> {
                             upper,
                         } = &**inner;
 
+                        // Range bounds must not be `Datum::Null` — `push_range_with`
+                        // panics on that invariant. Reject untrusted proto bytes
+                        // that would push a `Null` bound before calling it.
+                        let is_null_proto = |d: &ProtoDatum| {
+                            matches!(
+                                d.datum_type,
+                                Some(DatumType::Other(o))
+                                    if ProtoDatumOther::try_from(o)
+                                        == Ok(ProtoDatumOther::Null)
+                            )
+                        };
+                        if lower.as_deref().is_some_and(is_null_proto)
+                            || upper.as_deref().is_some_and(is_null_proto)
+                        {
+                            return Err("range bound cannot be Null".into());
+                        }
+
                         self.push_range_with(
                             RangeLowerBound {
                                 inclusive: *lower_inclusive,

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2134,6 +2134,14 @@ impl RowPacker<'_> {
             Some(DatumType::Numeric(x)) => {
                 // Reminder that special values like NaN, PosInf, and NegInf are
                 // represented as variants of ProtoDatumOther.
+                //
+                // `decPackedToNumber` (called via `Decimal::from_packed_bcd`)
+                // doesn't bounds-check its input and segfaults on empty bcd —
+                // reachable from untrusted proto bytes, so we reject before
+                // descending into the FFI.
+                if x.bcd.is_empty() {
+                    return Err("ProtoNumeric.bcd is empty".to_string());
+                }
                 let n = Decimal::from_packed_bcd(&x.bcd, x.scale).map_err(|err| err.to_string())?;
                 self.push(Datum::from(n))
             }

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2267,6 +2267,25 @@ mod tests {
     use crate::{ColumnName, RowArena, SqlColumnType, arb_datum_for_column, arb_row_for_relation};
     use crate::{Datum, RelationDesc, Row, SqlScalarType};
 
+    #[mz_ore::test]
+    fn proto_row_invalid_range_is_error() {
+        // A ProtoRow with a range whose bounds have inconsistent datum kinds
+        // (or a null/extra bound) must decode to an error, not panic — the range
+        // packer used to `assert!` these invariants. Regression for the
+        // row_proto_roundtrip cargo-fuzz finding.
+        use prost::Message;
+        let bytes: &[u8] = &[
+            0x0a, 0x03, 0xaa, 0x01, 0x00, 0x0a, 0x03, 0xaa, 0x01, 0x00, 0x0a, 0x03, 0xa2, 0x01,
+            0x00, 0x0a, 0x03, 0xaa, 0x01, 0x00, 0x0a, 0x20, 0xfa, 0x01, 0x1d, 0x1d, 0x9f, 0x00,
+            0x00, 0x00, 0xaa, 0x01, 0x00, 0x0a, 0x13, 0xf8, 0x01, 0x08, 0xaa, 0x0a, 0x03, 0xba,
+            0x01, 0x00, 0x22, 0x03, 0xba, 0x01, 0x00, 0x12, 0x03, 0xaa, 0x01, 0x00, 0x0a, 0x03,
+            0xaa, 0x01, 0x00,
+        ];
+        let proto = ProtoRow::decode(bytes).expect("crash input decodes as a proto");
+        let result: Result<Row, _> = proto.into_rust();
+        assert_err!(result);
+    }
+
     #[track_caller]
     fn roundtrip_datum<'a>(
         ty: SqlColumnType,

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2172,7 +2172,7 @@ impl RowPacker<'_> {
                                     .map(|d| |row: &mut RowPacker| row.try_push_proto(&*d)),
                             },
                         )
-                        .expect("decoding ProtoRow must succeed");
+                        .map_err(|err| err.to_string())?;
                     }
                 }
             }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1913,10 +1913,10 @@ impl RustType<ProtoScalarType> for SqlScalarType {
                         .map(|x| *x)
                         .into_rust_if_some("ProtoList::element_type")?,
                 ),
-                custom_id: x.custom_id.map(|id| id.into_rust().unwrap()),
+                custom_id: x.custom_id.map(|id| id.into_rust()).transpose()?,
             }),
             Record(x) => Ok(SqlScalarType::Record {
-                custom_id: x.custom_id.map(|id| id.into_rust().unwrap()),
+                custom_id: x.custom_id.map(|id| id.into_rust()).transpose()?,
                 fields: x.fields.into_rust()?,
             }),
             Map(x) => Ok(SqlScalarType::Map {
@@ -1925,7 +1925,7 @@ impl RustType<ProtoScalarType> for SqlScalarType {
                         .map(|x| *x)
                         .into_rust_if_some("ProtoMap::value_type")?,
                 ),
-                custom_id: x.custom_id.map(|id| id.into_rust().unwrap()),
+                custom_id: x.custom_id.map(|id| id.into_rust()).transpose()?,
             }),
             MzTimestamp(()) => Ok(SqlScalarType::MzTimestamp),
             Range(x) => Ok(SqlScalarType::Range {

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -731,7 +731,15 @@ where
 }
 
 pub fn parse_uuid(s: &str) -> Result<Uuid, ParseError> {
-    s.trim()
+    let trimmed = s.trim();
+    // The `uuid` crate panics while constructing a parse error for some short,
+    // brace-wrapped inputs (e.g. `{}`, `{\0}`) — it mis-slices the input. Reject
+    // anything that can't be a UUID before handing it to the crate: the shortest
+    // valid form is 32 hex digits and every form is ASCII.
+    if trimmed.len() < 32 || !trimmed.is_ascii() {
+        return Err(ParseError::invalid_input_syntax("uuid", s));
+    }
+    trimmed
         .parse()
         .map_err(|e| ParseError::invalid_input_syntax("uuid", s).with_details(e))
 }
@@ -2197,5 +2205,20 @@ mod tests {
 
         let s = format!("{}{}", "x".repeat(62), "א");
         assert_eq!("x".repeat(62), parse_pg_legacy_name(&s));
+    }
+
+    #[mz_ore::test]
+    fn test_parse_uuid_rejects_non_uuid_input() {
+        // The `uuid` crate panics while constructing a parse error for some
+        // short, brace-wrapped inputs (e.g. `{}`, `{\0}`). `parse_uuid` must
+        // reject anything that can't be a UUID as an error, never panic.
+        // Regression for the value_decode_text cargo-fuzz finding.
+        for s in ["", "{}", "{\0}", "{", "}", "xyz", "{ }", "\u{0}\u{0}\u{0}"] {
+            assert!(parse_uuid(s).is_err(), "parse_uuid({s:?}) should be Err");
+        }
+        // Valid UUIDs (and their accepted forms) still parse.
+        assert!(parse_uuid("00000000-0000-0000-0000-000000000000").is_ok());
+        assert!(parse_uuid("{00000000-0000-0000-0000-000000000000}").is_ok());
+        assert!(parse_uuid("00000000000000000000000000000000").is_ok());
     }
 }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -733,9 +733,9 @@ where
 pub fn parse_uuid(s: &str) -> Result<Uuid, ParseError> {
     let trimmed = s.trim();
     // The `uuid` crate panics while constructing a parse error for some short,
-    // brace-wrapped inputs (e.g. `{}`, `{\0}`) — it mis-slices the input. Reject
-    // anything that can't be a UUID before handing it to the crate: the shortest
-    // valid form is 32 hex digits and every form is ASCII.
+    // brace-wrapped inputs (e.g. `{}`, `{\0}`) because it mis-slices the input.
+    // Reject anything that can't be a UUID before handing it to the crate. The
+    // shortest valid form is 32 hex digits and every form is ASCII.
     if trimmed.len() < 32 || !trimmed.is_ascii() {
         return Err(ParseError::invalid_input_syntax("uuid", s));
     }

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -824,7 +824,8 @@ mod columnation {
                                 | e @ InvalidRangeError::InvalidRangeBoundFlags
                                 | e @ InvalidRangeError::DiscontiguousUnion
                                 | e @ InvalidRangeError::DiscontiguousDifference
-                                | e @ InvalidRangeError::NullRangeBoundFlags => e.clone(),
+                                | e @ InvalidRangeError::NullRangeBoundFlags
+                                | e @ InvalidRangeError::InvalidRangeData => e.clone(),
                                 InvalidRangeError::CanonicalizationOverflow(string) => {
                                     InvalidRangeError::CanonicalizationOverflow(
                                         self.string_region.copy(string),

--- a/src/storage-types/src/sources/casts.rs
+++ b/src/storage-types/src/sources/casts.rs
@@ -820,8 +820,8 @@ mod tests {
         fn error_uuid() {
             // `parse_uuid` rejects anything too short to be a UUID before the
             // `uuid` crate runs (the crate panics building an error for some
-            // short inputs), so the error carries no crate-specific detail —
-            // matching Postgres, whose message for `'bad'::uuid` has none.
+            // short inputs), so the error carries no crate-specific detail.
+            // This matches Postgres, whose message for `'bad'::uuid` has none.
             assert_eq!(
                 eval_cast_err(CastFunc::CastStringToUuid, "bad"),
                 parse_err("uuid", "bad"),

--- a/src/storage-types/src/sources/casts.rs
+++ b/src/storage-types/src/sources/casts.rs
@@ -818,13 +818,13 @@ mod tests {
 
         #[mz_ore::test]
         fn error_uuid() {
+            // `parse_uuid` rejects anything too short to be a UUID before the
+            // `uuid` crate runs (the crate panics building an error for some
+            // short inputs), so the error carries no crate-specific detail —
+            // matching Postgres, whose message for `'bad'::uuid` has none.
             assert_eq!(
                 eval_cast_err(CastFunc::CastStringToUuid, "bad"),
-                parse_err_with_details(
-                    "uuid",
-                    "bad",
-                    "invalid length: expected length 32 for simple format, found 3"
-                ),
+                parse_err("uuid", "bad"),
             );
         }
 


### PR DESCRIPTION
Hardens `mz-repr` proto/Row decoding against malformed/untrusted bytes — these paths are reachable from persisted state and the wire, so a panic is an availability bug. Replaces panics/asserts with proper decode errors and validates ranges (Date, CheckedTimestamp, ProtoNumeric, ProtoRange, ProtoRelationDesc, ProtoRow dict ordering, uuid parsing, leap-second truncation, Avro decimal).

Found by the cargo-fuzz suite ([separate infra PR](https://github.com/MaterializeInc/materialize/pull/36982)). Each fix has a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
