### PR TITLE
enable_gcp_connection feature flag

### DIFF
--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -321,6 +321,7 @@ impl ConnectionOptionExtracted {
                 ConnectionDetails::AwsPrivatelink(connection)
             }
             CreateConnectionType::Gcp => {
+                scx.require_feature_flag(&vars::ENABLE_GCP_CONNECTION)?;
                 let credentials_json = self
                     .service_account_key
                     .ok_or_else(|| sql_err!("SERVICE ACCOUNT KEY option is required"))?
@@ -730,6 +731,7 @@ impl ConnectionOptionExtracted {
                                 scope: self.scope.clone(),
                             },
                             (None, Some(gcp_connection)) => {
+                                scx.require_feature_flag(&vars::ENABLE_GCP_CONNECTION)?;
                                 /// All BigLake Iceberg REST Catalogs use the same catalog URI.
                                 const BIGLAKE_CATALOG_URI: &str =
                                     "https://biglake.googleapis.com/iceberg/v1/restcatalog";

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1977,6 +1977,12 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
+        name: enable_gcp_connection,
+        desc: "CREATE CONNECTION ... TO GCP",
+        default: false,
+        enable_for_item_parsing: true,
+    },
+    {
         name: enable_alter_set_cluster,
         desc: "ALTER ... SET CLUSTER syntax",
         default: false,


### PR DESCRIPTION
_I've not created the LaunchDarkly flag yet._

This feature flag should block creating GCP Connections and creating Iceberg Catalog Connections with GCP Connections.