### PR TITLE
expr: Don't panic in the subquery-size guard on a count of zero

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -22,7 +22,7 @@ use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
 
 use mz_ore::str::separated;
-use mz_ore::{soft_assert_eq_no_log, soft_assert_or_log, soft_panic_or_log};
+use mz_ore::{soft_assert_eq_no_log, soft_assert_or_log};
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
@@ -3595,22 +3595,19 @@ impl TableFunc {
                 generate_subscripts_array(datums[0], datums[1].unwrap_int32())
             }
             TableFunc::GuardSubquerySize { column_type: _ } => {
-                // We error if the count is not one,
-                // and produce no rows if equal to one.
+                // A subquery used as an expression may return at most one row;
+                // for 0 or 1 we emit no rows and let the subquery's own output
+                // flow through. Zero is benign, not "can't happen": constant
+                // folding can prove the body empty and fold its count to a
+                // literal `0`, which decorrelates to NULL via the outer lookup.
                 let count = datums[0].unwrap_int64();
-                if count == 1 {
-                    Ok(Box::new([].into_iter()))
-                } else if count > 1 {
+                if count > 1 {
                     Err(EvalError::MultipleRowsFromSubquery)
                 } else if count < 0 {
+                    // Would require negative multiplicities to reach the guard.
                     Err(EvalError::NegativeRowsFromSubquery)
                 } else {
-                    // This shouldn't happen because this is not an SQL `count` but an MIR `count`,
-                    // which produces no output on 0 input rows.
-                    soft_panic_or_log!("subquery counting unexpectedly produced 0");
-                    Err(EvalError::Internal(
-                        "subquery counting unexpectedly produced 0".into(),
-                    ))
+                    Ok(Box::new([].into_iter()))
                 }
             }
             TableFunc::RepeatRow => Ok(Box::new(repeat_row(datums[0]).into_iter())),
@@ -3971,3 +3968,40 @@ impl WithOrdinality {
 }
 
 pub const REPEAT_ROW_NAME: &str = "repeat_row";
+
+#[cfg(test)]
+mod tests {
+    use mz_repr::{Datum, RowArena, SqlScalarType};
+
+    use super::TableFunc;
+    use crate::EvalError;
+
+    /// 0 and 1 are valid (no guard rows), >1 errors with
+    /// `MultipleRowsFromSubquery`, <0 with `NegativeRowsFromSubquery`. Zero is
+    /// legitimate, not "can't happen": constant folding can fold an empty
+    /// subquery's count to `0`, which must not panic (regression for #37049).
+    #[mz_ore::test]
+    fn guard_subquery_size_accepts_zero_and_one() {
+        let func = TableFunc::GuardSubquerySize {
+            column_type: SqlScalarType::Int64,
+        };
+        let temp_storage = RowArena::new();
+
+        for count in [0_i64, 1] {
+            let rows = func
+                .eval(&[Datum::Int64(count)], &temp_storage)
+                .unwrap_or_else(|e| panic!("count {count} should be accepted, got {e:?}"))
+                .count();
+            assert_eq!(rows, 0, "count {count} should emit no guard rows");
+        }
+
+        assert_eq!(
+            func.eval(&[Datum::Int64(2)], &temp_storage).err(),
+            Some(EvalError::MultipleRowsFromSubquery),
+        );
+        assert_eq!(
+            func.eval(&[Datum::Int64(-1)], &temp_storage).err(),
+            Some(EvalError::NegativeRowsFromSubquery),
+        );
+    }
+}

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -919,3 +919,49 @@ query IT
 SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 END, 'TEXT';
 ----
 0  TEXT
+
+#
+# Regression: a scalar subquery whose body constant-folds to empty makes the
+# subquery-size guard see a count of 0. This used to hit a `soft_panic_or_log!`
+# ("subquery counting unexpectedly produced 0") and abort optimization; a count
+# of 0 is legitimate (the empty subquery yields NULL). Exposed by #37049, found
+# by the RQG `subqueries`/`simple-aggregates` workloads. These are the verbatim
+# failing queries; they need the RQG `simple.sql` schema (DOUBLE columns, NOT
+# NULL, materialized views), so re-create t1/t2 here.
+#
+
+statement ok
+DROP TABLE t1, t2, t3 CASCADE
+
+statement ok
+CREATE TABLE t1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL)
+
+statement ok
+INSERT INTO t1 VALUES (NULL, 0), (1, 1), (1, 1), (2, 2), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8)
+
+statement ok
+CREATE TABLE t2 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL)
+
+statement ok
+INSERT INTO t2 VALUES (NULL, 0), (NULL, 0), (1, 1), (2, 2), (2, 2), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8)
+
+statement ok
+CREATE MATERIALIZED VIEW pk1 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t1 WHERE f1 IS NOT NULL AND f2 IS NOT NULL
+
+statement ok
+CREATE MATERIALIZED VIEW pk2 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t2 WHERE f1 IS NOT NULL AND f2 IS NOT NULL
+
+query RR rowsort
+SELECT ( SELECT inner1 . f1  FROM t1 AS inner1 LEFT JOIN t2 AS inner2 ON ( inner2 . f1  = 5 ) WHERE inner2 . f2  IS  NULL AND outer1 . f1  IS NOT NULL ORDER BY 1 LIMIT 1 ) , ( SELECT inner2 . f1  FROM t1 AS inner1 LEFT JOIN t2 AS inner2 ON ( inner1 . f2 + 1 = inner2 . f1  ) WHERE inner2 . f2  = outer1 . f1  ORDER BY 1 LIMIT 0 ) FROM t1 AS outer1 RIGHT JOIN ( SELECT DISTINCT inner1 . f2  AS f1 , inner2 . f1  AS f2 FROM pk2 AS inner1 , pk2 AS inner2 WHERE inner1 . f2  IS  NULL OR inner1 . f2  = inner2 . f1  ) AS outer2 ON ( outer2 . f1 + 1  IN ( SELECT DISTINCT inner2 . f1 + 1 FROM t1 AS inner1 , t1 AS inner2 WHERE outer2 . f2 + 1 IS NOT NULL ) ) WHERE outer1 . f1  IS  NULL OR outer2 . f2  = ( SELECT inner1 . f2  FROM t1 AS inner1 LEFT JOIN t2 AS inner2 ON ( inner2 . f2  IS  NULL ) WHERE outer2 . f2 + 1 BETWEEN inner2 . f2  AND 7 OR inner2 . f1 + 1 BETWEEN 3 AND outer2 . f1 + 1 ORDER BY 1 LIMIT 1 )
+----
+NULL  NULL
+NULL  NULL
+NULL  NULL
+NULL  NULL
+NULL  NULL
+NULL  NULL
+NULL  NULL
+
+query IRIII rowsort
+SELECT DISTINCT (a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3, (MIN ( DISTINCT a1 . f1 + a1 . f2 )) AS agg1 , (SUM(LENGTH(a1 . f1::TEXT))) AS agg2 FROM (SELECT * FROM ( VALUES (1,2) ) t1 (f1,f2)) AS a1  JOIN ( SELECT a2 . f2 + a2 . f2 AS f1 , AVG (  a2 . f2 + a1 . f2 + NULLIF ( a1 . f1 , a2 . f1 ) ) AS f2 FROM pk2 AS a1  JOIN pk2 AS a2 ON ( NULLIF ( a2 . f1 , a1 . f2 ) IS  NULL ) WHERE a1 . f2  IN ( 2 , 0 ) AND a2 . f2 + a1 . f2 > a1 . f2 GROUP BY 1 ORDER BY 1 , 2 LIMIT 3 OFFSET 6 ) AS a2 ON ( a2 . f1 + a2 . f2 + a1 . f2 < a2 . f1 + a1 . f2 ) WHERE NOT ( a2 . f2  IN ( 3 , 9 ) ) OR a2 . f2 + a2 . f2  IN ( 8 , 3 , 4 ) GROUP BY 1 , 2 , 3 EXCEPT DISTINCT SELECT  (a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3, (MAX (  a1 . f2 )) AS agg1 , (ARRAY_LENGTH ( ARRAY_AGG ( a1 . f1 ), 1 )) AS agg2 FROM pk1 AS a1  JOIN ( SELECT a1 . f2 + a2 . f2 AS f1 , a2 . f2 + a1 . f1 AS f2 FROM t2 AS a1  JOIN t2 AS a2 USING ( f1 , f2 ) WHERE NOT ( NULLIF ( a1 . f2 , a1 . f2 )  IN ( 1 , 0 ) ) OR a2 . f1 IS NOT NULL OR a1 . f1 + a2 . f1 < ( SELECT  agg2 FROM ( SELECT  (a2 . f2) AS c1, (a2 . f2) AS c2, (a2 . f2 + a2 . f2) AS c3, (AVG ( a2 . f1 + a2 . f1 )) AS agg1 , (MIN (  a1 . f2 + a1 . f1 )) AS agg2 FROM t2 AS a1 LEFT JOIN ( SELECT a2 . f2 + a1 . f2 + a1 . f1 + a2 . f2 AS f1 , a2 . f2 + a1 . f2 AS f2 FROM pk1 AS a1 RIGHT JOIN pk2 AS a2 USING ( f1 ) WHERE a2 . f1 IS NOT NULL AND a2 . f2 + a2 . f2 + a2 . f1 IS  NULL ORDER BY 1 , 2 LIMIT 5  ) AS a2 ON ( NULLIF ( a1 . f2 , a1 . f2 ) = a2 . f2 ) WHERE a2 . f2 + a1 . f2 NOT IN ( 9 , 2 , 5 , 2 , 4 , 2 , 7 , 9 , 8 ) AND a1 . f2 + a1 . f1 NOT IN ( 9 , 5 ) OR NOT ( a2 . f1 IS  NULL ) OR a1 . f2 + a2 . f1  IN ( 6 , 8 , 4 ) OR NULLIF ( a2 . f2 , a1 . f1 ) IS NOT NULL AND a1 . f2 + NULLIF ( a1 . f2 , a1 . f2 ) = a2 . f1 + a1 . f2 AND a2 . f1 + a2 . f2 = a2 . f2 + a2 . f2 + NULLIF ( a1 . f2 , a1 . f2 ) AND NOT ( a1 . f2 + a2 . f2 = NULLIF ( a2 . f2 , a2 . f2 ) ) GROUP BY 1 , 2 , 3 ) AS dt ORDER BY 1 LIMIT 1 OFFSET 2 ) AND a1 . f2 + a1 . f2 + a1 . f2  IN ( 3 , 1 , 2 ) ORDER BY 1 , 2 ) AS a2 USING ( f2 ) WHERE NOT ( a1 . f1 > NULLIF ( a2 . f1 , a2 . f2 ) ) AND a2 . f2 + a2 . f2 NOT IN ( 6 , 0 ) GROUP BY 1 , 2 , 3
+----


### PR DESCRIPTION
GuardSubquerySize soft-panicked ("subquery counting unexpectedly produced 0") whenever its count was 0, assuming an MIR count never yields 0. That holds for a grouped reduce, but constant folding can prove a scalar subquery's body empty and fold its count to a literal 0, at which point the guard aborted optimization of otherwise-valid SQL.

A count of 0 is benign, the empty subquery decorrelates to NULL via the outer lookup, so treat 0 like 1.

Seen in the RQG runs in https://buildkite.com/materialize/nightly/builds/16829, caused by https://github.com/MaterializeInc/materialize/pull/37049, but the bug was pre-existing and is just showing up now. Nightly run: https://buildkite.com/materialize/nightly/builds/16837

Nightly test run: https://buildkite.com/materialize/nightly/builds/16837 (failures are unrelated)