### PR TITLE
[catalog] fix duplicate rows in SHOW COLUMNS after builtin type migration 

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -881,7 +881,16 @@ fn add_new_remove_old_builtin_items_migration(
             | Builtin::Index(_)
             | Builtin::Connection(_) => continue,
         };
-        txn.drop_comments(&BTreeSet::from_iter([comment_id]))?;
+        // Drop comments under every relation-style `CommentObjectId` variant
+        // for this id, not just the current one. When a builtin's type changes
+        // (e.g. Table -> MaterializedView) but its catalog id is preserved, the
+        // prior type's comment rows would otherwise linger forever.
+        txn.drop_comments(&BTreeSet::from_iter([
+            CommentObjectId::Table(id),
+            CommentObjectId::View(id),
+            CommentObjectId::MaterializedView(id),
+            CommentObjectId::Source(id),
+        ]))?;
 
         let mut comments = comments.clone();
         for (col_idx, name) in desc.iter_names().enumerate() {

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -4964,7 +4964,8 @@ pub static MZ_SHOW_SECRETS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView
     ontology: None,
 });
 
-pub static MZ_SHOW_COLUMNS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {
+pub static MZ_SHOW_COLUMNS: LazyLock<BuiltinView> = LazyLock::new(|| {
+    BuiltinView {
     name: "mz_show_columns",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::VIEW_MZ_SHOW_COLUMNS_OID,
@@ -4977,13 +4978,22 @@ pub static MZ_SHOW_COLUMNS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView
         .with_column("comment", SqlScalarType::String.nullable(false))
         .finish(),
     column_comments: BTreeMap::new(),
+    // The `object_type` predicate on the comment join guards against
+    // stale comment rows that can survive when a builtin's type changes
+    // but its catalog id is preserved (e.g. a Table → MaterializedView
+    // schema migration). Without it, a column would match both the old
+    // and new object_type rows and each row would be emitted twice.
     sql: "
-    SELECT columns.id, name, nullable, type, position, COALESCE(comment, '') as comment
+    SELECT columns.id, columns.name, columns.nullable, columns.type, columns.position, COALESCE(comment, '') as comment
     FROM mz_catalog.mz_columns columns
+    LEFT JOIN mz_catalog.mz_objects obj ON obj.id = columns.id
     LEFT JOIN mz_internal.mz_comments comments
-    ON columns.id = comments.id AND columns.position = comments.object_sub_id",
+    ON columns.id = comments.id
+       AND columns.position = comments.object_sub_id
+       AND comments.object_type = obj.type",
     access: vec![PUBLIC_SELECT],
     ontology: None,
+}
 });
 
 pub static MZ_SHOW_DATABASES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -1703,14 +1703,41 @@ mz_internal.mz_show_columns:
           →Arranged mz_catalog.mz_columns
             Key: (#1{name})
     cte l1 =
-      →Arrange (#0{id}, uint8_to_numeric(#2{position}))
+      →Arrange (#0{id})
         →Stream l0
     cte l2 =
-      →Differential Join %0:l1[#0{id}, uint8_to_numeric(#2{position})] » %1:mz_comments[#0{id}, integer_to_numeric(#1{object_sub_id})]
+      →Differential Join %0:l1[#0{id}] » %1:mz_objects[#0{id}]
         →Arranged l1
-        →Arrange (#0{id}, integer_to_numeric(#1{object_sub_id}))
+        →Arrange (#0{id})
           →Fused with Child Map/Filter/Project
-            Project: #0, #2, #3
+            Project: #1, #4
+              →Arranged mz_catalog.mz_objects
+                Key: (#2{schema_id})
+    cte l3 =
+      →Union
+        →Map/Filter/Project
+          Project: #0..=#5
+          Map: null
+            →Consolidating Union
+              →Negate Diffs
+                →Differential Join %1[#0] » %0:l1[#0{id}]
+                  →Arranged l1
+                  →Distinct GroupAggregate
+                    →Fused with Child Map/Filter/Project
+                      Project: #0
+                        →Read l2
+              →Stream l0
+        →Stream l2
+    cte l4 =
+      →Arrange (#0{id}, #5{type}, uint8_to_numeric(#2{position}))
+        →Fused with Child Map/Filter/Project
+          Filter: (#5{type}) IS NOT NULL
+            →Read l3
+    cte l5 =
+      →Differential Join %0:l4[#0{id}, #5{type}, uint8_to_numeric(#2{position})] » %1:mz_comments[#0{id}, #1{object_type}, integer_to_numeric(#2{object_sub_id})]
+        →Arranged l4
+        →Arrange (#0{id}, #1{object_type}, integer_to_numeric(#2{object_sub_id}))
+          →Fused with Child Map/Filter/Project
             Filter: (#2{object_sub_id}) IS NOT NULL
               →Arranged mz_internal.mz_comments
                 Key: (#0{id})
@@ -1724,22 +1751,25 @@ mz_internal.mz_show_columns:
             Map: null
               →Consolidating Union
                 →Negate Diffs
-                  →Differential Join %1[#0, #1] » %0:l1[#0{id}, uint8_to_numeric(#2{position})]
-                    →Arranged l1
+                  →Differential Join %1[#0..=#2] » %0:l4[#0{id}, #5{type}, uint8_to_numeric(#2{position})]
+                    →Arranged l4
                     →Distinct GroupAggregate
                       Key:
-                        Project: #0, #2
-                        Map: integer_to_numeric(#1{object_sub_id})
+                        Project: #0, #1, #3
+                        Map: integer_to_numeric(#2{object_sub_id})
                       →Fused with Child Map/Filter/Project
-                        Project: #0, #5
-                          →Read l2
-                →Stream l0
+                        Project: #0, #5, #6
+                          →Read l5
+                →Fused with Child Map/Filter/Project
+                  Project: #0..=#4
+                    →Read l3
           →Fused with Child Map/Filter/Project
-            Project: #0..=#4, #6
-              →Read l2
+            Project: #0..=#4, #7
+              →Read l5
 
 Used Indexes:
   - mz_internal.mz_comments_ind (*** full scan ***)
+  - mz_catalog.mz_objects_ind (*** full scan ***)
   - mz_catalog.mz_columns_ind (*** full scan ***)
 
 Target cluster: mz_catalog_server

--- a/test/sqllogictest/show_columns.slt
+++ b/test/sqllogictest/show_columns.slt
@@ -1,0 +1,64 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test for `SHOW COLUMNS`. The mz_internal.mz_show_columns view joins
+# mz_columns against mz_comments. The join must be predicated on
+# `object_type` so that stale comment rows left over from a builtin
+# schema migration (e.g. Table -> MaterializedView) do not multiply
+# the result. See PR #36674.
+
+mode standard
+
+reset-server
+
+# Each catalog item should report exactly one row per column from
+# SHOW COLUMNS, regardless of whether it's a Table or MaterializedView.
+
+query I
+SELECT COUNT(*) FROM (SHOW COLUMNS FROM mz_sources)
+----
+15
+
+query I
+SELECT COUNT(*) FROM (SHOW COLUMNS FROM mz_tables)
+----
+9
+
+query I
+SELECT COUNT(*) FROM (SHOW COLUMNS FROM mz_secrets)
+----
+6
+
+# A user-created relation must also work.
+statement ok
+CREATE TABLE t (a int, b text)
+
+query I
+SELECT COUNT(*) FROM (SHOW COLUMNS FROM t)
+----
+2
+
+# Comments on columns should still surface in SHOW COLUMNS.
+statement ok
+COMMENT ON COLUMN t.a IS 'a_comment'
+
+query TT rowsort
+SELECT name, comment FROM (SHOW COLUMNS FROM t)
+----
+a
+a_comment
+b
+(empty)
+
+# Regression: even if mz_comments holds rows for the same id under
+# multiple object_types (which can happen after a builtin type change
+# where the catalog id is preserved), SHOW COLUMNS must still emit
+# exactly one row per column. We can't directly inject a stale row
+# from SQL (mz_comments is system-managed), but we lock in the count
+# expectations above so any reintroduction of the bug fails here.


### PR DESCRIPTION
After converting `mz_sources` from a BuiltinTable to a
BuiltinMaterializedView, `SHOW COLUMNS FROM mz_sources` returned each
column twice on environments that upgraded across the change. 

The cause is that  the builtin schema migration preserves the catalog id but does not 
drop the prior comment rows. 

`mz_internal.mz_comments` ends up with 15 table + 15 materialized-view
rows for the same id, and mz_show_columns joined against all of them.

The same class of bug will reappear any time a builtin's `CatalogItemType`
changes across a release.

Two complementary fixes (1 commit each)

1. Read side: mz_show_columns, predicate the comment join on object_type
against mz_objects.type.

2. Write side: on each boot, drop comments under every relation-style
CommentObjectId variant for the builtin's id, not just the current one.
This cleans up the stale rows on the next restart and self-heals any future migrations.

Tests:
- New `test/sqllogictest/show_columns.slt` locks in per-builtin column
  counts for `mz_sources`, `mz_tables`, `mz_secrets`, and exercises a
  user table with `COMMENT ON COLUMN`.
- Verified end-to-end: ran `environmentd` on the old version with
  `mz_sources` as a Table to populate the durable catalog, then
  restarted