### PR TITLE
mz-debug: Support OIDC and SASL authentication modes

### DIFF
--- a/src/mz-debug/src/main.rs
+++ b/src/mz-debug/src/main.rs
@@ -107,7 +107,7 @@ pub struct Args {
     /// The username to use to connect to Materialize,
     #[clap(long, env = "MZ_USERNAME", global = true)]
     mz_username: Option<String>,
-    /// The password to use to connect to Materialize if the authenticator kind is Password.
+    /// The password to use to connect to Materialize if the authenticator kind is Password, Sasl, or Oidc.
     #[clap(long, env = "MZ_PASSWORD", global = true)]
     mz_password: Option<String>,
     /// The URL of the Materialize SQL connection used to dump the system catalog.

--- a/src/mz-debug/src/utils.rs
+++ b/src/mz-debug/src/utils.rs
@@ -96,7 +96,9 @@ pub async fn get_k8s_auth_mode(
 
     match authenticator_kind {
         AuthenticatorKind::None => Ok(AuthMode::None),
-        AuthenticatorKind::Password => {
+        // Sasl and Oidc both authenticate with a username and password, so they
+        // are handled identically to Password here.
+        AuthenticatorKind::Password | AuthenticatorKind::Sasl | AuthenticatorKind::Oidc => {
             if let (Some(mz_username), Some(mz_password)) = (&mz_username, &mz_password) {
                 Ok(AuthMode::Password(PasswordAuthCredentials {
                     username: mz_username.clone(),
@@ -108,7 +110,7 @@ pub async fn get_k8s_auth_mode(
                 ))
             }
         }
-        _ => Err(anyhow::anyhow!(
+        AuthenticatorKind::Frontegg => Err(anyhow::anyhow!(
             "Unsupported authenticator kind: {:?}",
             authenticator_kind
         )),


### PR DESCRIPTION
### Motivation
Realized currently the tool doesn't support the other authentication modes.
