### PR TITLE
ci: annotate catalog_server_explain coverage failures

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -110,6 +110,9 @@ ERROR_RE = re.compile(
     | source-table-migration\ issue
     # sql logic tests
     | Rewrite\ SLT\ files\ locally\ with:\ [\s\S]*? ^EOF$
+    # catalog_server_explain.slt coverage check (test/sqllogictest/mzcompose.py).
+    # Raised as a UIError, so it never reaches a junit file; match the log text.
+    | is\ out\ of\ date\ with\ the\ objects\ on\ mz_catalog_server\.[\s\S]*?catalog-server-explain\ --rewrite
     | ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+thread\ '.*?'\ panicked\ at\ .*\n.*
     # rdkafka assertions
     | Assertion\ `.*'\ failed\.


### PR DESCRIPTION
### Motivation

def- noticed that when the catalog-server EXPLAIN coverage check fails, CI produces no annotation (e.g. [build 125383, SLT 1](https://buildkite.com/materialize/test/builds/125383#019ebb7c-6de7-48c5-9d99-04c1987c908c)).

The coverage check in `test/sqllogictest/mzcompose.py` raises a `UIError` when `catalog_server_explain.slt` drifts from the live `mz_catalog_server` objects.
For the `sqllogictest` composition mzcompose suppresses its own junit (sqllogictest writes its own), so the failure never reaches a junit file, and its message matched no `ERROR_RE` pattern — so `ci-annotate-errors` had nothing to annotate.
The sibling failure on the actual `.slt` run (SLT 4) *is* annotated, because the sqllogictest binary emits the `Rewrite SLT files locally with: … EOF` block that `ERROR_RE` already matches.

### Description

Add an `ERROR_RE` pattern matching the coverage failure's log text, mirroring the existing SLT-rewrite pattern.
It captures from the headline through the regenerate command so the annotation tells you both what drifted and how to fix it.

### Verification

Unit-checked the regex against a realistic multi-line coverage-failure log: it matches and captures the actionable block, and does not match a benign line mentioning `mz_catalog_server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)