### PR TITLE
adapter: migrate LaunchDarkly SDK off fork to upstream 3.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1940,6 +1940,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2016,12 @@ dependencies = [
  "ciborium-io",
  "half 1.6.0",
 ]
+
+[[package]]
+name = "cidr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579504560394e388085d0c080ea587dfa5c15f7e251b4d5247d1e1a61d1d6928"
 
 [[package]]
 name = "cipher"
@@ -2345,6 +2362,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -3028,7 +3054,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3442,17 +3468,18 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.16.0"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26451361cde19fe2322835b6e684f4825902edf3139ce9d6a70e6542566a0b2"
+checksum = "96df8cfa11d3c8e4e1a48b81c9c600ecbe8c11d1326f41e1524cc4d42f7bf6d9"
 dependencies = [
  "base64 0.22.1",
+ "bytes",
  "futures",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
+ "http 1.4.2",
+ "launchdarkly-sdk-transport",
  "log",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -3997,9 +4024,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4425,6 +4464,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021e0ae20c08eadc94d0bdafdeda66d4f0858541c146ae6e46b219bfe58497e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.4.2",
+ "hyper 1.9.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-openssl"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,18 +4517,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -4532,7 +4578,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4751,7 +4797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.3",
  "serde",
  "serde_core",
 ]
@@ -4845,7 +4891,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4932,7 +4978,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5128,7 +5174,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-openssl",
- "hyper-timeout 0.5.1",
+ "hyper-timeout",
  "hyper-util",
  "jiff",
  "jsonpath-rust",
@@ -5210,19 +5256,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "launchdarkly-sdk-transport"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032d66802c461d7254ed1de887be6ca98ebbe126867d9a60c754baae81c4d10d"
+dependencies = [
+ "bytes",
+ "futures",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-http-proxy",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "log",
+ "no-proxy",
+ "tower 0.4.13",
+]
+
+[[package]]
 name = "launchdarkly-server-sdk"
-version = "2.6.2"
-source = "git+https://github.com/MaterializeInc/rust-server-sdk?rev=3e0a0b98b09a2970f292577a07e1c9382b65b5da#3e0a0b98b09a2970f292577a07e1c9382b65b5da"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0440c21aaa0670948071d9cbd8142e9d057a4b40feb3e6293e0efc6de9879b69"
 dependencies = [
  "aws-lc-rs",
+ "bitflags 2.11.0",
+ "bytes",
  "chrono",
  "crossbeam-channel",
  "data-encoding",
  "eventsource-client",
  "futures",
- "hyper 0.14.32",
+ "http 1.4.2",
+ "launchdarkly-sdk-transport",
  "launchdarkly-server-sdk-evaluation",
- "lazy_static",
  "log",
  "lru",
  "moka",
@@ -5238,9 +5307,9 @@ dependencies = [
 
 [[package]]
 name = "launchdarkly-server-sdk-evaluation"
-version = "2.0.1"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63706c23ee67f699563e5c52c7542361eccc966cba0430b6a7862c0ecaee9432"
+checksum = "4bc97a52681b9860197ad81a2c1a34d96bb647459bcdf067ac1fae42c9fe8c30"
 dependencies = [
  "base16ct",
  "chrono",
@@ -5843,10 +5912,10 @@ dependencies = [
  "hex",
  "http 1.4.2",
  "humantime",
- "hyper-tls 0.5.0",
  "imbl",
  "ipnet",
  "itertools 0.14.0",
+ "launchdarkly-sdk-transport",
  "launchdarkly-server-sdk",
  "maplit",
  "mz-adapter-types",
@@ -6137,6 +6206,7 @@ dependencies = [
  "prometheus",
  "proxy-header",
  "reqwest 0.12.28",
+ "rustls",
  "semver",
  "tempfile",
  "tokio",
@@ -6438,6 +6508,7 @@ dependencies = [
  "mz-txn-wal",
  "nix 0.31.3",
  "num_cpus",
+ "rustls",
  "serde",
  "tokio",
  "tower 0.5.3",
@@ -6761,7 +6832,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "humantime",
- "hyper-tls 0.5.0",
+ "launchdarkly-sdk-transport",
  "launchdarkly-server-sdk",
  "mz-build-info",
  "mz-dyncfg",
@@ -6887,6 +6958,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rlimit",
+ "rustls",
  "semver",
  "sentry-tracing",
  "serde",
@@ -8425,6 +8497,7 @@ dependencies = [
  "postgres-protocol",
  "regex",
  "reqwest 0.12.28",
+ "rustls",
  "serde_json",
  "shell-words",
  "tempfile",
@@ -8838,6 +8911,7 @@ dependencies = [
  "rdkafka",
  "regex",
  "reqwest 0.12.28",
+ "rustls",
  "semver",
  "serde",
  "serde_json",
@@ -9045,6 +9119,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no-proxy"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd3f71e44f009513a82ac2612c0c2da7e2924fad776931164317baa9695e150"
+dependencies = [
+ "cidr",
 ]
 
 [[package]]
@@ -10423,7 +10506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -10444,7 +10527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10670,6 +10753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10708,6 +10797,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -10767,6 +10867,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -11373,7 +11479,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11385,6 +11491,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -11951,7 +12058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -11968,7 +12075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
  "sha2-asm",
 ]
@@ -12492,10 +12599,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12514,7 +12621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12792,16 +12899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-io-utility"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13008,7 +13105,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-timeout 0.5.1",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
@@ -13073,6 +13170,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,7 +407,8 @@ junit-report = "0.8.3"
 k8s-controller = "0.11.0"
 k8s-openapi = { version = "0.27.0", features = ["schemars", "v1_32"] }
 kube = { version = "3.1.0", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
-launchdarkly-server-sdk = { version = "2.6.2", default-features = false }
+launchdarkly-server-sdk = { version = "3.1.1", default-features = false, features = ["hyper-rustls-native-roots", "crypto-aws-lc-rs"] }
+launchdarkly-sdk-transport = "0.1"
 lgalloc = "0.6.0"
 libc = "0.2.186"
 lru = "0.16.3"
@@ -652,9 +653,6 @@ postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array"
 
 # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
-
-# Waiting for resolution of https://github.com/launchdarkly/rust-server-sdk/issues/116
-launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", rev = "3e0a0b98b09a2970f292577a07e1c9382b65b5da" }
 
 # Waiting on https://github.com/edenhill/librdkafka/pull/4051.
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }

--- a/deny.toml
+++ b/deny.toml
@@ -150,6 +150,15 @@ skip = [
     { name = "hashlink", version = "0.9.1" },
     # held back by owo-colors 4.3 (mz-deploy terminal styling)
     { name = "supports-color", version = "2.1.0" },
+
+    # Pulled by launchdarkly-server-sdk 3.x via launchdarkly-sdk-transport /
+    # eventsource-client (proxy/timeout/rustls stack and the SDK's RNG path).
+    # NB: tower 0.4.13 is already skipped above (mz-deploy).
+    { name = "rustls-native-certs", version = "0.7.3" },
+    { name = "rand", version = "0.10.1" },
+    { name = "rand_core", version = "0.10.1" },
+    { name = "getrandom", version = "0.4.2" },
+    { name = "cpufeatures", version = "0.3.0" },
 ]
 
 [[bans.deny]]
@@ -206,6 +215,7 @@ wrappers = [
     "globset",
     "launchdarkly-server-sdk",
     "launchdarkly-server-sdk-evaluation",
+    "launchdarkly-sdk-transport",
     "native-tls",
     "opendal",
     "os_info",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -29,10 +29,10 @@ hex.workspace = true
 humantime.workspace = true
 imbl.workspace = true
 http.workspace = true
-hyper-tls = "0.5.0"
 ipnet.workspace = true
 itertools.workspace = true
 launchdarkly-server-sdk.workspace = true
+launchdarkly-sdk-transport.workspace = true
 maplit.workspace = true
 mz-adapter-types = { path = "../adapter-types" }
 mz-audit-log = { path = "../audit-log" }

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -10,16 +10,18 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
 use derivative::Derivative;
-use hyper_tls::HttpsConnector;
+use futures::TryStreamExt;
+use launchdarkly_sdk_transport::{ByteStream, HttpTransport, ResponseFuture};
 use launchdarkly_server_sdk as ld;
 use mz_build_info::BuildInfo;
 use mz_cloud_provider::CloudProvider;
 use mz_cluster_client::ReplicaId;
 use mz_controller_types::ClusterId;
+use mz_ore::metrics::UIntGauge;
 use mz_ore::now::NowFn;
 use mz_sql::catalog::EnvironmentId;
 use serde_json::Value as JsonValue;
@@ -71,7 +73,7 @@ impl SystemParameterFrontend {
     /// Create a new [SystemParameterFrontend] initialize.
     ///
     /// This will create and initialize an [ld::Client] instance. The
-    /// [ld::Client::initialized_async] call will be attempted in a loop with an
+    /// [ld::Client::wait_for_initialization] call will be attempted in a loop with an
     /// exponential backoff with power `2s` and max duration `60s`.
     pub async fn from(sync_config: &SystemParameterSyncConfig) -> Result<Self, anyhow::Error> {
         match &sync_config.backend_config {
@@ -347,25 +349,68 @@ pub struct ClusterEvalContext {
     pub cluster: ClusterScopeContext,
 }
 
-fn ld_config(api_key: &str, metrics: &Metrics) -> ld::Config {
+/// An [`HttpTransport`] wrapper that records timestamps on successful HTTP
+/// responses. Used to populate Prometheus metrics that track LaunchDarkly
+/// connectivity health.
+///
+/// Two instances are created — one for the event processor (CSE metric, tracks
+/// outbound event sends) and one for the streaming data source (SSE metric,
+/// tracks inbound SSE events).
+#[derive(Clone)]
+struct MetricsTransport<T> {
+    inner: T,
+    last_success_gauge: UIntGauge,
+    now_fn: NowFn,
+}
+
+impl<T: HttpTransport> HttpTransport for MetricsTransport<T> {
+    fn request(&self, request: http::Request<Option<Bytes>>) -> ResponseFuture {
+        let inner_fut = self.inner.request(request);
+        let gauge = self.last_success_gauge.clone();
+        let now_fn = self.now_fn.clone();
+        Box::pin(async move {
+            let resp = inner_fut.await?;
+            if resp.status().is_success() {
+                gauge.set(now_fn() / 1000);
+                let (parts, body) = resp.into_parts();
+                let wrapped: ByteStream = Box::pin(body.inspect_ok(move |_| {
+                    gauge.set(now_fn() / 1000);
+                }));
+                Ok(http::Response::from_parts(parts, wrapped))
+            } else {
+                Ok(resp)
+            }
+        })
+    }
+}
+
+fn ld_config(api_key: &str, metrics: &Metrics, now_fn: &NowFn) -> ld::Config {
+    let transport = launchdarkly_sdk_transport::HyperTransport::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .read_timeout(Duration::from_secs(300))
+        .build_https()
+        .expect("failed to create HTTPS transport");
+
+    let cse_transport = MetricsTransport {
+        inner: transport.clone(),
+        last_success_gauge: metrics.last_cse_time_seconds.clone(),
+        now_fn: now_fn.clone(),
+    };
+    let data_source_transport = MetricsTransport {
+        inner: transport,
+        last_success_gauge: metrics.last_sse_time_seconds.clone(),
+        now_fn: now_fn.clone(),
+    };
+
+    let mut event_processor = ld::EventProcessorBuilder::new();
+    event_processor.transport(cse_transport);
+
+    let mut data_source = ld::StreamingDataSourceBuilder::new();
+    data_source.transport(data_source_transport);
+
     ld::ConfigBuilder::new(api_key)
-        .event_processor(
-            ld::EventProcessorBuilder::new()
-                .https_connector(HttpsConnector::new())
-                .on_success({
-                    let last_cse_time_seconds = metrics.last_cse_time_seconds.clone();
-                    Arc::new(move |result| {
-                        if let Ok(ts) = u64::try_from(result.time_from_server / 1000) {
-                            last_cse_time_seconds.set(ts);
-                        } else {
-                            tracing::warn!(
-                                "Cannot convert time_from_server / 1000 from u128 to u64"
-                            );
-                        }
-                    })
-                }),
-        )
-        .data_source(ld::StreamingDataSourceBuilder::new().https_connector(HttpsConnector::new()))
+        .event_processor(&event_processor)
+        .data_source(&data_source)
         .build()
         .expect("valid config")
 }
@@ -375,19 +420,9 @@ async fn ld_client(
     metrics: &Metrics,
     now_fn: &NowFn,
 ) -> Result<ld::Client, anyhow::Error> {
-    let ld_client = ld::Client::build(ld_config(api_key, metrics))?;
+    let ld_client = ld::Client::build(ld_config(api_key, metrics, now_fn))?;
     tracing::info!("waiting for SystemParameterFrontend to initialize");
-    // Start and initialize LD client for the frontend. The callback passed
-    // will export the last time when an SSE event from the LD server was
-    // received in a Prometheus metric.
-    ld_client.start_with_default_executor_and_callback({
-        let last_sse_time_seconds = metrics.last_sse_time_seconds.clone();
-        let now_fn = now_fn.clone();
-        Arc::new(move |_ev| {
-            let ts = now_fn() / 1000;
-            last_sse_time_seconds.set(ts);
-        })
-    });
+    ld_client.start_with_default_executor();
 
     let max_backoff = Duration::from_secs(60);
     let mut backoff = Duration::from_secs(5);
@@ -579,7 +614,13 @@ fn ld_ctx(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use futures::StreamExt;
+    use launchdarkly_sdk_transport::{ByteStream, TransportError};
     use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_ore::metrics::MetricsRegistry;
 
     use super::*;
 
@@ -625,5 +666,213 @@ mod tests {
     #[mz_ore::test]
     fn environment_wide_context_is_unscoped() {
         ld_ctx(&env_id(), &DUMMY_BUILD_INFO, None, None).expect("environment-wide context builds");
+    }
+
+    /// A fake transport that simulates a long-lived SSE streaming connection:
+    /// returns 200 OK immediately, then delivers multiple SSE events as body
+    /// chunks (exactly how LaunchDarkly's streaming data source works).
+    #[derive(Clone)]
+    struct FakeSseTransport;
+
+    impl HttpTransport for FakeSseTransport {
+        fn request(&self, _request: http::Request<Option<Bytes>>) -> ResponseFuture {
+            let body: ByteStream = Box::pin(futures::stream::iter(vec![
+                Ok(Bytes::from("event: put\ndata: {\"flags\":{}}\n\n")),
+                Ok(Bytes::from("event: patch\ndata: {\"key\":\"flag1\"}\n\n")),
+                Ok(Bytes::from("event: patch\ndata: {\"key\":\"flag2\"}\n\n")),
+            ]));
+            Box::pin(async move {
+                http::Response::builder()
+                    .status(200)
+                    .body(body)
+                    .map_err(|e| TransportError::new(std::io::Error::other(e)))
+            })
+        }
+    }
+
+    /// A fake transport that returns an error, simulating a failed connection.
+    #[derive(Clone)]
+    struct FailingTransport;
+
+    impl HttpTransport for FailingTransport {
+        fn request(&self, _request: http::Request<Option<Bytes>>) -> ResponseFuture {
+            Box::pin(async move {
+                Err(TransportError::new(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "connection refused",
+                )))
+            })
+        }
+    }
+
+    /// A fake transport that returns 200 OK, delivers one event, then errors
+    /// mid-stream with a timeout: the non-Eof stream error a dropped long-lived
+    /// SSE connection surfaces.
+    #[derive(Clone)]
+    struct MidStreamFailureTransport;
+
+    impl HttpTransport for MidStreamFailureTransport {
+        fn request(&self, _request: http::Request<Option<Bytes>>) -> ResponseFuture {
+            let body: ByteStream = Box::pin(futures::stream::iter(vec![
+                Ok(Bytes::from("event: put\ndata: {\"flags\":{}}\n\n")),
+                Err(TransportError::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "body timed out",
+                ))),
+            ]));
+            Box::pin(async move {
+                http::Response::builder()
+                    .status(200)
+                    .body(body)
+                    .map_err(|e| TransportError::new(std::io::Error::other(e)))
+            })
+        }
+    }
+
+    fn test_gauge(registry: &MetricsRegistry, name: &str) -> UIntGauge {
+        registry.register(mz_ore::metric!(
+            name: name,
+            help: "test gauge",
+        ))
+    }
+
+    /// Verifies that MetricsTransport updates the gauge on each body chunk,
+    /// not just on the initial HTTP 200 response head. This matters for
+    /// long-lived streaming connections where SSE events arrive as body chunks.
+    #[mz_ore::test(tokio::test)]
+    async fn test_metric_updated_on_body_chunks() -> Result<(), anyhow::Error> {
+        let time = Arc::new(AtomicU64::new(1_000_000));
+        let time_clone = Arc::clone(&time);
+        let now_fn = NowFn::from(move || time_clone.load(Ordering::SeqCst));
+
+        let registry = MetricsRegistry::new();
+        let gauge = test_gauge(&registry, "test_sse_gauge");
+
+        let transport = MetricsTransport {
+            inner: FakeSseTransport,
+            last_success_gauge: gauge.clone(),
+            now_fn,
+        };
+
+        assert_eq!(gauge.get(), 0);
+
+        let request = http::Request::builder()
+            .uri("https://stream.launchdarkly.com/all")
+            .body(None)?;
+        let response = transport.request(request).await?;
+
+        assert_eq!(gauge.get(), 1000);
+
+        time.store(2_800_000, Ordering::SeqCst);
+
+        let mut body = response.into_body();
+        let mut event_count = 0;
+        while let Some(Ok(_chunk)) = body.next().await {
+            event_count += 1;
+        }
+        assert_eq!(event_count, 3);
+
+        assert_eq!(gauge.get(), 2800);
+        Ok(())
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_cse_metric_updates_correctly_per_request() -> Result<(), anyhow::Error> {
+        let time = Arc::new(AtomicU64::new(1_000_000));
+        let time_clone = Arc::clone(&time);
+        let now_fn = NowFn::from(move || time_clone.load(Ordering::SeqCst));
+
+        let registry = MetricsRegistry::new();
+        let gauge = test_gauge(&registry, "test_cse_gauge");
+
+        let transport = MetricsTransport {
+            inner: FakeSseTransport,
+            last_success_gauge: gauge.clone(),
+            now_fn,
+        };
+
+        let req = || -> Result<http::Request<Option<Bytes>>, http::Error> {
+            http::Request::builder()
+                .uri("https://events.launchdarkly.com/bulk")
+                .body(None)
+        };
+
+        let _ = transport.request(req()?).await?;
+        assert_eq!(gauge.get(), 1000);
+
+        time.store(2_000_000, Ordering::SeqCst);
+        let _ = transport.request(req()?).await?;
+        assert_eq!(gauge.get(), 2000);
+
+        time.store(3_000_000, Ordering::SeqCst);
+        let _ = transport.request(req()?).await?;
+        assert_eq!(gauge.get(), 3000);
+        Ok(())
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_metric_not_updated_on_failed_request() -> Result<(), anyhow::Error> {
+        let now_fn = NowFn::from(|| 5_000_000u64);
+
+        let registry = MetricsRegistry::new();
+        let gauge = test_gauge(&registry, "test_fail_gauge");
+
+        let transport = MetricsTransport {
+            inner: FailingTransport,
+            last_success_gauge: gauge.clone(),
+            now_fn,
+        };
+
+        let request = http::Request::builder()
+            .uri("https://stream.launchdarkly.com/all")
+            .body(None)?;
+        let result = transport.request(request).await;
+        assert!(result.is_err());
+        assert_eq!(gauge.get(), 0, "gauge must not update on transport error");
+        Ok(())
+    }
+
+    /// Verifies that when an SSE connection returns 200 OK and then dies
+    /// mid-stream, `last_sse_time_seconds` advances only for the events that
+    /// arrived and then freezes — the frozen timestamp is what lets the
+    /// staleness alert detect a stuck data source.
+    #[mz_ore::test(tokio::test)]
+    async fn test_metric_frozen_on_midstream_error() -> Result<(), anyhow::Error> {
+        let time = Arc::new(AtomicU64::new(1_000_000));
+        let time_clone = Arc::clone(&time);
+        let now_fn = NowFn::from(move || time_clone.load(Ordering::SeqCst));
+
+        let registry = MetricsRegistry::new();
+        let gauge = test_gauge(&registry, "test_midstream_gauge");
+
+        let transport = MetricsTransport {
+            inner: MidStreamFailureTransport,
+            last_success_gauge: gauge.clone(),
+            now_fn,
+        };
+
+        // The 200 OK response head updates the gauge.
+        let request = http::Request::builder()
+            .uri("https://stream.launchdarkly.com/all")
+            .body(None)?;
+        let response = transport.request(request).await?;
+        assert_eq!(gauge.get(), 1000);
+
+        // The first event arrives and advances the gauge.
+        time.store(2_000_000, Ordering::SeqCst);
+        let mut body = response.into_body();
+        assert!(matches!(body.next().await, Some(Ok(_))));
+        assert_eq!(gauge.get(), 2000);
+
+        // The stream then errors mid-flight. Time has moved forward, but the
+        // gauge must stay frozen at the last successful event.
+        time.store(9_000_000, Ordering::SeqCst);
+        assert!(matches!(body.next().await, Some(Err(_))));
+        assert_eq!(
+            gauge.get(),
+            2000,
+            "gauge must freeze on mid-stream error so the staleness alert can fire"
+        );
+        Ok(())
     }
 }

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -42,6 +42,7 @@ num_cpus.workspace = true
 openssl.workspace = true
 prometheus.workspace = true
 proxy-header.workspace = true
+rustls.workspace = true
 semver.workspace = true
 tokio.workspace = true
 tokio-openssl.workspace = true

--- a/src/balancerd/src/bin/balancerd.rs
+++ b/src/balancerd/src/bin/balancerd.rs
@@ -172,6 +172,14 @@ pub struct ServiceArgs {
 fn main() {
     let args: Args = cli::parse_args(CliConfig::default());
 
+    // Pin the rustls crypto provider to aws-lc-rs. The LaunchDarkly SDK uses
+    // hyper-rustls, so building its client resolves the process-default rustls
+    // provider. The workspace also links rustls' `ring` feature (pulled by
+    // other hyper-rustls chains), and with both provider features enabled
+    // rustls cannot choose a default on its own and panics. The call is
+    // idempotent, so ignore the result.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Mirror the tokio Runtime configuration in our production binaries.
     let ncpus_useful = usize::max(1, std::cmp::min(num_cpus::get(), num_cpus::get_physical()));
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -40,6 +40,7 @@ mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
 nix.workspace = true
 num_cpus.workspace = true
+rustls.workspace = true
 serde.workspace = true
 tokio.workspace = true
 tower.workspace = true

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -190,6 +190,14 @@ fn process_ordinal_from_hostname(hostname: &str) -> Option<&str> {
 pub fn main() {
     mz_ore::panic::install_enhanced_handler();
 
+    // Pin the rustls crypto provider to aws-lc-rs. The LaunchDarkly SDK uses
+    // hyper-rustls, so building its client resolves the process-default rustls
+    // provider. The workspace also links rustls' `ring` feature (pulled by
+    // other hyper-rustls chains), and with both provider features enabled
+    // rustls cannot choose a default on its own and panics. The call is
+    // idempotent, so ignore the result.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Derive `CLUSTERD_PROCESS` (the process ordinal) from the pod hostname
     // when running under Kubernetes and it was not set explicitly. The
     // distroless image has no shell entrypoint to do this, so clusterd does it

--- a/src/dyncfg-launchdarkly/Cargo.toml
+++ b/src/dyncfg-launchdarkly/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 humantime.workspace = true
-hyper-tls = "0.5.0"
 launchdarkly-server-sdk.workspace = true
+launchdarkly-sdk-transport.workspace = true
 mz-build-info = { path = "../build-info" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-ore = { path = "../ore", default-features = false, features = ["async"] }

--- a/src/dyncfg-launchdarkly/src/lib.rs
+++ b/src/dyncfg-launchdarkly/src/lib.rs
@@ -11,7 +11,6 @@
 
 use std::time::Duration;
 
-use hyper_tls::HttpsConnector;
 use launchdarkly_server_sdk as ld;
 use mz_build_info::BuildInfo;
 use mz_dyncfg::{ConfigSet, ConfigUpdates, ConfigVal};
@@ -50,13 +49,21 @@ where
         let _ = dyn_into_flag(entry.val())?;
     }
     let ld_client = if let Some(key) = launchdarkly_sdk_key {
+        let transport = launchdarkly_sdk_transport::HyperTransport::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .read_timeout(Duration::from_secs(300))
+            .build_https()
+            .expect("failed to create HTTPS transport");
+
+        let mut data_source = ld::StreamingDataSourceBuilder::new();
+        data_source.transport(transport.clone());
+
+        let mut event_processor = ld::EventProcessorBuilder::new();
+        event_processor.transport(transport);
+
         let config = ld::ConfigBuilder::new(key)
-            .event_processor(
-                ld::EventProcessorBuilder::new().https_connector(HttpsConnector::new()),
-            )
-            .data_source(
-                ld::StreamingDataSourceBuilder::new().https_connector(HttpsConnector::new()),
-            )
+            .data_source(&data_source)
+            .event_processor(&event_processor)
             .build()
             .expect("valid config");
         let client = ld::Client::build(config)?;

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -96,6 +96,7 @@ rand.workspace = true
 regex = { workspace = true, optional = true }
 reqwest.workspace = true
 rlimit.workspace = true
+rustls.workspace = true
 semver.workspace = true
 sentry-tracing.workspace = true
 serde.workspace = true

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -657,6 +657,15 @@ pub fn main() {
 
 fn run(mut args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::install_enhanced_handler();
+
+    // Pin the rustls crypto provider to aws-lc-rs. The LaunchDarkly SDK uses
+    // hyper-rustls, so building its client resolves the process-default rustls
+    // provider. The workspace also links rustls' `ring` feature (pulled by
+    // other hyper-rustls chains), and with both provider features enabled
+    // rustls cannot choose a default on its own and panics. The call is
+    // idempotent, so ignore the result.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let envd_start = Instant::now();
 
     // Configure signal handling as soon as possible. We want signals to be

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -46,6 +46,7 @@ mz-tracing = { path = "../tracing" }
 postgres-protocol.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 shell-words.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -114,6 +114,14 @@ struct Args {
 async fn main() -> ExitCode {
     mz_ore::panic::install_enhanced_handler();
 
+    // Pin the rustls crypto provider to aws-lc-rs. The LaunchDarkly SDK uses
+    // hyper-rustls, so building its client resolves the process-default rustls
+    // provider. The workspace also links rustls' `ring` feature (pulled by
+    // other hyper-rustls chains), and with both provider features enabled
+    // rustls cannot choose a default on its own and panics. The call is
+    // idempotent, so ignore the result.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let args: Args = cli::parse_args(CliConfig {
         env_prefix: Some("MZ_"),
         enable_version_flag: false,

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -66,6 +66,7 @@ rand.workspace = true
 rdkafka.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -300,6 +300,14 @@ struct Args {
 async fn main() {
     let args: Args = cli::parse_args(CliConfig::default());
 
+    // Pin the rustls crypto provider to aws-lc-rs. The LaunchDarkly SDK uses
+    // hyper-rustls, so building its client resolves the process-default rustls
+    // provider. The workspace also links rustls' `ring` feature (pulled by
+    // other hyper-rustls chains), and with both provider features enabled
+    // rustls cannot choose a default on its own and panics. The call is
+    // idempotent, so ignore the result.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from(args.log_filter))
         .with_writer(io::stdout)


### PR DESCRIPTION
**Part 1 of 3** in the LaunchDarkly upstream-SDK stack:

1. **#37025 (this PR)** — migrate off the fork to upstream 3.1.1
2. #37026 — + the reconnect integration test
3. #37460 — + pin to pre-fix 3.0.1 to prove the test fails (**DO NOT MERGE**)

## What this does

Moves `launchdarkly-server-sdk` from the `MaterializeInc/rust-server-sdk` fork back to upstream crates.io **3.1.1**, restoring the `launchdarkly-sdk-transport` + `MetricsTransport` setup and dropping the `[patch.crates-io]` override.

The fork existed for [rust-server-sdk#116](https://github.com/launchdarkly/rust-server-sdk/issues/116): a non-`Eof` stream error left the `StreamingDataSource` stuck with no reconnect, silently breaking LD sync. A prior upgrade to 3.0.1 was reverted (incident-984) because that bug was still unfixed upstream. The fixes have since landed — rust-server-sdk#168 and eventsource-client#134/#135 — and 3.1.1 resolves `eventsource-client` to 0.17.5, which carries them.

- Uses the rustls + aws-lc-rs features (`hyper-rustls-native-roots`, `crypto-aws-lc-rs`), avoiding the OpenSSL path.
- Because LD now builds a rustls client and the workspace links both rustls provider features (`aws_lc_rs` + `ring`, the latter transitively), each binary that builds an LD client installs the aws-lc-rs provider explicitly (environmentd, clusterd, balancerd, sqllogictest, testdrive) or it panics on first client build. orchestratord already installs it.
- Adds `MetricsTransport` unit tests, including `test_metric_frozen_on_midstream_error` modeling the incident-984 failure mode.

Rebased onto current `main`. Draft until the nightly LaunchDarkly jobs are confirmed green across the stack.
