### PR TITLE
mz-debug: read the always-installed v1alpha1 Materialize CRD

### DIFF
--- a/src/mz-debug/src/k8s_dumper.rs
+++ b/src/mz-debug/src/k8s_dumper.rs
@@ -38,7 +38,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomRe
 use kube::api::{ListParams, LogParams};
 use kube::{Api, Client};
 use mz_cloud_resources::crd::generated::cert_manager::certificates::Certificate;
-use mz_cloud_resources::crd::materialize::v1::Materialize;
+use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
 
 use serde::{Serialize, de::DeserializeOwned};
 use tracing::{info, warn};

--- a/src/mz-debug/src/utils.rs
+++ b/src/mz-debug/src/utils.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use kube::{Api, Client};
-use mz_cloud_resources::crd::materialize::v1::Materialize;
+use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
 use mz_server_core::listeners::AuthenticatorKind;
 use zip::ZipWriter;
 use zip::write::SimpleFileOptions;


### PR DESCRIPTION
Follow-up to #35418

I assume we want to keep mz-debug working on existing v1alpha CRDs or do we plan to upgrade them all to v1? Otherwise `mz-debug` loses:

* Auth-mode auto-detection (`get_k8s_auth_mode`) 404s and falls back to `AuthMode::None`, so SQL collection connects with the wrong auth mode on clusters using Password/Sasl/Oidc.
* The Materialize CR is dropped from the debug bundle, with only a log warning to indicate why.