### PR TITLE
SS-308 Re-enable old tests hurt by the drop/recreate bug

### DIFF
--- a/test/mysql-cdc-old-syntax/25-schema-changes.td
+++ b/test/mysql-cdc-old-syntax/25-schema-changes.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Reenable when https://linear.app/materializeinc/issue/SS-308 is fixed
-$ skip-if
-SELECT true
-
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 
 

--- a/test/mysql-cdc-old-syntax/alter-column-irrelevant.td
+++ b/test/mysql-cdc-old-syntax/alter-column-irrelevant.td
@@ -9,10 +9,6 @@
 
 $ set-sql-timeout duration=1s
 
-# TODO: Reenable when https://linear.app/materializeinc/issue/SS-308 is fixed
-$ skip-if
-SELECT true
-
 #
 # Test ALTER TABLE -- some column changes should not do any harm
 #

--- a/test/mysql-cdc-old-syntax/alter-source.td
+++ b/test/mysql-cdc-old-syntax/alter-source.td
@@ -45,10 +45,6 @@ $ mysql-execute name=mysql
 CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_a VALUES (9, 'nine');
 
-# TODO: Reenable when https://linear.app/materializeinc/issue/SS-308 is fixed
-$ skip-if
-SELECT true
-
 ! SELECT * FROM table_a;
 contains:table was dropped
 

--- a/test/mysql-cdc/25-schema-changes.td
+++ b/test/mysql-cdc/25-schema-changes.td
@@ -123,8 +123,9 @@ $ mysql-execute name=mysql
 ALTER TABLE reorder_column MODIFY f1 INT AFTER f2;
 INSERT INTO reorder_column VALUES (20, 10);
 
-! SELECT * from reorder_column;
-contains:incompatible schema change
+> SELECT * from reorder_column;
+1 2
+10 20
 
 > DROP SOURCE mz_source CASCADE;
 

--- a/test/mysql-cdc/25-schema-changes.td
+++ b/test/mysql-cdc/25-schema-changes.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Reenable when https://linear.app/materializeinc/issue/SS-308 is fixed
-$ skip-if
-SELECT true
-
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 
 

--- a/test/mysql-cdc/alter-column-irrelevant.td
+++ b/test/mysql-cdc/alter-column-irrelevant.td
@@ -9,10 +9,6 @@
 
 $ set-sql-timeout duration=1s
 
-# TODO: Reenable when https://linear.app/materializeinc/issue/SS-308 is fixed
-$ skip-if
-SELECT true
-
 #
 # Test ALTER TABLE -- some column changes should not do any harm
 #

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -47,10 +47,6 @@ $ mysql-execute name=mysql
 CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_a VALUES (9, 'nine');
 
-# TODO: Reenable when https://linear.app/materializeinc/issue/SS-308 is fixed
-$ skip-if
-SELECT true
-
 ! SELECT * FROM table_a;
 contains:table was dropped
 

--- a/test/mysql-cdc/move-table.td
+++ b/test/mysql-cdc/move-table.td
@@ -9,10 +9,6 @@
 
 $ set-sql-timeout duration=1s
 
-# TODO: Reenable when https://linear.app/materializeinc/issue/SS-308 is fixed
-$ skip-if
-SELECT true
-
 #
 # Test move table
 #


### PR DESCRIPTION
### Motivation
I recently fixed this mysql drop/create bug: https://linear.app/materializeinc/issue/SS-104/mysql-drop-create-data-corruption. 

This matches the same description as this old issue here: https://github.com/MaterializeInc/database-issues/issues/8127. 

A lot of tests have been disabled because of this issue, so thought it would be cool to re-enable them.

Closes [SS-308](https://linear.app/materializeinc/issue/SS-308/mysql-alter-sourcetd491-error-query-succeeded-but-expected-error)
Closes https://github.com/MaterializeInc/database-issues/issues/8127.

### Description
Re-enables testdrive tests disabled due to mysql drop/create bug.

I'm intentionally skipping re-enabling one mention of this issue that's in a postgres test because it likely wasn't fixed by this fix.
