### PR TITLE
sql: omit DETAILS from SHOW CREATE TABLE ... FROM SOURCE

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1055,13 +1055,24 @@ impl<'a> ShowColumnsSelect<'a> {
 
 /// Convert a SQL statement into a form that could be used as input, as well as
 /// is more amenable to human consumption.
+///
+/// Note that the bits we omit here (e.g. the internal `AS OF` of a materialized
+/// view, or the `DETAILS` of a `CREATE TABLE ... FROM SOURCE`) are not
+/// user-typeable, but remain accessible for debugging in the raw `create_sql`
+/// (and `redacted_create_sql`) column of catalog builtins like
+/// `mz_catalog.mz_materialized_views` and `mz_catalog.mz_tables`. They are not
+/// in the `definition` column, which is parsed back out of `create_sql` and only
+/// retains the inner query.
 fn humanize_sql_for_show_create(
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,
     sql: &str,
     redacted: bool,
 ) -> Result<String, PlanError> {
-    use mz_sql_parser::ast::{CreateSourceConnection, MySqlConfigOptionName, PgConfigOptionName};
+    use mz_sql_parser::ast::{
+        CreateSourceConnection, MySqlConfigOptionName, PgConfigOptionName,
+        TableFromSourceOptionName,
+    };
 
     let parsed = parse::parse(sql)?.into_element().ast;
     let (mut resolved, _) = names::resolve(catalog, parsed)?;
@@ -1073,6 +1084,18 @@ fn humanize_sql_for_show_create(
     match &mut resolved {
         // Strip internal `AS OF` syntax.
         Statement::CreateMaterializedView(stmt) => stmt.as_of = None,
+        // Strip the internal `DETAILS` option, which is not user-typeable and
+        // does not roundtrip.
+        Statement::CreateTableFromSource(stmt) => {
+            stmt.with_options.retain_mut(|o| match o.name {
+                TableFromSourceOptionName::TextColumns => true,
+                TableFromSourceOptionName::ExcludeColumns => true,
+                // Drop details, which does not roundtrip.
+                TableFromSourceOptionName::Details => false,
+                TableFromSourceOptionName::PartitionBy => true,
+                TableFromSourceOptionName::RetainHistory => true,
+            });
+        }
         // `CREATE SOURCE` statements should roundtrip. However, sources and
         // their subsources have a complex relationship, so we need to do a lot
         // of work to reconstruct the statement for multi-output sources.

--- a/test/mysql-cdc/30-text-columns.td
+++ b/test/mysql-cdc/30-text-columns.td
@@ -70,8 +70,11 @@ $ set-regex match="DETAILS = '[a-f0-9]+'" replacement=<DETAILS>
 >[version<2600700] SHOW CREATE TABLE t1;
 materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.text, f2 pg_catalog.text, f3 pg_catalog.text) FROM SOURCE materialize.public.da (REFERENCE = public.t1) WITH (TEXT COLUMNS = (f1, f2, f3), <DETAILS>);"
 
->[version>=2600700] SHOW CREATE TABLE t1;
+>[2600700<=version<2603000] SHOW CREATE TABLE t1;
 materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.text, f2 pg_catalog.text, f3 pg_catalog.text)\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (\n    TEXT COLUMNS = (f1, f2, f3),\n    <DETAILS>\n);"
+
+>[version>=2603000] SHOW CREATE TABLE t1;
+materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.text, f2 pg_catalog.text, f3 pg_catalog.text)\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (TEXT COLUMNS = (f1, f2, f3));"
 
 > DROP SOURCE da CASCADE;
 

--- a/test/mysql-cdc/35-exclude-columns.td
+++ b/test/mysql-cdc/35-exclude-columns.td
@@ -85,8 +85,11 @@ $ set-regex match="DETAILS = '[a-f0-9]+'" replacement=<DETAILS>
 >[version<2600700] SHOW CREATE TABLE t1;
 materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.int4, f4 pg_catalog.varchar(64)) FROM SOURCE materialize.public.da (REFERENCE = public.t1) WITH (EXCLUDE COLUMNS = (f2, f3), <DETAILS>);"
 
->[version>=2600700] SHOW CREATE TABLE t1;
+>[2600700<=version<2603000] SHOW CREATE TABLE t1;
 materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.int4, f4 pg_catalog.varchar(64))\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (\n    EXCLUDE COLUMNS = (f2, f3),\n    <DETAILS>\n);"
+
+>[version>=2603000] SHOW CREATE TABLE t1;
+materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.int4, f4 pg_catalog.varchar(64))\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (EXCLUDE COLUMNS = (f2, f3));"
 
 ! SELECT f2 FROM t1;
 contains:column "f2" does not exist

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -123,8 +123,11 @@ materialize.public.mz_source "CREATE SOURCE materialize.public.mz_source\nIN CLU
 >[version<2600700] SHOW CREATE TABLE table_a;
 materialize.public.table_a "CREATE TABLE materialize.public.table_a (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT \"PRIMARY\" PRIMARY KEY (pk)) FROM SOURCE materialize.public.mz_source (REFERENCE = public.table_a) WITH (<DETAILS>);"
 
->[version>=2600700] SHOW CREATE TABLE table_a;
+>[2600700<=version<2603000] SHOW CREATE TABLE table_a;
 materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT \"PRIMARY\" PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = public.table_a)\nWITH (\n    <DETAILS>\n);"
+
+>[version>=2603000] SHOW CREATE TABLE table_a;
+materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT \"PRIMARY\" PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = public.table_a);"
 
 #
 # Error checking

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -153,8 +153,11 @@ materialize.public.mz_source "CREATE SOURCE materialize.public.mz_source\nIN CLU
 >[version<2600700] SHOW CREATE TABLE table_a;
 materialize.public.table_a "CREATE TABLE materialize.public.table_a (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT table_a_pkey PRIMARY KEY (pk)) FROM SOURCE materialize.public.mz_source (REFERENCE = postgres.public.table_a) WITH (<DETAILS>);"
 
->[version>=2600700] SHOW CREATE TABLE table_a;
+>[2600700<=version<2603000] SHOW CREATE TABLE table_a;
 materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT table_a_pkey PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = postgres.public.table_a)\nWITH (\n    <DETAILS>\n);"
+
+>[version>=2603000] SHOW CREATE TABLE table_a;
+materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT table_a_pkey PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = postgres.public.table_a);"
 
 #
 # State checking

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -730,8 +730,11 @@ $ set-regex match="DETAILS = '[a-f0-9]+'" replacement=<DETAILS>
 >[version<2600700] SHOW CREATE TABLE enum_table
 materialize.public.enum_table "CREATE TABLE materialize.public.enum_table (a pg_catalog.text) FROM SOURCE materialize.public.enum_source (REFERENCE = postgres.public.enum_table) WITH (TEXT COLUMNS = (a), <DETAILS>);"
 
->[version>=2600700] SHOW CREATE TABLE enum_table
+>[2600700<=version<2603000] SHOW CREATE TABLE enum_table
 materialize.public.enum_table "CREATE TABLE materialize.public.enum_table (a pg_catalog.text)\nFROM SOURCE materialize.public.enum_source (REFERENCE = postgres.public.enum_table)\nWITH (\n    TEXT COLUMNS = (a),\n    <DETAILS>\n);"
+
+>[version>=2603000] SHOW CREATE TABLE enum_table
+materialize.public.enum_table "CREATE TABLE materialize.public.enum_table (a pg_catalog.text)\nFROM SOURCE materialize.public.enum_source (REFERENCE = postgres.public.enum_table)\nWITH (TEXT COLUMNS = (a));"
 
 # Test that TEXT COLUMN types can change
 $ postgres-execute connection=postgres://postgres:postgres@postgres

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -97,8 +97,11 @@ regex:.*FOR SCHEMAS.*unsupported
 >[version<2600700] SHOW CREATE TABLE accounts
 materialize.public.accounts "CREATE TABLE materialize.public.accounts (id pg_catalog.int8 NOT NULL, org_id pg_catalog.int8 NOT NULL, balance pg_catalog.int8 NOT NULL, UNIQUE (id)) FROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts) WITH (DETAILS = '1a040a021002');"
 
->[version>=2600700] SHOW CREATE TABLE accounts
+>[2600700<=version<2603000] SHOW CREATE TABLE accounts
 materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts)\nWITH (DETAILS = '1a040a021002');"
+
+>[version>=2603000] SHOW CREATE TABLE accounts
+materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts);"
 
 > SHOW SOURCES
 auction_house           load-generator ${arg.single-replica-cluster}    ""
@@ -157,8 +160,11 @@ $ set-regex match="DETAILS = '[a-f0-9]+'" replacement=<DETAILS>
 >[version<2600700] SHOW CREATE TABLE accounts
 materialize.public.accounts "CREATE TABLE materialize.public.accounts (id pg_catalog.int8 NOT NULL, org_id pg_catalog.int8 NOT NULL, balance pg_catalog.int8 NOT NULL, UNIQUE (id)) FROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts) WITH (<DETAILS>);"
 
->[version>=2600700] SHOW CREATE TABLE accounts
+>[2600700<=version<2603000] SHOW CREATE TABLE accounts
 materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts)\nWITH (<DETAILS>);"
+
+>[version>=2603000] SHOW CREATE TABLE accounts
+materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts);"
 
 # CLOCK load generator source
 


### PR DESCRIPTION
Fixes SQL-231 and fixes https://github.com/MaterializeInc/database-issues/issues/10034.

SHOW CREATE TABLE on a table created with CREATE TABLE ... FROM SOURCE emitted an internal DETAILS option that is not user-typeable, so the output could not be replayed (frustrating workload replay, mz-deploy, copy-paste, etc.). Strip DETAILS in humanize_sql_for_show_create, matching how the internal AS OF of materialized views is already hidden.

The omitted DETAILS remains accessible for debugging in the raw create_sql (and redacted_create_sql) columns of mz_catalog.mz_tables.

Nightly (because of the fiddly version guards in td): https://buildkite.com/materialize/nightly/builds/16809 Edit: Green (the SLT fail is unrelated, also present on `main`)