### PR TITLE
tests: Extend avro testing

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -150,16 +150,14 @@ def delivery_report(err: "KafkaError | None", msg: Any) -> None:
 
 # Avro base types that a narrower writer can be promoted *into* on read. An
 # `int` writer promotes to any of these, so it is a universal narrower writer
-# for a schema-evolution preamble. Kept in sync with `can_promote` in
-# `src/avro/src/schema.rs`.
+# for a schema-evolution preamble.
 _PROMOTABLE_TO_WIDER = {"long", "float", "double"}
 
 
 def _avro_value_type(field: Field) -> Any:
     # A nullable column is encoded as a `["null", T]` union rather than the bare
-    # type `T`. Decoding then goes through union schema resolution (numeric
-    # promotion, default substitution, ...), which exact-type-only matching used
-    # to get wrong (e.g. SS-277).
+    # type `T`, so decoding goes through union schema resolution (numeric
+    # promotion, default substitution, ...).
     base = str(field.data_type.name(Backend.AVRO)).lower()
     return ["null", base] if field.nullable else base
 
@@ -318,9 +316,9 @@ class KafkaExecutor(Executor):
         the source is created, so the source -- which fixes its reader schema to
         the latest (wider) registered version and reads the topic from the
         beginning -- must promote the writer's `int` union variant into the
-        wider reader variant. That is the union-resolution path SS-277 got
-        wrong; with writer and reader schemas otherwise identical it is never
-        exercised.
+        wider reader variant. This exercises union schema resolution with
+        numeric promotion, which a run with identical writer and reader schemas
+        never reaches.
         """
         value_fields = [f for f in self.fields if not f.is_key]
         key_fields = [f for f in self.fields if f.is_key]

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -148,6 +148,22 @@ def delivery_report(err: "KafkaError | None", msg: Any) -> None:
     assert err is None, f"Delivery failed for User record {msg.key()}: {err}"
 
 
+# Avro base types that a narrower writer can be promoted *into* on read. An
+# `int` writer promotes to any of these, so it is a universal narrower writer
+# for a schema-evolution preamble. Kept in sync with `can_promote` in
+# `src/avro/src/schema.rs`.
+_PROMOTABLE_TO_WIDER = {"long", "float", "double"}
+
+
+def _avro_value_type(field: Field) -> Any:
+    # A nullable column is encoded as a `["null", T]` union rather than the bare
+    # type `T`. Decoding then goes through union schema resolution (numeric
+    # promotion, default substitution, ...), which exact-type-only matching used
+    # to get wrong (e.g. SS-277).
+    base = str(field.data_type.name(Backend.AVRO)).lower()
+    return ["null", base] if field.nullable else base
+
+
 class KafkaExecutor(Executor):
     producer: confluent_kafka.Producer
     avro_serializer: AvroSerializer
@@ -167,23 +183,30 @@ class KafkaExecutor(Executor):
         cluster: str | None = None,
         mz_service: str | None = None,
         composition: Composition | None = None,
+        evolve_schema: bool = False,
     ):
         super().__init__(
             ports, fields, database, schema, cluster, mz_service, composition
         )
 
+        self.num = num
         self.topic = f"data-ingest-{num}"
         self.table = f"kafka_table{num}"
+        # When set, write a few records under a narrower (promotable) writer
+        # schema *before* creating the source, so the source's fixed reader
+        # schema must promote them. See `_write_promotion_preamble`.
+        self.evolve_schema = evolve_schema
 
     def create(self, logging_exe: Any | None = None) -> None:
         self.logging_exe = logging_exe
+
         schema = {
             "type": "record",
             "name": "value",
             "fields": [
                 {
                     "name": field.name,
-                    "type": str(field.data_type.name(Backend.AVRO)).lower(),
+                    "type": _avro_value_type(field),
                 }
                 for field in self.fields
                 if not field.is_key
@@ -227,26 +250,10 @@ class KafkaExecutor(Executor):
         }
         registry = SchemaRegistryClient(schema_registry_conf)
 
-        self.avro_serializer = AvroSerializer(
-            registry,
-            schema_str=json.dumps(schema),
-            to_dict=lambda d, ctx: d,
-        )
-
         self.key_avro_serializer = AvroSerializer(
             registry,
             schema_str=json.dumps(key_schema),
             to_dict=lambda d, ctx: d,
-        )
-
-        if logging_exe is not None:
-            logging_exe.log(f"{topic}-value: {json.dumps(schema)}")
-            logging_exe.log(f"{topic}-key: {json.dumps(key_schema)}")
-        registry.register_schema(
-            f"{topic}-value", Schema(json.dumps(schema), schema_type="AVRO")
-        )
-        registry.register_schema(
-            f"{topic}-key", Schema(json.dumps(key_schema), schema_type="AVRO")
         )
 
         self.serialization_context = SerializationContext(
@@ -257,6 +264,36 @@ class KafkaExecutor(Executor):
         )
 
         self.producer = confluent_kafka.Producer(kafka_conf)
+
+        # Optionally seed the topic with records under a narrower, promotable
+        # writer schema *before* the source (and its fixed reader schema) is
+        # created, so the decode path must promote them. Must run before the
+        # wider schema is registered below, so the narrower one is an earlier
+        # version and the wider one stays latest.
+        if self.evolve_schema:
+            self._write_promotion_preamble(registry)
+
+        if logging_exe is not None:
+            logging_exe.log(f"{topic}-value: {json.dumps(schema)}")
+            logging_exe.log(f"{topic}-key: {json.dumps(key_schema)}")
+        # Register the (wider) value schema last so it is the latest version;
+        # the source adopts the latest as its fixed reader schema.
+        registry.register_schema(
+            f"{topic}-value", Schema(json.dumps(schema), schema_type="AVRO")
+        )
+        registry.register_schema(
+            f"{topic}-key", Schema(json.dumps(key_schema), schema_type="AVRO")
+        )
+
+        # Construct the value serializer only after the wider schema is the
+        # latest registered version, so a promotion preamble's narrower schema
+        # stays the earlier version (and the source's reader schema is the wider
+        # one) regardless of when the serializer registers its schema.
+        self.avro_serializer = AvroSerializer(
+            registry,
+            schema_str=json.dumps(schema),
+            to_dict=lambda d, ctx: d,
+        )
 
         with self.mz_conn.cursor() as cur:
             self.execute_with_retry_on_error(
@@ -270,6 +307,85 @@ class KafkaExecutor(Executor):
                 required_error_message_substrs=[
                     "Topic does not exist",
                 ],
+            )
+
+    def _write_promotion_preamble(self, registry: SchemaRegistryClient) -> None:
+        """Seed the topic with records written under a narrower writer schema.
+
+        For each nullable value column whose Avro type is a promotion target
+        (`long`/`float`/`double`), render it instead as `["null", "int"]` and
+        produce a few records with `int` values. These land in the topic before
+        the source is created, so the source -- which fixes its reader schema to
+        the latest (wider) registered version and reads the topic from the
+        beginning -- must promote the writer's `int` union variant into the
+        wider reader variant. That is the union-resolution path SS-277 got
+        wrong; with writer and reader schemas otherwise identical it is never
+        exercised.
+        """
+        value_fields = [f for f in self.fields if not f.is_key]
+        key_fields = [f for f in self.fields if f.is_key]
+        narrowable = {
+            f.name
+            for f in value_fields
+            if f.nullable
+            and str(f.data_type.name(Backend.AVRO)).lower() in _PROMOTABLE_TO_WIDER
+        }
+        if not narrowable:
+            return
+
+        # `int` promotes to long/float/double, so it is a valid narrower writer
+        # for every wider reader variant we might have generated.
+        narrow_schema = {
+            "type": "record",
+            "name": "value",
+            "fields": [
+                {
+                    "name": f.name,
+                    "type": (
+                        ["null", "int"] if f.name in narrowable else _avro_value_type(f)
+                    ),
+                }
+                for f in value_fields
+            ],
+        }
+        # Disable subject compatibility checks so the wider schema can be
+        # registered on top of this narrower one regardless of the registry's
+        # configured compatibility level.
+        try:
+            registry.set_compatibility(f"{self.topic}-value", level="NONE")
+        except Exception:
+            pass
+        registry.register_schema(
+            f"{self.topic}-value",
+            Schema(json.dumps(narrow_schema), schema_type="AVRO"),
+        )
+        narrow_serializer = AvroSerializer(
+            registry,
+            schema_str=json.dumps(narrow_schema),
+            to_dict=lambda d, ctx: d,
+        )
+
+        rng = random.Random(self.num)
+        for _ in range(3):
+            value = {
+                f.name: (
+                    rng.randint(-1000, 1000)
+                    if f.name in narrowable
+                    else f.data_type.random_value(rng)
+                )
+                for f in value_fields
+            }
+            key = {f.name: f.data_type.random_value(rng) for f in key_fields}
+            self.producer.produce(
+                topic=self.topic,
+                key=self.key_avro_serializer(key, self.key_serialization_context),
+                value=narrow_serializer(value, self.serialization_context),
+                on_delivery=delivery_report,
+            )
+        self.producer.flush()
+        if self.logging_exe is not None:
+            self.logging_exe.log(
+                f"{self.topic}-value (promotion preamble): {json.dumps(narrow_schema)}"
             )
 
     def run(self, transaction: Transaction, logging_exe: Any | None = None) -> None:

--- a/misc/python/materialize/data_ingest/field.py
+++ b/misc/python/materialize/data_ingest/field.py
@@ -27,6 +27,10 @@ class Field:
     name: str
     data_type: type[DataType]
     is_key: bool
+    # When True, an Avro-backed executor encodes this field as a `["null", T]`
+    # union instead of the bare type `T`, exercising union schema resolution in
+    # the source decode path. Keys are never nullable.
+    nullable: bool
     # value_fn can be used to encode a value which is stored in this field, for example:
     # import uuid
     # namespace = uuid.uuid4()
@@ -39,11 +43,14 @@ class Field:
         data_type: type[DataType],
         is_key: bool,
         value_fn: Callable[[Any], Any] | None = None,
+        nullable: bool = False,
     ):
         self.name = name
         self.data_type = data_type
         self.is_key = is_key
+        self.nullable = nullable
         self.value_fn = value_fn or identity
 
     def __repr__(self) -> str:
-        return f"Field({'key' if self.is_key else 'value'}, {self.name}: {self.data_type.__name__})"
+        nullable = ", nullable" if self.nullable else ""
+        return f"Field({'key' if self.is_key else 'value'}, {self.name}: {self.data_type.__name__}{nullable})"

--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -283,7 +283,18 @@ def execute_workload(
     for i in range(random.randint(1, 10)):
         fields.append(Field(f"key{i}", random.choice(DATA_TYPES_FOR_KEY), True))
     for i in range(random.randint(0, 20)):
-        fields.append(Field(f"value{i}", random.choice(DATA_TYPES_FOR_AVRO), False))
+        # Randomly make value columns nullable so the Avro-backed executor
+        # encodes them as `["null", T]` unions, exercising union schema
+        # resolution. Generated values are never None, so this is transparent
+        # to the value-equality check against the Postgres source of truth.
+        fields.append(
+            Field(
+                f"value{i}",
+                random.choice(DATA_TYPES_FOR_AVRO),
+                False,
+                nullable=random.choice([True, False]),
+            )
+        )
     print(f"With fields: {fields}")
 
     executors = [

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -507,10 +507,25 @@ class KafkaSource(DBObject):
                 Field(f"key{i}", rng.choice(DATA_TYPES_FOR_AVRO), True)
             )
         for i in range(rng.randint(0, 20)):
-            fields.append(Field(f"value{i}", rng.choice(DATA_TYPES_FOR_AVRO), False))
+            # Value columns are randomly nullable so their Avro type becomes a
+            # `["null", T]` union, exercising union schema resolution in the
+            # source decode path. Keys stay non-nullable.
+            fields.append(
+                Field(
+                    f"value{i}",
+                    rng.choice(DATA_TYPES_FOR_AVRO),
+                    False,
+                    nullable=rng.choice([True, False]),
+                )
+            )
         self.columns = [
-            KafkaColumn(field.name, field.data_type, False, self) for field in fields
+            KafkaColumn(field.name, field.data_type, field.nullable, self)
+            for field in fields
         ]
+        # Sometimes evolve the schema before creating the source: write records
+        # under a narrower (promotable) writer schema first, so the source must
+        # promote them through union schema resolution (regression cover for
+        # SS-277). See KafkaExecutor._write_promotion_preamble.
         self.executor = KafkaExecutor(
             self.source_id,
             ports,
@@ -518,6 +533,7 @@ class KafkaSource(DBObject):
             schema.db.name(),
             schema.name(),
             cluster.name(),
+            evolve_schema=rng.choice([True, False]),
         )
         workload = rng.choice(list(WORKLOADS))(azurite=False)
         for transaction_def in workload.cycle:

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -524,8 +524,8 @@ class KafkaSource(DBObject):
         ]
         # Sometimes evolve the schema before creating the source: write records
         # under a narrower (promotable) writer schema first, so the source must
-        # promote them through union schema resolution (regression cover for
-        # SS-277). See KafkaExecutor._write_promotion_preamble.
+        # promote them through union schema resolution. See
+        # KafkaExecutor._write_promotion_preamble.
         self.executor = KafkaExecutor(
             self.source_id,
             ports,

--- a/misc/python/stubs/confluent_kafka/schema_registry/__init__.pyi
+++ b/misc/python/stubs/confluent_kafka/schema_registry/__init__.pyi
@@ -22,3 +22,6 @@ class SchemaRegistryClient:
     def register_schema(
         self, subject_name: str, schema: Schema, **kwargs: Any
     ) -> int: ...
+    def set_compatibility(
+        self, subject_name: str | None = None, level: str | None = None
+    ) -> str: ...

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -522,159 +522,95 @@ mod tests {
         assert_none!(reader.next());
     }
 
-    // Regression test for SS-277: an `int` -> `double` promotion inside a union
-    // (i.e. a nullable column whose type was promoted). The writer's `int`
-    // variant of `["null", "int"]` must resolve against the reader's `double`
-    // variant of `["null", "double"]`. Previously this failed with "Failed to
-    // match writer union variant `Int` against any variant in the reader",
-    // because union variant matching ignored numeric promotion.
+    // Regression coverage for SS-277 (PR #37087): Avro numeric promotion across
+    // every `can_promote` pair and every union-resolution arm. Promotion
+    // previously worked only for concrete (non-nullable) columns; the union
+    // (nullable) arms ignored it and failed at decode time with "Failed to
+    // match writer union variant ... against any variant in the reader".
+    //
+    // For each promotable `(writer, reader)` pair we render the field both bare
+    // (`"int"`) and nullable (`["null", "int"]`) on each side. The four
+    // combinations exercise all three matchers added in `schema.rs`:
+    //   * bare     -> nullable : `match_ref_promote_writer` (concrete -> union)
+    //   * nullable -> bare     : `match_ref_promote_reader` (union -> concrete)
+    //   * nullable -> nullable : `match_promote_writer`     (union -> union)
+    //   * bare     -> bare     : the pre-existing concrete promotion path
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
-    fn test_union_int_to_double_promotion() {
-        let writer_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "f1", "type": ["null", "int"]}
-                ]
+    fn test_numeric_promotion_matrix() {
+        // `123` is exactly representable in int/long/float/double, so a value
+        // promoted to `kind` equals that kind's representative value.
+        fn value_of(kind: &str) -> Value {
+            match kind {
+                "int" => Value::Int(123),
+                "long" => Value::Long(123),
+                "float" => Value::Float(123.0),
+                "double" => Value::Double(123.0),
+                other => panic!("unhandled kind {other}"),
             }
-        "#;
-        let reader_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "f1", "type": ["null", "double"]}
-                ]
-            }
-        "#;
-        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
-        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
-        let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
-        let mut record = Record::new(writer_schema.top_node()).unwrap();
-        record.put(
-            "f1",
-            Value::Union {
-                index: 1,
-                inner: Box::new(Value::Int(123)),
-                n_variants: 2,
-                null_variant: Some(0),
-            },
-        );
-        writer.append(record).unwrap();
-        writer.flush().unwrap();
-        let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
-        assert_eq!(
-            reader.next().unwrap().unwrap(),
-            Value::Record(vec![(
-                "f1".to_string(),
+        }
+        fn record_schema_json(kind: &str, nullable: bool) -> String {
+            let ty = if nullable {
+                format!(r#"["null", "{kind}"]"#)
+            } else {
+                format!(r#""{kind}""#)
+            };
+            format!(r#"{{"type":"record","name":"test","fields":[{{"name":"f1","type":{ty}}}]}}"#)
+        }
+        // A nullable field is a `["null", T]` union, so the value lives in
+        // variant 1 with the null variant at 0.
+        fn maybe_union(v: Value, nullable: bool) -> Value {
+            if nullable {
                 Value::Union {
                     index: 1,
-                    inner: Box::new(Value::Double(123.0)),
+                    inner: Box::new(v),
                     n_variants: 2,
                     null_variant: Some(0),
-                },
-            )]),
-        );
-        assert_none!(reader.next());
-    }
+                }
+            } else {
+                v
+            }
+        }
 
-    // Regression test for SS-277, concrete writer -> union reader: a column
-    // promoted from a non-nullable `int` to a nullable `double`. Exercises the
-    // `match_ref_promote_writer` resolution path.
-    #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
-    fn test_concrete_int_to_union_double_promotion() {
-        let writer_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "f1", "type": "int"}
-                ]
-            }
-        "#;
-        let reader_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "f1", "type": ["null", "double"]}
-                ]
-            }
-        "#;
-        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
-        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
-        let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
-        let mut record = Record::new(writer_schema.top_node()).unwrap();
-        record.put("f1", Value::Int(123));
-        writer.append(record).unwrap();
-        writer.flush().unwrap();
-        let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
-        assert_eq!(
-            reader.next().unwrap().unwrap(),
-            Value::Record(vec![(
-                "f1".to_string(),
-                Value::Union {
-                    index: 1,
-                    inner: Box::new(Value::Double(123.0)),
-                    n_variants: 2,
-                    null_variant: Some(0),
-                },
-            )]),
-        );
-        assert_none!(reader.next());
-    }
+        // Every pair `can_promote` (schema.rs) accepts. Kept in sync with it.
+        let pairs = [
+            ("int", "long"),
+            ("int", "float"),
+            ("int", "double"),
+            ("long", "float"),
+            ("long", "double"),
+            ("float", "double"),
+        ];
+        for (writer_kind, reader_kind) in pairs {
+            for writer_nullable in [false, true] {
+                for reader_nullable in [false, true] {
+                    let writer_schema =
+                        Schema::from_str(&record_schema_json(writer_kind, writer_nullable))
+                            .unwrap();
+                    let reader_schema =
+                        Schema::from_str(&record_schema_json(reader_kind, reader_nullable))
+                            .unwrap();
+                    let mut writer =
+                        Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
+                    let mut record = Record::new(writer_schema.top_node()).unwrap();
+                    record.put("f1", maybe_union(value_of(writer_kind), writer_nullable));
+                    writer.append(record).unwrap();
+                    writer.flush().unwrap();
+                    let input = writer.into_inner();
 
-    // Regression test for SS-277, union writer -> concrete reader: a column
-    // promoted from a nullable `int` to a non-nullable `double`. Exercises the
-    // `match_ref_promote_reader` resolution path.
-    #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
-    fn test_union_int_to_concrete_double_promotion() {
-        let writer_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "f1", "type": ["null", "int"]}
-                ]
+                    let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
+                    let expected = maybe_union(value_of(reader_kind), reader_nullable);
+                    assert_eq!(
+                        reader.next().unwrap().unwrap(),
+                        Value::Record(vec![("f1".to_string(), expected)]),
+                        "promotion {writer_kind}{} -> {reader_kind}{} decoded incorrectly",
+                        if writer_nullable { " (nullable)" } else { "" },
+                        if reader_nullable { " (nullable)" } else { "" },
+                    );
+                    assert_none!(reader.next());
+                }
             }
-        "#;
-        let reader_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "f1", "type": "double"}
-                ]
-            }
-        "#;
-        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
-        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
-        let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
-        let mut record = Record::new(writer_schema.top_node()).unwrap();
-        record.put(
-            "f1",
-            Value::Union {
-                index: 1,
-                inner: Box::new(Value::Int(123)),
-                n_variants: 2,
-                null_variant: Some(0),
-            },
-        );
-        writer.append(record).unwrap();
-        writer.flush().unwrap();
-        let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
-        assert_eq!(
-            reader.next().unwrap().unwrap(),
-            Value::Record(vec![("f1".to_string(), Value::Double(123.0))]),
-        );
-        assert_none!(reader.next());
+        }
     }
 
     //TODO: move where it fits better

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -522,19 +522,14 @@ mod tests {
         assert_none!(reader.next());
     }
 
-    // Regression coverage for SS-277 (PR #37087): Avro numeric promotion across
-    // every `can_promote` pair and every union-resolution arm. Promotion
-    // previously worked only for concrete (non-nullable) columns; the union
-    // (nullable) arms ignored it and failed at decode time with "Failed to
-    // match writer union variant ... against any variant in the reader".
-    //
-    // For each promotable `(writer, reader)` pair we render the field both bare
-    // (`"int"`) and nullable (`["null", "int"]`) on each side. The four
-    // combinations exercise all three matchers added in `schema.rs`:
-    //   * bare     -> nullable : `match_ref_promote_writer` (concrete -> union)
-    //   * nullable -> bare     : `match_ref_promote_reader` (union -> concrete)
-    //   * nullable -> nullable : `match_promote_writer`     (union -> union)
-    //   * bare     -> bare     : the pre-existing concrete promotion path
+    // Avro numeric promotion across every promotable pair, with the field
+    // rendered both bare (`"int"`) and nullable (`["null", "int"]`) on each
+    // side. Promoting a nullable column means promoting inside the `["null",
+    // T]` union; that previously failed at decode time with "Failed to match
+    // writer union variant ... against any variant in the reader" because union
+    // variant matching ignored promotion. The four bare/nullable combinations
+    // cover concrete -> union, union -> concrete, union -> union, and the plain
+    // concrete -> concrete path.
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
     fn test_numeric_promotion_matrix() {
@@ -572,7 +567,7 @@ mod tests {
             }
         }
 
-        // Every pair `can_promote` (schema.rs) accepts. Kept in sync with it.
+        // Every promotable numeric pair (int/long/float/double widening).
         let pairs = [
             ("int", "long"),
             ("int", "float"),
@@ -610,6 +605,73 @@ mod tests {
                     assert_none!(reader.next());
                 }
             }
+        }
+    }
+
+    // Promotion-aware union matching must still *reject* changes that are not
+    // valid promotions; a too-permissive matcher would match a variant and then
+    // mis-decode or silently corrupt the value. Each case is a numeric
+    // narrowing (`double` -> `int`) or an incompatible change (`string` ->
+    // `int`), across the same bare/nullable combinations as the positive
+    // matrix, and must fail rather than produce a value.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
+    fn test_non_promotable_changes_are_rejected() {
+        fn record_with_field(ty: &str) -> Schema {
+            Schema::from_str(&format!(
+                r#"{{"type":"record","name":"test","fields":[{{"name":"f1","type":{ty}}}]}}"#
+            ))
+            .unwrap()
+        }
+        // (writer field type, writer value, reader field type).
+        let cases = [
+            // Numeric narrowing, exercising each union matcher's reject path.
+            (
+                r#"["null", "double"]"#,
+                Value::Double(1.0),
+                r#"["null", "int"]"#,
+            ), // union -> union
+            (r#""double""#, Value::Double(1.0), r#"["null", "int"]"#), // bare  -> union
+            (r#"["null", "double"]"#, Value::Double(1.0), r#""int""#), // union -> bare
+            (r#""double""#, Value::Double(1.0), r#""int""#),           // bare  -> bare
+            // Incompatible (non-numeric) change.
+            (
+                r#"["null", "string"]"#,
+                Value::String("x".to_string()),
+                r#"["null", "int"]"#,
+            ),
+            (r#""string""#, Value::String("x".to_string()), r#""int""#),
+        ];
+        for (writer_ty, writer_value, reader_ty) in cases {
+            let writer_schema = record_with_field(writer_ty);
+            let reader_schema = record_with_field(reader_ty);
+            let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
+            let mut record = Record::new(writer_schema.top_node()).unwrap();
+            let field_value = if writer_ty.starts_with('[') {
+                Value::Union {
+                    index: 1,
+                    inner: Box::new(writer_value),
+                    n_variants: 2,
+                    null_variant: Some(0),
+                }
+            } else {
+                writer_value
+            };
+            record.put("f1", field_value);
+            writer.append(record).unwrap();
+            writer.flush().unwrap();
+            let input = writer.into_inner();
+
+            // Resolution may reject the pair up front, or decoding may error;
+            // either is acceptable, but it must never silently yield a value.
+            let produced_value = match Reader::with_schema(&reader_schema, &input[..]) {
+                Err(_) => false,
+                Ok(mut reader) => matches!(reader.next(), Some(Ok(_))),
+            };
+            assert!(
+                !produced_value,
+                "non-promotable change {writer_ty} -> {reader_ty} was not rejected",
+            );
         }
     }
 

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2765,6 +2765,61 @@ mod tests {
         assert!(reader.is_empty()); // all bytes should have been consumed
     }
 
+    /// Union variant matching decides on its own which numeric promotions are
+    /// legal, separately from the schema resolver that actually decodes a
+    /// writer value into a reader type. The two must agree: if matching accepts
+    /// a promotion the resolver rejects, a union variant can match but then
+    /// fail to decode at read time. This test pins that agreement over the
+    /// primitive types so they cannot drift apart.
+    #[mz_ore::test]
+    fn test_union_promotion_agrees_with_resolution() {
+        // Resolving two bare primitives drives exactly the resolution path that
+        // union matching consults, so it is the right oracle.
+        fn resolves(writer: &str, reader: &str) -> bool {
+            let writer = Schema::from_str(&format!("\"{writer}\"")).unwrap();
+            let reader = Schema::from_str(&format!("\"{reader}\"")).unwrap();
+            resolve_schemas(&writer, &reader).is_ok()
+        }
+        fn promotes(writer: &str, reader: &str) -> bool {
+            can_promote(
+                &Schema::parse_primitive(writer).unwrap(),
+                &Schema::parse_primitive(reader).unwrap(),
+            )
+        }
+
+        // The dangerous direction, over every primitive pair: any promotion
+        // matching accepts must actually be decodable by resolution.
+        let primitives = [
+            "null", "boolean", "int", "long", "float", "double", "bytes", "string",
+        ];
+        for w in primitives {
+            for r in primitives {
+                if promotes(w, r) {
+                    assert!(
+                        resolves(w, r),
+                        "{w} -> {r} is accepted for matching but cannot be resolved",
+                    );
+                }
+            }
+        }
+
+        // Over the numeric kinds, for distinct kinds the two must agree
+        // exactly. (Identical kinds resolve trivially but are not promotions,
+        // so matching reports false for them; exclude `w == r`.)
+        let numeric = ["int", "long", "float", "double"];
+        for w in numeric {
+            for r in numeric {
+                if w != r {
+                    assert_eq!(
+                        promotes(w, r),
+                        resolves(w, r),
+                        "matching and resolution disagree on {w} -> {r}",
+                    );
+                }
+            }
+        }
+    }
+
     #[mz_ore::test]
     fn default_non_nums() {
         let reader = r#"{

--- a/test/testdrive/avro-resolution-union-promote.td
+++ b/test/testdrive/avro-resolution-union-promote.td
@@ -67,7 +67,7 @@ $ kafka-ingest format=avro topic=resolution-union-promote schema=${reader-union-
 
 #
 # The full numeric-promotion matrix for nullable (union) columns. A single
-# schema evolution widens one nullable column per `can_promote` pair, so one
+# schema evolution widens one nullable column per promotable pair, so one
 # source exercises every promotion (int->long/float/double, long->float/double,
 # float->double) through the Kafka + CSR source decode path. Records written
 # with the old (narrow) schema must promote to the new (wide) reader schema.

--- a/test/testdrive/avro-resolution-union-promote.td
+++ b/test/testdrive/avro-resolution-union-promote.td
@@ -64,3 +64,42 @@ $ kafka-ingest format=avro topic=resolution-union-promote schema=${reader-union-
 123
 234.5
 <null>
+
+#
+# The full numeric-promotion matrix for nullable (union) columns. A single
+# schema evolution widens one nullable column per `can_promote` pair, so one
+# source exercises every promotion (int->long/float/double, long->float/double,
+# float->double) through the Kafka + CSR source decode path. Records written
+# with the old (narrow) schema must promote to the new (wide) reader schema.
+#
+
+$ set writer-matrix={"type": "record", "name": "schema_promote_matrix", "fields": [ {"name": "f_i2l", "type": ["null", "int"]}, {"name": "f_i2f", "type": ["null", "int"]}, {"name": "f_i2d", "type": ["null", "int"]}, {"name": "f_l2f", "type": ["null", "long"]}, {"name": "f_l2d", "type": ["null", "long"]}, {"name": "f_f2d", "type": ["null", "float"]} ] }
+$ set reader-matrix={"type": "record", "name": "schema_promote_matrix", "fields": [ {"name": "f_i2l", "type": ["null", "long"]}, {"name": "f_i2f", "type": ["null", "float"]}, {"name": "f_i2d", "type": ["null", "double"]}, {"name": "f_l2f", "type": ["null", "float"]}, {"name": "f_l2d", "type": ["null", "double"]}, {"name": "f_f2d", "type": ["null", "double"]} ] }
+
+$ kafka-create-topic topic=resolution-union-promote-matrix
+
+# Old (narrow) schema: a row exercising every writer branch, plus an all-null row.
+$ kafka-ingest format=avro topic=resolution-union-promote-matrix schema=${writer-matrix} timestamp=1
+{"f_i2l": {"int": 1}, "f_i2f": {"int": 2}, "f_i2d": {"int": 3}, "f_l2f": {"long": 4}, "f_l2d": {"long": 5}, "f_f2d": {"float": 6.5} }
+{"f_i2l": null, "f_i2f": null, "f_i2d": null, "f_l2f": null, "f_l2d": null, "f_f2d": null }
+
+# New (wide) schema, registered as the latest version (the source's reader schema).
+$ kafka-ingest format=avro topic=resolution-union-promote-matrix schema=${reader-matrix} timestamp=2
+{"f_i2l": {"long": 10}, "f_i2f": {"float": 20.5}, "f_i2d": {"double": 30.5}, "f_l2f": {"float": 40.5}, "f_l2d": {"double": 50.5}, "f_f2d": {"double": 60.5} }
+
+> BEGIN
+> CREATE SOURCE resolution_union_promote_matrix
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-resolution-union-promote-matrix-${testdrive.seed}')
+
+> CREATE TABLE resolution_union_promote_matrix_tbl FROM SOURCE resolution_union_promote_matrix (REFERENCE "testdrive-resolution-union-promote-matrix-${testdrive.seed}")
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+> COMMIT
+
+# The old-schema row promotes each column to the wider reader type; the
+# new-schema row decodes unchanged; the all-null row stays null.
+> SELECT f_i2l, f_i2f, f_i2d, f_l2f, f_l2d, f_f2d FROM resolution_union_promote_matrix_tbl
+1 2 3 4 5 6.5
+10 20.5 30.5 40.5 50.5 60.5
+<null> <null> <null> <null> <null> <null>


### PR DESCRIPTION
To automatically catch issues like https://github.com/MaterializeInc/materialize/pull/37087

Closes SS-278

It ran into another error, but might be unrelated: https://linear.app/materializeinc/issue/SS-281/sinks-in-stalled-state-kafkasink-24-3-dollardollar-kafka-transaction

Nightly runs for verification: https://buildkite.com/materialize/nightly/builds/16824