### PR TITLE
compute: scope per-batch decode arenas to the activation

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -300,7 +300,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         &self,
         key: Option<&Row>,
         max_demand: usize,
-        mut logic: L,
+        logic: L,
     ) -> (
         Stream<'scope, T, DCB::Container>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
@@ -317,30 +317,14 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
             ) -> usize
             + 'static,
     {
-        let mut datums = DatumVec::new();
-        // Reused across invocations: cleared per row rather than reallocated, so the arena's
-        // allocation spine persists. Declared before the borrow so it outlives any datums that
-        // decode into it.
-        let mut temp_storage = RowArena::new();
-        let logic = move |k: DatumSeq,
-                          v: DatumSeq,
-                          t,
-                          d,
-                          ok_session: &mut Session<T, DCB>,
-                          err_session: &mut Session<T, ECB<T>>| {
-            temp_storage.clear();
-            let mut datums_borrow = datums.borrow();
-            k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
-            let max_demand = max_demand.saturating_sub(datums_borrow.len());
-            v.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
-            logic(&mut datums_borrow, t, d, ok_session, err_session)
-        };
-
+        // `logic` is passed straight through to `flat_map_core_fallible`, which owns the per-row
+        // decode (and the activation-scoped arena it decodes into).
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
                 let (oks, mfp_errs) = CollectionBundle::<T>::flat_map_core_fallible::<_, _, DCB, _>(
                     oks.clone(),
                     key,
+                    max_demand,
                     logic,
                     REFUEL,
                 );
@@ -352,6 +336,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                 let (oks, mfp_errs) = CollectionBundle::<T>::flat_map_core_fallible::<_, _, DCB, _>(
                     oks.clone(),
                     key,
+                    max_demand,
                     logic,
                     REFUEL,
                 );
@@ -370,7 +355,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         &self,
         key: Option<&Row>,
         max_demand: usize,
-        mut logic: L,
+        logic: L,
     ) -> (
         Stream<'scope, T, DCB::Container>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
@@ -381,25 +366,12 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         L: for<'a, 'b> FnMut(&'a mut DatumVecBorrow<'b>, T, Diff, &mut Session<T, DCB>) -> usize
             + 'static,
     {
-        let mut datums = DatumVec::new();
-        // Reused across invocations: cleared per row rather than reallocated, so the arena's
-        // allocation spine persists. Declared before the borrow so it outlives any datums that
-        // decode into it.
-        let mut temp_storage = RowArena::new();
-        let logic = move |k: DatumSeq, v: DatumSeq, t, d, ok_session: &mut Session<T, DCB>| {
-            temp_storage.clear();
-            let mut datums_borrow = datums.borrow();
-            k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
-            let max_demand = max_demand.saturating_sub(datums_borrow.len());
-            v.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
-            logic(&mut datums_borrow, t, d, ok_session)
-        };
-
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
                 let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
                     oks.clone(),
                     key,
+                    max_demand,
                     logic,
                     REFUEL,
                 );
@@ -410,6 +382,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                 let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
                     oks.clone(),
                     key,
+                    max_demand,
                     logic,
                     REFUEL,
                 );
@@ -714,6 +687,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     fn flat_map_core_fallible<Tr, D, DCB, L>(
         trace: Arranged<'scope, Tr>,
         key: Option<&<Tr::KeyContainer as BatchContainer>::Owned>,
+        max_demand: usize,
         mut logic: L,
         refuel: usize,
     ) -> (
@@ -731,9 +705,11 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         <Tr::KeyContainer as BatchContainer>::Owned: PartialEq,
         D: Data,
         DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
-        L: FnMut(
-                Tr::Key<'_>,
-                Tr::Val<'_>,
+        // `logic` receives the key and value already decoded into a `DatumVecBorrow`. The decode
+        // (and its arena/`DatumVec`) lives in the per-activation closure below, so it is scoped to
+        // a single scheduling invocation rather than to the operator.
+        L: for<'a, 'b> FnMut(
+                &'a mut DatumVecBorrow<'b>,
                 T,
                 mz_repr::Diff,
                 &mut Session<T, DCB>,
@@ -784,12 +760,33 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     }
                 });
 
+                // Decode the key/value of each record into datums for `logic`. The arena and datum
+                // buffer are created here, so they are scoped to this activation (dropped when it
+                // returns) rather than retained for the operator's lifetime; both are reused across
+                // the records processed within the activation.
+                let mut temp_storage = RowArena::new();
+                let mut datums = DatumVec::new();
+                let mut decode_logic =
+                    |k: Tr::Key<'_>,
+                     v: Tr::Val<'_>,
+                     t: T,
+                     d: mz_repr::Diff,
+                     ok_session: &mut Session<T, DCB>,
+                     err_session: &mut Session<T, ECB<T>>| {
+                        temp_storage.clear();
+                        let mut datums_borrow = datums.borrow();
+                        k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
+                        let remaining = max_demand.saturating_sub(datums_borrow.len());
+                        v.extend_datums(&temp_storage, &mut datums_borrow, Some(remaining));
+                        logic(&mut datums_borrow, t, d, ok_session, err_session)
+                    };
+
                 // Second, make progress on `todo`.
                 let mut fuel = refuel;
                 while !todo.is_empty() && fuel > 0 {
                     todo.front_mut().unwrap().do_work(
                         key.as_ref(),
-                        &mut logic,
+                        &mut decode_logic,
                         &mut fuel,
                         &mut ok_output,
                         &mut err_output,
@@ -816,6 +813,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     fn flat_map_core_ok<Tr, D, DCB, L>(
         trace: Arranged<'scope, Tr>,
         key: Option<&<Tr::KeyContainer as BatchContainer>::Owned>,
+        max_demand: usize,
         mut logic: L,
         refuel: usize,
     ) -> Stream<'scope, T, DCB::Container>
@@ -830,7 +828,14 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         <Tr::KeyContainer as BatchContainer>::Owned: PartialEq,
         D: Data,
         DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
-        L: FnMut(Tr::Key<'_>, Tr::Val<'_>, T, mz_repr::Diff, &mut Session<T, DCB>) -> usize
+        // See `flat_map_core_fallible`: `logic` takes already-decoded datums; the decode lives in
+        // the per-activation closure below.
+        L: for<'a, 'b> FnMut(
+                &'a mut DatumVecBorrow<'b>,
+                T,
+                mz_repr::Diff,
+                &mut Session<T, DCB>,
+            ) -> usize
             + 'static,
     {
         let scope = trace.stream.scope();
@@ -866,11 +871,28 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     }
                 });
 
+                // Activation-scoped decode storage; see `flat_map_core_fallible`.
+                let mut temp_storage = RowArena::new();
+                let mut datums = DatumVec::new();
+                let mut decode_logic =
+                    |k: Tr::Key<'_>,
+                     v: Tr::Val<'_>,
+                     t: T,
+                     d: mz_repr::Diff,
+                     ok_session: &mut Session<T, DCB>| {
+                        temp_storage.clear();
+                        let mut datums_borrow = datums.borrow();
+                        k.extend_datums(&temp_storage, &mut datums_borrow, Some(max_demand));
+                        let remaining = max_demand.saturating_sub(datums_borrow.len());
+                        v.extend_datums(&temp_storage, &mut datums_borrow, Some(remaining));
+                        logic(&mut datums_borrow, t, d, ok_session)
+                    };
+
                 let mut fuel = refuel;
                 while !todo.is_empty() && fuel > 0 {
                     todo.front_mut().unwrap().do_work(
                         key.as_ref(),
-                        &mut logic,
+                        &mut decode_logic,
                         &mut fuel,
                         &mut ok_output,
                     );
@@ -1151,8 +1173,10 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             let mut key_buf = Row::default();
             let mut val_buf = Row::default();
             let mut datums = DatumVec::new();
-            let mut temp_storage = RowArena::new();
             move |_frontiers| {
+                // Scoped to the activation so the arena's retained capacity does not outlive a
+                // single scheduling invocation; cleared per row to reuse it within the batch.
+                let mut temp_storage = RowArena::new();
                 let mut ok_output = ok_output.activate();
                 let mut err_output = err_output.activate();
                 let mut passthrough_output = passthrough_output.activate();
@@ -1267,14 +1291,13 @@ where
         D: Data,
         DCB: ContainerBuilder + PushInto<(D, C::Time, C::Diff)>,
         L: FnMut(
-                C::Key<'_>,
-                C::Val<'_>,
-                C::Time,
-                C::Diff,
-                &mut Session<C::Time, DCB>,
-                &mut Session<C::Time, ECB<C::Time>>,
-            ) -> usize
-            + 'static,
+            C::Key<'_>,
+            C::Val<'_>,
+            C::Time,
+            C::Diff,
+            &mut Session<C::Time, DCB>,
+            &mut Session<C::Time, ECB<C::Time>>,
+        ) -> usize,
     {
         let mut ok_session = ok_output.session_with_builder(&self.ok_capability);
         let mut err_session = err_output.session_with_builder(&self.err_capability);
@@ -1318,8 +1341,7 @@ where
     ) where
         D: Data,
         DCB: ContainerBuilder + PushInto<(D, C::Time, C::Diff)>,
-        L: FnMut(C::Key<'_>, C::Val<'_>, C::Time, C::Diff, &mut Session<C::Time, DCB>) -> usize
-            + 'static,
+        L: FnMut(C::Key<'_>, C::Val<'_>, C::Time, C::Diff, &mut Session<C::Time, DCB>) -> usize,
     {
         let mut ok_session = ok_output.session_with_builder(&self.capability);
         walk_cursor(&mut self.cursor, &self.batch, key, fuel, |k, v, t, d| {


### PR DESCRIPTION
## What

Moves the `RowArena` (and accompanying `DatumVec`) used for per-row decode in the `ArrangementFlatMap`, `ArrangementFlatMapOk`, and `FormArrangementKey` operators from operator-**build** scope into the per-**activation** closure, so it is dropped at the end of each scheduling invocation while still being reused across the records processed within that activation.

## Why

These three operators created their decode arena once at build time and captured it for the operator's lifetime, clearing it per record. That's the only place in the compute/storage layer (verified by an exhaustive audit of every `RowArena.clear()` site) where an arena is both **clear-reused** and **dataflow-lived**.

It matters because of the companion change that makes `RowArena::clear()` retain its largest region for reuse (#37114): under that semantics, a build-captured + per-row-cleared arena pins its high-water region for the operator's whole life — a small (one record's worth) but *permanent* per-operator memory tax. Scoping the arena to the activation eliminates the tax (the region is freed when the activation returns) while keeping the within-activation reuse that retention buys.

The discipline this establishes — *fresh arena per scheduling invocation, cleared per record* — is the one already used by `LinearJoinKeyPreparation`; this brings the remaining clear-reuse arenas in line with it.

## How

- `FormArrangementKey`: a one-line move of `RowArena::new()` from the build closure into the `move |_frontiers|` closure.
- `flat_map` / `flat_map_ok`: the per-row decode wrapper (which owned the arena + `DatumVec`) is removed; `flat_map_core_{fallible,ok}` now take `max_demand` and the **decoded-form** `logic` directly and build the decode closure inside their per-activation closure. `do_work`'s `logic` bound drops a vestigial `+ 'static` (never required by `walk_cursor`) so it can accept the activation-scoped, borrowing decode closure.

No public API change; no behavior change — the decode and emitted results are identical. This is intended to land before #37114 so the region-retention change can never introduce a dataflow-lived arena tax.

## Tests

Covered by existing compute unit tests and the SLT/testdrive suites that exercise indexed MFPs, table functions, and arrangement formation. No behavior change, so no new tests.