### PR TITLE
console: rename "Freshness latency" to "Freshness" on environment overview

### DIFF
--- a/console/src/platform/environment-overview/ClusterFreshness.tsx
+++ b/console/src/platform/environment-overview/ClusterFreshness.tsx
@@ -113,7 +113,7 @@ const ClusterFreshnessTable = ({
         <Tr>
           <Th>Cluster name</Th>
           <Th>Object name</Th>
-          <Th>Freshness latency</Th>
+          <Th>Freshness</Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -234,7 +234,7 @@ const ClusterFreshness = () => {
         <HStack width="100%" justifyContent="space-between">
           <VStack alignItems="flex-start" gap="1">
             <Text textStyle="heading-md" color={colors.foreground.primary}>
-              Cluster freshness latency
+              Cluster freshness
             </Text>
             <Text textStyle="text-small" color={colors.foreground.secondary}>
               Materialize continuously monitors how far dataflows lag behind the
@@ -252,7 +252,7 @@ const ClusterFreshness = () => {
         </HStack>
       </VStack>
       <AppErrorBoundary
-        message="An error occurred fetching freshness latency data."
+        message="An error occurred fetching freshness data."
         containerProps={{
           padding: "4",
         }}


### PR DESCRIPTION
## Motivation

Follow-up to #37101. That PR renamed "Freshness latency" → "Freshness" on the cluster overview page, but left the same label on the **environment overview** page. This PR renames it there too so the terminology is consistent across the console (cluster, materialized view, and index pages all use just "Freshness").

## Changes

In `console/src/platform/environment-overview/ClusterFreshness.tsx`:
- Table column header: "Freshness latency" → "Freshness"
- Section heading: "Cluster freshness latency" → "Cluster freshness"
- Error message: "...fetching freshness latency data." → "...fetching freshness data."

## Context

Slack thread: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1781705065089519?thread_ts=1781704585.537959&cid=CU7ELJ6E9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDpF8XjDr6WQzTnfnVP4QD)_