### PR TITLE
ci: Annotate SLT failures more reliably

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -551,6 +551,32 @@ def annotate_logged_errors(
     errors = get_errors(log_files)
 
     if not errors:
+        # No error pattern was detected in the logs and no junit report
+        # contains an error, but the test may still have failed, so annotate
+        # the failure anyway so that it doesn't go unnoticed, and show the
+        # current failures on main branch.
+        # Only fetch the main branch status when we are running in CI, but not
+        # on main, so inside of a PR or a release branch instead.
+        if (
+            ui.env_is_truthy("BUILDKITE")
+            and os.getenv("BUILDKITE_BRANCH") != "main"
+            and test_result != 0
+            and get_job_state() not in ("canceling", "canceled")
+        ):
+            annotation = Annotation(
+                suite_name=get_suite_name(),
+                buildkite_job_id=os.getenv("BUILDKITE_JOB_ID", ""),
+                is_failure=True,
+                build_history_on_main=get_failures_on_main(test_analytics),
+                unknown_errors=[],
+                known_errors=[],
+                test_cmd=test_cmd,
+                test_desc=test_desc,
+                ignore_failure=False,
+            )
+            add_annotation_raw(style="error", markdown=annotation.to_markdown())
+
+            store_annotation_in_test_analytics(test_analytics, annotation)
         return (0, False)
 
     step_key: str = os.getenv("BUILDKITE_STEP_KEY", "")
@@ -761,34 +787,6 @@ def annotate_logged_errors(
         )
     except Exception as e:
         print(f"Annotating failed, continuing: {e}")
-
-    # No need for rest of the logic as no error logs were found, but since
-    # this script was called the test still failed, so showing the current
-    # failures on main branch.
-    # Only fetch the main branch status when we are running in CI, but no on
-    # main, so inside of a PR or a release branch instead.
-    if (
-        len(unknown_errors) == 0
-        and len(known_errors) == 0
-        and ui.env_is_truthy("BUILDKITE")
-        and os.getenv("BUILDKITE_BRANCH") != "main"
-        and test_result != 0
-        and get_job_state() not in ("canceling", "canceled")
-    ):
-        annotation = Annotation(
-            suite_name=get_suite_name(),
-            buildkite_job_id=os.getenv("BUILDKITE_JOB_ID", ""),
-            is_failure=True,
-            build_history_on_main=build_history_on_main,
-            unknown_errors=[],
-            known_errors=[],
-            test_cmd=test_cmd,
-            test_desc=test_desc,
-            ignore_failure=False,
-        )
-        add_annotation_raw(style="error", markdown=annotation.to_markdown())
-
-        store_annotation_in_test_analytics(test_analytics, annotation)
 
     store_known_issues_in_test_analytics(test_analytics, known_issues)
 

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -515,6 +515,46 @@ def annotate_errors(
     store_annotation_in_test_analytics(test_analytics_db, annotation)
 
 
+def annotate_unexplained_failure(
+    test_analytics: TestAnalyticsDb,
+    test_cmd: str,
+    test_desc: str,
+    test_result: int,
+    build_history_on_main: BuildHistory | None = None,
+) -> None:
+    """
+    Safety net: the test failed, but there are no unknown or known errors to
+    explain it with, so annotate the failure anyway so that it doesn't go
+    unnoticed, and show the current failures on main branch.
+    Only fetch the main branch status when we are running in CI, but not on
+    main, so inside of a PR or a release branch instead.
+    """
+    if (
+        ui.env_is_truthy("BUILDKITE")
+        and os.getenv("BUILDKITE_BRANCH") != "main"
+        and test_result != 0
+        and get_job_state() not in ("canceling", "canceled")
+    ):
+        annotation = Annotation(
+            suite_name=get_suite_name(),
+            buildkite_job_id=os.getenv("BUILDKITE_JOB_ID", ""),
+            is_failure=True,
+            build_history_on_main=(
+                build_history_on_main
+                if build_history_on_main is not None
+                else get_failures_on_main(test_analytics)
+            ),
+            unknown_errors=[],
+            known_errors=[],
+            test_cmd=test_cmd,
+            test_desc=test_desc,
+            ignore_failure=False,
+        )
+        add_annotation_raw(style="error", markdown=annotation.to_markdown())
+
+        store_annotation_in_test_analytics(test_analytics, annotation)
+
+
 def group_identical_errors(
     errors: Sequence[ObservedBaseError],
 ) -> Sequence[ObservedBaseError]:
@@ -552,31 +592,8 @@ def annotate_logged_errors(
 
     if not errors:
         # No error pattern was detected in the logs and no junit report
-        # contains an error, but the test may still have failed, so annotate
-        # the failure anyway so that it doesn't go unnoticed, and show the
-        # current failures on main branch.
-        # Only fetch the main branch status when we are running in CI, but not
-        # on main, so inside of a PR or a release branch instead.
-        if (
-            ui.env_is_truthy("BUILDKITE")
-            and os.getenv("BUILDKITE_BRANCH") != "main"
-            and test_result != 0
-            and get_job_state() not in ("canceling", "canceled")
-        ):
-            annotation = Annotation(
-                suite_name=get_suite_name(),
-                buildkite_job_id=os.getenv("BUILDKITE_JOB_ID", ""),
-                is_failure=True,
-                build_history_on_main=get_failures_on_main(test_analytics),
-                unknown_errors=[],
-                known_errors=[],
-                test_cmd=test_cmd,
-                test_desc=test_desc,
-                ignore_failure=False,
-            )
-            add_annotation_raw(style="error", markdown=annotation.to_markdown())
-
-            store_annotation_in_test_analytics(test_analytics, annotation)
+        # contains an error, but the test may still have failed.
+        annotate_unexplained_failure(test_analytics, test_cmd, test_desc, test_result)
         return (0, False)
 
     step_key: str = os.getenv("BUILDKITE_STEP_KEY", "")
@@ -774,19 +791,26 @@ def annotate_logged_errors(
                 break
 
     build_history_on_main = get_failures_on_main(test_analytics)
-    try:
-        annotate_errors(
-            unknown_errors,
-            known_errors,
-            build_history_on_main,
-            test_analytics,
-            test_cmd,
-            test_desc,
-            test_result,
-            ignore_failure,
+    if unknown_errors or known_errors:
+        try:
+            annotate_errors(
+                unknown_errors,
+                known_errors,
+                build_history_on_main,
+                test_analytics,
+                test_cmd,
+                test_desc,
+                test_result,
+                ignore_failure,
+            )
+        except Exception as e:
+            print(f"Annotating failed, continuing: {e}")
+    else:
+        # Errors were detected in the logs, but all of them were classified
+        # away, yet the test may still have failed.
+        annotate_unexplained_failure(
+            test_analytics, test_cmd, test_desc, test_result, build_history_on_main
         )
-    except Exception as e:
-        print(f"Annotating failed, continuing: {e}")
 
     store_known_issues_in_test_analytics(test_analytics, known_issues)
 

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -875,9 +875,14 @@ To see the available workflows, run:
             # Testdrive already produced a junit.xml with detailed errors;
             # skip the mzcompose-level junit to avoid duplicate annotations.
             return False
+        if composition.has_sqllogictest_junit:
+            # sqllogictest already produced junit.xml files with detailed
+            # errors; skip the mzcompose-level junit to avoid duplicate
+            # annotations. Workflow failures outside the sqllogictest run
+            # itself don't set the flag and thus still get the mzcompose-level
+            # junit, so ci-annotate-errors can annotate them.
+            return False
         return composition_name not in {
-            # sqllogictest already generates a proper junit.xml file
-            "sqllogictest",
             # testdrive already generates a proper junit.xml file
             "testdrive",
             # not a test, run as post-command, and should not overwrite an existing junit.xml from a previous test

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -133,6 +133,7 @@ class Composition:
         self.workflows: dict[str, Callable[..., None]] = {}
         self.test_results: OrderedDict[str, TestResult] = OrderedDict()
         self.has_testdrive_junit: bool = False
+        self.has_sqllogictest_junit: bool = False
         # Per-thread cached YAML file is held in self._tls.file_and_gen.
         # When self.compose is mutated, _invalidate_compose_files() bumps
         # self._compose_gen so each thread regenerates on its next invoke.

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -411,6 +411,18 @@ def run_sqllogictest(
                     os.remove(junit_report_path)
             except CommandFailureCausedUIError as e:
                 print(f"STDERR:\n{e.stderr}")
+                if (
+                    junit_report_path
+                    and junit_report_path.exists()
+                    and junit_report_path.stat().st_size > 0
+                ):
+                    # sqllogictest wrote a junit report with the failure
+                    # details; signal that the mzcompose-level junit should be
+                    # skipped to avoid duplicate annotations. Workflow failures
+                    # outside the sqllogictest run (or crashes that leave no
+                    # report behind) still get the mzcompose-level junit, so
+                    # ci-annotate-errors can annotate them.
+                    c.has_sqllogictest_junit = True
                 if not rewrite_results:
                     failed_files.append((step, file))
                     if ui.env_is_truthy("CI"):


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/125383#019ebb7c-6de7-48c5-9d99-04c1987c908c
Follow-up to https://github.com/MaterializeInc/materialize/pull/36995 which extended SLT to have a new kind of error, not in junit.xml