### PR TITLE
storage-controller: reuse DatumVec when truncating status history

### DIFF
--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -83,7 +83,7 @@ use mz_persist_client::batch::Added;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::write::WriteHandle;
 use mz_repr::adt::timestamp::CheckedTimestamp;
-use mz_repr::{ColumnName, Diff, GlobalId, Row, Timestamp};
+use mz_repr::{ColumnName, DatumVec, Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::client::{AppendOnlyUpdate, Status, TimestamplessUpdate};
 use mz_storage_client::controller::{IntrospectionType, MonotonicAppender, StorageWriteOp};
 use mz_storage_client::healthcheck::{
@@ -1605,8 +1605,10 @@ where
 
     let mut handle_row = {
         let latest_row_per_key = &mut latest_row_per_key;
+        // Re-used allocation for decoding rows, avoids allocating a fresh vector per row.
+        let mut datum_vec = DatumVec::new();
         move |row: &Row, diff| {
-            let datums = row.unpack();
+            let datums = datum_vec.borrow_with(row);
             let key = (status_history_desc.extract_key)(&datums);
             let timestamp = (status_history_desc.extract_time)(&datums);
 


### PR DESCRIPTION
### Motivation

The `handle_row` closure in `partially_truncate_status_history` decoded each snapshot row with `Row::unpack`, which allocates a fresh `Vec<Datum>` on every call. This runs in the hot per-row truncation loop over the status history shard.

This is a sibling change to the metrics-history truncation PR (#36990); same pattern, different call site.

### Tips for reviewer

The closure now captures a re-used `DatumVec` and decodes rows via `borrow_with`, which returns its allocation to the vector on drop and reuses it across rows. `extract_key`/`extract_time` take `&[Datum]`, and `&DatumVecBorrow` deref-coerces to `&[Datum]`, so the call sites are unchanged. The closure was already `mut`/`FnMut` (it mutates `latest_row_per_key`), so capturing the `DatumVec` by value and borrowing it mutably is fine.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Do1ud8hPYH5Pk3iM36AkEY)_