### PR TITLE
pgrepr: Fix i16 overflow panic decoding binary numeric

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -819,6 +819,14 @@ fn test_pgtest_mz_notice() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_numeric_binary_overflow() {
+    pg_test_inner(
+        Path::new("../../test/pgtest-mz/numeric-binary-overflow.pt"),
+        true,
+    );
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_parse_started() {
     pg_test_inner(Path::new("../../test/pgtest-mz/parse-started.pt"), true);
 }

--- a/src/pgrepr/src/value/numeric.rs
+++ b/src/pgrepr/src/value/numeric.rs
@@ -205,20 +205,39 @@ impl<'a> FromSql<'a> for Numeric {
             _ => return Err("bad sign in numeric".into()),
         }
 
-        let mut scale = (units - weight - 1) * 4;
+        // `units`, `weight`, and `in_scale` are read verbatim off the wire, so
+        // for a binary `Bind` parameter they are entirely user-controlled.
+        // Validate them and compute the scale in `i32`: done in `i16` (as this
+        // once was), a `weight` of `i16::MIN` makes `units - weight - 1` exceed
+        // `i16::MAX` and overflow, panicking the connection task.
+        if in_scale < 0 {
+            return Err(format!("invalid numeric binary value: negative dscale {in_scale}").into());
+        }
+        let base_pow = i32::try_from(TO_FROM_SQL_BASE_POW).expect("TO_FROM_SQL_BASE_POW fits i32");
+        let mut scale = (i32::from(units) - i32::from(weight) - 1) * base_pow;
+
+        // Reject headers whose implied scale is out of range rather than letting
+        // the decimal arithmetic below silently collapse the value to zero (or
+        // trip a downstream context-status error). A valid `numeric` decodes
+        // within the aggregation context's precision, so anything beyond that
+        // (e.g. the `weight = i16::MIN` value above, whose scale is ~131072) is
+        // not representable.
+        if scale.unsigned_abs() > u32::from(numeric::NUMERIC_AGG_MAX_PRECISION) {
+            return Err(format!("invalid numeric binary value: scale {scale} out of range").into());
+        }
 
         // Adjust scales
         if scale < 0 {
             // Multiply by 10^scale
-            cx.scaleb(&mut d, &AdtNumeric::from(-i32::from(scale)));
+            cx.scaleb(&mut d, &AdtNumeric::from(-scale));
             scale = 0;
-        } else if scale > in_scale {
+        } else if scale > i32::from(in_scale) {
             // Divide by 10^(difference in scale and in_scale)
-            cx.scaleb(&mut d, &AdtNumeric::from(-i32::from(scale - in_scale)));
-            scale = in_scale;
+            cx.scaleb(&mut d, &AdtNumeric::from(-(scale - i32::from(in_scale))));
+            scale = i32::from(in_scale);
         }
 
-        cx.scaleb(&mut d, &AdtNumeric::from(-i32::from(scale)));
+        cx.scaleb(&mut d, &AdtNumeric::from(-scale));
         cx.reduce(&mut d);
 
         let mut cx = cx_datum();

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -534,14 +534,27 @@ pub fn run_test(tf: &mut datadriven::TestFile, addr: String, user: String, timeo
                         "Sync" => frontend::sync(buf),
                         "Bind" => {
                             let v: Bind = serde_json::from_str(args).unwrap();
-                            let values = v.values.unwrap_or_default();
+                            // Parameter values as raw bytes. `binary_values`
+                            // supplies them verbatim, which (together with
+                            // `param_formats`) is what lets a test exercise the
+                            // binary parameter format; otherwise `values` are
+                            // sent as UTF-8 text, matching historical behavior.
+                            let values: Vec<Vec<u8>> = match v.binary_values {
+                                Some(binary_values) => binary_values,
+                                None => v
+                                    .values
+                                    .unwrap_or_default()
+                                    .into_iter()
+                                    .map(String::into_bytes)
+                                    .collect(),
+                            };
                             if frontend::bind(
                                 &v.portal.unwrap_or_else(|| "".into()),
                                 &v.statement.unwrap_or_else(|| "".into()),
-                                vec![], // formats
-                                values, // values
-                                |t, buf| {
-                                    buf.put_slice(t.as_bytes());
+                                v.param_formats.unwrap_or_default(), // formats
+                                values,                              // values
+                                |bytes: Vec<u8>, buf| {
+                                    buf.put_slice(&bytes);
                                     Ok(IsNull::No)
                                 }, // serializer
                                 v.result_formats.unwrap_or_default(),
@@ -641,6 +654,12 @@ pub struct Bind {
     pub portal: Option<String>,
     pub statement: Option<String>,
     pub values: Option<Vec<String>>,
+    /// Parameter format codes (0 = text, 1 = binary). Empty/absent means all
+    /// parameters use the text format, as before.
+    pub param_formats: Option<Vec<i16>>,
+    /// Raw parameter values, sent verbatim. Use this instead of `values` to put
+    /// arbitrary bytes (e.g. a binary-format parameter) on the wire.
+    pub binary_values: Option<Vec<Vec<u8>>>,
     pub result_formats: Option<Vec<i16>>,
 }
 

--- a/test/pgtest-mz/numeric-binary-overflow.pt
+++ b/test/pgtest-mz/numeric-binary-overflow.pt
@@ -1,0 +1,37 @@
+# Regression test for a user-controlled i16 overflow in Numeric::from_sql
+# (src/pgrepr/src/value/numeric.rs).
+#
+# from_sql reads the PostgreSQL `numeric` binary wire header
+# (ndigits/weight/sign/dscale) as i16. It used to compute the scale entirely in
+# i16:
+#
+#     let mut scale = (units - weight - 1) * 4;
+#
+# `weight` was never range-checked, so a Bind parameter carrying weight = -32768
+# made `units - weight` evaluate `1 - (-32768)` = 32769, overflowing i16::MAX.
+# The bytes are the client's own binary Bind parameter, so any authenticated
+# client reached this with no SQL or privilege barrier. With overflow-checks on
+# (debug-assertions, as in `cargo test` and the cargo `ci` profile) the
+# subtraction PANICKED, aborting environmentd: a remote, post-auth,
+# single-message DoS.
+#
+# The fix computes the scale in i32 (so no i16 input can overflow it) and
+# explicitly rejects headers whose implied scale is out of range, returning a
+# clean INVALID_PARAMETER_VALUE (22023) error and keeping the session alive.
+#
+# The crafted parameter below is ndigits=1, weight=-32768 (0x8000), sign=0,
+# dscale=0, digit[0]=1, sent in the binary format (param_formats=[1]).
+
+send
+Parse {"query": "SELECT $1::numeric"}
+Bind {"param_formats": [1], "binary_values": [[0, 1, 128, 0, 0, 0, 0, 0, 0, 1]]}
+Execute
+Sync
+----
+
+until err_field_typs=C
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"C","value":"22023"}]}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Fixes SQL-385

The `numeric` binary wire header (ndigits/weight/sign/dscale) is read as i16 straight from the client's Bind parameter, and the scale was computed in i16: `(units - weight - 1) * 4`. An user-controlled `weight` of i16::MIN overflows this, panicking (and, with overflow-checks, aborting) the pgwire connection task -- a remote, post-auth, single-message DoS.

Compute the scale in i32 (the i16 wire fields cannot overflow it) and explicitly reject headers whose implied scale exceeds the decode context's precision, returning a clean INVALID_PARAMETER_VALUE instead of panicking.

Adds a pgtest regression test (numeric-binary-overflow.pt) plus param_formats/binary_values support in the pgtest harness to drive binary-format parameters.
