### PR TITLE
Replace ToDatumIter with a push-based ExtendDatums trait

### DIFF
--- a/doc/developer/generated/repr/_crate.md
+++ b/doc/developer/generated/repr/_crate.md
@@ -24,7 +24,7 @@ The lingua franca of Materialize: defines the core data types that all layers of
 * `namespaces` — well-known schema name constants
 * `optimize` — `OptimizerFeatures`, `OptimizerFeatureOverrides`, and `OverrideFrom` trait
 * `refresh_schedule` — REFRESH EVERY/AT schedule representation
-* `fixed_length` — `ToDatumIter` abstraction
+* `fixed_length` — `ExtendDatums` abstraction
 * `datum_vec` — reusable `Datum` scratch buffer
 * `bytes` — PostgreSQL-compatible `ByteSize`
 * `user` — external user auth metadata

--- a/doc/developer/generated/repr/fixed_length.md
+++ b/doc/developer/generated/repr/fixed_length.md
@@ -5,4 +5,4 @@ revision: cbff1da032
 
 # mz-repr::fixed_length
 
-Defines `ToDatumIter`, a trait for types that can produce a borrowing `Datum` iterator, abstracting over `Row` and alternative trace representations (e.g., `DatumSeq` in `row_spine`) that avoid full `Row` allocation.
+Defines `ExtendDatums`, a trait for types that can append their datums to a `Vec<Datum>`, abstracting over `Row` and alternative trace representations (e.g., `DatumSeq` in `row_spine`) that avoid full `Row` allocation.

--- a/doc/developer/generated/row-spine/_crate.md
+++ b/doc/developer/generated/row-spine/_crate.md
@@ -10,7 +10,7 @@ Packed-bytes differential dataflow spine layouts for `Row`-valued arrangements. 
 ## Public types
 
 * `DatumContainer` — packed-bytes container for `Row` keys or values; implements `columnar::Container` and serves as the storage type for `Row`-valued spine layouts. Also implements `PushInto<&RowRef>`, pushing the raw bytes of a `RowRef` directly into the backing byte container.
-* `DatumSeq<'a>` — borrowing view of a packed byte sequence, decoded datum-by-datum as `Datum`s; implements `ToDatumIter` and `PartialEq<&RowRef>` (comparing the underlying byte slices).
+* `DatumSeq<'a>` — borrowing view of a packed byte sequence, decoded datum-by-datum as `Datum`s; implements `ExtendDatums` and `PartialEq<&RowRef>` (comparing the underlying byte slices).
 * `OffsetOptimized` — offset list implementation wrapping `differential_dataflow`'s `OffsetList`, used in `OrdValBatch` and `OrdKeyBatch` layouts.
 
 ## Spine type aliases

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -49,7 +49,7 @@ use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_types::PersistLocation;
 use mz_persist_types::codec_impls::UnitSchema;
-use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
 use mz_storage_operators::stats::StatsCursor;
 use mz_storage_types::StorageDiff;
@@ -1615,9 +1615,9 @@ impl IndexPeek {
     ) -> PeekStatus
     where
         for<'a> Tr: TraceReader<
-                Key<'a>: ToDatumIter + Eq,
+                Key<'a>: ExtendDatums + Eq,
                 KeyContainer: BatchContainer<Owned = Row>,
-                Val<'a>: ToDatumIter,
+                Val<'a>: ExtendDatums,
                 TimeGat<'a>: PartialOrder<Timestamp>,
                 DiffGat<'a> = &'a Diff,
             >,

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -12,7 +12,7 @@ use std::ops::Range;
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Cursor, TraceReader};
 use mz_ore::result::ResultExt;
-use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena};
 use timely::order::PartialOrder;
 
@@ -100,9 +100,9 @@ impl<Tr: TraceReader<KeyContainer: BatchContainer<Owned: Ord>>> Literals<Tr> {
 impl<Tr> PeekResultIterator<Tr>
 where
     for<'a> Tr: TraceReader<
-            Key<'a>: ToDatumIter + Eq,
+            Key<'a>: ExtendDatums + Eq,
             KeyContainer: BatchContainer<Owned = Row>,
-            Val<'a>: ToDatumIter,
+            Val<'a>: ExtendDatums,
             TimeGat<'a>: PartialOrder<mz_repr::Timestamp>,
             DiffGat<'a> = &'a Diff,
         >,
@@ -138,9 +138,9 @@ where
 
 impl<Tr> FusedIterator for PeekResultIterator<Tr> where
     for<'a> Tr: TraceReader<
-            Key<'a>: ToDatumIter + Eq,
+            Key<'a>: ExtendDatums + Eq,
             KeyContainer: BatchContainer<Owned = Row>,
-            Val<'a>: ToDatumIter,
+            Val<'a>: ExtendDatums,
             TimeGat<'a>: PartialOrder<mz_repr::Timestamp>,
             DiffGat<'a> = &'a Diff,
         >
@@ -150,9 +150,9 @@ impl<Tr> FusedIterator for PeekResultIterator<Tr> where
 impl<Tr> Iterator for PeekResultIterator<Tr>
 where
     for<'a> Tr: TraceReader<
-            Key<'a>: ToDatumIter + Eq,
+            Key<'a>: ExtendDatums + Eq,
             KeyContainer: BatchContainer<Owned = Row>,
-            Val<'a>: ToDatumIter,
+            Val<'a>: ExtendDatums,
             TimeGat<'a>: PartialOrder<mz_repr::Timestamp>,
             DiffGat<'a> = &'a Diff,
         >,
@@ -195,9 +195,9 @@ where
 impl<Tr> PeekResultIterator<Tr>
 where
     for<'a> Tr: TraceReader<
-            Key<'a>: ToDatumIter + Eq,
+            Key<'a>: ExtendDatums + Eq,
             KeyContainer: BatchContainer<Owned = Row>,
-            Val<'a>: ToDatumIter,
+            Val<'a>: ExtendDatums,
             TimeGat<'a>: PartialOrder<mz_repr::Timestamp>,
             DiffGat<'a> = &'a Diff,
         >,
@@ -220,8 +220,8 @@ where
         // before the borrow to ensure correct drop order.
         let maybe_literal;
         let mut borrow = self.datum_vec.borrow();
-        key_item.extend_datums(&mut borrow, None);
-        row_item.extend_datums(&mut borrow, None);
+        key_item.extend_datums(&arena, &mut borrow, None);
+        row_item.extend_datums(&arena, &mut borrow, None);
 
         if let Some(literals) = &mut self.literals
             && let Some(literal) = literals.peek()
@@ -229,7 +229,7 @@ where
             // The peek was created from an IndexedFilter join. We have to add those columns
             // here that the join would add in a dataflow.
             maybe_literal = literal;
-            maybe_literal.extend_datums(&mut borrow, None);
+            maybe_literal.extend_datums(&arena, &mut borrow, None);
         }
         if let Some(result) = self
             .map_filter_project

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -133,7 +133,8 @@ use mz_compute_types::plan::{ArrangementStrategy, LirId};
 use mz_expr::{EvalError, Id, LocalId, permutation_for_arrangement};
 use mz_persist_client::operators::shard_source::{ErrorHandler, SnapshotMode};
 use mz_repr::explain::DummyHumanizer;
-use mz_repr::{Datum, DatumVec, Diff, GlobalId, ReprRelationType, Row, SharedRow};
+use mz_repr::fixed_length::ExtendDatums;
+use mz_repr::{Datum, DatumVec, Diff, GlobalId, ReprRelationType, Row, RowArena, SharedRow};
 use mz_storage_operators::persist_source;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_timely_util::columnation::ColumnationChunker;
@@ -646,9 +647,10 @@ where
                             oks,
                             start_signal.clone(),
                             move |k: DatumSeq, v: DatumSeq| {
+                                let temp_storage = RowArena::new();
                                 let mut datums_borrow = datums.borrow();
-                                datums_borrow.extend(k);
-                                datums_borrow.extend(v);
+                                k.extend_datums(&temp_storage, &mut datums_borrow, None);
+                                v.extend_datums(&temp_storage, &mut datums_borrow, None);
                                 SharedRow::pack(permutation.iter().map(|i| datums_borrow[*i]))
                             },
                         )

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -27,7 +27,7 @@ use mz_compute_types::plan::{ArrangementStrategy, AvailableCollections};
 use mz_dyncfg::ConfigSet;
 use mz_expr::{Eval, Id, MapFilterProject, MirScalarExpr};
 use mz_ore::soft_assert_or_log;
-use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_timely_util::columnar::batcher;
@@ -323,10 +323,12 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                           d,
                           ok_session: &mut Session<T, DCB>,
                           err_session: &mut Session<T, ECB<T>>| {
+            // Declared before the borrow so it outlives any datums that decode into it.
+            let temp_storage = RowArena::new();
             let mut datums_borrow = datums.borrow();
-            k.extend_datums(&mut datums_borrow, Some(max_demand));
+            k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
             let max_demand = max_demand.saturating_sub(datums_borrow.len());
-            v.extend_datums(&mut datums_borrow, Some(max_demand));
+            v.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
             logic(&mut datums_borrow, t, d, ok_session, err_session)
         };
 
@@ -377,10 +379,12 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     {
         let mut datums = DatumVec::new();
         let logic = move |k: DatumSeq, v: DatumSeq, t, d, ok_session: &mut Session<T, DCB>| {
+            // Declared before the borrow so it outlives any datums that decode into it.
+            let temp_storage = RowArena::new();
             let mut datums_borrow = datums.borrow();
-            k.extend_datums(&mut datums_borrow, Some(max_demand));
+            k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
             let max_demand = max_demand.saturating_sub(datums_borrow.len());
-            v.extend_datums(&mut datums_borrow, Some(max_demand));
+            v.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
             logic(&mut datums_borrow, t, d, ok_session)
         };
 
@@ -711,8 +715,8 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     )
     where
         Tr: for<'a> TraceReader<
-                Key<'a>: ToDatumIter,
-                Val<'a>: ToDatumIter,
+                Key<'a>: ExtendDatums,
+                Val<'a>: ExtendDatums,
                 Time = T,
                 Diff = mz_repr::Diff,
             > + Clone
@@ -810,8 +814,8 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     ) -> Stream<'scope, T, DCB::Container>
     where
         Tr: for<'a> TraceReader<
-                Key<'a>: ToDatumIter,
-                Val<'a>: ToDatumIter,
+                Key<'a>: ExtendDatums,
+                Val<'a>: ExtendDatums,
                 Time = T,
                 Diff = mz_repr::Diff,
             > + Clone

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -246,9 +246,10 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     ) {
         let mut datums = DatumVec::new();
         let logic = move |k: DatumSeq, v: DatumSeq| {
+            let temp_storage = RowArena::new();
             let mut datums_borrow = datums.borrow();
-            datums_borrow.extend(k);
-            datums_borrow.extend(v);
+            k.extend_datums(&temp_storage, &mut datums_borrow, None);
+            v.extend_datums(&temp_storage, &mut datums_borrow, None);
             SharedRow::pack(&**datums_borrow)
         };
         match &self {

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -27,7 +27,7 @@ use mz_compute_types::plan::join::JoinClosure;
 use mz_compute_types::plan::join::delta_join::{DeltaJoinPlan, DeltaPathPlan, DeltaStagePlan};
 use mz_dyncfg::ConfigSet;
 use mz_expr::{Eval, MirScalarExpr};
-use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::container::CapacityContainerBuilder;
@@ -338,7 +338,7 @@ where
     Tr: TraceReader<KeyContainer: BatchContainer<Owned = Row>, Time = T, Diff = Diff>
         + Clone
         + 'static,
-    for<'a> Tr::Val<'a>: ToDatumIter,
+    for<'a> Tr::Val<'a>: ExtendDatums,
     CF: Fn(Tr::TimeGat<'_>, &T) -> bool + 'static,
 {
     let use_half_join2 = ENABLE_HALF_JOIN2.get(&config_set);
@@ -392,7 +392,7 @@ where
     Tr: TraceReader<KeyContainer: BatchContainer<Owned = Row>, Time = T, Diff = Diff>
         + Clone
         + 'static,
-    for<'a> Tr::Val<'a>: ToDatumIter,
+    for<'a> Tr::Val<'a>: ExtendDatums,
     CF: Fn(Tr::TimeGat<'_>, &T) -> bool + 'static,
 {
     type CB<C> = CapacityContainerBuilder<C>;
@@ -416,7 +416,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                lookup_row.extend_datums(&mut datums_local, None);
+                lookup_row.extend_datums(&temp_storage, &mut datums_local, None);
 
                 let row = closure.apply(&mut datums_local, &temp_storage, &mut row_builder);
 
@@ -464,7 +464,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                lookup_row.extend_datums(&mut datums_local, None);
+                lookup_row.extend_datums(&temp_storage, &mut datums_local, None);
 
                 if let Some(row) = closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -500,7 +500,7 @@ where
     Tr: TraceReader<KeyContainer: BatchContainer<Owned = Row>, Time = T, Diff = Diff>
         + Clone
         + 'static,
-    for<'a> Tr::Val<'a>: ToDatumIter,
+    for<'a> Tr::Val<'a>: ExtendDatums,
     CF: Fn(Tr::TimeGat<'_>, &T) -> bool + 'static,
 {
     type CB<C> = CapacityContainerBuilder<C>;
@@ -527,7 +527,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                lookup_row.extend_datums(&mut datums_local, None);
+                lookup_row.extend_datums(&temp_storage, &mut datums_local, None);
 
                 let row = closure.apply(&mut datums_local, &temp_storage, &mut row_builder);
 
@@ -574,7 +574,7 @@ where
                 let mut datums_local = datums.borrow();
                 datums_local.extend(key.iter());
                 datums_local.extend(stream_row.iter());
-                lookup_row.extend_datums(&mut datums_local, None);
+                lookup_row.extend_datums(&temp_storage, &mut datums_local, None);
 
                 if let Some(row) = closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -610,8 +610,8 @@ where
     T: RenderTimestamp,
     for<'a, 'b> &'a T: PartialEq<Tr::TimeGat<'b>>,
     Tr: for<'a> TraceReader<Time = T, Diff = Diff> + Clone + 'static,
-    for<'a> Tr::Key<'a>: ToDatumIter,
-    for<'a> Tr::Val<'a>: ToDatumIter,
+    for<'a> Tr::Key<'a>: ExtendDatums,
+    for<'a> Tr::Val<'a>: ExtendDatums,
 {
     let mut inner_as_of = Antichain::new();
     for event_time in as_of.elements().iter() {
@@ -654,8 +654,8 @@ where
                                         let temp_storage = RowArena::new();
 
                                         let mut datums_local = datums.borrow();
-                                        key.extend_datums(&mut datums_local, None);
-                                        val.extend_datums(&mut datums_local, None);
+                                        key.extend_datums(&temp_storage, &mut datums_local, None);
+                                        val.extend_datums(&temp_storage, &mut datums_local, None);
 
                                         if !initial_closure.is_identity() {
                                             match initial_closure

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -25,7 +25,7 @@ use mz_compute_types::plan::join::JoinClosure;
 use mz_compute_types::plan::join::linear_join::{LinearJoinPlan, LinearStagePlan};
 use mz_dyncfg::ConfigSet;
 use mz_expr::Eval;
-use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
@@ -481,9 +481,9 @@ where
     where
         Tr1: TraceReader<Time = T, Diff = Diff> + Clone + 'static,
         Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = T, Diff = Diff> + Clone + 'static,
-        for<'a> Tr1::Key<'a>: ToDatumIter,
-        for<'a> Tr1::Val<'a>: ToDatumIter,
-        for<'a> Tr2::Val<'a>: ToDatumIter,
+        for<'a> Tr1::Key<'a>: ExtendDatums,
+        for<'a> Tr1::Val<'a>: ExtendDatums,
+        for<'a> Tr2::Val<'a>: ExtendDatums,
     {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
@@ -496,9 +496,9 @@ where
                     let temp_storage = RowArena::new();
 
                     let mut datums_local = datums.borrow();
-                    key.extend_datums(&mut datums_local, None);
-                    old.extend_datums(&mut datums_local, None);
-                    new.extend_datums(&mut datums_local, None);
+                    key.extend_datums(&temp_storage, &mut datums_local, None);
+                    old.extend_datums(&temp_storage, &mut datums_local, None);
+                    new.extend_datums(&temp_storage, &mut datums_local, None);
 
                     closure
                         .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -524,9 +524,9 @@ where
                     let temp_storage = RowArena::new();
 
                     let mut datums_local = datums.borrow();
-                    key.extend_datums(&mut datums_local, None);
-                    old.extend_datums(&mut datums_local, None);
-                    new.extend_datums(&mut datums_local, None);
+                    key.extend_datums(&temp_storage, &mut datums_local, None);
+                    old.extend_datums(&temp_storage, &mut datums_local, None);
+                    new.extend_datums(&temp_storage, &mut datums_local, None);
 
                     closure
                         .apply(&mut datums_local, &temp_storage, &mut row_builder)

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -36,7 +36,7 @@ use mz_expr::{
 };
 use mz_ore::cast::CastLossy;
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
-use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{Datum, DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::CollectionExt;
@@ -319,7 +319,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 move |key, _input, output| {
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums1.borrow();
-                    key.extend_datums(&mut datums_local, None);
+                    key.extend_datums(&temp_storage, &mut datums_local, None);
 
                     // Note that the key contains all the columns in a `Distinct` and that `mfp_after` is
                     // required to preserve the key. Therefore, if `mfp_after` maps, then it must project
@@ -353,7 +353,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 let Some(mfp) = &mfp_after2 else { return };
                 let temp_storage = RowArena::new();
                 let mut datums_local = datums2.borrow();
-                key.extend_datums(&mut datums_local, None);
+                key.extend_datums(&temp_storage, &mut datums_local, None);
 
                 if let Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
                     output.push((e.into(), Diff::ONE));
@@ -429,7 +429,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 move |key, input, output| {
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums1.borrow();
-                    key.extend_datums(&mut datums_local, None);
+                    key.extend_datums(&temp_storage, &mut datums_local, None);
                     let key_len = datums_local.len();
 
                     for ((_, row), _) in input.iter() {
@@ -457,7 +457,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         // aggregate, we only need to look for MFP errors here.
                         let temp_storage = RowArena::new();
                         let mut datums_local = datums2.borrow();
-                        key.extend_datums(&mut datums_local, None);
+                        key.extend_datums(&temp_storage, &mut datums_local, None);
 
                         for ((_, row), _) in input.iter() {
                             datums_local.push(row.unpack_first());
@@ -558,6 +558,13 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let mut datums2 = DatumVec::new();
         let mut datums_key_1 = DatumVec::new();
         let mut datums_key_2 = DatumVec::new();
+        // Scratch buffers for decoding each input value's (single) datum into the
+        // arena, so the aggregates iterate arena-resident datums rather than the
+        // packed value bytes — a prerequisite for compressed value representations.
+        let mut vals1 = DatumVec::new();
+        let mut vals2 = DatumVec::new();
+        let mut vals_key_1 = DatumVec::new();
+        let mut vals_key_2 = DatumVec::new();
         let mfp_after1 = mfp_after.clone();
         let func2 = func.clone();
 
@@ -580,6 +587,11 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 .clone()
                 .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>(name, {
                     move |key, source, target| {
+                        let temp_storage = RowArena::new();
+                        // Decode each input value's single datum into the arena, reusing one
+                        // scratch buffer; the datum is `Copy` and is copied into the `repeat`
+                        // before the buffer is overwritten on the next row.
+                        let mut val_scratch = vals1.borrow();
                         // We respect the multiplicity here (unlike in hierarchical aggregation)
                         // because we don't know that the aggregation method is not sensitive
                         // to the number of records.
@@ -587,12 +599,13 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                             // Note that in the non-positive case, this is wrong, but harmless because
                             // our other reduction will produce an error.
                             let count = usize::try_from(w.into_inner()).unwrap_or(0);
-                            std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
+                            val_scratch.clear();
+                            v.extend_datums(&temp_storage, &mut val_scratch, Some(1));
+                            std::iter::repeat(val_scratch[0]).take(count)
                         });
 
-                        let temp_storage = RowArena::new();
                         let mut datums_local = datums1.borrow();
-                        key.extend_datums(&mut datums_local, None);
+                        key.extend_datums(&temp_storage, &mut datums_local, None);
                         let key_len = datums_local.len();
                         datums_local.push(
                         // Note that this is not necessarily a window aggregation, in which case
@@ -619,15 +632,18 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>(name, {
                     move |key, source, target| {
                         // This part is the same as in the `!fused_unnest_list` if branch above.
+                        let temp_storage = RowArena::new();
+                        let mut val_scratch = vals_key_1.borrow();
                         let iter = source.iter().flat_map(|(v, w)| {
                             let count = usize::try_from(w.into_inner()).unwrap_or(0);
-                            std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
+                            val_scratch.clear();
+                            v.extend_datums(&temp_storage, &mut val_scratch, Some(1));
+                            std::iter::repeat(val_scratch[0]).take(count)
                         });
 
                         // This is the part that is specific to the `fused_unnest_list` branch.
-                        let temp_storage = RowArena::new();
                         let mut datums_local = datums_key_1.borrow();
-                        key.extend_datums(&mut datums_local, None);
+                        key.extend_datums(&temp_storage, &mut datums_local, None);
                         let key_len = datums_local.len();
                         for datum in func
                             .eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(
@@ -684,16 +700,17 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 
                             // We know that `mfp_after` can error if it exists, so try to evaluate it here.
                             let Some(mfp) = &mfp_after2 else { return };
-                            let iter = source.iter().flat_map(|&(mut v, ref w)| {
+                            let temp_storage = RowArena::new();
+                            let mut val_scratch = vals2.borrow();
+                            let iter = source.iter().flat_map(|(v, w)| {
                                 let count = usize::try_from(w.into_inner()).unwrap_or(0);
-                                // This would ideally use `to_datum_iter` but we cannot as it needs to
-                                // borrow `v` and only presents datums with that lifetime, not any longer.
-                                std::iter::repeat(v.next().unwrap()).take(count)
+                                val_scratch.clear();
+                                v.extend_datums(&temp_storage, &mut val_scratch, Some(1));
+                                std::iter::repeat(val_scratch[0]).take(count)
                             });
 
-                            let temp_storage = RowArena::new();
                             let mut datums_local = datums2.borrow();
-                            key.extend_datums(&mut datums_local, None);
+                            key.extend_datums(&temp_storage, &mut datums_local, None);
                             datums_local.push(
                                 func2.eval_with_fast_window_agg::<
                                     _,
@@ -720,16 +737,17 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     .mz_reduce_abelian::<_, RowErrBuilder<_, _>, RowErrSpine<_, _>>(
                         &format!("{name} Error Check"),
                         move |key, source, target| {
-                            let iter = source.iter().flat_map(|&(mut v, ref w)| {
+                            let temp_storage = RowArena::new();
+                            let mut val_scratch = vals_key_2.borrow();
+                            let iter = source.iter().flat_map(|(v, w)| {
                                 let count = usize::try_from(w.into_inner()).unwrap_or(0);
-                                // This would ideally use `to_datum_iter` but we cannot as it needs to
-                                // borrow `v` and only presents datums with that lifetime, not any longer.
-                                std::iter::repeat(v.next().unwrap()).take(count)
+                                val_scratch.clear();
+                                v.extend_datums(&temp_storage, &mut val_scratch, Some(1));
+                                std::iter::repeat(val_scratch[0]).take(count)
                             });
 
-                            let temp_storage = RowArena::new();
                             let mut datums_local = datums_key_2.borrow();
-                            key.extend_datums(&mut datums_local, None);
+                            key.extend_datums(&temp_storage, &mut datums_local, None);
                             let key_len = datums_local.len();
                             for datum in func2
                                 .eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(
@@ -911,6 +929,11 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 // Allocations for the two closures.
                 let mut datums1 = DatumVec::new();
                 let mut datums2 = DatumVec::new();
+                // Scratch buffers for decoding the input values (one column per aggregate)
+                // into the arena, so the aggregates iterate arena-resident datums rather
+                // than the packed value bytes.
+                let mut vals1 = DatumVec::new();
+                let mut vals2 = DatumVec::new();
                 let mfp_after1 = mfp_after.clone();
                 let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
                 let aggr_funcs2 = aggr_funcs.clone();
@@ -964,15 +987,19 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                                 let Some(mfp) = &mfp_after2 else { return };
                                 let temp_storage = RowArena::new();
                                 let mut datums_local = datums2.borrow();
-                                key.extend_datums(&mut datums_local, None);
+                                key.extend_datums(&temp_storage, &mut datums_local, None);
 
-                                let mut source_iters = source
-                                    .iter()
-                                    .map(|(values, _cnt)| *values)
-                                    .collect::<Vec<_>>();
-                                for func in aggr_funcs2.iter() {
-                                    let column_iter = (0..source_iters.len())
-                                        .map(|i| source_iters[i].next().unwrap());
+                                // Decode every value row's datums into the arena, one column
+                                // per aggregate, then iterate them column-major below.
+                                let arity = aggr_funcs2.len();
+                                let mut decoded = vals2.borrow();
+                                for (values, _cnt) in source.iter() {
+                                    values.extend_datums(&temp_storage, &mut decoded, None);
+                                }
+                                assert_eq!(decoded.len(), source.len() * arity);
+                                for (col, func) in aggr_funcs2.iter().enumerate() {
+                                    let column_iter =
+                                        (0..source.len()).map(|r| decoded[r * arity + col]);
                                     datums_local.push(func.eval(column_iter, &temp_storage));
                                 }
                                 if let Result::Err(e) =
@@ -996,16 +1023,20 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         move |key, source, target| {
                             let temp_storage = RowArena::new();
                             let mut datums_local = datums1.borrow();
-                            key.extend_datums(&mut datums_local, None);
+                            key.extend_datums(&temp_storage, &mut datums_local, None);
                             let key_len = datums_local.len();
 
-                            let mut source_iters = source
-                                .iter()
-                                .map(|(values, _cnt)| *values)
-                                .collect::<Vec<_>>();
-                            for func in aggr_funcs.iter() {
-                                let column_iter = (0..source_iters.len())
-                                    .map(|i| source_iters[i].next().unwrap());
+                            // Decode every value row's datums into the arena, one column
+                            // per aggregate, then iterate them column-major below.
+                            let arity = aggr_funcs.len();
+                            let mut decoded = vals1.borrow();
+                            for (values, _cnt) in source.iter() {
+                                values.extend_datums(&temp_storage, &mut decoded, None);
+                            }
+                            assert_eq!(decoded.len(), source.len() * arity);
+                            for (col, func) in aggr_funcs.iter().enumerate() {
+                                let column_iter =
+                                    (0..source.len()).map(|r| decoded[r * arity + col]);
                                 datums_local.push(func.eval(column_iter, &temp_storage));
                             }
 
@@ -1128,6 +1159,9 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 "Arranged MinsMaxesHierarchical input",
             );
 
+        // Scratch buffer for decoding the input values (one column per aggregate) into the
+        // arena, so the aggregates iterate arena-resident datums rather than the packed bytes.
+        let mut value_datums = DatumVec::new();
         let reduced = arranged_input.clone().mz_reduce_abelian::<_, Bu, Tr>(
             "Reduced Fallibly MinsMaxesHierarchical",
             move |key, source, target| {
@@ -1151,17 +1185,21 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     }
                 }
 
+                // Decode every value row's datums into the arena, one column per aggregate,
+                // then iterate them column-major below.
+                let temp_storage = RowArena::new();
+                let arity = aggrs.len();
+                let mut decoded = value_datums.borrow();
+                for (values, _cnt) in source.iter() {
+                    values.extend_datums(&temp_storage, &mut decoded, None);
+                }
+                assert_eq!(decoded.len(), source.len() * arity);
+
                 let mut row_builder = SharedRow::get();
                 let mut row_packer = row_builder.packer();
-
-                let mut source_iters = source
-                    .iter()
-                    .map(|(values, _cnt)| *values)
-                    .collect::<Vec<_>>();
-                for func in aggrs.iter() {
-                    let column_iter =
-                        (0..source_iters.len()).map(|i| source_iters[i].next().unwrap());
-                    row_packer.push(func.eval(column_iter, &RowArena::new()));
+                for (col, func) in aggrs.iter().enumerate() {
+                    let column_iter = (0..source.len()).map(|r| decoded[r * arity + col]);
+                    row_packer.push(func.eval(column_iter, &temp_storage));
                 }
                 // We only want to arrange the parts of the input that are not part of the output.
                 // More specifically, we want to arrange it so that `input.concat(&output.negate())`
@@ -1258,7 +1296,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 move |key, input, output| {
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums1.borrow();
-                    key.extend_datums(&mut datums_local, None);
+                    key.extend_datums(&temp_storage, &mut datums_local, None);
                     let key_len = datums_local.len();
                     let accum = &input[0].1;
                     for monoid in accum.iter() {
@@ -1284,7 +1322,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     move |key, input, output| {
                         let temp_storage = RowArena::new();
                         let mut datums_local = datums2.borrow();
-                        key.extend_datums(&mut datums_local, None);
+                        key.extend_datums(&temp_storage, &mut datums_local, None);
                         let accum = &input[0].1;
                         for monoid in accum.iter() {
                             datums_local.extend(monoid.finalize().iter());
@@ -1453,7 +1491,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums1.borrow();
-                    key.extend_datums(&mut datums_local, None);
+                    key.extend_datums(&temp_storage, &mut datums_local, None);
                     let key_len = datums_local.len();
                     for (aggr, accum) in full_aggrs.iter().zip_eq(accums) {
                         datums_local.push(finalize_accum(&aggr.func, accum, total));
@@ -1512,7 +1550,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     let Some(mfp) = &mfp_after2 else { return };
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums2.borrow();
-                    key.extend_datums(&mut datums_local, None);
+                    key.extend_datums(&temp_storage, &mut datums_local, None);
                     for (aggr, accum) in full_aggrs2.iter().zip_eq(accums) {
                         datums_local.push(finalize_accum(&aggr.func, accum, total));
                     }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -32,6 +32,7 @@ use mz_expr::func::CastUint64ToInt64;
 use mz_expr::{BinaryFunc, Columns, Eval, EvalError, MirScalarExpr, UnaryFunc, func};
 use mz_ore::cast::CastFrom;
 use mz_ore::soft_assert_or_log;
+use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{Datum, DatumVec, Diff, ReprScalarType, Row, SharedRow};
 use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::CollectionExt;
@@ -628,7 +629,7 @@ where
     let reduced = arranged
         .clone()
         .mz_reduce_abelian::<_, Bu, Tr>("Reduced TopK input", {
-            move |mut hash_key, source, target: &mut Vec<(Tr::ValOwn, Diff)>| {
+            move |hash_key, source, target: &mut Vec<(Tr::ValOwn, Diff)>| {
                 // Unpack the limit, either into an integer literal or an expression to evaluate.
                 let limit = match &limit {
                     Some(Ok(lit)) => Some(*lit),
@@ -636,11 +637,11 @@ where
                         // Unpack `key` after skipping the hash and determine the limit.
                         // If the limit errors, use a zero limit; errors are surfaced elsewhere.
                         let temp_storage = mz_repr::RowArena::new();
-                        let _hash = hash_key.next();
                         let mut key_datums = datum_vec.borrow();
-                        key_datums.extend(hash_key);
+                        hash_key.extend_datums(&temp_storage, &mut key_datums, None);
+                        // `key_datums[0]` is the hash; the key columns follow it.
                         let datum_limit = expr
-                            .eval(&key_datums, &temp_storage)
+                            .eval(&key_datums[1..], &temp_storage)
                             .unwrap_or(Datum::Int64(0));
                         Some(match datum_limit {
                             Datum::Null => Diff::MAX,
@@ -684,9 +685,10 @@ where
                 let mut indexes = (0..source.len()).collect::<Vec<_>>();
                 // We decode the datums once, into a common buffer for efficiency.
                 // Each row should contain `arity` columns; we should check that.
+                let temp_storage = mz_repr::RowArena::new();
                 let mut buffer = datum_vec.borrow();
                 for (index, (datums, _)) in source.iter().enumerate() {
-                    buffer.extend(*datums);
+                    datums.extend_datums(&temp_storage, &mut buffer, None);
                     assert_eq!(buffer.len(), arity * (index + 1));
                 }
                 let width = buffer.len() / source.len();

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -7,64 +7,58 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Provides abstractions for types that can be converted into `Datum` iterators.
+//! Provides abstractions for types that can append their datums to a vector.
 //! `Row` is the most obvious implementor, but other trace types that may use more advanced
-//! representations only need to commit to implementing these traits.
+//! representations only need to commit to implementing this trait.
 
-use crate::row::DatumListIter;
-use crate::{Datum, Row};
+use crate::{Datum, Row, RowArena};
 
-/// A helper trait to turn a type into an iterator of datums.
-pub trait ToDatumIter: Sized {
-    /// An iterator type for use in `to_datum_iter`.
-    type DatumIter<'a>: IntoIterator<Item = Datum<'a>>
-    where
-        Self: 'a;
-
-    /// Obtains an iterator of datums out of an instance of `&Self`.
-    fn to_datum_iter(&self) -> Self::DatumIter<'_>;
-
+/// A helper trait for types that can append their datums to a `Vec<Datum>`.
+pub trait ExtendDatums {
     /// Append datums to `target` — all of them (`max == None`) or at most
     /// `max` (`Some`) — branching on representation ONCE rather than once per
     /// datum.
     ///
-    /// The default extends via `to_datum_iter`, identical to the prior
-    /// `target.extend(x.to_datum_iter()[.take(max)])` call sites. Implementors
-    /// backed by packed bytes (e.g. row-spine's `DatumSeq`) should override this
-    /// with a tight loop that pushes directly, avoiding the `Iterator::extend` /
-    /// `take` per-datum machinery.
-    #[inline]
-    fn extend_datums<'a>(&'a self, target: &mut Vec<Datum<'a>>, max: Option<usize>) {
-        match max {
-            Some(max) => target.extend(self.to_datum_iter().into_iter().take(max)),
-            None => target.extend(self.to_datum_iter()),
-        }
-    }
+    /// `arena` provides storage for data that the appended datums borrow from
+    /// but that does not already live in `self`. Representations backed directly
+    /// by packed bytes (`Row`, row-spine's `DatumSeq`) ignore it, while
+    /// compressed representations can decode into it so the resulting
+    /// `Datum<'a>`s borrow from the arena rather than from `self`. Implementors
+    /// should push directly into `target` in a tight loop, branching on their
+    /// representation once rather than once per datum.
+    fn extend_datums<'a>(
+        &'a self,
+        arena: &'a RowArena,
+        target: &mut Vec<Datum<'a>>,
+        max: Option<usize>,
+    );
 }
 
-impl<'b, T: ToDatumIter> ToDatumIter for &'b T {
-    type DatumIter<'a>
-        = T::DatumIter<'a>
-    where
-        Self: 'a;
-    fn to_datum_iter(&self) -> Self::DatumIter<'_> {
-        (**self).to_datum_iter()
-    }
+impl<T: ExtendDatums + ?Sized> ExtendDatums for &T {
     #[inline]
-    fn extend_datums<'a>(&'a self, target: &mut Vec<Datum<'a>>, max: Option<usize>) {
+    fn extend_datums<'a>(
+        &'a self,
+        arena: &'a RowArena,
+        target: &mut Vec<Datum<'a>>,
+        max: Option<usize>,
+    ) {
         // Forward to T's impl so an override isn't lost behind a reference.
-        (**self).extend_datums(target, max)
+        (**self).extend_datums(arena, target, max)
     }
 }
 
-// Blanket identity implementation for Row.
-impl ToDatumIter for Row {
-    /// Datum iterator for `Row`.
-    type DatumIter<'a> = DatumListIter<'a>;
-
-    /// Borrows `self` and gets an iterator from it.
+// Identity implementation for Row, whose datums borrow directly from its bytes.
+impl ExtendDatums for Row {
     #[inline]
-    fn to_datum_iter(&self) -> Self::DatumIter<'_> {
-        self.iter()
+    fn extend_datums<'a>(
+        &'a self,
+        _arena: &'a RowArena,
+        target: &mut Vec<Datum<'a>>,
+        max: Option<usize>,
+    ) {
+        match max {
+            Some(max) => target.extend(self.iter().take(max)),
+            None => target.extend(self.iter()),
+        }
     }
 }

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2238,7 +2238,6 @@ mod tests {
     use crate::adt::interval::Interval;
     use crate::adt::numeric::Numeric;
     use crate::adt::timestamp::CheckedTimestamp;
-    use crate::fixed_length::ToDatumIter;
     use crate::relation::arb_relation_desc;
     use crate::{ColumnName, RowArena, SqlColumnType, arb_datum_for_column, arb_row_for_relation};
     use crate::{Datum, RelationDesc, Row, SqlScalarType};
@@ -2393,8 +2392,8 @@ mod tests {
                 a_prefix.cmp(b_prefix).is_le(),
                 "ordering should be consistent on preserves_order columns: {:#?}\n{:?}\n{:?}",
                 desc.iter().take(ordered_prefix_len).collect_vec(),
-                a.to_datum_iter().take(ordered_prefix_len).collect_vec(),
-                b.to_datum_iter().take(ordered_prefix_len).collect_vec()
+                a.iter().take(ordered_prefix_len).collect_vec(),
+                b.iter().take(ordered_prefix_len).collect_vec()
             );
         }
 

--- a/src/row-spine/src/lib.rs
+++ b/src/row-spine/src/lib.rs
@@ -1400,33 +1400,27 @@ mod dictionary {
         type Item = Datum<'a>;
         #[inline(always)]
         fn next(&mut self) -> Option<Self::Item> {
-            // Fast path: no codec means raw row-encoded bytes. Parse directly off the
-            // cursor with a single `read_datum`, skipping the `ColumnsIter::next`
-            // round-trip that would size a slice and re-parse it.
-            if self.iter.index.is_none() {
-                if self.iter.data.is_empty() {
-                    return None;
-                }
-                return Some(unsafe { read_datum(&mut self.iter.data) });
-            }
+            // Delegate to `ColumnsIter`, which handles both the codec and no-codec
+            // cases. The no-codec scan hot path is served directly by `extend_datums`
+            // (which decodes without going through this iterator), so the only callers
+            // left here are the codec-encoded `extend_datums`/`to_row` paths and tests;
+            // none warrant a dedicated no-codec fast path.
             self.iter
                 .next()
                 .map(|mut bytes| unsafe { read_datum(&mut bytes) })
         }
     }
 
-    use mz_repr::fixed_length::ToDatumIter;
-    impl<'long> ToDatumIter for DatumSeq<'long> {
-        type DatumIter<'short>
-            = DatumSeq<'short>
-        where
-            Self: 'short;
-        #[inline(always)]
-        fn to_datum_iter<'short>(&'short self) -> Self::DatumIter<'short> {
-            *self
-        }
+    use mz_repr::RowArena;
+    use mz_repr::fixed_length::ExtendDatums;
+    impl<'long> ExtendDatums for DatumSeq<'long> {
         #[inline]
-        fn extend_datums<'a>(&'a self, target: &mut Vec<Datum<'a>>, max: Option<usize>) {
+        fn extend_datums<'a>(
+            &'a self,
+            _arena: &'a RowArena,
+            target: &mut Vec<Datum<'a>>,
+            max: Option<usize>,
+        ) {
             // Branch on codec presence ONCE per row rather than once per datum.
             // With no codec (the common, feature-off case) push raw datums in a
             // tight loop, matching the pre-dictionary path; with a codec, fall


### PR DESCRIPTION
## What

Replaces the GAT-based `ToDatumIter` trait ("hand me a borrowing `Datum` iterator") with a push-based `ExtendDatums` trait, and removes the remaining places that iterated a trace row (`DatumSeq`) directly.

- `ToDatumIter` → `ExtendDatums`, a single method:
  `extend_datums(&self, arena: &RowArena, target: &mut Vec<Datum>, max: Option<usize>)`.
  Drops the `DatumIter<'a>` GAT, the `to_datum_iter` method, and the `Sized` supertrait.
- The `&RowArena` parameter lets an implementor decode into caller-provided storage and return `Datum`s that borrow from the arena rather than from `&self`. `Row` and row-spine's `DatumSeq` ignore it today; it is the hook a future compressed row representation needs — any `Datum<'a>` tied to `&'a self` is fundamentally incompatible with a representation whose decoded bytes don't live in `self`.
- Converts the last external users of `DatumSeq`'s inherent `Iterator` (reduce, delta/linear joins, peek, top_k, and render's `as_collection`/filtered-index import) to `extend_datums`, so the only remaining `DatumSeq::Iterator` users are row-spine internals.

## Why

A no-op refactor that finishes the push-based datum-decode interface (`main` had already started the `extend_datums` migration) and adds the arena hook. It is a prerequisite for compressing in-memory arrangements (per-column codecs, prototyped separately — early TPCH benchmarks show ~-65% arrangement memory); landing it on its own keeps that follow-up small and reviewable.

## Tests

Existing `repr`, `row-spine`, and `compute` tests cover the changed paths. The `encode.rs` ordering test switches from `to_datum_iter` to `Row::iter`. No behavior change; no release note.