### PR TITLE
storage: clear the oneshot-source decode arena per row

### DIFF
--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -486,7 +486,6 @@ where
         let [_row_cap] = caps.try_into().unwrap();
 
         let mut datum_vec = DatumVec::default();
-        let row_arena = RowArena::default();
         let mut row_buf = Row::default();
 
         while let Some(event) = record_chunk_handle.next().await {
@@ -508,9 +507,14 @@ where
 
             match result {
                 Ok(rows) => {
+                    // Scoped to this chunk so the arena's retained capacity does not outlive it,
+                    // and cleared per row below so it only ever holds one row's MFP temporaries
+                    // rather than accumulating the whole source.
+                    let mut row_arena = RowArena::new();
                     // For each row of source data, we pass it through an MFP to re-arrange column
                     // orders and/or fill in default values for missing columns.
                     for row in rows {
+                        row_arena.clear();
                         let mut datums = datum_vec.borrow_with(&row);
                         let result = mfp
                             .evaluate_into(&mut *datums, &row_arena, &mut row_buf)


### PR DESCRIPTION
## What

`render_decode_chunk` (the oneshot/COPY decode operator) created one `RowArena` in the operator body and reused it across every chunk and every row **without ever clearing it**. The arena owns whatever is pushed into it for its lifetime, so the MFP-evaluation temporaries for the *entire source* accumulated until the COPY finished — an unbounded arena proportional to the data volume.

This scopes the arena to each decoded chunk and clears it per row, so it holds at most one row's worth of temporaries and is released when the chunk is processed.

## Why

Found while auditing `RowArena` lifetimes (companion to the arena work in #37114 / #37134). This was the only arena in the audit that was both operator-lived **and** never cleared — i.e. a genuine unbounded accumulation rather than a bounded high-water. It brings the operator in line with the "arena per batch, cleared per row" idiom the other operators use.

## Tests

No behavior change (the MFP output is identical; only the arena's lifetime changes). Covered by the existing oneshot-source / COPY FROM tests.