### PR TITLE
llm: Make `mz-test` skill more discoverable before running tests

### DIFF
--- a/.agents/skills/mz-test/SKILL.md
+++ b/.agents/skills/mz-test/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: mz-test
 description: >
-  Run tests + pick test framework in Materialize. Trigger: "run tests",
-  "run testdrive", "run sqllogictest", "run mzcompose", "run cargo test",
-  "run pgtest", "rewrite test results", "add a test", "reproduce a bug",
-  "write a regression test", or mentions testing, testdrive, sqllogictest,
-  mzcompose, pgtest, cargo test, nextest, flaky tests, test failures. Also
-  "test this" or "how do I verify this works". Specifics: mz-platform-checks
-  (upgrade/restart survival), mz-parallel-workload (concurrent stress),
-  mz-limits-test (many objects).
+  Run tests + pick test framework in Materialize. Invoke BEFORE running any test
+  command yourself, even mid-task — don't run one from memory, the canonical
+  command differs (e.g. `bin/sqllogictest --optimized`, not
+  `cargo build --bin sqllogictest`).
+  Trigger: "run tests", "run testdrive", "run sqllogictest", "run mzcompose",
+  "run cargo test", "run pgtest", "rewrite test results", "add a test",
+  "reproduce a bug", "write a regression test", or mentions testing, testdrive,
+  sqllogictest, mzcompose, pgtest, cargo test, nextest, flaky tests, test
+  failures. Also "test this" or "how do I verify this works". Specifics:
+  mz-platform-checks (upgrade/restart survival), mz-parallel-workload
+  (concurrent stress), mz-limits-test (many objects).
 ---
 
 # Testing Materialize

--- a/.agents/skills/mz-test/SKILL.md
+++ b/.agents/skills/mz-test/SKILL.md
@@ -1,17 +1,14 @@
 ---
 name: mz-test
 description: >
-  Run tests + pick test framework in Materialize. Invoke BEFORE running any test
-  command yourself, even mid-task — don't run one from memory, the canonical
-  command differs (e.g. `bin/sqllogictest --optimized`, not
-  `cargo build --bin sqllogictest`).
-  Trigger: "run tests", "run testdrive", "run sqllogictest", "run mzcompose",
-  "run cargo test", "run pgtest", "rewrite test results", "add a test",
-  "reproduce a bug", "write a regression test", or mentions testing, testdrive,
-  sqllogictest, mzcompose, pgtest, cargo test, nextest, flaky tests, test
-  failures. Also "test this" or "how do I verify this works". Specifics:
-  mz-platform-checks (upgrade/restart survival), mz-parallel-workload
-  (concurrent stress), mz-limits-test (many objects).
+  Run tests + pick test framework in Materialize. Trigger: "run tests",
+  "run testdrive", "run sqllogictest", "run mzcompose", "run cargo test",
+  "run pgtest", "rewrite test results", "add a test", "reproduce a bug",
+  "write a regression test", or mentions testing, testdrive, sqllogictest,
+  mzcompose, pgtest, cargo test, nextest, flaky tests, test failures. Also
+  "test this" or "how do I verify this works". Specifics: mz-platform-checks
+  (upgrade/restart survival), mz-parallel-workload (concurrent stress),
+  mz-limits-test (many objects).
 ---
 
 # Testing Materialize

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ for Claude Code. Check `mz-*` skill before tasks — encodes project conventions
 saves time.
 
 Use the `mz-test` skill before running ANY tests, even mid-task — the canonical
-commands aren't the obvious ones.
+commands aren't the obvious ones (e.g. `bin/sqllogictest --optimized`, not
+`cargo build --bin sqllogictest`).
 
 ## Code navigation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@ Canonical agent skills in `.agents/skills/`. `.claude/skills` is compat symlink
 for Claude Code. Check `mz-*` skill before tasks — encodes project conventions,
 saves time.
 
+Use the `mz-test` skill before running ANY tests, even mid-task — the canonical
+commands aren't the obvious ones.
+
 ## Code navigation
 
 For operation flow tracing, read first:


### PR DESCRIPTION
It happens to me quite often that Claude (or other agents) try to run a test with a wrong command, due to not having read the `mz-test` skill, because it thinks it knows how to run tests even without a skill. This causes various glitches.

Add a pointer in AGENTS.md and lead the mz-test skill description with an explicit self-trigger plus the canonical-command anti-pattern, so the skill is consulted before running test commands rather than reaching for the obvious (wrong) command from memory.