### PR TITLE
adapter: Drop comments when cascade-dropping replica-targeted MVs

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -3010,31 +3010,33 @@ impl ObjectsToDrop {
 
                 // Implicitly drop materialized views that target this replica.
                 // When the target replica is gone, no replica advances the
-                // persist shard's upper frontier, causing reads to hang.
+                // persist shard's upper frontier, causing reads to hang. Cascade
+                // to anything depending on the implicitly-dropped MV so we don't
+                // leave dangling references in the catalog.
                 //
-                // Also cascade to anything depending on the implicitly-dropped
-                // MV so we don't leave dangling references in the catalog.
-                // Plan-driven drops already include these via
-                // `cluster_replica_dependents`; this branch handles internal
-                // callers that build `Op::DropObjects` directly without going
-                // through the plan stage.
+                // Plan-driven drops already include these dependents as their
+                // own `DropObjectInfo::Item` entries (the plan stage expands
+                // them via `cluster_replica_dependents`), so each one's comment
+                // is recorded by the top-of-function `self.comments` insert.
+                // This branch handles internal callers that build
+                // `Op::DropObjects` directly with only the replica, so we expand
+                // the dependents and record their comments ourselves.
+                //
+                // `seen` is seeded from the items already collected so that the
+                // plan-driven path (where the dependents are processed before
+                // the replica, in reverse-dependency order) does not re-add them
+                // here.
                 let mut seen: BTreeSet<ObjectId> =
                     self.items.iter().copied().map(ObjectId::Item).collect();
-                for item_id in &cluster.bound_objects {
-                    let entry = state.get_entry(item_id);
-                    if let CatalogItem::MaterializedView(mv) = entry.item()
-                        && mv.target_replica == Some(replica_id)
-                        && !seen.contains(&ObjectId::Item(*item_id))
-                    {
+                for dep in state.cluster_replica_dependents(cluster_id, replica_id, &mut seen) {
+                    if let ObjectId::Item(dep_id) = dep {
                         info!(
-                            "implicitly dropping materialized view {} because target replica was dropped",
-                            entry.name().item,
+                            "implicitly dropping {} because target replica was dropped",
+                            state.get_entry(&dep_id).name().item,
                         );
-                        for dep in state.item_dependents(*item_id, &mut seen) {
-                            if let ObjectId::Item(dep_id) = dep {
-                                self.items.push(dep_id);
-                            }
-                        }
+                        self.comments
+                            .insert(state.get_comment_id(ObjectId::Item(dep_id)));
+                        self.items.push(dep_id);
                     }
                 }
             }

--- a/test/testdrive/materialized-view-replica-targeted.td
+++ b/test/testdrive/materialized-view-replica-targeted.td
@@ -193,9 +193,44 @@ contains:unknown catalog item 'mv_r1'
 r2 true
 
 # ---------------------------------------------------------------------------
+# Regression test for CLU-118: resizing a managed cluster that hosts a
+# replica-targeted MV with a COMMENT must not leave a dangling comment behind
+# (which previously tripped the coordinator consistency check and panicked).
+# ---------------------------------------------------------------------------
+
+> CREATE CLUSTER managed (SIZE 'scale=1,workers=1', REPLICATION FACTOR 1)
+
+> CREATE MATERIALIZED VIEW mv_managed IN CLUSTER managed REPLICA r1 AS SELECT sum(a) AS s FROM t
+
+> COMMENT ON MATERIALIZED VIEW mv_managed IS 'pinned to r1'
+
+> SELECT * FROM mv_managed
+10
+
+# Resizing tears down and recreates the replica, which implicitly drops the
+# targeted MV and must also drop its comment.
+> ALTER CLUSTER managed SET (SIZE 'scale=1,workers=2')
+
+# The targeted MV is gone.
+! SELECT * FROM mv_managed
+contains:unknown catalog item 'mv_managed'
+
+# No dangling comment is left behind.
+> SELECT count(*) FROM mz_internal.mz_comments c
+  JOIN mz_materialized_views mv ON (mv.id = c.id)
+  WHERE mv.name = 'mv_managed'
+0
+
+# The cluster is still usable after the resize.
+> CREATE MATERIALIZED VIEW mv_after IN CLUSTER managed AS SELECT sum(a) AS s FROM t
+> SELECT * FROM mv_after
+10
+
+# ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 
 > DROP MATERIALIZED VIEW mv_all
 > DROP TABLE t CASCADE
 > DROP CLUSTER test CASCADE
+> DROP CLUSTER managed CASCADE

--- a/test/testdrive/materialized-view-replica-targeted.td
+++ b/test/testdrive/materialized-view-replica-targeted.td
@@ -215,10 +215,10 @@ r2 true
 ! SELECT * FROM mv_managed
 contains:unknown catalog item 'mv_managed'
 
-# No dangling comment is left behind.
-> SELECT count(*) FROM mz_internal.mz_comments c
-  JOIN mz_materialized_views mv ON (mv.id = c.id)
-  WHERE mv.name = 'mv_managed'
+# No dangling comment is left behind. Check mz_comments directly: joining to
+# mz_materialized_views would vacuously return 0 once the MV is dropped, even if
+# an orphaned comment row survived.
+> SELECT count(*) FROM mz_internal.mz_comments WHERE comment = 'pinned to r1'
 0
 
 # The cluster is still usable after the resize.


### PR DESCRIPTION
### Motivation

Resizing a managed cluster that hosts a replica-targeted materialized view with a `COMMENT` panicked the coordinator:

```
coordinator inconsistency detected
  left: Err(... comments: [Dangling(MaterializedView(User(2)))] ...)
```

Fixes CLU-118.

### Description

Resizing a managed cluster tears down its replica via an internally-built `Op::DropObjects` that names only the replica, not the replica-targeted materialized views it implicitly drops.
The `ClusterReplica` branch of `ObjectsToDrop::add_item` expanded those MVs and their dependents into `self.items` but never recorded their comments in `self.comments`, so the MV was dropped while its comment survived.
Plan-driven drops (e.g. `DROP CLUSTER`) avoid this because the plan stage enumerates each dependent as its own `DropObjectInfo::Item`, whose comment is recorded by the top-of-function insert; only the direct-op resize path learns of the MV solely through this cascade.

The branch is rewritten to reuse `cluster_replica_dependents` — removing the duplicated `bound_objects`/`target_replica` loop — and to insert each dropped item's comment id alongside the item.
`seen` is still seeded from the items already collected, so the plan-driven path (dependents processed before the replica, in reverse-dependency order) does not re-add them.

### Verification

Extended `test/testdrive/materialized-view-replica-targeted.td` with a CLU-118 regression: a managed cluster with a commented replica-targeted MV is resized, then asserts the MV is gone, no dangling comment remains, and the cluster is still usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)