### PR TITLE
Reject zero sampling frequency in profiling API

### DIFF
--- a/src/prof/src/time.rs
+++ b/src/prof/src/time.rs
@@ -29,6 +29,9 @@ pub async unsafe fn prof_time(
     sample_freq: u32,
     merge_threads: bool,
 ) -> anyhow::Result<StackProfile> {
+    if sample_freq == 0 {
+        bail!("Sampling frequency must be greater than zero.");
+    }
     if sample_freq > 1_000_000 {
         bail!("Sub-microsecond intervals are not supported.");
     }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -3706,6 +3706,15 @@ def workflow_test_profile_fetch(c: Composition) -> None:
         ),
     )
 
+    # Regression test for CLU-109: a sampling frequency of zero used to reach
+    # pprof's `Timer::new`, which computes `1_000_000 / hz` and panicked with a
+    # division by zero, crashing the whole process. It must now be rejected with
+    # a clean error response instead.
+    test_post(
+        {"action": "time_fg", "time_secs": "1", "hz": "0"},
+        make_check(500, "Sampling frequency must be greater than zero."),
+    )
+
     # Deactivate memory profiling.
     test_post(
         {"action": "deactivate"},


### PR DESCRIPTION
### Motivation

Fixes CLU-109: When a sampling frequency of zero was passed to the profiling API, it would reach pprof's `Timer::new`, which computes `1_000_000 / hz` and panicked with a division by zero error, crashing the entire process.

### Description

Added validation in `prof_time()` to reject a sampling frequency of zero with a clean error response before it can reach the pprof library. The check is placed early in the function, before the existing check for frequencies above 1,000,000.

The error message "Sampling frequency must be greater than zero." is returned as a 500 HTTP response to the client, allowing graceful error handling instead of a process crash.

### Verification

Added a regression test in `test/cluster/mzcompose.py` that verifies:
- A POST request with `hz: "0"` returns a 500 status code
- The response contains the expected error message

The test is part of the profiling test suite and will run as part of the cluster test suite.

https://claude.ai/code/session_015wj2rXHwqbFS5h2s5rNsds