### PR TITLE
Fix array_fill max size calculation operator precedence bug

### DIFF
--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -252,7 +252,7 @@ fn array_fill<'a>(
     lower_bounds: OptionalArg<Option<Array<'a>>>,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
-    const MAX_SIZE: usize = 1 << 28 - 1;
+    const MAX_SIZE: usize = (1 << 28) - 1;
     const NULL_ARR_ERR: &str = "dimension array or low bound array";
     const NULL_ELEM_ERR: &str = "dimension values";
 

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -273,25 +273,25 @@ SELECT array_fill(1, ARRAY[4, 0, 3]);
 
 # Too large of array
 
-query error array size exceeds the maximum allowed \(134217728 bytes\)
+query error array size exceeds the maximum allowed \(268435455 bytes\)
 SELECT array_fill(2, ARRAY[-1]);
 
-query error array size exceeds the maximum allowed \(134217728 bytes\)
+query error array size exceeds the maximum allowed \(268435455 bytes\)
 SELECT array_fill(2, ARRAY[-1]);
 
-query error array size exceeds the maximum allowed \(134217728 bytes\)
+query error array size exceeds the maximum allowed \(268435455 bytes\)
 SELECT array_fill(1, ARRAY[4, -199]);
 
-query error array size exceeds the maximum allowed \(134217728 bytes\)
+query error array size exceeds the maximum allowed \(268435455 bytes\)
 SELECT array_fill(1, ARRAY[-199, 4]);
 
-query error array size exceeds the maximum allowed \(134217728 bytes\)
+query error array size exceeds the maximum allowed \(268435455 bytes\)
 SELECT array_fill(1, ARRAY[4, 3, -199]);
 
-query error array size exceeds the maximum allowed \(134217728 bytes\)
+query error array size exceeds the maximum allowed \(268435455 bytes\)
 SELECT array_fill(1, ARRAY[4, -199, 3]);
 
-query error array size exceeds the maximum allowed \(134217728 bytes\)
+query error array size exceeds the maximum allowed \(268435455 bytes\)
 SELECT array_fill(8, ARRAY[-1, -1, -1, -1]);
 
 query error number of array dimensions \(10\) exceeds the maximum allowed \(6\)
@@ -301,6 +301,17 @@ query error number of array dimensions \(10\) exceeds the maximum allowed \(6\)
 SELECT array_fill(1, ARRAY[1,1,1,1,1,1,1,1,1,1], ARRAY[1,1,1,1,1,1,1,1,1,1]);
 
 # But large arrays are still ok
+
+# Regression test for database-issues#11267: the limit was previously parsed as
+# `1 << (28 - 1)` instead of `(1 << 28) - 1`, so arrays just below the intended
+# limit were rejected.
+query I
+SELECT array_length(array_fill(false, ARRAY[134217728]), 1);
+----
+134217728
+
+query error array size exceeds the maximum allowed \(268435455 bytes\)
+SELECT array_length(array_fill(false, ARRAY[268435455]), 1);
 
 query II
 SELECT array_length(a, 1), array_length(a, 2) FROM (


### PR DESCRIPTION
### Motivation

Fixes database-issues#11267. The maximum array size constant in `array_fill` was incorrectly calculated due to operator precedence: `1 << 28 - 1` was evaluated as `1 << (28 - 1)` = 134,217,728 bytes instead of the intended `(1 << 28) - 1` = 268,435,455 bytes. This caused arrays just below the intended limit to be incorrectly rejected.

### Description

The fix involves two changes:

1. **Source code fix** (`src/expr/src/scalar/func/variadic.rs`): Added explicit parentheses to `MAX_SIZE` constant definition to ensure correct operator precedence: `(1 << 28) - 1` instead of `1 << 28 - 1`.

2. **Test updates** (`test/sqllogictest/array_fill.slt`): 
   - Updated all existing error message assertions to expect the correct limit of 268,435,455 bytes instead of 134,217,728 bytes
   - Added regression tests to verify that arrays at the correct boundary are now handled properly:
     - Arrays with 134,217,728 elements (previously rejected, now accepted)
     - Arrays with 268,435,455 elements (correctly rejected as exceeding the limit)

### Verification

The regression tests in the SQL logic test file verify the fix:
- `array_fill(false, ARRAY[134217728])` now succeeds (previously failed)
- `array_fill(false, ARRAY[268435455])` correctly fails with the proper error message
- All existing tests pass with updated error message expectations

https://claude.ai/code/session_01LbZSMyTkcigGXg2UV4RwtG