### PR TITLE
sql: Return graceful error for invalid id in type references

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -18,7 +18,6 @@ use std::sync::LazyLock;
 use anyhow::anyhow;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::LocalId;
-use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_repr::network_policy_id::NetworkPolicyId;
@@ -1413,9 +1412,14 @@ impl<'a> NameResolver<'a> {
                     }
                     RawItemName::Id(id, name, version) => {
                         let id: CatalogItemId = id.parse()?;
-                        let item = self.catalog.get_item(&id);
+                        let item = match self.catalog.try_get_item(&id) {
+                            Some(item) => item,
+                            None => return Err(PlanError::InvalidId(id)),
+                        };
                         let full_name = normalize::full_name(name)?;
-                        assert_none!(version, "no support for versioning data types");
+                        if version.is_some() {
+                            sql_bail!("specifying a version for a type reference is not supported");
+                        }
 
                         (full_name, item)
                     }

--- a/test/sqllogictest/id.slt
+++ b/test/sqllogictest/id.slt
@@ -60,6 +60,15 @@ SELECT y.a FROM [xx AS materialize.public.y]
 statement error invalid digit
 SELECT y.a FROM [ux AS materialize.public.y]
 
+# Regression test for SQL-200: a non-existent id used as a data type must
+# produce a graceful error instead of panicking environmentd.
+statement error invalid id
+CREATE TABLE bad_type (x [u100 AS materialize.public.foo])
+
+# A version specifier on a type reference must error gracefully, not panic.
+statement error specifying a version for a type reference is not supported
+CREATE TABLE bad_type (x [u1 AS materialize.public.x VERSION 5])
+
 statement ok
 CREATE VIEW foo AS SELECT * FROM x
 


### PR DESCRIPTION
### Motivation

Resolving a data type given by id --- the `[<id> AS <name>]` form, e.g.
`CREATE TABLE t (x [u1 AS materialize.public.foo VERSION 5])` --- panicked
`environmentd` instead of returning an error to the user:

```
thread 'tokio:work-3' panicked at src/adapter/src/catalog/state.rs:751:32:
catalog out of sync, missing id User(1)
```

Both failure modes are reachable from plain user input, so they should be
graceful errors, not panics.

Fixes SQL-200

### Description

In `NameResolver::resolve_data_type` (`src/sql/src/names.rs`), the
`RawItemName::Id` arm did two things that panic on bad input:

- it called the panicking `Catalog::get_item`, which aborts with "catalog out
  of sync" when the id does not exist;
- it asserted (`assert_none!`) that no `VERSION` was specified.

Both now resolve to a `PlanError` instead: a missing id returns
`PlanError::InvalidId` (displayed as `invalid id ...`), and a `VERSION`
specifier returns `specifying a version for a type reference is not
supported`. This mirrors how item-name-by-id resolution
(`resolve_item_name_id`) already handles a missing id via `try_get_item`.

### Verification

Added regression tests to `test/sqllogictest/id.slt` exercising the data-type
position specifically: a non-existent id (`[u100 AS materialize.public.foo]`)
now errors with `invalid id`, and a version specifier
(`[u1 AS materialize.public.x VERSION 5]`) errors gracefully. Both previously
panicked `environmentd`.
