### PR TITLE
sql: Reject non-MANUAL SCHEDULE on a cluster with REPLICATION FACTOR > 1

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -3508,6 +3508,15 @@ impl mz_sql::catalog::CatalogCluster<'_> for Cluster {
         }
     }
 
+    fn replication_factor(&self) -> Option<u32> {
+        match &self.config.variant {
+            ClusterVariant::Managed(ClusterVariantManaged {
+                replication_factor, ..
+            }) => Some(*replication_factor),
+            ClusterVariant::Unmanaged => None,
+        }
+    }
+
     fn try_to_plan(&self) -> Result<CreateClusterPlan, PlanError> {
         self.try_to_plan()
     }

--- a/src/mz-deploy/src/project/compiler/typecheck/catalog.rs
+++ b/src/mz-deploy/src/project/compiler/typecheck/catalog.rs
@@ -291,6 +291,10 @@ impl<'a> CatalogCluster<'a> for StubCluster {
         None
     }
 
+    fn replication_factor(&self) -> Option<u32> {
+        None
+    }
+
     fn try_to_plan(&self) -> Result<mz_sql::plan::CreateClusterPlan, PlanError> {
         Err(PlanError::Unsupported {
             feature: "clusters are not supported by the catalog typecheck backend".into(),

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -774,6 +774,9 @@ pub trait CatalogCluster<'a> {
     /// Returns the schedule of the cluster, if the cluster is a managed cluster.
     fn schedule(&self) -> Option<&ClusterSchedule>;
 
+    /// Returns the replication factor of the cluster, if the cluster is a managed cluster.
+    fn replication_factor(&self) -> Option<u32>;
+
     /// Try to convert this cluster into a [`CreateClusterPlan`].
     // TODO(jkosh44) Make this infallible and convert to `to_plan`.
     fn try_to_plan(&self) -> Result<CreateClusterPlan, PlanError>;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -28,8 +28,8 @@ use mz_interchange::avro::{AvroSchemaGenerator, DocTarget};
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::num::NonNeg;
-use mz_ore::soft_panic_or_log;
 use mz_ore::str::StrExt;
+use mz_ore::{soft_assert_or_log, soft_panic_or_log};
 use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
@@ -4934,9 +4934,15 @@ pub fn unplan_create_cluster(
             let replication_factor = match &schedule {
                 ClusterScheduleOptionValue::Manual => Some(replication_factor),
                 ClusterScheduleOptionValue::Refresh { .. } => {
-                    assert!(
+                    // A cluster with a refresh schedule is turned On/Off by the cluster scheduling
+                    // policy, so its replication factor should always be 0 or 1, and CREATE/ALTER
+                    // reject setting both a non-MANUAL schedule and a higher replication factor. If
+                    // we nevertheless find one (e.g., a cluster left in an invalid state by an
+                    // older version), log loudly rather than crashing the coordinator: the
+                    // replication factor is omitted from the rendered statement regardless.
+                    soft_assert_or_log!(
                         replication_factor <= 1,
-                        "replication factor, {replication_factor:?}, must be <= 1"
+                        "replication factor, {replication_factor:?}, must be <= 1 with a refresh schedule"
                     );
                     None
                 }
@@ -6176,6 +6182,24 @@ pub fn plan_alter_cluster(
                         && !matches!(schedule, Some(ClusterScheduleOptionValue::Manual))
                     {
                         scx.require_feature_flag(&ENABLE_CLUSTER_SCHEDULE_REFRESH)?;
+
+                        // A cluster with a non-MANUAL schedule is automatically turned On/Off by
+                        // the cluster scheduling policy, which means its replication factor is
+                        // always 0 or 1. If the cluster currently has a higher replication factor
+                        // and the user is not lowering it in the same statement (which would be
+                        // rejected just below), then reject the schedule change: otherwise we'd
+                        // leave the cluster in an invalid state with both a non-MANUAL schedule and
+                        // a replication factor > 1 (which would, e.g., make SHOW CREATE CLUSTER
+                        // panic).
+                        if replication_factor.is_none()
+                            && cluster.replication_factor().is_some_and(|rf| rf > 1)
+                        {
+                            sql_bail!(
+                                "SCHEDULE cannot be set to anything other than MANUAL while the \
+                                cluster's REPLICATION FACTOR is greater than 1; \
+                                set the REPLICATION FACTOR to 1 first"
+                            );
+                        }
                     }
 
                     if replication_factor.is_some() {

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1692,6 +1692,40 @@ ALTER SYSTEM SET cluster_refresh_mv_compaction_estimate = 0
 ----
 COMPLETE 0
 
+# Switching a managed cluster to a non-MANUAL SCHEDULE while its REPLICATION FACTOR is greater
+# than 1 must be rejected. Otherwise the cluster would be left in an invalid state (a refresh
+# schedule implies a replication factor of 0 or 1), which used to make SHOW CREATE CLUSTER panic
+# the coordinator (see database-issues SQL-215). This is placed at the end of the scheduling
+# section so that creating/dropping this cluster doesn't pollute the audit-event queries above.
+statement ok
+CREATE CLUSTER c_schedule_rf (SIZE = 'scale=1,workers=1', REPLICATION FACTOR = 2);
+
+statement error SCHEDULE cannot be set to anything other than MANUAL while the cluster's REPLICATION FACTOR is greater than 1; set the REPLICATION FACTOR to 1 first
+ALTER CLUSTER c_schedule_rf SET (SCHEDULE = ON REFRESH);
+
+# The rejected ALTER left the cluster unchanged, and SHOW CREATE CLUSTER still works.
+query T multiline
+SELECT create_sql FROM (SHOW CREATE CLUSTER c_schedule_rf);
+----
+CREATE CLUSTER "c_schedule_rf" (INTROSPECTION DEBUGGING = false, INTROSPECTION INTERVAL = INTERVAL '00:00:01', MANAGED = true, REPLICATION FACTOR = 2, SIZE = 'scale=1,workers=1', SCHEDULE = MANUAL)
+EOF
+
+# Lowering the REPLICATION FACTOR to 1 first lets the schedule change succeed.
+statement ok
+ALTER CLUSTER c_schedule_rf SET (REPLICATION FACTOR = 1);
+
+statement ok
+ALTER CLUSTER c_schedule_rf SET (SCHEDULE = ON REFRESH);
+
+query T multiline
+SELECT create_sql FROM (SHOW CREATE CLUSTER c_schedule_rf);
+----
+CREATE CLUSTER "c_schedule_rf" (INTROSPECTION DEBUGGING = false, INTROSPECTION INTERVAL = INTERVAL '00:00:01', MANAGED = true, SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '00:00:00'))
+EOF
+
+statement ok
+DROP CLUSTER c_schedule_rf;
+
 ## EXPLAIN FILTER PUSHDOWN can be run on materialized views in this file
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
Fixes SQL-215

A cluster with a refresh schedule is turned on/off by the cluster scheduling policy, so its replication factor is always 0 or 1. But `ALTER CLUSTER ... SET (SCHEDULE = ON REFRESH)` on a cluster that already had a higher replication factor left it in an invalid state, which made `SHOW CREATE CLUSTER` panic the coordinator.

Reject such an ALTER at plan time, pointing the user to lower the replication factor first. As defense in depth, downgrade the assertion in `unplan_create_cluster` to a soft assert so a cluster that somehow ends up in this state can no longer crash the coordinator.


