### PR TITLE
Increase Prometheus introspection scrape interval from 1s to 10s

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -466,7 +466,7 @@ pub const PEEK_STASH_BATCH_SIZE: Config<usize> = Config::new(
 /// Set to zero to disable scraping and retract any existing data.
 pub const COMPUTE_PROMETHEUS_INTROSPECTION_SCRAPE_INTERVAL: Config<Duration> = Config::new(
     "compute_prometheus_introspection_scrape_interval",
-    Duration::from_secs(1),
+    Duration::from_secs(10),
     "The collection interval for the Prometheus metrics introspection source. Set to zero to disable.",
 );
 

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -482,7 +482,6 @@ INTENTIONAL_LD_OVERRIDES: set[str] = {
     "cluster_topology_spread_min_domains",
     "column_paged_batcher_budget_fraction",
     "compute_logical_backpressure_inflight_slack",
-    "compute_prometheus_introspection_scrape_interval",
     "enable_lgalloc",
     "enable_timely_zero_copy_lgalloc",
     "enable_zero_downtime_cluster_reconfiguration",


### PR DESCRIPTION
This change increases the default collection interval for Prometheus metrics introspection from 1 second to 10 seconds. This reduces the frequency of scraping operations, which should decrease overhead and resource consumption while still maintaining reasonable observability into system metrics.

### Description

The `COMPUTE_PROMETHEUS_INTROSPECTION_SCRAPE_INTERVAL` configuration default has been updated from `Duration::from_secs(1)` to `Duration::from_secs(10)`. This is a straightforward configuration adjustment that affects how often the Prometheus metrics introspection source collects data.

### Verification

No testing needed — this is a configuration constant change. The existing configuration system will handle the new default value appropriately.