### PR TITLE
fix clippy on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6552,6 +6552,7 @@ dependencies = [
  "mz-controller-types",
  "mz-expr",
  "mz-ore",
+ "mz-postgres-util",
  "mz-repr",
  "mz-secrets",
  "mz-sql",

--- a/src/mz-deploy/Cargo.toml
+++ b/src/mz-deploy/Cargo.toml
@@ -20,6 +20,7 @@ rayon = { workspace = true }
 junit-report = { workspace = true }
 mz-build-info = { path = "../build-info" }
 mz-ore = { path = "../ore", default-features = false, features = ["async"] }
+mz-postgres-util = { path = "../postgres-util" }
 mz-aws-util = { path = "../aws-util", default-features = false }
 mz-catalog = { path = "../catalog" }
 mz-controller-types = { path = "../controller-types" }

--- a/src/mz-deploy/src/client/connection.rs
+++ b/src/mz-deploy/src/client/connection.rs
@@ -38,11 +38,10 @@
 use crate::client::errors::ConnectionError;
 use crate::config::{Profile, SslMode};
 use crate::info;
+use mz_postgres_util::Sql;
 use std::collections::BTreeMap;
 use tokio_postgres::types::ToSql;
-use tokio_postgres::{
-    Client as PgClient, NoTls, Row, SimpleQueryMessage, ToStatement, Transaction,
-};
+use tokio_postgres::{Client as PgClient, NoTls, Row, SimpleQueryMessage, Transaction};
 
 /// Database client for interacting with Materialize.
 ///
@@ -242,48 +241,48 @@ impl Client {
     }
 
     /// Execute a SQL statement that doesn't return rows.
-    pub async fn execute<T>(
+    pub async fn execute(
         &self,
-        statement: &T,
+        statement: &str,
         params: &[&(dyn ToSql + Sync)],
-    ) -> Result<u64, ConnectionError>
-    where
-        T: ?Sized + ToStatement,
-    {
-        self.client
-            .execute(statement, params)
-            .await
-            .map_err(ConnectionError::Query)
+    ) -> Result<u64, ConnectionError> {
+        mz_postgres_util::execute(
+            &self.client,
+            Sql::raw_unchecked(statement.to_string()),
+            params,
+        )
+        .await
+        .map_err(ConnectionError::from)
     }
 
     /// Execute a SQL query and return the resulting rows.
-    pub async fn query_one<T>(
+    pub async fn query_one(
         &self,
-        statement: &T,
+        statement: &str,
         params: &[&(dyn ToSql + Sync)],
-    ) -> Result<Row, ConnectionError>
-    where
-        T: ?Sized + ToStatement,
-    {
-        self.client
-            .query_one(statement, params)
-            .await
-            .map_err(ConnectionError::Query)
+    ) -> Result<Row, ConnectionError> {
+        mz_postgres_util::query_one(
+            &self.client,
+            Sql::raw_unchecked(statement.to_string()),
+            params,
+        )
+        .await
+        .map_err(ConnectionError::from)
     }
 
     /// Execute a SQL query and return the resulting rows.
-    pub async fn query<T>(
+    pub async fn query(
         &self,
-        statement: &T,
+        statement: &str,
         params: &[&(dyn ToSql + Sync)],
-    ) -> Result<Vec<Row>, ConnectionError>
-    where
-        T: ?Sized + ToStatement,
-    {
-        self.client
-            .query(statement, params)
-            .await
-            .map_err(ConnectionError::Query)
+    ) -> Result<Vec<Row>, ConnectionError> {
+        mz_postgres_util::query(
+            &self.client,
+            Sql::raw_unchecked(statement.to_string()),
+            params,
+        )
+        .await
+        .map_err(ConnectionError::from)
     }
 
     /// Execute a SQL statement using the simple query protocol (text-only, no binary encoding).
@@ -291,18 +290,16 @@ impl Client {
         &self,
         query: &str,
     ) -> Result<Vec<SimpleQueryMessage>, ConnectionError> {
-        self.client
-            .simple_query(query)
+        mz_postgres_util::simple_query(&self.client, Sql::raw_unchecked(query.to_string()))
             .await
-            .map_err(ConnectionError::Query)
+            .map_err(ConnectionError::from)
     }
 
     /// Execute one or more SQL statements that don't return rows, using the simple query protocol.
     pub async fn batch_execute(&self, query: &str) -> Result<(), ConnectionError> {
-        self.client
-            .batch_execute(query)
+        mz_postgres_util::batch_execute(&self.client, Sql::raw_unchecked(query.to_string()))
             .await
-            .map_err(ConnectionError::Query)
+            .map_err(ConnectionError::from)
     }
 }
 

--- a/src/mz-deploy/src/client/deployment_ops.rs
+++ b/src/mz-deploy/src/client/deployment_ops.rs
@@ -1542,7 +1542,8 @@ impl DeploymentsClientMut<'_> {
                     "DECLARE c CURSOR FOR SUBSCRIBE ({query})"
                 );
 
-                mz_postgres_util::execute(&txn, Sql::raw_unchecked(subscribe_sql), &[&pattern]).await?;
+                let subscribe_sql = Sql::raw_unchecked(subscribe_sql);
+                mz_postgres_util::execute(&txn, subscribe_sql, &[&pattern]).await?;
 
                 loop {
                     let rows = mz_postgres_util::query(&txn, Sql::new("FETCH ALL c"), &[]).await?;

--- a/src/mz-deploy/src/client/deployment_ops.rs
+++ b/src/mz-deploy/src/client/deployment_ops.rs
@@ -71,6 +71,7 @@ use crate::project::ir::object_id::ObjectId;
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
 use futures::Stream;
+use mz_postgres_util::Sql;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use tokio_postgres::types::ToSql;
@@ -1541,10 +1542,10 @@ impl DeploymentsClientMut<'_> {
                     "DECLARE c CURSOR FOR SUBSCRIBE ({query})"
                 );
 
-                txn.execute(&subscribe_sql, &[&pattern]).await?;
+                mz_postgres_util::execute(&txn, Sql::raw_unchecked(subscribe_sql), &[&pattern]).await?;
 
                 loop {
-                    let rows = txn.query("FETCH ALL c", &[]).await?;
+                    let rows = mz_postgres_util::query(&txn, Sql::new("FETCH ALL c"), &[]).await?;
                     if rows.is_empty() {
                         continue;
                     }

--- a/src/mz-deploy/src/client/errors.rs
+++ b/src/mz-deploy/src/client/errors.rs
@@ -154,6 +154,15 @@ impl From<tokio_postgres::Error> for ConnectionError {
     }
 }
 
+impl From<mz_postgres_util::PostgresError> for ConnectionError {
+    fn from(error: mz_postgres_util::PostgresError) -> Self {
+        match error {
+            mz_postgres_util::PostgresError::Postgres(error) => ConnectionError::Query(error),
+            other => ConnectionError::Message(other.to_string()),
+        }
+    }
+}
+
 /// Errors that can occur during project validation against the database.
 #[derive(Debug)]
 pub enum DatabaseValidationError {


### PR DESCRIPTION
## Motivation

`cargo clippy -p mz-deploy` surfaced 7 `clippy::disallowed_methods` warnings. The crate was calling `tokio_postgres` query/execute methods directly, which `clippy.toml` disallows repo-wide in favor of the `mz_postgres_util` `Sql` wrappers — these force SQL through the validated `Sql` type rather than raw strings.

## Changes

- **`src/mz-deploy/Cargo.toml`** — add `mz-postgres-util` as a path dependency (single-line `Cargo.lock` change, no version bumps).
- **`src/client/connection.rs`** — the five pass-through wrapper methods (`execute`, `query_one`, `query`, `simple_query`, `batch_execute`) now delegate to `mz_postgres_util::*`. Every call site passes string SQL (no prepared `Statement`), so the generic `ToStatement` bound is replaced with `&str`, wrapped via `Sql::raw_unchecked` — the sanctioned constructor for internally-assembled, already-trusted SQL.
- **`src/client/deployment_ops.rs`** — the two raw `Transaction` calls (the `SUBSCRIBE` cursor `execute` and the `FETCH ALL` `query`) go through `mz_postgres_util::execute`/`query`; the static `"FETCH ALL c"` uses `Sql::new`.
- **`src/client/errors.rs`** — add `From<mz_postgres_util::PostgresError> for ConnectionError`, mapping the `Postgres` variant back to `ConnectionError::Query` so the existing rich `as_db_error()` formatting is preserved.

## Testing

No behavioral change; this is a lint-compliance refactor that preserves the existing public API and error formatting of the `Client` wrapper. `cargo clippy -p mz-deploy --all-targets -- -D warnings` now passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)