### PR TITLE
doc: replica-scoped config is a ParsedStateUpdateKind, not in the catch-all

### DIFF
--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -61,8 +61,10 @@ logic to them. Extend the implications framework instead.
   belong, even though existing system-config pushes happen there today.
 - Several `StateUpdateKind`s are not yet represented as implications.
   `parse_state_update` returns `None` for them via its catch-all arm (this
-  covers the system-config kinds, among others). Representing a new kind may
-  require extending `ParsedStateUpdate` / `ParsedStateUpdateKind` first.
+  covers the environment-wide and cluster-scoped system-config kinds, among
+  others; the replica-scoped kind is represented as a `ParsedStateUpdateKind`).
+  Representing a new kind may require extending `ParsedStateUpdate` /
+  `ParsedStateUpdateKind` first.
 
 ## Correctness Invariants
 


### PR DESCRIPTION
### Motivation

#37151 moved `ReplicaSystemConfiguration` out of `parse_state_update`'s
catch-all into a real `ParsedStateUpdateKind`, so the adapter guide's note (added
in #37156) that the catch-all "covers the system-config kinds" is now inaccurate
for the replica-scoped kind.

### Description

Narrow the sentence to the environment-wide and cluster-scoped system-config
kinds, and note that the replica-scoped kind is now represented as an
implication.

### Verification

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)