### PR TITLE
Update documentation around self-managed Dashboards

### DIFF
--- a/doc/user/content/manage/monitor/self-managed/prometheus.md
+++ b/doc/user/content/manage/monitor/self-managed/prometheus.md
@@ -17,83 +17,54 @@ overall health of your Materialize instance using Prometheus and Grafana.
 
 ## Before you begin
 
-Ensure you have:
+Ensure you have one of:
 
-- A self-managed instance of Materialize installed with helm values `observability.enabled=true`, `observability.podMetrics.enabled=true`, and `prometheus.scrapeAnnotations.enabled=true`
-- [Helm](https://helm.sh/docs/intro/install/) version 3.2.0+ installed
+- A self-managed instance of Materialize running with materialize-terraform-self-managed Terraform module with
+  `enable_observability=true`.
+
+You also need the following tools:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and configured
+  - You will need administrative access to your Kubernetes cluster
 
-{{< important >}}
-This guide assumes you have administrative access to your Kubernetes cluster and the necessary permissions to install Prometheus.
-{{< /important >}}
+{{< tip >}}
+Exciting changes are coming in the near future to further enhance the monitoring experience for self-managed users.
+Stay tuned for updates!
+{{< /tip >}}
 
-## 1. Download our Prometheus scrape configurations (`prometheus.yml`)
-  Download the Prometheus scrape configurations that we'll use to configure Prometheus to collect metrics from Materialize:
-  {{% self-managed/step-download-prometheus-scrape-configs %}}
+## Accessing Grafana in materialize-terraform-self-managed
 
+If you are using materialize-terraform-self-managed, you already have Grafana available.
 
+You can use the following to enable port-forwarding to access the Grafana UI:
 
-## 2. Install Prometheus to your Kubernetes cluster
+```bash
+kubectl port-forward service/grafana 80:3000 -n monitoring
+```
 
-  {{< note >}}
-  This guide uses the [prometheus-community](https://github.com/prometheus-community/helm-charts) Helm chart to install Prometheus.
-  {{< /note >}}
+You should then be able to open the Grafana UI on [http://localhost:3000](http://localhost:3000) in a browser.
 
+{{< warning >}}
+The port forwarding method is for testing purposes only.
+For production environments, configure an ingress controller to securely expose the Grafana UI.
+{{< /warning >}}
 
-1. Download the prometheus-community default chart values (`values.yaml`):
-   ```bash
-   curl -O https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/heads/main/charts/prometheus/values.yaml
-   ```
+## Advanced Monitoring
 
-2. Within `values.yaml`, replace `serverFiles > prometheus.yml > scrape_configs` with our scrape configurations (`prometheus_scrape_configs.yml`).
+{{< warning >}}
+If you are using materialize-terraform-self-managed, you shouldn't need to do any manual changes to your Grafana or Prometheus configuration.
+{{< /warning >}}
 
-3. Install the operator with the updated `values.yaml`:
-   ```bash
-   kubectl create namespace prometheus
-   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-   helm repo update
-   helm install --namespace prometheus prometheus prometheus-community/prometheus \
-   --values values.yaml
-   ```
+### Updating Grafana Dashboards
 
-## 3. Optional. Visualize through Grafana
+Additional dashboards are available from the materialize-monitoring repository.
+You can download them from the [Grafana Dashboards](https://materializeinc.github.io/materialize-monitoring/dashboards/grafana/) page.
 
-1. Install the Grafana helm chart following [this guide](https://grafana.com/docs/grafana/latest/setup-grafana/installation/helm/).
+For historical dashboards and Changelogs, you can find them in the [materialize-monitoring releases](https://github.com/MaterializeInc/materialize-monitoring/releases?q=dashboards).
 
+### Updating your Prometheus ScrapeConfigs
 
-2.  Set up port forwarding to access the Grafana UI:
-    ```bash
-    MZ_POD_GRAFANA=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=grafana -o custom-columns="NAME:.metadata.name" --no-headers)
-    kubectl port-forward pod/$MZ_POD_GRAFANA 3000:3000 -n monitoring
-    ```
+Prometheus-Operator resources (ServiceMonitors and PodMonitors) are
+available in the materialize-monitoring repository.
+You can find them in the [Metrics Scraping](https://materializeinc.github.io/materialize-monitoring/metrics/scraping/) page.
 
-    {{< warning >}}
-  The port forwarding method is for testing purposes only. For production environments, configure an ingress controller to securely expose the Grafana UI.
-    {{< /warning >}}
-
-3. Open the Grafana UI on [http://localhost:3000](http://localhost:3000) in a browser.
-
-4. Add a Prometheus data source. In the Grafana UI, under **Connection > Data sources**,
-   - Click **Add data source** and select **prometheus**
-   - In the Connection section, set **Prometheus server URL** to `http://<prometheus server name>.<namespace>.svc.cluster.local:<port>`(e.g. `http://prometheus-server.prometheus.svc.cluster.local:80`).
-
-    ![Image of Materialize Console login screen with mz_system user](/images/self-managed/grafana-prometheus-datasource-setup.png)
-
-4. Download the following dashboards:
-    ### Environment overview dashboard
-    An overview of the state of different objects in your environment.
-
-    ```bash
-    # environment_overview_dashboard.json
-    curl -O https://raw.githubusercontent.com/MaterializeInc/materialize/refs/heads/self-managed-docs/v25.2/doc/user/data/monitoring/grafana_dashboards/environment_overview_dashboard.json
-    ```
-    ### Freshness overview dashboard
-    An overview of how out of date objects in your environment are.
-     ```bash
-     # freshness_overview_dashboard.json
-    curl -O https://raw.githubusercontent.com/MaterializeInc/materialize/refs/heads/self-managed-docs/v25.2/doc/user/data/monitoring/grafana_dashboards/freshness_overview_dashboard.json
-    ```
-
-5. [Import the dashboards using the Prometheus data source](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/#importing-a-dashboard)
-
-    ![Image of Materialize Console login screen with mz_system user](/images/self-managed/grafana-monitoring-success.png)
+Classic ScrapeConfigs are also available in [Metrics Scraping](https://materializeinc.github.io/materialize-monitoring/metrics/scraping/).

--- a/doc/user/data/self_managed/monitoring/prometheus.yml
+++ b/doc/user/data/self_managed/monitoring/prometheus.yml
@@ -3,187 +3,177 @@ global:
   scrape_interval: 1m
   scrape_timeout: 10s
 scrape_configs:
-- job_name: kubernetes-pods
+- job_name: podMonitor/clusterd/0
+  metrics_path: /metrics
   kubernetes_sd_configs:
   - role: pod
   relabel_configs:
-  - action: keep
-    regex: 'true'
-    source_labels:
-    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-  - action: replace
-    regex: '(https?)'
-    source_labels:
-    - __meta_kubernetes_pod_annotation_prometheus_io_scheme
-    target_label: __scheme__
-  - action: replace
-    regex: '(.+)'
-    source_labels:
-    - __meta_kubernetes_pod_annotation_prometheus_io_path
-    target_label: __metrics_path__
-  - action: replace
-    regex: '([^:]+)(?::\d+)?;(\d+)'
-    replacement: $1:$2
-    source_labels:
-    - __address__
-    - __meta_kubernetes_pod_annotation_prometheus_io_port
-    target_label: __address__
-  - action: labelmap
-    regex: '__meta_kubernetes_pod_annotation_prometheus_io_param_(.+)'
-    replacement: __param_$1
-  - action: labelmap
-    regex: '__meta_kubernetes_pod_label_(.+)'
-  - action: replace
-    source_labels:
+  - source_labels:
+    - __meta_kubernetes_pod_label_cluster_environmentd_materialize_cloud_type
+    - __meta_kubernetes_pod_labelpresent_cluster_environmentd_materialize_cloud_type
+    regex: (cluster);true
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: internal-http
+    action: keep
+  - source_labels:
     - __meta_kubernetes_namespace
-    target_label: kubernetes_namespace
-  - action: replace
-    source_labels:
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
     - __meta_kubernetes_pod_name
-    target_label: kubernetes_pod_name
-  - action: drop
-    regex: 'Pending|Succeeded|Failed|Completed'
-    source_labels:
-    - __meta_kubernetes_pod_phase
-- job_name: kubernetes-pods-mz-compute
+    target_label: pod
+- job_name: podMonitor/environmentd/0
+  metrics_path: /metrics
   kubernetes_sd_configs:
-    - role: pod
+  - role: pod
   relabel_configs:
-    - action: keep
-      regex: "true"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-    - action: replace
-      regex: "(https?)"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
-      target_label: __scheme__
-    - action: replace
-      regex: "(.+)"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_materialize_prometheus_io_mz_compute_path
-      target_label: __metrics_path__
-    - action: replace
-      regex: '([^:]+)(?::\d+)?;(\d+)'
-      replacement: $1:$2
-      source_labels:
-        - __address__
-        - __meta_kubernetes_pod_annotation_prometheus_io_port
-      target_label: __address__
-    - action: labelmap
-      regex: "__meta_kubernetes_pod_annotation_prometheus_io_param_(.+)"
-      replacement: __param_$1
-    - action: labelmap
-      regex: "__meta_kubernetes_pod_label_(.+)"
-    - action: replace
-      source_labels:
-        - __meta_kubernetes_namespace
-      target_label: kubernetes_namespace
-    - action: replace
-      source_labels:
-        - __meta_kubernetes_pod_name
-      target_label: kubernetes_pod_name
-    - action: drop
-      regex: "Pending|Succeeded|Failed|Completed"
-      source_labels:
-        - __meta_kubernetes_pod_phase
-- job_name: kubernetes-pods-mz-storage
+  - source_labels:
+    - __meta_kubernetes_pod_label_app_kubernetes_io_name
+    - __meta_kubernetes_pod_labelpresent_app_kubernetes_io_name
+    regex: (environmentd);true
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: internal-http
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+- job_name: podMonitor/materialize-operator/0
+  metrics_path: /metrics
   kubernetes_sd_configs:
-    - role: pod
+  - role: pod
   relabel_configs:
-    - action: keep
-      regex: "true"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-    - action: replace
-      regex: "(https?)"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
-      target_label: __scheme__
-    - action: replace
-      regex: "(.+)"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_materialize_prometheus_io_mz_storage_path
-      target_label: __metrics_path__
-    - action: replace
-      regex: '([^:]+)(?::\d+)?;(\d+)'
-      replacement: $1:$2
-      source_labels:
-        - __address__
-        - __meta_kubernetes_pod_annotation_prometheus_io_port
-      target_label: __address__
-    - action: labelmap
-      regex: "__meta_kubernetes_pod_annotation_prometheus_io_param_(.+)"
-      replacement: __param_$1
-    - action: labelmap
-      regex: "__meta_kubernetes_pod_label_(.+)"
-    - action: replace
-      source_labels:
-        - __meta_kubernetes_namespace
-      target_label: kubernetes_namespace
-    - action: replace
-      source_labels:
-        - __meta_kubernetes_pod_name
-      target_label: kubernetes_pod_name
-    - action: drop
-      regex: "Pending|Succeeded|Failed|Completed"
-      source_labels:
-        - __meta_kubernetes_pod_phase
-- job_name: kubernetes-pods-mz-usage
+  - source_labels:
+    - __meta_kubernetes_pod_label_app_kubernetes_io_name
+    - __meta_kubernetes_pod_labelpresent_app_kubernetes_io_name
+    regex: (materialize-operator);true
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: metrics
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+- job_name: podMonitor/materialize-sql/0
+  metrics_path: /metrics/mz_compute
   kubernetes_sd_configs:
-    - role: pod
+  - role: pod
   relabel_configs:
-    - action: keep
-      regex: "true"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-    - action: replace
-      regex: "(https?)"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
-      target_label: __scheme__
-    - action: replace
-      regex: "(.+)"
-      source_labels:
-        - __meta_kubernetes_pod_annotation_materialize_prometheus_io_mz_usage_path
-      target_label: __metrics_path__
-    - action: replace
-      regex: '([^:]+)(?::\d+)?;(\d+)'
-      replacement: $1:$2
-      source_labels:
-        - __address__
-        - __meta_kubernetes_pod_annotation_prometheus_io_port
-      target_label: __address__
-    - action: labelmap
-      regex: "__meta_kubernetes_pod_annotation_prometheus_io_param_(.+)"
-      replacement: __param_$1
-    - action: labelmap
-      regex: "__meta_kubernetes_pod_label_(.+)"
-    - action: replace
-      source_labels:
-        - __meta_kubernetes_namespace
-      target_label: kubernetes_namespace
-    - action: replace
-      source_labels:
-        - __meta_kubernetes_pod_name
-      target_label: kubernetes_pod_name
-    - action: drop
-      regex: "Pending|Succeeded|Failed|Completed"
-      source_labels:
-        - __meta_kubernetes_pod_phase
-- job_name: 'kubelet-cadvisor'
-  scheme: https
+  - source_labels:
+    - __meta_kubernetes_pod_label_app_kubernetes_io_name
+    - __meta_kubernetes_pod_labelpresent_app_kubernetes_io_name
+    regex: (environmentd);true
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: internal-http
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+- job_name: podMonitor/materialize-sql/1
+  metrics_path: /metrics/mz_frontier
+  kubernetes_sd_configs:
+  - role: pod
+  relabel_configs:
+  - source_labels:
+    - __meta_kubernetes_pod_label_app_kubernetes_io_name
+    - __meta_kubernetes_pod_labelpresent_app_kubernetes_io_name
+    regex: (environmentd);true
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: internal-http
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+- job_name: podMonitor/materialize-sql/2
+  metrics_path: /metrics/mz_storage
+  kubernetes_sd_configs:
+  - role: pod
+  relabel_configs:
+  - source_labels:
+    - __meta_kubernetes_pod_label_app_kubernetes_io_name
+    - __meta_kubernetes_pod_labelpresent_app_kubernetes_io_name
+    regex: (environmentd);true
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: internal-http
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+- job_name: podMonitor/materialize-sql/3
+  metrics_path: /metrics/mz_usage
+  kubernetes_sd_configs:
+  - role: pod
+  relabel_configs:
+  - source_labels:
+    - __meta_kubernetes_pod_label_app_kubernetes_io_name
+    - __meta_kubernetes_pod_labelpresent_app_kubernetes_io_name
+    regex: (environmentd);true
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: internal-http
+    action: keep
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+- job_name: mz-kubelet-cadvisor
   kubernetes_sd_configs:
   - role: node
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   relabel_configs:
-  - action: labelmap
-    regex: __meta_kubernetes_node_label_(.+)
+  - regex: __meta_kubernetes_node_label_(.+)
+    action: labelmap
   - target_label: __address__
     replacement: kubernetes.default.svc:443
-  - source_labels: [__meta_kubernetes_node_name]
-    regex: (.+)
+  - source_labels:
+    - __meta_kubernetes_node_name
     target_label: __metrics_path__
+    regex: (.+)
     replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor


### PR DESCRIPTION
### Motivation

The current documentation assumes a Helm install with no Grafana or Prometheus.
While that is possible, we want to not be so in the business of managing Grafana and
Prometheus best practices in this repository.
Most of materialize-terraform-self-managed already supports standing up Grafana and Prometheus
leaving a lot of this to not be super interesting.

### Description

This updates prometheus.yml to [a better scrapeconfig](https://materializeinc.github.io/materialize-monitoring/metrics/scraping/) since this is downloaded by default by materialize-terraform-self-managed implicitly.
Provide updated documentation for managing in materialize-terraform-self-managed.
Establish up-front baseline assumptions.
Link to more advanced documentation for now.

### Verification

(cd docs/user; hugo server)
