### PR TITLE
persist: tuned Postgres queries with READ COMMITTED isolation

### DIFF
--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -12,6 +12,7 @@
 use std::fmt::Formatter;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::anyhow;
@@ -27,7 +28,9 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::url::SensitiveUrl;
 use mz_postgres_client::metrics::PostgresClientMetrics;
-use mz_postgres_client::{PostgresClient, PostgresClientConfig, PostgresClientKnobs};
+use mz_postgres_client::{
+    IsolationLevel, PostgresClient, PostgresClientConfig, PostgresClientKnobs,
+};
 use postgres_protocol::escape::escape_identifier;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::{Row, Statement};
@@ -37,6 +40,7 @@ use crate::error::Error;
 use crate::location::{CaSResult, Consensus, ExternalError, ResultStream, SeqNo, VersionedData};
 
 /// Flag to use concensus queries that are tuned for vanilla Postgres.
+/// This flag is a no-op when connecting to a CockroachDB backend.
 pub const USE_POSTGRES_TUNED_QUERIES: mz_dyncfg::Config<bool> = mz_dyncfg::Config::new(
     "persist_use_postgres_tuned_queries",
     false,
@@ -146,12 +150,6 @@ pub struct PostgresConsensusConfig {
     knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
     dyncfg: Arc<ConfigSet>,
-}
-
-impl From<PostgresConsensusConfig> for PostgresClientConfig {
-    fn from(config: PostgresConsensusConfig) -> Self {
-        PostgresClientConfig::new(config.url, config.knobs, config.metrics)
-    }
 }
 
 impl PostgresConsensusConfig {
@@ -284,7 +282,25 @@ impl PostgresConsensus {
         );
 
         let dyncfg = Arc::clone(&config.dyncfg);
-        let postgres_client = PostgresClient::open(config.into())?;
+
+        // Filled in below once we've detected the backend. The isolation resolver runs per
+        // connection, so the flag takes effect as the pool cycles connections.
+        let is_pg_backend = Arc::new(AtomicBool::new(false));
+        let client_config = PostgresClientConfig::new(config.url, config.knobs, config.metrics)
+            .with_isolation(Arc::new({
+                let dyncfg = Arc::clone(&dyncfg);
+                let is_pg_backend = Arc::clone(&is_pg_backend);
+                move || {
+                    let flag_enabled = USE_POSTGRES_TUNED_QUERIES.get(&dyncfg);
+                    let is_pg_backend = is_pg_backend.load(Ordering::Relaxed);
+                    if flag_enabled && is_pg_backend {
+                        IsolationLevel::ReadCommitted
+                    } else {
+                        IsolationLevel::Serializable
+                    }
+                }
+            }));
+        let postgres_client = PostgresClient::open(client_config)?;
 
         let client = postgres_client.get_connection().await?;
 
@@ -319,8 +335,12 @@ impl PostgresConsensus {
             Err(e) => return Err(e.into()),
         };
 
-        if mode != PostgresMode::CockroachDB {
-            pg_batch_execute(&client, &format!("{}; {};", create_schema, SCHEMA)).await?;
+        match mode {
+            PostgresMode::CockroachDB => {}
+            PostgresMode::Postgres => {
+                is_pg_backend.store(true, Ordering::Relaxed);
+                pg_batch_execute(&client, &format!("{}; {};", create_schema, SCHEMA)).await?;
+            }
         }
 
         Ok(PostgresConsensus {
@@ -422,71 +442,181 @@ impl Consensus for PostgresConsensus {
     ) -> Result<CaSResult, ExternalError> {
         let expected = new.seqno.previous();
 
-        let result = if let Some(expected) = expected {
-            /// This query has been written to execute within a single
-            /// network round-trip. The insert performance has been tuned
-            /// against CockroachDB, ensuring it goes through the fast-path
-            /// 1-phase commit of CRDB. Any changes to this query should
-            /// confirm an EXPLAIN ANALYZE (VERBOSE) query plan contains
-            /// `auto commit`
-            static CRDB_CAS_QUERY: &str = "
+        let pg_tune_enabled =
+            USE_POSTGRES_TUNED_QUERIES.get(&self.dyncfg) && self.mode == PostgresMode::Postgres;
+        let result = match expected {
+            Some(expected) => {
+                /// This query has been written to execute within a single
+                /// network round-trip. The insert performance has been tuned
+                /// against CockroachDB, ensuring it goes through the fast-path
+                /// 1-phase commit of CRDB. Any changes to this query should
+                /// confirm an EXPLAIN ANALYZE (VERBOSE) query plan contains
+                /// `auto commit`
+                static CRDB_CAS_QUERY: &str = "
+                    INSERT INTO consensus (shard, sequence_number, data)
+                    SELECT $1, $2, $3
+                    WHERE (SELECT sequence_number FROM consensus
+                        WHERE shard = $1
+                        ORDER BY sequence_number DESC LIMIT 1) = $4;
+                ";
+
+                // ## Correctness argument
+                //
+                // The Postgres tuned queries run under READ COMMITTED isolation. In that mode each
+                // operation sees its own snapshot of the database and special care is needed to
+                // ensure that the observable behavior is linearizable.
+                //
+                // The whole argument rests on one invariant: with the exception of the `-1`
+                // sentinel of case 2, the live sequence numbers form a contiguous range with no
+                // gaps, whose maximum is the head. Appends only ever extend the head by one and
+                // truncation only ever removes a prefix, preserving contiguity. The cases below
+                // rely on the following equivalence:
+                //
+                //        `seqno` is the head iff `seqno` is present and `seqno+1` is absent.
+                //
+                // A client performs CaS operations at a seqno one above the seqno it has already
+                // observed, unless it is initializing the shard for the first time, in which case it
+                // does a plain insert. The two scenarios are analyzed separately:
+                //
+                // 1. CaS for `expected_seqno+1` issued after `expected_seqno` was observed
+                //
+                // Because `expected_seqno` was observed, the consensus table must have contained a
+                // row with it at some point, the `expected_row`.
+                //
+                // The first operation of the CaS query is to find `expected_row` and lock it with
+                // a `FOR KEY SHARE` lock. The `expected_row` may or may not still exist, depending on
+                // how outdated the client is. If `expected_seqno` is the current head the row is
+                // guaranteed to exist, since truncation never deletes the head. This gives two cases:
+                //
+                // 1.1. `expected_row` exists
+                //
+                // The INSERT is the linearization point of this CaS, and it commits a row iff
+                // `expected_seqno` is the head at the instant the INSERT runs. The held lock keeps
+                // `expected_seqno` present at that instant (see 1.1.3). By contiguity it is then
+                // the head iff `expected_seqno+1` is absent. This is exactly what the PRIMARY KEY
+                // tests as the INSERT tries to write `expected_seqno+1` (`$2`). So the INSERT
+                // writes one row and the call returns Committed (advancing the head to
+                // `expected_seqno+1`, the range still contiguous) precisely when `expected_seqno`
+                // was the head; otherwise the PK raises `unique_violation` and the call returns
+                // ExpectationMismatch with the table unchanged. The remaining obligation is that
+                // operations interleaving between the lock and the INSERT cannot break this. There
+                // are three cases:
+                //
+                // 1.1.1 Another CaS has taken its own `expected_row_2` lock but not inserted yet.
+                //
+                // `FOR KEY SHARE` is shared, so the two locks neither block each other nor wait:
+                // locks never serialize appenders, the PRIMARY KEY does. Having only locked, the
+                // other CaS has not changed the table, so it does not affect what this INSERT
+                // observes. If it is racing for the same head (`expected_row_2 == expected_row`) both
+                // appenders attempt to INSERT the same `expected_seqno+1`, and the PK admits exactly
+                // one. Whichever INSERT commits first is linearized first and becomes the head; the
+                // other then finds `expected_seqno+1` present and is rejected — case 1.1.2 from its
+                // side.
+                //
+                // 1.1.2 Another CaS has performed its `expected_seqno+1` insertion.
+                //
+                // By contiguity an append always targets head+1, so the only insertion that can
+                // affect this one is `expected_seqno+1` itself: nothing above it can be added while
+                // `expected_seqno+1` is still absent. If such an insert commits first, then
+                // `expected_seqno` is no longer the head, and this INSERT now finds `expected_seqno+1`
+                // present and is rejected by the PK → ExpectationMismatch. That is correct: this CaS
+                // is linearized after the other appender, and at that point it must fail.
+                //
+                // 1.1.3 A truncation has happened.
+                //
+                // A truncation deletes a prefix `[0, cut)` and never the head. Its DELETE takes a
+                // `FOR UPDATE`-strength row lock on each row it removes, and that conflicts with the
+                // `FOR KEY SHARE` held on `expected_seqno`. So no committed truncation can have
+                // removed `expected_seqno` while that lock is held: any truncation that commits in
+                // this window has `cut <= expected_seqno` and deletes only rows strictly below
+                // `expected_seqno`. That leaves `expected_seqno` present and the presence/absence of
+                // `expected_seqno+1` untouched, so it does not change the INSERT's outcome, and
+                // removing a low prefix keeps the range contiguous. This is also why, once locked,
+                // `expected_row` is still present at INSERT time, closing the "lock found a row, then
+                // it was GC'd before the INSERT" hole.
+                //
+                // 1.2. `expected_row` does not exist
+                //
+                // The CTE is empty, the INSERT touches zero rows, and the call returns
+                // ExpectationMismatch without modifying the table. This is correct: `expected_seqno`
+                // was observed, so it was present once, and the only way a present seqno later
+                // becomes absent is truncation (inserts never delete). A truncation that removed
+                // `expected_seqno` advanced the head strictly above it (it removes a prefix and keeps
+                // the head), so `expected_seqno` is not the head and the CaS must fail. This operation
+                // linearizes at its locking SELECT, where `expected_seqno` is already gone.
+                //
+                // 2. CaS that initializes the shard, issued with `expected` = None
+                //
+                // The init query inserts two rows in a single statement: the `-1` sentinel
+                // `($1, -1, '')` and the first real row `($1, 0, $3)`. There is no guard;
+                // correctness comes entirely from the PRIMARY KEY together with the fact that
+                // truncation never deletes the sentinel — `truncate` only removes rows with
+                // `sequence_number >= 0`. The sentinel is therefore a permanent, truncation-proof
+                // marker that the shard has ever been initialized.
+                //
+                // If the shard was never initialized neither `-1` nor `0` is present, both inserts
+                // succeed → Committed, and the head becomes `0`. If the shard was ever initialized
+                // the `-1` sentinel is still present (it can never have been truncated away), so the
+                // insert of `($1, -1, '')` hits the PRIMARY KEY → `unique_violation` →
+                // ExpectationMismatch, and nothing is written. Concurrent first-time inits are
+                // serialized by the PK on `-1`, so exactly one wins.
+                //
+                // Finally, the sentinel sits below all real data and is never the `expected_row` of
+                // an append (appends always have `expected_seqno >= 0`), so it never participates in
+                // the head test of case 1; the harmless gap it can leave below a truncated range
+                // does not affect contiguity of the real entries that case 1 reasons about.
+                static POSTGRES_CAS_QUERY: &str = "
+                WITH expected_row AS (
+                    SELECT sequence_number FROM consensus
+                    WHERE shard = $1 AND sequence_number = $4
+                    FOR KEY SHARE
+                )
                 INSERT INTO consensus (shard, sequence_number, data)
                 SELECT $1, $2, $3
-                WHERE (SELECT sequence_number FROM consensus
-                       WHERE shard = $1
-                       ORDER BY sequence_number DESC LIMIT 1) = $4;
-            ";
+                FROM expected_row;
+                ";
 
-            /// This query has been written to ensure we only get row level
-            /// locks on the `(shard, seq_no)` we're trying to update. The insert
-            /// performance has been tuned against Postgres 15 to ensure it
-            /// minimizes possible serialization conflicts.
-            static POSTGRES_CAS_QUERY: &str = "
-            WITH last_seq AS (
-                SELECT sequence_number FROM consensus
-                WHERE shard = $1
-                ORDER BY sequence_number DESC
-                LIMIT 1
-                FOR UPDATE
-            )
-            INSERT INTO consensus (shard, sequence_number, data)
-            SELECT $1, $2, $3
-            FROM last_seq
-            WHERE last_seq.sequence_number = $4;
-            ";
-
-            let q = if USE_POSTGRES_TUNED_QUERIES.get(&self.dyncfg)
-                && self.mode == PostgresMode::Postgres
-            {
-                POSTGRES_CAS_QUERY
-            } else {
-                CRDB_CAS_QUERY
-            };
-            let client = self.get_connection().await?;
-            let statement = client.prepare_cached(q).await?;
-            pg_execute_prepared(
-                &client,
-                &statement,
-                &[&key, &new.seqno, &new.data.as_ref(), &expected],
-            )
-            .await?
-        } else {
-            // Insert the new row as long as no other row exists for the same shard.
-            let q = "INSERT INTO consensus SELECT $1, $2, $3 WHERE
-                     NOT EXISTS (
-                         SELECT * FROM consensus WHERE shard = $1
-                     )
-                     ON CONFLICT DO NOTHING";
-            let client = self.get_connection().await?;
-            let statement = client.prepare_cached(q).await?;
-            pg_execute_prepared(&client, &statement, &[&key, &new.seqno, &new.data.as_ref()])
-                .await?
+                let q = if pg_tune_enabled {
+                    POSTGRES_CAS_QUERY
+                } else {
+                    CRDB_CAS_QUERY
+                };
+                let client = self.get_connection().await?;
+                let statement = client.prepare_cached(q).await?;
+                pg_execute_prepared(
+                    &client,
+                    &statement,
+                    &[&key, &new.seqno, &new.data.as_ref(), &expected],
+                )
+                .await
+            }
+            None => {
+                static CRDB_INIT_QUERY: &str = "INSERT INTO consensus SELECT $1, $2, $3 WHERE
+                    NOT EXISTS (
+                        SELECT * FROM consensus WHERE shard = $1
+                    )";
+                static POSTGRES_INIT_QUERY: &str =
+                    "INSERT INTO consensus (shard, sequence_number, data)
+                    VALUES ($1, -1, ''), ($1, $2, $3)";
+                let q = if pg_tune_enabled {
+                    POSTGRES_INIT_QUERY
+                } else {
+                    CRDB_INIT_QUERY
+                };
+                let client = self.get_connection().await?;
+                let statement = client.prepare_cached(q).await?;
+                pg_execute_prepared(&client, &statement, &[&key, &new.seqno, &new.data.as_ref()])
+                    .await
+            }
         };
 
-        if result == 1 {
-            Ok(CaSResult::Committed)
-        } else {
-            Ok(CaSResult::ExpectationMismatch)
+        match result {
+            Ok(n) if n >= 1 => Ok(CaSResult::Committed),
+            Ok(_) => Ok(CaSResult::ExpectationMismatch),
+            Err(e) if e.code() == Some(&SqlState::UNIQUE_VIOLATION) => {
+                Ok(CaSResult::ExpectationMismatch)
+            }
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -524,57 +654,19 @@ impl Consensus for PostgresConsensus {
     }
 
     async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<Option<usize>, ExternalError> {
-        static CRDB_TRUNCATE_QUERY: &str = "
+        // `sequence_number >= 0` keeps the seqno -1 sentinel (see `compare_and_set`); it is a no-op
+        // for shards that have no sentinel, since all of their seqnos are already >= 0.
+        static TRUNCATE_QUERY: &str = "
         DELETE FROM consensus
-        WHERE shard = $1 AND sequence_number < $2 AND
+        WHERE shard = $1 AND sequence_number >= 0 AND sequence_number < $2 AND
         EXISTS (
             SELECT * FROM consensus WHERE shard = $1 AND sequence_number >= $2
         )
         ";
 
-        /// This query has been specifically tuned to ensure we get the minimal
-        /// number of __row__ locks possible, and that it doesn't conflict with
-        /// concurrently running compare and swap operations that are trying to
-        /// evolve the shard.
-        ///
-        /// It's performance has been benchmarked against Postgres 15.
-        ///
-        /// Note: The `ORDER BY` in the newer_exists CTE exists so we obtain a
-        /// row lock on the lowest possible sequence number. This ensures
-        /// minimal conflict between concurrently running truncate and append
-        /// operations.
-        static POSTGRES_TRUNCATE_QUERY: &str = "
-        WITH newer_exists AS (
-            SELECT * FROM consensus
-            WHERE shard = $1
-                AND sequence_number >= $2
-            ORDER BY sequence_number ASC
-            LIMIT 1
-            FOR UPDATE
-        ),
-        to_lock AS (
-            SELECT ctid FROM consensus
-            WHERE shard = $1
-            AND sequence_number < $2
-            AND EXISTS (SELECT * FROM newer_exists)
-            ORDER BY sequence_number DESC
-            FOR UPDATE
-        )
-        DELETE FROM consensus
-        USING to_lock
-        WHERE consensus.ctid = to_lock.ctid;
-        ";
-
-        let q = if USE_POSTGRES_TUNED_QUERIES.get(&self.dyncfg)
-            && self.mode == PostgresMode::Postgres
-        {
-            POSTGRES_TRUNCATE_QUERY
-        } else {
-            CRDB_TRUNCATE_QUERY
-        };
         let result = {
             let client = self.get_connection().await?;
-            let statement = client.prepare_cached(q).await?;
+            let statement = client.prepare_cached(TRUNCATE_QUERY).await?;
             pg_execute_prepared(&client, &statement, &[&key, &seqno]).await?
         };
         if result == 0 {

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -66,16 +66,54 @@ pub trait PostgresClientKnobs: std::fmt::Debug + Send + Sync {
     fn statement_timeout(&self) -> Duration;
 }
 
+/// The transaction isolation level applied to new connections.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IsolationLevel {
+    /// `SERIALIZABLE` — the strongest level; the historical default for consensus.
+    Serializable,
+    /// `READ COMMITTED` — for callers (e.g. consensus) whose queries are correct without
+    /// serializable isolation (relying instead on the `PRIMARY KEY` / `FOR UPDATE` / `ON CONFLICT`).
+    ReadCommitted,
+}
+
+impl IsolationLevel {
+    /// The `SET SESSION CHARACTERISTICS` statement that selects this isolation level.
+    fn set_characteristics_sql(self) -> &'static str {
+        match self {
+            IsolationLevel::Serializable => {
+                "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE"
+            }
+            IsolationLevel::ReadCommitted => {
+                "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED"
+            }
+        }
+    }
+}
+
+/// Resolves the isolation level to apply to a connection. It is invoked once per connection
+/// creation, so a dyncfg-backed resolver lets a change take effect as the pool cycles connections.
+pub type IsolationLevelFn = Arc<dyn Fn() -> IsolationLevel + Send + Sync>;
+
 /// Configuration for creating a [PostgresClient].
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct PostgresClientConfig {
     url: SensitiveUrl,
     knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
+    isolation: IsolationLevelFn,
+}
+
+impl std::fmt::Debug for PostgresClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresClientConfig")
+            .field("url", &self.url)
+            .finish_non_exhaustive()
+    }
 }
 
 impl PostgresClientConfig {
-    /// Returns a new [PostgresClientConfig] for use in production.
+    /// Returns a new [PostgresClientConfig] for use in production. Connections default to
+    /// `SERIALIZABLE`; use [PostgresClientConfig::with_isolation] to override.
     pub fn new(
         url: SensitiveUrl,
         knobs: Arc<dyn PostgresClientKnobs>,
@@ -85,7 +123,14 @@ impl PostgresClientConfig {
             url,
             knobs,
             metrics,
+            isolation: Arc::new(|| IsolationLevel::Serializable),
         }
+    }
+
+    /// Sets the resolver that picks the isolation level applied to each new connection.
+    pub fn with_isolation(mut self, isolation: IsolationLevelFn) -> Self {
+        self.isolation = isolation;
+        self
     }
 }
 
@@ -133,6 +178,7 @@ impl PostgresClient {
         let connections_created = config.metrics.connpool_connections_created.clone();
         let ttl_reconnections = config.metrics.connpool_ttl_reconnections.clone();
         let knobs = Arc::clone(&config.knobs);
+        let isolation = Arc::clone(&config.isolation);
         let builder = Pool::builder(manager);
         let builder = match config.knobs.connection_pool_max_wait() {
             None => builder,
@@ -143,11 +189,12 @@ impl PostgresClient {
             .post_create(Hook::async_fn(move |client, _| {
                 connections_created.inc();
                 let knobs = Arc::clone(&knobs);
+                // Resolved per connection so a dyncfg-backed isolation level takes effect as the
+                // pool cycles connections. Defaults to SERIALIZABLE (see `new`).
+                let isolation = Arc::clone(&isolation);
                 Box::pin(async move {
                     debug!("opened new consensus postgres connection");
-                    let mut setup = String::from(
-                        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE",
-                    );
+                    let mut setup = isolation().set_characteristics_sql().to_owned();
                     // A zero `statement_timeout` is our sentinel for "leave it
                     // unset". We only emit the `SET` when non-zero so we don't
                     // override a timeout configured out of band.


### PR DESCRIPTION
This PR changes the mechanics of how Postgres tuned queries work in persist's consensus implementation. The new queries are able to:

* Increase throughput by at least 3x (see below)
* Avoid the throughput collapse of the SERIALIZABLE implementation

## Correctness

The way the queries interact with Postgres under READ COMMITTED and the correctness specification of the `Consensus` trait have been modeled in Lean4. In that system it was proven that any execution trace of the READ COMMITTED implementation is equivalent to an execution trace of an idealized linearizable system.

A version of the proof in prose is included as a comment in the source code.

## Performance characteristics 

Under my benchmarking the tuned queries are able to sustain **at least 3x** the throughput of the previous implementation. I say at least because I could not provision enough clusters to make the new configuration fail, so it's very likely even better.

The load test was made up of 20 clusters, each containing 600 trivial materialized views that select from an empty table. Each cluster starts with zero replicas and one by one is brought online, ramping up demand from the consensus implementation as more and more shards are written to.

These benchmarks were performed on a Materialize instance provisioned through our Terraform provider using a `db.r6g.2xlarge` RDS instance and 800cc replicas.

### READ COMMITTED results ([link to Grafana dashboard](https://snapshots.raintank.io/dashboard/snapshot/PaL74EvQIygv3s2EePGBEKbIO5aU4YQm?orgId=0&from=2026-06-25T19:29:45.000Z&to=2026-06-25T20:22:51.185Z&timezone=browser&refresh=5s))

<img width="1054" height="896" alt="image" src="https://github.com/user-attachments/assets/e8635bcb-dc65-46bd-b4c1-cb809b626c2d" />

In this screenshot we can see that the consensus implementation is able to easily follow the demanded load until the end of the experiment where it continuously sustains ~13k CaS ops/s. Anecdotally while working on these benchmarks there were situations that the sustained throughput was all the way up to 25k CaS ops/s.

The three big dips in throughput are due to the clusters not generating load versus the consensus implementation not being able to serve the demanded load. Supporting evidence for this is that during the dips we see the p99 latencies of CaS operations drop, connections being available in the connection pool, and RDS CPU dropping. The most likely explanation is that environmentd sometimes would struggle to advance the frontier of the singular table all those thousands of materialized views were reading from, stalling all the clusters.

### SERIALIZABLE results ([link to Grafana dashboard](https://snapshots.raintank.io/dashboard/snapshot/g6K99k3CBuDyJjAPk6JY9wsMzQ16Fd3a?orgId=0&from=2026-06-25T20:27:45.000Z&to=2026-06-25T20:53:47.775Z&timezone=browser&refresh=5s))

<img width="1049" height="897" alt="image" src="https://github.com/user-attachments/assets/da169fea-818a-4beb-8669-091dbadfc976" />

A very different outcome happened under the vanilla serializable queries. Here we see that the system entered a positive feedback loop at around 4.3k CaS ops/s after which throughput plummets and is unable to recover. CaS latencies skyrocket to 30 seconds and no connections are available in the connection pool. The culprit is the very large amount of SSIRead locks that are being taken, which peaked at ~100K.

I have uploaded snapshots of the grafana dashboards with the metrics here:

- [Read committed dashboard](https://snapshots.raintank.io/dashboard/snapshot/PaL74EvQIygv3s2EePGBEKbIO5aU4YQm?orgId=0&from=2026-06-25T19:29:45.000Z&to=2026-06-25T20:22:51.185Z&timezone=browser&refresh=5s)
- [Serializable dashboard](https://snapshots.raintank.io/dashboard/snapshot/g6K99k3CBuDyJjAPk6JY9wsMzQ16Fd3a?orgId=0&from=2026-06-25T20:27:45.000Z&to=2026-06-25T20:53:47.775Z&timezone=browser&refresh=5s)