### PR TITLE
Add in-map index for O(log n) jsonb field access

### DIFF
--- a/doc/developer/design/20260616_jsonb_map_index.md
+++ b/doc/developer/design/20260616_jsonb_map_index.md
@@ -79,22 +79,27 @@ For a map with `n > 0` entries the payload (the bytes counted by the existing
 `u64` length) becomes:
 
 ```text
-[ count: u32 ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ entries.. ]
+[ entries.. ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ count: u32 ]
 ```
 
-* `count` is `n`.
-* `offset_i` is the start of entry `i` relative to the first entry. Entry 0 is
-  always at offset 0 and is omitted, so the header is exactly `n` little-endian
-  `u32`s and the entries begin `4 * n` bytes in.
 * Entries are unchanged: `(key, value)` datum pairs sorted ascending by key.
+* `offset_i` is the start of entry `i` relative to the first entry. Entry 0 is
+  always at offset 0 and is omitted.
+* `count` is `n`.
 
-Empty maps keep an **empty** payload (no header), so they stay byte-identical to
-`DatumMap::empty()` and the encoding of every value remains canonical.
+The index is a **suffix** of exactly `n` little-endian `u32`s, so the entries
+occupy the first `len - 4 * n` bytes. Empty maps keep an **empty** payload (no
+suffix), so they stay byte-identical to `DatumMap::empty()` and the encoding of
+every value remains canonical.
 
 The index is built once, at the end of `RowPacker::push_dict_with`
-(`finish_dict`), by walking the just-written entries to record their offsets and
-splicing the header in front of them. Pushing an existing `Datum::Map` copies
-its bytes verbatim, so the index is never rebuilt or duplicated.
+(`finish_dict`), by walking the just-written entries. Because this runs on the
+hot path that decodes every `Row` out of persist, it is written to be cheap: the
+suffix layout lets us **append** the index instead of splicing it in front (no
+memmove), and each offset is written straight into the buffer as it is computed
+(no temporary allocation). The only inherent cost is the single `O(n)` walk of
+the entries. Pushing an existing `Datum::Map` copies its bytes verbatim, so the
+index is never rebuilt or duplicated.
 
 `DatumMap::iter()` skips the header (so the columnar encoder, proto conversion,
 equality, hashing, and ordering — all iter-based — are unaffected), and the new

--- a/doc/developer/design/20260616_jsonb_map_index.md
+++ b/doc/developer/design/20260616_jsonb_map_index.md
@@ -1,0 +1,142 @@
+# Faster `jsonb` field access via an in-map index
+
+## Summary
+
+Accessing a field of a `jsonb` value scans the underlying `DatumMap` linearly.
+A "JSON to columns" query that pulls `k` fields out of an object with `n` keys
+therefore does `O(n * k)` work per row, re-scanning the map once per field.
+
+This change adds a small, deterministic **index** to the in-memory `Row`
+encoding of maps so a single key can be found with a binary search. Field
+access drops to `O(log n)` and the whole "JSON to columns" pattern from
+`O(n * k)` to `O(k * log n)` per row, transparently for every existing
+`->`, `->>`, `#>`, and `#>>` expression — no planner or SQL changes.
+
+## Background
+
+`Datum::Map` is a thin view over a byte slice in the `Row` (`src/repr/src/row.rs`).
+The bytes are a flat, **key-sorted** sequence of `(key, value)` datum pairs:
+
+```text
+[ Tag::Dict ][ u64 byte-length ][ key0 ][ val0 ][ key1 ][ val1 ] ..
+```
+
+Decoding a `Datum::Map` is `O(1)` — it just wraps the slice — but the only way
+to find a key is `DatumMap::iter().find(..)`, a linear scan. The keys are
+already sorted (`adt::jsonb` sorts them at pack time), yet nothing exploited
+that, because the variable-length entries gave no way to jump to the middle of
+the sequence.
+
+## Goals
+
+* Sub-linear single-key access on `jsonb` objects.
+* No on-disk migration, no SQL-visible behavior change.
+* Preserve the invariants the rest of the system relies on.
+
+## The two ideas considered
+
+**1. Multi-valued scalar functions** — a `jsonb_access` that takes a list of
+field paths and returns many columns in one decode (`O(n)` per row). This is the
+asymptotically best option for "all fields", but `MirScalarExpr` is
+single-`Datum`-out by construction; producing multiple columns needs new
+expression/relation infrastructure (a multi-output operator or an optimizer
+transform that fuses sibling accesses) and only helps queries rewritten to use
+it.
+
+**2. An index in the `Row`/`Datum`** — store enough information in the map
+encoding to binary search by key (`O(log n)` per access). Contained to
+`src/repr`, and it speeds up **every** existing field access with zero query
+changes.
+
+We chose **idea 2**. It is the smaller, lower-risk change and delivers the win
+transparently. Idea 1 remains a viable future step for the extreme
+"extract every field" case (where `k ≈ n` makes a single `O(n)` decode beat
+`O(k log n)`); the two are complementary.
+
+## Why idea 2 is safe
+
+The in-memory `Tag`-based encoding is constrained by exactly three properties,
+all of which this change respects:
+
+1. **It is not persisted.** Durable storage uses `ProtoRow` (protobuf) and a
+   separate Arrow/Parquet columnar encoding (`src/repr/src/row/encode.rs`); the
+   `Tag` byte layout never reaches S3. So there is **no migration** and no
+   format-version concern.
+2. **`Row` sort order is implementation-defined.** `RowRef::cmp` compares raw
+   bytes purely as an arbitrary-but-consistent total order; no correctness
+   depends on map bytes sorting in any particular logical order. Changing the
+   map layout is therefore free of ordering-semantics fallout.
+3. **`Row` equality is byte equality.** This is the one hard constraint: two
+   equal map values *must* encode to identical bytes. The index is a pure,
+   deterministic function of the (already sorted) entries, so equal maps still
+   produce equal bytes.
+
+## Design
+
+### Encoding
+
+For a map with `n > 0` entries the payload (the bytes counted by the existing
+`u64` length) becomes:
+
+```text
+[ count: u32 ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ entries.. ]
+```
+
+* `count` is `n`.
+* `offset_i` is the start of entry `i` relative to the first entry. Entry 0 is
+  always at offset 0 and is omitted, so the header is exactly `n` little-endian
+  `u32`s and the entries begin `4 * n` bytes in.
+* Entries are unchanged: `(key, value)` datum pairs sorted ascending by key.
+
+Empty maps keep an **empty** payload (no header), so they stay byte-identical to
+`DatumMap::empty()` and the encoding of every value remains canonical.
+
+The index is built once, at the end of `RowPacker::push_dict_with`
+(`finish_dict`), by walking the just-written entries to record their offsets and
+splicing the header in front of them. Pushing an existing `Datum::Map` copies
+its bytes verbatim, so the index is never rebuilt or duplicated.
+
+`DatumMap::iter()` skips the header (so the columnar encoder, proto conversion,
+equality, hashing, and ordering — all iter-based — are unaffected), and the new
+`DatumMap::get()` binary searches the header.
+
+### Why not a new `Tag` or a runtime feature flag?
+
+A second tag (`DictIndexed` alongside `Dict`) would let indexed and legacy maps
+coexist — but coexistence is exactly what byte-equality forbids: if the same
+logical map could be emitted under either tag, two equal maps could differ in
+bytes and break dedup/join/arrangement keys. To stay canonical you would have to
+stop emitting plain `Dict` anyway, so the second tag buys nothing over changing
+`Dict` in place (and costs a discriminant plus dual read paths everywhere). The
+`Tag` `u8` space is not the constraint (~94 of 256 used); canonicalness is.
+
+For the same reason, a flag that *toggles the encoding* at runtime is unsafe:
+while both encodings are live in arrangements, equal maps have unequal bytes. If
+a kill-switch is ever wanted, the safe form gates only the **read** path
+(`get` falling back to a linear `iter().find`) — the index is always written and
+always canonical, so flipping the switch can never affect correctness, only
+which lookup algorithm runs. We did not add one: the change is correctness-safe,
+and threading dynamic config into these hot, stateless `Datum` accessors is
+awkward. Reverting is a redeploy.
+
+## Performance
+
+* Single access: `O(n)` → `O(log n)`.
+* "JSON to columns" (`k` fields): `O(n * k)` → `O(k * log n)` per row.
+* Cost: a `4 * n`-byte header per non-empty map (memory + a memmove at pack
+  time). Negligible for typical objects; see follow-ups if write-heavy
+  ingestion of large maps regresses.
+
+The `JsonbToColumns` Feature Benchmark scenario
+(`misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py`) reads
+50 fields back out of a 50-key object per row and aggregates, exercising exactly
+this path.
+
+## Follow-ups
+
+* Consider `SmallVec`/scratch reuse in `finish_dict` to avoid per-map
+  allocations on write-heavy paths.
+* Idea 1 (multi-output `jsonb_access`) for the `k ≈ n` "explode everything"
+  case, where a single `O(n)` decode wins.
+* The same index trick could extend to list element access if profiling shows
+  it matters.

--- a/doc/developer/design/20260616_jsonb_map_index.md
+++ b/doc/developer/design/20260616_jsonb_map_index.md
@@ -92,13 +92,24 @@ occupy the first `len - 4 * n` bytes. Empty maps keep an **empty** payload (no
 suffix), so they stay byte-identical to `DatumMap::empty()` and the encoding of
 every value remains canonical.
 
-The index is built once, at the end of `RowPacker::push_dict_with`
-(`finish_dict`), by walking the just-written entries. Because this runs on the
-hot path that decodes every `Row` out of persist, it is written to be cheap: the
-suffix layout lets us **append** the index instead of splicing it in front (no
-memmove), and each offset is written straight into the buffer as it is computed
-(no temporary allocation). The only inherent cost is the single `O(n)` walk of
-the entries. Pushing an existing `Datum::Map` copies its bytes verbatim, so the
+The index is built once, when a map is packed, as a suffix that is **appended**
+rather than spliced in front (no memmove). There are two builders:
+
+* `RowPacker::push_dict_with` (`finish_dict`) handles the general closure that
+  pushes arbitrary datums. It cannot know entry boundaries up front, so it walks
+  the just-written entries once to recover them — an `O(n)` re-pass.
+* `RowPacker::push_indexed_dict_with` (`DictBuilder` + `finish_dict_from_offsets`)
+  is used by the callers that already iterate entry-by-entry: JSON packing
+  (`jsonb::pack_dict`) and the columnar/proto decode paths. Each `push_entry`
+  records the entry's start offset as it writes it, so the suffix is built with
+  **no re-walk**. Offsets accumulate in an inline `SmallVec` (no heap allocation
+  for typical objects). The two builders emit byte-identical suffixes, so the map
+  encoding stays canonical regardless of which path produced it.
+
+The re-walk matters because Jsonb persists as JSON **text** (Arrow `Utf8`), and
+every decode out of persist re-parses it through `jsonb::pack_dict`; routing that
+path through the push-time builder removes the redundant pass entirely (see
+Performance). Pushing an existing `Datum::Map` copies its bytes verbatim, so the
 index is never rebuilt or duplicated.
 
 `DatumMap::iter()` skips the header (so the columnar encoder, proto conversion,
@@ -128,19 +139,25 @@ awkward. Reverting is a redeploy.
 
 * Single access: `O(n)` → `O(log n)`.
 * "JSON to columns" (`k` fields): `O(n * k)` → `O(k * log n)` per row.
-* Cost: a `4 * n`-byte header per non-empty map (memory + a memmove at pack
-  time). Negligible for typical objects; see follow-ups if write-heavy
-  ingestion of large maps regresses.
+* Cost: a `4 * n`-byte suffix per non-empty map (memory only — appended, no
+  memmove). On the hot decode/JSON-pack paths the index is built without a
+  re-walk and without a heap allocation for typical objects.
 
 The `JsonbToColumns` Feature Benchmark scenario
 (`misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py`) reads
 50 fields back out of a 50-key object per row and aggregates, exercising exactly
-this path.
+this path. The `jsonb_to_columns` group in `src/repr/benches/row.rs` isolates the
+same workload at the `repr` layer (decode, indexed access, and a linear-scan
+baseline). On a 50-key object × 10k rows it measures indexed access at ~7× the
+linear scan, and decode + access at ~3× the pre-index path; the push-time builder
+removes the decode re-walk (~13% off decode alone). Note the decode cost is
+dominated by re-parsing the JSON text, not by field access — so the index's win
+is largest when access dominates (large objects, many lookups).
 
 ## Follow-ups
 
-* Consider `SmallVec`/scratch reuse in `finish_dict` to avoid per-map
-  allocations on write-heavy paths.
+* The generic `finish_dict` (closure-based `push_dict_with`) still re-walks; if a
+  hot write path is found to use it, give it a push-time builder too.
 * Idea 1 (multi-output `jsonb_access`) for the `k ≈ n` "explode everything"
   case, where a single `O(n)` decode wins.
 * The same index trick could extend to list element access if profiling shows

--- a/doc/developer/design/20260616_jsonb_map_index.md
+++ b/doc/developer/design/20260616_jsonb_map_index.md
@@ -79,16 +79,21 @@ For a map with `n > 0` entries the payload (the bytes counted by the existing
 `u64` length) becomes:
 
 ```text
-[ entries.. ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ count: u32 ]
+[ entries.. ][ offset_1: W ] .. [ offset_{n-1}: W ][ count_word: u32 ]
 ```
 
 * Entries are unchanged: `(key, value)` datum pairs sorted ascending by key.
 * `offset_i` is the start of entry `i` relative to the first entry. Entry 0 is
   always at offset 0 and is omitted.
-* `count` is `n`.
+* `count_word` packs `n` in its low 30 bits and the offset-width class in its
+  top two bits.
 
-The index is a **suffix** of exactly `n` little-endian `u32`s, so the entries
-occupy the first `len - 4 * n` bytes. Empty maps keep an **empty** payload (no
+Offsets are stored at width `W` ∈ {1, 2, 4} bytes, the smallest that holds any
+offset, selected from the entries' total byte length (`≤256 → u8`, `≤65536 →
+u16`, else `u32`). `W` is a deterministic function of the entries' bytes, so
+equal maps select the same width and stay byte-identical. The index is a
+**suffix** of `W * (n - 1) + 4` bytes, so the entries occupy the first
+`len - 4 - W * (n - 1)` bytes. Empty maps keep an **empty** payload (no
 suffix), so they stay byte-identical to `DatumMap::empty()` and the encoding of
 every value remains canonical.
 
@@ -116,6 +121,20 @@ index is never rebuilt or duplicated.
 equality, hashing, and ordering — all iter-based — are unaffected), and the new
 `DatumMap::get()` binary searches the header.
 
+### Limits
+
+The index encoding caps a single map at:
+
+* **2³⁰ − 1 (~1.07 billion) entries**, since the count occupies 30 bits of the
+  count word (the other two are the width class).
+* **4 GiB of entry bytes**, since offsets are at most `u32`.
+
+Exceeding either panics during packing. Both are far above any practical `jsonb`
+value, and other limits (message size, memory, persist batch size) bind long
+before. Before this change the `Tag` encoding's `u64` dict-length prefix allowed
+(impractically) larger maps; the index makes these bounds explicit. These are
+in-memory-`Row` limits only and are not persisted.
+
 ### Why not a new `Tag` or a runtime feature flag?
 
 A second tag (`DictIndexed` alongside `Dict`) would let indexed and legacy maps
@@ -139,9 +158,11 @@ awkward. Reverting is a redeploy.
 
 * Single access: `O(n)` → `O(log n)`.
 * "JSON to columns" (`k` fields): `O(n * k)` → `O(k * log n)` per row.
-* Cost: a `4 * n`-byte suffix per non-empty map (memory only — appended, no
-  memmove). On the hot decode/JSON-pack paths the index is built without a
-  re-walk and without a heap allocation for typical objects.
+* Cost: a `W * (n - 1) + 4`-byte suffix per non-empty map (memory only;
+  appended, no memmove), where `W` is 1, 2, or 4 bytes. A small object's index
+  is `n - 1 + 4` bytes; a 50-key object near 1 KB uses `u16` offsets (~100 bytes
+  vs ~200 with fixed `u32`). On the hot decode/JSON-pack paths the index is built
+  without a re-walk and without a heap allocation for typical objects.
 
 The `JsonbToColumns` Feature Benchmark scenario
 (`misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py`) reads

--- a/doc/developer/design/20260616_jsonb_map_index.md
+++ b/doc/developer/design/20260616_jsonb_map_index.md
@@ -69,7 +69,16 @@ all of which this change respects:
 3. **`Row` equality is byte equality.** This is the one hard constraint: two
    equal map values *must* encode to identical bytes. The index is a pure,
    deterministic function of the (already sorted) entries, so equal maps still
-   produce equal bytes.
+   produce equal bytes. Both builders emit the same suffix for the same entries,
+   which `test_dict_builders_agree` pins down: a map packed by the closure path
+   must be byte-identical to the same map packed by the push-time path, or rows
+   built through different code paths would stop comparing equal.
+
+One consequence is worth calling out. `RowRef` hashes its raw bytes, so anything
+that places rows by `Row::hashed()` shifts with the new layout. `COPY TO` S3
+assigns rows to output files that way, so a `jsonb` row can land in a different
+file than before. The data is unchanged, only its distribution across files, and
+no correctness depends on the placement.
 
 ## Design
 
@@ -121,6 +130,16 @@ index is never rebuilt or duplicated.
 equality, hashing, and ordering — all iter-based — are unaffected), and the new
 `DatumMap::get()` binary searches the header.
 
+### Key ordering
+
+Ascending keys were already a `DatumMap` contract, but a linear scan tolerated a
+violation: it still found the key. A binary search does not, and silently reports
+a present key as missing. Both builders therefore check the order under soft
+assertions as they pack, so a caller that violates the contract fails where the
+map is built rather than at some later read. `finish_dict` re-reads the preceding
+key to do so, which is why the check is gated. The proto decode path, whose input
+is untrusted, rejects out-of-order keys outright as a decode error.
+
 ### Limits
 
 The index encoding caps a single map at:
@@ -158,27 +177,72 @@ awkward. Reverting is a redeploy.
 
 * Single access: `O(n)` → `O(log n)`.
 * "JSON to columns" (`k` fields): `O(n * k)` → `O(k * log n)` per row.
-* Cost: a `W * (n - 1) + 4`-byte suffix per non-empty map (memory only;
-  appended, no memmove), where `W` is 1, 2, or 4 bytes. A small object's index
-  is `n - 1 + 4` bytes; a 50-key object near 1 KB uses `u16` offsets (~100 bytes
-  vs ~200 with fixed `u32`). On the hot decode/JSON-pack paths the index is built
-  without a re-walk and without a heap allocation for typical objects.
+* Cost: a `W * (n - 1) + 4`-byte suffix per non-empty map, where `W` is 1, 2, or
+  4 bytes. On the hot decode/JSON-pack paths the index is built without a re-walk
+  and without a heap allocation for typical objects.
+
+### Memory cost
+
+The suffix costs roughly `W` bytes per entry, so its share of a `Row` tracks
+`W / average_entry_bytes`: worst for objects with many small entries, negligible
+for objects with few large values. Measured over `Jsonb::from_slice` on
+representative documents:
+
+| Object | JSON | `Row` bytes | Index bytes | Overhead |
+| --- | --- | --- | --- | --- |
+| `{"a":1,"b":2,"c":3}` | 19 B | 42 B | 6 B | +16.7% |
+| 12-key event object | 206 B | 209 B | 15 B | +7.7% |
+| 50 keys, short values | 1001 B | 1011 B | 102 B | +11.2% |
+| 50 keys, 100-byte values | 5601 B | 5611 B | 102 B | +1.9% |
+| 3 nested 3-key objects | 73 B | 150 B | 24 B | +19.0% |
+| 500 keys, integer values | 6891 B | 8511 B | 1002 B | +13.3% |
+
+This is an in-memory cost only. Durable encodings are built from `iter()`, which
+skips the suffix, so persisted bytes are unchanged. The growth lands in
+arrangements, `RowArena`s, and rows in flight. There is no opt-out: the index is
+always written, because a runtime toggle would break byte-canonicality (see
+above). Workloads that store `jsonb` without doing field access therefore pay
+the memory without collecting the win.
 
 The `JsonbToColumns` Feature Benchmark scenario
 (`misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py`) reads
 50 fields back out of a 50-key object per row and aggregates, exercising exactly
 this path. The `jsonb_to_columns` group in `src/repr/benches/row.rs` isolates the
 same workload at the `repr` layer (decode, indexed access, and a linear-scan
-baseline). On a 50-key object × 10k rows it measures indexed access at ~7× the
-linear scan, and decode + access at ~3× the pre-index path; the push-time builder
-removes the decode re-walk (~13% off decode alone). Note the decode cost is
-dominated by re-parsing the JSON text, not by field access — so the index's win
-is largest when access dominates (large objects, many lookups).
+baseline). On a 50-key object × 10k rows it measures indexed access at ~10× the
+linear scan (31.6 ms vs 313.4 ms), and the push-time builder removes the decode
+re-walk (~13% off decode alone).
+
+Both benchmarks measure the case the index is best at. Decode dominates the
+persist path: 64.1 ms of the 98.6 ms `decode_and_access` figure is re-parsing the
+JSON text, so a query scanning `jsonb` straight out of persist sees far less than
+10×. The feature benchmark arranges its table behind an index precisely so the
+parse is paid once and the measurement isolates field access, which is what a
+query reading from an arrangement or a materialized view actually pays. The win
+is largest where access dominates: large objects, many lookups per row, already
+decoded `Row`s.
+
+## Consumers of the index
+
+Every operator that resolves a single key by name uses `DatumMap::get`, so no
+call site pays the memory cost without collecting the benefit:
+
+* `jsonb`: `->`, `->>`, `#>`, `#>>` (`jsonb_get_string`, `jsonb_get_path`, and
+  the two stringifying wrappers), `?` (`jsonb_contains_string`), and the map arm
+  of `@>` (`jsonb_contains_jsonb`).
+* `map`: `->` (`map_get_value`, via `DatumMap::get_typed`), `?`, `?&`, `?|`, and
+  `@>` (`map_contains_map`).
+
+The containment operators go from `O(n * m)` to `O(m * log n)`.
+
+Writers that already iterate entry-by-entry use the push-time builder, so they
+never pay the re-walk: JSON packing, the columnar and proto decode paths, Avro
+map decoding, `text`-to-`map` casts, and the pgwire value paths. The closure-based
+`push_dict_with` (and thus `finish_dict`) remains for callers that push arbitrary
+datums without known entry boundaries.
 
 ## Follow-ups
 
-* The generic `finish_dict` (closure-based `push_dict_with`) still re-walks; if a
-  hot write path is found to use it, give it a push-time builder too.
 * Idea 1 (multi-output `jsonb_access`) for the `k ≈ n` "explode everything"
   case, where a single `O(n)` decode wins.
 * The same index trick could extend to list element access if profiling shows

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2779,6 +2779,13 @@ class JsonbToColumns(Jsonb):
     that the in-map index on `DatumMap` (binary-search key lookup, replacing the
     previous linear scan) is meant to speed up: it turns the per-row cost from
     O(NUM_KEYS * NUM_KEYS) into O(NUM_KEYS * log NUM_KEYS).
+
+    `t1` is arranged behind a default index so the query reads already-decoded
+    `Row`s from memory. This matters because `jsonb` persists as JSON *text*:
+    reading from persist (a plain table or a materialized view) re-parses the
+    JSON on every scan, and that parse — not field access — dominates, hiding
+    the index's effect. Reading from an arrangement pays the parse once at index
+    build, so the per-query cost is the field access this scenario targets.
     """
 
     # Number of keys in each object. Independent of `--scale`; only the row
@@ -2804,17 +2811,22 @@ class JsonbToColumns(Jsonb):
   SELECT g, '{self._object_literal()}'::jsonb
   FROM generate_series(1, {self.n()}) g;
 
+> CREATE DEFAULT INDEX ON t1;
+
 > SELECT COUNT(*) = {self.n()} FROM t1;
 true
 """),
         ]
 
     def benchmark(self) -> MeasurementSource:
-        # Read every key back out and sum them, forcing a decode of all
-        # `NUM_KEYS` fields for each of the `n()` rows.
-        projection = " + ".join(f"(data->>'{k}')::bigint" for k in self._keys())
-        # Each row contributes 0 + 1 + ... + (NUM_KEYS - 1).
-        expected = sum(range(self.NUM_KEYS)) * self.n()
+        # Touch every key in every row, but keep the per-access work down to the
+        # field lookup itself: `->` returns the value as `jsonb` (no text
+        # stringification, unlike `->>`) and `IS NOT NULL` is trivial, so the
+        # `DatumMap` lookup dominates. `(... IS NOT NULL)::int` forces all
+        # `NUM_KEYS` accesses (no short-circuit) and sums to `NUM_KEYS` per row.
+        projection = " + ".join(f"(data->'{k}' IS NOT NULL)::int" for k in self._keys())
+        # Every key is present, so each row contributes `NUM_KEYS`.
+        expected = self.NUM_KEYS * self.n()
         return Td(f"""
 > SELECT 1;
   /* A */

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2764,3 +2764,63 @@ class ReplicaExpiration(Scenario):
                   /* B */
                 1
                 """))
+
+
+class Jsonb(Scenario):
+    """Benchmarks around accessing fields of `jsonb` values."""
+
+
+class JsonbToColumns(Jsonb):
+    """Project many fields out of a `jsonb` column ("JSON to columns").
+
+    Each row holds a `jsonb` object with `NUM_KEYS` keys; the benchmark reads
+    every key back out as its own expression and aggregates the result, so the
+    cost is dominated by `NUM_KEYS` field accesses per row. This is the workload
+    that the in-map index on `DatumMap` (binary-search key lookup, replacing the
+    previous linear scan) is meant to speed up: it turns the per-row cost from
+    O(NUM_KEYS * NUM_KEYS) into O(NUM_KEYS * log NUM_KEYS).
+    """
+
+    # Number of keys in each object. Independent of `--scale`; only the row
+    # count scales.
+    NUM_KEYS = 50
+
+    def _keys(self) -> list[str]:
+        return [f"k{i:02}" for i in range(self.NUM_KEYS)]
+
+    def _object_literal(self) -> str:
+        # A single object, reused for every row. Whether the object is the same
+        # across rows is irrelevant to the access cost, since `data` is a column
+        # and every `->>` must decode it.
+        pairs = ", ".join(f'"{k}": {i}' for i, k in enumerate(self._keys()))
+        return "{" + pairs + "}"
+
+    def init(self) -> list[Action]:
+        return [
+            TdAction(f"""
+> CREATE TABLE t1 (id bigint, data jsonb);
+
+> INSERT INTO t1
+  SELECT g, '{self._object_literal()}'::jsonb
+  FROM generate_series(1, {self.n()}) g;
+
+> SELECT COUNT(*) = {self.n()} FROM t1;
+true
+"""),
+        ]
+
+    def benchmark(self) -> MeasurementSource:
+        # Read every key back out and sum them, forcing a decode of all
+        # `NUM_KEYS` fields for each of the `n()` rows.
+        projection = " + ".join(f"(data->>'{k}')::bigint" for k in self._keys())
+        # Each row contributes 0 + 1 + ... + (NUM_KEYS - 1).
+        expected = sum(range(self.NUM_KEYS)) * self.n()
+        return Td(f"""
+> SELECT 1;
+  /* A */
+1
+
+> SELECT SUM({projection}) FROM t1;
+  /* B */
+{expected}
+""")

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2949,3 +2949,63 @@ class ReplicaExpiration(Scenario):
                   /* B */
                 1
                 """))
+
+
+class Jsonb(Scenario):
+    """Benchmarks around accessing fields of `jsonb` values."""
+
+
+class JsonbToColumns(Jsonb):
+    """Project many fields out of a `jsonb` column ("JSON to columns").
+
+    Each row holds a `jsonb` object with `NUM_KEYS` keys; the benchmark reads
+    every key back out as its own expression and aggregates the result, so the
+    cost is dominated by `NUM_KEYS` field accesses per row. This is the workload
+    that the in-map index on `DatumMap` (binary-search key lookup, replacing the
+    previous linear scan) is meant to speed up: it turns the per-row cost from
+    O(NUM_KEYS * NUM_KEYS) into O(NUM_KEYS * log NUM_KEYS).
+    """
+
+    # Number of keys in each object. Independent of `--scale`; only the row
+    # count scales.
+    NUM_KEYS = 50
+
+    def _keys(self) -> list[str]:
+        return [f"k{i:02}" for i in range(self.NUM_KEYS)]
+
+    def _object_literal(self) -> str:
+        # A single object, reused for every row. Whether the object is the same
+        # across rows is irrelevant to the access cost, since `data` is a column
+        # and every `->>` must decode it.
+        pairs = ", ".join(f'"{k}": {i}' for i, k in enumerate(self._keys()))
+        return "{" + pairs + "}"
+
+    def init(self) -> list[Action]:
+        return [
+            TdAction(f"""
+> CREATE TABLE t1 (id bigint, data jsonb);
+
+> INSERT INTO t1
+  SELECT g, '{self._object_literal()}'::jsonb
+  FROM generate_series(1, {self.n()}) g;
+
+> SELECT COUNT(*) = {self.n()} FROM t1;
+true
+"""),
+        ]
+
+    def benchmark(self) -> MeasurementSource:
+        # Read every key back out and sum them, forcing a decode of all
+        # `NUM_KEYS` fields for each of the `n()` rows.
+        projection = " + ".join(f"(data->>'{k}')::bigint" for k in self._keys())
+        # Each row contributes 0 + 1 + ... + (NUM_KEYS - 1).
+        expected = sum(range(self.NUM_KEYS)) * self.n()
+        return Td(f"""
+> SELECT 1;
+  /* A */
+1
+
+> SELECT SUM({projection}) FROM t1;
+  /* B */
+{expected}
+""")

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2964,6 +2964,13 @@ class JsonbToColumns(Jsonb):
     that the in-map index on `DatumMap` (binary-search key lookup, replacing the
     previous linear scan) is meant to speed up: it turns the per-row cost from
     O(NUM_KEYS * NUM_KEYS) into O(NUM_KEYS * log NUM_KEYS).
+
+    `t1` is arranged behind a default index so the query reads already-decoded
+    `Row`s from memory. This matters because `jsonb` persists as JSON *text*:
+    reading from persist (a plain table or a materialized view) re-parses the
+    JSON on every scan, and that parse — not field access — dominates, hiding
+    the index's effect. Reading from an arrangement pays the parse once at index
+    build, so the per-query cost is the field access this scenario targets.
     """
 
     # Number of keys in each object. Independent of `--scale`; only the row
@@ -2989,17 +2996,22 @@ class JsonbToColumns(Jsonb):
   SELECT g, '{self._object_literal()}'::jsonb
   FROM generate_series(1, {self.n()}) g;
 
+> CREATE DEFAULT INDEX ON t1;
+
 > SELECT COUNT(*) = {self.n()} FROM t1;
 true
 """),
         ]
 
     def benchmark(self) -> MeasurementSource:
-        # Read every key back out and sum them, forcing a decode of all
-        # `NUM_KEYS` fields for each of the `n()` rows.
-        projection = " + ".join(f"(data->>'{k}')::bigint" for k in self._keys())
-        # Each row contributes 0 + 1 + ... + (NUM_KEYS - 1).
-        expected = sum(range(self.NUM_KEYS)) * self.n()
+        # Touch every key in every row, but keep the per-access work down to the
+        # field lookup itself: `->` returns the value as `jsonb` (no text
+        # stringification, unlike `->>`) and `IS NOT NULL` is trivial, so the
+        # `DatumMap` lookup dominates. `(... IS NOT NULL)::int` forces all
+        # `NUM_KEYS` accesses (no short-circuit) and sums to `NUM_KEYS` per row.
+        projection = " + ".join(f"(data->'{k}' IS NOT NULL)::int" for k in self._keys())
+        # Every key is present, so each row contributes `NUM_KEYS`.
+        expected = self.NUM_KEYS * self.n()
         return Td(f"""
 > SELECT 1;
   /* A */

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -1089,7 +1089,7 @@ impl ColReader {
                     .peekable();
 
                 packer
-                    .push_dict_with(|packer| {
+                    .push_indexed_dict_with(|builder| {
                         while let Some((key, i)) = kv_sorted.next() {
                             // Parquet docs state that if there are duplicate keys, the last value
                             // should be used, so skip duplicates here.
@@ -1101,8 +1101,7 @@ impl ColReader {
                                     continue;
                                 }
                             }
-                            packer.push(Datum::String(key));
-                            values.read(i, packer)?;
+                            builder.push_entry(key, |packer| values.read(i, packer))?;
                         }
                         Ok::<_, anyhow::Error>(())
                     })

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1683,7 +1683,7 @@ fn jsonb_get_int64_stringify<'a>(
 #[sqlfunc(sqlname = "->", is_infix_op = true)]
 fn jsonb_get_string<'a>(a: JsonbRef<'a>, k: &str) -> Option<JsonbRef<'a>> {
     let dict = DatumMap::try_from_result(Ok::<_, ()>(a.into_datum())).ok()?;
-    let v = dict.iter().find(|(k2, _v)| k == *k2).map(|(_k, v)| v)?;
+    let v = dict.get(k)?;
     JsonbRef::try_from_result(Ok::<_, ()>(v)).ok()
 }
 
@@ -1707,7 +1707,7 @@ fn jsonb_get_path<'a>(mut json: JsonbRef<'a>, b: Array<'a>) -> Option<JsonbRef<'
             _ => unreachable!("keys in jsonb_get_path known to be strings"),
         };
         let v = match json.into_datum() {
-            Datum::Map(map) => map.iter().find(|(k, _)| key == *k).map(|(_k, v)| v),
+            Datum::Map(map) => map.get(key),
             Datum::List(list) => {
                 let i = strconv::parse_int64(key).ok()?;
                 let i = if i >= 0 {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1891,7 +1891,7 @@ fn jsonb_get_int64_stringify<'a>(
 #[sqlfunc(sqlname = "->", is_infix_op = true)]
 fn jsonb_get_string<'a>(a: JsonbRef<'a>, k: &str) -> Option<JsonbRef<'a>> {
     let dict = DatumMap::try_from_result(Ok::<_, ()>(a.into_datum())).ok()?;
-    let v = dict.iter().find(|(k2, _v)| k == *k2).map(|(_k, v)| v)?;
+    let v = dict.get(k)?;
     JsonbRef::try_from_result(Ok::<_, ()>(v)).ok()
 }
 
@@ -1915,7 +1915,7 @@ fn jsonb_get_path<'a>(mut json: JsonbRef<'a>, b: Array<'a>) -> Option<JsonbRef<'
             _ => unreachable!("keys in jsonb_get_path known to be strings"),
         };
         let v = match json.into_datum() {
-            Datum::Map(map) => map.iter().find(|(k, _)| key == *k).map(|(_k, v)| v),
+            Datum::Map(map) => map.get(key),
             Datum::List(list) => {
                 let i = strconv::parse_int64(key).ok()?;
                 let i = if i >= 0 {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1952,7 +1952,7 @@ fn jsonb_contains_string<'a>(a: JsonbRef<'a>, k: &str) -> bool {
     // So, this function only runs for non-null jsonb; a.into_datum() never sees Datum::Null.
     match a.into_datum() {
         Datum::List(list) => list.iter().any(|k2| Datum::from(k) == k2),
-        Datum::Map(dict) => dict.iter().any(|(k2, _v)| k == k2),
+        Datum::Map(dict) => dict.get(k).is_some(),
         Datum::String(string) => string == k,
         _ => false,
     }
@@ -1961,37 +1961,32 @@ fn jsonb_contains_string<'a>(a: JsonbRef<'a>, k: &str) -> bool {
 #[sqlfunc(is_infix_op = true, sqlname = "?", propagates_nulls = true)]
 // Map keys are always text.
 fn map_contains_key<'a>(map: DatumMap<'a>, k: &str) -> bool {
-    map.iter().any(|(k2, _v)| k == k2)
+    map.get(k).is_some()
 }
 
 #[sqlfunc(is_infix_op = true, sqlname = "?&")]
 fn map_contains_all_keys<'a>(map: DatumMap<'a>, keys: Array<'a>) -> bool {
     keys.elements()
         .iter()
-        .all(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))
+        .all(|key| !key.is_null() && map.get(key.unwrap_str()).is_some())
 }
 
 #[sqlfunc(is_infix_op = true, sqlname = "?|", propagates_nulls = true)]
 fn map_contains_any_keys<'a>(map: DatumMap<'a>, keys: Array<'a>) -> bool {
     keys.elements()
         .iter()
-        .any(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))
+        .any(|key| !key.is_null() && map.get(key.unwrap_str()).is_some())
 }
 
 #[sqlfunc(is_infix_op = true, sqlname = "@>", propagates_nulls = true)]
 fn map_contains_map<'a>(map_a: DatumMap<'a>, b: DatumMap<'a>) -> bool {
-    b.iter().all(|(b_key, b_val)| {
-        map_a
-            .iter()
-            .any(|(a_key, a_val)| (a_key == b_key) && (a_val == b_val))
-    })
+    b.iter()
+        .all(|(b_key, b_val)| map_a.get(b_key) == Some(b_val))
 }
 
 #[sqlfunc(is_infix_op = true, sqlname = "->", propagates_nulls = true)]
 fn map_get_value<'a, T: FromDatum<'a>>(a: DatumMap<'a, T>, target_key: &str) -> Option<T> {
-    a.typed_iter()
-        .find(|(key, _v)| target_key == *key)
-        .map(|(_k, v)| v)
+    a.get_typed(target_key)
 }
 
 #[sqlfunc(is_infix_op = true, sqlname = "@>")]
@@ -2028,8 +2023,8 @@ fn jsonb_contains_jsonb<'a>(a: JsonbRef<'a>, b: JsonbRef<'a>) -> bool {
                 .iter()
                 .all(|b_elem| a.iter().any(|a_elem| contains(a_elem, b_elem, false))),
             (Datum::Map(a), Datum::Map(b)) => b.iter().all(|(b_key, b_val)| {
-                a.iter()
-                    .any(|(a_key, a_val)| (a_key == b_key) && contains(a_val, b_val, false))
+                a.get(b_key)
+                    .is_some_and(|a_val| contains(a_val, b_val, false))
             }),
 
             // fun special case

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -880,7 +880,7 @@ fn jsonb_build_object<'a>(
     // Checked after the dedup, so duplicate keys are counted once, as they are packed.
     check_datums_fit_budget(kvs.0.iter().flat_map(|(k, v)| [*k, *v]), temp_storage)?;
     let datum = temp_storage.try_make_datum(|packer| {
-        packer.push_dict_with(|packer| {
+        packer.push_indexed_dict_with(|builder| {
             for (k, v) in kvs {
                 if k.is_null() {
                     return Err(EvalError::KeyCannotBeNull);
@@ -889,8 +889,7 @@ fn jsonb_build_object<'a>(
                     Datum::Null => Datum::JsonNull,
                     d => d,
                 };
-                packer.push(k);
-                packer.push(v);
+                builder.push_entry(k.unwrap_str(), |packer| packer.push(v));
             }
             Ok(())
         })

--- a/src/interchange/fuzz/fuzz_targets/json_encode.rs
+++ b/src/interchange/fuzz/fuzz_targets/json_encode.rs
@@ -441,12 +441,13 @@ fn push_typed(
                 packer.push(Datum::Null);
             } else {
                 let n = u.int_in_range(0usize..=4)?;
-                packer.push_dict_with(|packer| {
+                packer.push_indexed_dict_with(|builder| {
                     // Keys must be pushed in ascending order and be unique. The
                     // zero-padded counter is lexically ascending.
                     for i in 0..n {
-                        packer.push(Datum::String(&format!("k{i:03}")));
-                        push_typed(packer, u, value, *value_nullable)?;
+                        builder.push_entry(&format!("k{i:03}"), |packer| {
+                            push_typed(packer, u, value, *value_nullable)
+                        })?;
                     }
                     Ok::<_, arbitrary::Error>(())
                 })?;

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -432,17 +432,18 @@ impl<'a, 'row> AvroDecode for AvroFlatDecoder<'a, 'row> {
             map.insert(name, f.decode_field(ValueDecoder)?);
         }
         self.packer
-            .push_dict_with(|packer| -> Result<(), AvroError> {
+            .push_indexed_dict_with(|builder| -> Result<(), AvroError> {
                 for (key, val) in map {
-                    packer.push(Datum::String(key.as_str()));
-                    give_value(
-                        AvroFlatDecoder {
-                            packer,
-                            buf: &mut vec![],
-                            is_top: false,
-                        },
-                        &val,
-                    )?;
+                    builder.push_entry(key.as_str(), |packer| {
+                        give_value(
+                            AvroFlatDecoder {
+                                packer,
+                                buf: &mut vec![],
+                                is_top: false,
+                            },
+                            &val,
+                        )
+                    })?;
                 }
                 Ok(())
             })?;

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -292,14 +292,14 @@ impl Value {
                     _ => panic!("Value::Map should have type Type::Map. Found {:?}", typ),
                 };
                 buf.try_make_datum(|packer| {
-                    packer.try_push_dict_with(|row| {
+                    packer.push_indexed_dict_with(|builder| {
                         for (k, v) in map {
-                            row.push(Datum::String(buf.push_string(k)));
+                            let key = buf.push_string(k);
                             let datum = match v {
                                 Some(elem) => elem.into_datum(buf, elem_pg_type)?,
                                 None => Datum::Null,
                             };
-                            row.push(datum);
+                            builder.push_entry(key, |row| row.push(datum));
                         }
                         Ok::<_, IntoDatumError>(())
                     })
@@ -828,13 +828,15 @@ impl Value {
                     strconv::parse_map(s, matches!(**value_type, Type::Map { .. }), |elem_text| {
                         elem_text.map(Ok::<_, String>).transpose()
                     })?;
-                packer.push_dict_with(|row| {
+                packer.push_indexed_dict_with(|builder| {
                     for (k, v) in map {
-                        row.push(Datum::String(&k));
-                        match v {
-                            Some(elem) => Value::decode_text_into_row(value_type, &elem, row)?,
-                            None => row.push(Datum::Null),
-                        }
+                        builder.push_entry(&k, |row| match v {
+                            Some(elem) => Value::decode_text_into_row(value_type, &elem, row),
+                            None => {
+                                row.push(Datum::Null);
+                                Ok(())
+                            }
+                        })?;
                     }
                     Ok::<_, Box<dyn Error + Sync + Send>>(())
                 })?;

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -13,6 +13,7 @@ use std::hint::black_box;
 use arrow::array::StructArray;
 use criterion::{Bencher, Criterion, Throughput, criterion_group, criterion_main};
 use itertools::Itertools;
+use mz_ore::cast::CastFrom;
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
 use mz_persist::metrics::ColumnarMetrics;
 use mz_persist_types::Codec;
@@ -473,6 +474,118 @@ fn bench_json(c: &mut Criterion) {
     });
 }
 
+/// Mimics the `JsonbToColumns` feature benchmark at the `repr` layer: a flat
+/// `jsonb` object with `N_KEYS` entries, from which a query pulls every field.
+/// Splitting decode and access apart lets us see which side the in-map index
+/// helps and which it taxes.
+fn bench_jsonb_to_columns(c: &mut Criterion) {
+    const NUM_ROWS: u64 = 10_000;
+    const N_KEYS: usize = 50;
+
+    let keys: Vec<String> = (0..N_KEYS).map(|i| format!("k{i:02}")).collect();
+
+    let mut row = Row::default();
+    row.packer().push_dict_with(|packer| {
+        for (i, key) in keys.iter().enumerate() {
+            packer.push(Datum::String(key));
+            packer.push(Datum::from(Numeric::from(u64::cast_from(i))));
+        }
+    });
+
+    let mut group = c.benchmark_group("jsonb_to_columns");
+    group.throughput(Throughput::Elements(NUM_ROWS));
+
+    let schema =
+        RelationDesc::from_names_and_types(vec![("a", SqlScalarType::Jsonb.nullable(false))]);
+
+    // Decode-only: exercises `finish_dict` (which rebuilds the index on every
+    // decode out of persist).
+    group.bench_function("decode", |b| {
+        let mut builder = PartBuilder::new(&schema, &UnitSchema);
+        builder.push(&row, &(), 1u64, 1i64);
+        let part = builder.finish();
+        let col = part
+            .key
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct array");
+        let decoder =
+            <RelationDesc as Schema<Row>>::decoder(&schema, col.clone()).expect("success");
+        let mut out = Row::default();
+        b.iter(|| {
+            for _ in 0..NUM_ROWS {
+                decoder.decode(0, black_box(&mut out));
+                black_box(&mut out);
+            }
+        });
+    });
+
+    // Access-only: every field looked up via the binary-searched index, on a
+    // row that is already decoded.
+    group.bench_function("access", |b| {
+        b.iter(|| {
+            for _ in 0..NUM_ROWS {
+                let map = match black_box(&row).unpack_first() {
+                    Datum::Map(map) => map,
+                    _ => unreachable!(),
+                };
+                for key in &keys {
+                    black_box(map.get(key));
+                }
+            }
+        });
+    });
+
+    // Access via a linear scan (the pre-index behavior), for comparison.
+    group.bench_function("access_linear", |b| {
+        b.iter(|| {
+            for _ in 0..NUM_ROWS {
+                let map = match black_box(&row).unpack_first() {
+                    Datum::Map(map) => map,
+                    _ => unreachable!(),
+                };
+                for key in &keys {
+                    let mut found = None;
+                    for (k, v) in &map {
+                        if k == key.as_str() {
+                            found = Some(v);
+                            break;
+                        }
+                    }
+                    black_box(found);
+                }
+            }
+        });
+    });
+
+    // Decode + access together, the shape of the real query.
+    group.bench_function("decode_and_access", |b| {
+        let mut builder = PartBuilder::new(&schema, &UnitSchema);
+        builder.push(&row, &(), 1u64, 1i64);
+        let part = builder.finish();
+        let col = part
+            .key
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct array");
+        let decoder =
+            <RelationDesc as Schema<Row>>::decoder(&schema, col.clone()).expect("success");
+        let mut out = Row::default();
+        b.iter(|| {
+            for _ in 0..NUM_ROWS {
+                decoder.decode(0, black_box(&mut out));
+                let map = match out.unpack_first() {
+                    Datum::Map(map) => map,
+                    _ => unreachable!(),
+                };
+                for key in &keys {
+                    black_box(map.get(key));
+                }
+            }
+        });
+    });
+}
+
 fn bench_string(c: &mut Criterion) {
     const NUM_ROWS: u64 = 10_000;
 
@@ -528,6 +641,7 @@ criterion_group!(
     bench_filter,
     bench_roundtrip,
     bench_json,
+    bench_jsonb_to_columns,
     bench_string
 );
 criterion_main!(benches);

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -550,12 +550,11 @@ fn pack_dict<'a, 'scratch>(
     // value for the key, as ordered by appearance in the source JSON, per
     // PostgreSQL's implementation.
     scratch.sort_by_key(|entry| entry.key);
-    packer.push_dict_with(|packer| {
+    packer.push_indexed_dict_with(|builder| {
         for i in 0..scratch.len() {
             if i == scratch.len() - 1 || scratch[i].key != scratch[i + 1].key {
                 let DictEntry { key, val } = scratch[i];
-                packer.push(Datum::String(key));
-                pack_value(packer, scratch.fresh(), val);
+                builder.push_entry(key, |packer| pack_value(packer, scratch.fresh(), val));
             }
         }
     });

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -66,9 +66,9 @@ pub use crate::relation::{
 pub use crate::row::encode::{RowColumnarDecoder, RowColumnarEncoder, preserves_order};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{
-    DatumDictTypedIter, DatumList, DatumListTypedIter, DatumMap, FromDatum, ProtoNumeric, ProtoRow,
-    Row, RowArena, RowPacker, RowRef, SharedRow, datum_list_size, datum_size, datums_size,
-    read_datum, row_size,
+    DatumDictTypedIter, DatumList, DatumListTypedIter, DatumMap, DictBuilder, FromDatum,
+    ProtoNumeric, ProtoRow, Row, RowArena, RowPacker, RowRef, SharedRow, datum_list_size,
+    datum_size, datums_size, read_datum, row_size,
 };
 pub use crate::scalar::{
     ArrayRustType, AsColumnType, Datum, DatumKind, ExcludeNull, InputDatumType, Int2Vector,

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -68,8 +68,7 @@ pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{
     DatumDictTypedIter, DatumList, DatumListTypedIter, DatumMap, DictBuilder, FromDatum,
     ProtoNumeric, ProtoRow, Row, RowArena, RowArenaBuf, RowPacker, RowRef, SharedRow, StableRow,
-    datum_list_size,
-    datum_size, datums_size, read_datum, row_size,
+    datum_list_size, datum_size, datums_size, read_datum, row_size,
 };
 pub use crate::scalar::{
     ArrayRustType, AsColumnType, Datum, DatumKind, ExcludeNull, InputDatumType, Int2Vector,

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -66,8 +66,9 @@ pub use crate::relation::{
 pub use crate::row::encode::{RowColumnarDecoder, RowColumnarEncoder, preserves_order};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{
-    DatumDictTypedIter, DatumList, DatumListTypedIter, DatumMap, FromDatum, ProtoNumeric, ProtoRow,
-    Row, RowArena, RowArenaBuf, RowPacker, RowRef, SharedRow, StableRow, datum_list_size,
+    DatumDictTypedIter, DatumList, DatumListTypedIter, DatumMap, DictBuilder, FromDatum,
+    ProtoNumeric, ProtoRow, Row, RowArena, RowArenaBuf, RowPacker, RowRef, SharedRow, StableRow,
+    datum_list_size,
     datum_size, datums_size, read_datum, row_size,
 };
 pub use crate::scalar::{

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -3897,7 +3897,11 @@ mod tests {
         let map = datum.unwrap_map();
         assert_eq!(map.get("scalar"), Some(Datum::Int64(7)));
         assert_eq!(
-            map.get("list").unwrap().unwrap_list().iter().collect::<Vec<_>>(),
+            map.get("list")
+                .unwrap()
+                .unwrap_list()
+                .iter()
+                .collect::<Vec<_>>(),
             vec![Datum::Int64(1), Datum::Int64(2)],
         );
         assert_eq!(map.get("missing"), None);

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -31,6 +31,7 @@ use proptest::prelude::*;
 #[cfg(any(test, feature = "proptest"))]
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use uuid::Uuid;
 
 use crate::adt::array::{
@@ -752,6 +753,47 @@ pub struct RowPacker<'a> {
     row: &'a mut Row,
 }
 
+/// Builds a [`DatumMap`] one `(key, value)` entry at a time for
+/// [`RowPacker::push_indexed_dict_with`], capturing each entry's start offset as
+/// it is written so the in-map index can be appended without a second pass over
+/// the entries.
+pub struct DictBuilder<'a, 'row> {
+    packer: &'a mut RowPacker<'row>,
+    /// Start of the entries region within `packer.row.data`.
+    entries_start: usize,
+    /// Start offset of each entry pushed so far, relative to `entries_start`.
+    /// The inline capacity covers typical JSON objects without a heap
+    /// allocation, keeping the common case allocation-free.
+    offsets: SmallVec<[u32; 32]>,
+}
+
+impl Debug for DictBuilder<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DictBuilder")
+            .field("entries_start", &self.entries_start)
+            .field("entries_pushed", &self.offsets.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl DictBuilder<'_, '_> {
+    /// Pushes one `(key, value)` entry, recording its start offset for the
+    /// index. `value` is run with the underlying packer to write the value,
+    /// which may itself be a nested list or dict.
+    ///
+    /// Keys must be pushed in ascending order, per the [`DatumMap`] contract.
+    pub fn push_entry<F, R>(&mut self, key: &str, value: F) -> R
+    where
+        F: FnOnce(&mut RowPacker) -> R,
+    {
+        let offset = self.packer.row.data.len() - self.entries_start;
+        self.offsets
+            .push(u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed"));
+        self.packer.push(Datum::String(key));
+        value(self.packer)
+    }
+}
+
 /// Infallible conversion from a [`Datum`] to a typed value.
 ///
 /// Used by [`DatumList::typed_iter`] to yield elements as `T` rather than
@@ -1289,6 +1331,30 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
         }
         p += before - cursor.len();
     }
+    data.extend_from_slice(&count.to_le_bytes());
+}
+
+/// Appends the in-map index suffix from offsets captured while the entries were
+/// written, instead of re-walking them as [`finish_dict`] does.
+///
+/// `offsets[i]` is the start of entry `i` relative to the start of the entries
+/// region. This produces a byte-identical suffix to [`finish_dict`] — the index
+/// is the same deterministic function of the (already sorted) entries — so the
+/// two builders are interchangeable and `Row`'s byte equality is preserved.
+///
+/// Empty dictionaries are left untouched, matching [`finish_dict`] and
+/// [`DatumMap::empty`].
+fn finish_dict_from_offsets(data: &mut CompactBytes, offsets: &[u32]) {
+    let n = offsets.len();
+    if n == 0 {
+        return;
+    }
+    // Append the start offsets of entries `1..n` (entry 0 is always at offset 0
+    // and is omitted), then the count. See [`DatumMap`] for the layout.
+    for offset in &offsets[1..] {
+        data.extend_from_slice(&offset.to_le_bytes());
+    }
+    let count = u32::try_from(n).expect("map with more than 4 billion entries");
     data.extend_from_slice(&count.to_le_bytes());
 }
 
@@ -2497,6 +2563,48 @@ impl RowPacker<'_> {
         self.push_dict_with(f)
     }
 
+    /// Pushes a [`DatumMap`] built one `(key, value)` entry at a time via a
+    /// [`DictBuilder`].
+    ///
+    /// This is equivalent to [`push_dict_with`](Self::push_dict_with) but builds
+    /// the in-map index from offsets captured as each entry is written, rather
+    /// than walking the entries a second time afterwards. Callers that already
+    /// iterate entry-by-entry (JSON packing, the columnar/proto decode paths)
+    /// should prefer this to avoid the redundant pass on the hot decode path.
+    ///
+    /// The same contract as [`push_dict_with`](Self::push_dict_with) applies:
+    /// entries **must** be pushed with keys in ascending order, and the closure
+    /// **must not** call [`clear`](Self::clear), [`truncate`](Self::truncate),
+    /// or [`truncate_datums`](Self::truncate_datums).
+    pub fn push_indexed_dict_with<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut DictBuilder<'_, '_>) -> R,
+    {
+        self.row.data.push(Tag::Dict.into());
+        let start = self.row.data.len();
+        // Write a dummy len, fixed up below.
+        self.row.data.extend_from_slice(&[0; size_of::<u64>()]);
+        let entries_start = self.row.data.len();
+
+        let mut builder = DictBuilder {
+            packer: self,
+            entries_start,
+            offsets: SmallVec::new(),
+        };
+        let res = f(&mut builder);
+        let offsets = std::mem::take(&mut builder.offsets);
+        // Drop the builder to release its borrow of `self` before we touch the
+        // row buffer again.
+        drop(builder);
+
+        finish_dict_from_offsets(&mut self.row.data, &offsets);
+
+        let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
+        self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
+
+        res
+    }
+
     /// Convenience function to construct an array from an iter of `Datum`s.
     ///
     /// Returns an error if the number of elements in `iter` does not match
@@ -2739,10 +2847,9 @@ impl RowPacker<'_> {
         I: IntoIterator<Item = (&'a str, D)>,
         D: Borrow<Datum<'a>>,
     {
-        self.push_dict_with(|packer| {
+        self.push_indexed_dict_with(|builder| {
             for (k, v) in iter {
-                packer.push(Datum::String(k));
-                packer.push(*v.borrow())
+                builder.push_entry(k, |packer| packer.push(*v.borrow()));
             }
         })
     }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -904,6 +904,23 @@ impl<T> PartialOrd for DatumList<'_, T> {
 
 /// A mapping from string keys to Datums
 ///
+/// # Payload layout
+///
+/// `data` points at the map's serialized payload, which carries a small index
+/// so that a key can be located with a binary search instead of a linear scan.
+/// For a map with `n > 0` entries the layout is:
+///
+/// ```text
+/// [ count: u32 ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ entries.. ]
+/// ```
+///
+/// where `count` is `n`, `offset_i` is the start of entry `i` relative to the
+/// first entry (entry 0 is always at offset 0 and so is omitted), and the
+/// entries are `(key, value)` datum pairs **sorted in ascending key order**.
+/// The index is thus exactly `n` little-endian `u32`s, so the entries begin
+/// `4 * n` bytes into the payload. An empty map has an empty payload (no
+/// header), keeping its encoding canonical.
+///
 /// The type parameter `T` represents the value type of the map. It is a
 /// phantom parameter — the actual values are stored as serialized bytes and
 /// `T` is not enforced at runtime. It is up to the caller to ensure `T`
@@ -913,7 +930,8 @@ impl<T> PartialOrd for DatumList<'_, T> {
 /// See `doc/developer/design/20260311_sqlfunc_generic.md` for the design
 /// behind the generic type parameter.
 pub struct DatumMap<'a, T = Datum<'a>> {
-    /// Points at the serialized datums, which should be sorted in key order
+    /// Points at the serialized payload (index header followed by the
+    /// key-sorted entries). See the type-level docs for the layout.
     data: &'a [u8],
     _phantom: PhantomData<fn() -> T>,
 }
@@ -1220,6 +1238,70 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
     let (bytes, next) = data.split_at(len);
     *data = next;
     bytes
+}
+
+/// Builds the in-map index for a dictionary the packer has just written.
+///
+/// On entry, `data[entries_start..]` holds the dictionary's entries as a
+/// sequence of sorted `(key, value)` datum pairs. This walks those entries to
+/// compute the byte offset of each one, then splices an index header in just
+/// before them. The resulting payload layout is documented on [`DatumMap`].
+///
+/// Empty dictionaries are left untouched so that they keep a canonical,
+/// header-free encoding (identical to [`DatumMap::empty`]). This keeps the
+/// encoding of any given map value deterministic, which `Row`'s byte-based
+/// equality relies on.
+fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
+    // Walk the freshly written entries, recording the start offset of each one
+    // relative to `entries_start`.
+    let mut offsets: Vec<u32> = Vec::new();
+    {
+        let entries = &data[entries_start..];
+        let entries_len = entries.len();
+        let mut cursor: &[u8] = entries;
+        while !cursor.is_empty() {
+            let offset = entries_len - cursor.len();
+            offsets.push(u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed"));
+            // SAFETY: `cursor` points at the key/value datums just written by
+            // the packer, which are well-formed per `push_dict_with`'s contract.
+            unsafe {
+                let _key = read_datum(&mut cursor);
+                let _val = read_datum(&mut cursor);
+            }
+        }
+    }
+
+    let n = offsets.len();
+    if n == 0 {
+        return;
+    }
+
+    // The header stores the entry count followed by the start offsets of
+    // entries `1..n`; entry 0 always starts at offset 0 and is omitted. This is
+    // exactly `n` little-endian `u32`s, so the entries begin `4 * n` bytes into
+    // the payload.
+    let mut header = Vec::with_capacity(size_of::<u32>() * n);
+    header.extend_from_slice(
+        &u32::try_from(n)
+            .expect("map with more than 4 billion entries")
+            .to_le_bytes(),
+    );
+    for offset in &offsets[1..] {
+        header.extend_from_slice(&offset.to_le_bytes());
+    }
+    let header_len = header.len();
+    let entries_len = data.len() - entries_start;
+
+    // Insert `header` just before the entries. `CompactBytes` has no `splice`,
+    // so we grow the buffer (reusing `header` as filler), shift the entries
+    // right to open a gap, then write the header into the gap. This mirrors the
+    // in-place shift in `push_list_with`'s `long_list`.
+    data.extend_from_slice(&header);
+    data.copy_within(
+        entries_start..entries_start + entries_len,
+        entries_start + header_len,
+    );
+    data[entries_start..entries_start + header_len].copy_from_slice(&header);
 }
 
 /// Read a data whose length is encoded in the row before its contents.
@@ -2406,6 +2488,12 @@ impl RowPacker<'_> {
 
         let res = f(self);
 
+        // Build an in-map index over the entries that were just written, so
+        // that individual keys can be located with a binary search rather than
+        // a linear scan. See [`DatumMap`] for the payload layout. This must
+        // happen before the length is fixed up, as it changes the payload size.
+        finish_dict(&mut self.row.data, start + size_of::<u64>());
+
         let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
         // fix up the len
         self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
@@ -2946,9 +3034,78 @@ impl<'a, T: FromDatum<'a>> Iterator for DatumListTypedIter<'a, T> {
 }
 
 impl<'a, T> DatumMap<'a, T> {
+    /// The number of entries in the map.
+    pub fn len(&self) -> usize {
+        if self.data.is_empty() {
+            0
+        } else {
+            let count = u32::from_le_bytes(self.data[..size_of::<u32>()].try_into().unwrap());
+            usize::cast_from(count)
+        }
+    }
+
+    /// Whether the map has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// The slice holding the entries, with the index header stripped off.
+    ///
+    /// See the type-level docs for the payload layout.
+    fn entries(&self) -> &'a [u8] {
+        if self.data.is_empty() {
+            return self.data;
+        }
+        // The header is exactly `len()` little-endian `u32`s.
+        let header_len = size_of::<u32>() * self.len();
+        &self.data[header_len..]
+    }
+
+    /// The start offset of entry `i` relative to the start of the entries
+    /// region. Entry 0 is implicitly at offset 0; the rest are read from the
+    /// index header. `i` must be in `0..len()`.
+    fn entry_offset(&self, i: usize) -> usize {
+        if i == 0 {
+            0
+        } else {
+            let at = size_of::<u32>() * i;
+            let offset =
+                u32::from_le_bytes(self.data[at..at + size_of::<u32>()].try_into().unwrap());
+            usize::cast_from(offset)
+        }
+    }
+
+    /// Looks up `key`, returning its value if present.
+    ///
+    /// Runs in `O(log n)` over the `n` entries by binary searching the
+    /// key-sorted index, rather than the `O(n)` linear scan of [`Self::iter`].
+    pub fn get(&self, key: &str) -> Option<Datum<'a>> {
+        let n = self.len();
+        if n == 0 {
+            return None;
+        }
+        let entries = self.entries();
+
+        let mut lo = 0;
+        let mut hi = n;
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            let mut cursor = &entries[self.entry_offset(mid)..];
+            // SAFETY: `cursor` points at a well-formed entry (a string key
+            // followed by its value), per the `DatumMap` payload contract.
+            let mid_key = unsafe { read_datum(&mut cursor) }.unwrap_str();
+            match key.cmp(mid_key) {
+                Ordering::Equal => return Some(unsafe { read_datum(&mut cursor) }),
+                Ordering::Less => hi = mid,
+                Ordering::Greater => lo = mid + 1,
+            }
+        }
+        None
+    }
+
     pub fn iter(&self) -> DatumDictIter<'a> {
         DatumDictIter {
-            data: self.data,
+            data: self.entries(),
             prev_key: None,
         }
     }
@@ -3685,6 +3842,65 @@ mod tests {
         assert_eq!(dict.next(), None);
 
         Ok(())
+    }
+
+    #[mz_ore::test]
+    fn test_datum_map_get() {
+        // For maps of various sizes, `DatumMap::get` (binary search over the
+        // in-map index) must agree with a linear scan for both present keys and
+        // misses, and `len`/`is_empty` must report the right cardinality.
+        for n in [0_usize, 1, 2, 3, 7, 16, 50] {
+            let keys: Vec<String> = (0..n).map(|i| format!("k{i:03}")).collect();
+            let mut row = Row::default();
+            row.packer().push_dict_with(|row| {
+                // `push_dict_with` requires keys in ascending order; `keys` is
+                // already sorted.
+                for (i, k) in keys.iter().enumerate() {
+                    row.push(Datum::String(k));
+                    row.push(Datum::Int64(i64::try_from(i).unwrap() * 10));
+                }
+            });
+            let datum = row.unpack_first();
+            let map = datum.unwrap_map();
+
+            assert_eq!(map.len(), n);
+            assert_eq!(map.is_empty(), n == 0);
+
+            // Every present key resolves to its value.
+            for (i, k) in keys.iter().enumerate() {
+                assert_eq!(
+                    map.get(k),
+                    Some(Datum::Int64(i64::try_from(i).unwrap() * 10)),
+                    "present key {k:?} with n={n}",
+                );
+            }
+
+            // Misses (before, between, and after the keys) agree with a scan.
+            for probe in ["", "k", "k000a", "k999", "zzz"] {
+                let linear = map.iter().find(|(k, _)| *k == probe).map(|(_, v)| v);
+                assert_eq!(map.get(probe), linear, "probe {probe:?} with n={n}");
+            }
+        }
+
+        // A nested value is returned intact via `get`.
+        let mut row = Row::default();
+        row.packer().push_dict_with(|row| {
+            row.push(Datum::String("list"));
+            row.push_list_with(|row| {
+                row.push(Datum::Int64(1));
+                row.push(Datum::Int64(2));
+            });
+            row.push(Datum::String("scalar"));
+            row.push(Datum::Int64(7));
+        });
+        let datum = row.unpack_first();
+        let map = datum.unwrap_map();
+        assert_eq!(map.get("scalar"), Some(Datum::Int64(7)));
+        assert_eq!(
+            map.get("list").unwrap().unwrap_list().iter().collect::<Vec<_>>(),
+            vec![Datum::Int64(1), Datum::Int64(2)],
+        );
+        assert_eq!(map.get("missing"), None);
     }
 
     #[mz_ore::test]

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -907,19 +907,21 @@ impl<T> PartialOrd for DatumList<'_, T> {
 /// # Payload layout
 ///
 /// `data` points at the map's serialized payload, which carries a small index
-/// so that a key can be located with a binary search instead of a linear scan.
-/// For a map with `n > 0` entries the layout is:
+/// *suffix* so that a key can be located with a binary search instead of a
+/// linear scan. For a map with `n > 0` entries the layout is:
 ///
 /// ```text
-/// [ count: u32 ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ entries.. ]
+/// [ entries.. ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ count: u32 ]
 /// ```
 ///
-/// where `count` is `n`, `offset_i` is the start of entry `i` relative to the
-/// first entry (entry 0 is always at offset 0 and so is omitted), and the
-/// entries are `(key, value)` datum pairs **sorted in ascending key order**.
-/// The index is thus exactly `n` little-endian `u32`s, so the entries begin
-/// `4 * n` bytes into the payload. An empty map has an empty payload (no
-/// header), keeping its encoding canonical.
+/// where the entries are `(key, value)` datum pairs **sorted in ascending key
+/// order**, `offset_i` is the start of entry `i` relative to the first entry
+/// (entry 0 is always at offset 0 and so is omitted), and `count` is `n`. The
+/// suffix is thus exactly `n` little-endian `u32`s, so the entries occupy the
+/// first `data.len() - 4 * n` bytes. The index lives at the end so the packer
+/// can append it (rather than splice it in front) once the entries are written.
+/// An empty map has an empty payload (no suffix), keeping its encoding
+/// canonical.
 ///
 /// The type parameter `T` represents the value type of the map. It is a
 /// phantom parameter — the actual values are stored as serialized bytes and
@@ -1244,64 +1246,50 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
 ///
 /// On entry, `data[entries_start..]` holds the dictionary's entries as a
 /// sequence of sorted `(key, value)` datum pairs. This walks those entries to
-/// compute the byte offset of each one, then splices an index header in just
-/// before them. The resulting payload layout is documented on [`DatumMap`].
+/// compute the byte offset of each one and appends an index *suffix*. The
+/// resulting payload layout is documented on [`DatumMap`].
+///
+/// The suffix layout lets us append the index rather than splice it in front
+/// (no memmove), and we write each offset straight into the buffer as we go
+/// (no temporary allocation) — both matter because this runs on the hot path
+/// that decodes every `Row` out of persist.
 ///
 /// Empty dictionaries are left untouched so that they keep a canonical,
 /// header-free encoding (identical to [`DatumMap::empty`]). This keeps the
 /// encoding of any given map value deterministic, which `Row`'s byte-based
 /// equality relies on.
 fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
-    // Walk the freshly written entries, recording the start offset of each one
-    // relative to `entries_start`.
-    let mut offsets: Vec<u32> = Vec::new();
-    {
-        let entries = &data[entries_start..];
-        let entries_len = entries.len();
-        let mut cursor: &[u8] = entries;
-        while !cursor.is_empty() {
-            let offset = entries_len - cursor.len();
-            offsets.push(u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed"));
-            // SAFETY: `cursor` points at the key/value datums just written by
-            // the packer, which are well-formed per `push_dict_with`'s contract.
-            unsafe {
-                let _key = read_datum(&mut cursor);
-                let _val = read_datum(&mut cursor);
-            }
-        }
-    }
-
-    let n = offsets.len();
-    if n == 0 {
+    let entries_end = data.len();
+    if entries_end == entries_start {
         return;
     }
 
-    // The header stores the entry count followed by the start offsets of
-    // entries `1..n`; entry 0 always starts at offset 0 and is omitted. This is
-    // exactly `n` little-endian `u32`s, so the entries begin `4 * n` bytes into
-    // the payload.
-    let mut header = Vec::with_capacity(size_of::<u32>() * n);
-    header.extend_from_slice(
-        &u32::try_from(n)
-            .expect("map with more than 4 billion entries")
-            .to_le_bytes(),
-    );
-    for offset in &offsets[1..] {
-        header.extend_from_slice(&offset.to_le_bytes());
+    // Walk the entries, appending the start offset of entries `1..count`
+    // (entry 0 is always at offset 0 and is omitted), then append `count`.
+    let mut p = entries_start;
+    let mut count: u32 = 0;
+    while p < entries_end {
+        if count > 0 {
+            let offset =
+                u32::try_from(p - entries_start).expect("map larger than 4 GiB cannot be indexed");
+            data.extend_from_slice(&offset.to_le_bytes());
+        }
+        count = count
+            .checked_add(1)
+            .expect("map with more than 4 billion entries");
+        // Re-borrow `data` here (after the append above) so the borrow never
+        // overlaps a mutation; `entries_end` keeps us within the entries.
+        let mut cursor: &[u8] = &data[p..entries_end];
+        let before = cursor.len();
+        // SAFETY: `cursor` points at the key/value datums just written by the
+        // packer, which are well-formed per `push_dict_with`'s contract.
+        unsafe {
+            read_datum(&mut cursor);
+            read_datum(&mut cursor);
+        }
+        p += before - cursor.len();
     }
-    let header_len = header.len();
-    let entries_len = data.len() - entries_start;
-
-    // Insert `header` just before the entries. `CompactBytes` has no `splice`,
-    // so we grow the buffer (reusing `header` as filler), shift the entries
-    // right to open a gap, then write the header into the gap. This mirrors the
-    // in-place shift in `push_list_with`'s `long_list`.
-    data.extend_from_slice(&header);
-    data.copy_within(
-        entries_start..entries_start + entries_len,
-        entries_start + header_len,
-    );
-    data[entries_start..entries_start + header_len].copy_from_slice(&header);
+    data.extend_from_slice(&count.to_le_bytes());
 }
 
 /// Read a data whose length is encoded in the row before its contents.
@@ -3039,7 +3027,9 @@ impl<'a, T> DatumMap<'a, T> {
         if self.data.is_empty() {
             0
         } else {
-            let count = u32::from_le_bytes(self.data[..size_of::<u32>()].try_into().unwrap());
+            // `count` is the final `u32` of the suffix.
+            let n = self.data.len();
+            let count = u32::from_le_bytes(self.data[n - size_of::<u32>()..].try_into().unwrap());
             usize::cast_from(count)
         }
     }
@@ -3049,26 +3039,30 @@ impl<'a, T> DatumMap<'a, T> {
         self.data.is_empty()
     }
 
-    /// The slice holding the entries, with the index header stripped off.
+    /// The number of bytes the entries occupy, i.e. the payload minus the index
+    /// suffix (which is exactly `len()` little-endian `u32`s).
+    fn entries_len(&self) -> usize {
+        self.data.len() - size_of::<u32>() * self.len()
+    }
+
+    /// The slice holding the entries, with the index suffix stripped off.
     ///
     /// See the type-level docs for the payload layout.
     fn entries(&self) -> &'a [u8] {
         if self.data.is_empty() {
             return self.data;
         }
-        // The header is exactly `len()` little-endian `u32`s.
-        let header_len = size_of::<u32>() * self.len();
-        &self.data[header_len..]
+        &self.data[..self.entries_len()]
     }
 
     /// The start offset of entry `i` relative to the start of the entries
     /// region. Entry 0 is implicitly at offset 0; the rest are read from the
-    /// index header. `i` must be in `0..len()`.
-    fn entry_offset(&self, i: usize) -> usize {
+    /// index suffix, which begins at `entries_len`. `i` must be in `0..len()`.
+    fn entry_offset(&self, entries_len: usize, i: usize) -> usize {
         if i == 0 {
             0
         } else {
-            let at = size_of::<u32>() * i;
+            let at = entries_len + size_of::<u32>() * (i - 1);
             let offset =
                 u32::from_le_bytes(self.data[at..at + size_of::<u32>()].try_into().unwrap());
             usize::cast_from(offset)
@@ -3084,13 +3078,14 @@ impl<'a, T> DatumMap<'a, T> {
         if n == 0 {
             return None;
         }
-        let entries = self.entries();
+        let entries_len = self.entries_len();
+        let entries = &self.data[..entries_len];
 
         let mut lo = 0;
         let mut hi = n;
         while lo < hi {
             let mid = lo + (hi - lo) / 2;
-            let mut cursor = &entries[self.entry_offset(mid)..];
+            let mut cursor = &entries[self.entry_offset(entries_len, mid)..];
             // SAFETY: `cursor` points at a well-formed entry (a string key
             // followed by its value), per the `DatumMap` payload contract.
             let mid_key = unsafe { read_datum(&mut cursor) }.unwrap_str();

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -953,16 +953,23 @@ impl<T> PartialOrd for DatumList<'_, T> {
 /// linear scan. For a map with `n > 0` entries the layout is:
 ///
 /// ```text
-/// [ entries.. ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ count: u32 ]
+/// [ entries.. ][ offset_1: W ] .. [ offset_{n-1}: W ][ count_word: u32 ]
 /// ```
 ///
 /// where the entries are `(key, value)` datum pairs **sorted in ascending key
 /// order**, `offset_i` is the start of entry `i` relative to the first entry
-/// (entry 0 is always at offset 0 and so is omitted), and `count` is `n`. The
-/// suffix is thus exactly `n` little-endian `u32`s, so the entries occupy the
-/// first `data.len() - 4 * n` bytes. The index lives at the end so the packer
-/// can append it (rather than splice it in front) once the entries are written.
-/// An empty map has an empty payload (no suffix), keeping its encoding
+/// (entry 0 is always at offset 0 and so is omitted), and `count_word` packs
+/// the entry count `n` in its low 30 bits with the offset-width class in its top
+/// two bits.
+///
+/// Offsets are stored at width `W` ∈ {1, 2, 4} bytes: the smallest that holds
+/// any offset, chosen from the entries' total byte length (`≤256 → u8`,
+/// `≤65536 → u16`, else `u32`). Because `W` is a deterministic function of the
+/// (fixed) entry bytes, equal maps pick the same width and encode identically.
+/// The suffix is thus `W * (n - 1) + 4` bytes, so the entries occupy the leading
+/// `data.len() - 4 - W * (n - 1)` bytes. The index lives at the end so the
+/// packer can append it (rather than splice it in front) once the entries are
+/// written. An empty map has an empty payload (no suffix), keeping its encoding
 /// canonical.
 ///
 /// The type parameter `T` represents the value type of the map. It is a
@@ -1284,6 +1291,74 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
     bytes
 }
 
+/// Number of low bits of the index count word that hold the entry count; the
+/// top two bits hold the offset-width class. See [`DatumMap`].
+const DICT_COUNT_BITS: u32 = 30;
+/// Mask selecting the entry count out of the index count word.
+const DICT_COUNT_MASK: u32 = (1 << DICT_COUNT_BITS) - 1;
+
+/// The width in bytes of each stored offset for a map whose entries occupy
+/// `entries_len` bytes. Offsets are positions in `0..entries_len`, so the
+/// width is the smallest that can hold `entries_len - 1`. Chosen purely from
+/// `entries_len` (a deterministic function of the entries' bytes) so that equal
+/// maps always pick the same width and encode identically.
+fn offset_width(entries_len: usize) -> usize {
+    if entries_len <= 0x100 {
+        1
+    } else if entries_len <= 0x1_0000 {
+        2
+    } else {
+        4
+    }
+}
+
+/// The width class (0/1/2) packed into the high bits of the count word for an
+/// offset width of 1/2/4 bytes.
+fn offset_width_class(width: usize) -> u32 {
+    match width {
+        1 => 0,
+        2 => 1,
+        4 => 2,
+        _ => unreachable!("offset width is 1, 2, or 4"),
+    }
+}
+
+/// Inverse of [`offset_width_class`].
+fn offset_width_for_class(class: u32) -> usize {
+    match class {
+        0 => 1,
+        1 => 2,
+        2 => 4,
+        _ => unreachable!("offset width class is 0, 1, or 2"),
+    }
+}
+
+/// Appends a single offset of `width` bytes (little-endian).
+fn append_offset(data: &mut CompactBytes, offset: usize, width: usize) {
+    let offset = u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed");
+    match width {
+        1 => data.push(u8::try_from(offset).expect("offset fits in u8 for this width class")),
+        2 => data.extend_from_slice(
+            &u16::try_from(offset)
+                .expect("offset fits in u16 for this width class")
+                .to_le_bytes(),
+        ),
+        _ => data.extend_from_slice(&offset.to_le_bytes()),
+    }
+}
+
+/// Appends the trailing count word: the entry count in the low [`DICT_COUNT_BITS`]
+/// bits, with the offset-width class in the top two bits.
+fn append_count_word(data: &mut CompactBytes, count: usize, width: usize) {
+    assert!(
+        u64::cast_from(count) <= u64::from(DICT_COUNT_MASK),
+        "jsonb map with more than {DICT_COUNT_MASK} entries cannot be indexed"
+    );
+    let count = u32::try_from(count).expect("count <= DICT_COUNT_MASK, checked above");
+    let word = (offset_width_class(width) << DICT_COUNT_BITS) | count;
+    data.extend_from_slice(&word.to_le_bytes());
+}
+
 /// Builds the in-map index for a dictionary the packer has just written.
 ///
 /// On entry, `data[entries_start..]` holds the dictionary's entries as a
@@ -1293,7 +1368,7 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
 ///
 /// The suffix layout lets us append the index rather than splice it in front
 /// (no memmove), and we write each offset straight into the buffer as we go
-/// (no temporary allocation) — both matter because this runs on the hot path
+/// (no temporary allocation). Both matter because this runs on the hot path
 /// that decodes every `Row` out of persist.
 ///
 /// Empty dictionaries are left untouched so that they keep a canonical,
@@ -1305,20 +1380,18 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
     if entries_end == entries_start {
         return;
     }
+    let width = offset_width(entries_end - entries_start);
 
     // Walk the entries, appending the start offset of entries `1..count`
-    // (entry 0 is always at offset 0 and is omitted), then append `count`.
+    // (entry 0 is always at offset 0 and is omitted), then append the count
+    // word.
     let mut p = entries_start;
-    let mut count: u32 = 0;
+    let mut count: usize = 0;
     while p < entries_end {
         if count > 0 {
-            let offset =
-                u32::try_from(p - entries_start).expect("map larger than 4 GiB cannot be indexed");
-            data.extend_from_slice(&offset.to_le_bytes());
+            append_offset(data, p - entries_start, width);
         }
-        count = count
-            .checked_add(1)
-            .expect("map with more than 4 billion entries");
+        count += 1;
         // Re-borrow `data` here (after the append above) so the borrow never
         // overlaps a mutation; `entries_end` keeps us within the entries.
         let mut cursor: &[u8] = &data[p..entries_end];
@@ -1331,31 +1404,32 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
         }
         p += before - cursor.len();
     }
-    data.extend_from_slice(&count.to_le_bytes());
+    append_count_word(data, count, width);
 }
 
 /// Appends the in-map index suffix from offsets captured while the entries were
 /// written, instead of re-walking them as [`finish_dict`] does.
 ///
-/// `offsets[i]` is the start of entry `i` relative to the start of the entries
-/// region. This produces a byte-identical suffix to [`finish_dict`] — the index
-/// is the same deterministic function of the (already sorted) entries — so the
-/// two builders are interchangeable and `Row`'s byte equality is preserved.
+/// `entries_start` is the offset of the entries region within `data`, and
+/// `offsets[i]` is the start of entry `i` relative to it. This produces a
+/// byte-identical suffix to [`finish_dict`]: the width is chosen from the same
+/// `entries_len` and the offsets are the same positions, so the two builders
+/// are interchangeable and `Row`'s byte equality is preserved.
 ///
 /// Empty dictionaries are left untouched, matching [`finish_dict`] and
 /// [`DatumMap::empty`].
-fn finish_dict_from_offsets(data: &mut CompactBytes, offsets: &[u32]) {
+fn finish_dict_from_offsets(data: &mut CompactBytes, entries_start: usize, offsets: &[u32]) {
     let n = offsets.len();
     if n == 0 {
         return;
     }
+    let width = offset_width(data.len() - entries_start);
     // Append the start offsets of entries `1..n` (entry 0 is always at offset 0
-    // and is omitted), then the count. See [`DatumMap`] for the layout.
-    for offset in &offsets[1..] {
-        data.extend_from_slice(&offset.to_le_bytes());
+    // and is omitted), then the count word. See [`DatumMap`] for the layout.
+    for &offset in &offsets[1..] {
+        append_offset(data, usize::cast_from(offset), width);
     }
-    let count = u32::try_from(n).expect("map with more than 4 billion entries");
-    data.extend_from_slice(&count.to_le_bytes());
+    append_count_word(data, n, width);
 }
 
 /// Read a data whose length is encoded in the row before its contents.
@@ -2597,7 +2671,7 @@ impl RowPacker<'_> {
         // row buffer again.
         drop(builder);
 
-        finish_dict_from_offsets(&mut self.row.data, &offsets);
+        finish_dict_from_offsets(&mut self.row.data, entries_start, &offsets);
 
         let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
         self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
@@ -3129,16 +3203,23 @@ impl<'a, T: FromDatum<'a>> Iterator for DatumListTypedIter<'a, T> {
 }
 
 impl<'a, T> DatumMap<'a, T> {
+    /// Reads the index header (the trailing count word) for a non-empty map,
+    /// returning `(n, offset_width)`. See [`DatumMap`] for the layout and how
+    /// the width is packed into the count's high bits.
+    fn header(&self) -> Option<(usize, usize)> {
+        if self.data.is_empty() {
+            return None;
+        }
+        let n = self.data.len();
+        let word = u32::from_le_bytes(self.data[n - size_of::<u32>()..].try_into().unwrap());
+        let count = usize::cast_from(word & DICT_COUNT_MASK);
+        let width = offset_width_for_class(word >> DICT_COUNT_BITS);
+        Some((count, width))
+    }
+
     /// The number of entries in the map.
     pub fn len(&self) -> usize {
-        if self.data.is_empty() {
-            0
-        } else {
-            // `count` is the final `u32` of the suffix.
-            let n = self.data.len();
-            let count = u32::from_le_bytes(self.data[n - size_of::<u32>()..].try_into().unwrap());
-            usize::cast_from(count)
-        }
+        self.header().map_or(0, |(count, _)| count)
     }
 
     /// Whether the map has no entries.
@@ -3147,32 +3228,36 @@ impl<'a, T> DatumMap<'a, T> {
     }
 
     /// The number of bytes the entries occupy, i.e. the payload minus the index
-    /// suffix (which is exactly `len()` little-endian `u32`s).
-    fn entries_len(&self) -> usize {
-        self.data.len() - size_of::<u32>() * self.len()
+    /// suffix. The suffix is `n - 1` offsets of `width` bytes plus the count
+    /// `u32`.
+    fn entries_len_for(&self, count: usize, width: usize) -> usize {
+        self.data.len() - size_of::<u32>() - width * (count - 1)
     }
 
     /// The slice holding the entries, with the index suffix stripped off.
     ///
     /// See the type-level docs for the payload layout.
     fn entries(&self) -> &'a [u8] {
-        if self.data.is_empty() {
-            return self.data;
+        match self.header() {
+            None => self.data,
+            Some((count, width)) => &self.data[..self.entries_len_for(count, width)],
         }
-        &self.data[..self.entries_len()]
     }
 
     /// The start offset of entry `i` relative to the start of the entries
     /// region. Entry 0 is implicitly at offset 0; the rest are read from the
-    /// index suffix, which begins at `entries_len`. `i` must be in `0..len()`.
-    fn entry_offset(&self, entries_len: usize, i: usize) -> usize {
+    /// index suffix (offsets of `width` bytes beginning at `entries_len`). `i`
+    /// must be in `0..count`.
+    fn entry_offset(&self, entries_len: usize, width: usize, i: usize) -> usize {
         if i == 0 {
-            0
-        } else {
-            let at = entries_len + size_of::<u32>() * (i - 1);
-            let offset =
-                u32::from_le_bytes(self.data[at..at + size_of::<u32>()].try_into().unwrap());
-            usize::cast_from(offset)
+            return 0;
+        }
+        let at = entries_len + width * (i - 1);
+        let bytes = &self.data[at..at + width];
+        match width {
+            1 => usize::from(bytes[0]),
+            2 => usize::from(u16::from_le_bytes(bytes.try_into().unwrap())),
+            _ => usize::cast_from(u32::from_le_bytes(bytes.try_into().unwrap())),
         }
     }
 
@@ -3181,18 +3266,15 @@ impl<'a, T> DatumMap<'a, T> {
     /// Runs in `O(log n)` over the `n` entries by binary searching the
     /// key-sorted index, rather than the `O(n)` linear scan of [`Self::iter`].
     pub fn get(&self, key: &str) -> Option<Datum<'a>> {
-        let n = self.len();
-        if n == 0 {
-            return None;
-        }
-        let entries_len = self.entries_len();
+        let (n, width) = self.header()?;
+        let entries_len = self.entries_len_for(n, width);
         let entries = &self.data[..entries_len];
 
         let mut lo = 0;
         let mut hi = n;
         while lo < hi {
             let mid = lo + (hi - lo) / 2;
-            let mut cursor = &entries[self.entry_offset(entries_len, mid)..];
+            let mut cursor = &entries[self.entry_offset(entries_len, width, mid)..];
             // SAFETY: `cursor` points at a well-formed entry (a string key
             // followed by its value), per the `DatumMap` payload contract.
             let mid_key = unsafe { read_datum(&mut cursor) }.unwrap_str();
@@ -3982,6 +4064,32 @@ mod tests {
                 let linear = map.iter().find(|(k, _)| *k == probe).map(|(_, v)| v);
                 assert_eq!(map.get(probe), linear, "probe {probe:?} with n={n}");
             }
+        }
+
+        // Exercise all three offset widths (u8/u16/u32) by padding the values so
+        // the entries region crosses the 256- and 65536-byte thresholds. A wrong
+        // width choice would corrupt offset reads.
+        for value_len in [1_usize, 80, 90, 300, 70_000] {
+            let keys = ["a", "b", "c"];
+            let val = "x".repeat(value_len);
+            let mut row = Row::default();
+            row.packer().push_dict_with(|row| {
+                for k in keys {
+                    row.push(Datum::String(k));
+                    row.push(Datum::String(val.as_str()));
+                }
+            });
+            let datum = row.unpack_first();
+            let map = datum.unwrap_map();
+            assert_eq!(map.len(), keys.len(), "value_len={value_len}");
+            for k in keys {
+                assert_eq!(
+                    map.get(k),
+                    Some(Datum::String(val.as_str())),
+                    "key {k:?} with value_len={value_len}",
+                );
+            }
+            assert_eq!(map.get("zzz"), None, "miss with value_len={value_len}");
         }
 
         // A nested value is returned intact via `get`.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -1467,13 +1467,15 @@ fn append_count_word(data: &mut CompactBytes, count: usize, width: usize) {
 ///
 /// On entry, `data[entries_start..]` holds the dictionary's entries as a
 /// sequence of sorted `(key, value)` datum pairs. This walks those entries to
-/// compute the byte offset of each one and appends an index *suffix*. The
-/// resulting payload layout is documented on [`DatumMap`].
+/// recover the byte offset of each one, then appends the index *suffix*
+/// documented on [`DatumMap`].
 ///
-/// The suffix layout lets us append the index rather than splice it in front
-/// (no memmove), and we write each offset straight into the buffer as we go
-/// (no temporary allocation). Both matter because this runs on the hot path
-/// that decodes every `Row` out of persist.
+/// A closure passed to [`RowPacker::push_dict_with`] may fail between pushing a
+/// key and pushing its value, which leaves a trailing key with no value. Such an
+/// entry is dropped: the walk stops at the last complete pair and the orphaned
+/// key is truncated away, so the map stays readable. The caller is abandoning the
+/// row on that path anyway, and reading past the orphan would walk off the end of
+/// the entries.
 ///
 /// Empty dictionaries are left untouched so that they keep a canonical,
 /// header-free encoding (identical to [`DatumMap::empty`]). This keeps the
@@ -1484,54 +1486,53 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
     if entries_end == entries_start {
         return;
     }
-    let width = offset_width(entries_end - entries_start);
 
-    // Walk the entries, appending the start offset of entries `1..count`
-    // (entry 0 is always at offset 0 and is omitted), then append the count
-    // word.
+    // Walk the entries read-only, collecting each one's start offset, then hand
+    // off to the shared appender. Nothing is written until the walk is done, so
+    // the offsets never have to be revised once a truncated entry turns up.
+    // Offsets accumulate in an inline `SmallVec`, so typical maps stay
+    // allocation-free.
+    let mut offsets: SmallVec<[u32; 32]> = SmallVec::new();
     let mut p = entries_start;
-    let mut count: usize = 0;
-    let mut prev_entry: Option<usize> = None;
+    let mut prev_key: Option<&str> = None;
     while p < entries_end {
-        if count > 0 {
-            append_offset(data, p - entries_start, width);
-        }
-        count += 1;
-        // Re-borrow `data` here (after the append above) so the borrow never
-        // overlaps a mutation; `entries_end` keeps us within the entries.
         let mut cursor: &[u8] = &data[p..entries_end];
         let before = cursor.len();
         // SAFETY: `cursor` points at the key/value datums just written by the
         // packer, which are well-formed per `push_dict_with`'s contract.
-        let key = unsafe {
-            let key = read_datum(&mut cursor);
-            read_datum(&mut cursor);
-            key
-        };
+        let key = unsafe { read_datum(&mut cursor) };
+        if cursor.is_empty() {
+            // A key with no value: the closure failed mid-entry. Stop before it.
+            break;
+        }
+        // SAFETY: as above, and the key was followed by at least one byte.
+        unsafe { read_datum(&mut cursor) };
 
         // Out-of-order keys make `DatumMap::get` miss keys that are present,
         // since it binary searches. Check here so a caller that violates
         // `push_dict_with`'s contract is caught where the map is built, rather
-        // than only if something later iterates it. Re-reading the previous
-        // key costs a second decode, so it is gated on soft assertions.
+        // than only if something later iterates it.
         if mz_ore::assert::soft_assertions_enabled() {
-            if let Some(prev) = prev_entry {
-                let mut prev_cursor: &[u8] = &data[prev..entries_end];
-                // SAFETY: as above, `prev` is a previously walked entry start.
-                let prev_key = unsafe { read_datum(&mut prev_cursor) }.unwrap_str();
+            let key = key.unwrap_str();
+            if let Some(prev_key) = prev_key {
                 mz_ore::soft_assert_no_log!(
-                    prev_key < key.unwrap_str(),
-                    "Dict keys must be unique and given in ascending order: {} came before {}",
-                    prev_key,
-                    key.unwrap_str()
+                    prev_key < key,
+                    "Dict keys must be unique and given in ascending order: \
+                     {prev_key} came before {key}"
                 );
             }
-            prev_entry = Some(p);
+            prev_key = Some(key);
         }
 
+        offsets.push(
+            u32::try_from(p - entries_start).expect("map larger than 4 GiB cannot be indexed"),
+        );
         p += before - cursor.len();
     }
-    append_count_word(data, count, width);
+
+    // Discard a truncated trailing entry, if the walk found one.
+    data.truncate(p);
+    finish_dict_from_offsets(data, entries_start, &offsets);
 }
 
 /// Appends the in-map index suffix from offsets captured while the entries were
@@ -4759,6 +4760,43 @@ mod tests {
             vec![Datum::Int64(1), Datum::Int64(2)],
         );
         assert_eq!(map.get("missing"), None);
+    }
+
+    #[mz_ore::test]
+    fn test_dict_with_failed_entry_is_readable() {
+        // A fallible closure can fail after pushing a key and before pushing its
+        // value. The index build must not walk off the end of that half-entry,
+        // and the map it leaves behind must still be readable, since callers
+        // that go on to inspect the row (a fuzz target, a `Debug` impl in an
+        // error path) would otherwise read past the entries.
+        for complete in [0_usize, 1, 2, 40] {
+            let mut row = Row::default();
+            let res: Result<(), &str> = row.packer().push_dict_with(|packer| {
+                for i in 0..complete {
+                    packer.push(Datum::String(&format!("k{i:03}")));
+                    packer.push(Datum::Int64(i64::try_from(i).unwrap()));
+                }
+                // The orphaned key, sorting after every complete entry.
+                packer.push(Datum::String("zzz"));
+                Err("value push failed")
+            });
+            assert_eq!(res, Err("value push failed"), "complete={complete}");
+
+            let datum = row.unpack_first();
+            let map = datum.unwrap_map();
+            assert_eq!(map.len(), complete, "complete={complete}");
+            assert_eq!(map.iter().count(), complete, "complete={complete}");
+            for i in 0..complete {
+                let key = format!("k{i:03}");
+                assert_eq!(
+                    map.get(&key),
+                    Some(Datum::Int64(i64::try_from(i).unwrap())),
+                    "complete={complete}",
+                );
+            }
+            // The orphaned entry is gone, not half-present.
+            assert_eq!(map.get("zzz"), None, "complete={complete}");
+        }
     }
 
     #[mz_ore::test]

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -36,6 +36,7 @@ use proptest::prelude::*;
 #[cfg(any(test, feature = "proptest"))]
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use uuid::Uuid;
 
 use crate::adt::array::{
@@ -812,6 +813,47 @@ pub struct RowPacker<'a> {
     row: &'a mut Row,
 }
 
+/// Builds a [`DatumMap`] one `(key, value)` entry at a time for
+/// [`RowPacker::push_indexed_dict_with`], capturing each entry's start offset as
+/// it is written so the in-map index can be appended without a second pass over
+/// the entries.
+pub struct DictBuilder<'a, 'row> {
+    packer: &'a mut RowPacker<'row>,
+    /// Start of the entries region within `packer.row.data`.
+    entries_start: usize,
+    /// Start offset of each entry pushed so far, relative to `entries_start`.
+    /// The inline capacity covers typical JSON objects without a heap
+    /// allocation, keeping the common case allocation-free.
+    offsets: SmallVec<[u32; 32]>,
+}
+
+impl Debug for DictBuilder<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DictBuilder")
+            .field("entries_start", &self.entries_start)
+            .field("entries_pushed", &self.offsets.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl DictBuilder<'_, '_> {
+    /// Pushes one `(key, value)` entry, recording its start offset for the
+    /// index. `value` is run with the underlying packer to write the value,
+    /// which may itself be a nested list or dict.
+    ///
+    /// Keys must be pushed in ascending order, per the [`DatumMap`] contract.
+    pub fn push_entry<F, R>(&mut self, key: &str, value: F) -> R
+    where
+        F: FnOnce(&mut RowPacker) -> R,
+    {
+        let offset = self.packer.row.data.len() - self.entries_start;
+        self.offsets
+            .push(u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed"));
+        self.packer.push(Datum::String(key));
+        value(self.packer)
+    }
+}
+
 /// Infallible conversion from a [`Datum`] to a typed value.
 ///
 /// Used by [`DatumList::typed_iter`] to yield elements as `T` rather than
@@ -1372,6 +1414,30 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
         }
         p += before - cursor.len();
     }
+    data.extend_from_slice(&count.to_le_bytes());
+}
+
+/// Appends the in-map index suffix from offsets captured while the entries were
+/// written, instead of re-walking them as [`finish_dict`] does.
+///
+/// `offsets[i]` is the start of entry `i` relative to the start of the entries
+/// region. This produces a byte-identical suffix to [`finish_dict`] — the index
+/// is the same deterministic function of the (already sorted) entries — so the
+/// two builders are interchangeable and `Row`'s byte equality is preserved.
+///
+/// Empty dictionaries are left untouched, matching [`finish_dict`] and
+/// [`DatumMap::empty`].
+fn finish_dict_from_offsets(data: &mut CompactBytes, offsets: &[u32]) {
+    let n = offsets.len();
+    if n == 0 {
+        return;
+    }
+    // Append the start offsets of entries `1..n` (entry 0 is always at offset 0
+    // and is omitted), then the count. See [`DatumMap`] for the layout.
+    for offset in &offsets[1..] {
+        data.extend_from_slice(&offset.to_le_bytes());
+    }
+    let count = u32::try_from(n).expect("map with more than 4 billion entries");
     data.extend_from_slice(&count.to_le_bytes());
 }
 
@@ -2580,6 +2646,48 @@ impl RowPacker<'_> {
         self.push_dict_with(f)
     }
 
+    /// Pushes a [`DatumMap`] built one `(key, value)` entry at a time via a
+    /// [`DictBuilder`].
+    ///
+    /// This is equivalent to [`push_dict_with`](Self::push_dict_with) but builds
+    /// the in-map index from offsets captured as each entry is written, rather
+    /// than walking the entries a second time afterwards. Callers that already
+    /// iterate entry-by-entry (JSON packing, the columnar/proto decode paths)
+    /// should prefer this to avoid the redundant pass on the hot decode path.
+    ///
+    /// The same contract as [`push_dict_with`](Self::push_dict_with) applies:
+    /// entries **must** be pushed with keys in ascending order, and the closure
+    /// **must not** call [`clear`](Self::clear), [`truncate`](Self::truncate),
+    /// or [`truncate_datums`](Self::truncate_datums).
+    pub fn push_indexed_dict_with<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut DictBuilder<'_, '_>) -> R,
+    {
+        self.row.data.push(Tag::Dict.into());
+        let start = self.row.data.len();
+        // Write a dummy len, fixed up below.
+        self.row.data.extend_from_slice(&[0; size_of::<u64>()]);
+        let entries_start = self.row.data.len();
+
+        let mut builder = DictBuilder {
+            packer: self,
+            entries_start,
+            offsets: SmallVec::new(),
+        };
+        let res = f(&mut builder);
+        let offsets = std::mem::take(&mut builder.offsets);
+        // Drop the builder to release its borrow of `self` before we touch the
+        // row buffer again.
+        drop(builder);
+
+        finish_dict_from_offsets(&mut self.row.data, &offsets);
+
+        let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
+        self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
+
+        res
+    }
+
     /// Convenience function to construct an array from an iter of `Datum`s.
     ///
     /// Returns an error if the number of elements in `iter` does not match
@@ -2835,10 +2943,9 @@ impl RowPacker<'_> {
         I: IntoIterator<Item = (&'a str, D)>,
         D: Borrow<Datum<'a>>,
     {
-        self.push_dict_with(|packer| {
+        self.push_indexed_dict_with(|builder| {
             for (k, v) in iter {
-                packer.push(Datum::String(k));
-                packer.push(*v.borrow())
+                builder.push_entry(k, |packer| packer.push(*v.borrow()));
             }
         })
     }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -985,6 +985,23 @@ impl<T> PartialOrd for DatumList<'_, T> {
 
 /// A mapping from string keys to Datums
 ///
+/// # Payload layout
+///
+/// `data` points at the map's serialized payload, which carries a small index
+/// so that a key can be located with a binary search instead of a linear scan.
+/// For a map with `n > 0` entries the layout is:
+///
+/// ```text
+/// [ count: u32 ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ entries.. ]
+/// ```
+///
+/// where `count` is `n`, `offset_i` is the start of entry `i` relative to the
+/// first entry (entry 0 is always at offset 0 and so is omitted), and the
+/// entries are `(key, value)` datum pairs **sorted in ascending key order**.
+/// The index is thus exactly `n` little-endian `u32`s, so the entries begin
+/// `4 * n` bytes into the payload. An empty map has an empty payload (no
+/// header), keeping its encoding canonical.
+///
 /// The type parameter `T` represents the value type of the map. It is a
 /// phantom parameter — the actual values are stored as serialized bytes and
 /// `T` is not enforced at runtime. It is up to the caller to ensure `T`
@@ -994,7 +1011,8 @@ impl<T> PartialOrd for DatumList<'_, T> {
 /// See `doc/developer/design/20260311_sqlfunc_generic.md` for the design
 /// behind the generic type parameter.
 pub struct DatumMap<'a, T = Datum<'a>> {
-    /// Points at the serialized datums, which should be sorted in key order
+    /// Points at the serialized payload (index header followed by the
+    /// key-sorted entries). See the type-level docs for the layout.
     data: &'a [u8],
     _phantom: PhantomData<fn() -> T>,
 }
@@ -1303,6 +1321,70 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
     let (bytes, next) = data.split_at(len);
     *data = next;
     bytes
+}
+
+/// Builds the in-map index for a dictionary the packer has just written.
+///
+/// On entry, `data[entries_start..]` holds the dictionary's entries as a
+/// sequence of sorted `(key, value)` datum pairs. This walks those entries to
+/// compute the byte offset of each one, then splices an index header in just
+/// before them. The resulting payload layout is documented on [`DatumMap`].
+///
+/// Empty dictionaries are left untouched so that they keep a canonical,
+/// header-free encoding (identical to [`DatumMap::empty`]). This keeps the
+/// encoding of any given map value deterministic, which `Row`'s byte-based
+/// equality relies on.
+fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
+    // Walk the freshly written entries, recording the start offset of each one
+    // relative to `entries_start`.
+    let mut offsets: Vec<u32> = Vec::new();
+    {
+        let entries = &data[entries_start..];
+        let entries_len = entries.len();
+        let mut cursor: &[u8] = entries;
+        while !cursor.is_empty() {
+            let offset = entries_len - cursor.len();
+            offsets.push(u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed"));
+            // SAFETY: `cursor` points at the key/value datums just written by
+            // the packer, which are well-formed per `push_dict_with`'s contract.
+            unsafe {
+                let _key = read_datum(&mut cursor);
+                let _val = read_datum(&mut cursor);
+            }
+        }
+    }
+
+    let n = offsets.len();
+    if n == 0 {
+        return;
+    }
+
+    // The header stores the entry count followed by the start offsets of
+    // entries `1..n`; entry 0 always starts at offset 0 and is omitted. This is
+    // exactly `n` little-endian `u32`s, so the entries begin `4 * n` bytes into
+    // the payload.
+    let mut header = Vec::with_capacity(size_of::<u32>() * n);
+    header.extend_from_slice(
+        &u32::try_from(n)
+            .expect("map with more than 4 billion entries")
+            .to_le_bytes(),
+    );
+    for offset in &offsets[1..] {
+        header.extend_from_slice(&offset.to_le_bytes());
+    }
+    let header_len = header.len();
+    let entries_len = data.len() - entries_start;
+
+    // Insert `header` just before the entries. `CompactBytes` has no `splice`,
+    // so we grow the buffer (reusing `header` as filler), shift the entries
+    // right to open a gap, then write the header into the gap. This mirrors the
+    // in-place shift in `push_list_with`'s `long_list`.
+    data.extend_from_slice(&header);
+    data.copy_within(
+        entries_start..entries_start + entries_len,
+        entries_start + header_len,
+    );
+    data[entries_start..entries_start + header_len].copy_from_slice(&header);
 }
 
 /// Read a data whose length is encoded in the row before its contents.
@@ -2489,6 +2571,12 @@ impl RowPacker<'_> {
 
         let res = f(self);
 
+        // Build an in-map index over the entries that were just written, so
+        // that individual keys can be located with a binary search rather than
+        // a linear scan. See [`DatumMap`] for the payload layout. This must
+        // happen before the length is fixed up, as it changes the payload size.
+        finish_dict(&mut self.row.data, start + size_of::<u64>());
+
         let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
         // fix up the len
         self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
@@ -3048,9 +3136,78 @@ impl<'a, T: FromDatum<'a>> Iterator for DatumListTypedIter<'a, T> {
 }
 
 impl<'a, T> DatumMap<'a, T> {
+    /// The number of entries in the map.
+    pub fn len(&self) -> usize {
+        if self.data.is_empty() {
+            0
+        } else {
+            let count = u32::from_le_bytes(self.data[..size_of::<u32>()].try_into().unwrap());
+            usize::cast_from(count)
+        }
+    }
+
+    /// Whether the map has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// The slice holding the entries, with the index header stripped off.
+    ///
+    /// See the type-level docs for the payload layout.
+    fn entries(&self) -> &'a [u8] {
+        if self.data.is_empty() {
+            return self.data;
+        }
+        // The header is exactly `len()` little-endian `u32`s.
+        let header_len = size_of::<u32>() * self.len();
+        &self.data[header_len..]
+    }
+
+    /// The start offset of entry `i` relative to the start of the entries
+    /// region. Entry 0 is implicitly at offset 0; the rest are read from the
+    /// index header. `i` must be in `0..len()`.
+    fn entry_offset(&self, i: usize) -> usize {
+        if i == 0 {
+            0
+        } else {
+            let at = size_of::<u32>() * i;
+            let offset =
+                u32::from_le_bytes(self.data[at..at + size_of::<u32>()].try_into().unwrap());
+            usize::cast_from(offset)
+        }
+    }
+
+    /// Looks up `key`, returning its value if present.
+    ///
+    /// Runs in `O(log n)` over the `n` entries by binary searching the
+    /// key-sorted index, rather than the `O(n)` linear scan of [`Self::iter`].
+    pub fn get(&self, key: &str) -> Option<Datum<'a>> {
+        let n = self.len();
+        if n == 0 {
+            return None;
+        }
+        let entries = self.entries();
+
+        let mut lo = 0;
+        let mut hi = n;
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            let mut cursor = &entries[self.entry_offset(mid)..];
+            // SAFETY: `cursor` points at a well-formed entry (a string key
+            // followed by its value), per the `DatumMap` payload contract.
+            let mid_key = unsafe { read_datum(&mut cursor) }.unwrap_str();
+            match key.cmp(mid_key) {
+                Ordering::Equal => return Some(unsafe { read_datum(&mut cursor) }),
+                Ordering::Less => hi = mid,
+                Ordering::Greater => lo = mid + 1,
+            }
+        }
+        None
+    }
+
     pub fn iter(&self) -> DatumDictIter<'a> {
         DatumDictIter {
-            data: self.data,
+            data: self.entries(),
             prev_key: None,
         }
     }
@@ -4274,6 +4431,65 @@ mod tests {
         assert_eq!(dict.next(), None);
 
         Ok(())
+    }
+
+    #[mz_ore::test]
+    fn test_datum_map_get() {
+        // For maps of various sizes, `DatumMap::get` (binary search over the
+        // in-map index) must agree with a linear scan for both present keys and
+        // misses, and `len`/`is_empty` must report the right cardinality.
+        for n in [0_usize, 1, 2, 3, 7, 16, 50] {
+            let keys: Vec<String> = (0..n).map(|i| format!("k{i:03}")).collect();
+            let mut row = Row::default();
+            row.packer().push_dict_with(|row| {
+                // `push_dict_with` requires keys in ascending order; `keys` is
+                // already sorted.
+                for (i, k) in keys.iter().enumerate() {
+                    row.push(Datum::String(k));
+                    row.push(Datum::Int64(i64::try_from(i).unwrap() * 10));
+                }
+            });
+            let datum = row.unpack_first();
+            let map = datum.unwrap_map();
+
+            assert_eq!(map.len(), n);
+            assert_eq!(map.is_empty(), n == 0);
+
+            // Every present key resolves to its value.
+            for (i, k) in keys.iter().enumerate() {
+                assert_eq!(
+                    map.get(k),
+                    Some(Datum::Int64(i64::try_from(i).unwrap() * 10)),
+                    "present key {k:?} with n={n}",
+                );
+            }
+
+            // Misses (before, between, and after the keys) agree with a scan.
+            for probe in ["", "k", "k000a", "k999", "zzz"] {
+                let linear = map.iter().find(|(k, _)| *k == probe).map(|(_, v)| v);
+                assert_eq!(map.get(probe), linear, "probe {probe:?} with n={n}");
+            }
+        }
+
+        // A nested value is returned intact via `get`.
+        let mut row = Row::default();
+        row.packer().push_dict_with(|row| {
+            row.push(Datum::String("list"));
+            row.push_list_with(|row| {
+                row.push(Datum::Int64(1));
+                row.push(Datum::Int64(2));
+            });
+            row.push(Datum::String("scalar"));
+            row.push(Datum::Int64(7));
+        });
+        let datum = row.unpack_first();
+        let map = datum.unwrap_map();
+        assert_eq!(map.get("scalar"), Some(Datum::Int64(7)));
+        assert_eq!(
+            map.get("list").unwrap().unwrap_list().iter().collect::<Vec<_>>(),
+            vec![Datum::Int64(1), Datum::Int64(2)],
+        );
+        assert_eq!(map.get("missing"), None);
     }
 
     #[mz_ore::test]

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -842,10 +842,31 @@ impl DictBuilder<'_, '_> {
     /// which may itself be a nested list or dict.
     ///
     /// Keys must be pushed in ascending order, per the [`DatumMap`] contract.
+    /// Violating that makes [`DatumMap::get`] miss keys that are present, since
+    /// it binary searches, so the order is checked here under soft assertions
+    /// rather than only when the map is later iterated.
     pub fn push_entry<F, R>(&mut self, key: &str, value: F) -> R
     where
         F: FnOnce(&mut RowPacker) -> R,
     {
+        // Read the previous entry's key back out of the buffer instead of
+        // keeping a copy, so the check needs no extra state. Both borrows end
+        // before the push below takes `data` mutably.
+        if mz_ore::assert::soft_assertions_enabled() {
+            if let Some(&prev_offset) = self.offsets.last() {
+                let at = self.entries_start + usize::cast_from(prev_offset);
+                let mut cursor: &[u8] = &self.packer.row.data[at..];
+                // SAFETY: `cursor` points at the key datum written by the
+                // preceding `push_entry`.
+                let prev_key = unsafe { read_datum(&mut cursor) }.unwrap_str();
+                mz_ore::soft_assert_no_log!(
+                    prev_key < key,
+                    "Dict keys must be unique and given in ascending order: \
+                     {prev_key} came before {key}"
+                );
+            }
+        }
+
         let offset = self.packer.row.data.len() - self.entries_start;
         self.offsets
             .push(u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed"));
@@ -1470,6 +1491,7 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
     // word.
     let mut p = entries_start;
     let mut count: usize = 0;
+    let mut prev_entry: Option<usize> = None;
     while p < entries_end {
         if count > 0 {
             append_offset(data, p - entries_start, width);
@@ -1481,10 +1503,32 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
         let before = cursor.len();
         // SAFETY: `cursor` points at the key/value datums just written by the
         // packer, which are well-formed per `push_dict_with`'s contract.
-        unsafe {
+        let key = unsafe {
+            let key = read_datum(&mut cursor);
             read_datum(&mut cursor);
-            read_datum(&mut cursor);
+            key
+        };
+
+        // Out-of-order keys make `DatumMap::get` miss keys that are present,
+        // since it binary searches. Check here so a caller that violates
+        // `push_dict_with`'s contract is caught where the map is built, rather
+        // than only if something later iterates it. Re-reading the previous
+        // key costs a second decode, so it is gated on soft assertions.
+        if mz_ore::assert::soft_assertions_enabled() {
+            if let Some(prev) = prev_entry {
+                let mut prev_cursor: &[u8] = &data[prev..entries_end];
+                // SAFETY: as above, `prev` is a previously walked entry start.
+                let prev_key = unsafe { read_datum(&mut prev_cursor) }.unwrap_str();
+                mz_ore::soft_assert_no_log!(
+                    prev_key < key.unwrap_str(),
+                    "Dict keys must be unique and given in ascending order: {} came before {}",
+                    prev_key,
+                    key.unwrap_str()
+                );
+            }
+            prev_entry = Some(p);
         }
+
         p += before - cursor.len();
     }
     append_count_word(data, count, width);
@@ -3326,7 +3370,7 @@ impl<'a, T> DatumMap<'a, T> {
 
     /// Whether the map has no entries.
     pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
+        self.len() == 0
     }
 
     /// The number of bytes the entries occupy, i.e. the payload minus the index
@@ -3387,6 +3431,17 @@ impl<'a, T> DatumMap<'a, T> {
             }
         }
         None
+    }
+
+    /// Looks up `key`, returning its value converted via [`FromDatum`].
+    ///
+    /// The typed counterpart to [`Self::get`], as [`Self::typed_iter`] is to
+    /// [`Self::iter`].
+    pub fn get_typed(&self, key: &str) -> Option<T>
+    where
+        T: FromDatum<'a>,
+    {
+        self.get(key).map(T::from_datum)
     }
 
     pub fn iter(&self) -> DatumDictIter<'a> {

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -4486,7 +4486,11 @@ mod tests {
         let map = datum.unwrap_map();
         assert_eq!(map.get("scalar"), Some(Datum::Int64(7)));
         assert_eq!(
-            map.get("list").unwrap().unwrap_list().iter().collect::<Vec<_>>(),
+            map.get("list")
+                .unwrap()
+                .unwrap_list()
+                .iter()
+                .collect::<Vec<_>>(),
             vec![Datum::Int64(1), Datum::Int64(2)],
         );
         assert_eq!(map.get("missing"), None);

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -4762,6 +4762,91 @@ mod tests {
     }
 
     #[mz_ore::test]
+    fn test_dict_builders_agree() {
+        // The two index builders must emit byte-identical maps: `finish_dict`
+        // (the closure path) and `finish_dict_from_offsets` (the push-time
+        // path). `Row` equality is byte equality, so a mismatch would make the
+        // same logical map compare unequal depending on which code packed it,
+        // breaking joins, dedup, and arrangement keys across paths that use
+        // different builders.
+        let cases: Vec<Vec<(String, String)>> = vec![
+            // Empty, single, and small maps.
+            vec![],
+            vec![("a".into(), "1".into())],
+            (0..3).map(|i| (format!("k{i}"), format!("v{i}"))).collect(),
+            // Straddles all three offset widths: u8, u16, then u32.
+            (0..50)
+                .map(|i| (format!("k{i:02}"), format!("v{i:02}")))
+                .collect(),
+            (0..5).map(|i| (format!("k{i}"), "x".repeat(100))).collect(),
+            (0..5)
+                .map(|i| (format!("k{i}"), "x".repeat(20_000)))
+                .collect(),
+            (0..500)
+                .map(|i| (format!("k{i:03}"), format!("{i}")))
+                .collect(),
+        ];
+
+        for entries in &cases {
+            let mut via_closure = Row::default();
+            via_closure.packer().push_dict_with(|packer| {
+                for (k, v) in entries {
+                    packer.push(Datum::String(k));
+                    packer.push(Datum::String(v));
+                }
+            });
+
+            let mut via_builder = Row::default();
+            via_builder.packer().push_indexed_dict_with(|builder| {
+                for (k, v) in entries {
+                    builder.push_entry(k, |packer| packer.push(Datum::String(v)));
+                }
+            });
+
+            assert_eq!(
+                via_closure.data.as_slice(),
+                via_builder.data.as_slice(),
+                "builders disagree for {} entries",
+                entries.len(),
+            );
+        }
+
+        // Nested maps and lists, built both ways.
+        let mut via_closure = Row::default();
+        via_closure.packer().push_dict_with(|packer| {
+            packer.push(Datum::String("inner"));
+            packer.push_dict_with(|packer| {
+                packer.push(Datum::String("x"));
+                packer.push(Datum::Int64(1));
+            });
+            packer.push(Datum::String("list"));
+            packer.push_list_with(|packer| {
+                packer.push(Datum::Int64(1));
+                packer.push(Datum::Int64(2));
+            });
+        });
+        let mut via_builder = Row::default();
+        via_builder.packer().push_indexed_dict_with(|builder| {
+            builder.push_entry("inner", |packer| {
+                packer.push_indexed_dict_with(|inner| {
+                    inner.push_entry("x", |packer| packer.push(Datum::Int64(1)));
+                })
+            });
+            builder.push_entry("list", |packer| {
+                packer.push_list_with(|packer| {
+                    packer.push(Datum::Int64(1));
+                    packer.push(Datum::Int64(2));
+                })
+            });
+        });
+        assert_eq!(
+            via_closure.data.as_slice(),
+            via_builder.data.as_slice(),
+            "builders disagree for a nested map",
+        );
+    }
+
+    #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     fn test_datum_sizes() {
         let arena = RowArena::new();

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -988,19 +988,21 @@ impl<T> PartialOrd for DatumList<'_, T> {
 /// # Payload layout
 ///
 /// `data` points at the map's serialized payload, which carries a small index
-/// so that a key can be located with a binary search instead of a linear scan.
-/// For a map with `n > 0` entries the layout is:
+/// *suffix* so that a key can be located with a binary search instead of a
+/// linear scan. For a map with `n > 0` entries the layout is:
 ///
 /// ```text
-/// [ count: u32 ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ entries.. ]
+/// [ entries.. ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ count: u32 ]
 /// ```
 ///
-/// where `count` is `n`, `offset_i` is the start of entry `i` relative to the
-/// first entry (entry 0 is always at offset 0 and so is omitted), and the
-/// entries are `(key, value)` datum pairs **sorted in ascending key order**.
-/// The index is thus exactly `n` little-endian `u32`s, so the entries begin
-/// `4 * n` bytes into the payload. An empty map has an empty payload (no
-/// header), keeping its encoding canonical.
+/// where the entries are `(key, value)` datum pairs **sorted in ascending key
+/// order**, `offset_i` is the start of entry `i` relative to the first entry
+/// (entry 0 is always at offset 0 and so is omitted), and `count` is `n`. The
+/// suffix is thus exactly `n` little-endian `u32`s, so the entries occupy the
+/// first `data.len() - 4 * n` bytes. The index lives at the end so the packer
+/// can append it (rather than splice it in front) once the entries are written.
+/// An empty map has an empty payload (no suffix), keeping its encoding
+/// canonical.
 ///
 /// The type parameter `T` represents the value type of the map. It is a
 /// phantom parameter — the actual values are stored as serialized bytes and
@@ -1327,64 +1329,50 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
 ///
 /// On entry, `data[entries_start..]` holds the dictionary's entries as a
 /// sequence of sorted `(key, value)` datum pairs. This walks those entries to
-/// compute the byte offset of each one, then splices an index header in just
-/// before them. The resulting payload layout is documented on [`DatumMap`].
+/// compute the byte offset of each one and appends an index *suffix*. The
+/// resulting payload layout is documented on [`DatumMap`].
+///
+/// The suffix layout lets us append the index rather than splice it in front
+/// (no memmove), and we write each offset straight into the buffer as we go
+/// (no temporary allocation) — both matter because this runs on the hot path
+/// that decodes every `Row` out of persist.
 ///
 /// Empty dictionaries are left untouched so that they keep a canonical,
 /// header-free encoding (identical to [`DatumMap::empty`]). This keeps the
 /// encoding of any given map value deterministic, which `Row`'s byte-based
 /// equality relies on.
 fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
-    // Walk the freshly written entries, recording the start offset of each one
-    // relative to `entries_start`.
-    let mut offsets: Vec<u32> = Vec::new();
-    {
-        let entries = &data[entries_start..];
-        let entries_len = entries.len();
-        let mut cursor: &[u8] = entries;
-        while !cursor.is_empty() {
-            let offset = entries_len - cursor.len();
-            offsets.push(u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed"));
-            // SAFETY: `cursor` points at the key/value datums just written by
-            // the packer, which are well-formed per `push_dict_with`'s contract.
-            unsafe {
-                let _key = read_datum(&mut cursor);
-                let _val = read_datum(&mut cursor);
-            }
-        }
-    }
-
-    let n = offsets.len();
-    if n == 0 {
+    let entries_end = data.len();
+    if entries_end == entries_start {
         return;
     }
 
-    // The header stores the entry count followed by the start offsets of
-    // entries `1..n`; entry 0 always starts at offset 0 and is omitted. This is
-    // exactly `n` little-endian `u32`s, so the entries begin `4 * n` bytes into
-    // the payload.
-    let mut header = Vec::with_capacity(size_of::<u32>() * n);
-    header.extend_from_slice(
-        &u32::try_from(n)
-            .expect("map with more than 4 billion entries")
-            .to_le_bytes(),
-    );
-    for offset in &offsets[1..] {
-        header.extend_from_slice(&offset.to_le_bytes());
+    // Walk the entries, appending the start offset of entries `1..count`
+    // (entry 0 is always at offset 0 and is omitted), then append `count`.
+    let mut p = entries_start;
+    let mut count: u32 = 0;
+    while p < entries_end {
+        if count > 0 {
+            let offset =
+                u32::try_from(p - entries_start).expect("map larger than 4 GiB cannot be indexed");
+            data.extend_from_slice(&offset.to_le_bytes());
+        }
+        count = count
+            .checked_add(1)
+            .expect("map with more than 4 billion entries");
+        // Re-borrow `data` here (after the append above) so the borrow never
+        // overlaps a mutation; `entries_end` keeps us within the entries.
+        let mut cursor: &[u8] = &data[p..entries_end];
+        let before = cursor.len();
+        // SAFETY: `cursor` points at the key/value datums just written by the
+        // packer, which are well-formed per `push_dict_with`'s contract.
+        unsafe {
+            read_datum(&mut cursor);
+            read_datum(&mut cursor);
+        }
+        p += before - cursor.len();
     }
-    let header_len = header.len();
-    let entries_len = data.len() - entries_start;
-
-    // Insert `header` just before the entries. `CompactBytes` has no `splice`,
-    // so we grow the buffer (reusing `header` as filler), shift the entries
-    // right to open a gap, then write the header into the gap. This mirrors the
-    // in-place shift in `push_list_with`'s `long_list`.
-    data.extend_from_slice(&header);
-    data.copy_within(
-        entries_start..entries_start + entries_len,
-        entries_start + header_len,
-    );
-    data[entries_start..entries_start + header_len].copy_from_slice(&header);
+    data.extend_from_slice(&count.to_le_bytes());
 }
 
 /// Read a data whose length is encoded in the row before its contents.
@@ -3141,7 +3129,9 @@ impl<'a, T> DatumMap<'a, T> {
         if self.data.is_empty() {
             0
         } else {
-            let count = u32::from_le_bytes(self.data[..size_of::<u32>()].try_into().unwrap());
+            // `count` is the final `u32` of the suffix.
+            let n = self.data.len();
+            let count = u32::from_le_bytes(self.data[n - size_of::<u32>()..].try_into().unwrap());
             usize::cast_from(count)
         }
     }
@@ -3151,26 +3141,30 @@ impl<'a, T> DatumMap<'a, T> {
         self.data.is_empty()
     }
 
-    /// The slice holding the entries, with the index header stripped off.
+    /// The number of bytes the entries occupy, i.e. the payload minus the index
+    /// suffix (which is exactly `len()` little-endian `u32`s).
+    fn entries_len(&self) -> usize {
+        self.data.len() - size_of::<u32>() * self.len()
+    }
+
+    /// The slice holding the entries, with the index suffix stripped off.
     ///
     /// See the type-level docs for the payload layout.
     fn entries(&self) -> &'a [u8] {
         if self.data.is_empty() {
             return self.data;
         }
-        // The header is exactly `len()` little-endian `u32`s.
-        let header_len = size_of::<u32>() * self.len();
-        &self.data[header_len..]
+        &self.data[..self.entries_len()]
     }
 
     /// The start offset of entry `i` relative to the start of the entries
     /// region. Entry 0 is implicitly at offset 0; the rest are read from the
-    /// index header. `i` must be in `0..len()`.
-    fn entry_offset(&self, i: usize) -> usize {
+    /// index suffix, which begins at `entries_len`. `i` must be in `0..len()`.
+    fn entry_offset(&self, entries_len: usize, i: usize) -> usize {
         if i == 0 {
             0
         } else {
-            let at = size_of::<u32>() * i;
+            let at = entries_len + size_of::<u32>() * (i - 1);
             let offset =
                 u32::from_le_bytes(self.data[at..at + size_of::<u32>()].try_into().unwrap());
             usize::cast_from(offset)
@@ -3186,13 +3180,14 @@ impl<'a, T> DatumMap<'a, T> {
         if n == 0 {
             return None;
         }
-        let entries = self.entries();
+        let entries_len = self.entries_len();
+        let entries = &self.data[..entries_len];
 
         let mut lo = 0;
         let mut hi = n;
         while lo < hi {
             let mid = lo + (hi - lo) / 2;
-            let mut cursor = &entries[self.entry_offset(mid)..];
+            let mut cursor = &entries[self.entry_offset(entries_len, mid)..];
             // SAFETY: `cursor` points at a well-formed entry (a string key
             // followed by its value), per the `DatumMap` payload contract.
             let mid_key = unsafe { read_datum(&mut cursor) }.unwrap_str();

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -1034,16 +1034,23 @@ impl<T> PartialOrd for DatumList<'_, T> {
 /// linear scan. For a map with `n > 0` entries the layout is:
 ///
 /// ```text
-/// [ entries.. ][ offset_1: u32 ] .. [ offset_{n-1}: u32 ][ count: u32 ]
+/// [ entries.. ][ offset_1: W ] .. [ offset_{n-1}: W ][ count_word: u32 ]
 /// ```
 ///
 /// where the entries are `(key, value)` datum pairs **sorted in ascending key
 /// order**, `offset_i` is the start of entry `i` relative to the first entry
-/// (entry 0 is always at offset 0 and so is omitted), and `count` is `n`. The
-/// suffix is thus exactly `n` little-endian `u32`s, so the entries occupy the
-/// first `data.len() - 4 * n` bytes. The index lives at the end so the packer
-/// can append it (rather than splice it in front) once the entries are written.
-/// An empty map has an empty payload (no suffix), keeping its encoding
+/// (entry 0 is always at offset 0 and so is omitted), and `count_word` packs
+/// the entry count `n` in its low 30 bits with the offset-width class in its top
+/// two bits.
+///
+/// Offsets are stored at width `W` ∈ {1, 2, 4} bytes: the smallest that holds
+/// any offset, chosen from the entries' total byte length (`≤256 → u8`,
+/// `≤65536 → u16`, else `u32`). Because `W` is a deterministic function of the
+/// (fixed) entry bytes, equal maps pick the same width and encode identically.
+/// The suffix is thus `W * (n - 1) + 4` bytes, so the entries occupy the leading
+/// `data.len() - 4 - W * (n - 1)` bytes. The index lives at the end so the
+/// packer can append it (rather than splice it in front) once the entries are
+/// written. An empty map has an empty payload (no suffix), keeping its encoding
 /// canonical.
 ///
 /// The type parameter `T` represents the value type of the map. It is a
@@ -1367,6 +1374,74 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
     bytes
 }
 
+/// Number of low bits of the index count word that hold the entry count; the
+/// top two bits hold the offset-width class. See [`DatumMap`].
+const DICT_COUNT_BITS: u32 = 30;
+/// Mask selecting the entry count out of the index count word.
+const DICT_COUNT_MASK: u32 = (1 << DICT_COUNT_BITS) - 1;
+
+/// The width in bytes of each stored offset for a map whose entries occupy
+/// `entries_len` bytes. Offsets are positions in `0..entries_len`, so the
+/// width is the smallest that can hold `entries_len - 1`. Chosen purely from
+/// `entries_len` (a deterministic function of the entries' bytes) so that equal
+/// maps always pick the same width and encode identically.
+fn offset_width(entries_len: usize) -> usize {
+    if entries_len <= 0x100 {
+        1
+    } else if entries_len <= 0x1_0000 {
+        2
+    } else {
+        4
+    }
+}
+
+/// The width class (0/1/2) packed into the high bits of the count word for an
+/// offset width of 1/2/4 bytes.
+fn offset_width_class(width: usize) -> u32 {
+    match width {
+        1 => 0,
+        2 => 1,
+        4 => 2,
+        _ => unreachable!("offset width is 1, 2, or 4"),
+    }
+}
+
+/// Inverse of [`offset_width_class`].
+fn offset_width_for_class(class: u32) -> usize {
+    match class {
+        0 => 1,
+        1 => 2,
+        2 => 4,
+        _ => unreachable!("offset width class is 0, 1, or 2"),
+    }
+}
+
+/// Appends a single offset of `width` bytes (little-endian).
+fn append_offset(data: &mut CompactBytes, offset: usize, width: usize) {
+    let offset = u32::try_from(offset).expect("map larger than 4 GiB cannot be indexed");
+    match width {
+        1 => data.push(u8::try_from(offset).expect("offset fits in u8 for this width class")),
+        2 => data.extend_from_slice(
+            &u16::try_from(offset)
+                .expect("offset fits in u16 for this width class")
+                .to_le_bytes(),
+        ),
+        _ => data.extend_from_slice(&offset.to_le_bytes()),
+    }
+}
+
+/// Appends the trailing count word: the entry count in the low [`DICT_COUNT_BITS`]
+/// bits, with the offset-width class in the top two bits.
+fn append_count_word(data: &mut CompactBytes, count: usize, width: usize) {
+    assert!(
+        u64::cast_from(count) <= u64::from(DICT_COUNT_MASK),
+        "jsonb map with more than {DICT_COUNT_MASK} entries cannot be indexed"
+    );
+    let count = u32::try_from(count).expect("count <= DICT_COUNT_MASK, checked above");
+    let word = (offset_width_class(width) << DICT_COUNT_BITS) | count;
+    data.extend_from_slice(&word.to_le_bytes());
+}
+
 /// Builds the in-map index for a dictionary the packer has just written.
 ///
 /// On entry, `data[entries_start..]` holds the dictionary's entries as a
@@ -1376,7 +1451,7 @@ fn read_untagged_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
 ///
 /// The suffix layout lets us append the index rather than splice it in front
 /// (no memmove), and we write each offset straight into the buffer as we go
-/// (no temporary allocation) — both matter because this runs on the hot path
+/// (no temporary allocation). Both matter because this runs on the hot path
 /// that decodes every `Row` out of persist.
 ///
 /// Empty dictionaries are left untouched so that they keep a canonical,
@@ -1388,20 +1463,18 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
     if entries_end == entries_start {
         return;
     }
+    let width = offset_width(entries_end - entries_start);
 
     // Walk the entries, appending the start offset of entries `1..count`
-    // (entry 0 is always at offset 0 and is omitted), then append `count`.
+    // (entry 0 is always at offset 0 and is omitted), then append the count
+    // word.
     let mut p = entries_start;
-    let mut count: u32 = 0;
+    let mut count: usize = 0;
     while p < entries_end {
         if count > 0 {
-            let offset =
-                u32::try_from(p - entries_start).expect("map larger than 4 GiB cannot be indexed");
-            data.extend_from_slice(&offset.to_le_bytes());
+            append_offset(data, p - entries_start, width);
         }
-        count = count
-            .checked_add(1)
-            .expect("map with more than 4 billion entries");
+        count += 1;
         // Re-borrow `data` here (after the append above) so the borrow never
         // overlaps a mutation; `entries_end` keeps us within the entries.
         let mut cursor: &[u8] = &data[p..entries_end];
@@ -1414,31 +1487,32 @@ fn finish_dict(data: &mut CompactBytes, entries_start: usize) {
         }
         p += before - cursor.len();
     }
-    data.extend_from_slice(&count.to_le_bytes());
+    append_count_word(data, count, width);
 }
 
 /// Appends the in-map index suffix from offsets captured while the entries were
 /// written, instead of re-walking them as [`finish_dict`] does.
 ///
-/// `offsets[i]` is the start of entry `i` relative to the start of the entries
-/// region. This produces a byte-identical suffix to [`finish_dict`] — the index
-/// is the same deterministic function of the (already sorted) entries — so the
-/// two builders are interchangeable and `Row`'s byte equality is preserved.
+/// `entries_start` is the offset of the entries region within `data`, and
+/// `offsets[i]` is the start of entry `i` relative to it. This produces a
+/// byte-identical suffix to [`finish_dict`]: the width is chosen from the same
+/// `entries_len` and the offsets are the same positions, so the two builders
+/// are interchangeable and `Row`'s byte equality is preserved.
 ///
 /// Empty dictionaries are left untouched, matching [`finish_dict`] and
 /// [`DatumMap::empty`].
-fn finish_dict_from_offsets(data: &mut CompactBytes, offsets: &[u32]) {
+fn finish_dict_from_offsets(data: &mut CompactBytes, entries_start: usize, offsets: &[u32]) {
     let n = offsets.len();
     if n == 0 {
         return;
     }
+    let width = offset_width(data.len() - entries_start);
     // Append the start offsets of entries `1..n` (entry 0 is always at offset 0
-    // and is omitted), then the count. See [`DatumMap`] for the layout.
-    for offset in &offsets[1..] {
-        data.extend_from_slice(&offset.to_le_bytes());
+    // and is omitted), then the count word. See [`DatumMap`] for the layout.
+    for &offset in &offsets[1..] {
+        append_offset(data, usize::cast_from(offset), width);
     }
-    let count = u32::try_from(n).expect("map with more than 4 billion entries");
-    data.extend_from_slice(&count.to_le_bytes());
+    append_count_word(data, n, width);
 }
 
 /// Read a data whose length is encoded in the row before its contents.
@@ -2680,7 +2754,7 @@ impl RowPacker<'_> {
         // row buffer again.
         drop(builder);
 
-        finish_dict_from_offsets(&mut self.row.data, &offsets);
+        finish_dict_from_offsets(&mut self.row.data, entries_start, &offsets);
 
         let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
         self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
@@ -3231,16 +3305,23 @@ impl<'a, T: FromDatum<'a>> Iterator for DatumListTypedIter<'a, T> {
 }
 
 impl<'a, T> DatumMap<'a, T> {
+    /// Reads the index header (the trailing count word) for a non-empty map,
+    /// returning `(n, offset_width)`. See [`DatumMap`] for the layout and how
+    /// the width is packed into the count's high bits.
+    fn header(&self) -> Option<(usize, usize)> {
+        if self.data.is_empty() {
+            return None;
+        }
+        let n = self.data.len();
+        let word = u32::from_le_bytes(self.data[n - size_of::<u32>()..].try_into().unwrap());
+        let count = usize::cast_from(word & DICT_COUNT_MASK);
+        let width = offset_width_for_class(word >> DICT_COUNT_BITS);
+        Some((count, width))
+    }
+
     /// The number of entries in the map.
     pub fn len(&self) -> usize {
-        if self.data.is_empty() {
-            0
-        } else {
-            // `count` is the final `u32` of the suffix.
-            let n = self.data.len();
-            let count = u32::from_le_bytes(self.data[n - size_of::<u32>()..].try_into().unwrap());
-            usize::cast_from(count)
-        }
+        self.header().map_or(0, |(count, _)| count)
     }
 
     /// Whether the map has no entries.
@@ -3249,32 +3330,36 @@ impl<'a, T> DatumMap<'a, T> {
     }
 
     /// The number of bytes the entries occupy, i.e. the payload minus the index
-    /// suffix (which is exactly `len()` little-endian `u32`s).
-    fn entries_len(&self) -> usize {
-        self.data.len() - size_of::<u32>() * self.len()
+    /// suffix. The suffix is `n - 1` offsets of `width` bytes plus the count
+    /// `u32`.
+    fn entries_len_for(&self, count: usize, width: usize) -> usize {
+        self.data.len() - size_of::<u32>() - width * (count - 1)
     }
 
     /// The slice holding the entries, with the index suffix stripped off.
     ///
     /// See the type-level docs for the payload layout.
     fn entries(&self) -> &'a [u8] {
-        if self.data.is_empty() {
-            return self.data;
+        match self.header() {
+            None => self.data,
+            Some((count, width)) => &self.data[..self.entries_len_for(count, width)],
         }
-        &self.data[..self.entries_len()]
     }
 
     /// The start offset of entry `i` relative to the start of the entries
     /// region. Entry 0 is implicitly at offset 0; the rest are read from the
-    /// index suffix, which begins at `entries_len`. `i` must be in `0..len()`.
-    fn entry_offset(&self, entries_len: usize, i: usize) -> usize {
+    /// index suffix (offsets of `width` bytes beginning at `entries_len`). `i`
+    /// must be in `0..count`.
+    fn entry_offset(&self, entries_len: usize, width: usize, i: usize) -> usize {
         if i == 0 {
-            0
-        } else {
-            let at = entries_len + size_of::<u32>() * (i - 1);
-            let offset =
-                u32::from_le_bytes(self.data[at..at + size_of::<u32>()].try_into().unwrap());
-            usize::cast_from(offset)
+            return 0;
+        }
+        let at = entries_len + width * (i - 1);
+        let bytes = &self.data[at..at + width];
+        match width {
+            1 => usize::from(bytes[0]),
+            2 => usize::from(u16::from_le_bytes(bytes.try_into().unwrap())),
+            _ => usize::cast_from(u32::from_le_bytes(bytes.try_into().unwrap())),
         }
     }
 
@@ -3283,18 +3368,15 @@ impl<'a, T> DatumMap<'a, T> {
     /// Runs in `O(log n)` over the `n` entries by binary searching the
     /// key-sorted index, rather than the `O(n)` linear scan of [`Self::iter`].
     pub fn get(&self, key: &str) -> Option<Datum<'a>> {
-        let n = self.len();
-        if n == 0 {
-            return None;
-        }
-        let entries_len = self.entries_len();
+        let (n, width) = self.header()?;
+        let entries_len = self.entries_len_for(n, width);
         let entries = &self.data[..entries_len];
 
         let mut lo = 0;
         let mut hi = n;
         while lo < hi {
             let mid = lo + (hi - lo) / 2;
-            let mut cursor = &entries[self.entry_offset(entries_len, mid)..];
+            let mut cursor = &entries[self.entry_offset(entries_len, width, mid)..];
             // SAFETY: `cursor` points at a well-formed entry (a string key
             // followed by its value), per the `DatumMap` payload contract.
             let mid_key = unsafe { read_datum(&mut cursor) }.unwrap_str();
@@ -4571,6 +4653,32 @@ mod tests {
                 let linear = map.iter().find(|(k, _)| *k == probe).map(|(_, v)| v);
                 assert_eq!(map.get(probe), linear, "probe {probe:?} with n={n}");
             }
+        }
+
+        // Exercise all three offset widths (u8/u16/u32) by padding the values so
+        // the entries region crosses the 256- and 65536-byte thresholds. A wrong
+        // width choice would corrupt offset reads.
+        for value_len in [1_usize, 80, 90, 300, 70_000] {
+            let keys = ["a", "b", "c"];
+            let val = "x".repeat(value_len);
+            let mut row = Row::default();
+            row.packer().push_dict_with(|row| {
+                for k in keys {
+                    row.push(Datum::String(k));
+                    row.push(Datum::String(val.as_str()));
+                }
+            });
+            let datum = row.unpack_first();
+            let map = datum.unwrap_map();
+            assert_eq!(map.len(), keys.len(), "value_len={value_len}");
+            for k in keys {
+                assert_eq!(
+                    map.get(k),
+                    Some(Datum::String(val.as_str())),
+                    "key {k:?} with value_len={value_len}",
+                );
+            }
+            assert_eq!(map.get("zzz"), None, "miss with value_len={value_len}");
         }
 
         // A nested value is returned intact via `get`.

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -1137,10 +1137,9 @@ impl DatumColumnDecoder {
                     .try_into()
                     .expect("unexpected negative offset");
 
-                packer.push_dict_with(|packer| {
+                packer.push_indexed_dict_with(|builder| {
                     for idx in start..end {
-                        packer.push(Datum::String(keys.value(idx)));
-                        vals.get(idx, packer);
+                        builder.push_entry(keys.value(idx), |packer| vals.get(idx, packer));
                     }
                 });
 
@@ -2120,17 +2119,18 @@ impl RowPacker<'_> {
                 }
                 .map_err(|err| err.to_string())?
             }
-            Some(DatumType::Dict(x)) => self.push_dict_with(|row| -> Result<(), String> {
-                for e in x.elements.iter() {
-                    row.push(Datum::from(e.key.as_str()));
-                    let val = e
-                        .val
-                        .as_ref()
-                        .ok_or_else(|| format!("missing val for key: {}", e.key))?;
-                    row.try_push_proto(val)?;
-                }
-                Ok(())
-            })?,
+            Some(DatumType::Dict(x)) => {
+                self.push_indexed_dict_with(|builder| -> Result<(), String> {
+                    for e in x.elements.iter() {
+                        let val = e
+                            .val
+                            .as_ref()
+                            .ok_or_else(|| format!("missing val for key: {}", e.key))?;
+                        builder.push_entry(e.key.as_str(), |row| row.try_push_proto(val))?;
+                    }
+                    Ok(())
+                })?
+            }
             Some(DatumType::Numeric(x)) => {
                 // Reminder that special values like NaN, PosInf, and NegInf are
                 // represented as variants of ProtoDatumOther.

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -1137,10 +1137,9 @@ impl DatumColumnDecoder {
                     .try_into()
                     .expect("unexpected negative offset");
 
-                packer.push_dict_with(|packer| {
+                packer.push_indexed_dict_with(|builder| {
                     for idx in start..end {
-                        packer.push(Datum::String(keys.value(idx)));
-                        vals.get(idx, packer);
+                        builder.push_entry(keys.value(idx), |packer| vals.get(idx, packer));
                     }
                 });
 
@@ -2128,31 +2127,32 @@ impl RowPacker<'_> {
                 }
                 .map_err(|err| err.to_string())?
             }
-            Some(DatumType::Dict(x)) => self.push_dict_with(|row| -> Result<(), String> {
-                let mut prev_key: Option<&str> = None;
-                for e in x.elements.iter() {
-                    // Map keys must be unique and strictly ascending; iterating a
-                    // map that violates this trips a debug_assert. A crafted
-                    // proto can, so reject it as a decode error here instead.
-                    if let Some(prev) = prev_key
-                        && e.key.as_str() <= prev
-                    {
-                        return Err(format!(
-                            "dict keys must be unique and in ascending order, \
-                             but {:?} came after {:?}",
-                            e.key, prev,
-                        ));
+            Some(DatumType::Dict(x)) => {
+                self.push_indexed_dict_with(|builder| -> Result<(), String> {
+                    let mut prev_key: Option<&str> = None;
+                    for e in x.elements.iter() {
+                        // Map keys must be unique and strictly ascending; iterating a
+                        // map that violates this trips a debug_assert. A crafted
+                        // proto can, so reject it as a decode error here instead.
+                        if let Some(prev) = prev_key
+                            && e.key.as_str() <= prev
+                        {
+                            return Err(format!(
+                                "dict keys must be unique and in ascending order, \
+                                 but {:?} came after {:?}",
+                                e.key, prev,
+                            ));
+                        }
+                        prev_key = Some(e.key.as_str());
+                        let val = e
+                            .val
+                            .as_ref()
+                            .ok_or_else(|| format!("missing val for key: {}", e.key))?;
+                        builder.push_entry(e.key.as_str(), |row| row.try_push_proto(val))?;
                     }
-                    prev_key = Some(e.key.as_str());
-                    row.push(Datum::from(e.key.as_str()));
-                    let val = e
-                        .val
-                        .as_ref()
-                        .ok_or_else(|| format!("missing val for key: {}", e.key))?;
-                    row.try_push_proto(val)?;
-                }
-                Ok(())
-            })?,
+                    Ok(())
+                })?
+            }
             Some(DatumType::Numeric(x)) => {
                 // Reminder that special values like NaN, PosInf, and NegInf are
                 // represented as variants of ProtoDatumOther.

--- a/src/storage-types/src/sources/casts.rs
+++ b/src/storage-types/src/sources/casts.rs
@@ -358,10 +358,9 @@ impl CastFunc {
                 pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
                 pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
                 Ok(arena.make_datum(|packer| {
-                    packer.push_dict_with(|packer| {
+                    packer.push_indexed_dict_with(|builder| {
                         for (k, v) in pairs {
-                            packer.push(Datum::String(&k));
-                            packer.push(v);
+                            builder.push_entry(&k, |packer| packer.push(v));
                         }
                     })
                 }))

--- a/test/testdrive/copy-s3-roundtrip-minio.td
+++ b/test/testdrive/copy-s3-roundtrip-minio.td
@@ -232,7 +232,12 @@ a
 $ s3-verify-data bucket=copytos3 key=test/3 sort-rows=true
 "{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,2010-10-10 08:10:10+00,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
 
+# Two files are written here for the same reason as test/2_5 above: rows are
+# exchanged to files by their hash modulo the batch count, and worker 0 always
+# emits batch 0's file (here empty, just a header). The single row hashes to a
+# non-zero batch, so its file carries the second header plus the data.
 $ s3-verify-data bucket=copytos3 key=test/4_5 sort-rows=true
+array;int4;jsonb;timestamp
 array;int4;jsonb;timestamp
 {1,2};83647;`{"s":"ab``c"}`;2010-10-10 10:10:10
 


### PR DESCRIPTION
### Motivation

Accessing a `jsonb` field linearly scans the underlying `DatumMap`, so a "JSON to columns" query pulling `k` fields from an `n`-key object does `O(n * k)` work per row. Map entries are already key-sorted at pack time, so a small in-map index lets a key be found by binary search.

### Description

Adds a deterministic index to the in-memory `Row` map encoding, making single-key lookup `O(log n)`. A non-empty map gains a suffix `[ offsets ][ count_word ]`: offsets are stored at the smallest width (u8/u16/u32) that fits the entries, and the width class is packed into the high bits of the count word, so the suffix costs `W*(n-1)+4` bytes rather than `4n`. The index is built at pack time with no re-walk on the entry-by-entry paths (JSON packing, columnar/proto decode, Avro map decoding, `text`-to-`map` casts, the pgwire value paths); `iter()` skips it, so equality, hashing, ordering, and columnar/proto encoding are unchanged.

Every operator that resolves a single key by name uses the index, so no call site pays its cost without collecting the benefit: `->`, `->>`, `#>`, `#>>`, and `?` on `jsonb`, `->`, `?`, `?&`, `?|` on `map`, and the map arms of both `@>` implementations. The two containment operators probed one map once per entry of the other, so they drop from `O(n * m)` to `O(m * log n)`.

This is safe because the `Tag` byte layout is never persisted (persist uses Arrow, so no migration), `Row` equality is byte equality and the index is a deterministic function of the sorted entries (equal maps stay byte-identical), and `Row` sort order is implementation-defined.

### Cost

The suffix is roughly `W` bytes per entry, so its share of a `Row` tracks `W / average_entry_bytes`: worst for objects with many small entries, negligible for objects with few large values. Measured over `Jsonb::from_slice`:

| Object | JSON | `Row` bytes | Index bytes | Overhead |
| --- | --- | --- | --- | --- |
| `{"a":1,"b":2,"c":3}` | 19 B | 42 B | 6 B | +16.7% |
| 12-key event object | 206 B | 209 B | 15 B | +7.7% |
| 50 keys, short values | 1001 B | 1011 B | 102 B | +11.2% |
| 50 keys, 100-byte values | 5601 B | 5611 B | 102 B | +1.9% |
| 3 nested 3-key objects | 73 B | 150 B | 24 B | +19.0% |
| 500 keys, integer values | 6891 B | 8511 B | 1002 B | +13.3% |

The cost is in-memory only. Durable encodings are built from `iter()`, so persisted bytes are unchanged and the growth lands in arrangements, `RowArena`s, and rows in flight. There is no opt-out, because a runtime toggle over the encoding would break byte-canonicality while both forms were live in arrangements. A workload that stores `jsonb` without doing field access therefore pays the memory without collecting the win.

### Behavior changes

Ascending keys were already a `DatumMap` contract, but a linear scan tolerated a violation: it still found the key. A binary search reports a present key as missing instead, so both index builders now check the order as they pack, under soft assertions, and the proto decode path rejects out-of-order keys outright since its input is untrusted.

`RowRef` hashes its raw bytes, so anything placing rows by `Row::hashed()` shifts with the new layout. `COPY TO` S3 assigns rows to output files that way, which is why `copy-s3-roundtrip-minio.td` now expects two files for `test/4_5`. The data is unchanged, only its distribution across files.

### Performance

On the `jsonb_to_columns` microbench (50-key object, 10k rows), indexed access runs at ~10x the linear scan, 31.6 ms against 313.4 ms, and the push-time builder takes ~13% off decode alone.

Both benchmarks measure the case the index is best at. Decode dominates the persist path: 64.1 ms of the 98.6 ms `decode_and_access` figure is re-parsing JSON text, so a query scanning `jsonb` straight out of persist sees far less than 10x. The `JsonbToColumns` feature benchmark arranges its table behind an index precisely so the parse is paid once and the measurement isolates field access, which is what a query reading from an arrangement or a materialized view actually pays.

Design doc: `doc/developer/design/20260616_jsonb_map_index.md`. Tests added: `test_datum_map_get` covers lookup against a linear scan across all three offset widths, and `test_dict_builders_agree` pins down that the closure and push-time builders emit byte-identical maps, which `Row`'s byte equality depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)