### PR TITLE
[test] normalize quickstart REPLICATION FACTOR in mz_clusters/mz_cluster_replicas SLTs

### DIFF
--- a/test/sqllogictest/mz_cluster_replicas.slt
+++ b/test/sqllogictest/mz_cluster_replicas.slt
@@ -13,6 +13,14 @@ mode cockroach
 
 reset-server
 
+# Normalize quickstart's REPLICATION FACTOR so assertions about its replicas
+# pass regardless of mzcompose --replicas overrides (nightly runs slow-tests
+# with --replicas=2).
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR 1);
+----
+COMPLETE 0
+
 # --- Schema -------------------------------------------------------------------
 
 # Lock down: 7 columns, canonical order, types, and nullability.

--- a/test/sqllogictest/mz_clusters.slt
+++ b/test/sqllogictest/mz_clusters.slt
@@ -20,6 +20,14 @@ ALTER SYSTEM SET enable_managed_cluster_availability_zones TO true;
 ----
 COMPLETE 0
 
+# Normalize quickstart's REPLICATION FACTOR so assertions about the default
+# user cluster pass regardless of mzcompose --replicas overrides (nightly
+# runs slow-tests with --replicas=2).
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR 1);
+----
+COMPLETE 0
+
 # --- Schema -------------------------------------------------------------------
 
 # Lock down: 11 columns, canonical order, types, and nullability.


### PR DESCRIPTION
New behavioural tests for mz_catalog.mz_clusters and mz_catalog.mz_cluster_replicas assert that the default quickstart cluster has replication_factor=1 and exactly one replica row.

Nightly's slow-tests workflow runs sqllogictest with --replicas=2, which bootstraps quickstart at replication_factor=2 and breaks these assertions.

Normalize quickstart to REPLICATION FACTOR 1 right after reset-server so the assertions are deterministic regardless of mzcompose's --replicas override.

