### PR TITLE
Add GlueSchemaCache and WriterSchemaProvider::Glue variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7020,6 +7020,7 @@ dependencies = [
  "itertools 0.14.0",
  "maplit",
  "mz-avro",
+ "mz-aws-glue-schema-registry",
  "mz-build-tools",
  "mz-ccsr",
  "mz-ore",

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -24,6 +24,7 @@ differential-dataflow.workspace = true
 itertools.workspace = true
 maplit.workspace = true
 mz-avro = { path = "../avro", features = ["snappy"] }
+mz-aws-glue-schema-registry = { path = "../aws-glue-schema-registry" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["network", "cli"] }
 mz-repr = { path = "../repr" }

--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -359,6 +359,91 @@ mod tests {
             .expect("diamond reuse of a named type should be allowed");
         assert_eq!(desc.arity(), 2);
     }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_commercial() {
+        assert_eq!(
+            registry_name_from_schema_arn(
+                "arn:aws:glue:us-east-1:123456789012:schema/myreg/myschema"
+            ),
+            Some("myreg")
+        );
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_china_partition() {
+        assert_eq!(
+            registry_name_from_schema_arn(
+                "arn:aws-cn:glue:cn-north-1:123456789012:schema/myreg/myschema"
+            ),
+            Some("myreg")
+        );
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_govcloud_partition() {
+        assert_eq!(
+            registry_name_from_schema_arn(
+                "arn:aws-us-gov:glue:us-gov-west-1:123456789012:schema/myreg/myschema"
+            ),
+            Some("myreg")
+        );
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_rejects_non_aws_partition() {
+        assert_eq!(
+            registry_name_from_schema_arn(
+                "arn:gcp:glue:us-east-1:123456789012:schema/myreg/myschema"
+            ),
+            None
+        );
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_rejects_missing_arn_prefix() {
+        // Bare `schema/...` fragments must not parse — see the anchor on
+        // `arn:` in [`registry_name_from_schema_arn`].
+        assert_eq!(registry_name_from_schema_arn("schema/myreg/myschema"), None);
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_rejects_non_glue_service() {
+        assert_eq!(
+            registry_name_from_schema_arn(
+                "arn:aws:s3:us-east-1:123456789012:schema/myreg/myschema"
+            ),
+            None
+        );
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_rejects_missing_schema_segment() {
+        assert_eq!(
+            registry_name_from_schema_arn("arn:aws:glue:us-east-1:123456789012:table/myreg/foo"),
+            None
+        );
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_rejects_empty_registry() {
+        assert_eq!(
+            registry_name_from_schema_arn("arn:aws:glue:us-east-1:123456789012:schema//myschema"),
+            None
+        );
+    }
+
+    #[mz_ore::test]
+    fn registry_name_from_schema_arn_allows_schema_name_with_slashes() {
+        // Glue schema *names* aren't restricted the way registry names are.
+        // Only the segment before the first `/` matters for the registry.
+        assert_eq!(
+            registry_name_from_schema_arn(
+                "arn:aws:glue:us-east-1:123456789012:schema/myreg/path/like/name"
+            ),
+            Some("myreg")
+        );
+    }
 }
 
 /// Identifier carried in a wire-format header that points at the writer's
@@ -384,8 +469,9 @@ impl fmt::Display for WriterSchemaKey {
 /// Provides writer schemas to an [`AvroSchemaResolver`].
 ///
 /// Mirrors the `WireFormat<C>` enum on the catalog side: a decoder can run
-/// without any wire-format framing or with Confluent framing (optionally
-/// without a registry to fetch from). Each variant owns its cache type by
+/// without any wire-format framing, with Confluent framing, or with AWS
+/// Glue framing (each of the framed variants optionally without a
+/// registry to fetch from). Each variant owns its cache type by
 /// construction, so the resolver cannot mis-route a key to the wrong
 /// cache.
 pub enum WriterSchemaProvider {
@@ -396,6 +482,9 @@ pub enum WriterSchemaProvider {
     /// schema id (no registry attached); `cache: Some` means fetch from
     /// the cache.
     Confluent { cache: Option<SchemaCache> },
+    /// AWS Glue framing. `cache: None` means strip-and-discard the UUID
+    /// (no registry attached); `cache: Some` means fetch from the cache.
+    Glue { cache: Option<GlueSchemaCache> },
 }
 
 impl fmt::Debug for WriterSchemaProvider {
@@ -404,6 +493,8 @@ impl fmt::Debug for WriterSchemaProvider {
             WriterSchemaProvider::None => "none",
             WriterSchemaProvider::Confluent { cache: None } => "confluent (no cache)",
             WriterSchemaProvider::Confluent { cache: Some(_) } => "confluent",
+            WriterSchemaProvider::Glue { cache: None } => "glue (no cache)",
+            WriterSchemaProvider::Glue { cache: Some(_) } => "glue",
         };
         f.debug_tuple("WriterSchemaProvider").field(&tag).finish()
     }
@@ -416,6 +507,22 @@ impl WriterSchemaProvider {
     pub fn confluent(ccsr_client: Option<mz_ccsr::Client>) -> Self {
         let cache = ccsr_client.map(SchemaCache::new);
         WriterSchemaProvider::Confluent { cache }
+    }
+
+    /// Build the Glue variant from an optional (client, registry-name)
+    /// pair. `None` means "Glue framing but no registry to fetch from" —
+    /// the resolver strips the UUID header and falls back to the reader
+    /// schema. When the pair is supplied, the registry name is the one
+    /// the catalog connection points at; the cache rejects any UUID
+    /// whose `SchemaArn` doesn't sit under that registry. (Schema
+    /// *names* aren't unique across Glue registries, so the registry
+    /// name is the only meaningful scope here.) Pairing the two in a
+    /// tuple makes the "no client → no registry name" case unrepresentable.
+    pub fn glue(
+        client_with_registry: Option<(mz_aws_glue_schema_registry::Client, String)>,
+    ) -> Self {
+        let cache = client_with_registry.map(|(c, registry)| GlueSchemaCache::new(c, registry));
+        WriterSchemaProvider::Glue { cache }
     }
 }
 
@@ -478,6 +585,34 @@ impl AvroSchemaResolver {
                 };
                 (schema, Some(WriterSchemaKey::Confluent(id)))
             }
+
+            WriterSchemaProvider::Glue { cache: None } => {
+                // Strip + discard the header; no registry to look up.
+                match crate::glue::extract_avro_header(bytes) {
+                    Ok((_uuid, adjusted_bytes)) => {
+                        bytes = adjusted_bytes;
+                        (&self.reader_schema, None)
+                    }
+                    Err(err) => return Ok(Err(err)),
+                }
+            }
+
+            WriterSchemaProvider::Glue { cache: Some(cache) } => {
+                let (uuid, adjusted_bytes) = match crate::glue::extract_avro_header(bytes) {
+                    Ok(ok) => ok,
+                    Err(err) => return Ok(Err(err)),
+                };
+                bytes = adjusted_bytes;
+                let result = cache
+                    .get(uuid, &self.reader_schema)
+                    .await?
+                    .with_context(|| format!("failed to resolve Avro schema (uuid = {uuid})"));
+                let schema = match result {
+                    Ok(schema) => schema,
+                    Err(err) => return Ok(Err(err)),
+                };
+                (schema, Some(WriterSchemaKey::Glue(uuid)))
+            }
         };
         Ok(Ok((bytes, resolved_schema, key)))
     }
@@ -490,6 +625,167 @@ impl fmt::Debug for AvroSchemaResolver {
             .field("writer_schemas", &self.writer_schemas)
             .finish()
     }
+}
+
+/// Glue-side analogue of [`SchemaCache`].
+///
+/// Differences from the CSR cache:
+/// * Keys are UUIDs (Glue schema-version IDs), not `i32`s.
+/// * Glue schemas are single definitions — no `references` field on
+///   `GetSchemaVersion`, so the cache does not chase a dependency graph.
+/// * No outer retry layer. `aws-sdk-glue` ships a "standard" retry policy
+///   by default that handles transient errors; layering our own
+///   `Retry::default()` on top would only amplify backoff.
+#[derive(Debug)]
+pub struct GlueSchemaCache {
+    cache: BTreeMap<Uuid, Result<Schema, AvroError>>,
+    glue_client: mz_aws_glue_schema_registry::Client,
+    /// The registry name the catalog connection points at. Per-UUID
+    /// fetches are cross-checked against this; mismatches become decode
+    /// errors. See type-level docs.
+    expected_registry: String,
+}
+
+impl GlueSchemaCache {
+    fn new(glue_client: mz_aws_glue_schema_registry::Client, expected_registry: String) -> Self {
+        GlueSchemaCache {
+            cache: BTreeMap::new(),
+            glue_client,
+            expected_registry,
+        }
+    }
+
+    /// Look up the writer schema for `uuid`, fetching from Glue on a
+    /// cache miss. Mirrors [`SchemaCache::get`]: the outer `Result`
+    /// surfaces transient errors (network, auth, throttling — already
+    /// retried by the SDK) that the caller may retry on; the inner
+    /// `Result` carries permanent failures (schema not found,
+    /// non-`Available` lifecycle, registry mismatch, parse failure) that
+    /// get cached so the same bad UUID does not re-hit Glue on every
+    /// record.
+    async fn get(
+        &mut self,
+        uuid: Uuid,
+        reader_schema: &Schema,
+    ) -> anyhow::Result<anyhow::Result<&Schema>> {
+        let entry = match self.cache.entry(uuid) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => {
+                let parsed: Result<Schema, AvroError> = match self
+                    .glue_client
+                    .get_schema_version_by_id(uuid)
+                    .await
+                {
+                    Ok(version) => {
+                        Self::parse_version(version, uuid, &self.expected_registry, reader_schema)
+                    }
+                    // Permanent: UUID does not exist in any visible
+                    // registry. Cache so we don't re-fetch on every
+                    // record carrying this UUID.
+                    Err(mz_aws_glue_schema_registry::GetSchemaVersionError::NotFound) => Err(
+                        ParseSchemaError::new(format!("Glue schema version {uuid} not found"))
+                            .into(),
+                    ),
+                    // Transient: SDK has already retried; surface to the
+                    // outer Result so the source can decide. The explicit
+                    // `Other` arm (rather than a wildcard) makes any
+                    // future variant a compile error rather than a
+                    // silent reclassification.
+                    Err(e @ mz_aws_glue_schema_registry::GetSchemaVersionError::Other(_)) => {
+                        return Err(e.into());
+                    }
+                };
+                v.insert(parsed)
+            }
+        };
+        Ok(entry.as_ref().map_err(|e| anyhow::Error::new(e.clone())))
+    }
+
+    /// Validate and parse a fetched [`mz_aws_glue_schema_registry::SchemaVersion`] into an Avro schema.
+    ///
+    /// All failures here are permanent (a retry would return the same
+    /// `SchemaVersion`) and get cached by the caller.
+    fn parse_version(
+        version: mz_aws_glue_schema_registry::SchemaVersion,
+        uuid: Uuid,
+        expected_registry: &str,
+        reader_schema: &Schema,
+    ) -> Result<Schema, AvroError> {
+        use mz_aws_glue_schema_registry::SchemaVersionLifecycleStatus;
+
+        // Reject anything not Available. Pending/Failure versions may
+        // still carry a `definition` from the SDK, but decoding records
+        // against them would yield garbage.
+        if !matches!(
+            version.lifecycle_status,
+            Some(SchemaVersionLifecycleStatus::Available)
+        ) {
+            return Err(ParseSchemaError::new(format!(
+                "Glue schema version {uuid} is not Available (status: {:?}); \
+                 refusing to decode",
+                version.lifecycle_status
+            ))
+            .into());
+        }
+        let definition = version.definition.ok_or_else(|| {
+            ParseSchemaError::new(format!(
+                "Glue schema version {uuid} returned without a definition"
+            ))
+        })?;
+        // Enforce that the fetched version actually lives in the
+        // registry our catalog connection points at. Without this, any
+        // UUID the credentials can resolve would decode silently,
+        // defeating the per-connection scope.
+        let arn = version.schema_arn.as_deref().ok_or_else(|| {
+            ParseSchemaError::new(format!(
+                "Glue schema version {uuid} returned without a SchemaArn; \
+                 cannot verify registry membership"
+            ))
+        })?;
+        let actual_registry = registry_name_from_schema_arn(arn).ok_or_else(|| {
+            ParseSchemaError::new(format!(
+                "Glue SchemaArn {arn:?} did not match the expected \
+                 arn:aws[-...]:glue:<region>:<account>:schema/<registry>/<schema> form"
+            ))
+        })?;
+        if actual_registry != expected_registry {
+            return Err(ParseSchemaError::new(format!(
+                "Glue schema version {uuid} lives in registry {actual_registry:?} \
+                 but this source is configured for registry {expected:?}; \
+                 refusing to decode",
+                expected = expected_registry,
+            ))
+            .into());
+        }
+        let value: serde_json::Value = serde_json::from_str(&definition)
+            .map_err(|e| ParseSchemaError::new(format!("Error parsing JSON: {e}")))?;
+        let schema = Schema::parse_with_references(&value, &[])?;
+        resolve_schemas(&schema, reader_schema)
+    }
+}
+
+/// Parse the registry name out of a Glue `SchemaArn`.
+///
+/// Glue schema ARNs have the shape
+/// `arn:<partition>:glue:<region>:<account>:schema/<registry>/<schema>`,
+/// where `<partition>` is `aws`, `aws-cn`, `aws-us-gov`, etc. We anchor
+/// on `arn:` and the `:glue:` segment so a fragment like
+/// `:schema/foo/bar` alone won't parse. Returns `None` if the input
+/// doesn't match — we surface that as a decode error rather than
+/// panicking, so schemas in unexpected partitions or future ARN shapes
+/// don't crash the source.
+fn registry_name_from_schema_arn(arn: &str) -> Option<&str> {
+    let rest = arn.strip_prefix("arn:")?;
+    let (partition, after_partition) = rest.split_once(":glue:")?;
+    if !partition.starts_with("aws") {
+        return None;
+    }
+    let (_, after_schema) = after_partition.split_once(":schema/")?;
+    let (registry, _) = after_schema.split_once('/')?;
+    if registry.is_empty() {
+        return None;
+    }
+    Some(registry)
 }
 
 /// Cache of writer schemas fetched from a Confluent Schema Registry. Held


### PR DESCRIPTION
Adds the `WriterSchemaProvider::Glue` variant and implements `GlueSchemaCache`. 

This also adds `SchemaArn` parsing (not provided by AWS rust SDK). The Glue API searches all registries reachable by the given credentials when looking up via `SchemaVersionId` (UUID). We parse the returned ARN to ensure that the registry name matches the source configuration, returning an error on mismatch.

