### PR TITLE
row-spine: inline DatumContainer::index to fix CLU-116 regression

### DIFF
--- a/src/row-spine/src/lib.rs
+++ b/src/row-spine/src/lib.rs
@@ -1089,7 +1089,14 @@ mod dictionary {
                 stats: None,
             }
         }
-        #[inline]
+        // `inline(always)`, not merely `inline`: the read item `DatumSeq { ColumnsIter }` is 32
+        // bytes (codec pointer + column + slice), which exceeds the System V two-register return
+        // threshold. Emitted out-of-line, this method returns via a hidden `sret` pointer and
+        // spills registers around the offset-decode jump table, costing ~250ms (one quarter of a
+        // ~10% `ParallelDataflows` wallclock regression) even when compression is disabled. Forcing
+        // the inline lets the caller build the read item in registers (SROA) and drop the unused
+        // codec/column fields on the no-codec path (DCE), matching the pre-dictionary cost. CLU-116.
+        #[inline(always)]
         fn index(&self, index: usize) -> Self::ReadItem<'_> {
             let data = self.inner.index(index);
             let iter = if let Some(codec) = &self.codec {


### PR DESCRIPTION
### Motivation

MaterializeInc/materialize#32095 (dictionary-compressed arrangements, alpha, default off) introduced a \~10% wallclock regression in the `ParallelDataflows` feature benchmark, present even with the feature disabled ([CLU-116](https://linear.app/materializeinc/issue/CLU-116/dictionary-compressed-arrangements-causes-10percent-time-regression-in)).

### Description

The dictionary read item `DatumSeq { ColumnsIter }` is 32 bytes (codec pointer + column + slice), exceeding the System V two-register return threshold. Emitted out-of-line, `DatumContainer::index` returns via a hidden `sret` pointer and spills registers around the offset-decode jump table — \~250ms of the regression, on the read path of every arrangement regardless of the flag. Before the dictionary work the read item was a 16-byte `&[u8]` returned in registers.

Marking `index` `#[inline(always)]` removes the call boundary: the caller builds the read item in registers (SROA) and drops the unused codec/column fields on the no-codec path (DCE), restoring the pre-dictionary cost. This is not an inlining-loss or branch-mispredict issue — the codec check is a branchless `cmovnz` and the reduce `compute` closure self-time is unchanged; it is purely the return-value ABI.

### Verification

A/B of optimized builds at the PR commit vs its parent, cold (fresh `environmentd --reset` per trial), profiled with samply

* Regression reproduced: +2.2% (n=100k×25), +1.7% (n=2M×10).
* With the fix: +0.3% (within run-to-run noise).
* `DatumContainer::index` disappears as a profile symbol (inlined), leaving only the inner `BytesContainer::index` at its pre-dictionary self-cost (1374 vs 1357 samples).
* clusterd memory unaffected (≤0.7% delta at both scales); the CI memory delta was sub-threshold noise.