### PR TITLE
compute: hoist the flat_map decode arena out of the per-row closure

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -318,14 +318,17 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
             + 'static,
     {
         let mut datums = DatumVec::new();
+        // Reused across invocations: cleared per row rather than reallocated, so the arena's
+        // allocation spine persists. Declared before the borrow so it outlives any datums that
+        // decode into it.
+        let mut temp_storage = RowArena::new();
         let logic = move |k: DatumSeq,
                           v: DatumSeq,
                           t,
                           d,
                           ok_session: &mut Session<T, DCB>,
                           err_session: &mut Session<T, ECB<T>>| {
-            // Declared before the borrow so it outlives any datums that decode into it.
-            let temp_storage = RowArena::new();
+            temp_storage.clear();
             let mut datums_borrow = datums.borrow();
             k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
             let max_demand = max_demand.saturating_sub(datums_borrow.len());
@@ -379,9 +382,12 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
             + 'static,
     {
         let mut datums = DatumVec::new();
+        // Reused across invocations: cleared per row rather than reallocated, so the arena's
+        // allocation spine persists. Declared before the borrow so it outlives any datums that
+        // decode into it.
+        let mut temp_storage = RowArena::new();
         let logic = move |k: DatumSeq, v: DatumSeq, t, d, ok_session: &mut Session<T, DCB>| {
-            // Declared before the borrow so it outlives any datums that decode into it.
-            let temp_storage = RowArena::new();
+            temp_storage.clear();
             let mut datums_borrow = datums.borrow();
             k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
             let max_demand = max_demand.saturating_sub(datums_borrow.len());


### PR DESCRIPTION
## What

`ArrangementFlavor::flat_map` and `flat_map_ok` constructed a fresh
`RowArena::new()` *inside* the per-row `logic` closure, so an arena was
allocated and dropped on every row processed. This hoists the arena to the
enclosing scope and `clear()`s it once per row instead, reusing its allocation
spine across invocations.

## Why

Addresses post-merge review feedback from @antiguru on #37110 (the
`ExtendDatums` refactor): the arena is the caller-provided decode target a
compressed row representation decodes into. With per-column arrangement codecs
(follow-up #37111) each row actually populates the arena, so reallocating it per
row would churn; clearing-and-reusing keeps the spine.

Note that `RowArena::clear()` today drops the inner per-value `Vec<u8>` buffers
(it clears the outer `Vec<Vec<u8>>`), so this reuses the outer spine but not the
individual buffers — recycling those is a separate, larger `RowArena` change.

## Tests

No behavior change; existing `compute` tests cover these paths.