### PR TITLE
Mark idempotent FoundationDB transactions as retryable

### DIFF
--- a/src/timestamp-oracle/src/foundationdb_oracle.rs
+++ b/src/timestamp-oracle/src/foundationdb_oracle.rs
@@ -234,7 +234,10 @@ impl<N: Sync> FdbTimestampOracle<N> {
             .transact_boxed(
                 &(),
                 |trx, ()| self.max_rs_trx(trx).boxed(),
-                TransactOption::default(),
+                // This transaction is a pure read, so it is safe to retry on a
+                // `commit_unknown_result` ("transaction may or may not have
+                // committed") error.
+                TransactOption::idempotent(),
             )
             .await?;
         Ok(max_ts)
@@ -482,7 +485,12 @@ where
                     .transact_boxed(
                         &proposed_next_ts,
                         |trx, proposed_next_ts| self.write_ts_trx(trx, **proposed_next_ts).boxed(),
-                        TransactOption::default(),
+                        // Safe to retry on a `commit_unknown_result` error: the
+                        // transaction re-reads `write_ts` and hands out
+                        // `max(write_ts + 1, proposed_next_ts)`, so a retry only
+                        // ever advances the timestamp further, preserving
+                        // monotonicity (it may skip a timestamp, which is fine).
+                        TransactOption::idempotent(),
                     )
                     .await
                     .map_err(anyhow::Error::from)
@@ -515,7 +523,8 @@ where
                     .transact_boxed(
                         &(),
                         |trx, ()| self.peek_write_ts_trx(trx).boxed(),
-                        TransactOption::default(),
+                        // Pure read, safe to retry on `commit_unknown_result`.
+                        TransactOption::idempotent(),
                     )
                     .await
                     .map_err(anyhow::Error::from)?
@@ -544,7 +553,8 @@ where
                     .transact_boxed(
                         &(),
                         |trx, ()| self.read_ts_trx(trx).boxed(),
-                        TransactOption::default(),
+                        // Pure read, safe to retry on `commit_unknown_result`.
+                        TransactOption::idempotent(),
                     )
                     .await
                     .map_err(anyhow::Error::from)?
@@ -576,7 +586,12 @@ where
                     .transact_boxed(
                         &write_ts,
                         |trx, write_ts| self.apply_write_trx(trx, **write_ts).boxed(),
-                        TransactOption::default(),
+                        // `apply_write_trx` only bumps `read_ts`/`write_ts` to
+                        // `GREATEST(current, write_ts)`, so it is idempotent and
+                        // safe to retry on a `commit_unknown_result` ("transaction
+                        // may or may not have committed") error rather than
+                        // panicking. This is the failure observed in PER-25.
+                        TransactOption::idempotent(),
                     )
                     .await
                     .map_err(anyhow::Error::from)


### PR DESCRIPTION
### Motivation

FoundationDB transactions can fail with a `commit_unknown_result` error, indicating the transaction may or may not have committed. Currently, all transactions in the timestamp oracle use `TransactOption::default()`, which causes these errors to propagate as failures rather than being retried.

Several transactions in the timestamp oracle are idempotent and safe to retry on this error:
- Read-only transactions (they have no side effects)
- Transactions that use `GREATEST()` to monotonically advance values (retries only move the value further forward)

This change improves reliability by allowing safe retries instead of failures.

Closes PER-25.

### Description

Updated four transaction sites in `src/timestamp-oracle/src/foundationdb_oracle.rs` to use `TransactOption::idempotent()` instead of `TransactOption::default()`:

1. **`max_read_ts()`** — Pure read transaction, safe to retry
2. **`write_ts()` in `TimestampOracle::next()`** — Uses `max(write_ts + 1, proposed_next_ts)`, so retries only advance the timestamp further while preserving monotonicity
3. **`peek_write_ts()`** — Pure read transaction, safe to retry
4. **`read_ts()`** — Pure read transaction, safe to retry
5. **`apply_write()`** — Uses `GREATEST(current, write_ts)` to bump values, making it idempotent; retries cannot cause regression

Each change includes a comment explaining why the transaction is safe to retry on `commit_unknown_result` errors.

### Verification

No new tests added — this change improves error handling for existing transaction patterns. The idempotency properties are documented in the code comments and follow from the transaction logic (read-only operations and monotonic value updates via `GREATEST()`).

https://claude.ai/code/session_012DArBrNjtGVVBSdTomhsuF