### PR TITLE
expr: Avoid super-linear LIKE matching on multi-% patterns

### DIFF
--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -149,7 +149,18 @@ pub fn compile(pattern: &str, case_insensitive: bool) -> Result<Matcher, EvalErr
         return Err(EvalError::LikePatternTooLong);
     }
     let subpatterns = build_subpatterns(pattern)?;
-    let matcher_impl = match case_insensitive || subpatterns.len() > MAX_SUBPATTERNS {
+    // `is_match_subpatterns` resolves each `%` (a `many` subpattern) by searching
+    // for the following suffix and backtracking over every candidate position. A
+    // single `%` is near-linear, but with two or more the backtracking nests and
+    // the cost becomes super-linear in the text length — an adversarial pattern
+    // like `%a%a%a` against a long run of `a`s takes time proportional to
+    // `len(text)^(number of %)`, which can stall a worker for many minutes. The
+    // regex engine matches the same patterns in linear time with no backtracking,
+    // so fall back to it whenever more than one `many` subpattern is present (and
+    // for the existing case-insensitive / too-many-subpatterns reasons).
+    let many_subpatterns = subpatterns.iter().filter(|s| s.many).count();
+    let use_regex = case_insensitive || subpatterns.len() > MAX_SUBPATTERNS || many_subpatterns > 1;
+    let matcher_impl = match use_regex {
         false => MatcherImpl::String(subpatterns),
         true => MatcherImpl::Regex(build_regex(&subpatterns, case_insensitive)?),
     };
@@ -497,6 +508,43 @@ mod test {
                     input.matches,
                 );
             }
+        }
+    }
+
+    // Patterns with two or more `%` wildcards now compile to the linear regex
+    // matcher instead of the back-tracking string matcher, which was
+    // super-linear: an adversarial pattern like `%a%a%a` against a long run of
+    // `a`s took time proportional to `len(text)^(number of %)`. Verify the
+    // routing change still yields correct match results (the regex matcher and
+    // the string matcher must agree), including the previously-pathological
+    // shape, which now completes instantly regardless of text length.
+    #[mz_ore::test]
+    fn test_many_wildcards_match_correctly() {
+        let long_a = "a".repeat(64);
+        let cases: &[(&str, &str, bool)] = &[
+            ("%a%a%a", "xaxaxa", true),
+            ("%a%a%a", "aaa", true),
+            ("%a%a%a", "aa", false),
+            ("%a%b%c%", "zzabqcz", true),
+            ("%a%b%c%", "cba", false),
+            ("a%b%c", "abc", true),
+            ("a%b%c", "axxbxxc", true),
+            ("a%b%c", "abcd", false),
+            // A single `%` still uses the (near-linear) string matcher.
+            ("%_%_%", "ab", true),
+            ("%%%%", "", true),
+            // The exact pathological shape from the fuzzer; super-linear before
+            // the fix, instant after.
+            ("%a%a%a%a%a", &long_a, true),
+            ("%a%a%a%a%a", "aaaa", false),
+        ];
+        for (pat, text, expected) in cases {
+            let m = compile(pat, false).unwrap();
+            assert_eq!(
+                m.is_match(text),
+                *expected,
+                "pattern {pat:?} against {text:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
The string matcher (`is_match_subpatterns`, used for patterns with up to MAX_SUBPATTERNS subpatterns) resolves each `%` by searching for the following suffix and back-tracking over every candidate position. With two or more `%` the back-tracking nests, so matching an adversarial pattern like `%a%a%a` against a long run of `a`s costs time proportional to len(text)^(number of %) — a fuzzer (like_pattern_escape) hit a single input that ran for 1667s.

The regex engine matches these patterns in linear time with no back-tracking, so route any pattern with more than one `many` (`%`) subpattern to it, alongside the existing case-insensitive and too-many-subpatterns cases. The string matcher now only handles patterns with at most one `%`, where it is near-linear. The regex and string matchers produce identical results, so this changes only performance.

Found by fuzzing. Adds a regression test covering the pathological shape (instant after the fix) and confirming the routing still matches correctly.

Split out from https://github.com/MaterializeInc/materialize/pull/36987