### PR TITLE
docs: update tokio-console guide to use upstream crate

### DIFF
--- a/doc/developer/guide-tokio-console.md
+++ b/doc/developer/guide-tokio-console.md
@@ -4,11 +4,10 @@ This guide details how to run `tokio-console` with Materialize.
 
 ## Overview
 
-First, install `tokio-console`. We require support for Unix domain sockets, [which is still pending
-upstream][uds-pr], so we need to install from a fork for now.
+First, install `tokio-console`:
 
 ```text
-cargo install tokio-console --git https://github.com/MaterializeInc/tokio-console.git
+cargo install tokio-console
 ```
 
 Then run `environmentd`:
@@ -39,7 +38,6 @@ tokio-console <listen-address>
 
 This [README] has some docs on how to navigate the ui.
 
-[uds-pr]: https://github.com/tokio-rs/console/pull/388
 [README]: https://github.com/tokio-rs/console/tree/main/tokio-console
 
 ### Notes on compilation times:


### PR DESCRIPTION
## Summary

The `guide-tokio-console.md` was directing developers to install from the
`MaterializeInc/tokio-console` fork because Unix domain socket support was
"still pending upstream." That's no longer true:

- [tokio-rs/console#388](https://github.com/tokio-rs/console/pull/388) (UDS support, authored by @benesch) merged upstream in March 2023.
- The latest upstream release is `tokio-console` v0.1.14 (October 2025).
- The MaterializeInc fork is 192+ commits behind and unused.

This PR removes the fork install instruction and the now-dead `[uds-pr]`
footnote. Developers can now just `cargo install tokio-console`.

The `rust-prometheus` fork mentioned in `guide-changes.md` as a cautionary
example is also no longer in use (we're on the upstream crates.io `prometheus`
v0.14.0), but that reference is historical context rather than an install
instruction, so no change is needed there.

## Test plan

- Doc-only change; no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)