### PR TITLE
sql-parser: quote `INTO` identifiers so `COPY` relations round-trip

### DIFF
--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -19,7 +19,7 @@
 // limitations under the License.
 
 use mz_ore::str::StrExt;
-use mz_sql_lexer::keywords::{ALL, ANY, AS, DISTINCT, Keyword, LIST, PREPARE, SOME, WHEN};
+use mz_sql_lexer::keywords::{ALL, ANY, AS, DISTINCT, INTO, Keyword, LIST, PREPARE, SOME, WHEN};
 use mz_sql_lexer::lexer::{IdentString, MAX_IDENTIFIER_LENGTH};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -350,6 +350,12 @@ impl Ident {
                         // ("expected an expression, found dot"). Quoting it keeps
                         // the operand an identifier.
                         || kw == WHEN
+                        // `COPY [INTO] <table> FROM …` accepts an optional `INTO`
+                        // keyword before the relation name, so a bare `into`
+                        // relation is consumed as that keyword on reparse
+                        // (`COPY into FROM x` -> `COPY INTO <name=from> …`, which
+                        // then fails expecting the FROM/TO direction).
+                        || kw == INTO
                 })
                 .unwrap_or(false)
     }


### PR DESCRIPTION
`parse_copy` accepts an optional `INTO` keyword (`COPY INTO <table> FROM …`), so a `COPY` statement whose relation is named `into` did not survive the `to_ast_string_simple()` -> reparse round-trip: the bare `into` was consumed as that optional keyword (`COPY into FROM x` -> `COPY INTO <name=from> …`), shifting the `FROM`/`TO` direction so it failed to reparse. Stable-mode output already quoted it; simple-mode did not.

Add `INTO` to `Ident::can_be_printed_bare`'s keyword-exclusion list (alongside `AS`, `LIST`, `PREPARE`, `WHEN`) so it is always quoted.