### PR TITLE
Document read-only policy for generated documentation

### DIFF
--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -3,6 +3,13 @@
 Refresh `doc/developer/generated/` to reflect source changes since each doc was last written.
 Do **not** modify any source files.
 
+This workflow is the recurring documentation agent. It is the **only** sanctioned
+way to edit `doc/developer/generated/`. The read-only guard in `AGENTS.md`
+(`CLAUDE.md`) that forbids other sessions from touching that tree does **not**
+apply here — running this command *is* that exception. Edits, creations, and
+deletions under `doc/developer/generated/` are expected and in scope. Stay within
+that directory: do not change source files or anything outside the generated tree.
+
 ## Procedure
 
 ### 1. Detect stale docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,22 @@ For operation flow tracing, read first:
 * `doc/developer/generated/<crate>/_crate.md` — per-crate overview: modules, key types, dependencies.
 * `doc/developer/generated/<crate>/<module>.md` — per-file docs.
 
+> **READ-ONLY: `doc/developer/generated/` is generated, not authored.**
+> The entire `doc/developer/generated/` tree is maintained exclusively by the
+> recurring documentation agent, which runs the `update-docs` skill/command.
+> That agent is the *only* session permitted to create, edit, or delete files
+> under this directory.
+>
+> In any other session: **treat `doc/developer/generated/` as read-only.** Use
+> it for navigation and context, but never edit, create, delete, or regenerate
+> files there — not even to "fix" something you noticed, and not as part of an
+> unrelated change. These files carry `source`/`revision` front-matter that the
+> recurring agent manages; hand edits desync that bookkeeping. If a generated
+> doc is wrong or stale, report it in your response rather than editing it, and
+> leave the correction to the `update-docs` agent. Do not stage or commit any
+> path under `doc/developer/generated/` unless you are explicitly running the
+> `update-docs` workflow.
+
 ## Dependency management
 
 ### Workspace dependencies


### PR DESCRIPTION
The `doc/developer/generated/` directory is maintained exclusively by an automated documentation agent. However, there was no clear guidance for other sessions about how to interact with this directory, creating risk of accidental edits that would desync the agent's bookkeeping (source/revision front-matter).

### Description

This PR adds explicit documentation of the read-only policy for `doc/developer/generated/`:

1. **AGENTS.md**: Added a prominent read-only guard that explains:
   - The directory is generated and maintained exclusively by the recurring documentation agent
   - Other sessions must treat it as read-only for navigation and context only
   - Hand edits desync the agent's bookkeeping and should be avoided
   - If generated docs are wrong or stale, they should be reported rather than edited
   - The `update-docs` workflow is the only sanctioned way to regenerate files

2. **.claude/commands/update-docs.md**: Added clarification that:
   - This workflow is the only exception to the read-only policy
   - It is the exclusive sanctioned way to edit `doc/developer/generated/`
   - Edits and creations under that directory are expected and in scope when running this command
   - Source files and content outside the generated tree should not be modified

These changes establish clear boundaries and prevent accidental desynchronization of generated documentation.

### Verification

No testing needed — this is documentation clarification. The changes establish policy and guidance without modifying any functional code or build artifacts.
