### PR TITLE
console: rename "Freshness latency" to "Freshness" on environment overview page

### DIFF
--- a/console/src/platform/environment-overview/ClusterFreshness.tsx
+++ b/console/src/platform/environment-overview/ClusterFreshness.tsx
@@ -113,7 +113,7 @@ const ClusterFreshnessTable = ({
         <Tr>
           <Th>Cluster name</Th>
           <Th>Object name</Th>
-          <Th>Freshness latency</Th>
+          <Th>Freshness</Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -234,7 +234,7 @@ const ClusterFreshness = () => {
         <HStack width="100%" justifyContent="space-between">
           <VStack alignItems="flex-start" gap="1">
             <Text textStyle="heading-md" color={colors.foreground.primary}>
-              Cluster freshness latency
+              Cluster freshness
             </Text>
             <Text textStyle="text-small" color={colors.foreground.secondary}>
               Materialize continuously monitors how far dataflows lag behind the
@@ -252,7 +252,7 @@ const ClusterFreshness = () => {
         </HStack>
       </VStack>
       <AppErrorBoundary
-        message="An error occurred fetching freshness latency data."
+        message="An error occurred fetching freshness data."
         containerProps={{
           padding: "4",
         }}


### PR DESCRIPTION
## Motivation

Follow-up to #37101, which renamed "Freshness latency" to "Freshness" on the cluster detail page. This applies the same change to the **environment overview** page so the language is consistent across the console (materialized view and index pages already use just "Freshness").

## What changed

In `console/src/platform/environment-overview/ClusterFreshness.tsx`:
- Table column header: "Freshness latency" → "Freshness"
- Section heading: "Cluster freshness latency" → "Cluster freshness"
- Error message: "...fetching freshness latency data." → "...fetching freshness data."

## Context

Requested in [this Slack thread](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1781705065089519?thread_ts=1781704585.537959&cid=CU7ELJ6E9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013MamsURUmZApbP1Qf49ZYA)_