### PR TITLE
compute: consolidate read-only MV sink correction buffer (CLU-131)

### DIFF
--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -276,7 +276,7 @@ where
         sink_id,
         persist_api.clone(),
         as_of.clone(),
-        read_only_rx,
+        read_only_rx.clone(),
         desired,
     );
 
@@ -287,6 +287,7 @@ where
         desired,
         persist,
         descs.clone(),
+        read_only_rx,
         Rc::clone(&compute_state.worker_config),
     );
 
@@ -781,6 +782,7 @@ mod write {
         desired: DesiredStreams<'s>,
         persist: PersistStreams<'s>,
         descs: DescsStream<'s>,
+        mut read_only_rx: watch::Receiver<bool>,
         worker_config: Rc<ConfigSet>,
     ) -> (BatchesStream<'s>, PressOnDropButton) {
         let scope = desired.ok.scope();
@@ -832,6 +834,7 @@ mod write {
 
             let writer = persist_api.open_writer().await;
             let sink_metrics = persist_api.open_metrics().await;
+            let read_only = *read_only_rx.borrow_and_update();
             let mut state = State::new(
                 sink_id,
                 worker_id,
@@ -839,6 +842,7 @@ mod write {
                 sink_metrics,
                 channel_logging,
                 as_of,
+                read_only,
                 &worker_config,
             );
             let mut correction_logger = correction_logger;
@@ -913,6 +917,14 @@ mod write {
                             Event::Progress(_frontier) => None,
                         }
                     }
+                    // Track read-only mode so the forced consolidation stops re-arming once
+                    // writes are allowed and the batch-write path takes over.
+                    Ok(()) = read_only_rx.changed(), if state.read_only => {
+                        if !*read_only_rx.borrow_and_update() {
+                            state.set_read_only(false);
+                        }
+                        None
+                    }
                     // All inputs are exhausted, so we can shut down.
                     else => return,
                 };
@@ -953,9 +965,13 @@ mod write {
         ///
         /// Normally we force a consolidation whenever we write a batch, but there are periods
         /// (like read-only mode) when that doesn't happen, and we need to manually force
-        /// consolidation instead. Currently this is only used to ensure we quickly get rid of the
-        /// snapshot updates.
+        /// consolidation instead. In read-only mode this is re-armed after each firing so it
+        /// keeps sweeping forward as the frontiers advance (see `maybe_force_consolidation`).
         force_consolidation_after: Option<Antichain<Timestamp>>,
+        /// Whether the sink is in read-only mode. While read-only the `write` operator mints no
+        /// batches, so the batch-write path never sweeps `consolidate_before(upper)` forward; the
+        /// forced consolidation stands in for it and is re-armed as long as this holds.
+        read_only: bool,
     }
 
     impl State {
@@ -966,6 +982,7 @@ mod write {
             metrics: SinkMetrics,
             logging: Option<ChannelLogging>,
             as_of: Antichain<Timestamp>,
+            read_only: bool,
             worker_config: &ConfigSet,
         ) -> Self {
             let worker_metrics = metrics.for_worker(worker_id);
@@ -991,6 +1008,7 @@ mod write {
                 persist_frontiers: OkErr::new_frontiers(),
                 batch_description: None,
                 force_consolidation_after,
+                read_only,
             };
 
             // Immediately advance the persist frontier tracking to the `as_of`.
@@ -1080,9 +1098,26 @@ mod write {
                 self.corrections.ok.consolidate_at_since();
                 self.corrections.err.consolidate_at_since();
 
-                // Remove the consolidation request, now that we have fulfilled it.
-                self.force_consolidation_after = None;
+                // In read-only mode the sink mints no batches, so the batch-write path never
+                // sweeps `consolidate_before(upper)` forward and a single forced consolidation
+                // only covers the band below the `since` at the moment it fires, leaving the
+                // forward region uncancelled for the whole read-only window (CLU-131). Re-arm at
+                // the current persist frontier so the forced consolidation keeps sweeping forward
+                // as `desired`/`persist` advance. Once writes are allowed, the batch-write path
+                // takes over and we disarm.
+                self.force_consolidation_after = if self.read_only {
+                    Some(persist_frontier.to_owned())
+                } else {
+                    None
+                };
             }
+        }
+
+        /// Update read-only mode. While read-only the forced consolidation re-arms itself; once
+        /// writes are allowed the still-armed request fires one final time and then disarms, after
+        /// which the batch-write path drives consolidation.
+        fn set_read_only(&mut self, read_only: bool) {
+            self.read_only = read_only;
         }
 
         fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -111,7 +111,7 @@ pub(super) fn persist_sink<'s>(
         sink_id,
         persist_api.clone(),
         as_of.clone(),
-        read_only_rx,
+        read_only_rx.clone(),
         desired,
     );
 
@@ -127,6 +127,7 @@ pub(super) fn persist_sink<'s>(
         desired,
         persist,
         descs.clone(),
+        read_only_rx,
         Rc::clone(&compute_state.worker_config),
     );
 
@@ -572,6 +573,7 @@ mod write {
         desired: DesiredStreams<'s>,
         persist: PersistStreams<'s>,
         descs: DescsStream<'s>,
+        mut read_only_rx: watch::Receiver<bool>,
         worker_config: Rc<ConfigSet>,
     ) -> BatchesStream<'s> {
         let scope = desired.ok.scope();
@@ -693,16 +695,35 @@ mod write {
             .abort_on_drop()
         };
 
+        // In read-only mode, wake the operator when writes are allowed so the forced
+        // consolidation stops re-arming and the `WriteBatch` path takes over promptly. Without
+        // this the operator only learns of the transition on its next input activation, which an
+        // idle sink may not get for a while.
+        let read_only_watch_handle = (*read_only_rx.borrow()).then(|| {
+            let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
+            let mut rx = read_only_rx.clone();
+            mz_ore::task::spawn(
+                || operator_name(sink_id, "write::read_only_watch"),
+                async move {
+                    let _ = rx.changed().await;
+                    let _ = sync_activator.activate();
+                },
+            )
+            .abort_on_drop()
+        });
+
         builder.build(move |capabilities| {
             // We will use the data capabilities from the `descs` input to produce output, so no
             // need to hold onto the initial capabilities.
             drop(capabilities);
 
+            let read_only = *read_only_rx.borrow_and_update();
             let mut state = State::new(
                 sink_id,
                 worker_id,
                 as_of,
                 advance_persist_frontiers_at_startup,
+                read_only,
             );
 
             // Whether a batch write is currently in flight in the Tokio task.
@@ -714,8 +735,9 @@ mod write {
             let mut correction_logger = correction_logger;
 
             move |frontiers| {
-                // Keep task handle alive so it is aborted when the operator is dropped.
+                // Keep task handles alive so they are aborted when the operator is dropped.
                 let _ = &write_task_handle;
+                let _ = &read_only_watch_handle;
 
                 // Acknowledge activation so the Tokio task can activate us again.
                 activation_ack.ack();
@@ -758,6 +780,14 @@ mod write {
                 {
                     batch.persist_frontier = Some(state.persist_frontiers.frontier().to_owned());
                 }
+                // Track read-only mode so the forced consolidation stops re-arming once writes
+                // are allowed and the `WriteBatch` path takes over driving consolidation.
+                if state.read_only && read_only_rx.has_changed().unwrap_or(false) {
+                    if !*read_only_rx.borrow_and_update() {
+                        state.set_read_only(false);
+                    }
+                }
+
                 if state.should_force_consolidation() {
                     batch.force_consolidation = true;
                 }
@@ -897,9 +927,13 @@ mod write {
         ///
         /// Normally we force a consolidation whenever we write a batch, but there are periods
         /// (like read-only mode) when that doesn't happen, and we need to manually force
-        /// consolidation instead. Currently this is only used to ensure we quickly get rid of the
-        /// snapshot updates.
+        /// consolidation instead. In read-only mode this is re-armed after each firing so it
+        /// keeps sweeping forward as the frontiers advance (see `should_force_consolidation`).
         force_consolidation_after: Option<Antichain<Timestamp>>,
+        /// Whether the sink is in read-only mode. While read-only the `write` operator mints no
+        /// batches, so the `WriteBatch` path never sweeps `consolidate_before(upper)` forward;
+        /// the forced consolidation stands in for it and is re-armed as long as this holds.
+        read_only: bool,
     }
 
     impl State {
@@ -908,6 +942,7 @@ mod write {
             worker_id: usize,
             as_of: Antichain<Timestamp>,
             advance_persist_frontiers_at_startup: bool,
+            read_only: bool,
         ) -> Self {
             // Force a consolidation of corrections after the snapshot updates have been fully
             // processed, to ensure we get rid of those as quickly as possible.
@@ -920,6 +955,7 @@ mod write {
                 persist_frontiers: OkErr::new_frontiers(),
                 batch_description: None,
                 force_consolidation_after,
+                read_only,
             };
 
             // Immediately advance the persist frontier tracking to the `as_of`.
@@ -1011,11 +1047,29 @@ mod write {
                 && PartialOrder::less_than(request, persist_frontier)
             {
                 self.trace("requesting correction consolidation");
-                self.force_consolidation_after = None;
+                // In read-only mode the sink mints no batches, so the `WriteBatch` path never
+                // sweeps `consolidate_before(upper)` forward and a single forced consolidation
+                // only covers the band below the `since` at the moment it fires, leaving the
+                // forward region uncancelled for the whole read-only window (CLU-131). Re-arm at
+                // the current persist frontier so the forced consolidation keeps sweeping forward
+                // as `desired`/`persist` advance, mirroring the read-write path. Once writes are
+                // allowed, the `WriteBatch` path takes over and we disarm.
+                self.force_consolidation_after = if self.read_only {
+                    Some(persist_frontier.to_owned())
+                } else {
+                    None
+                };
                 true
             } else {
                 false
             }
+        }
+
+        /// Update read-only mode. While read-only the forced consolidation re-arms itself; once
+        /// writes are allowed the still-armed request fires one final time and then disarms, after
+        /// which the `WriteBatch` path drives consolidation.
+        fn set_read_only(&mut self, read_only: bool) {
+            self.read_only = read_only;
         }
 
         fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -2000,6 +2000,190 @@ def workflow_materialized_view_correction_pruning(c: Composition) -> None:
         )
 
 
+def workflow_materialized_view_read_only_correction_pruning(
+    c: Composition,
+) -> None:
+    """
+    Verify that a read-only replica's materialized-view sink consolidates its
+    correction buffer instead of retaining one record per write made during the
+    read-only window — the memory blow-up of CLU-131 (a factor in the INC-1095
+    OOM).
+
+    During a 0dt upgrade the new generation hydrates read-only while the old
+    generation keeps writing. A read-only sink mints no batches, so the
+    `WriteBatch` path that drives `consolidate_before` forward never runs, and the
+    `desired`/`persist` pairs for each forward write are never cancelled: the
+    correction buffer grows by roughly one record per written row and stays
+    resident for the whole read-only window. The fix re-arms the forced
+    consolidation in read-only mode, so the buffer is swept per batch and stays
+    near zero. The pre-existing single-INSERT `materialized_view_correction_pruning`
+    scenario only exercises the snapshot, which the one-shot consolidation already
+    handles, so it cannot catch this; the forward writes below are what expose it.
+
+    The replica is unorchestrated and runs inside the mz_new container.
+    environmentd's federated /metrics does not surface it, so we scrape the
+    replica's own clusterd internal HTTP socket.
+    """
+
+    c.down(destroy_volumes=True)
+    c.up("mz_old")
+
+    c.sql(
+        "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    initial_rows = 1_000
+    batch_rows = 10_000
+    forward_rows = 300_000
+    payload_bytes = 1_024
+    memory_growth_bound_bytes = 384 * 1024**2
+
+    c.sql(
+        f"""
+         CREATE TABLE t (a int, payload text);
+         INSERT INTO t
+           SELECT g, repeat('x', {payload_bytes})
+           FROM generate_series(1, {initial_rows}) AS g;
+         CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+         SELECT * FROM mv LIMIT 1;
+         """,
+        service="mz_old",
+    )
+
+    # Boot the new generation read-only and hydrate the MV there. It is never
+    # promoted, so it stays read-only for the whole test.
+    c.up("mz_new")
+    c.sql("SELECT * FROM mv LIMIT 1", service="mz_new")
+
+    def replica_metrics_addr() -> str:
+        # The read-only replica is unorchestrated and runs inside the mz_new
+        # container; environmentd's federated /metrics does not surface it, so we
+        # hit the replica's own clusterd internal HTTP unix socket, whose path it
+        # logs at startup. Match any generation and take the latest.
+        logs = c.invoke("logs", "mz_new", capture=True).stdout
+        addr = None
+        for line in logs.splitlines():
+            if (
+                "cluster-u1-replica-u1-gen-" in line
+                and "mz_clusterd: serving internal HTTP server on" in line
+            ):
+                addr = line.split(" ")[-1]
+        if addr is None:
+            raise RuntimeError("no clusterd internal HTTP socket found in mz_new logs")
+        return addr
+
+    def anon_bytes() -> int:
+        # Anonymous (heap) memory of the mz_new container from the cgroup, where
+        # the correction buffer lives. cgroup v2 reports `anon`; v1 `total_rss`
+        # or `rss`.
+        return int(
+            c.exec(
+                "mz_new",
+                "sh",
+                "-lc",
+                r"""awk '$1=="anon" || $1=="total_rss" || $1=="rss" { print $2; exit }' \
+                    /sys/fs/cgroup/memory.stat 2>/dev/null || \
+                    awk '$1=="anon" || $1=="total_rss" || $1=="rss" { print $2; exit }' \
+                    /sys/fs/cgroup/memory/memory.stat""",
+                capture=True,
+            ).stdout
+        )
+
+    def mib(value: int) -> str:
+        return f"{value / 1024**2:.1f} MiB"
+
+    def correction_metrics() -> tuple[int, int]:
+        resp = c.exec(
+            "mz_new",
+            "curl",
+            "-s",
+            "--unix-socket",
+            replica_metrics_addr(),
+            "http:/prof/metrics",
+            capture=True,
+        ).stdout
+
+        insertions = deletions = 0
+        for line in resp.splitlines():
+            if line.startswith("#"):
+                continue
+            if line.startswith("mz_persist_sink_correction_insertions_total"):
+                insertions += int(float(line.rsplit(maxsplit=1)[-1]))
+            elif line.startswith("mz_persist_sink_correction_deletions_total"):
+                deletions += int(float(line.rsplit(maxsplit=1)[-1]))
+        return (insertions, deletions)
+
+    # Wait for the read-only generation to process and prune the initial snapshot
+    # before measuring the memory baseline. The snapshot is small enough not to
+    # matter for RSS, but this preserves the older test's signal.
+    insertions = deletions = 0
+    for _ in range(30):
+        insertions, deletions = correction_metrics()
+        if insertions >= initial_rows and insertions - deletions == 0:
+            break
+        time.sleep(1)
+    else:
+        raise AssertionError(
+            f"snapshot correction buffer did not consolidate: {insertions=}, "
+            f"{deletions=}, net={insertions - deletions}"
+        )
+
+    baseline_anon = anon_bytes()
+
+    # The old generation writes meaningful volume while mz_new stays read-only.
+    # Wide payloads make the retained correction buffer visible in anonymous RSS:
+    # on an unfixed build the desired and persist halves retain roughly
+    # `2 * forward_rows * payload_bytes`, while the fixed build keeps at most a
+    # small batch resident before forced consolidation drains it.
+    for lo in range(initial_rows + 1, initial_rows + forward_rows + 1, batch_rows):
+        hi = min(lo + batch_rows - 1, initial_rows + forward_rows)
+        c.sql(
+            f"""
+            INSERT INTO t
+              SELECT g, repeat('x', {payload_bytes})
+              FROM generate_series({lo}, {hi}) AS g;
+            """,
+            service="mz_old",
+        )
+        _wait_for_mz_count(c, "SELECT count(*) FROM mv", hi, "mz_old")
+        time.sleep(1)
+
+    # The read-only sink must consolidate the forward writes away rather than
+    # retain one record per written row. With the fix the buffer holds at most a
+    # batch or so in flight; before it, `insertions - deletions` stays near
+    # `forward_rows` (CLU-131) and the wide rows push mz_new's anonymous memory
+    # hundreds of MiB above baseline.
+    correction_bound = batch_rows * 4
+    memory_ceiling = baseline_anon + memory_growth_bound_bytes
+    for _ in range(150):
+        insertions, deletions = correction_metrics()
+        settled_anon = anon_bytes()
+        if (
+            insertions >= forward_rows
+            and insertions - deletions < correction_bound
+            and settled_anon <= memory_ceiling
+        ):
+            break
+        time.sleep(1)
+
+    net = insertions - deletions
+    memory_growth = settled_anon - baseline_anon
+    if (
+        insertions < forward_rows
+        or net >= correction_bound
+        or settled_anon > memory_ceiling
+    ):
+        raise AssertionError(
+            f"read-only correction buffer did not consolidate: {insertions=}, "
+            f"{deletions=}, net={net} (bound {correction_bound}, "
+            f"forward_rows {forward_rows}, memory_growth={mib(memory_growth)}, "
+            f"memory_bound={mib(memory_growth_bound_bytes)}); CLU-131"
+        )
+
+
 def setup(c: Composition) -> None:
     # Make sure cluster is owned by the system so it doesn't get dropped
     # between testdrive runs.


### PR DESCRIPTION
A materialized-view sink in read-only mode held a `desired - persist` correction buffer that grows by \~one record per write the old generation makes during the read-only window, doubling the memory of a hydrating replica during a 0dt upgrade (contributor to INC-1095).

A read-only sink mints no batches, so the `WriteBatch` path that drives `consolidate_before` forward never runs. The one-shot consolidation cancels the snapshot, but every forward write adds a `desired`/`persist` pair that is never consolidated — `advance_since` only advances times lazily, it does not cancel. The buffer therefore accumulates and stays resident until promotion. Re-arm the forced consolidation in read-only mode at the current persist frontier so it keeps sweeping forward as the frontiers advance, mirroring the read-write path. Applied to both the v2 (sync) and original (async) sinks; v2 also gets a watch task to wake the operator on the read-only -> read-write transition.

Adds the `materialized_view_read_only_correction_pruning` 0dt scenario: `mz_new` hydrates read-only and is never promoted while `mz_old` writes 300k wide rows. It scrapes the read-only replica's own clusterd metrics socket (environmentd's federated `/metrics` does not surface an unorchestrated read-only replica) and asserts both that the correction buffer stays bounded and that `mz_new`'s anonymous memory stays within a few hundred MiB of baseline. Verified: fails on unfixed `main` (buffer climbs to net \~400k, anon memory \~435–715 MiB over baseline), passes with this fix (buffer drains per batch, memory near baseline). The pre-existing single-INSERT `materialized_view_correction_pruning` scenario only exercises the snapshot and is left unchanged.

[CPU-131](https://linear.app/materializeinc/issue/CPU-131/mv-sink-forced-consolidation-in-read-only-mode-is-one-shot-snapshot).

The clusterd-test-driver tooling and its `clu_131.spec` repro live in a separate stacked PR (MaterializeInc/materialize#37240).