### PR TITLE
mz-deploy: init, help, and docs fixes

### DIFF
--- a/doc/developer/design/20260610_mz_deploy.md
+++ b/doc/developer/design/20260610_mz_deploy.md
@@ -1226,7 +1226,7 @@ state survives between tests even within one session.
 #### The Docker runtime (`docker_runtime.rs`)
 
 Tests (and `explain`) run against a long-lived local container named
-`mz-deploy-typecheck`, publishing Materialize on host port 16875, started
+`mz-deploy-sandbox`, publishing Materialize on host port 16875, started
 with `MZ_EAT_MY_DATA=1` and raised object limits. `get_client()` tries a
 fast-path connection first and only shells out to Docker (existence check →
 running check → health check → restart or recreate) when that fails, so the
@@ -1235,7 +1235,7 @@ comes from `project.toml`'s `mz_version` or the `--docker-image` flag.
 
 Two sharp edges: the container is shared *globally*, not per project — any
 project on the machine reuses it; and reuse is by name, not image, so
-changing the image requires `docker rm -f mz-deploy-typecheck` before the
+changing the image requires `docker rm -f mz-deploy-sandbox` before the
 new one takes effect. Connections to it use the unpinned variant
 (`connect_with_profile_no_pin`) since the container has no
 `_mz_deploy_server` cluster.
@@ -1512,7 +1512,7 @@ The full implementation exists and is validated end to end:
   project); two projects declaring the same database name under one profile
   would collide on the overlay name. Worth either a project component in
   the name or a documented restriction.
-- **Docker image rotation.** The shared `mz-deploy-typecheck` container is
+- **Docker image rotation.** The shared `mz-deploy-sandbox` container is
   reused by name, so changing `mz_version` requires a manual
   `docker rm -f`. The runtime could compare the running container's image
   against the requested one and recreate automatically.

--- a/doc/user/content/manage/mz-deploy/local-development.md
+++ b/doc/user/content/manage/mz-deploy/local-development.md
@@ -141,8 +141,9 @@ mz-deploy test --junit-xml results.xml
 ## Explain query plans
 
 {{< note >}}
-Requires Docker and a database connection. The command stages objects in a
-temporary schema on your live Materialize instance.
+Requires Docker; no live Materialize connection is needed. The command stages
+the target's dependencies in a temporary schema inside an ephemeral local
+Materialize container.
 {{< /note >}}
 
 ```bash

--- a/doc/user/content/manage/mz-deploy/project-structure.md
+++ b/doc/user/content/manage/mz-deploy/project-structure.md
@@ -132,8 +132,9 @@ database-level statements:
 
 The `project.toml` file in your project root controls project-wide settings:
 
-- **`mz_version`** — the Materialize version used for local type-checking. Set
-  to `"cloud"` to use the latest cloud version.
+- **`mz_version`** — the Materialize version used to run `test` and `explain`
+  locally (it selects the Docker image). Set to `"cloud"` to use the latest
+  cloud version.
 - **`dependencies`** — external dependency declarations for objects your project
   references but does not own. See [Local development](/manage/mz-deploy/local-development/)
   for details.

--- a/src/mz-deploy/src/bin/mz-deploy/main.rs
+++ b/src/mz-deploy/src/bin/mz-deploy/main.rs
@@ -116,7 +116,7 @@ struct GlobalArgs {
     #[arg(short, long, global = true, env = "MZ_DEPLOY_PROFILE")]
     profile: Option<String>,
 
-    /// Materialize Docker image to use for tests
+    /// Materialize Docker image to use for `test` and `explain`
     #[arg(long, value_name = "IMAGE", global = true)]
     docker_image: Option<String>,
 

--- a/src/mz-deploy/src/cli/commands.rs
+++ b/src/mz-deploy/src/cli/commands.rs
@@ -16,8 +16,7 @@
 //! ## Commands
 //!
 //! - **[`new_project`]** — Scaffold a new mz-deploy project directory.
-//! - **[`compile`]** — Parse and validate the project, optionally type-checking
-//!   against a Docker container.
+//! - **[`compile`]** — Parse, validate, and type-check the project locally.
 //! - **[`explain`]** — Show the EXPLAIN plan for a materialized view or index.
 //! - **[`stage`]** — Deploy the project to a staging environment.
 //! - **[`wait`]** — Check hydration status of a staged deployment.

--- a/src/mz-deploy/src/cli/commands/new_project.rs
+++ b/src/mz-deploy/src/cli/commands/new_project.rs
@@ -173,6 +173,10 @@ fn print_skill_hint() {
 }
 
 /// Common scaffolding logic shared by `new` and `init`.
+///
+/// Idempotent: files that already exist are left untouched, and the git commit
+/// is skipped when there is nothing staged. The commit sets an explicit author
+/// and committer so it does not depend on the user's git identity.
 fn scaffold(project_dir: &Path, name: &str, opts: &ScaffoldOpts) -> Result<(), CliError> {
     create_dir(project_dir, "models/materialize/public")?;
     create_dir(project_dir, "clusters")?;
@@ -222,34 +226,85 @@ fn scaffold(project_dir: &Path, name: &str, opts: &ScaffoldOpts) -> Result<(), C
             return Err(CliError::Message("git add failed".to_string()));
         }
 
-        let status = Command::new("git")
-            .args([
-                "commit",
-                "--author",
-                "Materialize Inc <noreply@materialize.com>",
-                "-m",
-                "Initial commit",
-            ])
+        let nothing_staged = Command::new("git")
+            .args(["diff", "--cached", "--quiet"])
             .current_dir(project_dir)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
-            .map_err(|e| CliError::Message(format!("failed to run git commit: {}", e)))?;
+            .map_err(|e| CliError::Message(format!("failed to run git diff: {}", e)))?
+            .success();
 
-        if !status.success() {
-            return Err(CliError::Message("git commit failed".to_string()));
+        if !nothing_staged {
+            let status = Command::new("git")
+                .args([
+                    "commit",
+                    "--author",
+                    "Materialize Inc <noreply@materialize.com>",
+                    "-m",
+                    "Initial commit",
+                ])
+                .env("GIT_COMMITTER_NAME", "Materialize Inc")
+                .env("GIT_COMMITTER_EMAIL", "noreply@materialize.com")
+                .current_dir(project_dir)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map_err(|e| CliError::Message(format!("failed to run git commit: {}", e)))?;
+
+            if !status.success() {
+                return Err(CliError::Message("git commit failed".to_string()));
+            }
         }
     }
 
     Ok(())
 }
 
+/// Writes a scaffold file, leaving any file that already exists untouched.
 fn add_file(project_dir: &Path, file: &str, content: &str) -> Result<(), CliError> {
-    fs::write(project_dir.join(file), content)
+    let path = project_dir.join(file);
+    if path.exists() {
+        return Ok(());
+    }
+    fs::write(&path, content)
         .map_err(|e| CliError::Message(format!("failed to write {}: {}", file, e)))
 }
 
 fn create_dir(project_dir: &Path, path: &str) -> Result<(), CliError> {
     fs::create_dir_all(project_dir.join(path))
         .map_err(|e| CliError::Message(format!("failed to create directories: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Scaffolding the same directory twice succeeds — including the git path,
+    /// where the second run has nothing to commit. Regression for `init`
+    /// failing with "git commit failed" on an already-committed project.
+    #[cfg_attr(miri, ignore)] // spawns the `git` binary
+    #[mz_ore::test]
+    fn scaffold_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let opts = ScaffoldOpts { init_git: true };
+        scaffold(dir.path(), "proj", &opts).expect("first scaffold should succeed");
+        scaffold(dir.path(), "proj", &opts).expect("second scaffold should be idempotent");
+        assert!(dir.path().join("project.toml").exists());
+    }
+
+    /// Re-scaffolding never overwrites a file the user already has.
+    #[cfg_attr(miri, ignore)] // touches the filesystem
+    #[mz_ore::test]
+    fn scaffold_preserves_existing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let custom = "mz_version = \"cloud\"\ndependencies = [\"app.public.foo\"]\n";
+        fs::write(dir.path().join("project.toml"), custom).unwrap();
+
+        scaffold(dir.path(), "proj", &ScaffoldOpts { init_git: false })
+            .expect("scaffold should succeed over an existing project.toml");
+
+        let contents = fs::read_to_string(dir.path().join("project.toml")).unwrap();
+        assert_eq!(contents, custom, "existing project.toml must be preserved");
+    }
 }

--- a/src/mz-deploy/src/cli/error.rs
+++ b/src/mz-deploy/src/cli/error.rs
@@ -271,7 +271,7 @@ impl CliError {
             Self::Connection(e) => match e {
                 ConnectionError::DeploymentNotFound { deploy_id } => Some(format!(
                     "verify the staging environment name '{}' is correct, or deploy to staging first using:\n  \
-                     {} {} {} --name {}",
+                     {} {} {} --deploy-id {}",
                     deploy_id.if_supports_color(Stream::Stderr, |t| t.yellow()),
                     "mz-deploy".if_supports_color(Stream::Stderr, |t| t.cyan()),
                     "stage".if_supports_color(Stream::Stderr, |t| t.cyan()),
@@ -306,12 +306,12 @@ impl CliError {
                     "the following schemas were updated in production after your deployment started:\n{}\n\n\
                      Rebase your deployment by running:\n  \
                      {} {} {}\n  \
-                     {} {} {} --name <staging-env>\n\n\
+                     {} {} {} --deploy-id <staging-env>\n\n\
                      Or use {} to force the deployment (may overwrite recent changes)",
                     conflict_list,
                     "mz-deploy".if_supports_color(Stream::Stderr, |t| t.cyan()),
                     "abort".if_supports_color(Stream::Stderr, |t| t.cyan()),
-                    "--name <staging-env>".if_supports_color(Stream::Stderr, |t| t.cyan()),
+                    "<staging-env>".if_supports_color(Stream::Stderr, |t| t.cyan()),
                     "mz-deploy".if_supports_color(Stream::Stderr, |t| t.cyan()),
                     "stage".if_supports_color(Stream::Stderr, |t| t.cyan()),
                     ".".if_supports_color(Stream::Stderr, |t| t.cyan()),
@@ -320,7 +320,7 @@ impl CliError {
             }
             Self::GitShaFailed => Some(
                 "either run mz-deploy from inside a git repository, or provide a staging environment name using:\n  \
-                 mz-deploy stage . --name <environment-name>"
+                 mz-deploy stage . --deploy-id <environment-name>"
                     .to_string(),
             ),
             Self::GitDirty => Some(

--- a/src/mz-deploy/src/cli/help/debug.md
+++ b/src/mz-deploy/src/cli/help/debug.md
@@ -42,7 +42,7 @@ connectivity and configuration before running deployments.
 - **Profile not found** — List available profiles in `profiles.toml`
   or create one with the connection details.
 - **Docker not installed** — Install Docker from https://docs.docker.com/get-docker/.
-  Docker is required for `mz-deploy test`.
+  Docker is required for `mz-deploy test` and `mz-deploy explain`.
 - **Docker daemon not running** — Start Docker Desktop or the Docker daemon
   (`sudo systemctl start docker` on Linux).
 

--- a/src/mz-deploy/src/cli/help/explain.md
+++ b/src/mz-deploy/src/cli/help/explain.md
@@ -27,10 +27,10 @@ object type that supports indexes.
 2. Compiles the project and verifies the target exists with the expected
    type (materialized view, or any object with the named index).
 3. Starts a Materialize Docker container, or reuses the existing one. The
-   container has a fixed name (`mz-deploy-typecheck`) and is shared across
+   container has a fixed name (`mz-deploy-sandbox`) and is shared across
    `test` and `explain` invocations on this host. Reuse is by name, not
    by image — to pick up a different `--docker-image`, remove the
-   container first: `docker rm -f mz-deploy-typecheck`.
+   container first: `docker rm -f mz-deploy-sandbox`.
 4. Creates a temporary schema (`_mz_explain_<timestamp>`) and stages the
    target's transitive dependencies into it as stub tables, indexes, or
    views.

--- a/src/mz-deploy/src/cli/help/init.md
+++ b/src/mz-deploy/src/cli/help/init.md
@@ -15,12 +15,12 @@ derived from the current directory name.
     - `models/materialize/public/` — SQL files for views, MVs, etc.
     - `clusters/` — Cluster definitions
     - `roles/` — Role definitions
+    - `network-policies/` — Network policy definitions
 3. Writes boilerplate files:
     - `project.toml` — Project configuration
-    - `.gitignore` — Ignores `target/` build artifact directory
+    - `.gitignore` — Ignores `target/` and the per-developer `.mzprofile`
     - `README.md` — Getting-started documentation
-    - `.agents/skills/mz-deploy/SKILL.md` — LLM agent skill file
-    - `.claude/skills/mz-deploy/` — Symlink (auto-loaded by Claude Code)
+    - `.vscode/extensions.json` — Recommended editor extensions
 4. Initializes a git repository (unless `--no-git`).
 
 ## Flags

--- a/src/mz-deploy/src/cli/help/new.md
+++ b/src/mz-deploy/src/cli/help/new.md
@@ -15,12 +15,12 @@ repository.
     - `models/materialize/public/` — SQL files for views, MVs, etc.
     - `clusters/` — Cluster definitions
     - `roles/` — Role definitions
+    - `network-policies/` — Network policy definitions
 3. Writes boilerplate files:
     - `project.toml` — Project configuration
-    - `.gitignore` — Ignores `target/` build artifact directory
+    - `.gitignore` — Ignores `target/` and the per-developer `.mzprofile`
     - `README.md` — Getting-started documentation
-    - `.agents/skills/mz-deploy/SKILL.md` — LLM agent skill file
-    - `.claude/skills/mz-deploy/` — Symlink (auto-loaded by Claude Code)
+    - `.vscode/extensions.json` — Recommended editor extensions
 4. Initializes a git repository (unless `--no-git`).
 
 ## Flags

--- a/src/mz-deploy/src/cli/help/test.md
+++ b/src/mz-deploy/src/cli/help/test.md
@@ -78,10 +78,10 @@ used during test execution:
 
 1. Compiles the project and discovers all `EXECUTE UNIT TEST` statements.
 2. Starts a Materialize Docker container, or reuses the existing one. The
-   container has a fixed name (`mz-deploy-typecheck`) and is shared across
+   container has a fixed name (`mz-deploy-sandbox`) and is shared across
    `test` and `explain` invocations on this host. Reuse is by name, not by
    image, so to pick up a different `--docker-image` you must remove the
-   container first: `docker rm -f mz-deploy-typecheck`.
+   container first: `docker rm -f mz-deploy-sandbox`.
 3. Loads type information from `types.lock` (external dependencies) and
    the compiler database (internal types, regenerated if stale).
 4. For each test:

--- a/src/mz-deploy/src/config.rs
+++ b/src/mz-deploy/src/config.rs
@@ -620,7 +620,7 @@ pub struct Settings {
     /// Resolved profile name (CLI --profile overrides project.toml default).
     /// `None` when no profile is configured and the command doesn't require one.
     pub profile_name: Option<String>,
-    /// Resolved Docker image for type checking and tests.
+    /// Resolved Docker image for the ephemeral container used by `test` and `explain`.
     pub docker_image: String,
     /// Per-profile config (security, profile_suffix) — used for SecretResolver.
     /// Default-constructed (empty variables, no suffix) when `profile_name` is `None`.

--- a/src/mz-deploy/src/docker_runtime.rs
+++ b/src/mz-deploy/src/docker_runtime.rs
@@ -37,8 +37,8 @@ pub(crate) enum DockerStatus {
     NotInstalled,
 }
 
-/// Name of the persistent Docker container.
-const CONTAINER_NAME: &str = "mz-deploy-typecheck";
+/// Name of the persistent Docker container used by `test` and `explain`.
+const CONTAINER_NAME: &str = "mz-deploy-sandbox";
 
 /// Host port to bind for the persistent container.
 const CONTAINER_PORT: u16 = 16875;
@@ -100,7 +100,7 @@ impl DockerRuntime {
 
     fn make_profile() -> Profile {
         Profile {
-            name: "docker-typecheck".to_string(),
+            name: "docker-sandbox".to_string(),
             host: Some("localhost".to_string()),
             port: CONTAINER_PORT,
             username: "materialize".to_string(),


### PR DESCRIPTION
Small, low-risk `mz-deploy` ergonomics fixes for `init`, command help, and docs.
Split out from the larger fix batch so they can land quickly.

### How to review

**Each commit is a self-contained change and can be reviewed on its own.** Every
commit here is either *trivially correct* (a docs/help/string change with no
behavioral risk) or *provably correct* against the test that ships in the same
commit.

### Commits

1. **correct stale `--name` flag in error hints**
   An error hint referenced a `--name` flag that no longer exists. Fixes the hint
   text. *Trivially correct:* user-facing string only.

2. **make init idempotent**
   `mz-deploy init` was not quite idempotent — re-running it in an initialized
   directory could error. Makes it a no-op on already-initialized projects.
   *Provably correct:* test runs `init` twice and in an existing git repo.

3. **drop nonexistent files from init/new help text**
   `init`/`new` help listed files the commands don't create. Trims the help to
   what is actually generated. *Trivially correct:* help text only.

4. **stop describing Docker as a type-checking tool**
   Documentation incorrectly described Docker as performing type checking. Docs
   wording fix. *Trivially correct:* docs only.

### Release notes

This release will make `mz-deploy init` idempotent and correct several
`mz-deploy` help and documentation strings.
