### PR TITLE
[SS-187] Document minimum version for materialize support for consuming from a physical replica

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -18,7 +18,7 @@ include_blurb=true >}}
 
 {{% create-source/intro %}}
 Materialize supports PostgreSQL (11+) as a data source. PostgreSQL 16+ is
-required for connecting Materialize to a read-only standby. To connect to a
+required for connecting Materialize to a physical replica. To connect to a
 PostgreSQL instance, you first need to [create a connection](#creating-a-connection)
 that specifies access and authentication parameters.
 Once created, a connection is **reusable** across multiple `CREATE SOURCE`

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -17,7 +17,8 @@ other_ref="[new reference page](/sql/create-source/postgres-v2)"
 include_blurb=true >}}
 
 {{% create-source/intro %}}
-Materialize supports PostgreSQL (11+) as a data source. To connect to a
+Materialize supports PostgreSQL (11+) as a data source. PostgreSQL 16+ is
+required for connecting Materialize to a read-only standby. To connect to a
 PostgreSQL instance, you first need to [create a connection](#creating-a-connection)
 that specifies access and authentication parameters.
 Once created, a connection is **reusable** across multiple `CREATE SOURCE`


### PR DESCRIPTION
### Motivation

This is part of SS-187 -- adding support for connecting materialize to a physical postgres replica. 

### Description

Add documentation for minimum version required to connect materialize to a postgres physical replica.
