### PR TITLE
console: simplify connect modal instructions text

### DIFF
--- a/console/src/components/OidcConnectModal.tsx
+++ b/console/src/components/OidcConnectModal.tsx
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 import {
-  Code,
   ModalBody,
   ModalCloseButton,
   ModalContent,
@@ -27,7 +26,6 @@ import {
 } from "~/components/copyableComponents";
 import McpConnectInstructions from "~/components/McpConnectInstructions";
 import { Modal } from "~/components/Modal";
-import TextLink from "~/components/TextLink";
 import { useAppConfig } from "~/config/useAppConfig";
 import { type AuthContextProps } from "~/external-library-wrappers/oidc";
 import { useSelfManagedProfile } from "~/hooks/useSelfManagedProfile";
@@ -76,21 +74,7 @@ const OidcConnectModal = ({
             whiteSpace="normal"
             color={colors.foreground.secondary}
           >
-            {!balancerdHost && (
-              <>
-                Replace <Code fontSize="xs">{HOST_PLACEHOLDER}</Code> with your
-                Materialize SQL endpoint.{" "}
-              </>
-            )}
-            See the{" "}
-            <TextLink
-              href="https://materialize.com/docs/self-managed-deployments/installation/install-on-gcp/#step-3-apply-the-terraform"
-              isExternal
-            >
-              installation docs
-            </TextLink>{" "}
-            for full setup details. When prompted for a password, paste the ID
-            token below.
+            When prompted for a password, paste the ID token below.
           </Text>
           {idToken ? (
             <VStack alignItems="stretch" spacing={6} mt="4">


### PR DESCRIPTION
## Motivation

In the console's "Connect To Materialize" modal (`OidcConnectModal`), the instructions text linked specifically to the **GCP** installation guide:

```
https://materialize.com/docs/self-managed-deployments/installation/install-on-gcp/#step-3-apply-the-terraform
```

This modal is shown for all self-managed deployments regardless of cloud provider, so the provider-specific link was misleading for users on AWS, Azure, or local kind/minikube. This was flagged in Slack.

## Changes

Simplify the instructions text to just the relevant instruction, dropping the provider-specific link (and the now-unused `Code` / `TextLink` imports):

> When prompted for a password, paste the ID token below.

## Context

Slack thread: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1781299955523019?thread_ts=1781299703.506719&cid=CU7ELJ6E9
