### PR TITLE
sql-parser: Fix `IS [NOT] DISTINCT FROM` precedence vs AND/OR

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1241,7 +1241,17 @@ impl<'a> Parser<'a> {
                                 UNKNOWN => IsExprConstruct::Unknown,
                                 DISTINCT => {
                                     self.expect_keyword(FROM)?;
-                                    let expr = self.parse_expr()?;
+                                    // Parse the right-hand side at the
+                                    // precedence of the `IS` operator we are in
+                                    // the middle of, not at `Precedence::Zero`.
+                                    // Otherwise we greedily pull a trailing
+                                    // `AND`/`OR` into the RHS and parse `a IS
+                                    // DISTINCT FROM b AND c` as `a IS DISTINCT
+                                    // FROM (b AND c)`. `IS DISTINCT FROM` binds
+                                    // tighter than `AND`/`OR` (and looser than
+                                    // comparison and arithmetic), matching
+                                    // PostgreSQL.
+                                    let expr = self.parse_subexpr(precedence)?;
                                     IsExprConstruct::DistinctFrom(Box::new(expr))
                                 }
                                 _ => unreachable!(),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1231,31 +1231,31 @@ impl<'a> Parser<'a> {
                     if let Some(construct) =
                         self.parse_one_of_keywords(&[NULL, TRUE, FALSE, UNKNOWN, DISTINCT])
                     {
+                        let construct = match construct {
+                            NULL => IsExprConstruct::Null,
+                            TRUE => IsExprConstruct::True,
+                            FALSE => IsExprConstruct::False,
+                            UNKNOWN => IsExprConstruct::Unknown,
+                            DISTINCT => {
+                                self.expect_keyword(FROM)?;
+                                // Parse the right-hand side at the precedence of
+                                // the `IS` operator we are in the middle of, not
+                                // at `Precedence::Zero`. Otherwise we greedily
+                                // pull a trailing `AND`/`OR` into the RHS and
+                                // parse `a IS DISTINCT FROM b AND c` as `a IS
+                                // DISTINCT FROM (b AND c)`. `IS DISTINCT FROM`
+                                // binds tighter than `AND`/`OR` (and looser than
+                                // comparison and arithmetic), matching
+                                // PostgreSQL.
+                                let expr = self.parse_subexpr(precedence)?;
+                                IsExprConstruct::DistinctFrom(Box::new(expr))
+                            }
+                            _ => unreachable!(),
+                        };
                         Ok(Expr::IsExpr {
                             expr: Box::new(expr),
                             negated,
-                            construct: match construct {
-                                NULL => IsExprConstruct::Null,
-                                TRUE => IsExprConstruct::True,
-                                FALSE => IsExprConstruct::False,
-                                UNKNOWN => IsExprConstruct::Unknown,
-                                DISTINCT => {
-                                    self.expect_keyword(FROM)?;
-                                    // Parse the right-hand side at the
-                                    // precedence of the `IS` operator we are in
-                                    // the middle of, not at `Precedence::Zero`.
-                                    // Otherwise we greedily pull a trailing
-                                    // `AND`/`OR` into the RHS and parse `a IS
-                                    // DISTINCT FROM b AND c` as `a IS DISTINCT
-                                    // FROM (b AND c)`. `IS DISTINCT FROM` binds
-                                    // tighter than `AND`/`OR` (and looser than
-                                    // comparison and arithmetic), matching
-                                    // PostgreSQL.
-                                    let expr = self.parse_subexpr(precedence)?;
-                                    IsExprConstruct::DistinctFrom(Box::new(expr))
-                                }
-                                _ => unreachable!(),
-                            },
+                            construct,
                         })
                     } else {
                         self.expected(

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -148,6 +148,21 @@ error: Expected FROM, found NOT
                   ^
 
 parse-scalar
+a IS DISTINCT FROM b AND c
+----
+And { left: IsExpr { expr: Identifier([Ident("a")]), construct: DistinctFrom(Identifier([Ident("b")])), negated: false }, right: Identifier([Ident("c")]) }
+
+parse-scalar
+a IS NOT DISTINCT FROM b OR c
+----
+Or { left: IsExpr { expr: Identifier([Ident("a")]), construct: DistinctFrom(Identifier([Ident("b")])), negated: true }, right: Identifier([Ident("c")]) }
+
+parse-scalar
+a IS DISTINCT FROM b + c
+----
+IsExpr { expr: Identifier([Ident("a")]), construct: DistinctFrom(Op { op: Op { namespace: None, op: "+" }, expr1: Identifier([Ident("b")]), expr2: Some(Identifier([Ident("c")])) }), negated: false }
+
+parse-scalar
 a ~ 'foo'
 ----
 Op { op: Op { namespace: None, op: "~" }, expr1: Identifier([Ident("a")]), expr2: Some(Value(String("foo"))) }

--- a/test/sqllogictest/distinct_from.slt
+++ b/test/sqllogictest/distinct_from.slt
@@ -121,3 +121,55 @@ CREATE TABLE t0(c0 INT , c1 BOOLEAN );
 
 statement error operator does not exist: boolean <> double precision
 SELECT t0.c0, t0.c1 FROM t0 INNER  JOIN  (SELECT CBRT(t0.c0) AS col0 FROM t0) AS sub0  ON ((true)IS NOT DISTINCT FROM(sub0.col0)) WHERE t0.c1 ORDER BY (NOT t0.c1) ASC;
+
+# Regression test for SQL-236: `IS [NOT] DISTINCT FROM` must bind tighter than
+# `AND`/`OR`, so a trailing boolean connective is not pulled into the RHS.
+# `a IS DISTINCT FROM b AND c` parses as `(a IS DISTINCT FROM b) AND c`,
+# matching PostgreSQL.
+
+statement ok
+CREATE TABLE idf_bug (flag boolean, active boolean)
+
+statement ok
+INSERT INTO idf_bug VALUES (true, true), (false, true), (NULL, true), (true, false)
+
+# AND must not be consumed into the RHS: equivalent to
+# (flag IS DISTINCT FROM false) AND (active = true).
+query BB rowsort
+SELECT flag, active FROM idf_bug WHERE flag IS DISTINCT FROM false AND active = true
+----
+NULL  true
+true  true
+
+# OR must not be consumed into the RHS: equivalent to
+# (flag IS DISTINCT FROM false) OR (active = false).
+query BB rowsort
+SELECT flag, active FROM idf_bug WHERE flag IS DISTINCT FROM false OR active = false
+----
+NULL  true
+true  false
+true  true
+
+# Explicit parens produce the same results as the unparenthesized forms above.
+query BB rowsort
+SELECT flag, active FROM idf_bug WHERE (flag IS DISTINCT FROM false) AND (active = true)
+----
+NULL  true
+true  true
+
+query BB rowsort
+SELECT flag, active FROM idf_bug WHERE (flag IS DISTINCT FROM false) OR (active = false)
+----
+NULL  true
+true  false
+true  true
+
+# Comparison and arithmetic still bind tighter than IS DISTINCT FROM, so they
+# are consumed into the RHS (matching PostgreSQL).
+query B
+SELECT 3 IS DISTINCT FROM 1 + 2
+----
+false
+
+statement ok
+DROP TABLE idf_bug


### PR DESCRIPTION
### Motivation

Fixes SQL-236.

The right-hand side of `IS [NOT] DISTINCT FROM` was parsed at
`Precedence::Zero`, the lowest precedence, so the parser greedily pulled a
trailing `AND`/`OR` into the RHS. `a IS DISTINCT FROM b AND c` parsed as
`a IS DISTINCT FROM (b AND c)` instead of `(a IS DISTINCT FROM b) AND c`,
silently producing wrong results for any predicate combining
`IS [NOT] DISTINCT FROM` with a following boolean connective.

### Description

Parse the RHS of `IS [NOT] DISTINCT FROM` at the precedence of the `IS`
operator (`self.parse_subexpr(precedence)`) rather than `parse_expr()`
(`Precedence::Zero`). With that precedence:

- `AND`/`OR` (lower precedence) are left for the surrounding expression, so
  they are no longer absorbed into the RHS.
- comparison and arithmetic operators (higher precedence) are still consumed
  into the RHS, unchanged.

This matches PostgreSQL, where `IS DISTINCT FROM` binds tighter than
`AND`/`OR` but looser than comparison/arithmetic.

### Verification

- New `mz-sql-parser` datadriven cases (`src/sql-parser/tests/testdata/scalar`)
  assert the parse tree for `a IS DISTINCT FROM b AND c`,
  `a IS NOT DISTINCT FROM b OR c`, and `a IS DISTINCT FROM b + c`.
- New sqllogictest regression cases in `test/sqllogictest/distinct_from.slt`
  cover the exact queries from the report and assert the unparenthesized forms
  now match the explicitly-parenthesized ones.
- Expected results were cross-checked against PostgreSQL 16 (the same queries
  return the same rows there).