### PR TITLE
[SS-187] Unify max_lsn behind a single function

### DIFF
--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -13,7 +13,7 @@
 pub mod replication;
 #[cfg(feature = "replication")]
 pub use replication::{
-    available_replication_slots, drop_replication_slots, get_current_wal_lsn, get_max_wal_senders,
+    available_replication_slots, drop_replication_slots, fetch_max_lsn, get_max_wal_senders,
     get_timeline_id, get_wal_level, validate_no_rls_policies,
 };
 #[cfg(feature = "schemas")]

--- a/src/postgres-util/src/replication.rs
+++ b/src/postgres-util/src/replication.rs
@@ -237,7 +237,11 @@ pub async fn get_timeline_id(client: &Client) -> Result<u64, PostgresError> {
     }
 }
 
-pub async fn get_current_wal_lsn(client: &Client) -> Result<PgLsn, PostgresError> {
+pub async fn fetch_max_lsn(client: &Client) -> Result<PgLsn, PostgresError> {
+    // Based on the documentation, it appears that `pg_current_wal_lsn` has
+    // the same "upper" semantics of `confirmed_flush_lsn`:
+    // <https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-BACKUP>
+    // We may need to revisit this and use `pg_current_wal_flush_lsn`.
     let row = query_one(client, crate::sql!("SELECT pg_current_wal_lsn()"), &[]).await?;
     let lsn: PgLsn = row.get(0);
 

--- a/src/postgres-util/src/replication.rs
+++ b/src/postgres-util/src/replication.rs
@@ -243,7 +243,12 @@ pub async fn fetch_max_lsn(client: &Client) -> Result<PgLsn, PostgresError> {
     // <https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-BACKUP>
     // We may need to revisit this and use `pg_current_wal_flush_lsn`.
     let row = query_one(client, crate::sql!("SELECT pg_current_wal_lsn()"), &[]).await?;
-    let lsn: PgLsn = row.get(0);
+    let lsn: Option<PgLsn> = row.get(0);
+    if let Some(lsn) = lsn {
+        return Ok(lsn);
+    }
 
-    Ok(lsn)
+    Err(PostgresError::Generic(anyhow::anyhow!(
+        "pg_current_wal_lsn() mysteriously has no value"
+    )))
 }

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -84,7 +84,7 @@ impl PostgresSourceConnection {
             )
             .await?;
 
-        let lsn = mz_postgres_util::get_current_wal_lsn(&client).await?;
+        let lsn = mz_postgres_util::fetch_max_lsn(&client).await?;
 
         let current_upper = Antichain::from_elem(MzOffset::from(u64::from(lsn)));
         Ok(current_upper)

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -454,25 +454,6 @@ async fn fetch_slot_metadata(
     }
 }
 
-/// Fetch the `pg_current_wal_lsn`, used to report metrics.
-async fn fetch_max_lsn(client: &Client) -> Result<MzOffset, TransientError> {
-    let row = simple_query_opt(client, sql!("SELECT pg_current_wal_lsn()")).await?;
-
-    match row.and_then(|row| {
-        row.get("pg_current_wal_lsn")
-            .map(|lsn| lsn.parse::<PgLsn>().unwrap())
-    }) {
-        // Based on the documentation, it appears that `pg_current_wal_lsn` has
-        // the same "upper" semantics of `confirmed_flush_lsn`:
-        // <https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-BACKUP>
-        // We may need to revisit this and use `pg_current_wal_flush_lsn`.
-        Some(lsn) => Ok(MzOffset::from(lsn)),
-        None => Err(TransientError::Generic(anyhow::anyhow!(
-            "pg_current_wal_lsn() mysteriously has no value"
-        ))),
-    }
-}
-
 // Ensures that the table with oid `oid` and expected schema `expected_schema` is still compatible
 // with the current upstream schema `upstream_info`.
 fn verify_schema(

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -323,10 +323,10 @@ pub(crate) fn render<'scope>(
             // Note that we need to fetch the probe LSN _after_ having created the replication
             // slot, to make sure the fetched LSN will be included in the replication stream.
             let probe_ts = (config.now_fn)().into();
-            let max_lsn = super::fetch_max_lsn(&*metadata_client).await?;
+            let max_lsn = mz_postgres_util::fetch_max_lsn(&*metadata_client).await?;
             let probe = Probe {
                 probe_ts,
-                upstream_frontier: Antichain::from_elem(max_lsn),
+                upstream_frontier: Antichain::from_elem(MzOffset::from(max_lsn)),
             };
             probe_output.give(&probe_cap[0], probe);
 
@@ -741,11 +741,11 @@ async fn raw_stream<'a>(
 
             while !probe_tx.is_closed() {
                 let probe_ts = probe_ticker.tick().await;
-                let probe_or_err = super::fetch_max_lsn(&*metadata_client)
+                let probe_or_err = mz_postgres_util::fetch_max_lsn(&*metadata_client)
                     .await
                     .map(|lsn| Probe {
                         probe_ts,
-                        upstream_frontier: Antichain::from_elem(lsn),
+                        upstream_frontier: Antichain::from_elem(MzOffset::from(lsn)),
                     });
                 let _ = probe_tx.send(Some(probe_or_err));
             }


### PR DESCRIPTION
### Motivation

This PR is to try to unify the two spots where we call `SELECT pg_current_wal_lsn()`.

This is a small refactor ahead of adding support for replication from a physical standby.

### Description

Unifies all calls to select pg_current_wal_lsn to the method in src/postgres-util/src/replication.rs. This is not a pure refactor as the potential errors returned aren't the same on the off chance nothing is returned.

