### PR TITLE
images: use statically-linked AWS-LC ssh in prod base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,21 @@ updates:
         - minor
         - patch
 - package-ecosystem: docker
+  directory: /misc/images/openssh-static
+  schedule:
+    interval: weekly
+    day: sunday
+    time: "22:00"
+  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
+  open-pull-requests-limit: 50
+  labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
+- package-ecosystem: docker
   directory: /ci/builder
   schedule:
     interval: weekly

--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -11,6 +11,9 @@
 # every time we get a CI builder with a cold cache.
 MZFROM console AS console
 
+# Statically-linked `ssh` client, used by the SSH tunnel feature.
+MZFROM openssh-static AS openssh-static
+
 MZFROM ubuntu-base
 
 ARG CI_SANITIZER=none
@@ -24,7 +27,6 @@ RUN groupadd --system --gid=999 materialize \
         gettext-base \
         nginx \
         postgresql-16 \
-        openssh-client \
         tini \
     && if [ "$CI_SANITIZER" != "none" ]; then \
         TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends llvm; \
@@ -61,6 +63,8 @@ COPY postgresql.conf pg_hba.conf /etc/postgresql/
 
 COPY --from=console /usr/share/nginx/html /usr/share/nginx/html
 COPY console_nginx.template /etc/nginx/templates/default.conf.template
+
+COPY --from=openssh-static /output/ssh /usr/bin/ssh
 
 # Configure the console to listen on port 6874 and proxy API requests through to
 # the Materialize instance that will be started and listening for requests on

--- a/misc/images/prod-base/Dockerfile
+++ b/misc/images/prod-base/Dockerfile
@@ -10,6 +10,9 @@
 # This is a separate mzimage so that we don't have to re-install the apt things
 # every time we get a CI builder with a cold cache.
 
+# Statically-linked `ssh` client, used by the SSH tunnel feature.
+MZFROM openssh-static AS openssh-static
+
 MZFROM ubuntu-base
 
 RUN groupadd --system --gid=999 materialize \
@@ -22,7 +25,6 @@ RUN apt-get update \
         ca-certificates \
         curl \
         tini \
-        openssh-client \
     && if [ "$CI_SANITIZER" != "none" ]; then \
         TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends llvm; \
        fi \
@@ -31,3 +33,5 @@ RUN apt-get update \
     && chown materialize /scratch \
     && mkdir /mzdata \
     && chown materialize /mzdata
+
+COPY --from=openssh-static /output/ssh /usr/bin/ssh


### PR DESCRIPTION
## Motivation

Part of container hardening: move the production images toward distroless bases. Distroless ships no apt and no `/usr/bin/ssh`, but the SSH tunnel feature (`src/ssh-util`) shells out to a system `ssh` binary via the `openssh` crate. This PR removes the dependency on apt's `openssh-client` by copying in the statically-linked `ssh` client from the existing `openssh-static` mzbuild image (OpenSSH 10.3p1 built against AWS-LC).

## Changes

- `misc/images/prod-base/Dockerfile` (feeds `clusterd`, `environmentd`, `mz`, `jobs`) and `misc/images/materialized-base/Dockerfile` (feeds `materialized`) now:
  - declare `MZFROM openssh-static AS openssh-static`
  - `COPY --from=openssh-static /output/ssh /usr/bin/ssh`
  - drop `openssh-client` from the apt install list

  This follows the existing cross-image `COPY` pattern already used for `console` in `materialized-base`. mzbuild picks up `openssh-static` as a dependency automatically (verified via `bin/mzimage describe`).

As a side benefit, `openssh-static` becomes an actually-consumed image rather than a built-but-orphaned leaf — relevant to DB-146, where the orphaned private image was being rebuilt from source on every CI build.

## Verification

Local build of `prod-base`:
- `ssh -V` → `OpenSSH_10.3p1, AWS-LC 1.54.0`
- `ldd /usr/bin/ssh` → *not a dynamic executable* (~4 MB, static)
- `dpkg -l | grep openssh` → none (apt package removed)

## Risk / what reviewers should check

The static build ships **only** `ssh` — no `ssh-keygen`/`scp`/`sftp`, no `/etc/ssh/ssh_config`, no system known_hosts/moduli. The tunnel code uses `KnownHosts::Accept` and only needs the `ssh` client, so this should be fine, but the **SSH source/sink nightly tests should run against these images before merge** to confirm the runtime tunnel path. Opening as a draft to let CI exercise this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)