### PR TITLE
docs: add guide for ingesting from a dedicated PostgreSQL replica

### DIFF
--- a/doc/user/content/ingest-data/postgres/faq.md
+++ b/doc/user/content/ingest-data/postgres/faq.md
@@ -44,6 +44,9 @@ cannot modify your existing tables, here are some common alternatives:
   you want to replicate, setting these tables with `REPLICA IDENTITY FULL`. You
   can then use the sidecar for Materialize instead of your primary database.
 
+  For step-by-step instructions, see [Ingest from a dedicated PostgreSQL
+  replica](/ingest-data/postgres/logical-replica/).
+
 - **Debezium + Kafka**
 
   With [Debezium + Kafka](/ingest-data/postgres/postgres-debezium/), if the

--- a/doc/user/content/ingest-data/postgres/logical-replica.md
+++ b/doc/user/content/ingest-data/postgres/logical-replica.md
@@ -1,0 +1,246 @@
+---
+title: "Guide: Ingest from a dedicated PostgreSQL replica"
+description: "How to point a Materialize PostgreSQL source at a dedicated logical replica instead of your production primary."
+aliases:
+  - /ingest-data/postgres/sidecar/
+menu:
+  main:
+    parent: "postgresql"
+    name: "Ingest from a dedicated replica"
+    weight: 55
+---
+
+{{< note >}}
+We **nearly always recommend** connecting Materialize directly to your primary
+(see [self-hosted PostgreSQL](/ingest-data/postgres/self-hosted/) or the guide
+for your [hosted service](/ingest-data/postgres/)). The dedicated-replica setup
+on this page is an exception path: reach for it only when you have a **serious,
+specific concern** that direct replication can't address. It adds an extra
+system to operate and an extra hop of replication lag.
+{{< /note >}}
+
+This guide shows you how to stand up a dedicated PostgreSQL **replica** using
+native [PostgreSQL logical
+replication](https://www.postgresql.org/docs/current/logical-replication.html),
+and then point a Materialize [PostgreSQL source](/sql/create-source/postgres/)
+at that replica instead of your production primary. This is sometimes referred
+to as the **sidecar pattern**.
+
+## When to use this
+
+Materialize connects to PostgreSQL using the replication protocol, which holds a
+[replication slot](/ingest-data/postgres/replication-slot-active/) open on the
+upstream database. For the vast majority of deployments, connecting directly to
+the primary is the right choice. Consider a dedicated replica only when you have
+a concrete concern such as:
+
+- **You need to isolate WAL-retention risk from the primary.** A replication
+  slot pins WAL on whichever database it lives on, so a paused or lagging
+  Materialize source can retain WAL and risk filling that database's disk.
+  Pointing Materialize at a replica keeps this risk off your production primary.
+
+- **You can't reconfigure the primary.** Enabling `wal_level = logical` requires
+  a restart, and you may not be able to restart or modify the primary. You can
+  instead enable it on a replica you control.
+
+- **You can't set `REPLICA IDENTITY FULL` on the primary's tables.** Materialize
+  requires `REPLICA IDENTITY FULL` to capture all column values in change
+  events. If you can't alter the primary's tables, you can set it on the
+  replica's copies instead. See also the [PostgreSQL source
+  FAQ](/ingest-data/postgres/faq/).
+
+If none of these apply, prefer connecting directly to the primary — the replica
+adds an extra system to operate and its own replication lag on top of the
+primary.
+
+## How it works
+
+There are **two** logical-replication hops to set up:
+
+```
+  primary  ──(native PG logical replication)──▶  replica  ──(Materialize source)──▶  Materialize
+```
+
+1. **primary → replica:** native PostgreSQL logical replication keeps the
+   replica's tables in sync with the primary. The primary is the *publisher*;
+   the replica is the *subscriber*.
+1. **replica → Materialize:** the replica acts as a *publisher* for Materialize.
+   This means the **replica** also needs `wal_level = logical`, its own
+   publication, and `REPLICA IDENTITY FULL` on the tables you replicate.
+
+## Prerequisites
+
+- A PostgreSQL primary on **PostgreSQL 11+**, with the tables you want to
+  replicate.
+- A separate PostgreSQL instance (**11+**) to act as the replica, with network
+  connectivity from the replica to the primary.
+- A superuser (or a role with `REPLICATION` and the relevant table privileges)
+  on each instance.
+
+## A. Set up native logical replication (primary → replica)
+
+### 1. Enable logical replication on both instances
+
+On **both** the primary and the replica, set `wal_level = logical` in
+`postgresql.conf`. The replica needs it too because it will, in turn, publish to
+Materialize.
+
+```ini
+wal_level = logical
+max_replication_slots = 10
+max_wal_senders = 10
+```
+
+This requires a **restart** (not just a reload). On managed services the
+parameter name differs — for example, Amazon RDS uses
+`rds.logical_replication = 1` in the parameter group.
+
+After restarting, verify on each instance:
+
+```postgres
+SHOW wal_level;   -- should return: logical
+```
+
+### 2. Create the tables on the replica
+
+Logical replication does **not** copy DDL, so create the table structure
+yourself on the replica. Columns are matched by name; the replica table may have
+extra columns or a different column order, but replicated columns must have
+compatible types.
+
+On the **replica**, recreate each table you want to replicate. For example:
+
+```postgres
+CREATE TABLE orders (
+    id         bigint PRIMARY KEY,
+    customer   text,
+    amount     numeric,
+    created_at timestamptz
+);
+```
+
+### 3. Set `REPLICA IDENTITY FULL` on the replica's tables
+
+So that Materialize can capture all column values, set `REPLICA IDENTITY FULL`
+on each replicated table **on the replica**:
+
+```postgres
+ALTER TABLE orders REPLICA IDENTITY FULL;
+```
+
+{{< note >}}
+A table with a primary key already has a usable replica identity for
+`UPDATE`/`DELETE`. However, Materialize requires `REPLICA IDENTITY FULL` to
+ingest unchanged
+[TOASTed](https://www.postgresql.org/docs/current/storage-toast.html) values.
+{{< /note >}}
+
+### 4. Create a publication and replication user on the primary
+
+On the **primary**, create a publication for the tables to replicate:
+
+```postgres
+CREATE PUBLICATION repl_to_replica FOR TABLE orders;
+```
+
+To add more tables later: `ALTER PUBLICATION repl_to_replica ADD TABLE
+other_table;`
+
+Create a role for the replica to connect as. It needs `REPLICATION` and `SELECT`
+on the tables:
+
+```postgres
+CREATE ROLE repuser WITH REPLICATION LOGIN PASSWORD '<strong_password>';
+GRANT SELECT ON orders TO repuser;
+```
+
+Allow the connection in the primary's `pg_hba.conf` (adjust the replica's
+IP/CIDR), then reload:
+
+```
+host    all    repuser    <replica_ip>/32    scram-sha-256
+```
+
+```postgres
+SELECT pg_reload_conf();
+```
+
+### 5. Create the subscription on the replica
+
+On the **replica**, create a subscription to the primary's publication:
+
+```postgres
+CREATE SUBSCRIPTION orders_sub
+    CONNECTION 'host=<primary_host> port=5432 dbname=<db> user=repuser password=<strong_password>'
+    PUBLICATION repl_to_replica;
+```
+
+By default this immediately creates a replication slot on the primary, copies
+the existing table data, and begins streaming ongoing changes.
+
+### 6. Verify the primary → replica hop
+
+On the **replica**:
+
+```postgres
+SELECT subname, subenabled FROM pg_subscription;
+SELECT * FROM pg_stat_subscription;   -- last_msg_receipt_time should advance
+```
+
+On the **primary**:
+
+```postgres
+SELECT slot_name, active, restart_lsn FROM pg_replication_slots;
+SELECT * FROM pg_stat_replication;
+```
+
+Then test end to end: insert a row on the primary and confirm it appears on the
+replica.
+
+```postgres
+-- primary
+INSERT INTO orders VALUES (1, 'acme', 99.50, now());
+-- replica (a moment later)
+SELECT * FROM orders WHERE id = 1;
+```
+
+## B. Create a publication for Materialize (on the replica)
+
+Materialize ingests from a publication on the **replica**. Create a separate
+publication for it (keep it distinct from the `primary → replica` publication):
+
+```postgres
+CREATE PUBLICATION mz_source FOR TABLE orders;
+```
+
+## C. Connect Materialize to the replica
+
+From here, treat the replica as you would any self-hosted PostgreSQL source.
+Follow the [self-hosted PostgreSQL guide](/ingest-data/postgres/self-hosted/) to
+configure network security, create a connection, and create the source —
+pointing the connection at your **replica** and using the `mz_source`
+publication you just created:
+
+```mzsql
+CREATE SOURCE mz_source
+    FROM POSTGRES CONNECTION pg_replica (PUBLICATION 'mz_source')
+    FOR ALL TABLES;
+```
+
+## Things to watch out for
+
+- **Don't leave orphaned replication slots.** Both hops use replication slots
+  that pin WAL while inactive. Drop subscriptions cleanly (`DROP SUBSCRIPTION`,
+  which also drops the remote slot) rather than just disabling them, and
+  [drop the Materialize source](/sql/drop-source/) when you no longer need it.
+  See [Replication slot is
+  active](/ingest-data/postgres/replication-slot-active/).
+- **DDL is not replicated.** When you add a column, apply it on the replica
+  first, then the primary, to avoid replication errors. For handling schema
+  changes in Materialize, see [Handle upstream schema
+  changes](/ingest-data/postgres/source-versioning/).
+- **Sequences are not replicated** by native logical replication — only table
+  data.
+- **The replica adds lag.** Changes reach Materialize only after they've been
+  applied on the replica, so end-to-end latency is the primary → replica lag
+  plus the replica → Materialize lag.

--- a/doc/user/content/ingest-data/postgres/logical-replica.md
+++ b/doc/user/content/ingest-data/postgres/logical-replica.md
@@ -10,14 +10,13 @@ menu:
     weight: 55
 ---
 
-{{< note >}}
-We **nearly always recommend** connecting Materialize directly to your primary
-(see [self-hosted PostgreSQL](/ingest-data/postgres/self-hosted/) or the guide
-for your [hosted service](/ingest-data/postgres/)). The dedicated-replica setup
-on this page is an exception path: reach for it only when you have a **serious,
-specific concern** that direct replication can't address. It adds an extra
-system to operate and an extra hop of replication lag.
-{{< /note >}}
+{{< note >}} We **nearly always recommend** connecting Materialize directly to
+your primary (see [self-hosted PostgreSQL](/ingest-data/postgres/self-hosted/)
+or the guide for your [hosted
+service](/ingest-data/postgres/#integration-guides)). The dedicated-replica
+setup on this page is an exception path: reach for it only when you have a
+**serious, specific concern** that direct replication can't address. It adds an
+extra system to operate and an extra hop of replication lag. {{< /note >}}
 
 This guide shows you how to stand up a dedicated PostgreSQL **replica** using
 native [PostgreSQL logical
@@ -58,7 +57,7 @@ primary.
 There are **two** logical-replication hops to set up:
 
 ```
-  primary  ──(native PG logical replication)──▶  replica  ──(Materialize source)──▶  Materialize
+primary  ──(native PG logical replication)──▶  replica  ──(Materialize source)──▶  Materialize
 ```
 
 1. **primary → replica:** native PostgreSQL logical replication keeps the
@@ -77,40 +76,107 @@ There are **two** logical-replication hops to set up:
 - A superuser (or a role with `REPLICATION` and the relevant table privileges)
   on each instance.
 
-## A. Set up native logical replication (primary → replica)
+## A. Configure the primary
 
-### 1. Enable logical replication on both instances
+### 1. Enable logical replication on the primary
 
-On **both** the primary and the replica, set `wal_level = logical` in
-`postgresql.conf`. The replica needs it too because it will, in turn, publish to
-Materialize.
+1. Set `wal_level = logical` in `postgresql.conf` on the primary.
 
-```ini
-wal_level = logical
-max_replication_slots = 10
-max_wal_senders = 10
-```
+   ```ini
+   wal_level = logical
+   max_replication_slots = 10
+   max_wal_senders = 10
+   ```
 
-This requires a **restart** (not just a reload). On managed services the
-parameter name differs — for example, Amazon RDS uses
-`rds.logical_replication = 1` in the parameter group.
+   {{< note >}}
 
-After restarting, verify on each instance:
+   On managed PostgreSQL services, enabling logical replication may differ. For
+   example, Amazon RDS uses `rds.logical_replication = 1` in the parameter
+   group. Refer to your service's documentation.
 
-```postgres
-SHOW wal_level;   -- should return: logical
-```
+   {{< /note >}}
+
+1. **Restart** the primary (reloading is not sufficient).
+
+1. After the restart, verify the setting:
+
+   ```sql
+   SHOW wal_level;   -- should return: logical
+   ```
+
+### 2. Create a publication and replication user on the primary
+
+1. On the **primary**, create a publication for the tables to replicate:
+
+   ```sql
+   CREATE PUBLICATION repl_to_replica FOR TABLE orders;
+   ```
+
+   To add more tables later, you can use `ALTER PUBLICATION repl_to_replica ADD
+   TABLE <other_table>;`.
+
+1. On the **primary**, create a role for the replica to connect as. The role
+   needs `REPLICATION` and `SELECT` on the tables:
+
+   ```sql
+   CREATE ROLE repuser WITH REPLICATION LOGIN PASSWORD '<strong_password>';
+   GRANT SELECT ON orders TO repuser;
+   ```
+
+1. Update the primary's `pg_hba.conf` to allow the connection (update with the
+   replica's IP/CIDR):
+
+   ```
+   host    all    repuser    <replica_ip>/32    scram-sha-256
+   ```
+
+1. Reload the updated config:
+
+   ```sql
+   SELECT pg_reload_conf();
+   ```
+
+## B. Configure the replica
+
+### 1. Enable logical replication on the replica
+
+1. Set `wal_level = logical` in `postgresql.conf` on the replica. The replica
+   also requires this because it will, in turn, publish to Materialize.
+
+   ```ini
+   wal_level = logical
+   max_replication_slots = 10
+   max_wal_senders = 10
+   ```
+
+   {{< note >}}
+
+   On managed PostgreSQL services, enabling logical replication may differ. For
+   example, Amazon RDS uses `rds.logical_replication = 1` in the parameter
+   group. Refer to your service's documentation.
+
+   {{< /note >}}
+
+1. **Restart** the replica (reloading is not sufficient).
+
+1. After the restart, verify the setting:
+
+   ```sql
+   SHOW wal_level;   -- should return: logical
+   ```
 
 ### 2. Create the tables on the replica
 
-Logical replication does **not** copy DDL, so create the table structure
-yourself on the replica. Columns are matched by name; the replica table may have
-extra columns or a different column order, but replicated columns must have
-compatible types.
+Logical replication does **not** copy DDL, so you must create the table
+structure on the replica yourself. Columns are matched by name: the replica
+table must contain every column the publication sends, but it may also have
+extra columns or a different column order. Replicated columns must have
+compatible data types.
 
-On the **replica**, recreate each table you want to replicate. For example:
+On the **replica**, recreate each table you want to replicate. For example, the
+following creates the table `orders` on the replica:
 
-```postgres
+```sql
 CREATE TABLE orders (
     id         bigint PRIMARY KEY,
     customer   text,
@@ -121,10 +187,10 @@ CREATE TABLE orders (
 
 ### 3. Set `REPLICA IDENTITY FULL` on the replica's tables
 
-So that Materialize can capture all column values, set `REPLICA IDENTITY FULL`
-on each replicated table **on the replica**:
+**On the replica**, set `REPLICA IDENTITY FULL` on each replicated table, so
+that Materialize can capture all column values.
 
-```postgres
+```sql
 ALTER TABLE orders REPLICA IDENTITY FULL;
 ```
 
@@ -135,97 +201,79 @@ ingest unchanged
 [TOASTed](https://www.postgresql.org/docs/current/storage-toast.html) values.
 {{< /note >}}
 
-### 4. Create a publication and replication user on the primary
-
-On the **primary**, create a publication for the tables to replicate:
-
-```postgres
-CREATE PUBLICATION repl_to_replica FOR TABLE orders;
-```
-
-To add more tables later: `ALTER PUBLICATION repl_to_replica ADD TABLE
-other_table;`
-
-Create a role for the replica to connect as. It needs `REPLICATION` and `SELECT`
-on the tables:
-
-```postgres
-CREATE ROLE repuser WITH REPLICATION LOGIN PASSWORD '<strong_password>';
-GRANT SELECT ON orders TO repuser;
-```
-
-Allow the connection in the primary's `pg_hba.conf` (adjust the replica's
-IP/CIDR), then reload:
-
-```
-host    all    repuser    <replica_ip>/32    scram-sha-256
-```
-
-```postgres
-SELECT pg_reload_conf();
-```
-
-### 5. Create the subscription on the replica
+### 4. Create the subscription on the replica
 
 On the **replica**, create a subscription to the primary's publication:
 
-```postgres
+```sql
 CREATE SUBSCRIPTION orders_sub
     CONNECTION 'host=<primary_host> port=5432 dbname=<db> user=repuser password=<strong_password>'
     PUBLICATION repl_to_replica;
 ```
 
-By default this immediately creates a replication slot on the primary, copies
+By default, this immediately creates a replication slot on the primary, copies
 the existing table data, and begins streaming ongoing changes.
 
-### 6. Verify the primary → replica hop
+### 5. Verify the primary → replica hop
 
-On the **replica**:
+- On the **replica**:
 
-```postgres
-SELECT subname, subenabled FROM pg_subscription;
-SELECT * FROM pg_stat_subscription;   -- last_msg_receipt_time should advance
-```
+  ```sql
+  SELECT subname, subenabled FROM pg_subscription;
+  SELECT * FROM pg_stat_subscription;   -- last_msg_receipt_time should advance
+  ```
 
-On the **primary**:
+- On the **primary**:
 
-```postgres
-SELECT slot_name, active, restart_lsn FROM pg_replication_slots;
-SELECT * FROM pg_stat_replication;
-```
+  ```sql
+  SELECT slot_name, active, restart_lsn FROM pg_replication_slots;
+  SELECT * FROM pg_stat_replication;
+  ```
 
-Then test end to end: insert a row on the primary and confirm it appears on the
-replica.
+- To test end to end:
 
-```postgres
--- primary
-INSERT INTO orders VALUES (1, 'acme', 99.50, now());
--- replica (a moment later)
-SELECT * FROM orders WHERE id = 1;
-```
+  - Insert a row on the primary:
 
-## B. Create a publication for Materialize (on the replica)
+    ```sql
+    -- primary
+    INSERT INTO orders VALUES (1, 'acme', 99.50, now());
+    ```
+  - Confirm it appears on the replica.
 
-Materialize ingests from a publication on the **replica**. Create a separate
-publication for it (keep it distinct from the `primary → replica` publication):
+    ```sql
+    -- replica
+    SELECT * FROM orders WHERE id = 1;
+    ```
 
-```postgres
+### 6. Create a publication for Materialize on the replica
+
+On the **replica**, create a separate publication that Materialize will use
+(keep it distinct from the `primary → replica` publication):
+
+```sql
+-- replica
 CREATE PUBLICATION mz_source FOR TABLE orders;
 ```
 
 ## C. Connect Materialize to the replica
 
-From here, treat the replica as you would any self-hosted PostgreSQL source.
-Follow the [self-hosted PostgreSQL guide](/ingest-data/postgres/self-hosted/) to
-configure network security, create a connection, and create the source —
-pointing the connection at your **replica** and using the `mz_source`
-publication you just created:
+At this point, you can treat the replica as you would any self-hosted PostgreSQL
+source. Follow the [self-hosted PostgreSQL
+guide](/ingest-data/postgres/self-hosted/) to:
 
-```mzsql
-CREATE SOURCE mz_source
-    FROM POSTGRES CONNECTION pg_replica (PUBLICATION 'mz_source')
-    FOR ALL TABLES;
-```
+- [Configure network security for your
+  replica](/ingest-data/postgres/self-hosted/#b-optional-configure-network-security).
+
+- [Create a connection to your
+  replica](/ingest-data/postgres/self-hosted/#2-create-a-connection).
+
+- Create the source using the `mz_source` publication from your **replica**:
+
+  ```mzsql
+  CREATE SOURCE mz_source
+      FROM POSTGRES CONNECTION pg_replica (PUBLICATION 'mz_source')
+      FOR ALL TABLES;
+  ```
 
 ## Things to watch out for
 

--- a/doc/user/content/ingest-data/postgres/self-hosted.md
+++ b/doc/user/content/ingest-data/postgres/self-hosted.md
@@ -18,6 +18,14 @@ Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 {{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
+{{< note >}}
+Connecting directly to your primary, as described here, is the recommended
+setup. In the exceptional case where you can't reconfigure the primary, or need
+to keep WAL-retention risk off it, you can point Materialize at a dedicated
+replica instead. See [Ingest from a dedicated PostgreSQL
+replica](/ingest-data/postgres/logical-replica/).
+{{< /note >}}
+
 ## Before you begin
 
 {{% include-from-yaml data="ingest_postgres" name="before-you-begin" %}}


### PR DESCRIPTION
Adds a goal-first guide for the "sidecar" pattern: standing up a dedicated PostgreSQL replica via native logical replication and pointing a Materialize PostgreSQL source at it instead of the production primary.

Previously this pattern was only mentioned inside the PostgreSQL source FAQ, filed under "what if I can't use REPLICA IDENTITY FULL?" — so users whose actual motivation was keeping replication load/WAL-retention risk off their primary, or who couldn't reconfigure the primary, had no discoverable entry point. The new page is titled and framed around that goal and is reachable directly from the PostgreSQL ingest menu.

The guide makes explicit the two logical-replication hops involved (primary -> replica via native PG logical replication, then replica -> Materialize), which means the replica itself needs wal_level = logical, REPLICA IDENTITY FULL on its tables, and a separate publication for Materialize. It leads with a strong recommendation to connect directly to the primary and frames the replica as an exception path, then hands off to the self-hosted guide for source creation rather than duplicating it.

Cross-links added from the FAQ sidecar entry and the self-hosted guide so both motivations funnel into the new page.

No code changes; documentation only.

Remove these sections if your commit already has a good description!

### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
