### PR TITLE
ci/console: time-bound Playwright browser install so hangs retry

### DIFF
--- a/ci/test/console/e2e-prod.sh
+++ b/ci/test/console/e2e-prod.sh
@@ -44,7 +44,9 @@ corepack enable
 
 ci_collapsed_heading "Installing dependencies"
 retry yarn install --immutable --network-timeout 30000
-retry yarn playwright install --with-deps
+# `retry` only re-runs on a non-zero exit, but a stalled browser download
+# hangs forever; wrap in `timeout` so a hung fetch is killed and retried.
+retry timeout -k 30 600 yarn playwright install --with-deps
 ci_collapsed_heading "Pulling Vercel production environment"
 npx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
 mv .vercel/.env.production.local .vercel/.env.preview.local

--- a/ci/test/console/e2e.sh
+++ b/ci/test/console/e2e.sh
@@ -187,7 +187,9 @@ cd console
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 corepack enable
 retry yarn install --immutable --network-timeout 30000
-retry yarn playwright install --with-deps
+# `retry` only re-runs on a non-zero exit, but a stalled browser download
+# hangs forever; wrap in `timeout` so a hung fetch is killed and retried.
+retry timeout -k 30 600 yarn playwright install --with-deps
 
 # --- Run tests ---
 


### PR DESCRIPTION
## Problem

The Console E2E jobs (`Console E2E/staging`, `Console E2E/prod`) install Playwright browsers via:

```bash
retry yarn playwright install --with-deps
```

The `retry` helper loops `until "$@"` — it only re-runs on a **non-zero exit**. When the Chromium download from the Playwright CDN *stalls* (rather than failing), the command hangs indefinitely with no output, so `retry` never kicks in and the job runs all the way to the **60-minute pipeline timeout** before being killed (`signal: terminated`, exit `-1`).

This was observed on [test build 125767](https://buildkite.com/materialize/test/builds/125767) (PR #37084), where both E2E shards hung at the Chromium download:
- prod — download reached 100% then went silent for ~60 min
- staging — download stalled mid-fetch then went silent for ~60 min

Neither shard reached the actual test or deploy steps; the failure was purely the browser install hanging.

## Fix

Wrap the install in `timeout -k 30 600` so a stalled fetch is killed after 10 minutes (SIGTERM, then SIGKILL 30s later), producing a non-zero exit that `retry` catches and re-runs. Worst case is 3 × 10 min = 30 min, still comfortably under the 60-min job timeout, versus a single hang burning the full hour.

Applied to both `ci/test/console/e2e.sh` and `ci/test/console/e2e-prod.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)