### PR TITLE
sql: omit derived columns from SHOW CREATE TABLE ... FROM SOURCE

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1070,7 +1070,7 @@ fn humanize_sql_for_show_create(
     redacted: bool,
 ) -> Result<String, PlanError> {
     use mz_sql_parser::ast::{
-        CreateSourceConnection, MySqlConfigOptionName, PgConfigOptionName,
+        CreateSourceConnection, MySqlConfigOptionName, PgConfigOptionName, TableFromSourceColumns,
         TableFromSourceOptionName,
     };
 
@@ -1095,6 +1095,19 @@ fn humanize_sql_for_show_create(
                 TableFromSourceOptionName::PartitionBy => true,
                 TableFromSourceOptionName::RetainHistory => true,
             });
+            // The `Defined` column list and constraints are populated during
+            // purification (from the upstream schema), and `CREATE TABLE ... FROM
+            // SOURCE` rejects them as input. Omit them so the statement
+            // roundtrips; purification re-derives them from the source on replay,
+            // and the schema-affecting `TEXT COLUMNS` / `EXCLUDE COLUMNS` options
+            // are retained above so the re-derived schema matches. A user-typed
+            // `Named` column list is left intact, since it does roundtrip.
+            if matches!(stmt.columns, TableFromSourceColumns::Defined(_)) {
+                stmt.columns = TableFromSourceColumns::NotSpecified;
+            }
+            // Constraints are never valid input here (purification populates them
+            // alongside `Defined` columns), so always drop them.
+            stmt.constraints = Vec::new();
         }
         // `CREATE SOURCE` statements should roundtrip. However, sources and
         // their subsources have a complex relationship, so we need to do a lot

--- a/test/mysql-cdc/30-text-columns.td
+++ b/test/mysql-cdc/30-text-columns.td
@@ -74,7 +74,13 @@ materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.text, f
 materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.text, f2 pg_catalog.text, f3 pg_catalog.text)\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (\n    TEXT COLUMNS = (f1, f2, f3),\n    <DETAILS>\n);"
 
 >[version>=2603000] SHOW CREATE TABLE t1;
-materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.text, f2 pg_catalog.text, f3 pg_catalog.text)\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (TEXT COLUMNS = (f1, f2, f3));"
+materialize.public.t1 "CREATE TABLE materialize.public.t1\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (TEXT COLUMNS = (f1, f2, f3));"
+
+# Regression test for SQL-392: the full `SHOW CREATE TABLE` output (no derived
+# column list, bare `TEXT COLUMNS`, `REFERENCE = ...`) must round-trip.
+>[version>=2603000] CREATE TABLE t1_roundtrip FROM SOURCE da (REFERENCE = public.t1) WITH (TEXT COLUMNS = (f1, f2, f3));
+
+>[version>=2603000] DROP TABLE t1_roundtrip;
 
 > DROP SOURCE da CASCADE;
 

--- a/test/mysql-cdc/35-exclude-columns.td
+++ b/test/mysql-cdc/35-exclude-columns.td
@@ -89,7 +89,13 @@ materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.int4, f
 materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.int4, f4 pg_catalog.varchar(64))\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (\n    EXCLUDE COLUMNS = (f2, f3),\n    <DETAILS>\n);"
 
 >[version>=2603000] SHOW CREATE TABLE t1;
-materialize.public.t1 "CREATE TABLE materialize.public.t1 (f1 pg_catalog.int4, f4 pg_catalog.varchar(64))\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (EXCLUDE COLUMNS = (f2, f3));"
+materialize.public.t1 "CREATE TABLE materialize.public.t1\nFROM SOURCE materialize.public.da (REFERENCE = public.t1)\nWITH (EXCLUDE COLUMNS = (f2, f3));"
+
+# Regression test for SQL-392: the full `SHOW CREATE TABLE` output (no derived
+# column list, bare `EXCLUDE COLUMNS`, `REFERENCE = ...`) must round-trip.
+>[version>=2603000] CREATE TABLE t1_roundtrip FROM SOURCE da (REFERENCE = public.t1) WITH (EXCLUDE COLUMNS = (f2, f3));
+
+>[version>=2603000] DROP TABLE t1_roundtrip;
 
 ! SELECT f2 FROM t1;
 contains:column "f2" does not exist

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -127,7 +127,7 @@ materialize.public.table_a "CREATE TABLE materialize.public.table_a (pk pg_catal
 materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT \"PRIMARY\" PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = public.table_a)\nWITH (\n    <DETAILS>\n);"
 
 >[version>=2603000] SHOW CREATE TABLE table_a;
-materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT \"PRIMARY\" PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = public.table_a);"
+materialize.public.table_a "CREATE TABLE materialize.public.table_a\nFROM SOURCE materialize.public.mz_source (REFERENCE = public.table_a);"
 
 #
 # Error checking

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -157,7 +157,7 @@ materialize.public.table_a "CREATE TABLE materialize.public.table_a (pk pg_catal
 materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT table_a_pkey PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = postgres.public.table_a)\nWITH (\n    <DETAILS>\n);"
 
 >[version>=2603000] SHOW CREATE TABLE table_a;
-materialize.public.table_a "CREATE TABLE\n    materialize.public.table_a\n        (pk pg_catalog.int4 NOT NULL, f2 pg_catalog.text, CONSTRAINT table_a_pkey PRIMARY KEY (pk))\nFROM SOURCE materialize.public.mz_source (REFERENCE = postgres.public.table_a);"
+materialize.public.table_a "CREATE TABLE materialize.public.table_a\nFROM SOURCE materialize.public.mz_source (REFERENCE = postgres.public.table_a);"
 
 #
 # State checking

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -734,7 +734,7 @@ materialize.public.enum_table "CREATE TABLE materialize.public.enum_table (a pg_
 materialize.public.enum_table "CREATE TABLE materialize.public.enum_table (a pg_catalog.text)\nFROM SOURCE materialize.public.enum_source (REFERENCE = postgres.public.enum_table)\nWITH (\n    TEXT COLUMNS = (a),\n    <DETAILS>\n);"
 
 >[version>=2603000] SHOW CREATE TABLE enum_table
-materialize.public.enum_table "CREATE TABLE materialize.public.enum_table (a pg_catalog.text)\nFROM SOURCE materialize.public.enum_source (REFERENCE = postgres.public.enum_table)\nWITH (TEXT COLUMNS = (a));"
+materialize.public.enum_table "CREATE TABLE materialize.public.enum_table\nFROM SOURCE materialize.public.enum_source (REFERENCE = postgres.public.enum_table)\nWITH (TEXT COLUMNS = (a));"
 
 # Test that TEXT COLUMN types can change
 $ postgres-execute connection=postgres://postgres:postgres@postgres

--- a/test/sql-server-cdc/source-tables.td
+++ b/test/sql-server-cdc/source-tables.td
@@ -73,8 +73,14 @@ a "hello world"
 b "foobar"
 c "anotha one"
 
-# Regression test for database-issues#10010: the fully-qualified 3-part
-# `REFERENCE` (database.schema.table) printed by `SHOW CREATE TABLE` must
+# Regression test for SQL-392: `SHOW CREATE TABLE` must omit the
+# purification-populated column definitions and constraints, which `CREATE TABLE
+# .. FROM SOURCE` rejects as input.
+>[version>=2603000] SHOW CREATE TABLE t1;
+materialize.public.t1 "CREATE TABLE materialize.public.t1\nFROM SOURCE materialize.public.ms_src (REFERENCE = test.dbo.t1_pk);"
+
+# Regression test for database-issues#10010 and SQL-392: the full statement
+# printed by `SHOW CREATE TABLE` (3-part `REFERENCE`, no column list) must
 # round-trip back into a `CREATE TABLE`.
 >[version>=2603000] CREATE TABLE t_roundtrip FROM SOURCE ms_src (REFERENCE test.dbo.t1_pk);
 

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -101,10 +101,11 @@ materialize.public.accounts "CREATE TABLE materialize.public.accounts (id pg_cat
 materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts)\nWITH (DETAILS = '1a040a021002');"
 
 >[version>=2603000] SHOW CREATE TABLE accounts
-materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts);"
+materialize.public.accounts "CREATE TABLE materialize.public.accounts\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts);"
 
-# Regression test for database-issues#10010: the fully-qualified `REFERENCE`
-# printed by `SHOW CREATE TABLE` must round-trip back into a `CREATE TABLE`.
+# Regression test for database-issues#10010 and SQL-392: the full statement
+# printed by `SHOW CREATE TABLE` (fully-qualified `REFERENCE`, no column list)
+# must round-trip back into a `CREATE TABLE`.
 >[version>=2603000] CREATE TABLE accounts_roundtrip FROM SOURCE auction_house (REFERENCE mz_load_generators.auction.accounts);
 
 >[version>=2603000] DROP TABLE accounts_roundtrip;
@@ -170,7 +171,7 @@ materialize.public.accounts "CREATE TABLE materialize.public.accounts (id pg_cat
 materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts)\nWITH (<DETAILS>);"
 
 >[version>=2603000] SHOW CREATE TABLE accounts
-materialize.public.accounts "CREATE TABLE\n    materialize.public.accounts\n        (\n            id pg_catalog.int8 NOT NULL,\n            org_id pg_catalog.int8 NOT NULL,\n            balance pg_catalog.int8 NOT NULL,\n            UNIQUE (id)\n        )\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts);"
+materialize.public.accounts "CREATE TABLE materialize.public.accounts\nFROM SOURCE materialize.public.auction_house (REFERENCE = mz_load_generators.auction.accounts);"
 
 # CLOCK load generator source
 


### PR DESCRIPTION
Fixes https://linear.app/materializeinc/issue/SQL-392

SHOW CREATE TABLE on a table created with CREATE TABLE ... FROM SOURCE emitted the column definitions and constraints that purification populates from the upstream schema (the `Defined` column variant). CREATE TABLE ... FROM SOURCE rejects those on input ("column definitions cannot be specified directly"), so the printed statement did not round-trip. This affected Postgres, MySQL, SQL Server, and multi-output load generator sources.

Strip the derived columns and constraints in humanize_sql_for_show_create, matching how the internal AS OF (materialized views) and DETAILS (this statement) are already hidden. The schema-affecting TEXT COLUMNS / EXCLUDE COLUMNS options are retained, so purification re-derives the same schema on replay. A user-typed `Named` column list is left intact, since it does round-trip.

**Strip vs accept**: the alternative was to make CREATE TABLE ... FROM SOURCE tolerate column definitions on input, which would keep them visible in SHOW CREATE. We strip instead because it is simpler (no validation of input columns against the derived schema, no schema-drift questions) and consistent with the AS OF / DETAILS precedent. Stripping loses no information: the column schema remains available via SHOW COLUMNS, mz_columns, and \d, and the full original (columns and constraints) is preserved verbatim in the raw create_sql / redacted_create_sql columns of mz_catalog.mz_tables.

Nightly: https://buildkite.com/materialize/nightly/builds/16815 (unrelated redness)