### PR TITLE
all: remove gratuitous unsafe at three sites

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -71,10 +71,7 @@ use crate::memory;
 pub(crate) type Timestamp = mz_repr::Timestamp;
 
 /// The minimum value of an epoch.
-///
-/// # Safety
-/// `new_unchecked` is safe to call with a non-zero value.
-const MIN_EPOCH: Epoch = unsafe { Epoch::new_unchecked(1) };
+const MIN_EPOCH: Epoch = Epoch::new(1).expect("1 is non-zero");
 
 /// Human readable catalog shard name.
 const CATALOG_SHARD_NAME: &str = "catalog";

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -34,9 +34,8 @@ use uuid::Uuid;
 use crate::metrics::Metrics;
 use crate::{ApiTokenArgs, AppPassword, Client, Error, FronteggCliArgs};
 
-/// SAFETY: Value is known to be non-zero.
 pub const DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE: NonZeroUsize =
-    unsafe { NonZeroUsize::new_unchecked(1024) };
+    NonZeroUsize::new(1024).expect("1024 is non-zero");
 
 /// If a session is dropped within [`DEFAULT_REFRESH_DROP_FACTOR`] `* valid_for` seconds of an
 /// authentication token expiring, then we'll continue to refresh the auth token, with the

--- a/src/ore/src/hint.rs
+++ b/src/ore/src/hint.rs
@@ -27,14 +27,9 @@
 /// A function that is opaque to the optimizer, used to prevent the compiler
 /// from optimizing away computations in a benchmark.
 ///
-/// This variant is stable-compatible, but it may cause some performance
-/// overhead or fail to prevent code from being eliminated.
-///
-/// When `std::hint::black_box` is stabilized, this function can be removed.
+/// Now that [`std::hint::black_box`] is stable this is a thin forwarding
+/// wrapper; prefer calling `std::hint::black_box` directly. Retained only for
+/// existing call sites and can be removed once they migrate.
 pub fn black_box<T>(dummy: T) -> T {
-    unsafe {
-        let ret = std::ptr::read_volatile(&dummy);
-        std::mem::forget(dummy);
-        ret
-    }
+    std::hint::black_box(dummy)
 }


### PR DESCRIPTION
None of these `unsafe` blocks were buying anything; each has a zero-cost safe form (confirmed by an unsafe-usage audit of the crate).

* ore: `hint::black_box` forwards to the now-stable `std::hint::black_box` instead of a hand-rolled `read_volatile` + `forget`.
* catalog: `MIN_EPOCH` uses `Epoch::new(1).expect(..)` (const-evaluable, as in `mz-auth`'s `NonZeroU32::new(..).expect(..)`) instead of `new_unchecked`.
* frontegg-auth: `DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE` likewise uses `NonZeroUsize::new(1024).expect(..)` instead of `new_unchecked`.