### PR TITLE
[catalog] bump mz_indexes for mz_cluster_replica_size_internal_ind

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1085,7 +1085,6 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
-        skip: "https://linear.app/materializeinc/issue/SQL-398"
 
       - id: checks-self-managed-upgrade
         label: "Checks Self-Managed upgrade, whole-Mz restart"
@@ -1159,7 +1158,6 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
-        skip: "https://linear.app/materializeinc/issue/SQL-398"
 
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
@@ -1172,7 +1170,6 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
-        skip: "https://linear.app/materializeinc/issue/SQL-398"
 
       - id: checks-0dt-upgrade-entire-mz-four-versions
         label: "Checks 0dt upgrade across four versions"
@@ -1185,7 +1182,6 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
-        skip: "https://linear.app/materializeinc/issue/SQL-398"
 
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"
@@ -2117,7 +2113,6 @@ steps:
               args: ["--versions-source=git"]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
-        skip: "https://linear.app/materializeinc/issue/SQL-398"
 
       - id: legacy-upgrade-docs
         label: Legacy upgrade (last version from docs)

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -514,7 +514,6 @@ steps:
           ]
     agents:
       queue: hetzner-x86-64-4cpu-8gb
-    skip: "https://linear.app/materializeinc/issue/SQL-398"
 
   - id: source-sink-errors
     label: "S&S error reporting"

--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -197,6 +197,16 @@ static MIGRATIONS: LazyLock<Vec<MigrationStep>> = LazyLock::new(|| {
             MZ_CATALOG_SCHEMA,
             "mz_role_parameters",
         ),
+        // Required because we added `mz_cluster_replica_size_internal_ind` builtin
+        // index without bumping mz_indexes. make_mz_indexes inlines the builtin-index
+        // set as VALUES, so any add/remove changes its SQL fingerprint and requires
+        // an explicit replacement step.
+        MigrationStep::replacement(
+            "26.30.0-dev.0",
+            CatalogItemType::MaterializedView,
+            MZ_CATALOG_SCHEMA,
+            "mz_indexes",
+        ),
         MigrationStep::replacement(
             "26.30.0-dev.0",
             CatalogItemType::MaterializedView,


### PR DESCRIPTION
A new builtin index was added at 26.30.0-dev.0 without bumping mz_indexes. make_mz_indexes inlines the builtin-index set as VALUES, so its SQL fingerprint changed without a matching migration step, causing 0dt upgrades from 26.29.0 to panic in update_fingerprints.

Re-enables the upgrade-smoke-test that was disabled in #37118.

Fixes SQL-398.