### PR TITLE
test/launchdarkly-flag-consistency: drop archived MCP flags from KNOWN_STALE_LD_FLAGS

### DIFF
--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -441,9 +441,6 @@ KNOWN_STALE_LD_FLAGS: set[str] = set("""
     enable_explain_broken
     enable_iceberg_sink
     enable_kafka_sink_partition_by
-    enable_mcp_agents
-    enable_mcp_agents_query_tool
-    enable_mcp_observatory
     enable_multi_replica_sources
     enable_reduce_reduction
     enable_repr_typecheck


### PR DESCRIPTION
The plural `enable_mcp_agents` / `enable_mcp_agents_query_tool` and the renamed `enable_mcp_observatory` LaunchDarkly flags are all archived now, so drop them from the allowlist. Closes [DEX-100](https://linear.app/materializeinc/issue/DB-100/archive-misnamed-plural-mcp-launchdarkly-flags-enable-mcp-agents).

### Motivation

Tips for changelog and release notes:
- Use present tense.
- Use community-friendly language.
- Mention any prerequisites for using the feature.
- Open with the feature name.
- Aim for less than 200 characters.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing $T ⇔ Proto$T mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.