### PR TITLE
Scoped feature flags: create-time evaluation

### DIFF
--- a/src/adapter/src/config.rs
+++ b/src/adapter/src/config.rs
@@ -30,7 +30,6 @@ pub use frontend::{
     SystemParameterFrontend,
 };
 pub use params::{ModifiedParameter, SynchronizedParameters};
-pub(crate) use sync::evaluate_scoped_parameters;
 pub use sync::system_parameter_sync;
 
 /// Scoped (per-cluster and per-replica) system-parameter overrides, keyed by

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -118,7 +118,7 @@ use mz_controller::clusters::{
 };
 use mz_controller::{ControllerConfig, Readiness};
 use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
-use mz_dyncfg::ConfigUpdates;
+use mz_dyncfg::{ConfigUpdates, ParameterScope};
 use mz_expr::{MapFilterProject, MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_license_keys::{ExpirationBehavior, ValidatedLicenseKey};
 use mz_orchestrator::OfflineReason;
@@ -185,8 +185,8 @@ use crate::catalog::{BuiltinTableUpdate, Catalog, OpenCatalogResult};
 use crate::client::{Client, Handle};
 use crate::command::{Command, ExecuteResponse};
 use crate::config::{
-    ScopedParameters, ScopedParametersScope, SynchronizedParameters, SystemParameterFrontend,
-    SystemParameterSyncConfig, evaluate_scoped_parameters,
+    ClusterEvalContext, ReplicaEvalContext, ScopedParameters, ScopedParametersScope,
+    SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig,
 };
 use crate::coord::appends::{
     BuiltinTableAppendNotify, DeferredOp, GroupCommitPermit, PendingWriteTxn,
@@ -2037,9 +2037,10 @@ impl Coordinator {
     /// Persists the scoped system-parameter working copy and reconciles it into
     /// the per-scope resolution boundaries.
     ///
-    /// The system-parameter sync loop and the create-time resolve
-    /// (`resolve_scoped_for_new_objects`) are the only writers, both serialized
-    /// on the coordinator loop. The diff is persisted to the
+    /// The system-parameter sync loop and the create-time fold
+    /// (`scoped_overrides_create_op`, folded into the create transaction) are the
+    /// only writers, both serialized on the coordinator loop. The diff is
+    /// persisted to the
     /// durable cache (so values survive an `environmentd` restart and an LD
     /// outage) via `Op::UpdateScopedSystemParameters`, which also updates the
     /// in-memory working copy in [`CatalogState`] and the
@@ -2064,7 +2065,7 @@ impl Coordinator {
 
         // Persist the diff and update the in-memory working copy + introspection
         // through the catalog transaction, serialized on the coordinator loop
-        // with the create-time resolve. The replica-scoped
+        // with the create-time fold. The replica-scoped
         // controller push is derived from this transaction's diff by the catalog
         // implication. `prune_scope` bounds removals to the evaluated objects, so
         // a concurrently-created object's override is not wiped. Best-effort: a
@@ -2083,52 +2084,75 @@ impl Coordinator {
         }
     }
 
-    /// Synchronously resolves the scoped overrides for the given freshly-created
-    /// clusters and replicas and folds them into the working copy, so a new
-    /// object observes its overrides immediately, before its first plan
-    /// (cluster-coherent) or first controller configuration (replica-local),
-    /// rather than after the next sync tick. Render-frozen flags (optimizer
-    /// features baked into an immutable dataflow) make the tick-latency window a
-    /// correctness problem, not just a delay, which is why this exists.
+    /// Evaluates the scoped overrides for freshly-created objects from explicit
+    /// eval contexts and returns an [`Op::UpdateScopedSystemParameters`] to fold
+    /// into the same transaction that creates them.
     ///
-    /// No-op when the feature is gated off or the shared frontend is not yet
-    /// installed (e.g. before LaunchDarkly connects), in which case the object
-    /// resolves to the environment-wide value, the cold-cache fallback. The
-    /// periodic sync loop remains the authoritative full-state reconciler.
-    pub(crate) async fn resolve_scoped_for_new_objects(
-        &mut self,
-        clusters: &BTreeSet<ClusterId>,
-        replicas: &BTreeSet<ReplicaId>,
-    ) {
-        if clusters.is_empty() && replicas.is_empty() {
-            return;
-        }
-        let Some(frontend) = self.scoped_frontend.clone() else {
-            return;
-        };
+    /// The objects are not yet in the catalog, so the contexts are built from
+    /// plan data and pre-allocated ids. Folding the op into the create
+    /// transaction makes its committed diff drive the replica-scoped controller
+    /// push, as a catalog implication, before `create_replica`. A new replica's
+    /// first configuration then carries its overrides rather than the env-wide
+    /// values. Render-frozen flags (e.g. the column-paged batcher, chosen at
+    /// arrangement-build time) make a later push too late, which is why this
+    /// happens in the create transaction rather than the next sync tick.
+    ///
+    /// Returns `None` when the feature is gated off, the shared frontend is not
+    /// yet installed (e.g. before LaunchDarkly connects), or no override
+    /// applies. The new objects then resolve to the environment-wide value, and
+    /// the periodic sync loop remains the authoritative full-state reconciler.
+    ///
+    /// [`Op::UpdateScopedSystemParameters`]: crate::catalog::Op::UpdateScopedSystemParameters
+    fn scoped_overrides_create_op(
+        &self,
+        clusters: &[ClusterEvalContext],
+        replicas: &[ReplicaEvalContext],
+    ) -> Option<crate::catalog::Op> {
+        let frontend = self.scoped_frontend.clone()?;
         let catalog = self.catalog();
-        if !ENABLE_SCOPED_SYSTEM_PARAMETERS.get(catalog.system_config().dyncfgs()) {
-            return;
+        let system_config = catalog.system_config();
+        if !ENABLE_SCOPED_SYSTEM_PARAMETERS.get(system_config.dyncfgs()) {
+            return None;
         }
 
-        // Evaluate only the new objects, then merge onto the current working copy
-        // so reconcile keeps the overrides of objects it did not re-evaluate.
-        let params = SynchronizedParameters::new(catalog.system_config().clone());
-        let evaluated =
-            evaluate_scoped_parameters(&frontend, &params, catalog, Some(clusters), Some(replicas));
-        let merged = catalog.state().scoped_system_parameters().merge(&evaluated);
-        // This runs synchronously after the create transaction, so the catalog
-        // already reflects the new objects. The merged state is authoritative
-        // for all live objects, so prune within them.
+        // Partition the synced parameters by scope class, as the sync loop does,
+        // so we evaluate exactly the flags in use at each scope.
+        let replica_param_names: Vec<&'static str> = system_config
+            .iter_synced()
+            .filter(|var| var.scope() == ParameterScope::Replica)
+            .map(|var| var.name())
+            .collect();
+        let cluster_param_names: Vec<&'static str> = system_config
+            .iter_synced()
+            .filter(|var| var.scope() == ParameterScope::Cluster)
+            .map(|var| var.name())
+            .collect();
+
+        let params = SynchronizedParameters::new(system_config.clone());
+        let mut evaluated = ScopedParameters::default();
+        if !cluster_param_names.is_empty() && !clusters.is_empty() {
+            evaluated.cluster =
+                frontend.pull_cluster_overrides(&params, &cluster_param_names, clusters);
+        }
+        if !replica_param_names.is_empty() && !replicas.is_empty() {
+            evaluated.replica =
+                frontend.pull_replica_overrides(&params, &replica_param_names, replicas);
+        }
+        if evaluated.is_empty() {
+            return None;
+        }
+
+        // Prune only within the objects being created. They have no prior rows,
+        // so nothing is removed, and this op never touches another object whose
+        // override a concurrent reconcile may be writing.
         let prune_scope = ScopedParametersScope {
-            clusters: catalog.clusters().map(|cluster| cluster.id).collect(),
-            replicas: catalog
-                .clusters()
-                .flat_map(|cluster| cluster.replicas().map(|replica| replica.replica_id))
-                .collect(),
+            clusters: clusters.iter().map(|cluster| cluster.cluster_id).collect(),
+            replicas: replicas.iter().map(|replica| replica.replica_id).collect(),
         };
-        self.reconcile_scoped_system_parameters(merged, Some(prune_scope))
-            .await;
+        Some(crate::catalog::Op::UpdateScopedSystemParameters {
+            scoped: evaluated,
+            prune_scope: Some(prune_scope),
+        })
     }
 
     /// Resolves the replica-local scoped overrides from the catalog working copy

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -41,6 +41,9 @@ use tracing::{Instrument, Span, debug};
 use super::return_if_err;
 use crate::AdapterError::AlterClusterWhilePendingReplicas;
 use crate::catalog::{self, Op, ReplicaCreateDropReason};
+use crate::config::{
+    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
+};
 use crate::coord::{
     AlterCluster, AlterClusterFinalize, AlterClusterWaitForHydrated, ClusterStage, Coordinator,
     Message, PlanValidity, StageResult, Staged,
@@ -654,11 +657,11 @@ impl Coordinator {
 
         match variant {
             CreateClusterVariant::Managed(plan) => {
-                self.sequence_create_managed_cluster(session, plan, id, ops)
+                self.sequence_create_managed_cluster(session, plan, id, name, ops)
                     .await
             }
             CreateClusterVariant::Unmanaged(plan) => {
-                self.sequence_create_unmanaged_cluster(session, plan, id, ops)
+                self.sequence_create_unmanaged_cluster(session, plan, id, name, ops)
                     .await
             }
         }
@@ -677,6 +680,7 @@ impl Coordinator {
             schedule: _,
         }: CreateClusterManagedPlan,
         cluster_id: ClusterId,
+        cluster_name: String,
         mut ops: Vec<catalog::Op>,
     ) -> Result<ExecuteResponse, AdapterError> {
         tracing::debug!("sequence_create_managed_cluster");
@@ -707,23 +711,31 @@ impl Coordinator {
         }
 
         // Pre-allocate replica ids out-of-band via the durable allocator,
-        // picking the id type from the owning cluster. This mirrors how cluster
-        // and item ids are allocated, so nothing allocates a replica id
-        // in-apply.
+        // picking the id type from the owning cluster, so each replica's scoped
+        // overrides can be folded into the create transaction below (the
+        // overrides are keyed by the replica id). This mirrors how cluster and
+        // item ids are allocated, so nothing allocates a replica id in-apply.
         let id_ts = self.get_catalog_write_ts().await;
         let replica_ids = self
             .catalog()
             .allocate_replica_ids(cluster_id, u64::from(replication_factor), id_ts)
             .await?;
 
+        let cluster_ctx = ClusterScopeContext {
+            id: cluster_id.to_string(),
+            name: cluster_name.clone(),
+            is_builtin: cluster_id.is_system(),
+        };
+
+        let mut replica_ctxs = Vec::new();
         for (replica_id, replica_name) in replica_ids
             .into_iter()
             .zip_eq((0..replication_factor).map(managed_cluster_replica_name))
         {
-            self.create_managed_cluster_replica_op(
+            let size_family = self.create_managed_cluster_replica_op(
                 cluster_id,
                 replica_id,
-                replica_name,
+                replica_name.clone(),
                 &compute,
                 &size,
                 &mut ops,
@@ -736,22 +748,37 @@ impl Coordinator {
                 *session.current_role_id(),
                 ReplicaCreateDropReason::Manual,
             )?;
+            replica_ctxs.push(ReplicaEvalContext {
+                cluster_id,
+                replica_id,
+                cluster: cluster_ctx.clone(),
+                replica: ReplicaScopeContext {
+                    id: replica_id.to_string(),
+                    name: replica_name,
+                    is_builtin: cluster_id.is_system(),
+                    size: size.clone(),
+                    size_family,
+                    cluster_id: cluster_id.to_string(),
+                    cluster_name: cluster_name.clone(),
+                },
+            });
+        }
+
+        // Fold the new cluster's cluster-coherent and the replicas' replica-local
+        // scoped overrides into the create transaction. Folding (rather than a
+        // post-transact resolve) makes the committed diff drive the
+        // replica-scoped controller push before create_replica, which
+        // render-frozen flags require, and gives the new cluster its optimizer
+        // overrides for its first plan.
+        let cluster_eval = ClusterEvalContext {
+            cluster_id,
+            cluster: cluster_ctx,
+        };
+        if let Some(scoped_op) = self.scoped_overrides_create_op(&[cluster_eval], &replica_ctxs) {
+            ops.push(scoped_op);
         }
 
         self.catalog_transact(Some(session), ops).await?;
-
-        // Resolve the new cluster's cluster-scoped overrides now, so its first
-        // plan uses them rather than the env-wide values. Optimizer features are
-        // baked into immutable dataflows, so a value applied on a later sync tick
-        // cannot retrofit an already planned dataflow.
-        //
-        // TODO: this resolves only the cluster-scoped overrides. Replicas created
-        // in this same transaction reach the controller with env-wide config and
-        // pick up their replica-local overrides on the next sync tick, which is
-        // too late for render-frozen flags. The follow-up materialize#37158 folds
-        // replica resolution into the create transaction.
-        self.resolve_scoped_for_new_objects(&BTreeSet::from([cluster_id]), &BTreeSet::new())
-            .await;
 
         Ok(ExecuteResponse::CreatedCluster)
     }
@@ -768,7 +795,7 @@ impl Coordinator {
         pending: bool,
         owner_id: RoleId,
         reason: ReplicaCreateDropReason,
-    ) -> Result<(), AdapterError> {
+    ) -> Result<String, AdapterError> {
         let location = mz_catalog::durable::ReplicaLocation::Managed {
             // Concretized below from the cluster config; this intermediate value
             // is discarded, so the list is left empty here.
@@ -801,8 +828,18 @@ impl Coordinator {
         };
 
         // The caller pre-allocates `replica_id` out-of-band via the durable
-        // allocator, mirroring how cluster and item ids are allocated, so
-        // nothing allocates a replica id in-apply.
+        // allocator, so nothing allocates a replica id in-apply.
+        //
+        // Extract the size family before `config` moves into the op, for the
+        // replica's scoped eval context.
+        let size_family = match &config.location {
+            ReplicaLocation::Managed(location) => location.allocation.family().to_string(),
+            // A managed replica always concretizes to a managed location.
+            ReplicaLocation::Unmanaged(_) => {
+                unreachable!("managed cluster replica has a managed location")
+            }
+        };
+
         ops.push(catalog::Op::CreateClusterReplica {
             cluster_id,
             replica_id,
@@ -811,7 +848,7 @@ impl Coordinator {
             owner_id,
             reason,
         });
-        Ok(())
+        Ok(size_family)
     }
 
     fn ensure_valid_azs<'a, I: IntoIterator<Item = &'a String>>(
@@ -836,6 +873,7 @@ impl Coordinator {
         session: &Session,
         CreateClusterUnmanagedPlan { replicas }: CreateClusterUnmanagedPlan,
         id: ClusterId,
+        cluster_name: String,
         mut ops: Vec<catalog::Op>,
     ) -> Result<ExecuteResponse, AdapterError> {
         tracing::debug!("sequence_create_unmanaged_cluster");
@@ -867,14 +905,22 @@ impl Coordinator {
         }
 
         // Pre-allocate replica ids out-of-band via the durable allocator,
-        // picking the id type from the owning cluster. This mirrors how cluster
-        // and item ids are allocated, so nothing allocates a replica id
-        // in-apply.
+        // picking the id type from the owning cluster, so each replica's scoped
+        // overrides can be folded into the create transaction below. This
+        // mirrors how cluster and item ids are allocated, so nothing allocates
+        // a replica id in-apply.
         let id_ts = self.get_catalog_write_ts().await;
         let replica_ids = self
             .catalog()
             .allocate_replica_ids(id, u64::cast_from(replicas.len()), id_ts)
             .await?;
+
+        let cluster_ctx = ClusterScopeContext {
+            id: id.to_string(),
+            name: cluster_name.clone(),
+            is_builtin: id.is_system(),
+        };
+        let mut replica_ctxs = Vec::new();
 
         for (replica_id, (replica_name, replica_config)) in replica_ids.into_iter().zip_eq(replicas)
         {
@@ -943,6 +989,25 @@ impl Coordinator {
                 compute: ComputeReplicaConfig { logging },
             };
 
+            // Only orchestrated (managed-location) replicas have a size and size
+            // family, so only they carry replica-local overrides.
+            if let ReplicaLocation::Managed(location) = &config.location {
+                replica_ctxs.push(ReplicaEvalContext {
+                    cluster_id: id,
+                    replica_id,
+                    cluster: cluster_ctx.clone(),
+                    replica: ReplicaScopeContext {
+                        id: replica_id.to_string(),
+                        name: replica_name.clone(),
+                        is_builtin: id.is_system(),
+                        size: location.size.clone(),
+                        size_family: location.allocation.family().to_string(),
+                        cluster_id: id.to_string(),
+                        cluster_name: cluster_name.clone(),
+                    },
+                });
+            }
+
             ops.push(catalog::Op::CreateClusterReplica {
                 cluster_id: id,
                 replica_id,
@@ -953,12 +1018,17 @@ impl Coordinator {
             });
         }
 
-        self.catalog_transact(Some(session), ops).await?;
+        // Fold the new cluster's and replicas' scoped overrides into the create
+        // transaction (see the managed path for rationale).
+        let cluster_eval = ClusterEvalContext {
+            cluster_id: id,
+            cluster: cluster_ctx,
+        };
+        if let Some(scoped_op) = self.scoped_overrides_create_op(&[cluster_eval], &replica_ctxs) {
+            ops.push(scoped_op);
+        }
 
-        // Resolve the new cluster's cluster-coherent scoped overrides now (see
-        // the managed path for rationale).
-        self.resolve_scoped_for_new_objects(&BTreeSet::from([id]), &BTreeSet::new())
-            .await;
+        self.catalog_transact(Some(session), ops).await?;
 
         Ok(ExecuteResponse::CreatedCluster)
     }
@@ -1059,14 +1129,20 @@ impl Coordinator {
             }
         }
 
-        // Replicas have the same owner as their cluster.
+        // Replicas have the same owner as their cluster. Extract the owned
+        // cluster info we need before the borrow is dropped for the awaits below.
         let owner_id = cluster.owner_id();
 
+        let cluster_name = cluster.name.clone();
+        let is_builtin = cluster_id.is_system();
+
         // Pre-allocate the replica id out-of-band via the durable allocator,
-        // picking the id type from the target cluster. The target cluster may
-        // be a system cluster, so dispatch on its id type. This mirrors how
-        // cluster and item ids are allocated, so nothing allocates a replica id
-        // in-apply.
+        // picking the id type from the target cluster, which may be a system
+        // cluster, so the replica's scoped overrides can be folded into the same
+        // transaction. The overrides are keyed by replica id, and the
+        // replica-scoped controller push must run before `create_replica`. This
+        // mirrors how cluster and item ids are allocated, so nothing allocates a
+        // replica id in-apply.
         let id_ts = self.get_catalog_write_ts().await;
         let replica_id = self
             .catalog()
@@ -1074,16 +1150,49 @@ impl Coordinator {
             .await?
             .into_element();
 
-        let op = catalog::Op::CreateClusterReplica {
+        // Build the replica's eval context from the plan before `config` moves
+        // into the op. Only managed replicas have a size (and size family).
+        let replica_ctx = match &config.location {
+            ReplicaLocation::Managed(location) => Some(ReplicaEvalContext {
+                cluster_id,
+                replica_id,
+                cluster: ClusterScopeContext {
+                    id: cluster_id.to_string(),
+                    name: cluster_name.clone(),
+                    is_builtin,
+                },
+                replica: ReplicaScopeContext {
+                    id: replica_id.to_string(),
+                    name: name.to_string(),
+                    is_builtin,
+                    size: location.size.clone(),
+                    size_family: location.allocation.family().to_string(),
+                    cluster_id: cluster_id.to_string(),
+                    cluster_name,
+                },
+            }),
+            ReplicaLocation::Unmanaged(_) => None,
+        };
+
+        let mut ops = vec![catalog::Op::CreateClusterReplica {
             cluster_id,
             replica_id,
             name: name.clone(),
             config,
             owner_id,
             reason: ReplicaCreateDropReason::Manual,
-        };
+        }];
 
-        self.catalog_transact(Some(session), vec![op]).await?;
+        // The cluster already exists, so only this replica's local overrides
+        // need resolving. Fold them into the create transaction so the
+        // replica-scoped push runs before `create_replica`.
+        if let Some(replica_ctx) = replica_ctx {
+            if let Some(scoped_op) = self.scoped_overrides_create_op(&[], &[replica_ctx]) {
+                ops.push(scoped_op);
+            }
+        }
+
+        self.catalog_transact(Some(session), ops).await?;
 
         Ok(ExecuteResponse::CreatedClusterReplica)
     }
@@ -1223,6 +1332,20 @@ impl Coordinator {
             Vec::<ReplicaId>::new().into_iter()
         };
 
+        // Collect an eval context for each replica recreated below, so the alter
+        // transaction folds the replicas' replica-scoped overrides the same way
+        // the create paths do. ALTER CLUSTER SET (SIZE ...) to a different size
+        // family flips size-family-keyed render-frozen flags, so the override
+        // must reach the controller before the recreated replica renders. Only
+        // the replica scope is folded. The cluster already exists and its
+        // cluster-scoped overrides are unaffected by this alter.
+        let cluster_ctx = ClusterScopeContext {
+            id: cluster_id.to_string(),
+            name: name.clone(),
+            is_builtin: cluster_id.is_system(),
+        };
+        let mut replica_ctxs = Vec::new();
+
         if config_changed {
             self.ensure_valid_azs(new_availability_zones.iter())?;
             // If we're not doing a zero-downtime reconfig tear down all
@@ -1242,14 +1365,18 @@ impl Coordinator {
                         })
                         .collect();
                     ops.push(catalog::Op::DropObjects(replica_ids_and_reasons));
-                    for name in (0..*new_replication_factor).map(managed_cluster_replica_name) {
+                    for replica_name in
+                        (0..*new_replication_factor).map(managed_cluster_replica_name)
+                    {
+                        // The replica id is pre-allocated above like the create
+                        // paths so its scoped overrides can be folded below.
                         let replica_id = new_replica_ids
                             .next()
                             .expect("pre-allocated enough replica ids");
-                        self.create_managed_cluster_replica_op(
+                        let size_family = self.create_managed_cluster_replica_op(
                             cluster_id,
                             replica_id,
-                            name.clone(),
+                            replica_name.clone(),
                             &compute,
                             new_size,
                             &mut ops,
@@ -1258,18 +1385,34 @@ impl Coordinator {
                             owner_id,
                             reason.clone(),
                         )?;
+                        replica_ctxs.push(ReplicaEvalContext {
+                            cluster_id,
+                            replica_id,
+                            cluster: cluster_ctx.clone(),
+                            replica: ReplicaScopeContext {
+                                id: replica_id.to_string(),
+                                name: replica_name,
+                                is_builtin: cluster_id.is_system(),
+                                size: new_size.clone(),
+                                size_family,
+                                cluster_id: cluster_id.to_string(),
+                                cluster_name: cluster_ctx.name.clone(),
+                            },
+                        });
                     }
                 }
                 AlterClusterPlanStrategy::For(_) | AlterClusterPlanStrategy::UntilReady { .. } => {
-                    for name in (0..*new_replication_factor).map(managed_cluster_replica_name) {
-                        let name = format!("{name}{PENDING_REPLICA_SUFFIX}");
+                    for replica_name in
+                        (0..*new_replication_factor).map(managed_cluster_replica_name)
+                    {
+                        let replica_name = format!("{replica_name}{PENDING_REPLICA_SUFFIX}");
                         let replica_id = new_replica_ids
                             .next()
                             .expect("pre-allocated enough replica ids");
-                        self.create_managed_cluster_replica_op(
+                        let size_family = self.create_managed_cluster_replica_op(
                             cluster_id,
                             replica_id,
-                            name.clone(),
+                            replica_name.clone(),
                             &compute,
                             new_size,
                             &mut ops,
@@ -1278,6 +1421,20 @@ impl Coordinator {
                             owner_id,
                             reason.clone(),
                         )?;
+                        replica_ctxs.push(ReplicaEvalContext {
+                            cluster_id,
+                            replica_id,
+                            cluster: cluster_ctx.clone(),
+                            replica: ReplicaScopeContext {
+                                id: replica_id.to_string(),
+                                name: replica_name,
+                                is_builtin: cluster_id.is_system(),
+                                size: new_size.clone(),
+                                size_family,
+                                cluster_id: cluster_id.to_string(),
+                                cluster_name: cluster_ctx.name.clone(),
+                            },
+                        });
                     }
                     finalization_needed = NeedsFinalization::Yes;
                 }
@@ -1298,16 +1455,16 @@ impl Coordinator {
             ops.push(catalog::Op::DropObjects(replica_ids));
         } else if *new_replication_factor > replication_factor {
             // Adjust replica count up
-            for name in
+            for replica_name in
                 (replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
             {
                 let replica_id = new_replica_ids
                     .next()
                     .expect("pre-allocated enough replica ids");
-                self.create_managed_cluster_replica_op(
+                let size_family = self.create_managed_cluster_replica_op(
                     cluster_id,
                     replica_id,
-                    name.clone(),
+                    replica_name.clone(),
                     &compute,
                     new_size,
                     &mut ops,
@@ -1318,6 +1475,20 @@ impl Coordinator {
                     owner_id,
                     reason.clone(),
                 )?;
+                replica_ctxs.push(ReplicaEvalContext {
+                    cluster_id,
+                    replica_id,
+                    cluster: cluster_ctx.clone(),
+                    replica: ReplicaScopeContext {
+                        id: replica_id.to_string(),
+                        name: replica_name,
+                        is_builtin: cluster_id.is_system(),
+                        size: new_size.clone(),
+                        size_family,
+                        cluster_id: cluster_id.to_string(),
+                        cluster_name: cluster_ctx.name.clone(),
+                    },
+                });
             }
         }
 
@@ -1333,6 +1504,17 @@ impl Coordinator {
             }
             NeedsFinalization::Yes => {}
         }
+
+        // Fold the recreated replicas' replica-scoped overrides into the same
+        // transaction, so the committed diff drives the replica-scoped controller
+        // push before create_replica. Render-frozen flags (chosen at
+        // arrangement-build time) require the override to land before the replica
+        // renders. Scale-down and no-op alters recreate no replicas, so this is
+        // empty and folds nothing.
+        if let Some(scoped_op) = self.scoped_overrides_create_op(&[], &replica_ctxs) {
+            ops.push(scoped_op);
+        }
+
         self.catalog_transact(session, ops).await?;
         Ok(finalization_needed)
     }

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -530,15 +530,17 @@ def run_scoped_feature_flag_cases(
             )
             c.stop("materialized")
 
-        # Create-time resolution: a cluster created between sync ticks must
-        # resolve its cluster-coherent overrides synchronously, before its first
-        # plan, since optimizer features are baked into immutable dataflows. We
-        # isolate this from the periodic loop by running with a very long sync
-        # interval: the frontend is still installed on the first (immediate)
-        # tick, but no further reconcile happens during the test, so a row that
-        # appears right after `CREATE CLUSTER` can only come from create-time
-        # resolution. (testdrive `>` retries, but the periodic loop cannot fire
-        # within the retry window at this interval.)
+        # Create-time resolution: a cluster and its replicas created between sync
+        # ticks must resolve their overrides synchronously, before the cluster's
+        # first plan (cluster-coherent, optimizer features are baked into
+        # immutable dataflows) and before the replica renders (replica-local,
+        # render-frozen flags like the column-paged batcher). We isolate this from
+        # the periodic loop by running with a very long sync interval: the
+        # frontend is still installed on the first (immediate) tick, but no
+        # further reconcile happens during the test, so a row that appears right
+        # after `CREATE CLUSTER` can only come from create-time resolution.
+        # (testdrive `>` retries, but the periodic loop cannot fire within the
+        # retry window at this interval.)
         slow_mz = Materialized(
             environment_extra=[
                 f"MZ_LAUNCHDARKLY_SDK_KEY={LAUNCHDARKLY_SDK_KEY}",
@@ -566,6 +568,22 @@ def run_scoped_feature_flag_cases(
                     [
                         f"> SELECT c.name, p.value FROM mz_internal.mz_cluster_system_parameters p JOIN mz_clusters c ON c.id = p.cluster_id WHERE p.name = '{OPTIMIZER_PARAM}' AND c.name = 'ld_sync'",
                         "ld_sync true",
+                    ]
+                )
+            )
+            # Create-time replica resolution: `ld_sync` is a legacy-family
+            # cluster, so its replica is served `enable_lgalloc=false`, which
+            # differs from the env-wide `true` and is recorded. The override is
+            # folded into the create transaction, so the row appears immediately,
+            # before the (disabled) sync loop could write it. This is the
+            # replica-local counterpart to the cluster-coherent case above, and it
+            # would not appear if the replica's override were resolved only after
+            # the create transaction.
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT cr.name, p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_sync'",
+                        "r1 false",
                     ]
                 )
             )


### PR DESCRIPTION
### Motivation

Resolve scoped feature flags for a freshly created cluster or replica at create
time, rather than on the next sync tick. Stacked on #36959 (resolution and
gating); the catalog-implications foundation #37151 has merged.

Without this, a new object gets its overrides on the next sync tick (≤1s). For
render-frozen replica-scoped flags (e.g. the column-paged batcher, chosen at
arrangement-build time) that is too late: the override must reach the controller
before the replica's dataflows render.

### Description

Evaluate a freshly created cluster or replica from its plan through the shared
`SystemParameterFrontend`, and fold the resulting overrides as an
`Op::UpdateScopedSystemParameters` into the *same* transaction that creates the
objects. The committed diff then drives the replica-scoped controller push (the
implication from #37151) before `create_replica`, so the new replica's first
configuration replays with its overrides.

The override map is keyed by replica id, so the create paths pre-allocate
replica ids out-of-band (`allocate_replica_ids`, user or system per the owning
cluster, as of #37178) and carry them in `Op::CreateClusterReplica`'s required
`replica_id` field. This replaces the post-transact `resolve_scoped_for_new_objects`
from #36959.

`ALTER CLUSTER` paths that recreate replicas (size or availability-zone change,
scale-up, zero-downtime reconfig) fold their replica-scoped overrides the same
way, so a size-family change that flips a render-frozen flag reaches the
recreated replica before it renders. Scale-down and no-op alters recreate no
replicas and fold nothing.

### Verification

The create-time cases in the `test/launchdarkly` mzcompose workflow (introduced
in #36959) exercise this path, validated against a live LaunchDarkly project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUorxx5m6B8TT2VAek2STo