### PR TITLE
SS-16: Add FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY parsing

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -113,6 +113,47 @@ impl WithOptionName for AvroSchemaOptionName {
     }
 }
 
+/// Options accepted on the `USING AWS GLUE SCHEMA REGISTRY CONNECTION <name> (…)`
+/// form. Today there is only `SCHEMA NAME`, which is required (the Glue
+/// purification step needs it to fetch the writer schema's latest
+/// version at `CREATE SOURCE` time).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GlueAvroOptionName {
+    /// The `SCHEMA NAME [=] '<name>'` option. Names the schema within a
+    /// Glue registry whose latest version is fetched during purification.
+    SchemaName,
+}
+
+impl AstDisplay for GlueAvroOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            GlueAvroOptionName::SchemaName => f.write_str("SCHEMA NAME"),
+        }
+    }
+}
+
+impl WithOptionName for GlueAvroOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            // A schema *name* is a user-chosen identifier, no more
+            // sensitive than a table name.
+            Self::SchemaName => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GlueAvroOption<T: AstInfo> {
+    pub name: GlueAvroOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+impl_display_for_with_option!(GlueAvroOption);
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AvroSchemaOption<T: AstInfo> {
     pub name: AvroSchemaOptionName,
@@ -129,6 +170,13 @@ pub enum AvroSchema<T: AstInfo> {
         schema: Schema,
         with_options: Vec<AvroSchemaOption<T>>,
     },
+    /// `USING AWS GLUE SCHEMA REGISTRY CONNECTION <name> (SCHEMA NAME = '<n>')`.
+    ///
+    /// Parallel to the `Csr` variant.
+    Glue {
+        connection: T::ItemName,
+        with_options: Vec<GlueAvroOption<T>>,
+    },
 }
 
 impl<T: AstInfo> AstDisplay for AvroSchema<T> {
@@ -143,6 +191,18 @@ impl<T: AstInfo> AstDisplay for AvroSchema<T> {
             } => {
                 f.write_str("USING ");
                 schema.fmt(f);
+                if !with_options.is_empty() {
+                    f.write_str(" (");
+                    f.write_node(&display::comma_separated(with_options));
+                    f.write_str(")");
+                }
+            }
+            Self::Glue {
+                connection,
+                with_options,
+            } => {
+                f.write_str("USING AWS GLUE SCHEMA REGISTRY CONNECTION ");
+                f.write_node(connection);
                 if !with_options.is_empty() {
                     f.write_str(" (");
                     f.write_node(&display::comma_separated(with_options));

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2258,7 +2258,7 @@ impl<'a> Parser<'a> {
         // `(...)` with no SCHEMA NAME bypass this function entirely. This also allows
         // us to provide more detailed errors.
         //
-        // Future work may add mutually exclusive options (or interpert a lack of schema name).
+        // Future work may add mutually exclusive options (or interpret a lack of schema name).
         // For example, a lack of schema name may fall back to the default AWS Glue naming strategy:
         // See <https://github.com/awslabs/aws-glue-schema-registry/blob/4b9cac477d6876a883e2a8893738a30c072694dc/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaNamingStrategyDefaultImpl.java#L18>
         Ok(GlueAvroOption {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2201,6 +2201,20 @@ impl<'a> Parser<'a> {
         let avro_schema = if self.parse_keywords(&[CONFLUENT, SCHEMA, REGISTRY]) {
             let csr_connection = self.parse_csr_connection_avro()?;
             AvroSchema::Csr { csr_connection }
+        } else if self.parse_keywords(&[AWS, GLUE, SCHEMA, REGISTRY]) {
+            self.expect_keyword(CONNECTION)?;
+            let connection = self.parse_raw_name()?;
+            let with_options = if self.consume_token(&Token::LParen) {
+                let opts = self.parse_comma_separated(Parser::parse_glue_avro_option)?;
+                self.expect_token(&Token::RParen)?;
+                opts
+            } else {
+                vec![]
+            };
+            AvroSchema::Glue {
+                connection,
+                with_options,
+            }
         } else if self.parse_keyword(SCHEMA) {
             self.prev_token();
             self.expect_keyword(SCHEMA)?;
@@ -2221,7 +2235,7 @@ impl<'a> Parser<'a> {
         } else {
             return self.expected(
                 self.peek_pos(),
-                "CONFLUENT SCHEMA REGISTRY or SCHEMA",
+                "CONFLUENT SCHEMA REGISTRY, AWS GLUE SCHEMA REGISTRY, or SCHEMA",
                 self.peek_token(),
             );
         };
@@ -2232,6 +2246,23 @@ impl<'a> Parser<'a> {
         self.expect_keywords(&[CONFLUENT, WIRE, FORMAT])?;
         Ok(AvroSchemaOption {
             name: AvroSchemaOptionName::ConfluentWireFormat,
+            value: self.parse_optional_option_value()?,
+        })
+    }
+
+    fn parse_glue_avro_option(&mut self) -> Result<GlueAvroOption<Raw>, ParserError> {
+        self.expect_keywords(&[SCHEMA, NAME])?;
+        // The value is parsed as optional even though SCHEMA NAME requires one currently.
+        // Enforcing it here wouldn't let us drop the purification-layer check:
+        // the whole option list is optional, so `CONNECTION glue_conn` and
+        // `(...)` with no SCHEMA NAME bypass this function entirely. This also allows
+        // us to provide more detailed errors.
+        //
+        // Future work may add mutually exclusive options (or interpert a lack of schema name).
+        // For example, a lack of schema name may fall back to the default AWS Glue naming strategy:
+        // See <https://github.com/awslabs/aws-glue-schema-registry/blob/4b9cac477d6876a883e2a8893738a30c072694dc/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaNamingStrategyDefaultImpl.java#L18>
+        Ok(GlueAvroOption {
+            name: GlueAvroOptionName::SchemaName,
             value: self.parse_optional_option_value()?,
         })
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -3655,3 +3655,35 @@ DROP NETWORK POLICY if exists q
 DROP NETWORK POLICY IF EXISTS q
 =>
 DropObjects(DropObjectsStatement { object_type: NetworkPolicy, if_exists: true, names: [NetworkPolicy(Ident("q"))], cascade: false })
+
+# AWS Glue Schema Registry — Avro source format. Parser-only; the planner
+# rejects this variant with a "not yet implemented" error until the
+# follow-up PR.
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema')
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema')
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("my-schema"))) }] }))), envelope: None })
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [] }))), envelope: None })
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY
+----
+error: Expected CONNECTION, found EOF
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY
+                                                                                           ^
+
+parse-statement
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema') ENVELOPE NONE
+----
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema') ENVELOPE NONE
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("my-schema"))) }] }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2379,6 +2379,12 @@ fn get_encoding_inner(
                         sql_bail!("Avro CSR seed resolution has not been performed")
                     }
                 }
+                AvroSchema::Glue { .. } => {
+                    sql_bail!(
+                        "FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY is not yet \
+                         implemented"
+                    )
+                }
             };
 
             // Map the legacy (csr_connection, confluent_wire_format) pair to

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -343,6 +343,7 @@ pub(crate) fn purify_create_sink_avro_doc_on_options(
     let mut avro_format_options = vec![];
     for_each_format(format, |doc_on_schema, fmt| match fmt {
         Format::Avro(AvroSchema::InlineSchema { .. })
+        | Format::Avro(AvroSchema::Glue { .. })
         | Format::Bytes
         | Format::Csv { .. }
         | Format::Json { .. }
@@ -633,6 +634,7 @@ async fn purify_create_sink(
     let mut csr_connection_ids = BTreeSet::new();
     for_each_format(format, |_, fmt| match fmt {
         Format::Avro(AvroSchema::InlineSchema { .. })
+        | Format::Avro(AvroSchema::Glue { .. })
         | Format::Bytes
         | Format::Csv { .. }
         | Format::Json { .. }
@@ -2310,6 +2312,12 @@ async fn purify_source_format_single(
                 .await?
             }
             AvroSchema::InlineSchema { .. } => {}
+            AvroSchema::Glue { .. } => {
+                sql_bail!(
+                    "FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY is not yet \
+                     implemented"
+                );
+            }
         },
         Format::Protobuf(schema) => match schema {
             ProtobufSchema::Csr { csr_connection } => {


### PR DESCRIPTION
Adds new SQL syntax to `CREATE SOURCE` and `CREATE TABLE .. FROM SOURCE` to specify a Glue schema registry connection and schema name.

Note that `SCHEMA NAME` is required currently, but not enforced at the parser level. This doesn't need to remain a requirement, so it's added via `WITH (...)`. By enforcing the requirement at purification, it simplifies error reporting.