### PR TITLE
sql: Don't panic when a to-text cast needs a disallowed subquery

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2026,7 +2026,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                         SqlScalarType::Char { length } => {
                             expr.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         }
-                        _ => typeconv::to_string(ecx, expr)
+                        _ => typeconv::to_string(ecx, expr)?
                     });
                 }
                 Ok(HirScalarExpr::call_variadic(variadic::Concat, exprs))
@@ -2052,7 +2052,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                         SqlScalarType::Char { length } => {
                             expr.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         }
-                        _ => typeconv::to_string(ecx, expr)
+                        _ => typeconv::to_string(ecx, expr)?
                     });
                 }
                 Ok(HirScalarExpr::call_variadic(variadic::ConcatWs, exprs))
@@ -2395,7 +2395,10 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
             params!(Any...) => Operation::variadic(|ecx, exprs| {
                 Ok(HirScalarExpr::call_variadic(
                     variadic::JsonbBuildArray,
-                    exprs.into_iter().map(|e| typeconv::to_jsonb(ecx, e)).collect(),
+                    exprs
+                        .into_iter()
+                        .map(|e| typeconv::to_jsonb(ecx, e))
+                        .collect::<Result<Vec<_>, _>>()?,
                 ))
             }) => Jsonb, 3271;
         },
@@ -2405,13 +2408,12 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 if exprs.len() % 2 != 0 {
                     sql_bail!("argument list must have even number of elements")
                 }
-                Ok(HirScalarExpr::call_variadic(
-                    variadic::JsonbBuildObject,
-                    exprs.into_iter().tuples().map(|(key, val)| {
-                        let key = typeconv::to_string(ecx, key);
-                        let val = typeconv::to_jsonb(ecx, val);
-                        vec![key, val]
-                    }).flatten().collect()))
+                let mut elems = Vec::with_capacity(exprs.len());
+                for (key, val) in exprs.into_iter().tuples() {
+                    elems.push(typeconv::to_string(ecx, key)?);
+                    elems.push(typeconv::to_jsonb(ecx, val)?);
+                }
+                Ok(HirScalarExpr::call_variadic(variadic::JsonbBuildObject, elems))
             }) => Jsonb, 3273;
         },
         "jsonb_pretty" => Scalar {
@@ -3111,7 +3113,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                     }
                     _ => e,
                 };
-                Ok(typeconv::to_jsonb(ecx, e))
+                typeconv::to_jsonb(ecx, e)
             }) => Jsonb, 3787;
         },
         "to_timestamp" => Scalar {
@@ -3753,7 +3755,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 let json_null = HirScalarExpr::literal(Datum::JsonNull, SqlScalarType::Jsonb);
                 let e = HirScalarExpr::call_variadic(
                     variadic::Coalesce,
-                    vec![typeconv::to_jsonb(ecx, e), json_null],
+                    vec![typeconv::to_jsonb(ecx, e)?, json_null],
                 );
                 Ok((e, AggregateFunc::JsonbAgg { order_by }))
             }) => Jsonb, 3267;
@@ -3775,7 +3777,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 };
 
                 let json_null = HirScalarExpr::literal(Datum::JsonNull, SqlScalarType::Jsonb);
-                let key = typeconv::to_string(ecx, key);
+                let key = typeconv::to_string(ecx, key)?;
                 // `AggregateFunc::JsonbObjectAgg` uses the same underlying
                 // implementation as `AggregateFunc::MapAgg`, so it's our
                 // responsibility to apply the JSON-specific behavior of casting
@@ -3784,7 +3786,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 // `SqlScalarType::Jsonb` type.
                 let val = HirScalarExpr::call_variadic(
                     variadic::Coalesce,
-                    vec![typeconv::to_jsonb(ecx, val), json_null],
+                    vec![typeconv::to_jsonb(ecx, val)?, json_null],
                 );
                 let e = HirScalarExpr::call_variadic(
                     variadic::RecordCreate {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4578,7 +4578,7 @@ fn plan_subscript_jsonb(
             // Integers are converted to a string here and then re-parsed as an
             // integer by `JsonbGetPath`. Weird, but this is how PostgreSQL says to
             // do it.
-            typeconv::to_string(ecx, subscript)
+            typeconv::to_string(ecx, subscript)?
         } else {
             sql_bail!("jsonb subscript type must be coercible to integer or text");
         };

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -1156,10 +1156,13 @@ fn get_cast(
 
 /// Converts an expression to `SqlScalarType::String`.
 ///
-/// All types are convertible to string, so this never fails.
-pub fn to_string(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
+/// Most types have an explicit cast to string, but a few do not: `mz_aclitem`
+/// has no text cast at all, and the `reg*` casts are implemented as subqueries
+/// that `plan_cast` rejects in contexts that disallow subqueries (e.g. a
+/// `RETURNING` clause or a `to_jsonb` element cast). We surface those as a
+/// planning error rather than panicking.
+pub fn to_string(ecx: &ExprContext, expr: HirScalarExpr) -> Result<HirScalarExpr, PlanError> {
     plan_cast(ecx, CastContext::Explicit, expr, &SqlScalarType::String)
-        .expect("cast known to exist")
 }
 
 /// Converts an expression to `SqlScalarType::Jsonb`.
@@ -1170,12 +1173,13 @@ pub fn to_string(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
 ///   * Records are converted to a JSON object where the record's field names
 ///     are the keys of the object, and the record's fields are recursively
 ///     converted to JSON by `to_jsonb`.
-///   * Other types are converted to strings by their usual cast function an
-//      become JSON strings.
-pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
+///   * Other types are converted to strings by their usual cast function and
+///     become JSON strings. That cast can fail (see `to_string`), in which case
+///     we propagate the planning error instead of panicking.
+pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> Result<HirScalarExpr, PlanError> {
     use SqlScalarType::*;
 
-    match ecx.scalar_type(&expr) {
+    Ok(match ecx.scalar_type(&expr) {
         Bool | Jsonb | Numeric { .. } => {
             expr.call_unary(UnaryFunc::CastJsonbableToJsonb(func::CastJsonbableToJsonb))
         }
@@ -1198,7 +1202,7 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
                     ecx,
                     expr.clone()
                         .call_unary(UnaryFunc::RecordGet(func::RecordGet(i))),
-                ));
+                )?);
             }
             HirScalarExpr::call_variadic(JsonbBuildObject, exprs)
         }
@@ -1222,7 +1226,7 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
 
             // Create an element-casting expression by calling `to_jsonb` on
             // an expression that references the first column in a row.
-            let cast_element = to_jsonb(&ecx, HirScalarExpr::column(0));
+            let cast_element = to_jsonb(&ecx, HirScalarExpr::column(0))?;
             let cast_element = cast_element
                 .lower_uncorrelated(ecx.catalog().system_vars())
                 .expect("to_jsonb does not produce correlated expressions on uncorrelated input");
@@ -1263,9 +1267,9 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
         | MzTimestamp
         | Range { .. }
         | MzAclItem
-        | AclItem => to_string(ecx, expr)
+        | AclItem => to_string(ecx, expr)?
             .call_unary(UnaryFunc::CastJsonbableToJsonb(func::CastJsonbableToJsonb)),
-    }
+    })
 }
 
 /// Guesses the most-common type among a set of [`SqlScalarType`]s that all members

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -2248,3 +2248,16 @@ Source materialize.public.t3
 Target cluster: quickstart
 
 EOF
+
+# Regression test for SQL-269: `to_jsonb` of an array/list converts each element
+# to text. The `mz_aclitem` and `reg*` text casts are implemented as subqueries,
+# which the element-cast context (`allow_subqueries: false`) rejects. This must
+# surface as a graceful planning error rather than panicking environmentd.
+query error to_jsonb does not support casting from mz_aclitem to text
+SELECT to_jsonb(ARRAY[mz_internal.make_mz_aclitem('u1', 'u2', 'USAGE')])
+
+query error to_jsonb does not support casting from mz_aclitem to text
+SELECT jsonb_build_array(ARRAY[mz_internal.make_mz_aclitem('u1', 'u2', 'USAGE')])
+
+query error to_jsonb does not support casting from regclass to text
+SELECT to_jsonb(ARRAY['mz_databases'::regclass])

--- a/test/sqllogictest/regtype.slt
+++ b/test/sqllogictest/regtype.slt
@@ -221,3 +221,18 @@ query T
 SELECT 'array_length'::regtype::text;
 ----
 array_length
+
+# Regression test for SQL-270: the `regtype`->text cast is implemented as a
+# subquery. It works in contexts that allow subqueries (e.g. a plain SELECT)...
+statement ok
+CREATE TABLE regtype_returning (a regtype)
+
+query T
+SELECT concat(a) FROM (VALUES ('date'::regtype)) AS v (a)
+----
+date
+
+# ...but a RETURNING clause does not allow subqueries, so the same cast must
+# produce a graceful planning error there instead of panicking environmentd.
+query error pg_catalog.concat does not support casting from regtype to text
+INSERT INTO regtype_returning VALUES ('date'::regtype) RETURNING concat(a)


### PR DESCRIPTION
### Motivation

Fixes SQL-270
Fixes SQL-269

Several SQLancer/SQLsmith builds hit a coordinator/worker panic:

```
thread 'tokio:work-9' panicked at src/sql/src/plan/typeconv.rs:1162:10:
cast known to exist: InvalidCast { name: "pg_catalog.concat", ccx: Explicit, from: "regtype", to: "text" }
```

`typeconv::to_string` and `to_jsonb` assumed that casting any type to text
always succeeds and called `.expect("cast known to exist")`. That assumption is
wrong: the `mz_aclitem` and `reg*` (`regtype`, `regclass`, ...) text casts are
implemented as catalog subqueries, and `plan_cast` rejects subqueries in
contexts that disallow them -- a `RETURNING` clause, or the element-cast context
of `to_jsonb` on an array/list. The cast returns an error, and `.expect()`
turned that into a panic that crashes the worker. Reachable from plain user
input, e.g.:

```sql
CREATE TABLE t (a regtype);
INSERT INTO t VALUES ('date'::regtype) RETURNING concat(a);   -- SQL-270
SELECT to_jsonb(ARRAY[mz_internal.make_mz_aclitem('u1', 'u2', 'USAGE')]);  -- SQL-269
SELECT to_jsonb(ARRAY['mz_databases']::regclass[]);            -- SQL-269
```

### Description

Change `to_string` and `to_jsonb` to return `Result<HirScalarExpr, PlanError>`
and thread the `plan_cast` error through their (few) callers with `?`. The
casts that genuinely never fail (numeric widening for JSON numbers) keep their
`.expect()`.

These queries now produce a graceful, query-level planning error instead of
panicking, e.g. `pg_catalog.concat does not support casting from regtype to text` and `to_jsonb does not support casting from mz_aclitem to text`.

This is the "stop the bleeding" fix that the team agreed on in the issue
discussion. It does **not** make these casts work in subquery-disallowed
contexts, so it diverges from PostgreSQL, which evaluates them via the type's
output function and succeeds. Closing that gap (planning such casts as Rust
functions that read the catalog directly, or lifting the `allow_subqueries`
restriction where a dataflow is involved) is a larger change left as follow-up.

### Verification

New regression tests:

* `test/sqllogictest/regtype.slt` -- `concat(regtype)` succeeds in a plain
  `SELECT` but errors gracefully in a `RETURNING` clause (SQL-270).
* `test/sqllogictest/jsonb.slt` -- `to_jsonb` / `jsonb_build_array` over
  `mz_aclitem[]` and `regclass[]` error gracefully (SQL-269).

I also confirmed against a real PostgreSQL 16 that all of these queries succeed
there, which is why full parity is called out as follow-up rather than the
behavior asserted here.

`cargo check`, `cargo fmt`, and `cargo clippy -p mz-sql --all-targets -- -D
warnings` pass locally.
