### PR TITLE
row-spine: carry first-byte bitmap through safe codec install

### DIFF
--- a/src/row-spine/src/lib.rs
+++ b/src/row-spine/src/lib.rs
@@ -279,6 +279,76 @@ mod tests {
         }
     }
 
+    /// Regression test for a dictionary-codec soundness bug in the safe-install
+    /// path (`new_safe`), reachable with the paged batcher enabled.
+    ///
+    /// A from-scratch container stores its pre-install rows *raw* while gathering
+    /// statistics, then installs a *safe* codec via `new_safe`. `new_safe` used to
+    /// discard the first-byte bitmap gathered over those raw rows. That bitmap is
+    /// soundness-critical: a later `new_from` merge consults it to decide which
+    /// one-byte tags are free to hand out as dictionary keys. With the bitmap
+    /// dropped, the merge could assign a dictionary tag equal to a raw datum's
+    /// first byte, after which `decode` resolves that literal datum to the
+    /// dictionary entry — returning the wrong value.
+    ///
+    /// We drive the lifecycle directly: observe short strings (first byte
+    /// `StringTiny`) into the pre-install statistics, install a safe codec, then
+    /// feed it many distinct *long* strings (first byte `StringShort`)
+    /// post-install so the merge has heavy hitters to compress. Merging via
+    /// `new_from` and re-encoding the short strings then exercises the raw
+    /// fall-through whose first byte the merge must not have claimed as a tag.
+    /// Before the fix the `StringTiny` tag was handed out and the round-trip
+    /// produced a long string (and tripped `encode`'s soundness `debug_assert`).
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // integer-to-pointer casts in row decoding are unsupported under miri
+    fn test_safe_codec_merge_bitmap_carryover() {
+        use crate::row_codec::ColumnsCodec;
+
+        // Short strings: length < 256, so they encode with the `StringTiny` tag.
+        // Unique, so MisraGries never makes them dictionary entries; they always
+        // fall through raw, exposing their first byte.
+        let short_rows: Vec<Row> = (0..256)
+            .map(|i| Row::pack_slice(&[Datum::String(&format!("s{i}"))]))
+            .collect();
+        // Long strings: length >= 256, so they encode with the `StringShort` tag —
+        // a *different* first byte than the short strings. Distinct values, each
+        // repeated, so the post-install codec accrues many heavy hitters and the
+        // merge assigns dictionary tags across the low byte range, reaching the
+        // short strings' `StringTiny` tag unless the bitmap reserves it.
+        let long_values: Vec<String> = (0..64).map(|i| format!("{i:0>300}")).collect();
+
+        // Pre-install statistics observe only the short strings' first bytes.
+        let mut stats = ColumnsCodec::default();
+        let mut scratch = Vec::new();
+        for row in &short_rows {
+            scratch.clear();
+            stats.encode(ColumnsCodec::borrow_row(row), &mut scratch);
+        }
+
+        // Install a safe codec, then feed it the long strings post-install so it
+        // accrues heavy hitters (and observes only the `StringShort` first byte).
+        let mut safe = stats.new_safe();
+        for _ in 0..8 {
+            for v in &long_values {
+                let row = Row::pack_slice(&[Datum::String(v)]);
+                scratch.clear();
+                safe.encode(ColumnsCodec::borrow_row(&row), &mut scratch);
+            }
+        }
+
+        // Merge, then round-trip the short strings. With the bitmap carried over,
+        // no dictionary tag collides with the short strings' first byte; without
+        // it, one does.
+        let mut merged = ColumnsCodec::new_from([&safe]);
+        for row in &short_rows {
+            let mut buf = Vec::new();
+            merged.encode(ColumnsCodec::borrow_row(row), &mut buf);
+            let decoded = merged.decode(&buf).collect::<Vec<_>>();
+            let expected = ColumnsCodec::borrow_row(row).collect::<Vec<_>>();
+            assert_eq!(decoded, expected, "round-trip mismatch for {row:?}");
+        }
+    }
+
     /// Confirms the structural assumption underpinning `SAFE_TAG_BASE`: every
     /// datum the row format produces encodes with a first byte strictly less
     /// than `SAFE_TAG_BASE`. If `mz_repr` ever introduces a tag that crosses
@@ -1753,9 +1823,18 @@ mod row_codec {
             /// These tags never collide with datum first-bytes, so the codec can be
             /// installed without observing all data first.
             pub(super) fn new_safe(stats: Self) -> Self {
-                let mut mg = stats
-                    .stats
-                    .0
+                // The container stores its pre-install rows raw, so the first-byte
+                // bitmap (`stats.1`) gathered while observing them must carry over to
+                // the installed codec. The bitmap is soundness-critical: a later
+                // `new_from` merge consults it to decide which one-byte tags are free
+                // to hand out as dictionary keys. If we dropped it here, the merge
+                // could assign a dictionary tag equal to a pre-install datum's first
+                // byte, after which `decode` would resolve that literal datum to the
+                // dictionary entry. The MisraGries summary (`stats.0`), by contrast,
+                // is consumed below to seed the dictionary and is reset, since the
+                // installed codec re-accumulates it from rows it sees post-install.
+                let (mg, observed_tags) = stats.stats;
+                let mut mg = mg
                     .done()
                     .into_iter()
                     .filter(|(next_bytes, count)| next_bytes.len() > 1 && count > &1);
@@ -1775,7 +1854,7 @@ mod row_codec {
                 Self {
                     encode,
                     decode,
-                    stats: (MisraGries::default(), [0u64; 4]),
+                    stats: (MisraGries::default(), observed_tags),
                 }
             }
         }

--- a/test/testdrive/arrangement-dictionary-compression.td
+++ b/test/testdrive/arrangement-dictionary-compression.td
@@ -1,0 +1,93 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for arrangement dictionary compression (materialize#32095)
+# on the paged arrange path: a batch of > 64Ki rows installs its codec
+# mid-container (`STATS_THRESHOLD` in mz-row-spine), storing its first 64Ki
+# rows raw. The codec's first-byte tag bitmap must still cover those raw rows:
+# when two compressed batches merge, the merged codec reuses any tag absent
+# from the union of the bitmaps as a dictionary tag for a popular value. If
+# the bitmap under-reports, a dictionary tag collides with a raw-stored
+# datum's first byte and reads silently decode it as the popular value.
+#
+# Setup: single worker; 70k-row batches; 1000 "rare" rows whose small keys
+# sort first, pinning their tiny-string value '1' (tag StringTiny) into the
+# raw region, while all other values are 200 distinct 259-char strings (tag
+# StringShort) that become dictionary entries. On corruption, a rare row's v
+# decodes as a 259-char filler string. In debug-assertions builds the merge
+# panics the replica instead and rehydration heals the data, hence the final
+# assertion that no replica went offline.
+
+$ set-sql-timeout duration=120s
+
+# Must precede CREATE CLUSTER: the compression flag is captured once at
+# replica creation.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_arrangement_dictionary_compression_alpha = true
+ALTER SYSTEM SET enable_column_paged_batcher = true
+
+> CREATE CLUSTER dict_compression SIZE 'scale=1,workers=1'
+
+> SET cluster = dict_compression
+
+> CREATE TABLE t (k bigint, v text)
+
+> INSERT INTO t SELECT g::bigint, '1' FROM generate_series(1, 1000) g
+
+> INSERT INTO t
+  SELECT (4300000000 + g)::bigint, repeat('x', 256) || lpad((g % 200)::text, 3, '0')
+  FROM generate_series(1, 69000) g
+
+> CREATE INDEX t_dict_idx ON t (k)
+
+> SELECT count(*) FROM t
+70000
+
+# Each single-statement insert lands as one spine batch; introducing a
+# same-scale batch forces the pending lower merge to complete, so the snapshot
+# batch physically merges with batch 2.
+> INSERT INTO t
+  SELECT (4400000000 + g)::bigint, repeat('x', 256) || lpad((g % 200)::text, 3, '0')
+  FROM generate_series(1, 70000) g
+
+> INSERT INTO t
+  SELECT (4500000000 + g)::bigint, repeat('x', 256) || lpad((g % 200)::text, 3, '0')
+  FROM generate_series(1, 70000) g
+
+> INSERT INTO t
+  SELECT (4600000000 + g)::bigint, repeat('x', 256) || lpad((g % 200)::text, 3, '0')
+  FROM generate_series(1, 70000) g
+
+# 4 batches went in; reaching <= 3 requires a merge, and the snapshot batch's
+# merge is necessarily the first to complete. The records guard keeps this
+# from passing before all batches arrived.
+> SELECT s.batches <= 3
+  FROM mz_introspection.mz_arrangement_sizes s
+  JOIN mz_introspection.mz_dataflow_operator_dataflows d ON s.operator_id = d.id
+  WHERE d.dataflow_name LIKE '%t_dict_idx%' AND s.records >= 280000
+true
+
+# The raw-stored rare rows must survive the merge.
+> SELECT v FROM t WHERE k = 17
+1
+
+> SELECT count(*), count(DISTINCT v), min(length(v)), max(length(v)) FROM t
+280000 201 1 259
+
+# Catch the debug-assertions failure mode (merge panic + rehydration).
+> SELECT count(*)
+  FROM mz_internal.mz_cluster_replica_status_history h
+  JOIN mz_catalog.mz_cluster_replicas r ON h.replica_id = r.id
+  JOIN mz_catalog.mz_clusters c ON r.cluster_id = c.id
+  WHERE c.name = 'dict_compression' AND h.status = 'offline'
+0
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET enable_arrangement_dictionary_compression_alpha
+ALTER SYSTEM RESET enable_column_paged_batcher


### PR DESCRIPTION
### Motivation

Fixes a dictionary-codec soundness bug surfaced by [arrangement-dictionary-compression.td](<http://arrangement-dictionary-compression.td/>): with enable_arrangement_dictionary_compression_alpha *and* enable_column_paged_batcher on, SELECT v FROM t WHERE k = 17 returned a long dictionary value (xxx…135) instead of the stored "1". Disabling either flag returned correct results.

### Root cause

A from-scratch DatumContainer stores its pre-install rows raw while gathering statistics, then installs a safe codec via new_safe once it crosses STATS_THRESHOLD. new_safe discarded the first-byte bitmap (stats.1) gathered over those raw rows.

That bitmap is soundness-critical: new_from (the merge path) hands out any unused one-byte tag as a dictionary key and decides "unused" purely from the OR of its inputs' bitmaps. A safe codec is sound on its own — it only uses tags >= SAFE_TAG_BASE, which no datum first-byte can equal — so the dropped bitmap goes unnoticed until two such containers merge. With the pre-install bitmap gone, the installed codec's bitmap covered only post-install rows, so the merge could assign a low dictionary tag equal to a pre-install datum's first byte (StringTiny = 19 here). decode then resolves that literal datum to the dictionary entry and returns the wrong value.

### Fix

Carry the observed-tag bitmap into the installed codec so it covers both pre- and post-install rows. The MisraGries summary is still reset, since the installed codec re-accumulates it from rows it sees post-install. The symmetric reset in new_from is correct as-is: a new_from container re-encodes every row through encode, so observe sees them all — there are no bypassed raw rows there.

### Tests

Adds test_safe_codec_merge_bitmap_carryover, which drives the install-then-merge lifecycle directly. It trips encode's soundness debug_assert (raw datum first-byte 19 collides with a dictionary tag) before the fix and passes after.

Closes CLU-110