### PR TITLE
adapter: derive replica-scoped override push from catalog implications

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -117,6 +117,7 @@ use mz_controller::clusters::{
 };
 use mz_controller::{ControllerConfig, Readiness};
 use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
+use mz_dyncfg::ConfigUpdates;
 use mz_expr::{MapFilterProject, MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_license_keys::{ExpirationBehavior, ValidatedLicenseKey};
 use mz_orchestrator::OfflineReason;
@@ -2013,6 +2014,76 @@ pub struct Coordinator {
 }
 
 impl Coordinator {
+    /// Resolves the replica-local scoped overrides from the catalog working copy
+    /// into the compute controller's per-replica dyncfg layer, then re-pushes
+    /// the environment-wide compute configuration so replicas observe the new
+    /// values. Driven by the catalog implication for replica-scoped
+    /// configuration changes, and called once on bootstrap.
+    pub(crate) fn push_replica_dyncfg_overrides(&mut self) {
+        // Clone the (sparse) replica overrides so we don't hold a catalog borrow
+        // across the mutable controller calls below.
+        let replica_overrides = self
+            .catalog()
+            .state()
+            .scoped_system_parameters()
+            .replica
+            .clone();
+
+        let dyncfgs = self.catalog().system_config().dyncfgs();
+        let mut instance_overrides: BTreeMap<
+            ComputeInstanceId,
+            BTreeMap<ReplicaId, ConfigUpdates>,
+        > = BTreeMap::new();
+        for cluster in self.catalog().clusters() {
+            for replica in cluster.replicas() {
+                let Some(values) = replica_overrides.get(&replica.replica_id) else {
+                    continue;
+                };
+                let mut updates = ConfigUpdates::default();
+                for (name, value) in values {
+                    let Some(entry) = dyncfgs.entry(name) else {
+                        // A replica-local parameter that is not a dyncfg has no
+                        // per-replica realization, so skip it.
+                        continue;
+                    };
+                    match entry.parse_val(value) {
+                        Ok(val) => updates.add_dynamic(name, val),
+                        Err(e) => {
+                            tracing::warn!(%name, %value, "cannot parse scoped override: {e}")
+                        }
+                    }
+                }
+                if !updates.updates.is_empty() {
+                    instance_overrides
+                        .entry(cluster.id)
+                        .or_default()
+                        .insert(replica.replica_id, updates);
+                }
+            }
+        }
+
+        // Only the compute controller's per-replica dyncfg layer is pushed, but on
+        // `clusterd` that also reaches storage. Compute and storage share one
+        // process, and the compute worker's `handle_update_configuration` applies
+        // the pushed dyncfg updates both to compute's own worker `ConfigSet` and to
+        // the shared persist client `ConfigSet` (`persist_clients.cfg()`) that the
+        // co-located storage server reads from the same `Arc`. So persist-backed and
+        // process-global replica-local configs such as the persist pager, LZ4,
+        // persist client tuning, and `lgalloc` take effect on storage too. The only
+        // gap would be a future `Replica`-scoped config realized solely in the
+        // storage worker's own `ConfigSet`, of which none exists today.
+        self.controller
+            .compute
+            .update_replica_dyncfg_overrides(instance_overrides);
+        // Re-push the env-wide compute config so existing replicas pick up their
+        // (possibly changed) overrides. This also reverts a removed override: the
+        // per-replica layer no longer carries the key, so the replica falls back
+        // to the env-wide value, which `compute_config` always includes because it
+        // renders the full dyncfg set.
+        let compute_config = crate::flags::compute_config(self.catalog().system_config());
+        self.controller.compute.update_configuration(compute_config);
+    }
+
     /// Initializes coordinator state based on the contained catalog. Must be
     /// called after creating the coordinator and before calling the
     /// `Coordinator::serve` method.
@@ -2131,6 +2202,19 @@ impl Coordinator {
                 )?;
             }
         }
+
+        // Now that the compute instances and their replicas exist, push the
+        // replica-local scoped overrides into the compute controller so existing
+        // replicas observe them at startup. The scoped (per-cluster and
+        // per-replica) working copy was restored from the durable cache into
+        // `CatalogState` while opening the catalog, so the last-known values are
+        // in effect before the first parameter sync and through a sync outage.
+        // This must run after the creation loop above: the push iterates the
+        // controller's instances, so before they exist it is a no-op. It also
+        // runs before dataflows are rendered later in bootstrap, so render-frozen
+        // replica flags take effect. The cluster-coherent layer is read at plan
+        // time.
+        self.push_replica_dyncfg_overrides();
 
         info!(
             "startup: coordinator init: bootstrap: preamble complete in {:?}",

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -98,6 +98,10 @@ impl Coordinator {
         // need Altered support.
         let mut introspection_source_indexes: BTreeMap<ClusterId, BTreeMap<LogVariant, GlobalId>> =
             BTreeMap::new();
+        // Whether any replica-scoped system-parameter override changed in this
+        // batch. The push re-pushes the complete per-replica dyncfg layer, so we
+        // only track that a change happened, not the individual rows.
+        let mut replica_scoped_config_changed = false;
 
         for update in catalog_updates {
             tracing::trace!(?update, "got parsed state update");
@@ -159,6 +163,12 @@ impl Coordinator {
                     // Retractions don't need handling: introspection
                     // source indexes are dropped with their cluster.
                 }
+                ParsedStateUpdateKind::ReplicaSystemConfiguration { durable: _ } => {
+                    // Additions and retractions both re-derive the full
+                    // per-replica layer from the working copy, so the diff sign
+                    // does not matter here.
+                    replica_scoped_config_changed = true;
+                }
             }
         }
 
@@ -168,6 +178,7 @@ impl Coordinator {
             cluster_commands.into_iter().collect_vec(),
             cluster_replica_commands.into_iter().collect_vec(),
             introspection_source_indexes,
+            replica_scoped_config_changed,
         )
         .await?;
 
@@ -186,6 +197,7 @@ impl Coordinator {
         cluster_commands: Vec<(ClusterId, CatalogImplication)>,
         cluster_replica_commands: Vec<((ClusterId, ReplicaId), CatalogImplication)>,
         mut introspection_source_indexes: BTreeMap<ClusterId, BTreeMap<LogVariant, GlobalId>>,
+        replica_scoped_config_changed: bool,
     ) -> Result<(), AdapterError> {
         let mut tables_to_drop = BTreeSet::new();
         let mut sources_to_drop = vec![];
@@ -618,6 +630,16 @@ impl Coordinator {
                     );
                 }
             }
+        }
+
+        // Apply replica-scoped overrides after clusters are created (so their
+        // compute instances exist) but before replicas are created below. The
+        // override layer must be set before `create_replica`, so the new
+        // replica's first configuration replays with its override. The push
+        // reads the catalog working copy, which already reflects this
+        // transaction's scoped-config changes.
+        if replica_scoped_config_changed {
+            self.push_replica_dyncfg_overrides();
         }
 
         for ((cluster_id, replica_id), command) in cluster_replica_commands {
@@ -1825,6 +1847,11 @@ impl CatalogImplication {
                 // separately in apply_catalog_implications and not
                 // routed through absorb.
                 unreachable!("IntrospectionSourceIndex should not be passed to absorb");
+            }
+            ParsedStateUpdateKind::ReplicaSystemConfiguration { .. } => {
+                // ReplicaSystemConfiguration updates are collected separately in
+                // apply_catalog_implications and not routed through absorb.
+                unreachable!("ReplicaSystemConfiguration should not be passed to absorb");
             }
         }
     }

--- a/src/adapter/src/coord/catalog_implications/parsed_state_updates.rs
+++ b/src/adapter/src/coord/catalog_implications/parsed_state_updates.rs
@@ -64,6 +64,13 @@ pub enum ParsedStateUpdateKind {
         log: LogVariant,
         index_id: GlobalId,
     },
+    /// A replica-scoped system-parameter override changed. The implication
+    /// re-pushes the complete per-replica dyncfg layer from the catalog working
+    /// copy, so it does not consume `durable`. We keep the row only so it shows
+    /// up in the `tracing::trace!` of the parsed update.
+    ReplicaSystemConfiguration {
+        durable: durable::objects::ReplicaSystemConfiguration,
+    },
 }
 
 /// Potentially generate a [ParsedStateUpdate] that corresponds to the given
@@ -98,9 +105,14 @@ pub fn parse_state_update(
         StateUpdateKind::IntrospectionSourceIndex(isi) => {
             Some(parse_introspection_source_index_update(isi))
         }
+        StateUpdateKind::ReplicaSystemConfiguration(durable) => {
+            Some(ParsedStateUpdateKind::ReplicaSystemConfiguration { durable })
+        }
         _ => {
             // The controllers are currently not interested in other kinds of
-            // changes to the catalog.
+            // changes to the catalog. Cluster-scoped system-parameter overrides
+            // are read at plan time and have no controller effect, so they stay
+            // here too.
             None
         }
     };
@@ -208,5 +220,44 @@ fn parse_cluster_replica_update(
     ParsedStateUpdateKind::ClusterReplica {
         durable_cluster_replica,
         parsed_cluster_replica: parsed_cluster_replica.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_catalog::durable::objects::ReplicaSystemConfiguration;
+    use mz_catalog::memory::objects::{StateDiff, StateUpdate, StateUpdateKind};
+    use mz_controller_types::ReplicaId;
+    use mz_repr::Timestamp;
+
+    use crate::catalog::Catalog;
+
+    use super::{ParsedStateUpdateKind, parse_state_update};
+
+    /// A replica-scoped system-parameter change must produce a parsed update so
+    /// the controller push fires. It was previously dropped as a change the
+    /// controllers were not interested in.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function on OS `linux`
+    async fn replica_system_configuration_is_parsed() {
+        Catalog::with_debug(|catalog| async move {
+            let durable = ReplicaSystemConfiguration {
+                replica_id: ReplicaId::User(1),
+                name: "persist_pager".to_string(),
+                value: "on".to_string(),
+            };
+            let update = StateUpdate {
+                kind: StateUpdateKind::ReplicaSystemConfiguration(durable),
+                ts: Timestamp::MIN,
+                diff: StateDiff::Addition,
+            };
+            let parsed = parse_state_update(catalog.state(), update)
+                .expect("replica system configuration must produce a parsed update");
+            assert!(matches!(
+                parsed.kind,
+                ParsedStateUpdateKind::ReplicaSystemConfiguration { .. }
+            ));
+        })
+        .await
     }
 }


### PR DESCRIPTION
### Motivation

Scoped feature flags need the per-replica controller push to be *derived from**<br>**the committed catalog diff* rather than issued as a side effect in the<br>sequencer. Deriving it removes the working-copy/controller divergence that lets<br>a create-time replica override be wiped by a reconcile in the same DDL, and it<br>makes the push fire for a follower `environmentd` that only replays the catalog<br>diff. This is the pattern the catalog-implications framework ([#29673](<https://github.com/MaterializeInc/materialize/issues/29673>),<br>`TODO(aljoscha)`) exists to provide, which until now ignored config-type<br>changes.

### Description

`parse_state_update` no longer drops `ReplicaSystemConfiguration` updates; it<br>emits a `ParsedStateUpdateKind::ReplicaSystemConfiguration`. When such an update<br>is present in a transaction, `apply_catalog_implications` rebuilds the complete<br>per-replica compute dyncfg layer from the catalog working copy and pushes it<br>after clusters are created and before replicas are created, so a new replica's<br>first configuration replays with its override. The same push runs once on<br>bootstrap from the restored working copy.

Because the push reads the working copy that the same transaction's catalog<br>apply has already updated, the diff drives the push. The push mechanism<br>(`push_replica_dynogcfg_overrides`) lives here. Cluster-scoped overrides are read<br>at plan time and have no controller effect, so they remain unparsed.

This is the foundation under MaterializeInc/materialize#36959, which adds the writers that drive the<br>implication; the implication is dormant until that PR lands on top.

### Verification

Adds a unit test asserting a `ReplicaSystemConfiguration` update is parsed<br>rather than dropped. End-to-end controller behavior is covered by the<br>LaunchDarkly mzcompose test in MaterializeInc/materialize#36959.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_01FUorxx5m6B8TT2VAek2STo](<https://claude.ai/code/session_01FUorxx5m6B8TT2VAek2STo>)