### PR TITLE
mz-test: don't default to sqllogictest --optimized for single files

### DIFF
--- a/.agents/skills/mz-test/SKILL.md
+++ b/.agents/skills/mz-test/SKILL.md
@@ -36,12 +36,15 @@ Use a bash timeout of at least 600000ms (10 min) for test commands.
 Run sqllogictest files with:
 
 ```
-bin/sqllogictest --optimized -- PATH
+bin/sqllogictest -- PATH [PATH ...]
 ```
 
 `PATH` is relative to the repo root, usually a file in `test/sqllogictest/`.
+sqllogictest accepts a list of files, not just one, and runs them in order.
 Rewrite expected results with `bin/sqllogictest -- --rewrite-results PATH`.
-For large test files, `--optimized` significantly improves execution speed at the cost of longer compile time.
+
+Add `--optimized` when running many or large files: it significantly improves execution speed at the cost of a longer one-time compile.
+For a single small file, skip `--optimized`, since the extra compile time outweighs the runtime savings.
 You can use `-v` for printing each query before it is run, e.g. to figure out where we are crashing.
 
 ## Testdrive


### PR DESCRIPTION
The mz-test skill instructed agents to always run `bin/sqllogictest --optimized`.
That flag trades a longer one-time compile for faster query execution, so it only pays off when running many or large files.
For a single small file the extra compile time dominates, making the `--optimized` default slower than a plain run.

This reframes the default command as plain `bin/sqllogictest -- PATH` and documents `--optimized` as opt-in for many or large files.
It also notes that sqllogictest accepts a list of files and runs them in order, which the prior single-`PATH` example obscured (verified against `paths: Vec<String>` in `src/sqllogictest/src/bin/sqllogictest.rs`).

Docs-only change to `.agents/skills/mz-test/SKILL.md`; no code or tests affected.