### PR TITLE
sql: Fix panic on duplicate positional GROUP BY keys

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2382,14 +2382,24 @@ fn plan_select_from_where(
             let (group_expr, expr) = plan_group_by_expr(ecx, group_expr, &projection)?;
             let new_column = group_key.len();
 
-            if let Some(group_expr) = group_expr {
-                // Multiple AST expressions can map to the same HIR expression.
-                // If we already have a ScopeItem for this HIR, we can add this
-                // next AST expression to its set
-                if let Some(existing_scope_item) = group_exprs.get_mut(&expr) {
+            // Multiple AST expressions can map to the same HIR expression, e.g.
+            // `GROUP BY 1, 1` or `GROUP BY a, 1` where the positional reference
+            // `1` resolves to the same column as `a`. When we already have a
+            // ScopeItem for this HIR expression we must deduplicate: skip adding
+            // a second group key for it. We must not gate this on `group_expr`
+            // being `Some`, because a positional reference to an input column
+            // (e.g. `GROUP BY 1`) has no AST expression to record yet still
+            // needs to dedup against the existing key; gating on `Some` here is
+            // what made `GROUP BY 1, 1` panic on the `group_hir_exprs.len() ==
+            // group_exprs.len()` assertion below.
+            if let Some(existing_scope_item) = group_exprs.get_mut(&expr) {
+                // If this AST expression is a named expression (not a bare
+                // positional reference), record it on the existing ScopeItem so
+                // name resolution can find it.
+                if let Some(group_expr) = group_expr {
                     existing_scope_item.exprs.insert(group_expr.clone());
-                    continue;
                 }
+                continue;
             }
 
             let mut scope_item = if let HirScalarExpr::Column(

--- a/test/sqllogictest/select_all_group_by.slt
+++ b/test/sqllogictest/select_all_group_by.slt
@@ -31,6 +31,37 @@ SELECT *, count(*) FROM foo GROUP BY a, a, a + 1
 ----
 37 1
 
+# Regression test for duplicate GROUP BY keys via positional references.
+# `GROUP BY 1, 1` (and `GROUP BY a, 1` etc.) used to panic the planner because
+# positional references to input columns skipped group-key deduplication. See
+# database-issues#11286.
+query II
+SELECT *, count(*) FROM foo GROUP BY 1, 1
+----
+37 1
+
+query II
+SELECT *, count(*) FROM foo GROUP BY a, 1
+----
+37 1
+
+query II
+SELECT *, count(*) FROM foo GROUP BY 1, a
+----
+37 1
+
+query II
+SELECT a, count(*) FROM bar GROUP BY 1, 1
+----
+37 2
+
+# A duplicate positional key alongside other distinct keys: the dedup must match
+# a non-trailing group key, not just the most recently added one.
+query III
+SELECT a, b, count(*) FROM bar GROUP BY 1, 2, 1
+----
+37 42 2
+
 query I
 SELECT a FROM foo GROUP BY a, foo.a
 ----


### PR DESCRIPTION
### Motivation

A query that repeats a positional `GROUP BY` reference to an input column, such as `SELECT *, count(*) FROM t GROUP BY 1, 1`, panicked the planner on the `group_hir_exprs.len() == group_exprs.len()` assertion in `plan_select_from_where`.

Fixes SQL-238

### Description

The GROUP BY loop in `plan_select_from_where` deduplicates keys that map to the same HIR expression, but the dedup check was gated on the AST expression being present (`Some`). `plan_group_by_expr` returns `None` for a positional reference to a bare input column, so a duplicate positional key (e.g. the second `1` in `GROUP BY 1, 1`, or the `1` in `GROUP BY a, 1`) skipped the dedup path: the HIR expr was pushed onto the `group_hir_exprs` Vec twice while the `group_exprs` map deduplicated it, tripping the length assertion.

The fix runs the dedup lookup unconditionally and only records the AST expression on the existing scope item when one is actually present (i.e. for named expressions, not bare positional references).

### Verification

Added regression tests to `test/sqllogictest/select_all_group_by.slt` covering `GROUP BY 1, 1`, `GROUP BY a, 1`, `GROUP BY 1, a`, and a multi-row `GROUP BY 1, 1`. The first three panicked before this change.

### Release notes

This release fixes a panic when a `GROUP BY` clause repeated a positional column reference, such as `GROUP BY 1, 1`.