### PR TITLE
ci: correct stale homebrew-crosstools self-hosted runner docs

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -139,30 +139,6 @@ recent macOS versions.
 The agent runs as the default MacStadium `administrator` user, since there isn't
 an easy way to isolate builds on macOS.
 
-The GitHub Actions runner also needs to be installed for CI on
-[MaterializeInc/homebrew-crosstools]. Running two separate CI agents on the same
-machine is not ideal, as both Buildkite and GitHub Actions might schedule jobs
-on the same agent concurrently. But homebrew-crosstools is not active enough to
-warrant its own dedicated agent; nor is it easy to run CI for a Homebrew tap on
-Buildkite. Homebrew's CI tooling is very tightly coupled to GitHub Actions.
-
-To configure a GitHub Actions agent:
-
-1. Follow the instructions for creating a self-hosted runner in our GitHub
-   Enterprise account: https://github.com/enterprises/materializeinc/settings/actions/runners/new
-
-2. Run `./config.sh` and follow the interactive configuration prompts, applying
-   the label `macos-x86_64` or `macos-aarch64` depending on the platform.
-
-3. Skip the step that says `run.sh` and run `./svc.sh install && ./svc.sh start`
-   instead to install a launchd configuration that automatically starts the
-   GitHub Actions agent on boot.
-
-4. On ARM, the service needs to run under Rosetta until [actions/runner#805]
-   is resolved. Prefix the calls to `config.sh` and `svc.sh` with `arch -x86_64`
-   to accomplish this, as in `arch -x86_64 ./config.sh`.
-
-
 ## Agent security
 
 Unlike builds on a CI platform where hardware is provided, like Travis CI or
@@ -323,7 +299,5 @@ $ gdb -p <FAULTY-PROCESS-PID>
 [Docker Compose]: https://docs.docker.com/compose/
 [MacStadium]: https://www.macstadium.com
 [materialized-docker]: https://hub.docker.com/repository/docker/materialize/materialized
-[MaterializeInc/homebrew-crosstools]: https://github.com/MaterializeInc/homebrew-crosstools
 [materializer GitHub user]: https://github.com/materializer
-[actions/runner#805]: https://github.com/actions/runner/issues/805
 [elastic-yml]: https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.yml


### PR DESCRIPTION
Removes stale macOS-agent docs claiming a self-hosted GitHub Actions runner must run on the MacStadium box for [`homebrew-crosstools`](https://github.com/MaterializeInc/homebrew-crosstools) CI. That CI is GitHub-hosted (`macos-15` + `ubuntu-latest`) with no dependency on that machine, so the section (and its now-unused link refs) is just outdated clutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)