### PR TITLE
SS-197 Ignore constraints on PG source tables where one or more columns are excluded

### DIFF
--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -48,7 +48,9 @@ pub enum PgSourcePurificationError {
     DanglingTextColumns { items: Vec<PartialItemName> },
     #[error("EXCLUDE COLUMNS refers to table not currently being added")]
     DanglingExcludeColumns { items: Vec<PartialItemName> },
-    #[error("cannot exclude column \"{column}\" from table \"{table}\" because it is part of a key constraint")]
+    #[error(
+        "cannot exclude column \"{column}\" from table \"{table}\" because it is part of a key constraint"
+    )]
     ExcludedKeyColumn { column: String, table: String },
     #[error("duplicated column name references: {0:?}")]
     DuplicatedColumnNames(Vec<String>),

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -48,6 +48,8 @@ pub enum PgSourcePurificationError {
     DanglingTextColumns { items: Vec<PartialItemName> },
     #[error("EXCLUDE COLUMNS refers to table not currently being added")]
     DanglingExcludeColumns { items: Vec<PartialItemName> },
+    #[error("cannot exclude column \"{column}\" from table \"{table}\" because it is part of a key constraint")]
+    ExcludedKeyColumn { column: String, table: String },
     #[error("duplicated column name references: {0:?}")]
     DuplicatedColumnNames(Vec<String>),
     #[error("referenced tables use unsupported types")]

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -48,10 +48,6 @@ pub enum PgSourcePurificationError {
     DanglingTextColumns { items: Vec<PartialItemName> },
     #[error("EXCLUDE COLUMNS refers to table not currently being added")]
     DanglingExcludeColumns { items: Vec<PartialItemName> },
-    #[error(
-        "cannot exclude column \"{column}\" from table \"{table}\" because it is part of a key constraint"
-    )]
-    ExcludedKeyColumn { column: String, table: String },
     #[error("duplicated column name references: {0:?}")]
     DuplicatedColumnNames(Vec<String>),
     #[error("referenced tables use unsupported types")]

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -284,18 +284,22 @@ pub(super) fn generate_source_export_statement_values(
     let mut constraints = vec![];
     for key in table.keys.clone() {
         let mut key_columns = vec![];
+        let mut all_key_cols_included = true;
 
         for col_num in key.cols {
-            let ident = Ident::new(
-                table
-                    .columns
-                    .iter()
-                    .find(|col| col.col_num == col_num)
-                    .expect("key exists as column")
-                    .name
-                    .clone(),
-            )?;
-            key_columns.push(ident);
+            match table.columns.iter().find(|col| col.col_num == col_num) {
+                Some(col) => {
+                    let ident = Ident::new(col.name.clone())?;
+                    key_columns.push(ident);
+                }
+                None => {
+                    all_key_cols_included = false;
+                    break;
+                }
+            }
+        }
+        if !all_key_cols_included {
+            continue;
         }
 
         let constraint = mz_sql_parser::ast::TableConstraint::Unique {
@@ -447,25 +451,6 @@ pub(super) async fn purify_source_exports(
             let exclude_columns = exclude_column_map.remove(&desc.oid);
 
             if let Some(exclude_cols) = &exclude_columns {
-                // Reject exclusion of key columns before mutating desc.columns.
-                // generate_source_export_statement_values resolves key col_nums
-                // back to columns; excluding a key column leaves a dangling
-                // attnum and triggers a panic there.
-                let key_col_nums: BTreeSet<u16> = desc
-                    .keys
-                    .iter()
-                    .flat_map(|k| k.cols.iter().copied())
-                    .collect();
-                for col_name in exclude_cols.iter() {
-                    if let Some(col) = desc.columns.iter().find(|c| c.name == *col_name) {
-                        if key_col_nums.contains(&col.col_num) {
-                            return Err(PgSourcePurificationError::ExcludedKeyColumn {
-                                column: col_name.clone(),
-                                table: format!("{}.{}", desc.namespace, desc.name),
-                            });
-                        }
-                    }
-                }
                 desc.columns.retain(|c| !exclude_cols.contains(&c.name));
             }
 

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -451,8 +451,11 @@ pub(super) async fn purify_source_exports(
                 // generate_source_export_statement_values resolves key col_nums
                 // back to columns; excluding a key column leaves a dangling
                 // attnum and triggers a panic there.
-                let key_col_nums: BTreeSet<u16> =
-                    desc.keys.iter().flat_map(|k| k.cols.iter().copied()).collect();
+                let key_col_nums: BTreeSet<u16> = desc
+                    .keys
+                    .iter()
+                    .flat_map(|k| k.cols.iter().copied())
+                    .collect();
                 for col_name in exclude_cols.iter() {
                     if let Some(col) = desc.columns.iter().find(|c| c.name == *col_name) {
                         if key_col_nums.contains(&col.col_num) {

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -447,6 +447,22 @@ pub(super) async fn purify_source_exports(
             let exclude_columns = exclude_column_map.remove(&desc.oid);
 
             if let Some(exclude_cols) = &exclude_columns {
+                // Reject exclusion of key columns before mutating desc.columns.
+                // generate_source_export_statement_values resolves key col_nums
+                // back to columns; excluding a key column leaves a dangling
+                // attnum and triggers a panic there.
+                let key_col_nums: BTreeSet<u16> =
+                    desc.keys.iter().flat_map(|k| k.cols.iter().copied()).collect();
+                for col_name in exclude_cols.iter() {
+                    if let Some(col) = desc.columns.iter().find(|c| c.name == *col_name) {
+                        if key_col_nums.contains(&col.col_num) {
+                            return Err(PgSourcePurificationError::ExcludedKeyColumn {
+                                column: col_name.clone(),
+                                table: format!("{}.{}", desc.namespace, desc.name),
+                            });
+                        }
+                    }
+                }
                 desc.columns.retain(|c| !exclude_cols.contains(&c.name));
             }
 

--- a/test/pg-cdc/exclude-columns-key.td
+++ b/test/pg-cdc/exclude-columns-key.td
@@ -35,8 +35,8 @@ CREATE TABLE pk_table (id int PRIMARY KEY, val text);
 INSERT INTO pk_table VALUES (1, 'a'), (2, 'b');
 ALTER TABLE pk_table REPLICA IDENTITY FULL;
 
-# A table with a UNIQUE constraint: `(id, u)` 
-CREATE TABLE uniq_table (id int, u int, val text, UNIQUE (id, u));
+# A table with a UNIQUE constraint: `(id, u)`
+CREATE TABLE uniq_table (id int NOT NULL, u int NOT NULL, val text NOT NULL, UNIQUE (id, u));
 INSERT INTO uniq_table VALUES (1, 10, 'a'), (2, 20, 'b');
 ALTER TABLE uniq_table REPLICA IDENTITY FULL;
 

--- a/test/pg-cdc/exclude-columns-key.td
+++ b/test/pg-cdc/exclude-columns-key.td
@@ -61,24 +61,22 @@ ANALYZE;
   IN CLUSTER storage
   FROM POSTGRES CONNECTION pg (PUBLICATION mz_source);
 
-# Excluding the PRIMARY KEY column must produce a clean error, not crash envd.
-! CREATE TABLE pk_table
+# Excluding the PRIMARY KEY column should be fine
+> CREATE TABLE pk_table
   FROM SOURCE mz_source (REFERENCE public.pk_table)
   WITH (EXCLUDE COLUMNS (id));
-contains:cannot exclude column
 
-# Excluding a UNIQUE-constraint column must likewise be rejected gracefully.
-! CREATE TABLE uniq_table
+# Excluding a UNIQUE-constraint column also okay
+> CREATE TABLE jkljkljhhjk
   FROM SOURCE mz_source (REFERENCE public.uniq_table)
   WITH (EXCLUDE COLUMNS (u));
-contains:cannot exclude column
 
 # Sanity: excluding a non-key column on a keyed table still works, and the key
 # constraint is preserved on the resulting table.
-> CREATE TABLE pk_table
+> CREATE TABLE pk_table_2
   FROM SOURCE mz_source (REFERENCE public.pk_table)
   WITH (EXCLUDE COLUMNS (val));
 
-> SELECT * FROM pk_table;
+> SELECT * FROM pk_table_2;
 1
 2

--- a/test/pg-cdc/exclude-columns-key.td
+++ b/test/pg-cdc/exclude-columns-key.td
@@ -8,23 +8,8 @@
 # by the Apache License, Version 2.0.
 
 #
-# Regression test: EXCLUDE COLUMNS naming a key column must be rejected with a
-# graceful planning error, NOT a process-aborting panic.
-#
-# `purify_source_exports` prunes excluded columns from the table descriptor's
-# column list (src/sql/src/pure/postgres.rs) but leaves `desc.keys` referencing
-# the removed column's attnum. `generate_source_export_statement_values` then
-# walks every key and resolves each `col_num` back to a column via
-# `.find(...).expect("key exists as column")`. Excluding a PRIMARY KEY or UNIQUE
-# column leaves a dangling attnum in `key.cols`, so the lookup returns `None` and
-# the `.expect()` panics. Purification runs in a `task::spawn` future that is not
-# wrapped in `catch_unwind`, so the enhanced panic handler calls `process::abort()`
-# and takes down all of environmentd. Keys are loaded from `pg_constraint`
-# (contype IN ('p','u')) independent of replica identity, so this is reachable on
-# any REPLICA IDENTITY FULL table that also has a key.
-#
-# The existing test/pg-cdc/exclude-columns.td only excludes a non-key column on a
-# keyless table, so this path had no coverage.
+# We can support the exclusion of constraint columns, and any constraint for which one or more
+# columns is excluded will simply be ignored.
 #
 
 > CREATE CLUSTER storage SIZE '${arg.default-replica-size}'
@@ -50,8 +35,8 @@ CREATE TABLE pk_table (id int PRIMARY KEY, val text);
 INSERT INTO pk_table VALUES (1, 'a'), (2, 'b');
 ALTER TABLE pk_table REPLICA IDENTITY FULL;
 
-# A table with a UNIQUE constraint: `u` (attnum 2) participates in the key.
-CREATE TABLE uniq_table (id int, u int UNIQUE, val text);
+# A table with a UNIQUE constraint: `(id, u)` 
+CREATE TABLE uniq_table (id int, u int, val text, UNIQUE (id, u));
 INSERT INTO uniq_table VALUES (1, 10, 'a'), (2, 20, 'b');
 ALTER TABLE uniq_table REPLICA IDENTITY FULL;
 
@@ -67,9 +52,26 @@ ANALYZE;
   WITH (EXCLUDE COLUMNS (id));
 
 # Excluding a UNIQUE-constraint column also okay
-> CREATE TABLE jkljkljhhjk
+> CREATE TABLE uniq_table
   FROM SOURCE mz_source (REFERENCE public.uniq_table)
   WITH (EXCLUDE COLUMNS (u));
+
+# Verify that the constraint is ignored on uniq_table
+> CREATE DEFAULT INDEX ON uniq_table;
+
+> SELECT key FROM (SHOW INDEXES ON uniq_table);
+{id,val}
+
+? EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT DISTINCT id FROM uniq_table
+Explained Query:
+  Distinct project=[#0]
+    Project (#0)
+      ReadIndex on=uniq_table uniq_table_primary_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.uniq_table_primary_idx (*** full scan ***)
+
+Target cluster: quickstart
 
 # Sanity: excluding a non-key column on a keyed table still works, and the key
 # constraint is preserved on the resulting table.

--- a/test/pg-cdc/exclude-columns-key.td
+++ b/test/pg-cdc/exclude-columns-key.td
@@ -1,0 +1,84 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Regression test: EXCLUDE COLUMNS naming a key column must be rejected with a
+# graceful planning error, NOT a process-aborting panic.
+#
+# `purify_source_exports` prunes excluded columns from the table descriptor's
+# column list (src/sql/src/pure/postgres.rs) but leaves `desc.keys` referencing
+# the removed column's attnum. `generate_source_export_statement_values` then
+# walks every key and resolves each `col_num` back to a column via
+# `.find(...).expect("key exists as column")`. Excluding a PRIMARY KEY or UNIQUE
+# column leaves a dangling attnum in `key.cols`, so the lookup returns `None` and
+# the `.expect()` panics. Purification runs in a `task::spawn` future that is not
+# wrapped in `catch_unwind`, so the enhanced panic handler calls `process::abort()`
+# and takes down all of environmentd. Keys are loaded from `pg_constraint`
+# (contype IN ('p','u')) independent of replica identity, so this is reachable on
+# any REPLICA IDENTITY FULL table that also has a key.
+#
+# The existing test/pg-cdc/exclude-columns.td only excludes a non-key column on a
+# keyless table, so this path had no coverage.
+#
+
+> CREATE CLUSTER storage SIZE '${arg.default-replica-size}'
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+# A table with a PRIMARY KEY: `id` (attnum 1) participates in the key.
+CREATE TABLE pk_table (id int PRIMARY KEY, val text);
+INSERT INTO pk_table VALUES (1, 'a'), (2, 'b');
+ALTER TABLE pk_table REPLICA IDENTITY FULL;
+
+# A table with a UNIQUE constraint: `u` (attnum 2) participates in the key.
+CREATE TABLE uniq_table (id int, u int UNIQUE, val text);
+INSERT INTO uniq_table VALUES (1, 10, 'a'), (2, 20, 'b');
+ALTER TABLE uniq_table REPLICA IDENTITY FULL;
+
+ANALYZE;
+
+> CREATE SOURCE mz_source
+  IN CLUSTER storage
+  FROM POSTGRES CONNECTION pg (PUBLICATION mz_source);
+
+# Excluding the PRIMARY KEY column must produce a clean error, not crash envd.
+! CREATE TABLE pk_table
+  FROM SOURCE mz_source (REFERENCE public.pk_table)
+  WITH (EXCLUDE COLUMNS (id));
+contains:cannot exclude column
+
+# Excluding a UNIQUE-constraint column must likewise be rejected gracefully.
+! CREATE TABLE uniq_table
+  FROM SOURCE mz_source (REFERENCE public.uniq_table)
+  WITH (EXCLUDE COLUMNS (u));
+contains:cannot exclude column
+
+# Sanity: excluding a non-key column on a keyed table still works, and the key
+# constraint is preserved on the resulting table.
+> CREATE TABLE pk_table
+  FROM SOURCE mz_source (REFERENCE public.pk_table)
+  WITH (EXCLUDE COLUMNS (val));
+
+> SELECT * FROM pk_table;
+1
+2


### PR DESCRIPTION
Adds a new error type and check during postgres `CREATE TABLE` purification to validate that none of the excluded columns are primary keys.

https://linear.app/materializeinc/issue/SS-197/thread-tokiowork-3-panicked-at-srcsqlsrcpurepostgresrs29422-key-exists
