### PR TITLE
avro: support numeric promotion for nullable (union) columns

### DIFF
--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -522,6 +522,161 @@ mod tests {
         assert_none!(reader.next());
     }
 
+    // Regression test for SS-277: an `int` -> `double` promotion inside a union
+    // (i.e. a nullable column whose type was promoted). The writer's `int`
+    // variant of `["null", "int"]` must resolve against the reader's `double`
+    // variant of `["null", "double"]`. Previously this failed with "Failed to
+    // match writer union variant `Int` against any variant in the reader",
+    // because union variant matching ignored numeric promotion.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
+    fn test_union_int_to_double_promotion() {
+        let writer_raw_schema = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "f1", "type": ["null", "int"]}
+                ]
+            }
+        "#;
+        let reader_raw_schema = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "f1", "type": ["null", "double"]}
+                ]
+            }
+        "#;
+        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
+        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
+        let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
+        let mut record = Record::new(writer_schema.top_node()).unwrap();
+        record.put(
+            "f1",
+            Value::Union {
+                index: 1,
+                inner: Box::new(Value::Int(123)),
+                n_variants: 2,
+                null_variant: Some(0),
+            },
+        );
+        writer.append(record).unwrap();
+        writer.flush().unwrap();
+        let input = writer.into_inner();
+        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            Value::Record(vec![(
+                "f1".to_string(),
+                Value::Union {
+                    index: 1,
+                    inner: Box::new(Value::Double(123.0)),
+                    n_variants: 2,
+                    null_variant: Some(0),
+                },
+            )]),
+        );
+        assert_none!(reader.next());
+    }
+
+    // Regression test for SS-277, concrete writer -> union reader: a column
+    // promoted from a non-nullable `int` to a nullable `double`. Exercises the
+    // `match_ref_promote_writer` resolution path.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
+    fn test_concrete_int_to_union_double_promotion() {
+        let writer_raw_schema = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "f1", "type": "int"}
+                ]
+            }
+        "#;
+        let reader_raw_schema = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "f1", "type": ["null", "double"]}
+                ]
+            }
+        "#;
+        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
+        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
+        let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
+        let mut record = Record::new(writer_schema.top_node()).unwrap();
+        record.put("f1", Value::Int(123));
+        writer.append(record).unwrap();
+        writer.flush().unwrap();
+        let input = writer.into_inner();
+        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            Value::Record(vec![(
+                "f1".to_string(),
+                Value::Union {
+                    index: 1,
+                    inner: Box::new(Value::Double(123.0)),
+                    n_variants: 2,
+                    null_variant: Some(0),
+                },
+            )]),
+        );
+        assert_none!(reader.next());
+    }
+
+    // Regression test for SS-277, union writer -> concrete reader: a column
+    // promoted from a nullable `int` to a non-nullable `double`. Exercises the
+    // `match_ref_promote_reader` resolution path.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
+    fn test_union_int_to_concrete_double_promotion() {
+        let writer_raw_schema = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "f1", "type": ["null", "int"]}
+                ]
+            }
+        "#;
+        let reader_raw_schema = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "f1", "type": "double"}
+                ]
+            }
+        "#;
+        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
+        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
+        let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
+        let mut record = Record::new(writer_schema.top_node()).unwrap();
+        record.put(
+            "f1",
+            Value::Union {
+                index: 1,
+                inner: Box::new(Value::Int(123)),
+                n_variants: 2,
+                null_variant: Some(0),
+            },
+        );
+        writer.append(record).unwrap();
+        writer.flush().unwrap();
+        let input = writer.into_inner();
+        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            Value::Record(vec![("f1".to_string(), Value::Double(123.0))]),
+        );
+        assert_none!(reader.next());
+    }
+
     //TODO: move where it fits better
     #[mz_ore::test]
     fn test_enum_no_reader_schema() {

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -641,7 +641,7 @@ impl<'a> SchemaResolver<'a> {
                     .iter()
                     .map(|w_variant| {
                         let (r_idx, r_variant) =
-                            r_inner.match_(w_variant, &w2r).ok_or_else(|| {
+                            r_inner.match_promote_writer(w_variant, &w2r).ok_or_else(|| {
                                 SchemaResolutionError::new(format!(
                                     "Failed to match writer union variant `{}` against any variant in the reader for field `{}`",
                                     w_variant.get_human_name(writer.root),
@@ -672,7 +672,7 @@ impl<'a> SchemaResolver<'a> {
                     .iter()
                     .position(|v| v == &SchemaPieceOrNamed::Piece(SchemaPiece::Null));
                 let (index, r_inner) = r_inner
-                    .match_ref(other, &self.writer_to_reader_names)
+                    .match_ref_promote_writer(other, &self.writer_to_reader_names)
                     .ok_or_else(|| {
                         SchemaResolutionError::new(
                             format!("No matching schema in reader union for writer type `{}` for field `{}`",
@@ -690,7 +690,7 @@ impl<'a> SchemaResolver<'a> {
             // Writer is union; reader is concrete
             (SchemaPieceRefOrNamed::Piece(SchemaPiece::Union(w_inner)), other) => {
                 let (index, w_inner) = w_inner
-                    .match_ref(other, &self.reader_to_writer_names)
+                    .match_ref_promote_reader(other, &self.reader_to_writer_names)
                     .ok_or_else(|| {
                         // `other` is the reader's concrete node (the second element
                         // of the match), so its name must be looked up in the

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -868,7 +868,7 @@ impl UnionSchema {
     /// writer piece. An exact match (by kind for anonymous pieces, by name for
     /// named ones) is preferred; otherwise the first reader variant in
     /// declaration order that `writer` can be promoted into is returned. See
-    /// [`can_promote`].
+    /// `can_promote`.
     pub fn match_ref_promote_writer(
         &self,
         writer: SchemaPieceRefOrNamed,
@@ -893,7 +893,7 @@ impl UnionSchema {
     /// promotion. `self` is the *writer* union and `reader` is a concrete
     /// reader piece. An exact match is preferred; otherwise the first writer
     /// variant in declaration order that can be promoted into `reader` is
-    /// returned. See [`can_promote`].
+    /// returned. See `can_promote`.
     pub fn match_ref_promote_reader(
         &self,
         reader: SchemaPieceRefOrNamed,

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -851,6 +851,89 @@ impl UnionSchema {
     ) -> Option<(usize, &SchemaPieceOrNamed)> {
         self.match_ref(other.as_ref(), names_map)
     }
+
+    /// Like [`UnionSchema::match_`], but additionally honors Avro numeric
+    /// promotion. Here `self` is the *reader* union and `writer` is a writer
+    /// variant being resolved against it.
+    pub fn match_promote_writer(
+        &self,
+        writer: &SchemaPieceOrNamed,
+        names_map: &BTreeMap<usize, usize>,
+    ) -> Option<(usize, &SchemaPieceOrNamed)> {
+        self.match_ref_promote_writer(writer.as_ref(), names_map)
+    }
+
+    /// Like [`UnionSchema::match_ref`], but additionally honors Avro numeric
+    /// promotion. `self` is the *reader* union and `writer` is a concrete
+    /// writer piece. An exact match (by kind for anonymous pieces, by name for
+    /// named ones) is preferred; otherwise the first reader variant in
+    /// declaration order that `writer` can be promoted into is returned. See
+    /// [`can_promote`].
+    pub fn match_ref_promote_writer(
+        &self,
+        writer: SchemaPieceRefOrNamed,
+        names_map: &BTreeMap<usize, usize>,
+    ) -> Option<(usize, &SchemaPieceOrNamed)> {
+        if let Some(hit) = self.match_ref(writer, names_map) {
+            return Some(hit);
+        }
+        let SchemaPieceRefOrNamed::Piece(wp) = writer else {
+            return None;
+        };
+        self.schemas
+            .iter()
+            .enumerate()
+            .find_map(|(idx, variant)| match variant {
+                SchemaPieceOrNamed::Piece(rp) if can_promote(wp, rp) => Some((idx, variant)),
+                _ => None,
+            })
+    }
+
+    /// Like [`UnionSchema::match_ref`], but additionally honors Avro numeric
+    /// promotion. `self` is the *writer* union and `reader` is a concrete
+    /// reader piece. An exact match is preferred; otherwise the first writer
+    /// variant in declaration order that can be promoted into `reader` is
+    /// returned. See [`can_promote`].
+    pub fn match_ref_promote_reader(
+        &self,
+        reader: SchemaPieceRefOrNamed,
+        names_map: &BTreeMap<usize, usize>,
+    ) -> Option<(usize, &SchemaPieceOrNamed)> {
+        if let Some(hit) = self.match_ref(reader, names_map) {
+            return Some(hit);
+        }
+        let SchemaPieceRefOrNamed::Piece(rp) = reader else {
+            return None;
+        };
+        self.schemas
+            .iter()
+            .enumerate()
+            .find_map(|(idx, variant)| match variant {
+                SchemaPieceOrNamed::Piece(wp) if can_promote(wp, rp) => Some((idx, variant)),
+                _ => None,
+            })
+    }
+}
+
+/// Returns `true` if a value written with primitive schema `writer` can be read
+/// as primitive `reader` under Avro's numeric promotion rules: `int` →
+/// `long`/`float`/`double`, `long` → `float`/`double`, and `float` → `double`.
+///
+/// These are exactly the promotions performed during schema resolution in
+/// `reader.rs` (`ResolveIntLong`, `ResolveIntDouble`, ...). The two must be
+/// kept in sync: only return `true` here for a pair that resolution can
+/// actually decode, otherwise a union variant would match but fail to resolve.
+fn can_promote(writer: &SchemaPiece, reader: &SchemaPiece) -> bool {
+    use SchemaPiece::*;
+    matches!(
+        (writer, reader),
+        (Int, Long)
+            | (Int, Float)
+            | (Int, Double)
+            | (Long, Float)
+            | (Long, Double)
+            | (Float, Double)
+    )
 }
 
 // No need to compare variant_index, it is derivative of schemas.

--- a/test/testdrive/avro-resolution-union-promote.td
+++ b/test/testdrive/avro-resolution-union-promote.td
@@ -1,0 +1,66 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-arg-default single-replica-cluster=quickstart
+
+#
+# A nullable column whose type is promoted from `int` to `double` is a
+# non-breaking Avro change: `int` is promotable to `double`, so a record
+# written with the old schema must still decode against the new (reader)
+# schema. Because a nullable column is encoded as a union (`["null", T]`),
+# this exercises union-vs-union schema resolution, which must honor numeric
+# promotion when matching the writer's `int` variant to the reader's `double`
+# variant.
+#
+# Regression test: this previously failed with
+#   "Failed to match writer union variant `Int` against any variant in the
+#    reader"
+# because union variant matching ignored numeric promotion.
+#
+
+$ set writer-union-int={"type": "record", "name": "schema_promote", "fields": [ {"name": "f1", "type": ["null", "int"] } ] }
+$ set reader-union-double={"type": "record", "name": "schema_promote", "fields": [ {"name": "f1", "type": ["null", "double"] } ] }
+
+$ kafka-create-topic topic=resolution-union-promote
+
+# Write a record with the OLD schema (f1: ["null", "int"]). This registers the
+# int schema as version 1.
+$ kafka-ingest format=avro topic=resolution-union-promote schema=${writer-union-int} timestamp=1
+{"f1": {"int": 123 } }
+{"f1": null }
+
+# Write a record with the NEW schema (f1: ["null", "double"]). This registers
+# the double schema as the latest version, which the source below will adopt
+# as its reader schema.
+$ kafka-ingest format=avro topic=resolution-union-promote schema=${reader-union-double} timestamp=2
+{"f1": {"double": 234.5 } }
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> BEGIN
+> CREATE SOURCE resolution_union_promote
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-resolution-union-promote-${testdrive.seed}')
+
+> CREATE TABLE resolution_union_promote_tbl FROM SOURCE resolution_union_promote (REFERENCE "testdrive-resolution-union-promote-${testdrive.seed}")
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+> COMMIT
+
+# The int-written record (123) must promote to double; the null and the
+# double-written record must decode unchanged.
+> SELECT f1 FROM resolution_union_promote_tbl
+123
+234.5
+<null>


### PR DESCRIPTION
Fixes [SS-277](https://linear.app/materializeinc/issue/SS-277/avro-intdouble-promotion-fails-for-nullable-union-columns-during).

## Motivation

A customer's Kafka + Confluent Schema Registry source failed to decode records written with an older schema version after a nullable column's type was promoted from `int` to `double`:

```
Decode error: avro deserialization error: unable to decode row (Avro schema id = 38):
Schema resolution error: Failed to match writer union variant `Int` against any variant
in the reader for field `...rentable_area_size`
```

`int` → `double` is a valid, non-breaking Avro promotion. We already handle it for non-nullable columns, but a nullable column is encoded as a union (`["null","int"]` → `["null","double"]`), and union-variant matching used an exact `SchemaKind` lookup with no promotion. The writer's `Int` variant never matched the reader's `Double` variant, so the pairing was stored as an error in the resolved union and re-raised at decode time when a record expressed the int branch.

## Changes

- `src/avro/src/schema.rs`: add `can_promote()` (the numeric promotions, kept in sync with the pairs `reader.rs` can actually resolve) and promotion-aware `UnionSchema` matchers (`match_promote_writer`, `match_ref_promote_writer`, `match_ref_promote_reader`).
- `src/avro/src/reader.rs`: use the promotion-aware matchers in all three union resolution arms (union↔union, concrete→union, union→concrete). An exact match is still preferred; only on a miss do we look for a promotion target, choosing the first reader variant in declaration order. No decoder change is needed.

## Tests

- Three in-process unit tests in `src/avro/src/lib.rs`, one per resolution arm (`test_union_int_to_double_promotion`, `test_concrete_int_to_union_double_promotion`, `test_union_int_to_concrete_double_promotion`).
- `test/testdrive/avro-resolution-union-promote.td` as an end-to-end repro through a Kafka source + CSR.
- `cargo test -p mz-avro --lib` passes (66 tests). Confirmed the existing `avro-resolution-*` tests do not regress: every error-asserting case is a genuine narrowing / `Null` / `String` mismatch, for which `can_promote` returns false.

## Serialization

Checked the Avro sink/encode path per review: no analogous issue. The encoder is purely structural (it trusts the union index and writes against `variants()[index]`), the sink encoder builds unions by fixed index against a schema Materialize generates itself, and none of the changed matching functions are reachable from the encode path. Encoding never reconciles two schemas, so there is nothing to promote on the write side.

### Scope / follow-ups

- Limited to numeric promotion. Avro also permits `string` ↔ `bytes` promotion, which has the same union-matching gap and could be added to `can_promote` later.
- When a reader union contains multiple promotion targets (e.g. `["long","double"]` for a writer `int`), we take the first in declaration order. This is unambiguous for the common `["null", T]` shape.

## Release note

> Fix a schema-resolution error (`Failed to match writer union variant ...`) that caused Avro-formatted sources to fail decoding records written with an older schema after a nullable column's type was promoted to a wider numeric type (`int` → `long`/`float`/`double`, `long` → `float`/`double`, or `float` → `double`). These are valid, non-breaking Avro promotions; they already worked for non-nullable columns and now work for nullable columns (unions) too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
