### PR TITLE
ci: trial Buildkite-hosted macOS runner in parallel (DRAFT)

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -220,6 +220,39 @@ steps:
         coverage: skip
         sanitizer: skip
 
+      # DRAFT: trial the Buildkite-hosted macOS runner alongside the MacStadium
+      # agent above. Mirrors lint-macos but targets the hosted queue and is
+      # soft_fail, so it validates the hosted runner without ever gating merges.
+      # Scoped to `main` to bound cost during the trial -- broaden (drop the
+      # `branches` key or gate on a label) once we're happy. Requires a hosted
+      # macOS queue keyed `mac-aarch64-hosted` in Buildkite (UI; see PR desc).
+      # Hosted agents are ephemeral and ship no Rust toolchain, so we install it
+      # at job start (no disk-cleanup hack needed -- the VM is destroyed after).
+      - id: lint-macos-hosted
+        label: ":rust: macOS Clippy (Buildkite hosted, trial)"
+        command: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          source "$$HOME/.cargo/env"
+          rustup component add clippy
+          brew install --quiet cmake
+          cargo clippy --all-targets -- -D warnings
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTUP_TOOLCHAIN: $RUST_VERSION
+        inputs:
+          - Cargo.lock
+          - Cargo.toml
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        depends_on: []
+        timeout_in_minutes: 45
+        branches: main
+        agents:
+          queue: mac-aarch64-hosted
+        soft_fail: true
+        coverage: skip
+        sanitizer: skip
+
       - id: lint-deps
         label: Lint dependencies
         command: bin/ci-builder run stable ci/test/lint-deps.sh


### PR DESCRIPTION
Stands up a Buildkite-hosted macOS runner **in parallel** with the MacStadium agent so we can validate it before cutting over.

## This PR
Adds a `soft_fail` `lint-macos-hosted` Clippy step mirroring the existing MacStadium `lint-macos`, but on a hosted queue (`mac-aarch64-hosted`):
- **soft_fail** → validates the hosted runner without ever gating merges.
- **`branches: main`** → bounds trial cost (hosted Mac is per-minute); broaden once happy.
- Installs rustup + clippy + cmake at job start (hosted VMs are ephemeral and ship no Rust toolchain; no disk-cleanup hack needed).

## Requires a manual Buildkite step (not codeable here)
Create a hosted **macOS** queue keyed **`mac-aarch64-hosted`** in the Buildkite cluster UI (pick the macOS/Xcode shape). That's the actual "runner" — see the gap below.

## ⚠️ Gap: Buildkite cluster/queue config is not managed as code
Today i2 manages the **compute** (elastic-ci-stack on EC2, the Hetzner autoscaler), but **Buildkite clusters, queues, hosted agents, and the agent/queue tags are configured only in the Buildkite UI** — including the existing MacStadium agent. So the hosted-Mac queue this PR targets must be hand-created, and there's no source-of-truth or review for queue changes.

**Proposed plan (separate from this trial):**
1. **Adopt Buildkite-as-code** via the [Buildkite Terraform provider](https://registry.terraform.io/providers/buildkite/buildkite/latest) (or `pulumi-buildkite`) in i2 — declare clusters + queues (incl. the hosted macOS queue) with the API token in Secrets Manager, matching how we handle the Hetzner token.
2. **Codify the queue→shape mapping** so hosted-agent shapes/macOS versions are reviewed, not UI-clicked.
3. **Migration sequence**: trial here (lint only) → move `ci/test` macOS build → move the `deploy_mz*` release builds once `MACOSX_DEPLOYMENT_TARGET` is confirmed against the support matrix → retire MacStadium (nothing else depends on it; the homebrew-crosstools runner is already GitHub-hosted, see #37146).

## Open questions
- Cache tuning (cargo registry/target on a hosted cache volume) — deferred; first prove functionality.
- Confirm a hosted macOS image satisfies the deploy-binary min-OS target before migrating deploys (lint is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)