### PR TITLE
environmentd: fix flaky test_auth_oidc_fetch_error

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -2302,21 +2302,40 @@ async fn test_auth_oidc_fetch_error() {
     .unwrap();
 
     let oidc_user = "user@example.com";
-    let issuer = oidc_server.issuer.clone();
-    // Generate a JWT while the server is still up (correct issuer, valid signature).
+    // Point the issuer at a loopback port that is guaranteed to refuse
+    // connections instead of at the mock server's just-freed ephemeral port.
+    // Under high test parallelism (`--test-threads=48`) the OS could reassign
+    // that freed port to another OIDC test's mock server before environmentd
+    // performed the discovery fetch. environmentd would then fetch a valid JWKS
+    // for the shared `kid` ("test-key-1") from the wrong server and fail JWT
+    // signature validation, so this assertion intermittently saw "failed to
+    // validate JWT" instead of the expected fetch error. Port 1 is privileged
+    // and is never bound by the ephemeral-port mock servers, so it cannot be
+    // hijacked.
+    let unreachable_issuer = "http://127.0.0.1:1";
+
+    // Mint a validly-signed JWT whose issuer matches the (unreachable)
+    // configured issuer. The mock server is only needed to sign the token; the
+    // discovery fetch fails before the signature or issuer is ever checked.
     let jwt_token = oidc_server.generate_jwt(
         oidc_user,
         GenerateJwtOptions {
+            issuer: Some(unreachable_issuer),
             ..Default::default()
         },
     );
 
-    // Stop the OIDC server so the JWKS endpoint becomes unreachable.
+    // The mock server has served its purpose; shut it down.
     oidc_server.handle.abort_and_wait().await;
 
     let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
-        .with_oidc_auth(Some(issuer), Some("sub".to_string()), None, None)
+        .with_oidc_auth(
+            Some(unreachable_issuer.to_string()),
+            Some("sub".to_string()),
+            None,
+            None,
+        )
         .start()
         .await;
 


### PR DESCRIPTION
test_auth_oidc_fetch_error aborted its OIDC mock server and then pointed environmentd's configured issuer at the server's just-freed ephemeral port, expecting the JWKS discovery fetch to fail with "failed to fetch OIDC provider configuration".

Under high test parallelism (cargo nextest --test-threads=48) the OS can hand that freed port to another OIDC test's mock server before environmentd performs the discovery fetch. Because every OIDC test shares the same hardcoded kid ("test-key-1"), find_key() then succeeds against the wrong server's JWKS and JWT signature validation fails, so the assertion intermittently observed "failed to validate JWT" instead of the expected fetch error.

Point the configured issuer at a loopback port that is guaranteed to refuse connections (127.0.0.1:1, which is privileged and never bound by the ephemeral-port mock servers), so the discovery fetch fails deterministically regardless of port reuse. The mock server is now only used to mint a validly-signed JWT whose issuer matches the configured one.

Closes SQL-412