### PR TITLE
Reuse DatumVec allocation in metrics history truncation

### DIFF
--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -83,7 +83,7 @@ use mz_persist_client::batch::Added;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::write::WriteHandle;
 use mz_repr::adt::timestamp::CheckedTimestamp;
-use mz_repr::{ColumnName, Diff, GlobalId, Row, Timestamp};
+use mz_repr::{ColumnName, DatumVec, Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::client::{AppendOnlyUpdate, Status, TimestamplessUpdate};
 use mz_storage_client::controller::{IntrospectionType, MonotonicAppender, StorageWriteOp};
 use mz_storage_client::healthcheck::{
@@ -1521,10 +1521,12 @@ async fn partially_truncate_metrics_history(
 
     // Produce retractions by inverting diffs of rows we want to delete.
     let mut builder = write_handle.builder(Antichain::from_elem(old_upper_ts));
+    // Re-used allocation for decoding rows, avoids allocating a fresh vector per row.
+    let mut datum_vec = DatumVec::new();
     while let Some(chunk) = rows.next().await {
         for (data, _t, diff) in chunk {
             let Ok(row) = &data.0 else { continue };
-            let datums = row.unpack();
+            let datums = datum_vec.borrow_with(row);
             let occurred_at = datums[occurred_at_col].unwrap_timestamptz();
             if *occurred_at >= keep_since {
                 continue;


### PR DESCRIPTION
### Motivation

Optimize memory allocation in the `partially_truncate_metrics_history` function by reusing a single `DatumVec` allocation across multiple row unpacking operations instead of allocating a fresh vector for each row.

### Description

This change introduces a performance optimization in the metrics history truncation logic. Previously, each call to `row.unpack()` would allocate a new vector to hold the unpacked datums. By reusing a single `DatumVec` allocation across the loop, we avoid repeated allocations and deallocations.

The change:
1. Adds `DatumVec` to the imports from `mz_repr`
2. Creates a single `DatumVec` instance before the loop
3. Replaces `row.unpack()` with `datum_vec.borrow_with(row)` to reuse the allocation

This is a straightforward refactoring that maintains identical behavior while reducing memory pressure during metrics history truncation operations.

### Verification

This is a performance optimization with no functional changes. The behavior remains identical — we're just reusing an allocation. Existing tests for metrics history truncation will continue to pass.

https://claude.ai/code/session_01Do1ud8hPYH5Pk3iM36AkEY