### PR TITLE
mzbuild: fail the build if pushed images aren't public

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -12,6 +12,7 @@
 import os
 import shutil
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from materialize import mzbuild, spawn, ui
@@ -27,6 +28,10 @@ from materialize.mzbuild import (
 )
 from materialize.rustc_flags import Sanitizer
 from materialize.xcompile import Arch
+
+
+class ImagesNotPublicError(Exception):
+    """Raised when one or more built images are not public on Docker Hub/GHCR."""
 
 
 def main() -> None:
@@ -46,7 +51,22 @@ def main() -> None:
         # so they are accessible to other build agents.
         print("--- Acquiring mzbuild images")
         deps = repo.resolve_dependencies(image for image in repo if image.publish)
-        deps.ensure(pre_build=lambda images: upload_debuginfo(repo, images))
+        # An image's registry visibility is the same across every build step, so
+        # only verify it from the primary x86_64 build. That keeps the anonymous
+        # registry-API load to one set of queries per pipeline instead of one per
+        # arch/coverage/sanitizer variant, and the check is independent of this
+        # build, so we run it concurrently with the slow build+push and join it
+        # below before reporting success.
+        check_public = (
+            repo.rd.arch == Arch.X86_64 and not coverage and sanitizer == Sanitizer.none
+        )
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            public_check = (
+                executor.submit(check_images_public, deps) if check_public else None
+            )
+            deps.ensure(pre_build=lambda images: upload_debuginfo(repo, images))
+            if public_check is not None:
+                public_check.result()
         set_build_status("success")
         annotate_buildkite_with_tags(repo.rd.arch, deps)
     except RustIncrementalBuildFailure:
@@ -76,6 +96,65 @@ def set_build_status(status: str) -> None:
                 status,
             ]
         )
+
+
+def check_images_public(deps: mzbuild.DependencySet) -> None:
+    """Fail the build if any image's repository is private on Docker Hub or GHCR.
+
+    Repositories must be made public manually, so a new (or silently-regressed)
+    image would otherwise only surface when an unauthenticated consumer fails to
+    pull it. `is_public()` is tri-state: a registry that we genuinely couldn't
+    reach (None) is reported as a non-fatal warning rather than masquerading as a
+    private repo, so a registry blip doesn't turn into a misleading red build.
+
+    Only ever invoked from this CI build step; running it elsewhere would fire
+    one anonymous registry request per image.
+    """
+    publishable = [dep for dep in deps if dep.publish]
+    if not publishable:
+        return
+
+    # Plain log line, not a `---` Buildkite section marker: this runs in a
+    # background thread concurrently with deps.ensure()'s own sections, and a
+    # competing marker would scramble the log grouping.
+    print("Checking that mzbuild images are public on Docker Hub and GHCR")
+    with ThreadPoolExecutor(max_workers=min(len(publishable), 16)) as executor:
+        results = zip(
+            publishable, executor.map(lambda dep: dep.is_public(), publishable)
+        )
+
+    private = []
+    undetermined = []
+    for dep, (dockerhub, ghcr) in results:
+        registries = [("DockerHub", dockerhub), ("GHCR", ghcr)]
+        if bad := [r for r, ok in registries if ok is False]:
+            private.append(
+                f"Image {dep.name} is not public on {' and '.join(bad)}, "
+                "ask @team-testing to make it public"
+            )
+        if unknown := [r for r, ok in registries if ok is None]:
+            undetermined.append(
+                f"Could not determine whether image {dep.name} is public on "
+                f"{' and '.join(unknown)} (registry error); will recheck next build"
+            )
+
+    for message in undetermined + private:
+        print(message)
+    if ui.env_is_truthy("CI"):
+        if private:
+            _annotate("error", "images-not-public", private)
+        if undetermined:
+            _annotate("warning", "images-public-undetermined", undetermined)
+
+    if private:
+        raise ImagesNotPublicError(f"{len(private)} image(s) are not public")
+
+
+def _annotate(style: str, context: str, messages: list[str]) -> None:
+    spawn.runv(
+        ["buildkite-agent", "annotate", f"--style={style}", f"--context={context}"],
+        stdin="\n".join(f"* {m}" for m in messages).encode(),
+    )
 
 
 def annotate_buildkite_with_tags(arch: Arch, deps: mzbuild.DependencySet) -> None:

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -401,6 +401,108 @@ def is_ghcr_image_pushed(name: str) -> bool:
     return exists
 
 
+# Registry HTTP statuses that indicate a transient problem rather than a
+# definitive answer about visibility, so the public check retries instead of
+# concluding the image is private.
+_TRANSIENT_REGISTRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _get_with_retries(url: str, **kwargs: Any) -> requests.Response | None:
+    """GET `url`, retrying transient failures; returns None if all retries fail."""
+    for sleep_time in [2, 5, 10, None]:
+        try:
+            response = requests.get(url, timeout=10, **kwargs)
+        except requests.RequestException as e:
+            if sleep_time is None:
+                print(f"Error requesting {url}: {e}")
+                return None
+        else:
+            if response.status_code not in _TRANSIENT_REGISTRY_STATUSES:
+                return response
+        if sleep_time is not None:
+            time.sleep(sleep_time)
+    return None
+
+
+# These intentionally do *not* share code with `is_*_image_pushed`: those check
+# existence, authenticate when possible, and cache hits in `known-docker-images`.
+# These check *public visibility*, so they must stay anonymous (no auth
+# fallback) and uncached. They return a tri-state so callers can tell a private
+# repo (actionable) apart from a registry blip (retry the build), see
+# `_get_with_retries` returning None:
+#   True  -> definitively public
+#   False -> definitively not public (private, or repo does not exist)
+#   None  -> could not determine (transient registry/network error)
+
+
+def _json_dict_or_none(response: requests.Response) -> dict[str, Any] | None:
+    """Parse `response` as a JSON object, or None if the body isn't one.
+
+    A malformed body must read as "couldn't determine" (None), not crash the
+    caller out of the tri-state handling and fail the whole build.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def is_docker_image_public(name: str) -> bool | None:
+    """Whether the Docker Hub repository for `name` is public (tri-state).
+
+    Reads repository metadata (`is_private`) via the Hub API rather than the
+    registry, which both avoids the registry's anonymous pull-rate limit (see
+    `mz_image_tag_exists`) and is tag-independent. A 404 means the repo is
+    private or absent; transient errors yield None rather than a false "private".
+    """
+    repo = name.rsplit(":", 1)[0]
+    response = _get_with_retries(f"https://hub.docker.com/v2/repositories/{repo}/")
+    if response is None:
+        return None
+    if response.status_code == 404:
+        return False
+    if response.status_code != 200:
+        return None
+    body = _json_dict_or_none(response)
+    return None if body is None else not body.get("is_private", True)
+
+
+def is_ghcr_image_public(name: str) -> bool | None:
+    """Whether the GHCR repository for `name` is public (tri-state).
+
+    Requests an *anonymous* pull token and lists tags: a public repo authorizes
+    the anonymous client (200), a private or missing one rejects it (401/403/404).
+    Like the Docker Hub check, this is tag-independent.
+    """
+    image = name.removeprefix("ghcr.io/").rsplit(":", 1)[0]
+    token_response = _get_with_retries(
+        "https://ghcr.io/token", params={"scope": f"repository:{image}:pull"}
+    )
+    if token_response is None:
+        return None
+    if token_response.status_code in (401, 403):
+        return False
+    if token_response.status_code != 200:
+        return None
+    body = _json_dict_or_none(token_response)
+    if body is None or "token" not in body:
+        return None
+    token = body["token"]
+    response = _get_with_retries(
+        f"https://ghcr.io/v2/{image}/tags/list",
+        params={"n": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    if response is None:
+        return None
+    if response.status_code == 200:
+        return True
+    if response.status_code in (401, 403, 404):
+        return False
+    return None
+
+
 def chmod_x(path: Path) -> None:
     """Set the executable bit on a file or directory."""
     # https://stackoverflow.com/a/30463972/1122351
@@ -1096,6 +1198,21 @@ class ResolvedImage:
             ui.say(f"{spec} already exists")
             return True
         return False
+
+    def is_public(self) -> tuple[bool | None, bool | None]:
+        """Report whether the image's repo is public on (Docker Hub, GHCR).
+
+        Each element is True (public), False (private/absent), or None (could
+        not determine). Non-publishable images are reported as public on both,
+        since they are never pushed and so the check does not apply to them.
+        """
+        if not self.publish:
+            return (True, True)
+        spec = self.spec()
+        if spec.startswith(GHCR_PREFIX):
+            spec = spec.removeprefix(GHCR_PREFIX)
+        ghcr_spec = f"{GHCR_PREFIX}{spec}"
+        return (is_docker_image_public(spec), is_ghcr_image_public(ghcr_spec))
 
     def run(
         self,


### PR DESCRIPTION
After ensuring images in ci/test/build.py, verify each publishable image is anonymously pullable on both Docker Hub and GHCR, and fail with an actionable annotation otherwise. Repositories are private by default and must be flipped manually, so this catches new (or silently-regressed) images before consumers hit a pull failure.

Follow-up to DB-146, would have prevented it