### PR TITLE
console: Bump js-cookie to 3.0.8

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -350,6 +350,7 @@
     "esbuild": "^0.25.0",
     "glob": "^12.0.0",
     "ip-address": "^10.2.0",
+    "js-cookie": "^3.0.7",
     "jsondiffpatch": "^0.7.2",
     "react-router": "^6.30.2",
     "react-router-dom": "^6.30.2",

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -10499,10 +10499,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:3.0.1":
-  version: 3.0.1
-  resolution: "js-cookie@npm:3.0.1"
-  checksum: 10c0/a7dab91286c49610fb198bcc0d78fbafe9be869cf3cea6f7eaea515abdfdc9d347982fe22316e34666b479a0701119482d46faa3a350a3a3404eb954405edf72
+"js-cookie@npm:^3.0.7":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/security/dependabot/421