### PR TITLE
Disable mz-ore default features in mz-postgres-util

### DIFF
--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow.workspace = true
 itertools.workspace = true
 mz-cloud-resources = { path = "../cloud-resources", optional = true }
-mz-ore = { path = "../ore", features = ["async"], optional = true }
+mz-ore = { path = "../ore", default-features = false, features = ["async"], optional = true }
 mz-proto = { path = "../proto", optional = true }
 mz-repr = { path = "../repr", optional = true }
 mz-sql-parser = { path = "../sql-parser" }


### PR DESCRIPTION
Disable mz-ore default features in mz-postgres-util

### Motivation

This pulls in extra features and dependencies in the cloud repo which are not used there. In addition to bloating the build, this breaks compilation due to mismatch of features with mz-orchestrator-tracing.

### Verification

If it builds, it should work.