### PR TITLE
Re-enable flaky FoundationDB unit tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,18 @@ slow-timeout = { period = "1200s", terminate-after = 2 }
 # For a given configuration parameter, the first override to match wins. Keep
 # these sorted in order from most specific to least specific.
 
+# The FoundationDB unit tests talk to an external FDB server; retry them so a
+# transient server stall reruns rather than failing the build (DB-103).
+[[profile.default.overrides]]
+filter = "package(mz-persist) and test(foundationdb::tests::fdb_consensus)"
+retries = 2
+priority = 100
+
+[[profile.default.overrides]]
+filter = "package(mz-timestamp-oracle) and test(foundationdb_oracle::tests::test_fdb_timestamp_oracle)"
+retries = 2
+priority = 100
+
 [[profile.default.overrides]]
 filter = "package(mz-environmentd) and test(test_concurrent_id_reuse)"
 priority = 100

--- a/src/foundationdb/src/lib.rs
+++ b/src/foundationdb/src/lib.rs
@@ -16,10 +16,32 @@
 use std::sync::Mutex;
 
 use foundationdb::api::NetworkAutoStop;
+use foundationdb::options::DatabaseOption;
 use mz_ore::url::SensitiveUrl;
 
 /// Re-export the `foundationdb` crate for convenience.
 pub use foundationdb::*;
+
+/// Default transaction timeout, in milliseconds, applied to a [`Database`] in
+/// tests via [`set_test_transaction_timeout`].
+///
+/// Chosen well below the test harness's 180s termination so that an unavailable
+/// or stalled server surfaces a `transaction_timed_out` error the test can
+/// report and retry on, rather than hanging until the harness kills the process.
+const TEST_TRANSACTION_TIMEOUT_MS: i32 = 60_000;
+
+/// Sets a default transaction timeout on `db` for use in tests.
+///
+/// Production code intentionally does not bound transactions here; that is a
+/// separate product decision. Tests call this so that a FoundationDB server that
+/// becomes unresponsive (for example under heavy parallel CI load) fails the
+/// affected operation promptly instead of blocking forever.
+pub fn set_test_transaction_timeout(db: &Database) {
+    db.set_option(DatabaseOption::TransactionTimeout(
+        TEST_TRANSACTION_TIMEOUT_MS,
+    ))
+    .expect("setting transaction timeout option");
+}
 
 /// FoundationDB network handle.
 /// The first element is `Some` if the network is initialized.
@@ -31,13 +53,14 @@ static FDB_NETWORK: Mutex<(Option<NetworkAutoStop>, bool)> = Mutex::new((None, f
 /// This function is safe to call multiple times - only the first call will
 /// actually initialize the network, subsequent calls return immediately.
 ///
-/// After calling `shutdown_network()`, any subsequent calls to this function
-/// will panic.
+/// The FoundationDB network can be booted once per process and can never be
+/// restarted: after [`shutdown_network()`], any subsequent call to this function
+/// panics.
 ///
-/// The user is required to call [`shutdown_network()`] before the process exits to
-/// ensure a clean shutdown of the FoundationDB network. Otherwise, strange memory
-/// corruption issues during shutdown may occur. This is a limitation of the
-/// FoundationDB C API.
+/// Before the process exits, drop all `Database` and transaction handles and then
+/// call [`shutdown_network()`]. Skipping the shutdown can segfault the
+/// FoundationDB client during teardown; calling it while a handle is still alive
+/// can instead block on the network thread join.
 pub fn init_network() {
     let mut guard = FDB_NETWORK.lock().expect("mutex poisoned");
     if guard.0.is_none() {
@@ -55,7 +78,12 @@ pub fn init_network() {
 
 /// Shut down the FoundationDB network.
 ///
-/// After calling this function, any subsequent calls to `init_network()` will panic.
+/// Call this once, after dropping all `Database` and transaction handles, before
+/// the process exits. Not stopping the network can segfault the client during
+/// teardown. The network can never be restarted afterwards: any subsequent call
+/// to [`init_network()`] will panic. Stopping the network joins the network
+/// thread, which can block indefinitely if a handle or in-flight transaction is
+/// still alive.
 pub fn shutdown_network() {
     let mut guard = FDB_NETWORK.lock().expect("mutex poisoned");
     if guard.0.is_some() {

--- a/src/persist/src/foundationdb.rs
+++ b/src/persist/src/foundationdb.rs
@@ -166,6 +166,10 @@ impl FdbConsensus {
         mz_foundationdb::init_network();
 
         let db = Database::new(None)?;
+        // In tests, bound transactions so an unresponsive server fails fast
+        // instead of hanging until the harness terminates the process.
+        #[cfg(test)]
+        mz_foundationdb::set_test_transaction_timeout(&db);
         let directory = DirectoryLayer::default();
         let keys_path: Vec<_> = fdb_config
             .prefix
@@ -455,7 +459,6 @@ mod tests {
 
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    #[ignore] // TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/10076 is fixed
     async fn fdb_consensus() -> Result<(), ExternalError> {
         let config = FdbConsensusConfig::new(
             std::str::FromStr::from_str("foundationdb:?prefix=test/consensus").unwrap(),
@@ -507,6 +510,12 @@ mod tests {
 
         assert_eq!(consensus.head(&key).await, Ok(None));
 
+        // Drop all FoundationDB handles before stopping the network, then shut it
+        // down. The network must be stopped before the process exits, otherwise
+        // the client can segfault during teardown. Stopping it while a `Database`
+        // is still alive can instead block on the network thread join, so drop
+        // `consensus` first.
+        drop(consensus);
         mz_foundationdb::shutdown_network();
         Ok(())
     }

--- a/src/timestamp-oracle/src/foundationdb_oracle.rs
+++ b/src/timestamp-oracle/src/foundationdb_oracle.rs
@@ -283,6 +283,10 @@ where
         mz_foundationdb::init_network();
 
         let db = Arc::new(Database::new(None)?);
+        // In tests, bound transactions so an unresponsive server fails fast
+        // instead of hanging until the harness terminates the process.
+        #[cfg(test)]
+        mz_foundationdb::set_test_transaction_timeout(&db);
         let metrics = Arc::clone(&config.metrics);
         let prefix = fdb_config.prefix;
         let directory = DirectoryLayer::default();
@@ -343,6 +347,10 @@ where
         mz_foundationdb::init_network();
 
         let db = Arc::new(Database::new(None)?);
+        // In tests, bound transactions so an unresponsive server fails fast
+        // instead of hanging until the harness terminates the process.
+        #[cfg(test)]
+        mz_foundationdb::set_test_transaction_timeout(&db);
         let metrics = Arc::clone(&config.metrics);
         let prefix = fdb_config.prefix;
         let directory = DirectoryLayer::default();
@@ -617,7 +625,6 @@ mod tests {
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function
-    #[ignore] // TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/10076 is fixed
     async fn test_fdb_timestamp_oracle() -> Result<(), anyhow::Error> {
         let config = FdbTimestampOracleConfig::new_for_test();
 
@@ -636,6 +643,10 @@ mod tests {
         })
         .await?;
 
+        // The network must be stopped before the process exits, otherwise the
+        // FoundationDB client can segfault during teardown. All oracles (and their
+        // `Database` handles) created above have been dropped by now, so the
+        // network thread join does not block.
         mz_foundationdb::shutdown_network();
 
         Ok(())


### PR DESCRIPTION
### Motivation

`fdb_consensus` and `test_fdb_timestamp_oracle` were `#[ignore]`'d because they timed out sporadically (nextest terminated them at 180s).

Fixes database-issues#10076
Closes DB-103

### Description

The FoundationDB network can be booted once per process and never restarted.
Stopping it joins the network thread, which can block indefinitely when a `Database` or in-flight transaction is still alive; `fdb_consensus` called `shutdown_network()` while its `Database` was still in scope.
Conversely, skipping the shutdown lets the process tear down with the network thread still running, which segfaults the client.
Under nextest each test runs in its own process and each of these crates has a single network-using test, so booting once and shutting down once per process is correct.

Re-enable both tests and tear down cleanly:

* Drop all `Database` handles before calling `shutdown_network()`, so the network thread join does not block. `fdb_consensus` now drops its handle first; the oracle's handles are already dropped by the time it shuts down.
* Correct the `init_network` / `shutdown_network` documentation: boot once, drop handles, then shut down before exit.
* A 60s default transaction timeout on the database, applied only in tests, so a genuinely unresponsive server surfaces a prompt `transaction_timed_out` error instead of hanging. Production behavior is unchanged.
* `retries = 2` on both tests, so a transient stall reruns rather than failing the build.

### Verification

The flake is sporadic and load-dependent, so CI across repeated runs is the verification surface.
