### PR TITLE
Wire storage decoder Glue path and simplify Decoder::new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8440,6 +8440,7 @@ dependencies = [
  "mysql_async",
  "mysql_common",
  "mz-arrow-util",
+ "mz-aws-glue-schema-registry",
  "mz-build-info",
  "mz-ccsr",
  "mz-cluster",

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -11,7 +11,7 @@ use std::hint::black_box;
 use byteorder::{NetworkEndian, WriteBytesExt};
 use criterion::{Criterion, Throughput};
 use mz_avro::types::Value as AvroValue;
-use mz_interchange::avro::{Decoder, parse_schema};
+use mz_interchange::avro::{Decoder, WriterSchemaProvider, parse_schema};
 use mz_ore::cast::CastFrom;
 use mz_repr::adt::date::Date;
 use tokio::runtime::Runtime;
@@ -394,7 +394,13 @@ pub fn bench_avro(c: &mut Criterion) {
     buf.extend(mz_avro::to_avro_datum(&schema, record).unwrap());
     let len = u64::cast_from(buf.len());
 
-    let mut decoder = Decoder::new(schema_str, &[], None, "avro_bench".to_string(), false).unwrap();
+    let mut decoder = Decoder::new(
+        schema_str,
+        &[],
+        WriterSchemaProvider::None,
+        "avro_bench".to_string(),
+    )
+    .unwrap();
 
     let mut bg = c.benchmark_group("avro");
     bg.throughput(Throughput::Bytes(len));

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -42,7 +42,7 @@ mod tests {
     use mz_ore::assert_err;
     use mz_repr::{Datum, Row};
 
-    use crate::avro::Decoder;
+    use crate::avro::{Decoder, WriterSchemaProvider};
 
     #[mz_ore::test(tokio::test)]
     async fn test_error_followed_by_success() {
@@ -51,7 +51,8 @@ mod tests {
 "name": "test",
 "fields": [{"name": "f1", "type": "int"}, {"name": "f2", "type": "int"}]
 }"#;
-        let mut decoder = Decoder::new(schema, &[], None, "Test".to_string(), false).unwrap();
+        let mut decoder =
+            Decoder::new(schema, &[], WriterSchemaProvider::None, "Test".to_string()).unwrap();
         // This is not a valid Avro blob for the given schema
         let mut bad_bytes: &[u8] = &[0];
         assert_err!(decoder.decode(&mut bad_bytes).await.unwrap());
@@ -78,23 +79,9 @@ impl Decoder {
     pub fn new(
         reader_schema: &str,
         reader_reference_schemas: &[String],
-        ccsr_client: Option<mz_ccsr::Client>,
+        writer_schemas: crate::avro::WriterSchemaProvider,
         debug_name: String,
-        confluent_wire_format: bool,
     ) -> anyhow::Result<Decoder> {
-        // Map the legacy (ccsr_client, confluent_wire_format) pair to the
-        // unified `WriterSchemaProvider` enum. `(Some, false)` is rejected by the
-        // planner today; treat it as an internal error.
-        let writer_schemas = match (ccsr_client, confluent_wire_format) {
-            (None, false) => crate::avro::WriterSchemaProvider::None,
-            (client, true) => crate::avro::WriterSchemaProvider::confluent(client),
-            (Some(_), false) => {
-                anyhow::bail!(
-                    "internal error: Avro decoder received a CSR client but \
-                     confluent_wire_format = false"
-                )
-            }
-        };
         let csr_avro =
             AvroSchemaResolver::new(reader_schema, reader_reference_schemas, writer_schemas)?;
 

--- a/src/interchange/src/bin/avro-decode.rs
+++ b/src/interchange/src/bin/avro-decode.rs
@@ -51,11 +51,14 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let schema = fs::read_to_string(&args.schema_file)
         .await
         .context("reading schema file")?;
-    let ccsr_client: Option<mz_ccsr::Client> = None;
     let debug_name = String::from("avro-decode");
-    let confluent_wire_format = false;
-    let mut decoder = Decoder::new(&schema, &[], ccsr_client, debug_name, confluent_wire_format)
-        .context("creating decoder")?;
+    let mut decoder = Decoder::new(
+        &schema,
+        &[],
+        mz_interchange::avro::WriterSchemaProvider::None,
+        debug_name,
+    )
+    .context("creating decoder")?;
     let row = decoder.decode(&mut data).await.context("decoding data")?;
     println!("row: {row:?}");
     Ok(())

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -41,6 +41,7 @@ maplit.workspace = true
 mysql_async.workspace = true
 mysql_common.workspace = true
 mz-arrow-util = { path = "../arrow-util" }
+mz-aws-glue-schema-registry = { path = "../aws-glue-schema-registry" }
 mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }
 mz-cluster-client = { path = "../cluster-client" }

--- a/src/storage/src/decode.rs
+++ b/src/storage/src/decode.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use differential_dataflow::capture::{Message, Progress};
 use differential_dataflow::{AsCollection, Hashable, VecCollection};
 use futures::StreamExt;
+use mz_interchange::avro::WriterSchemaProvider;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_repr::{Datum, Diff, Row};
@@ -357,29 +358,54 @@ async fn get_decoder(
         }) => {
             // Only the Confluent variant is reachable from SQL today; Glue
             // is not yet wired to the planner.
-            let (csr_client, confluent_wire_format) = match wire_format {
-                WireFormat::None => (None, false),
-                WireFormat::Confluent { registry: None } => (None, true),
-                WireFormat::Confluent {
-                    registry: Some(csr_connection),
-                } => {
-                    let client = csr_connection
-                        .connect(storage_configuration, InTask::Yes)
-                        .await?;
-                    (Some(client), true)
+
+            let writer_schemas = match wire_format {
+                WireFormat::None => WriterSchemaProvider::None,
+                WireFormat::Confluent { registry } => {
+                    let client = match registry {
+                        None => None,
+                        Some(csr_connection) => Some(
+                            csr_connection
+                                .connect(storage_configuration, InTask::Yes)
+                                .await?,
+                        ),
+                    };
+                    WriterSchemaProvider::confluent(client)
                 }
-                WireFormat::Glue { .. } => {
-                    unreachable!("AWS Glue Schema Registry not supported yet")
+                WireFormat::Glue { registry } => {
+                    let client_with_registry = match registry {
+                        None => None,
+                        Some(glue_connection) => {
+                            let enforce_external_addresses =
+                                mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+                                    .get(storage_configuration.config_set());
+                            let sdk_config = glue_connection
+                                .aws_connection
+                                .connection
+                                .load_sdk_config(
+                                    &storage_configuration.connection_context,
+                                    glue_connection.aws_connection.connection_id,
+                                    InTask::Yes,
+                                    enforce_external_addresses,
+                                )
+                                .await?;
+                            let client =
+                                mz_aws_glue_schema_registry::ClientConfig::new(sdk_config).build();
+                            Some((client, glue_connection.registry_name.clone()))
+                        }
+                    };
+                    WriterSchemaProvider::glue(client_with_registry)
                 }
             };
             let state = avro::AvroDecoderState::new(
                 &schema,
                 &reference_schemas,
-                csr_client,
+                writer_schemas,
                 debug_name.to_string(),
-                confluent_wire_format,
             )
-            .expect("Failed to create avro decoder, even though we validated ccsr client creation in purification.");
+            .expect(
+                "avro decoder construction is infallible once writer-schema setup has succeeded",
+            );
             DataDecoder {
                 inner: DataDecoderInner::Avro(state),
                 metrics,

--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_interchange::avro::Decoder;
+use mz_interchange::avro::{Decoder, WriterSchemaProvider};
 use mz_ore::error::ErrorExt;
 use mz_repr::Row;
 use mz_storage_types::errors::DecodeErrorKind;
@@ -22,18 +22,11 @@ impl AvroDecoderState {
     pub fn new(
         value_schema: &str,
         reference_schemas: &[String],
-        ccsr_client: Option<mz_ccsr::Client>,
+        writer_schemas: WriterSchemaProvider,
         debug_name: String,
-        confluent_wire_format: bool,
     ) -> Result<Self, anyhow::Error> {
         Ok(AvroDecoderState {
-            decoder: Decoder::new(
-                value_schema,
-                reference_schemas,
-                ccsr_client,
-                debug_name,
-                confluent_wire_format,
-            )?,
+            decoder: Decoder::new(value_schema, reference_schemas, writer_schemas, debug_name)?,
             events_success: 0,
         })
     }


### PR DESCRIPTION
Drops the legacy (ccsr_client, confluent_wire_format) pair from `Decoder::new` in favor of taking `WriterSchemaProvider` directly.

No functional changes, everything continues to work as before (or better).
