### PR TITLE
sql: Fix panic on out-of-range interval WITH options

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2893,7 +2893,13 @@ pub fn plan_create_materialized_view(
                         sql_bail!("REFRESH interval must not involve units larger than days");
                     }
                     let interval = interval.duration()?;
-                    if u64::try_from(interval.as_millis()).is_err() {
+                    // `Interval::from_duration` (needed to unparse the interval, e.g. for
+                    // `mz_materialized_view_refresh_strategies`) requires the micros to fit
+                    // in an i64, which is a tighter bound than `Duration::duration` enforces.
+                    // Reject too-large intervals here to avoid panicking later.
+                    if u64::try_from(interval.as_millis()).is_err()
+                        || Interval::from_duration(&interval).is_err()
+                    {
                         sql_bail!("REFRESH interval too large");
                     }
                     if interval.as_micros() < 1000 {

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -284,7 +284,13 @@ impl ImpliedValue for StringOrSecret {
 impl TryFromValue<Value> for Duration {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
         let interval = Interval::try_from_value(v)?;
-        Ok(interval.duration()?)
+        let duration = interval.duration()?;
+        // `try_into_value` (used during unplanning) requires that the `Duration`
+        // is convertible back to an `Interval`, which has a smaller range than
+        // `Duration`. Enforce that here so we return a graceful error instead of
+        // panicking later. See database-issues SQL-361.
+        Interval::from_duration(&duration).map_err(|_| sql_err!("interval out of range"))?;
+        Ok(duration)
     }
 
     fn try_into_value(self, catalog: &dyn SessionCatalog) -> Option<Value> {

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -120,6 +120,11 @@ CREATE CLUSTER baz REPLICAS (), INTROSPECTION DEBUGGING = true
 statement error INTROSPECTION INTERVAL not supported for unmanaged clusters
 CREATE CLUSTER baz REPLICAS (), INTROSPECTION INTERVAL 1
 
+# An out-of-range INTROSPECTION INTERVAL should error gracefully, not panic.
+# See database-issues SQL-361.
+statement error interval out of range
+CREATE CLUSTER baz (SIZE 'scale=1,workers=1', INTROSPECTION INTERVAL = '150000000 days')
+
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster != 'quickstart' ORDER BY 1, 2, 3
 ----

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -748,6 +748,12 @@ CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY ASSERT NOT NULL x) AS SELECT
 query error invalid input syntax for type interval: Overflows maximum days; cannot exceed 2147483647/\-2147483648 days: "213503982001"
 CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '213503982001' days) AS SELECT * FROM t2;
 
+# An interval whose microseconds fit in u64 but not i64 must error gracefully
+# rather than panic when unparsed (e.g. for mz_materialized_view_refresh_strategies).
+# See database-issues SQL-361.
+query error REFRESH interval too large
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '150000000 days') AS SELECT * FROM t2;
+
 query error REFRESH interval must be at least 1 ms
 CREATE MATERIALIZED VIEW mv_bad
   WITH (REFRESH EVERY '999 microseconds')

--- a/test/sqllogictest/retain_history.slt
+++ b/test/sqllogictest/retain_history.slt
@@ -215,3 +215,16 @@ CREATE SOURCE low_rh FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '1ms')
 
 statement error RETAIN HISTORY cannot be disabled or set to 0
 CREATE SOURCE low_rh FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '0')
+
+# Check retain history upper bound. An interval whose microseconds fit in u64 but
+# not i64 must be rejected gracefully rather than panicking later when unparsed
+# (e.g. for SHOW CREATE). See database-issues SQL-361.
+statement error interval out of range
+ALTER SOURCE counter SET (RETAIN HISTORY FOR '150000000 days')
+
+statement error interval out of range
+CREATE SOURCE big_rh FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '150000000 days')
+
+# A large but in-range interval is still accepted.
+statement ok
+ALTER SOURCE counter SET (RETAIN HISTORY FOR '1000000 days')


### PR DESCRIPTION
Fixes SQL-361.

An interval whose microseconds fit in u64 but not i64 (e.g. '150000000 days') passed `Interval::duration()` during planning but panicked later in `Interval::from_duration()`, which narrows to i64. This affected INTROSPECTION INTERVAL (during the unplan round-trip in `plan_create_cluster`) and REFRESH EVERY (when populating `mz_materialized_view_refresh_strategies`).

Validate the round-trip at planning time so we return a graceful error instead of panicking. The fix in `Duration::try_from_value` covers all Duration/OptionalDuration WITH options generically; REFRESH EVERY gets the same guard that HYDRATION TIME ESTIMATE already had.

**Backcompat:** `try_from_value` also runs when re-planning create_sql on boot, so a legacy object with an out-of-range value would now fail to load (it only panicked on SHOW CREATE before). The only affected option is RETAIN HISTORY (clusters store the interval structurally and don't re-plan; REFRESH EVERY already panics on boot today). The threshold is ~292,000 years, far outside documented usage (default 1s, examples in hours, some builtin objects 30 days), and the release upgrade-check re-plans every real catalog and would flag it before the real rollout. I'd say it's fine to accept this slight risk. (Btw. do self-managed users run `upgrade-check`? Anyhow, the read-only env wouldn't boot up.)
