### PR TITLE
catalog: allocate cluster replica ids durably, single-source

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -677,6 +677,51 @@ impl Catalog {
             .err_into()
     }
 
+    /// Allocate `amount` many user replica IDs. See
+    /// [`DurableCatalogState::allocate_user_replica_ids`].
+    pub async fn allocate_user_replica_ids(
+        &self,
+        amount: u64,
+        commit_ts: mz_repr::Timestamp,
+    ) -> Result<Vec<ReplicaId>, Error> {
+        self.storage()
+            .await
+            .allocate_user_replica_ids(amount, commit_ts)
+            .await
+            .maybe_terminate("allocating user replica ids")
+            .err_into()
+    }
+
+    /// Allocate `amount` many system replica IDs. See
+    /// [`DurableCatalogState::allocate_system_replica_ids`].
+    pub async fn allocate_system_replica_ids(
+        &self,
+        amount: u64,
+        commit_ts: mz_repr::Timestamp,
+    ) -> Result<Vec<ReplicaId>, Error> {
+        self.storage()
+            .await
+            .allocate_system_replica_ids(amount, commit_ts)
+            .await
+            .maybe_terminate("allocating system replica ids")
+            .err_into()
+    }
+
+    /// Allocate `amount` many replica IDs for `cluster_id`, picking user or
+    /// system IDs based on the cluster's ID type.
+    pub async fn allocate_replica_ids(
+        &self,
+        cluster_id: ClusterId,
+        amount: u64,
+        commit_ts: mz_repr::Timestamp,
+    ) -> Result<Vec<ReplicaId>, Error> {
+        if cluster_id.is_system() {
+            self.allocate_system_replica_ids(amount, commit_ts).await
+        } else {
+            self.allocate_user_replica_ids(amount, commit_ts).await
+        }
+    }
+
     /// Get the next system replica id without allocating it.
     pub async fn get_next_system_replica_id(&self) -> Result<u64, Error> {
         self.storage()

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1152,8 +1152,13 @@ fn add_new_remove_old_builtin_cluster_replicas_migration(
             };
 
             let config = builtin_cluster_replica_config(replica_size.clone());
-            let replica_id = txn.insert_cluster_replica(
+            // Builtin replicas live on system clusters. This runs inside the
+            // catalog-open transaction with no coordinator, so allocating from
+            // the same transaction is single-source and safe.
+            let replica_id = txn.allocate_system_replica_id()?;
+            txn.insert_cluster_replica_with_id(
                 cluster.id,
+                replica_id,
                 builtin_replica.name,
                 config,
                 MZ_SYSTEM_ROLE_ID,

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -149,6 +149,7 @@ pub enum Op {
     },
     CreateClusterReplica {
         cluster_id: ClusterId,
+        replica_id: ReplicaId,
         name: String,
         config: ReplicaConfig,
         owner_id: RoleId,
@@ -1324,6 +1325,7 @@ impl Catalog {
             }
             Op::CreateClusterReplica {
                 cluster_id,
+                replica_id,
                 name,
                 config,
                 owner_id,
@@ -1335,8 +1337,16 @@ impl Catalog {
                     )));
                 }
                 let cluster = state.get_cluster(cluster_id);
-                let id =
-                    tx.insert_cluster_replica(cluster_id, &name, config.clone().into(), owner_id)?;
+                // The replica id is allocated out-of-band by the durable
+                // allocator before the transaction, mirroring cluster and item
+                // ids. Nothing allocates a replica id in-apply.
+                tx.insert_cluster_replica_with_id(
+                    cluster_id,
+                    replica_id,
+                    &name,
+                    config.clone().into(),
+                    owner_id,
+                )?;
                 if let ReplicaLocation::Managed(ManagedReplicaLocation {
                     size,
                     billed_as,
@@ -1349,7 +1359,7 @@ impl Catalog {
                         mz_audit_log::CreateClusterReplicaV4 {
                             cluster_id: cluster_id.to_string(),
                             cluster_name: cluster.name.clone(),
-                            replica_id: Some(id.to_string()),
+                            replica_id: Some(replica_id.to_string()),
                             replica_name: name.clone(),
                             logical_size: size.clone(),
                             billed_as: billed_as.clone(),

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::{Duration, Instant};
 
 use itertools::Itertools;
@@ -20,8 +20,9 @@ use mz_compute_types::config::ComputeReplicaConfig;
 use mz_controller::clusters::{
     ManagedReplicaLocation, ReplicaConfig, ReplicaLocation, ReplicaLogging,
 };
-use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL};
+use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId};
 use mz_ore::cast::CastFrom;
+use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_repr::role_id::RoleId;
 use mz_sql::ast::{Ident, QualifiedReplica};
@@ -705,9 +706,23 @@ impl Coordinator {
             )?;
         }
 
-        for replica_name in (0..replication_factor).map(managed_cluster_replica_name) {
+        // Pre-allocate replica ids out-of-band via the durable allocator,
+        // picking the id type from the owning cluster. This mirrors how cluster
+        // and item ids are allocated, so nothing allocates a replica id
+        // in-apply.
+        let id_ts = self.get_catalog_write_ts().await;
+        let replica_ids = self
+            .catalog()
+            .allocate_replica_ids(cluster_id, u64::from(replication_factor), id_ts)
+            .await?;
+
+        for (replica_id, replica_name) in replica_ids
+            .into_iter()
+            .zip_eq((0..replication_factor).map(managed_cluster_replica_name))
+        {
             self.create_managed_cluster_replica_op(
                 cluster_id,
+                replica_id,
                 replica_name,
                 &compute,
                 &size,
@@ -731,6 +746,7 @@ impl Coordinator {
     fn create_managed_cluster_replica_op(
         &self,
         cluster_id: ClusterId,
+        replica_id: ReplicaId,
         name: String,
         compute: &mz_sql::plan::ComputeReplicaConfig,
         size: &String,
@@ -771,8 +787,12 @@ impl Coordinator {
             compute: ComputeReplicaConfig { logging },
         };
 
+        // The caller pre-allocates `replica_id` out-of-band via the durable
+        // allocator, mirroring how cluster and item ids are allocated, so
+        // nothing allocates a replica id in-apply.
         ops.push(catalog::Op::CreateClusterReplica {
             cluster_id,
+            replica_id,
             name,
             config,
             owner_id,
@@ -833,7 +853,18 @@ impl Coordinator {
             )?;
         }
 
-        for (replica_name, replica_config) in replicas {
+        // Pre-allocate replica ids out-of-band via the durable allocator,
+        // picking the id type from the owning cluster. This mirrors how cluster
+        // and item ids are allocated, so nothing allocates a replica id
+        // in-apply.
+        let id_ts = self.get_catalog_write_ts().await;
+        let replica_ids = self
+            .catalog()
+            .allocate_replica_ids(id, u64::cast_from(replicas.len()), id_ts)
+            .await?;
+
+        for (replica_id, (replica_name, replica_config)) in replica_ids.into_iter().zip_eq(replicas)
+        {
             // If the AZ was not specified, choose one, round-robin, from the ones with
             // the lowest number of configured replicas for this cluster.
             let (compute, location) = match replica_config {
@@ -901,6 +932,7 @@ impl Coordinator {
 
             ops.push(catalog::Op::CreateClusterReplica {
                 cluster_id: id,
+                replica_id,
                 name: replica_name.clone(),
                 config,
                 owner_id: *session.current_role_id(),
@@ -1011,8 +1043,22 @@ impl Coordinator {
 
         // Replicas have the same owner as their cluster.
         let owner_id = cluster.owner_id();
+
+        // Pre-allocate the replica id out-of-band via the durable allocator,
+        // picking the id type from the target cluster. The target cluster may
+        // be a system cluster, so dispatch on its id type. This mirrors how
+        // cluster and item ids are allocated, so nothing allocates a replica id
+        // in-apply.
+        let id_ts = self.get_catalog_write_ts().await;
+        let replica_id = self
+            .catalog()
+            .allocate_replica_ids(cluster_id, 1, id_ts)
+            .await?
+            .into_element();
+
         let op = catalog::Op::CreateClusterReplica {
             cluster_id,
+            replica_id,
             name: name.clone(),
             config,
             owner_id,
@@ -1061,6 +1107,13 @@ impl Coordinator {
         else {
             panic!("expected existing managed cluster config");
         };
+        // Clone the existing managed config out of the cluster so the immutable
+        // catalog borrow can be released before the out-of-band replica id
+        // allocation below, which needs mutable access to self.
+        let size = size.clone();
+        let availability_zones = availability_zones.clone();
+        let logging = logging.clone();
+        let replication_factor = *replication_factor;
         let ClusterVariant::Managed(ClusterVariantManaged {
             size: new_size,
             replication_factor: new_replication_factor,
@@ -1088,6 +1141,13 @@ impl Coordinator {
             return Err(AlterClusterWhilePendingReplicas);
         }
 
+        // Resolve existing replica ids by name before releasing the catalog
+        // borrow, so the drop branches below can build their ops without it.
+        let replica_id_by_name: BTreeMap<String, ReplicaId> = cluster
+            .replicas()
+            .map(|r| (r.name.clone(), r.replica_id))
+            .collect();
+
         let compute = mz_sql::plan::ComputeReplicaConfig {
             introspection: new_logging
                 .interval
@@ -1101,11 +1161,11 @@ impl Coordinator {
         // `catalog_transact` will do this validation too, but allocating
         // replica IDs is expensive enough that we need to do this validation
         // before allocating replica IDs. See database-issues#6046.
-        if new_replication_factor > replication_factor {
+        if *new_replication_factor > replication_factor {
             if cluster_id.is_user() {
                 self.validate_resource_limit(
-                    usize::cast_from(*replication_factor),
-                    i64::from(*new_replication_factor) - i64::from(*replication_factor),
+                    usize::cast_from(replication_factor),
+                    i64::from(*new_replication_factor) - i64::from(replication_factor),
                     SystemVars::max_replicas_per_cluster,
                     "cluster replica",
                     MAX_REPLICAS_PER_CLUSTER.name(),
@@ -1113,22 +1173,51 @@ impl Coordinator {
             }
         }
 
-        if new_size != size
-            || new_availability_zones != availability_zones
-            || new_logging != logging
-        {
+        // Count exactly as many replica ids as the branches below consume. The
+        // config-changed branches recreate all replicas; a pure scale-up
+        // creates only the delta; scale-down and no-op create none.
+        let config_changed = new_size != &size
+            || new_availability_zones != &availability_zones
+            || new_logging != &logging;
+        let needed_replica_ids = if config_changed {
+            *new_replication_factor
+        } else if *new_replication_factor > replication_factor {
+            *new_replication_factor - replication_factor
+        } else {
+            0
+        };
+        // Allocate the replica ids out-of-band via the durable allocator, only
+        // after the eager limit validation above so a rejected alter allocates
+        // nothing. Pick the id type from the target cluster, which may be a
+        // system cluster. This mirrors how cluster and item ids are allocated,
+        // so nothing allocates a replica id in-apply. Fetch the catalog write
+        // timestamp lazily here, since it needs mutable access to self (the
+        // cluster borrow above is already released) and scale-down, no-op, and
+        // automated scheduling turn-off alters must not pay an oracle
+        // round-trip just to allocate nothing.
+        let mut new_replica_ids = if needed_replica_ids > 0 {
+            let id_ts = self.get_catalog_write_ts().await;
+            self.catalog()
+                .allocate_replica_ids(cluster_id, u64::from(needed_replica_ids), id_ts)
+                .await?
+                .into_iter()
+        } else {
+            Vec::<ReplicaId>::new().into_iter()
+        };
+
+        if config_changed {
             self.ensure_valid_azs(new_availability_zones.iter())?;
             // If we're not doing a zero-downtime reconfig tear down all
             // replicas, create new ones else create the pending replicas and
             // return early asking for finalization
             match strategy {
                 AlterClusterPlanStrategy::None => {
-                    let replica_ids_and_reasons = (0..*replication_factor)
+                    let replica_ids_and_reasons = (0..replication_factor)
                         .map(managed_cluster_replica_name)
-                        .filter_map(|name| cluster.replica_id(&name))
+                        .filter_map(|name| replica_id_by_name.get(&name).copied())
                         .map(|replica_id| {
                             catalog::DropObjectInfo::ClusterReplica((
-                                cluster.id(),
+                                cluster_id,
                                 replica_id,
                                 reason.clone(),
                             ))
@@ -1136,8 +1225,12 @@ impl Coordinator {
                         .collect();
                     ops.push(catalog::Op::DropObjects(replica_ids_and_reasons));
                     for name in (0..*new_replication_factor).map(managed_cluster_replica_name) {
+                        let replica_id = new_replica_ids
+                            .next()
+                            .expect("pre-allocated enough replica ids");
                         self.create_managed_cluster_replica_op(
                             cluster_id,
+                            replica_id,
                             name.clone(),
                             &compute,
                             new_size,
@@ -1152,8 +1245,12 @@ impl Coordinator {
                 AlterClusterPlanStrategy::For(_) | AlterClusterPlanStrategy::UntilReady { .. } => {
                     for name in (0..*new_replication_factor).map(managed_cluster_replica_name) {
                         let name = format!("{name}{PENDING_REPLICA_SUFFIX}");
+                        let replica_id = new_replica_ids
+                            .next()
+                            .expect("pre-allocated enough replica ids");
                         self.create_managed_cluster_replica_op(
                             cluster_id,
+                            replica_id,
                             name.clone(),
                             &compute,
                             new_size,
@@ -1167,27 +1264,31 @@ impl Coordinator {
                     finalization_needed = NeedsFinalization::Yes;
                 }
             }
-        } else if new_replication_factor < replication_factor {
+        } else if *new_replication_factor < replication_factor {
             // Adjust replica count down
-            let replica_ids = (*new_replication_factor..*replication_factor)
+            let replica_ids = (*new_replication_factor..replication_factor)
                 .map(managed_cluster_replica_name)
-                .filter_map(|name| cluster.replica_id(&name))
+                .filter_map(|name| replica_id_by_name.get(&name).copied())
                 .map(|replica_id| {
                     catalog::DropObjectInfo::ClusterReplica((
-                        cluster.id(),
+                        cluster_id,
                         replica_id,
                         reason.clone(),
                     ))
                 })
                 .collect();
             ops.push(catalog::Op::DropObjects(replica_ids));
-        } else if new_replication_factor > replication_factor {
+        } else if *new_replication_factor > replication_factor {
             // Adjust replica count up
             for name in
-                (*replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
+                (replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
             {
+                let replica_id = new_replica_ids
+                    .next()
+                    .expect("pre-allocated enough replica ids");
                 self.create_managed_cluster_replica_op(
                     cluster_id,
+                    replica_id,
                     name.clone(),
                     &compute,
                     new_size,

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use itertools::Itertools;
 use mz_audit_log::VersionedEvent;
-use mz_controller_types::ClusterId;
+use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_persist_client::PersistClient;
@@ -395,6 +395,36 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
             .await?
             .into_element();
         Ok(ClusterId::user(id).ok_or(SqlCatalogError::IdExhaustion)?)
+    }
+
+    /// Allocates and returns `amount` many user [`ReplicaId`]s.
+    ///
+    /// See [`Self::commit_transaction`] for details on `commit_ts`.
+    async fn allocate_user_replica_ids(
+        &mut self,
+        amount: u64,
+        commit_ts: Timestamp,
+    ) -> Result<Vec<ReplicaId>, CatalogError> {
+        let ids = self
+            .allocate_id(USER_REPLICA_ID_ALLOC_KEY, amount, commit_ts)
+            .await?;
+        let ids = ids.into_iter().map(ReplicaId::User).collect();
+        Ok(ids)
+    }
+
+    /// Allocates and returns `amount` many system [`ReplicaId`]s.
+    ///
+    /// See [`Self::commit_transaction`] for details on `commit_ts`.
+    async fn allocate_system_replica_ids(
+        &mut self,
+        amount: u64,
+        commit_ts: Timestamp,
+    ) -> Result<Vec<ReplicaId>, CatalogError> {
+        let ids = self
+            .allocate_id(SYSTEM_REPLICA_ID_ALLOC_KEY, amount, commit_ts)
+            .await?;
+        let ids = ids.into_iter().map(ReplicaId::System).collect();
+        Ok(ids)
     }
 
     fn shard_id(&self) -> ShardId;

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -3564,13 +3564,16 @@ where
 mod tests {
     use super::*;
 
+    use mz_controller::clusters::ReplicaLogging;
     use mz_ore::now::SYSTEM_TIME;
     use mz_ore::{assert_none, assert_ok};
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_types::PersistLocation;
     use semver::Version;
 
-    use crate::durable::{TestCatalogStateBuilder, test_bootstrap_args};
+    use crate::durable::{
+        ReplicaConfig, ReplicaLocation, TestCatalogStateBuilder, test_bootstrap_args,
+    };
     use crate::memory;
 
     #[mz_ore::test]
@@ -4156,6 +4159,84 @@ mod tests {
         assert_eq!(db_name, db.name);
         assert_eq!(db_owner, db.owner_id);
         assert_eq!(db_privileges, db.privileges);
+    }
+
+    /// Regression test for DB-147: inserting a replica with an explicit id must not consume the
+    /// `IdAlloc` counter, and the durable allocator must advance independently so a later
+    /// allocation never collides with an explicitly inserted id.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn test_insert_replica_with_id_does_not_consume_allocator() {
+        const VERSION: Version = Version::new(26, 0, 0);
+        let mut persist_cache = PersistClientCache::new_no_metrics();
+        persist_cache.cfg.build_version = VERSION;
+        let persist_client = persist_cache
+            .open(PersistLocation::new_in_mem())
+            .await
+            .unwrap();
+        let state_builder = TestCatalogStateBuilder::new(persist_client)
+            .with_default_deploy_generation()
+            .with_version(VERSION);
+        let mut state = state_builder
+            .unwrap_build()
+            .await
+            .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+            .await
+            .unwrap()
+            .0;
+
+        // The cluster does not need to exist: `insert_cluster_replica_with_id` only writes a
+        // `cluster_replicas` row and does not validate the referenced cluster.
+        let cluster_id = ClusterId::User(1);
+        let owner_id = RoleId::User(1);
+        let config = ReplicaConfig {
+            location: ReplicaLocation::Managed {
+                size: "1".to_string(),
+                availability_zones: Vec::new(),
+                internal: false,
+                billed_as: None,
+                pending: false,
+            },
+            logging: ReplicaLogging {
+                log_logging: false,
+                interval: Some(Duration::from_secs(1)),
+            },
+        };
+
+        // Step 1: allocate one user replica id out-of-band via the durable allocator.
+        let commit_ts = state.current_upper().await;
+        let a = state
+            .allocate_user_replica_ids(1, commit_ts)
+            .await
+            .unwrap()
+            .into_element();
+        assert!(a.is_user());
+
+        // Step 2: insert a replica with that explicit id and commit.
+        let mut txn = state.transaction().await.unwrap();
+        txn.insert_cluster_replica_with_id(cluster_id, a, "explicit", config, owner_id)
+            .unwrap();
+        let commit_ts = txn.upper();
+        txn.commit_internal(commit_ts).await.unwrap();
+
+        // Step 3: allocate one more user replica id.
+        let commit_ts = state.current_upper().await;
+        let b = state
+            .allocate_user_replica_ids(1, commit_ts)
+            .await
+            .unwrap()
+            .into_element();
+
+        // Step 4: the explicit insert consumed zero ids, so the allocator's next value is the
+        // direct successor of the first allocation.
+        assert_eq!(b.inner_id(), a.inner_id() + 1);
+
+        // Step 5: the explicitly inserted replica is present in the committed state.
+        let txn = state.transaction().await.unwrap();
+        let found = txn
+            .get_cluster_replicas()
+            .any(|replica| replica.replica_id == a);
+        assert!(found, "explicitly inserted replica {a} not found");
     }
 
     #[mz_ore::test]

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -68,7 +68,7 @@ use crate::durable::{
     EXPRESSION_CACHE_SHARD_KEY, MOCK_AUTHENTICATION_NONCE_KEY, NetworkPolicy, OID_ALLOC_KEY,
     SCHEMA_ID_ALLOC_KEY, SYSTEM_CLUSTER_ID_ALLOC_KEY, SYSTEM_ITEM_ALLOC_KEY,
     SYSTEM_REPLICA_ID_ALLOC_KEY, Snapshot, SystemConfiguration, USER_ITEM_ALLOC_KEY,
-    USER_NETWORK_POLICY_ID_ALLOC_KEY, USER_REPLICA_ID_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
+    USER_NETWORK_POLICY_ID_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
 };
 use crate::memory::objects::{StateDiff, StateUpdate, StateUpdateKind};
 
@@ -564,28 +564,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn insert_cluster_replica(
-        &mut self,
-        cluster_id: ClusterId,
-        replica_name: &str,
-        config: ReplicaConfig,
-        owner_id: RoleId,
-    ) -> Result<ReplicaId, CatalogError> {
-        let replica_id = match cluster_id {
-            ClusterId::System(_) => self.allocate_system_replica_id()?,
-            ClusterId::User(_) => self.allocate_user_replica_id()?,
-        };
-        self.insert_cluster_replica_with_id(
-            cluster_id,
-            replica_id,
-            replica_name,
-            config,
-            owner_id,
-        )?;
-        Ok(replica_id)
-    }
-
-    pub(crate) fn insert_cluster_replica_with_id(
+    pub fn insert_cluster_replica_with_id(
         &mut self,
         cluster_id: ClusterId,
         replica_id: ReplicaId,
@@ -897,11 +876,6 @@ impl<'a> Transaction<'a> {
             // TODO(alter_table): Use separate ID allocators.
             .map(|x| (CatalogItemId::User(x), GlobalId::User(x)))
             .collect())
-    }
-
-    pub fn allocate_user_replica_id(&mut self) -> Result<ReplicaId, CatalogError> {
-        let id = self.get_and_increment_id(USER_REPLICA_ID_ALLOC_KEY.to_string())?;
-        Ok(ReplicaId::User(id))
     }
 
     pub fn allocate_system_replica_id(&mut self) -> Result<ReplicaId, CatalogError> {


### PR DESCRIPTION
### Motivation

Closes https://linear.app/materializeinc/issue/DB-147

Cluster replica ids are allocated in-apply by `insert_cluster_replica`, reading the `IdAlloc` counter from the snapshot the coordinator opened the transaction with.
Cluster and item ids are instead allocated out-of-band by the durable allocator before the transaction, and the op carries the explicit id.
That asymmetry breaks any caller that pre-allocates a replica id out-of-band: the coordinator does not apply `IdAlloc` updates to its in-memory catalog, so a later in-apply allocation reuses the id and a `DuplicateReplica` panic surfaces on the next bootstrap.

### Description

Make replica ids durable-allocated and single-source like cluster ids.
`Op::CreateClusterReplica` carries a required `replica_id`; the apply path always uses `insert_cluster_replica_with_id` and never allocates.
Runtime construction sites pre-allocate via the durable allocator, choosing user or system ids from the owning cluster.
The catalog-open builtin-replica migration keeps a transaction-level system allocation, which is single-source inside the open transaction with no coordinator.
The in-apply `insert_cluster_replica` and the unused transaction-level user allocator are removed.

This is pre-work for the scoped feature flags stack (#36959, #37158), which needs to pre-allocate a replica id to fold replica-scoped data into the create transaction.

### Operational note

Replica creation now does two durable writes instead of one: the `allocate_replica_ids` transaction plus the create transaction, each with its own timestamp-oracle round-trip.
`CREATE CLUSTER` (with replicas), `CREATE CLUSTER REPLICA`, and config-changing/scale-up `ALTER CLUSTER` each gain one durable write and one oracle round-trip, batched (N replicas in one statement is one allocation write).
This is exactly the cost clusters and items already pay; if it ever shows up, the established lever is batching through the `IdPool`, not folding allocation back into the transaction.
Allocation happens only after the eager `max_replicas_per_cluster` validation and only when ids are actually needed, so a rejected alter and scale-down/no-op/scheduling-turn-off alters allocate nothing and skip the oracle.
As a side effect, replica ids are no longer guaranteed contiguous: a crash or rejected create between the two commits burns the allocated id, leaving gaps in `u`/`s` replica ids. This is harmless and matches cluster/item behavior.

### Verification

`cargo test -p mz-catalog` and the `cluster` mzcompose suite.