### PR TITLE
sql: Gate all paths that set the bounded staleness isolation level

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -52,7 +52,8 @@ use mz_sql::rbac;
 use mz_sql::rbac::CREATE_ITEM_USAGE;
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{
-    EndTransactionAction, NETWORK_POLICY, OwnedVarInput, STATEMENT_LOGGING_SAMPLE_RATE, Value, Var,
+    EndTransactionAction, NETWORK_POLICY, OwnedVarInput, STATEMENT_LOGGING_SAMPLE_RATE,
+    TRANSACTION_ISOLATION_VAR_NAME, Value, Var, check_transaction_isolation_feature_flag,
 };
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
@@ -958,6 +959,23 @@ impl Coordinator {
                 .vars()
                 .map(|(name, val)| (name.to_string(), val.clone())),
         );
+
+        // If the resolved `transaction_isolation` default names a feature-flagged
+        // isolation level whose flag is now disabled (e.g. a role default set
+        // while `bounded staleness` was enabled, then the flag turned off), drop
+        // it so the session falls back to the built-in default rather than
+        // silently using a gated level.
+        if let Some(value) = session_defaults.get(TRANSACTION_ISOLATION_VAR_NAME) {
+            if check_transaction_isolation_feature_flag(
+                TRANSACTION_ISOLATION_VAR_NAME,
+                value.borrow(),
+                system_config,
+            )
+            .is_err()
+            {
+                session_defaults.remove(TRANSACTION_ISOLATION_VAR_NAME);
+            }
+        }
 
         // Validate network policies for external users. Internal users can only connect on the
         // internal interfaces (internal HTTP/ pgwire). It is up to the person deploying the system

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -166,7 +166,7 @@ use crate::plan::{
 use crate::session::vars::{
     self, ENABLE_CLUSTER_SCHEDULE_REFRESH, ENABLE_COLLECTION_PARTITION_BY,
     ENABLE_CREATE_TABLE_FROM_SOURCE, ENABLE_KAFKA_SINK_HEADERS, ENABLE_REFRESH_EVERY_MVS,
-    ENABLE_REPLICA_TARGETED_MATERIALIZED_VIEWS,
+    ENABLE_REPLICA_TARGETED_MATERIALIZED_VIEWS, VarInput,
 };
 use crate::{names, parse};
 
@@ -4446,12 +4446,25 @@ impl PlannedRoleVariable {
     }
 }
 
-fn plan_role_variable(variable: SetRoleVar) -> Result<PlannedRoleVariable, PlanError> {
+fn plan_role_variable(
+    scx: &StatementContext,
+    variable: SetRoleVar,
+) -> Result<PlannedRoleVariable, PlanError> {
     let plan = match variable {
-        SetRoleVar::Set { name, value } => PlannedRoleVariable::Set {
-            name: name.to_string(),
-            value: scl::plan_set_variable_to(value)?,
-        },
+        SetRoleVar::Set { name, value } => {
+            let name = name.to_string();
+            let value = scl::plan_set_variable_to(value)?;
+            // Gate feature-flagged isolation levels, matching the `SET` and
+            // connection-option paths in `SessionVars::set`.
+            if let VariableValue::Values(values) = &value {
+                vars::check_transaction_isolation_feature_flag(
+                    &name,
+                    VarInput::SqlSet(values),
+                    scx.catalog.system_vars(),
+                )?;
+            }
+            PlannedRoleVariable::Set { name, value }
+        }
         SetRoleVar::Reset { name } => PlannedRoleVariable::Reset {
             name: name.to_string(),
         },
@@ -7438,7 +7451,7 @@ pub fn plan_alter_role(
             PlannedAlterRoleOption::Attributes(attrs)
         }
         AlterRoleOption::Variable(variable) => {
-            let var = plan_role_variable(variable)?;
+            let var = plan_role_variable(scx, variable)?;
             PlannedAlterRoleOption::Variable(var)
         }
     };

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -31,9 +31,7 @@ use crate::plan::{
     ShowVariablePlan, VariableValue, describe, query,
 };
 use crate::session::vars;
-use crate::session::vars::{
-    IsolationLevel, SCHEMA_ALIAS, TRANSACTION_ISOLATION_VAR_NAME, Value, VarInput,
-};
+use crate::session::vars::{SCHEMA_ALIAS, VarInput};
 
 pub fn describe_set_variable(
     _: &StatementContext,
@@ -53,27 +51,15 @@ pub fn plan_set_variable(
     let value = plan_set_variable_to(to)?;
     let name = variable.into_string();
 
+    // Gate feature-flagged isolation levels at plan time. The same check runs in
+    // `SessionVars::set`, which also covers `ALTER ROLE ... SET` and connection
+    // options; running it here too surfaces the error before sequencing.
     if let VariableValue::Values(values) = &value {
-        if let Some(value) = values.first() {
-            if name.as_str() == TRANSACTION_ISOLATION_VAR_NAME {
-                // Parse the value to identify the isolation level kind. Parse
-                // failures are deliberately ignored here — the actual SET path
-                // surfaces them — but a successful parse lets us gate
-                // parameterised levels (like `bounded staleness 5s`) behind
-                // their feature flags.
-                if let Ok(level) = IsolationLevel::parse(VarInput::Flat(value)) {
-                    match level {
-                        IsolationLevel::StrongSessionSerializable => {
-                            scx.require_feature_flag(&vars::ENABLE_SESSION_TIMELINES)?;
-                        }
-                        IsolationLevel::BoundedStaleness(_) => {
-                            scx.require_feature_flag(&vars::ENABLE_BOUNDED_STALENESS_ISOLATION)?;
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
+        vars::check_transaction_isolation_feature_flag(
+            &name,
+            VarInput::SqlSet(values),
+            scx.catalog.system_vars(),
+        )?;
     }
 
     Ok(Plan::SetVariable(SetVariablePlan { name, value, local }))

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -584,6 +584,8 @@ impl SessionVars {
     ) -> Result<(), VarError> {
         let (name, input) = compat_translate(name, input);
 
+        check_transaction_isolation_feature_flag(name, input, system_vars)?;
+
         let name = UncasedStr::new(name);
         self.check_read_only(name)?;
 
@@ -983,6 +985,36 @@ fn compat_translate<'a, 'b>(name: &'a str, input: VarInput<'b>) -> (&'a str, Var
 fn compat_translate_name(name: &str) -> &str {
     let (name, _) = compat_translate(name, VarInput::Flat(""));
     name
+}
+
+/// Enforces feature-flag gating for `transaction_isolation` levels that sit
+/// behind a flag (`bounded staleness <duration>` and
+/// `strong session serializable`).
+///
+/// Returns `Ok(())` for any other variable, and for an unparseable value
+/// (parse errors surface on the actual set). This is shared by every path that
+/// assigns `transaction_isolation` — `SET`, `SET TRANSACTION`,
+/// `ALTER ROLE ... SET`, and connection options — so that the gate cannot be
+/// bypassed by choosing a different syntax or letter case.
+pub fn check_transaction_isolation_feature_flag(
+    name: &str,
+    input: VarInput,
+    system_vars: &SystemVars,
+) -> Result<(), VarError> {
+    if UncasedStr::new(name) != UncasedStr::new(TRANSACTION_ISOLATION_VAR_NAME) {
+        return Ok(());
+    }
+    // Ignore parse failures here; the actual set surfaces them.
+    let Ok(level) = IsolationLevel::parse(input) else {
+        return Ok(());
+    };
+    match level {
+        IsolationLevel::StrongSessionSerializable => ENABLE_SESSION_TIMELINES.require(system_vars),
+        IsolationLevel::BoundedStaleness(_) => {
+            ENABLE_BOUNDED_STALENESS_ISOLATION.require(system_vars)
+        }
+        _ => Ok(()),
+    }
 }
 
 /// A `SystemVar` is persisted on disk value for a configuration parameter. If unset,
@@ -2468,5 +2500,56 @@ impl Var for User {
 
     fn visible(&self, _: &User, _: &SystemVars) -> Result<(), VarError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod isolation_feature_flag_tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn gates_bounded_staleness_value() {
+        let mut system_vars = SystemVars::new();
+
+        // Default-on: the value passes the gate.
+        check_transaction_isolation_feature_flag(
+            TRANSACTION_ISOLATION_VAR_NAME,
+            VarInput::Flat("bounded staleness 5s"),
+            &system_vars,
+        )
+        .expect("flag on by default");
+
+        // Turn the flag off: the value is rejected regardless of the letter case
+        // of the variable name. This covers `SET`, `SET "TRANSACTION_ISOLATION"`,
+        // `ALTER ROLE ... SET`, and connection options, which all route through
+        // `SessionVars::set` and this shared check.
+        system_vars
+            .set("enable_bounded_staleness_isolation", VarInput::Flat("off"))
+            .expect("set flag");
+        for name in ["transaction_isolation", "TRANSACTION_ISOLATION"] {
+            let err = check_transaction_isolation_feature_flag(
+                name,
+                VarInput::Flat("bounded staleness 5s"),
+                &system_vars,
+            )
+            .expect_err("flag off rejects bounded staleness");
+            assert!(matches!(err, VarError::RequiresFeatureFlag { .. }));
+        }
+
+        // Non-gated levels are unaffected.
+        check_transaction_isolation_feature_flag(
+            TRANSACTION_ISOLATION_VAR_NAME,
+            VarInput::Flat("serializable"),
+            &system_vars,
+        )
+        .expect("serializable always allowed");
+
+        // Unrelated variables are ignored, even with a gated-looking value.
+        check_transaction_isolation_feature_flag(
+            CLUSTER.name(),
+            VarInput::Flat("bounded staleness 5s"),
+            &system_vars,
+        )
+        .expect("unrelated var ignored");
     }
 }

--- a/test/sqllogictest/bounded_staleness.slt
+++ b/test/sqllogictest/bounded_staleness.slt
@@ -229,6 +229,14 @@ COMPLETE 0
 statement error the `bounded staleness <duration>` transaction isolation level is not available
 SET transaction_isolation TO 'bounded staleness 5s'
 
+# The gate must not be bypassable via a quoted, upper-cased variable name.
+statement error the `bounded staleness <duration>` transaction isolation level is not available
+SET "TRANSACTION_ISOLATION" TO 'bounded staleness 5s'
+
+# ... nor via `ALTER ROLE ... SET`.
+statement error the `bounded staleness <duration>` transaction isolation level is not available
+ALTER ROLE materialize SET transaction_isolation = 'bounded staleness 5s'
+
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_bounded_staleness_isolation = true;
 ----
@@ -239,3 +247,39 @@ SET transaction_isolation TO 'bounded staleness 5s'
 
 statement ok
 RESET transaction_isolation
+
+# --- role-default fallback when the flag is later disabled --------------------
+#
+# A role default set while the flag is on must not silently take effect once the
+# flag is turned off; fresh sessions fall back to the built-in default.
+
+statement ok
+ALTER ROLE materialize SET transaction_isolation = 'bounded staleness 5s'
+
+# A fresh session picks up the role default while the flag is on.
+simple conn=role_on,user=materialize
+SHOW transaction_isolation
+----
+bounded staleness 5s
+COMPLETE 1
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_bounded_staleness_isolation = false;
+----
+COMPLETE 0
+
+# With the flag off, a fresh session falls back to the built-in default rather
+# than applying the gated role default.
+simple conn=role_off,user=materialize
+SHOW transaction_isolation
+----
+strict serializable
+COMPLETE 1
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_bounded_staleness_isolation = true;
+----
+COMPLETE 0
+
+statement ok
+ALTER ROLE materialize RESET transaction_isolation


### PR DESCRIPTION
### Motivation

Fixes CLU-115.

`enable_bounded_staleness_isolation` was meant to gate the `bounded staleness <duration>` isolation level, but only `SET transaction_isolation TO ...` was blocked, and that check compared the variable name case-sensitively.
The flag could be bypassed three ways: a quoted/upper-cased name (`SET "TRANSACTION_ISOLATION" TO ...`), `ALTER ROLE ... SET transaction_isolation = ...`, and passing `transaction_isolation` as a connection option.

### Description

The gating logic now lives in a single case-insensitive helper, `check_transaction_isolation_feature_flag`, called from the chokepoint `SessionVars::set` (which all of `SET`, `SET TRANSACTION`, and connection options route through) and at plan time for both `SET` and `ALTER ROLE ... SET`.
A role default that names a gated level whose flag is later disabled is dropped when building session defaults, so a fresh session falls back to the built-in default rather than silently using the gated level.
The same helper also gates `strong session serializable` behind `enable_session_timelines`, closing the equivalent bypasses for that level.

### Verification

Added coverage in `test/sqllogictest/bounded_staleness.slt` for the quoted-name `SET`, `ALTER ROLE ... SET`, and the role-default fallback when the flag is disabled, plus a unit test in `src/sql/src/session/vars.rs` exercising the helper directly (flag on/off, name case-insensitivity, non-gated levels, unrelated variables).
