### PR TITLE
Fix panic when parsing IDs with multi-byte leading characters

### DIFF
--- a/src/repr/src/catalog_item_id.rs
+++ b/src/repr/src/catalog_item_id.rs
@@ -73,7 +73,7 @@ impl FromStr for CatalogItemId {
             return Err(anyhow!("couldn't parse id {}", s));
         }
         let tag = s.chars().next().unwrap();
-        s = &s[1..];
+        s = &s[tag.len_utf8()..];
         let variant = match tag {
             's' => {
                 if Some('i') == s.chars().next() {
@@ -145,5 +145,17 @@ mod tests {
         proptest!(|(id in any::<CatalogItemId>())| {
             testcase(id);
         })
+    }
+
+    #[mz_ore::test]
+    fn test_catalog_item_id_from_str_non_ascii() {
+        // Regression test for a panic on multi-byte leading characters, where
+        // slicing off a single byte landed inside a UTF-8 char boundary (SQL-195).
+        for invalid in ["ü1", "ü", "é42", "🦀7", ""] {
+            assert!(
+                invalid.parse::<CatalogItemId>().is_err(),
+                "expected {invalid:?} to fail to parse"
+            );
+        }
     }
 }

--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -88,7 +88,7 @@ impl FromStr for GlobalId {
             return Ok(GlobalId::Explain);
         }
         let tag = s.chars().next().unwrap();
-        s = &s[1..];
+        s = &s[tag.len_utf8()..];
         let variant = match tag {
             's' => {
                 if Some('i') == s.chars().next() {
@@ -133,5 +133,37 @@ impl TransientIdGen {
     pub fn allocate_id(&self) -> (CatalogItemId, GlobalId) {
         let inner = self.0.allocate_id();
         (CatalogItemId::Transient(inner), GlobalId::Transient(inner))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[mz_ore::test]
+    fn proptest_global_id_roundtrips() {
+        fn testcase(og: GlobalId) {
+            let s = og.to_string();
+            let rnd: GlobalId = s.parse().unwrap();
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(id in any::<GlobalId>())| {
+            testcase(id);
+        })
+    }
+
+    #[mz_ore::test]
+    fn test_global_id_from_str_non_ascii() {
+        // Regression test for a panic on multi-byte leading characters, where
+        // slicing off a single byte landed inside a UTF-8 char boundary (SQL-195).
+        for invalid in ["ü1", "ü", "é42", "🦀7", ""] {
+            assert!(
+                invalid.parse::<GlobalId>().is_err(),
+                "expected {invalid:?} to fail to parse"
+            );
+        }
     }
 }

--- a/src/sql-parser/tests/testdata/id
+++ b/src/sql-parser/tests/testdata/id
@@ -76,3 +76,14 @@ CREATE VIEW "materialize"."public"."v3" AS SELECT * FROM [u1 AS "materialize"."p
 error: Expected literal unsigned integer, found operator "-"
 CREATE VIEW "materialize"."public"."v3" AS SELECT * FROM [u1 AS "materialize"."public"."t1" VERSION -101]
                                                                                                     ^
+
+# An id with a multi-byte leading character parses fine; it is name resolution
+# that rejects it as an invalid id. Previously this id panicked the server while
+# resolving the name because `CatalogItemId::from_str` sliced off a single byte,
+# landing inside the multi-byte char (SQL-195).
+parse-statement
+SELECT * FROM [ü1 AS materialize.public.foo]
+----
+SELECT * FROM [ü1 AS materialize.public.foo]
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("ü1", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")]), None), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -947,21 +947,16 @@ impl FromStr for SchemaId {
     type Err = PlanError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() < 2 {
-            return Err(PlanError::Unstructured(format!(
-                "couldn't parse SchemaId {}",
-                s
-            )));
-        }
-        let val: u64 = s[1..].parse()?;
-        match s.chars().next() {
-            Some('s') => Ok(SchemaId::System(val)),
-            Some('u') => Ok(SchemaId::User(val)),
-            _ => Err(PlanError::Unstructured(format!(
-                "couldn't parse SchemaId {}",
-                s
-            ))),
-        }
+        let err = || PlanError::Unstructured(format!("couldn't parse SchemaId {}", s));
+        // Validate the (single-byte, ASCII) tag before slicing so that a
+        // multi-byte leading character doesn't slice inside a UTF-8 boundary.
+        let variant = match s.chars().next() {
+            Some('s') => SchemaId::System,
+            Some('u') => SchemaId::User,
+            _ => return Err(err()),
+        };
+        let val: u64 = s[1..].parse().map_err(|_| err())?;
+        Ok(variant(val))
     }
 }
 
@@ -1007,21 +1002,16 @@ impl FromStr for DatabaseId {
     type Err = PlanError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() < 2 {
-            return Err(PlanError::Unstructured(format!(
-                "couldn't parse DatabaseId {}",
-                s
-            )));
-        }
-        let val: u64 = s[1..].parse()?;
-        match s.chars().next() {
-            Some('s') => Ok(DatabaseId::System(val)),
-            Some('u') => Ok(DatabaseId::User(val)),
-            _ => Err(PlanError::Unstructured(format!(
-                "couldn't parse DatabaseId {}",
-                s
-            ))),
-        }
+        let err = || PlanError::Unstructured(format!("couldn't parse DatabaseId {}", s));
+        // Validate the (single-byte, ASCII) tag before slicing so that a
+        // multi-byte leading character doesn't slice inside a UTF-8 boundary.
+        let variant = match s.chars().next() {
+            Some('s') => DatabaseId::System,
+            Some('u') => DatabaseId::User,
+            _ => return Err(err()),
+        };
+        let val: u64 = s[1..].parse().map_err(|_| err())?;
+        Ok(variant(val))
     }
 }
 
@@ -2579,6 +2569,69 @@ impl<'ast> Visit<'ast, Raw> for IdDependencVisitor {
                     self.error = Some(e);
                 }
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[mz_ore::test]
+    fn proptest_schema_id_roundtrips() {
+        fn testcase(og: SchemaId) {
+            let s = og.to_string();
+            let rnd: SchemaId = s.parse().unwrap();
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(id in any::<SchemaId>())| {
+            testcase(id);
+        })
+    }
+
+    #[mz_ore::test]
+    fn proptest_database_id_roundtrips() {
+        fn testcase(og: DatabaseId) {
+            let s = og.to_string();
+            let rnd: DatabaseId = s.parse().unwrap();
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(id in any::<DatabaseId>())| {
+            testcase(id);
+        })
+    }
+
+    #[mz_ore::test]
+    fn test_schema_id_from_str() {
+        assert_eq!("s5".parse::<SchemaId>().unwrap(), SchemaId::System(5));
+        assert_eq!("u5".parse::<SchemaId>().unwrap(), SchemaId::User(5));
+
+        // Regression test for a panic on multi-byte leading characters, where
+        // slicing off a single byte landed inside a UTF-8 char boundary (SQL-195).
+        for invalid in ["ü1", "ü", "é42", "🦀7", "", "x1", "s"] {
+            assert!(
+                invalid.parse::<SchemaId>().is_err(),
+                "expected {invalid:?} to fail to parse"
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_database_id_from_str() {
+        assert_eq!("s5".parse::<DatabaseId>().unwrap(), DatabaseId::System(5));
+        assert_eq!("u5".parse::<DatabaseId>().unwrap(), DatabaseId::User(5));
+
+        // Regression test for a panic on multi-byte leading characters, where
+        // slicing off a single byte landed inside a UTF-8 char boundary (SQL-195).
+        for invalid in ["ü1", "ü", "é42", "🦀7", "", "x1", "u"] {
+            assert!(
+                invalid.parse::<DatabaseId>().is_err(),
+                "expected {invalid:?} to fail to parse"
+            );
         }
     }
 }

--- a/src/storage-types/src/instances.rs
+++ b/src/storage-types/src/instances.rs
@@ -13,6 +13,10 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::bail;
+#[cfg(any(test, feature = "proptest"))]
+use proptest::arbitrary::Arbitrary;
+#[cfg(any(test, feature = "proptest"))]
+use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -83,15 +87,15 @@ impl FromStr for StorageInstanceId {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() < 2 {
-            bail!("couldn't parse compute instance id {}", s);
-        }
-        let val: u64 = s[1..].parse()?;
-        match s.chars().next().unwrap() {
-            's' => Ok(Self::System(val)),
-            'u' => Ok(Self::User(val)),
+        // Validate the (single-byte, ASCII) tag before slicing so that a
+        // multi-byte leading character doesn't slice inside a UTF-8 boundary.
+        let variant = match s.chars().next() {
+            Some('s') => Self::System,
+            Some('u') => Self::User,
             _ => bail!("couldn't parse compute instance id {}", s),
-        }
+        };
+        let val: u64 = s[1..].parse()?;
+        Ok(variant(val))
     }
 }
 
@@ -100,6 +104,71 @@ impl fmt::Display for StorageInstanceId {
         match self {
             Self::System(id) => write!(f, "s{}", id),
             Self::User(id) => write!(f, "u{}", id),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "proptest"))]
+impl Arbitrary for StorageInstanceId {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<StorageInstanceId>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // The inner id must fit in 48 bits: the top 16 are reserved because the
+        // id gets packed into `mz_repr::GlobalId::IntrospectionSourceIndex` (see
+        // `Self::new`). Only generate ids in that valid range so we never produce
+        // an instance that couldn't actually be allocated. Build the variants
+        // directly rather than via `Self::system`/`Self::user` to avoid their
+        // soft "running out of IDs" warning firing during tests.
+        (proptest::arbitrary::any::<bool>(), 0u64..(1 << 48))
+            .prop_map(|(is_system, id)| {
+                if is_system {
+                    StorageInstanceId::System(id)
+                } else {
+                    StorageInstanceId::User(id)
+                }
+            })
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[mz_ore::test]
+    fn proptest_storage_instance_id_roundtrips() {
+        fn testcase(og: StorageInstanceId) {
+            let s = og.to_string();
+            let rnd: StorageInstanceId = s.parse().unwrap();
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(id in any::<StorageInstanceId>())| {
+            testcase(id);
+        })
+    }
+
+    #[mz_ore::test]
+    fn test_storage_instance_id_from_str() {
+        assert_eq!(
+            "s5".parse::<StorageInstanceId>().unwrap(),
+            StorageInstanceId::System(5)
+        );
+        assert_eq!(
+            "u5".parse::<StorageInstanceId>().unwrap(),
+            StorageInstanceId::User(5)
+        );
+
+        // Regression test for a panic on multi-byte leading characters, where
+        // slicing off a single byte landed inside a UTF-8 char boundary (SQL-195).
+        for invalid in ["ü1", "ü", "é42", "🦀7", "", "x1", "u"] {
+            assert!(
+                invalid.parse::<StorageInstanceId>().is_err(),
+                "expected {invalid:?} to fail to parse"
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes SQL-195.

`FromStr` for `CatalogItemId`, `GlobalId`, `SchemaId`, `DatabaseId`, and `StorageInstanceId` sliced off the leading tag byte before validating it, so a multi-byte leading character (e.g. `SELECT * FROM [ü1 AS ...]`) sliced inside a UTF-8 boundary and panicked the worker. Validate the ASCII tag first, or advance by its UTF-8 length, so malformed IDs return a parse error instead.

It also adds a bunch of tests.
