### PR TITLE
adapter: thread resolved_ids through DeferredPlan to fix restrict_to_user_objects bypass

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -118,7 +118,7 @@ pub struct DeferredPlan {
     /// bypassed `restrict_to_user_objects` for deferred reads (SQL-383).
     pub resolved_ids: ResolvedIds,
     /// Kept separate from `resolved_ids` to mirror the `sequence_plan`
-    /// signature; see [`rbac::check_plan`].
+    /// signature; see [`mz_sql::rbac::check_plan`].
     pub sql_impl_resolved_ids: ResolvedIds,
 }
 

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -113,6 +113,13 @@ pub struct DeferredPlan {
     pub plan: Plan,
     pub validity: PlanValidity,
     pub requires_locks: BTreeSet<CatalogItemId>,
+    /// Forwarded to the resumed `sequence_plan` so `rbac::check_plan` sees the
+    /// same dependencies as on the non-deferred path. Dropping these silently
+    /// bypassed `restrict_to_user_objects` for deferred reads (SQL-383).
+    pub resolved_ids: ResolvedIds,
+    /// Kept separate from `resolved_ids` to mirror the `sequence_plan`
+    /// signature; see [`rbac::check_plan`].
+    pub sql_impl_resolved_ids: ResolvedIds,
 }
 
 #[derive(Debug)]
@@ -237,10 +244,6 @@ impl Coordinator {
                 if let Err(e) = deferred.validity.check(self.catalog()) {
                     deferred.ctx.retire(Err(e))
                 } else {
-                    // Write statements never need to track resolved IDs (NOTE: This is not the
-                    // same thing as plan dependencies, which we do need to re-validate).
-                    let resolved_ids = ResolvedIds::empty();
-
                     // If we pre-acquired our locks, grant them to the session.
                     if let Some(locks) = write_locks {
                         let conn_id = deferred.ctx.session().conn_id().clone();
@@ -257,11 +260,13 @@ impl Coordinator {
                     };
 
                     // Note: This plan is not guaranteed to run, it may get deferred again.
+                    // Resolved IDs are forwarded so the resumed `rbac::check_plan` sees the
+                    // same dependencies as the non-deferred path (SQL-383).
                     self.sequence_plan(
                         deferred.ctx,
                         deferred.plan,
-                        resolved_ids,
-                        ResolvedIds::empty(),
+                        deferred.resolved_ids,
+                        deferred.sql_impl_resolved_ids,
                     )
                     .await;
                 }

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -113,12 +113,7 @@ pub struct DeferredPlan {
     pub plan: Plan,
     pub validity: PlanValidity,
     pub requires_locks: BTreeSet<CatalogItemId>,
-    /// Forwarded to the resumed `sequence_plan` so `rbac::check_plan` sees the
-    /// same dependencies as on the non-deferred path. Dropping these silently
-    /// bypassed `restrict_to_user_objects` for deferred reads (SQL-383).
     pub resolved_ids: ResolvedIds,
-    /// Kept separate from `resolved_ids` to mirror the `sequence_plan`
-    /// signature; see [`mz_sql::rbac::check_plan`].
     pub sql_impl_resolved_ids: ResolvedIds,
 }
 
@@ -260,8 +255,6 @@ impl Coordinator {
                     };
 
                     // Note: This plan is not guaranteed to run, it may get deferred again.
-                    // Resolved IDs are forwarded so the resumed `rbac::check_plan` sees the
-                    // same dependencies as the non-deferred path (SQL-383).
                     self.sequence_plan(
                         deferred.ctx,
                         deferred.plan,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -136,6 +136,8 @@ impl Coordinator {
                     plan,
                     validity,
                     requires_locks: BTreeSet::default(),
+                    resolved_ids,
+                    sql_impl_resolved_ids,
                 };
                 // Defer op accepts an optional write lock, but there aren't any writes occurring
                 // here, since the map to `None`.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2735,7 +2735,7 @@ impl Coordinator {
                             role_metadata,
                         ),
                         requires_locks: source_ids,
-                        // Writes don't track resolved IDs on this path.
+                        // Writes don't track resolved IDs.
                         resolved_ids: ResolvedIds::empty(),
                         sql_impl_resolved_ids: ResolvedIds::empty(),
                     };

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2735,6 +2735,9 @@ impl Coordinator {
                             role_metadata,
                         ),
                         requires_locks: source_ids,
+                        // Writes don't track resolved IDs on this path.
+                        resolved_ids: ResolvedIds::empty(),
+                        sql_impl_resolved_ids: ResolvedIds::empty(),
                     };
                     return self.defer_op(acquire_future, DeferredOp::Plan(plan));
                 }

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -911,9 +911,7 @@ def workflow_restrict_to_user_objects_startup_append_bypass(c: Composition) -> N
 
     def fresh_cursor() -> Cursor:
         # Every check needs a fresh session whose startup append is still pending.
-        return c.sql_cursor(
-            user="restricted_agent", port=6875, reuse_connection=False
-        )
+        return c.sql_cursor(user="restricted_agent", port=6875, reuse_connection=False)
 
     with c.test_case("explain_timestamp_first_statement_blocked"):
         cur = fresh_cursor()

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -965,6 +965,51 @@ def workflow_restrict_to_user_objects_startup_append_bypass(c: Composition) -> N
         )
         assert rows[0][0] == "restricted_agent", rows
 
+    with c.test_case("unrestricted_role_first_statement_succeeds"):
+        # Positive control on the resume path: an unrestricted role running
+        # the same deferred statement as its first statement must succeed,
+        # not error. If `DeferredPlan` now carries `resolved_ids` correctly
+        # the resumed `rbac::check_plan` returns Ok (no `restrict_to_user_objects`
+        # to enforce), and the EXPLAIN TIMESTAMP plan flows through. A
+        # regression here would mean we broke the non-restricted deferral path.
+        cur = c.sql_cursor(user="materialize", port=6875, reuse_connection=False)
+        outcome = run(cur, BYPASS)
+        assert outcome.startswith("ok:"), (
+            f"unrestricted EXPLAIN TIMESTAMP over mz_sessions should succeed "
+            f"as first statement, got: {outcome!r}"
+        )
+
+    with c.test_case("restricted_agent_user_table_first_statement_succeeds"):
+        # Positive control: a restricted role's first statement against a
+        # user-owned object that does NOT depend on mz_sessions must succeed.
+        # Confirms the fix only blocks the system-catalog refs and leaves
+        # legitimate first-statement reads alone.
+        c.sql(
+            """
+            DROP TABLE IF EXISTS restricted_smoke;
+            CREATE TABLE restricted_smoke (a int);
+            INSERT INTO restricted_smoke VALUES (1), (2), (3);
+            GRANT SELECT ON restricted_smoke TO restricted_agent;
+            GRANT USAGE ON SCHEMA public TO restricted_agent;
+            """,
+            user="mz_system",
+            port=6877,
+            print_statement=False,
+        )
+        rows = c.sql_query(
+            "SELECT count(*) FROM restricted_smoke",
+            user="restricted_agent",
+            port=6875,
+            reuse_connection=False,
+        )
+        assert rows[0][0] == 3, rows
+        c.sql(
+            "DROP TABLE restricted_smoke;",
+            user="mz_system",
+            port=6877,
+            print_statement=False,
+        )
+
     # test_case swallows assertion failures, so the cleanup always runs.
     c.sql(
         "DROP ROLE restricted_agent;",

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -1011,8 +1011,14 @@ def workflow_restrict_to_user_objects_startup_append_bypass(c: Composition) -> N
         )
 
     # test_case swallows assertion failures, so the cleanup always runs.
+    # DROP OWNED BY first revokes the schema/object grants the positive-control
+    # cases hand to the role, otherwise DROP ROLE fails with
+    # `DependentObjectsStillExist`.
     c.sql(
-        "DROP ROLE restricted_agent;",
+        """
+        DROP OWNED BY restricted_agent;
+        DROP ROLE restricted_agent;
+        """,
         user="mz_system",
         port=6877,
         print_statement=False,

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -14,6 +14,7 @@ import re
 import time
 
 import requests
+from psycopg import Cursor
 
 from materialize import MZ_ROOT
 from materialize.mzcompose.composition import Composition
@@ -863,6 +864,116 @@ def workflow_endpoints(c: Composition) -> None:
             "replica_count",
             "hydrated_replica_count",
         }, f"unexpected keys in hydration object: {hydration}"
+
+
+def workflow_restrict_to_user_objects_startup_append_bypass(c: Composition) -> None:
+    """Regression test for SQL-383: a `restrict_to_user_objects` read deferred
+    on the session's startup `mz_sessions` builtin-table append resumed with
+    empty `resolved_ids`, silently skipping the system-catalog guard. Same
+    bug class as the SHOW fix in #36543.
+
+    `EXPLAIN TIMESTAMP` is the reliable vector — it reaches `sequence_plan`
+    and its raw plan depends on `mz_sessions`. The deferral fires only on the
+    *first* `mz_sessions` reference in a session, so the same statement is
+    correctly blocked once the wait future is cleared; we use that for a
+    differential check.
+    """
+    c.up("materialized")
+
+    # `restrict_to_user_objects` is enforced independently of
+    # `enable_rbac_checks`, and the no-auth external SQL listener (port 6875)
+    # lets a LOGIN role connect without a password, so each new connection is
+    # a fresh restricted session.
+    c.sql(
+        """
+        DROP ROLE IF EXISTS restricted_agent;
+        CREATE ROLE restricted_agent LOGIN;
+        ALTER ROLE restricted_agent SET restrict_to_user_objects = true;
+        """,
+        user="mz_system",
+        port=6877,
+        print_statement=False,
+    )
+
+    RESTRICTED = "is restricted"
+    # mz_sessions is the only REQUIRED_BUILTIN_TABLE.
+    BYPASS = "EXPLAIN TIMESTAMP FOR SELECT * FROM mz_internal.mz_sessions"
+
+    def run(cur: Cursor, sql: str) -> str:
+        """Run `sql`; return ``"ok:<nrows>"`` or the error message string."""
+        try:
+            cur.execute(sql.encode())
+        except Exception as e:  # noqa: BLE001 — the message is the assertion
+            return str(e)
+        if cur.description is None:
+            return "ok:0"
+        return f"ok:{len(cur.fetchall())}"
+
+    def fresh_cursor() -> Cursor:
+        # Every check needs a fresh session whose startup append is still pending.
+        return c.sql_cursor(
+            user="restricted_agent", port=6875, reuse_connection=False
+        )
+
+    with c.test_case("explain_timestamp_first_statement_blocked"):
+        cur = fresh_cursor()
+        # First reference: deferred for the startup append, then resumed.
+        first = run(cur, BYPASS)
+        # Second reference: wait future already cleared, no deferral.
+        second = run(cur, BYPASS)
+
+        # Control: holds on both builds; proves the restriction works and that
+        # the statement's resolved_ids carry mz_sessions.
+        assert RESTRICTED in second, (
+            "non-deferred EXPLAIN TIMESTAMP over mz_sessions should be blocked, "
+            f"got: {second!r}"
+        )
+
+        # Regression: fails on the buggy build, passes once `DeferredPlan`
+        # carries `resolved_ids` into the resumed `check_plan`.
+        assert RESTRICTED in first, (
+            f"deferred EXPLAIN TIMESTAMP bypassed restrict_to_user_objects, "
+            f"got: {first!r}"
+        )
+
+    with c.test_case("non_required_builtin_blocked_as_first_statement"):
+        # mz_roles is not a REQUIRED_BUILTIN_TABLE, so no deferral fires —
+        # blocked even as the first statement.
+        outcome = run(
+            fresh_cursor(),
+            "EXPLAIN TIMESTAMP FOR SELECT * FROM mz_catalog.mz_roles",
+        )
+        assert RESTRICTED in outcome, (
+            f"first-statement EXPLAIN TIMESTAMP over mz_roles should be blocked, "
+            f"got: {outcome!r}"
+        )
+
+    with c.test_case("frontend_peek_path_not_vulnerable"):
+        # SELECT uses the frontend peek path, which runs the RBAC check before
+        # awaiting the startup appends. Pins that SELECT is not a bypass vector.
+        outcome = run(fresh_cursor(), "SELECT * FROM mz_internal.mz_sessions")
+        assert RESTRICTED in outcome, (
+            f"first-statement SELECT over mz_sessions should be blocked, "
+            f"got: {outcome!r}"
+        )
+
+    with c.test_case("restricted_agent_can_still_run_safe_queries"):
+        # Sanity: the restriction is targeted, not a blanket failure.
+        rows = c.sql_query(
+            "SELECT current_user",
+            user="restricted_agent",
+            port=6875,
+            reuse_connection=False,
+        )
+        assert rows[0][0] == "restricted_agent", rows
+
+    # test_case swallows assertion failures, so the cleanup always runs.
+    c.sql(
+        "DROP ROLE restricted_agent;",
+        user="mz_system",
+        port=6877,
+        print_statement=False,
+    )
 
 
 def workflow_oauth_metadata_host_injection(c: Composition) -> None:


### PR DESCRIPTION
A `restrict_to_user_objects` read deferred for the session's startup `mz_sessions` builtin-table append resumed `sequence_plan` with `ResolvedIds::empty()`, silently skipping the system-catalog guard. The fix carries the planner's resolved IDs through `DeferredPlan` so the resumed `rbac::check_plan` sees the same dependencies as the non-deferred path. Same bug class as the SHOW fix in #36543. Fixes [SQL-383](https://linear.app/materializeinc/issue/SQL-383/mcp-restrict-to-user-objects-rbac-bypass).
