### PR TITLE
sql: Reject unsupported COPY FROM URL/S3 formats in planning

### DIFF
--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -1951,7 +1951,7 @@ fn plan_copy_from(
     target: &CopyTarget<Aug>,
     table_name: ResolvedItemName,
     columns: Vec<Ident>,
-    format: CopyFormat,
+    format: Option<CopyFormat>,
     options: CopyOptionExtracted,
 ) -> Result<Plan, PlanError> {
     fn only_available_with_csv<T>(option: Option<T>, param: &str) -> Result<(), PlanError> {
@@ -2000,6 +2000,20 @@ fn plan_copy_from(
             }
         }
         CopyTarget::Stdout => bail_never_supported!("COPY FROM {} not supported", target),
+    };
+
+    // COPY FROM a URL or S3 bucket only supports CSV and Parquet. Unlike COPY
+    // FROM STDIN there's no sensible default format, so one must be specified
+    // explicitly. Reject unsupported formats here in planning; the coordinator
+    // relies on this and would otherwise soft-panic.
+    let format = match &source {
+        CopyFromSource::Stdin => format.unwrap_or(CopyFormat::Text),
+        CopyFromSource::Url(_) | CopyFromSource::AwsS3 { .. } => match format {
+            None => sql_bail!("COPY FROM <expr> requires a FORMAT option"),
+            Some(CopyFormat::Text) => bail_unsupported!("FORMAT TEXT"),
+            Some(CopyFormat::Binary) => bail_unsupported!("FORMAT BINARY"),
+            Some(format @ (CopyFormat::Csv | CopyFormat::Parquet)) => format,
+        },
     };
 
     let params = match format {
@@ -2148,14 +2162,9 @@ pub fn plan_copy(
             }
         }
         (CopyDirection::From, target) => match relation {
-            CopyRelation::Named { name, columns } => plan_copy_from(
-                scx,
-                target,
-                name,
-                columns,
-                format.unwrap_or(CopyFormat::Text),
-                options,
-            ),
+            CopyRelation::Named { name, columns } => {
+                plan_copy_from(scx, target, name, columns, format, options)
+            }
             _ => sql_bail!("COPY FROM {} not supported", target),
         },
         (CopyDirection::To, CopyTarget::Expr(to_expr)) => {

--- a/test/testdrive/copy-from-s3-minio.td
+++ b/test/testdrive/copy-from-s3-minio.td
@@ -91,6 +91,15 @@ contains:did not match desc
 100 none 1.11 <null>
 100 none 1.11 <null>
 
+# COPY FROM <url>/S3 only supports CSV and Parquet: TEXT — including the
+# implicit default when no FORMAT is given — must be rejected at planning
+# rather than soft-panicking in the coordinator.
+! COPY INTO t1 FROM '${1_csv_url}';
+contains:COPY FROM <expr> requires a FORMAT option
+
+! COPY INTO t1 FROM '${1_csv_url}' WITH (FORMAT = 'text');
+contains:FORMAT TEXT not yet supported
+
 # gzip Compression.
 
 $ s3-file-upload bucket=copytos3 key=csv/2.csv.gz repeat=2 compression=gzip
@@ -220,6 +229,10 @@ zstd 500
 > SELECT * FROM t4;
 none 100
 none 100
+
+# The S3 source must reject TEXT at planning time too.
+! COPY INTO t4 FROM 's3://copytos3/csv' (FORMAT = 'text', AWS CONNECTION = aws_conn, FILES = ["csv/1.csv"]);
+contains:FORMAT TEXT not yet supported
 
 # Test pagination: upload >1000 objects to force multiple ListObjectsV2 pages.
 


### PR DESCRIPTION
COPY FROM a URL or S3 source only supports CSV and Parquet, but the format was never validated against the source during planning. The format defaulted to TEXT when omitted, so both `COPY FROM <url>` with no FORMAT and an explicit `FORMAT text`/`binary` produced a plan that the coordinator could not execute, tripping a soft-panic in sequence_copy_from.

Validate the format against the source in plan_copy_from: STDIN keeps its TEXT default, while URL/S3 sources now require an explicit FORMAT and reject TEXT/BINARY with a clear planning error. COPY FROM STDIN and both COPY TO directions are unaffected.

Adds testdrive coverage to copy-from-s3-minio.td for the formatless URL, explicit TEXT URL, and explicit TEXT S3 cases.