### PR TITLE
console: rename "Freshness latency" to "Freshness" on cluster page

### DIFF
--- a/console/src/platform/clusters/ClusterOverview/ClusterFreshness.tsx
+++ b/console/src/platform/clusters/ClusterOverview/ClusterFreshness.tsx
@@ -68,7 +68,7 @@ const ClusterFreshnessTable = ({
       <Thead>
         <Tr>
           <Th>Name</Th>
-          <Th>Freshness latency</Th>
+          <Th>Freshness</Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -169,7 +169,7 @@ const ClusterFreshness = ({ clusterId }: { clusterId: string }) => {
           <VStack alignItems="flex-start" gap="1">
             <HStack>
               <Text textStyle="heading-md" color={colors.foreground.primary}>
-                Freshness latency
+                Freshness
               </Text>
             </HStack>
 
@@ -189,7 +189,7 @@ const ClusterFreshness = ({ clusterId }: { clusterId: string }) => {
         </HStack>
       </VStack>
       <AppErrorBoundary
-        message="An error occurred fetching freshness latency data."
+        message="An error occurred fetching freshness data."
         containerProps={{
           padding: "4",
         }}


### PR DESCRIPTION
## Motivation

On the cluster overview page in the console, the freshness metric was labeled "Freshness latency", while the materialized view and index pages label the same concept simply "Freshness". This inconsistency caused confusion about whether these were different metrics (see thread below).

This PR aligns the cluster page terminology with the rest of the console by renaming "Freshness latency" to just "Freshness".

## Changes

In `console/src/platform/clusters/ClusterOverview/ClusterFreshness.tsx`:
- Table column header: "Freshness latency" → "Freshness"
- Section heading: "Freshness latency" → "Freshness"
- Error message: "...fetching freshness latency data." → "...fetching freshness data."

## Context

Slack thread: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1781704758421249?thread_ts=1781704585.537959&cid=CU7ELJ6E9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3RBnxADkJa1V6Q6Ufo21b)_