### PR TITLE
docs: add bounded staleness to transaction_isolation parameter values

### DIFF
--- a/doc/user/content/headless/configuration-parameters.md
+++ b/doc/user/content/headless/configuration-parameters.md
@@ -9,7 +9,7 @@ Name                                        | Default value             |  Descr
 `cluster_replica`                           |                           | The target cluster replica for `SELECT` queries.                      | Yes
 `database`                                  | `materialize`             | The current database.                                                 | Yes
 `search_path`                               | `public`                  | The schema search order for names that are not schema-qualified.      | Yes
-`transaction_isolation`                     | `strict serializable`     | The transaction isolation level. For more information, see [Isolation level](/reference/isolation-level/). <br/><br/> Accepts values: `serializable`, `strict serializable`. | Yes
+`transaction_isolation`                     | `strict serializable`     | The transaction isolation level. For more information, see [Isolation level](/reference/isolation-level/). <br/><br/> Accepts values: `serializable`, `strict serializable`{{< if-released "v26.29" >}}, `bounded staleness <duration>` (for example, `bounded staleness 5s`){{< /if-released >}}. | Yes
 
 ### Other configuration parameters
 


### PR DESCRIPTION
## Motivation

The [Key configuration parameters](https://materialize.com/docs/sql/set/#key-configuration-parameters) table on the `SET` docs page lists the permitted values for `transaction_isolation`, but it only mentioned `serializable` and `strict serializable`. With bounded staleness shipping this release, the table should also list it as a permitted isolation level.

## Changes

- Add `bounded staleness <duration>` (with an example) to the list of accepted values for the `transaction_isolation` configuration parameter in `doc/user/content/headless/configuration-parameters.md` (included by the `SET` page).
- The addition is gated behind `{{< if-released "v26.29" >}}`, matching how [`reference/isolation-level.md`](https://materialize.com/docs/reference/isolation-level/) already documents bounded staleness as a public-preview isolation level, so it only surfaces once v26.29 is released.

The existing isolation-level reference page describes the behavior (serves reads at a timestamp at most `<duration>` stale, never blocks, errors with `SQLSTATE 40001` if the bound can't be met); this change just makes that value discoverable from the `SET` parameter list.

## Context

Requested in [this Slack thread](https://materializeinc.slack.com/archives/C09ERRA0YAK/p1781798620420639?thread_ts=1781798273.577049&cid=C09ERRA0YAK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0172LkcXCAsoYtAo3QVwTDMK)_