### PR TITLE
llm: Note that bin/fmt takes no file arguments

### DIFF
--- a/.agents/skills/mz-commit/SKILL.md
+++ b/.agents/skills/mz-commit/SKILL.md
@@ -14,7 +14,7 @@ Read `doc/developer/guide-changes.md` for the full conventions on submitting and
 
 Before committing, run these and fix any warnings:
 
-1. `bin/fmt` (formats `.rs`, `.py`, and `.proto` files)
+1. `bin/fmt` (formats all `.rs`, `.py`, and `.proto` files; takes no file arguments)
 2. `bin/lint` (can error if tools are missing; use `bin/ci-builder run stable bin/lint` as an alternative)
 3. `cargo clippy --all-targets -- -D warnings`
 

--- a/.agents/skills/mz-run/SKILL.md
+++ b/.agents/skills/mz-run/SKILL.md
@@ -41,7 +41,8 @@ Other useful flags:
 
 ## Formatting and linting
 
-Format Rust, Python, and Protobuf files with `bin/fmt`.
+Format Rust, Python, and Protobuf files with `bin/fmt`. Takes no file
+arguments — it always formats the whole tree (only flag: `--check`).
 Run `bin/lint` to check for lint errors.
 Run `cargo clippy --all-targets -- -D warnings` to check for Rust-specific warnings.
 


### PR DESCRIPTION
It happens to me quite often that Claude tried to run `bin/fmt` with file arguments, but actually `bin/fmt` always formats the whole tree (only flag is --check); passing file paths errors. Make that explicit where it's documented in the `mz-run` and `mz-commit` skills, since the obvious formatter convention (scope to changed files) is wrong here.

(Separate PR from https://github.com/MaterializeInc/materialize/pull/37074, because that edits the top-level claude.md and skill descriptions, while this one just edits skill bodies, which is much less token-count sensitive.)