### PR TITLE
ci/console: restore CSP header injection in Vercel deploys

### DIFF
--- a/ci/deploy/console-impersonation.sh
+++ b/ci/deploy/console-impersonation.sh
@@ -25,6 +25,7 @@ npx vercel@latest pull --yes \
   --environment="$VERCEL_ENVIRONMENT" \
   --git-branch=deploy/internal-impersonation \
   --token="$VERCEL_TOKEN"
+bin/apply-vercel-csp.js --sentry-release="$SENTRY_RELEASE"
 npx vercel@latest build --token="$VERCEL_TOKEN"
 
 deployment_url="$(npx vercel@latest deploy --prebuilt --token="$VERCEL_TOKEN")"

--- a/ci/deploy/console.sh
+++ b/ci/deploy/console.sh
@@ -19,6 +19,7 @@ corepack enable
 yarn install --immutable --network-timeout 30000
 
 npx vercel@latest pull --yes --environment="$VERCEL_ENVIRONMENT" --token="$VERCEL_TOKEN"
+bin/apply-vercel-csp.js --sentry-release="$SENTRY_RELEASE"
 npx vercel@latest build --token="$VERCEL_TOKEN" --prod
 
 npx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/ci/test/console/vercel-preview.sh
+++ b/ci/test/console/vercel-preview.sh
@@ -21,6 +21,7 @@ corepack enable
 retry yarn install --immutable --network-timeout 30000
 
 npx vercel@latest pull --yes --environment="$VERCEL_ENVIRONMENT" --token="$VERCEL_TOKEN"
+bin/apply-vercel-csp.js --sentry-release="$SENTRY_RELEASE"
 npx vercel@latest build --token="$VERCEL_TOKEN"
 
 deployment_url="$(npx vercel@latest deploy --prebuilt --token="$VERCEL_TOKEN")"


### PR DESCRIPTION
## Problem

The console's `Content-Security-Policy` header is **not** committed in `console/vercel.json` — it's injected at build time by `console/bin/apply-vercel-csp.js`, which must run *before* `vercel build`.

In the original `MaterializeInc/console` repo, both the production (`deploy-prod.yml`) and preview (`deploy-preview.yml`) deploys went through `bin/build-ci`, which ran `apply-vercel-csp.js` before building.

When the console was ported into this repo (#35032), the deploy logic was reimplemented as Buildkite scripts that call `vercel build` directly and **dropped the `apply-vercel-csp.js` step**. `console/bin/build-ci` was carried over intact but is no longer invoked by anything.

As a result, the real console deploys ship with **no CSP header at all**:

| Deploy | Script | CSP injected? |
|---|---|---|
| Production (`console.materialize.com`) | `ci/deploy/console.sh` | ❌ before |
| Impersonation (`internal.console.materialize.com`) | `ci/deploy/console-impersonation.sh` | ❌ before |
| PR preview | `ci/test/console/vercel-preview.sh` | ❌ before |
| e2e test (throwaway preview) | `ci/test/console/e2e-prod.sh` | ✅ (unchanged) |

Confirmed live — `curl -sI https://console.materialize.com` returns `x-frame-options` and `referrer-policy` but **no `content-security-policy`**.

## Fix

Run `bin/apply-vercel-csp.js --sentry-release="$SENTRY_RELEASE"` before `vercel build` in all three real deploy scripts, matching the original `bin/build-ci` behavior. All three already export `SENTRY_RELEASE`.

The policy itself (`console/contentSecurityPolicy.js`) is unchanged.

## Verification

After this lands and deploys, `curl -sI https://console.materialize.com | grep -i content-security` should return the CSP header.

Closes SEC-606

🤖 Generated with [Claude Code](https://claude.com/claude-code)