### PR TITLE
round-trip `SHOW CREATE TABLE` references for SQL Server and load generators

### DIFF
--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -16,7 +16,9 @@ use mz_repr::RelationDesc;
 use mz_sql_parser::ast::{ExternalReferences, Ident, IdentError, UnresolvedItemName};
 use mz_sql_server_util::SqlServerError;
 use mz_sql_server_util::desc::SqlServerTableRaw;
-use mz_storage_types::sources::load_generator::{LoadGenerator, LoadGeneratorOutput};
+use mz_storage_types::sources::load_generator::{
+    LOAD_GENERATOR_DATABASE_NAME, LoadGenerator, LoadGeneratorOutput,
+};
 use mz_storage_types::sources::{ExternalReferenceResolutionError, SourceReferenceResolver};
 
 use crate::names::{FullItemName, RawDatabaseSpecifier};
@@ -169,10 +171,7 @@ impl ReferenceMetadata {
                 name, namespace, ..
             } => {
                 let name = FullItemName {
-                    database: RawDatabaseSpecifier::Name(
-                        mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME
-                            .to_owned(),
-                    ),
+                    database: RawDatabaseSpecifier::Name(LOAD_GENERATOR_DATABASE_NAME.to_owned()),
                     schema: namespace.to_string(),
                     item: name.to_string(),
                 };
@@ -190,11 +189,18 @@ pub(super) struct RetrievedSourceReferences {
     resolver: SourceReferenceResolver,
 }
 
-/// The name of the fake database that we use for non-Postgres sources
-/// to fit the model of a 3-layer catalog used to resolve references
-/// in the `SourceReferenceResolver`. This isn't actually stored in
-/// the catalog since the `ReferenceMetadata::external_reference`
-/// method only includes the database name for Postgres sources.
+/// The name of the fake database used to fit references into the 3-layer catalog
+/// model of the [`SourceReferenceResolver`] for source types whose
+/// [`ReferenceMetadata::external_reference`] stores no database component
+/// (MySQL and Kafka). Because those references are never fully qualified with a
+/// database, the resolver's database name is never matched against and this
+/// placeholder is never stored in the catalog.
+///
+/// Note: this is *not* usable for every non-Postgres source. SQL Server and load
+/// generators do store a database in their external reference (the real upstream
+/// database and the synthetic `mz_load_generators`, respectively), so their
+/// resolvers must be built with that same database for the stored reference to
+/// resolve. See the resolver construction in [`SourceReferenceClient`].
 pub(crate) static DATABASE_FAKE_NAME: &str = "database";
 
 impl<'a> SourceReferenceClient<'a> {
@@ -339,11 +345,27 @@ impl<'a> SourceReferenceClient<'a> {
                 )
             })
             .collect();
+        // The resolver's database must match the database that each source type
+        // embeds in its `ReferenceMetadata::external_reference()`, otherwise the
+        // fully-qualified reference we store (and print in `SHOW CREATE TABLE`)
+        // won't resolve when fed back in. Postgres and SQL Server store the real
+        // upstream database; load generators store the synthetic
+        // `mz_load_generators` database. MySQL and Kafka store no database
+        // component, so the resolver's database is never matched against and the
+        // fake name is fine.
         let resolver = match self {
             SourceReferenceClient::Postgres { database, .. } => {
                 SourceReferenceResolver::new(database, &reference_names)
             }
-            _ => SourceReferenceResolver::new(DATABASE_FAKE_NAME, &reference_names),
+            SourceReferenceClient::SqlServer { database, .. } => {
+                SourceReferenceResolver::new(&database, &reference_names)
+            }
+            SourceReferenceClient::LoadGenerator { .. } => {
+                SourceReferenceResolver::new(LOAD_GENERATOR_DATABASE_NAME, &reference_names)
+            }
+            SourceReferenceClient::MySql { .. } | SourceReferenceClient::Kafka { .. } => {
+                SourceReferenceResolver::new(DATABASE_FAKE_NAME, &reference_names)
+            }
         }?;
 
         Ok(RetrievedSourceReferences {

--- a/test/sql-server-cdc/source-tables.td
+++ b/test/sql-server-cdc/source-tables.td
@@ -73,6 +73,13 @@ a "hello world"
 b "foobar"
 c "anotha one"
 
+# Regression test for database-issues#10010: the fully-qualified 3-part
+# `REFERENCE` (database.schema.table) printed by `SHOW CREATE TABLE` must
+# round-trip back into a `CREATE TABLE`.
+>[version>=2603000] CREATE TABLE t_roundtrip FROM SOURCE ms_src (REFERENCE test.dbo.t1_pk);
+
+>[version>=2603000] DROP TABLE t_roundtrip;
+
 # source tables see updates
 $ sql-server-execute name=sql-server
 DELETE FROM t1_pk WHERE key_col = 'a';

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -103,6 +103,12 @@ materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n    
 >[version>=2603000] SHOW CREATE TABLE accounts
 materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts);"
 
+# Regression test for database-issues#10010: the fully-qualified `REFERENCE`
+# printed by `SHOW CREATE TABLE` must round-trip back into a `CREATE TABLE`.
+>[version>=2603000] CREATE TABLE accounts_roundtrip FROM SOURCE auction_house (REFERENCE mz_load_generators.auction.accounts);
+
+>[version>=2603000] DROP TABLE accounts_roundtrip;
+
 > SHOW SOURCES
 auction_house           load-generator ${arg.single-replica-cluster}    ""
 


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/10010, a `SHOW CREATE` roundtripping issue.

SHOW CREATE TABLE on a `CREATE TABLE ... FROM SOURCE` prints a fully-qualified
3-part REFERENCE (database.schema.name) for SQL Server (the real upstream
database) and load generator (the synthetic `mz_load_generators`) sources.
Replaying that exact statement failed with "reference ... not found in source",
because the SourceReferenceResolver for those types was built with the
placeholder DATABASE_FAKE_NAME ("database") rather than the database actually
embedded in the stored reference. Only Postgres built its resolver with the real
database, so only Postgres round-tripped; MySQL and Kafka store no database
component in their reference, so they were unaffected.

Build the resolver with the database each source type stores in its external
reference: the real upstream database for SQL Server, `mz_load_generators` for
load generators. The resolver's database is only used for matching (resolve_idx)
and is never propagated, so stored/printed references are unchanged and no
catalog migration is needed.

Fix A vs Fix B: the alternative ("Fix B") was to drop the database from the
stored reference so it becomes 2-part like MySQL -- which is what the issue
reporter expected for load generators. We chose this approach ("Fix A") because
Fix B requires a catalog migration to rewrite existing tables' create_sql, which
is substantial hassle for little benefit, especially as load generator sources
may be deprecated soon. Fix A also keeps SQL Server consistent with Postgres,
where the database in the reference is genuinely meaningful.

Also rewrites the stale DATABASE_FAKE_NAME doc comment, which predated the SQL
Server source and wrongly claimed only Postgres stores a database in its
reference.
