### PR TITLE
adapter: report error to clients when table writer terminates

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -590,14 +590,22 @@ impl Coordinator {
             || "group_commit_apply",
             async move {
                 // Wait for the writes to complete.
-                match append_fut
+                let write_result = match append_fut
                     .instrument(debug_span!("group_commit_apply::append_fut"))
                     .await
                 {
                     Ok(append_result) => {
-                        append_result.unwrap_or_terminate("cannot fail to apply appends")
+                        append_result.unwrap_or_terminate("cannot fail to apply appends");
+                        Ok(())
                     }
-                    Err(_) => warn!("Writer terminated with writes in indefinite state"),
+                    // The writer's oneshot channel was dropped before it sent a
+                    // result, so the writes are in an indefinite state. We must
+                    // not report success to clients, since their writes may not
+                    // have been durably persisted.
+                    Err(_) => {
+                        warn!("Writer terminated with writes in indefinite state");
+                        Err(())
+                    }
                 };
 
                 // Apply the write by marking the timestamp as complete on the timeline.
@@ -609,6 +617,17 @@ impl Coordinator {
                 for response in responses {
                     let (mut ctx, result) = response.finalize();
                     ctx.session_mut().apply_write(timestamp);
+                    // If the writer terminated with the writes in an indefinite
+                    // state, report an error rather than telling the client a
+                    // success that we cannot guarantee.
+                    let result = match write_result {
+                        Ok(()) => result,
+                        Err(()) => Err(AdapterError::Internal(
+                            "table write failed: writer terminated with writes in \
+                             an indefinite state"
+                                .to_string(),
+                        )),
+                    };
                     ctx.retire(result);
                 }
 


### PR DESCRIPTION
### Motivation

In `group_commit_apply`, when the persist table writer's oneshot channel returns `Err` (the sender was dropped before sending a result), the writes are in an indefinite state. Previously we only logged a warning and then fell through to advance the oracle and notify clients of success via `ctx.retire(result)` — telling clients their writes were durably persisted when they may not have been.

### Description

On the `Err` branch we now record that the write is in an indefinite state and, when retiring each affected client, replace the success result with an `AdapterError::Internal` rather than reporting success. The rest of the flow (oracle advance, timeline advancement, internal notifies) is unchanged, matching the prior best-effort behavior on this shutdown-adjacent path.

### Verification

No automated test added — this is a narrow error-reporting fix on a hard-to-reproduce failure path (writer task aborted mid-append). Verified by review; the change is local to the notification logic in `appends.rs`.