### PR TITLE
[DNM] Metric removal test

### DIFF
--- a/bin/gen-metrics-catalog
+++ b/bin/gen-metrics-catalog
@@ -12,11 +12,13 @@
 # gen-metrics-catalog — regenerate the `metric!` catalog consumed by the docs.
 #
 # Walks the Rust source tree for `metric!` definitions and writes them to
-# doc/user/data/metrics.yml. CI runs this and fails if the result differs from
-# what's checked in (see ci/test/lint-main/checks/check-generation.sh).
+# doc/user/data/metrics.yml, or to the file given as the first argument.
+#
+# To verify the checked-in catalog is up to date, run
+# ci/test/lint-metrics-catalog.sh (pass --rewrite to update it).
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-cargo run --quiet -p mz-metrics-catalog -- src doc/user/data/metrics.yml
+cargo run --quiet -p mz-metrics-catalog -- src "${1:-doc/user/data/metrics.yml}"

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -21,5 +21,6 @@ try hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --conf
 echo "<!doctype html>" > ci/www/public/index.html
 try htmltest -s ci/www/public -c doc/user/.htmltest.yml
 try ci/test/lint-docs-catalog.sh
+try ci/test/lint-metrics-catalog.sh
 
 try_status_report

--- a/ci/test/lint-main/checks/check-generation.sh
+++ b/ci/test/lint-main/checks/check-generation.sh
@@ -19,6 +19,5 @@ cd "$(dirname "$0")/../../../.."
 
 try bin/gen-completion check
 try bin/gen-lints
-try bin/gen-metrics-catalog
 
 try_status_report

--- a/ci/test/lint-metrics-catalog.sh
+++ b/ci/test/lint-metrics-catalog.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Checks that the generated metrics catalog (doc/user/data/metrics.yml) is up to
+# date with the `metric!` definitions in the Rust source tree. This guards
+# against the checked-in catalog drifting from the source of truth.
+#
+# Example usages:
+#
+#     $ ci/test/lint-metrics-catalog.sh
+#
+# To rewrite the stored catalog, pass the --rewrite option.
+
+set -euo pipefail
+
+. misc/shlib/shlib.bash
+
+catalog=doc/user/data/metrics.yml
+
+if [[ "${1:-}" = --rewrite ]]; then
+    ci_uncollapsed_heading "Linting metrics catalog; rewriting $catalog"
+    try bin/gen-metrics-catalog
+else
+    ci_uncollapsed_heading "Linting metrics catalog, run $0 --rewrite to update $catalog"
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' EXIT
+    try bin/gen-metrics-catalog "$tmp"
+    try diff "$catalog" "$tmp"
+fi
+
+try_status_report

--- a/doc/user/content/manage/monitor/essential-metrics.md
+++ b/doc/user/content/manage/monitor/essential-metrics.md
@@ -12,9 +12,7 @@ disable_list: true
 
 This page lists the essential Prometheus metrics exposed by Materialize: the
 ones we recommend building dashboards and alerts on. This list may evolve as
-we add observability for new features and refine what's most useful. A `*` in
-a metric name denotes a family of metrics whose name is completed at runtime
-(for example, `mz_persist_*_bytes`).
+we add observability for new features and refine what's most useful.
 
 The metrics are grouped by the component of Materialize they describe. A
 grouping is shown only when it has at least one metric. For the complete list

--- a/doc/user/content/manage/monitor/essential-metrics.md
+++ b/doc/user/content/manage/monitor/essential-metrics.md
@@ -1,7 +1,6 @@
 ---
 title: "Essential metrics"
 description: "The Prometheus metrics Materialize recommends building dashboards and alerts on."
-disable_toc: true
 disable_list: true
 # TODO (SangJunBak): Unhide once ready to publish
 # menu:
@@ -17,8 +16,17 @@ we add observability for new features and refine what's most useful. A `*` in
 a metric name denotes a family of metrics whose name is completed at runtime
 (for example, `mz_persist_*_bytes`).
 
-For the complete list of metrics Materialize exposes, including internal metrics
-that are subject to change, see [Appendix:
+The metrics are grouped by the component of Materialize they describe. A
+grouping is shown only when it has at least one metric. For the complete list
+of metrics Materialize exposes, see [Appendix:
 Metrics](/manage/monitor/appendix-metrics/).
 
-{{< metrics-table visibility="public" >}}
+{{< metrics-table visibility="public" tag="environment" heading="Environment-level metrics" description="Metrics for the control plane: client connections, availability, and the catalog." >}}
+
+{{< metrics-table visibility="public" tag="compute" heading="Compute metrics" description="Metrics for compute objects, such as indexes and materialized views, running on [clusters](/concepts/clusters/) and their replicas." >}}
+
+{{< metrics-table visibility="public" tag="source" heading="Source metrics" description="Metrics for data ingestion from external systems." >}}
+
+{{< metrics-table visibility="public" tag="sink" heading="Sink metrics" description="Metrics for data output to external systems." >}}
+
+{{< metrics-table visibility="public" untagged="true" heading="Uncategorized metrics" description="Essential metrics that haven't yet been assigned to one of the groupings above." >}}

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -87,12 +87,16 @@ metrics:
   - session_type
   source: src/adapter/src/metrics.rs
   visibility: public
+  tags:
+  - environment
 - name: mz_active_subscribes
   help: The number of active SUBSCRIBE queries.
   labels:
   - session_type
   source: src/adapter/src/metrics.rs
   visibility: public
+  tags:
+  - environment
 - name: mz_adapter_commands
   help: The total number of adapter commands issued of the given type since process start.
   labels:
@@ -101,6 +105,8 @@ metrics:
   - status
   source: src/adapter/src/metrics.rs
   visibility: public
+  tags:
+  - environment
 - name: mz_append_table_duration_seconds
   help: Latency for appending to any (user or system) table.
   source: src/adapter/src/metrics.rs
@@ -121,6 +127,8 @@ metrics:
   - worker_id
   source: src/compute/src/metrics.rs
   visibility: public
+  tags:
+  - compute
 - name: mz_arrangement_sizes_collection_time_seconds
   help: Seconds to read mz_object_arrangement_sizes and prepare history-table updates for one snapshot.
   source: src/adapter/src/metrics.rs
@@ -300,6 +308,8 @@ metrics:
   - size
   source: src/adapter/src/coord/info_metrics.rs
   visibility: public
+  tags:
+  - compute
 - name: mz_cluster_server_last_command_received
   help: The time (in seconds since the Unix epoch) at which the server last received data from the controller, including CTP keepalives. Used to detect controller connections that are no longer reachable.
   labels:
@@ -373,6 +383,8 @@ metrics:
   - replica_id
   source: src/compute-client/src/metrics.rs
   visibility: public
+  tags:
+  - compute
 - name: mz_compute_controller_collection_count
   help: The number of installed compute collections.
   labels:
@@ -424,6 +436,8 @@ metrics:
   - replica_id
   source: src/compute-client/src/metrics.rs
   visibility: public
+  tags:
+  - compute
 - name: mz_compute_controller_peek_count
   help: The number of pending peeks.
   labels:
@@ -475,6 +489,8 @@ metrics:
   - result
   source: src/compute-client/src/metrics.rs
   visibility: public
+  tags:
+  - compute
 - name: mz_compute_peeks_total
   help: The total number of peeks served.
   labels:
@@ -508,6 +524,8 @@ metrics:
   - worker_id
   source: src/compute/src/metrics.rs
   visibility: public
+  tags:
+  - compute
 - name: mz_compute_response_message_bytes_total
   help: The total number of bytes sent in compute response messages.
   labels:
@@ -572,6 +590,10 @@ metrics:
   - replica_id
   source: src/cluster-client/src/metrics.rs
   visibility: public
+  tags:
+  - compute
+  - source
+  - sink
 - name: mz_dataflow_wallclock_lag_seconds_count
   help: The total count of dataflow wallclock lag measurements.
   labels:
@@ -947,6 +969,8 @@ metrics:
   - type
   source: src/adapter/src/coord/info_metrics.rs
   visibility: public
+  tags:
+  - environment
 - name: mz_optimization_notices
   help: Number of optimization notices per notice type.
   labels:
@@ -2313,6 +2337,8 @@ metrics:
   - statement_type
   source: src/adapter/src/metrics.rs
   visibility: public
+  tags:
+  - environment
 - name: mz_replica_info
   help: Maps cluster replica IDs to the replica's name and size. Constant 1.
   labels:
@@ -2322,6 +2348,8 @@ metrics:
   - size
   source: src/adapter/src/coord/info_metrics.rs
   visibility: public
+  tags:
+  - compute
 - name: mz_result_rows_first_to_last_byte_seconds
   help: The time from just before sending the first result row to sending a final response message after having successfully flushed the last result row to the connection. (This can span multiple FETCH statements.) (This is never observed for unbounded SUBSCRIBEs, i.e., which have no last result row.)
   labels:
@@ -2369,6 +2397,8 @@ metrics:
   - worker_id
   source: src/storage/src/statistics.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_bytes_staged
   help: The number of bytes staged but possibly not committed to the sink.
   labels:
@@ -2376,6 +2406,8 @@ metrics:
   - worker_id
   source: src/storage/src/statistics.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_consumed_progress_records
   help: The number of progress records consumed by the sink.
   labels:
@@ -2389,6 +2421,8 @@ metrics:
   - worker_id
   source: src/storage/src/metrics/sink/iceberg.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_iceberg_commit_duration_seconds
   help: Time spent committing batches to Iceberg in seconds
   labels:
@@ -2396,6 +2430,8 @@ metrics:
   - worker_id
   source: src/storage/src/metrics/sink/iceberg.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_iceberg_commit_failures
   help: Number of commit failures in the iceberg sink
   labels:
@@ -2403,6 +2439,8 @@ metrics:
   - worker_id
   source: src/storage/src/metrics/sink/iceberg.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_iceberg_data_files_written
   help: Number of data files written by the iceberg sink
   labels:
@@ -2410,6 +2448,8 @@ metrics:
   - worker_id
   source: src/storage/src/metrics/sink/iceberg.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_iceberg_delete_files_written
   help: Number of delete files written by the iceberg sink
   labels:
@@ -2417,6 +2457,8 @@ metrics:
   - worker_id
   source: src/storage/src/metrics/sink/iceberg.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_iceberg_snapshots_committed
   help: Number of snapshots committed by the iceberg sink
   labels:
@@ -2424,6 +2466,8 @@ metrics:
   - worker_id
   source: src/storage/src/metrics/sink/iceberg.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_iceberg_stashed_rows
   help: Number of stashed rows in the iceberg sink
   labels:
@@ -2447,6 +2491,8 @@ metrics:
   - type
   source: src/adapter/src/coord/info_metrics.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_messages_committed
   help: The number of messages committed to the sink.
   labels:
@@ -2479,12 +2525,16 @@ metrics:
   - sink_id
   source: src/storage/src/metrics/sink/kafka.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_rdkafka_disconnects
   help: The number of disconnections, whether triggered by the broker, the network, the load balancer, or something else across all brokers.
   labels:
   - sink_id
   source: src/storage/src/metrics/sink/kafka.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_rdkafka_msg_cnt
   help: The current number of messages in producer queues.
   labels:
@@ -2509,6 +2559,8 @@ metrics:
   - sink_id
   source: src/storage/src/metrics/sink/kafka.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_rdkafka_req_timeouts
   help: The total number of requests that timed out across all brokers.
   labels:
@@ -2533,6 +2585,8 @@ metrics:
   - sink_id
   source: src/storage/src/metrics/sink/kafka.rs
   visibility: public
+  tags:
+  - sink
 - name: mz_sink_rdkafka_txmsg_bytes
   help: The total number of bytes transmitted (produced) to brokers.
   labels:
@@ -2586,6 +2640,8 @@ metrics:
   - worker_id
   source: src/storage/src/statistics.rs
   visibility: public
+  tags:
+  - source
 - name: mz_source_commit_upper_accepted_times
   help: The number of accepted remap bindings that are held in the reclock commit upper operator.
   labels:
@@ -2634,6 +2690,8 @@ metrics:
   - type
   source: src/adapter/src/coord/info_metrics.rs
   visibility: public
+  tags:
+  - source
 - name: mz_source_messages_received
   help: The number of raw messages the worker has received from upstream.
   labels:
@@ -2642,12 +2700,16 @@ metrics:
   - worker_id
   source: src/storage/src/statistics.rs
   visibility: public
+  tags:
+  - source
 - name: mz_source_offset_commit_failures
   help: A counter representing how many times we have failed to commit offsets for a source
   labels:
   - source_id
   source: src/storage/src/metrics/source.rs
   visibility: public
+  tags:
+  - source
 - name: mz_source_offset_committed
   help: The total number of _values_ (source-defined unit) we have fully processed, and storage and committed.
   labels:
@@ -2656,6 +2718,8 @@ metrics:
   - worker_id
   source: src/storage/src/statistics.rs
   visibility: public
+  tags:
+  - source
 - name: mz_source_offset_known
   help: The total number of _values_ (source-defined unit) present in upstream.
   labels:
@@ -2664,6 +2728,8 @@ metrics:
   - worker_id
   source: src/storage/src/statistics.rs
   visibility: public
+  tags:
+  - source
 - name: mz_source_processed_batches
   help: A counter representing the number of persist sink batches with actual data we have successfully processed.
   labels:

--- a/doc/user/layouts/shortcodes/metrics-table.html
+++ b/doc/user/layouts/shortcodes/metrics-table.html
@@ -5,28 +5,57 @@ Labels. A `*` in a metric name denotes a parameterized family whose concrete
 name is substituted at runtime.
 
 Accepts an optional `visibility` parameter to list only metrics with that
-visibility, e.g. `{{< metrics-table visibility="public">}}`. Omit it to list
-  every metric.
-  */}}
-  {{- $metrics := $.Site.Data.metrics.metrics }}
-  {{- with .Get "visibility" }}
-  {{- $metrics = where $metrics "visibility" . }}
-  {{- end }}
-  <table>
-    <thead>
-      <tr>
-        <th>Metric</th>
-        <th>Description</th>
-        <th>Labels</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{- range $metrics }}
-      <tr>
-        <td><code>{{ .name }}</code></td>
-        <td>{{ .help }}</td>
-        <td>{{- range $i, $label := .labels }}{{ if $i }}, {{ end }}<code>{{ $label }}</code>{{- end }}</td>
-      </tr>
-      {{- end }}
-    </tbody>
-  </table>
+visibility, e.g. `{{< metrics-table visibility="public" >}}`. Omit it to list
+every metric.
+
+Accepts an optional `tag` parameter to list only metrics carrying that tag,
+e.g. `{{< metrics-table visibility="public" tag="source" >}}`. A tag names the
+functional grouping a metric belongs to; see `mz_ore::metrics::MetricTag`.
+
+Accepts an optional `untagged="true"` parameter to list only metrics with no
+tag at all. Mutually exclusive with `tag`.
+
+The filters combine (logical AND).
+
+Accepts optional `heading` and `description` parameters that render a section
+heading (an `<h2>`, anchored like a Markdown heading so it lands in the table
+of contents) and an intro paragraph above the table. When the filtered metric
+set is empty, the whole section — heading, description, and table — is omitted,
+so empty groupings don't show up.
+*/}}
+{{- $metrics := $.Site.Data.metrics.metrics }}
+{{- with .Get "visibility" }}
+{{- $metrics = where $metrics "visibility" . }}
+{{- end }}
+{{- with .Get "tag" }}
+{{- $metrics = where $metrics "tags" "intersect" (slice .) }}
+{{- end }}
+{{- if eq (.Get "untagged") "true" }}
+{{- $metrics = where $metrics "tags" nil }}
+{{- end }}
+{{- if $metrics }}
+{{- with .Get "heading" }}
+<h2 id="{{ . | anchorize }}">{{ . }}</h2>
+{{- end }}
+{{- with .Get "description" }}
+{{ . | markdownify }}
+{{- end }}
+<table>
+  <thead>
+    <tr>
+      <th>Metric</th>
+      <th>Description</th>
+      <th>Labels</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{- range $metrics }}
+    <tr>
+      <td><code>{{ .name }}</code></td>
+      <td>{{ .help }}</td>
+      <td>{{- range $i, $label := .labels }}{{ if $i }}, {{ end }}<code>{{ $label }}</code>{{- end }}</td>
+    </tr>
+    {{- end }}
+  </tbody>
+</table>
+{{- end }}

--- a/src/adapter/src/coord/info_metrics.rs
+++ b/src/adapter/src/coord/info_metrics.rs
@@ -30,7 +30,7 @@ use mz_catalog::memory::objects::{
 use mz_controller::clusters::ReplicaLocation;
 use mz_ore::metric;
 use mz_ore::metrics::{
-    DeleteOnDropGauge, Histogram, MetricVisibility, MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropGauge, Histogram, MetricTag, MetricVisibility, MetricsRegistry, UIntGaugeVec,
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_ore::task;
@@ -86,33 +86,38 @@ impl CatalogInfoMetrics {
                 help: "Maps catalog object IDs to the object's name, schema, database, and \
                        type. Constant 1.",
                 var_labels: ["object_id", "global_id", "name", "schema_name", "database_name", "type"],
-                visibility: MetricVisibility::Public
+                visibility: MetricVisibility::Public,
+                tags: [MetricTag::Environment],
             )),
             cluster_info: registry.register(metric!(
                 name: "mz_cluster_info",
                 help: "Maps cluster IDs to the cluster's name and size. Constant 1.",
                 var_labels: ["cluster_id", "name", "size"],
-                visibility: MetricVisibility::Public
+                visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute],
             )),
             replica_info: registry.register(metric!(
                 name: "mz_replica_info",
                 help: "Maps cluster replica IDs to the replica's name and size. Constant 1.",
                 var_labels: ["replica_id", "cluster_id", "name", "size"],
-                visibility: MetricVisibility::Public
+                visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute],
             )),
             source_info: registry.register(metric!(
                 name: "mz_source_info",
                 help: "Maps user source IDs to the source's type, envelope type, and \
                        cluster. Constant 1.",
                 var_labels: ["source_id", "type", "envelope_type", "cluster_id"],
-                visibility: MetricVisibility::Public
+                visibility: MetricVisibility::Public,
+                tags: [MetricTag::Source],
             )),
             sink_info: registry.register(metric!(
                 name: "mz_sink_info",
                 help: "Maps user sink IDs to the sink's type, envelope type, and \
                        cluster. Constant 1.",
                 var_labels: ["sink_id", "type", "envelope_type", "cluster_id"],
-                visibility: MetricVisibility::Public
+                visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             series: Vec::new(),
             last_revision: None,

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mz_ore::metric;
-use mz_ore::metrics::{MetricVisibility, MetricsRegistry};
+use mz_ore::metrics::{MetricTag, MetricVisibility, MetricsRegistry};
 use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
 use mz_sql::session::user::User;
@@ -66,18 +66,21 @@ impl Metrics {
                 help: "The total number of queries issued of the given type since process start.",
                 var_labels: ["session_type", "statement_type"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Environment],
             )),
             active_sessions: registry.register(metric!(
                 name: "mz_active_sessions",
                 help: "The number of active coordinator sessions.",
                 var_labels: ["session_type"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Environment],
             )),
             active_subscribes: registry.register(metric!(
                 name: "mz_active_subscribes",
                 help: "The number of active SUBSCRIBE queries.",
                 var_labels: ["session_type"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Environment],
             )),
             active_copy_tos: registry.register(metric!(
                 name: "mz_active_copy_tos",
@@ -111,6 +114,7 @@ impl Metrics {
                 help: "The total number of adapter commands issued of the given type since process start.",
                 var_labels: ["command_type", "status", "application_name"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Environment],
             )),
             storage_usage_collection_time_seconds: registry.register(metric!(
                 name: "mz_storage_usage_collection_time_seconds",

--- a/src/cluster-client/src/metrics.rs
+++ b/src/cluster-client/src/metrics.rs
@@ -12,8 +12,8 @@
 use mz_ore::cast::CastLossy;
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVec, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, IntCounterVec, MetricVisibility,
-    MetricsRegistry,
+    CounterVec, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, IntCounterVec, MetricTag,
+    MetricVisibility, MetricsRegistry,
 };
 use mz_ore::stats::SlidingMinMax;
 use prometheus::core::{AtomicF64, AtomicU64};
@@ -39,6 +39,7 @@ impl ControllerMetrics {
                        to wallclock time, aggregated over the last minute.",
                 var_labels: ["instance_id", "replica_id", "collection_id", "quantile"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute, MetricTag::Source, MetricTag::Sink],
             )),
             dataflow_wallclock_lag_seconds_sum: metrics_registry.register(metric!(
                 name: "mz_dataflow_wallclock_lag_seconds_sum",

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -21,7 +21,7 @@ use mz_ore::metric;
 use mz_ore::metrics::raw::UIntGaugeVec;
 use mz_ore::metrics::{
     CounterVec, DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, HistogramVec,
-    IntCounterVec, MetricVecExt, MetricVisibility, MetricsRegistry,
+    IntCounterVec, MetricTag, MetricVecExt, MetricVisibility, MetricsRegistry,
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_repr::GlobalId;
@@ -83,6 +83,7 @@ impl ComputeControllerMetrics {
                 help: "The total number of compute commands sent.",
                 var_labels: ["instance_id", "replica_id", "command_type"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute],
             )),
             command_message_bytes_total: metrics_registry.register(metric!(
                 name: "mz_compute_command_message_bytes_total",
@@ -149,6 +150,7 @@ impl ComputeControllerMetrics {
                 help: "The size of the compute hydration queue.",
                 var_labels: ["instance_id", "replica_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute],
             )),
             history_command_count: metrics_registry.register(metric!(
                 name: "mz_compute_controller_history_command_count",
@@ -171,6 +173,7 @@ impl ComputeControllerMetrics {
                 var_labels: ["instance_id", "result"],
                 buckets: histogram_seconds_buckets(0.000_500, 32.),
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute],
             )),
             connected_replica_count: metrics_registry.register(metric!(
                 name: "mz_compute_controller_connected_replica_count",

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use mz_compute_client::metrics::{CommandMetrics, HistoryMetrics};
 use mz_ore::cast::CastFrom;
 use mz_ore::metric;
-use mz_ore::metrics::{MetricVisibility, MetricsRegistry, UIntGauge, raw};
+use mz_ore::metrics::{MetricTag, MetricVisibility, MetricsRegistry, UIntGauge, raw};
 use mz_repr::{GlobalId, SharedRow};
 use prometheus::core::{AtomicF64, GenericCounter};
 use prometheus::proto::LabelPair;
@@ -123,6 +123,7 @@ impl ComputeMetrics {
                 help: "The number of dataflows in the replica's command history.",
                 var_labels: ["worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute],
             )),
             reconciliation_reused_dataflows_count_total: registry.register(metric!(
                 name: "mz_compute_reconciliation_reused_dataflows_count_total",
@@ -139,6 +140,7 @@ impl ComputeMetrics {
                 help: "The total time spent maintaining arrangements.",
                 var_labels: ["worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Compute],
             )),
             arrangement_maintenance_active_info: registry.register(metric!(
                 name: "mz_arrangement_maintenance_active_info",

--- a/src/metrics-catalog/src/main.rs
+++ b/src/metrics-catalog/src/main.rs
@@ -18,7 +18,7 @@
 use std::process;
 
 use anyhow::{Context, bail};
-use mz_ore::metrics::MetricVisibility;
+use mz_ore::metrics::{MetricTag, MetricVisibility};
 use quote::ToTokens;
 use serde::Serialize;
 use syn::parse::{Parse, ParseStream};
@@ -50,6 +50,27 @@ fn visibility_from_expr(expr: Option<&Expr>) -> MetricVisibility {
     }
 }
 
+/// Maps an element from a `metric!`'s `tags:` expression to a [`MetricTag`].
+fn tag_from_expr(e: &Expr, source: &str) -> MetricTag {
+    let Expr::Path(path) = e else {
+        panic!(
+            "unexpected tag expression in {source}: {}",
+            e.to_token_stream()
+        );
+    };
+    let ident = match path.path.segments.last() {
+        Some(seg) => seg.ident.to_string(),
+        None => panic!("empty tag path in {source}"),
+    };
+    match ident.as_str() {
+        "Environment" => MetricTag::Environment,
+        "Compute" => MetricTag::Compute,
+        "Source" => MetricTag::Source,
+        "Sink" => MetricTag::Sink,
+        other => panic!("unknown MetricTag `{other}` in {source}"),
+    }
+}
+
 /// The catalog as serialized to YAML.
 #[derive(Serialize)]
 struct Catalog {
@@ -70,11 +91,15 @@ struct MetricDoc {
     source: String,
     /// Whether customers should build dashboards and alerts on this metric.
     visibility: MetricVisibility,
+    /// The metric's [`MetricTag`]s, in the order they're declared. Tags
+    /// categorize a metric. Omitted from the YAML when the metric is untagged.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<MetricTag>,
 }
 
 /// Parses the token body of a `metric!` invocation. Mirrors the grammar in
 /// `mz_ore::metric!`.
-/// Only `name`, `help`, `subsystem`, `visibility`, and the label keys
+/// Only `name`, `help`, `subsystem`, `visibility`, `tags`, and the label keys
 /// (`var_labels` and the keys of `const_labels`) are retained; the remaining
 /// fields are consumed but discarded so token parsing stays in sync with the
 /// real macro grammar.
@@ -83,6 +108,8 @@ struct MetricArgs {
     help: Option<Expr>,
     subsystem: Option<Expr>,
     visibility: Option<Expr>,
+    /// The `tags` entries (e.g. `MetricTag::Source`).
+    tags: Vec<Expr>,
     /// The keys of `const_labels` (the `k` in each `k => v` pair); the values
     /// are dropped.
     const_label_keys: Vec<Expr>,
@@ -97,6 +124,7 @@ impl Parse for MetricArgs {
             help: None,
             subsystem: None,
             visibility: None,
+            tags: Vec::new(),
             const_label_keys: Vec::new(),
             var_labels: Vec::new(),
         };
@@ -128,6 +156,12 @@ impl Parse for MetricArgs {
                     bracketed!(content in input);
                     let labels = Punctuated::<Expr, Token![,]>::parse_terminated(&content)?;
                     args.var_labels.extend(labels);
+                }
+                "tags" => {
+                    let content;
+                    bracketed!(content in input);
+                    let tags = Punctuated::<Expr, Token![,]>::parse_terminated(&content)?;
+                    args.tags.extend(tags);
                 }
                 _ => {
                     // Unknown field; consume one expression to stay in sync.
@@ -167,12 +201,19 @@ impl MetricArgs {
             .collect();
         labels.sort();
         labels.dedup();
+
+        let tags = self
+            .tags
+            .iter()
+            .map(|tag| tag_from_expr(tag, source))
+            .collect();
         MetricDoc {
             name,
             help: self.help.as_ref().map(expr_to_string).unwrap_or_default(),
             labels,
             source: source.to_owned(),
             visibility,
+            tags,
         }
     }
 }
@@ -387,6 +428,7 @@ fn run() -> anyhow::Result<()> {
             labels,
             source: source.to_owned(),
             visibility: MetricVisibility::Internal,
+            tags: Vec::new(),
         });
     }
 
@@ -398,6 +440,7 @@ fn run() -> anyhow::Result<()> {
             labels,
             source: source.to_owned(),
             visibility: MetricVisibility::Internal,
+            tags: Vec::new(),
         });
     }
 
@@ -690,6 +733,49 @@ mod tests {
     fn visibility_defaults_to_internal() {
         let doc = parse_metric(r#"metric!(name: "mz_foo", help: "h")"#);
         assert_eq!(doc.visibility, MetricVisibility::Internal);
+    }
+
+    /// `tags:` entries resolve to the corresponding [`MetricTag`], in
+    /// declaration order
+    #[mz_ore::test]
+    fn parses_tags() {
+        let doc = parse_metric(
+            r#"metric!(
+                name: "mz_foo",
+                help: "h",
+                visibility: MetricVisibility::Public,
+                tags: [MetricTag::Source, mz_ore::metrics::MetricTag::Sink],
+            )"#,
+        );
+        assert_eq!(doc.tags, vec![MetricTag::Source, MetricTag::Sink]);
+    }
+
+    #[mz_ore::test]
+    fn parses_tags_with_trailing_comma() {
+        let doc = parse_metric(r#"metric!(name: "mz_foo", help: "h", tags: [MetricTag::Sink,])"#);
+        assert_eq!(doc.tags, vec![MetricTag::Sink]);
+    }
+
+    #[mz_ore::test]
+    fn parses_tags_with_extraneous_spaces() {
+        let doc = parse_metric(
+            r#"metric!(name: "mz_foo", help: "h", tags: [MetricTag::Sink,   MetricTag::Environment])"#,
+        );
+        assert_eq!(doc.tags, vec![MetricTag::Sink, MetricTag::Environment]);
+    }
+
+    #[mz_ore::test]
+    fn no_tags_renders_as_empty() {
+        let doc = parse_metric(r#"metric!(name: "mz_foo", help: "h")"#);
+        assert!(doc.tags.is_empty());
+        let doc = parse_metric(r#"metric!(name: "mz_foo", help: "h", tags: [])"#);
+        assert!(doc.tags.is_empty());
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "unknown MetricTag `Bogus`")]
+    fn unknown_tag_panics() {
+        parse_metric(r#"metric!(name: "mz_foo", help: "h", tags: [MetricTag::Bogus])"#);
     }
 
     /// Parses `#[<attr>] fn f() {}` and returns its attributes, so `is_test_only`

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -74,6 +74,7 @@ macro_rules! metric {
         $(, var_labels: [ $($vl_name:expr),* ])?
         $(, buckets: $bk_name:expr)?
         $(, visibility: $visibility:expr)?
+        $(, tags: [ $($tag:expr),* $(,)? ])?
         $(,)?
     ) => {{
         let const_labels = (&[
@@ -100,6 +101,9 @@ macro_rules! metric {
         // It has no runtime effect; we only type-check it here so a bad value is
         // a compile error rather than silently ignored.
         $(let _: $crate::metrics::MetricVisibility = $visibility;)?
+        // `tags` is documentation metadata for the metrics catalog.
+        // It has no runtime effect.
+        $($(let _: $crate::metrics::MetricTag = $tag;)*)?
         mk_opts
     }}
 }
@@ -129,6 +133,27 @@ pub enum MetricVisibility {
     /// alerts on. We do not guarantee stability for this group
     /// of metrics.
     Public,
+}
+
+/// A tag categorizing a metric in the user-facing metrics catalog.
+///
+/// It is set via the optional `tags:` field of [`metric!`] and
+/// consumed by the metrics catalog (`bin/gen-metrics-catalog`).
+/// It has no effect on the metric at runtime.
+///
+/// A metric may carry many tags, or none (the default). A tag names the
+/// grouping the metric is presented under in user-facing documentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricTag {
+    /// Control plane metrics (client connections, availability, catalog).
+    Environment,
+    /// Metrics for compute objects (indexes, materialized views).
+    Compute,
+    /// Metrics for sources.
+    Source,
+    /// Metrics for sinks.
+    Sink,
 }
 
 /// The materialize metrics registry.

--- a/src/storage/src/metrics/sink/iceberg.rs
+++ b/src/storage/src/metrics/sink/iceberg.rs
@@ -32,8 +32,6 @@ pub(crate) struct IcebergSinkMetricDefs {
     pub snapshots_committed: IntCounterVec,
     /// Commit failures in the iceberg sink.
     pub commit_failures: IntCounterVec,
-    /// Commit conflicts in the iceberg sink.
-    pub commit_conflicts: IntCounterVec,
     /// Time spent committing batches to Iceberg.
     pub commit_duration_seconds: HistogramVec,
     /// Time spent closing Iceberg DeltaWriters.
@@ -81,13 +79,6 @@ impl IcebergSinkMetricDefs {
                 visibility: MetricVisibility::Public,
                 tags: [MetricTag::Sink],
             )),
-            commit_conflicts: registry.register(metric!(
-                name: "mz_sink_iceberg_commit_conflicts",
-                help: "Number of commit conflicts in the iceberg sink",
-                var_labels: ["sink_id", "worker_id"],
-                visibility: MetricVisibility::Public,
-                tags: [MetricTag::Sink],
-            )),
             commit_duration_seconds: registry.register(metric!(
                 name: "mz_sink_iceberg_commit_duration_seconds",
                 help: "Time spent committing batches to Iceberg in seconds",
@@ -117,8 +108,6 @@ pub(crate) struct IcebergSinkMetrics {
     pub snapshots_committed: DeleteOnDropCounter<AtomicU64, Vec<String>>,
     /// Number of commit failures in the iceberg sink.
     pub commit_failures: DeleteOnDropCounter<AtomicU64, Vec<String>>,
-    /// Number of commit conflicts in the iceberg sink.
-    pub commit_conflicts: DeleteOnDropCounter<AtomicU64, Vec<String>>,
     /// Time spent committing batches to Iceberg.
     pub commit_duration_seconds: DeleteOnDropHistogram<Vec<String>>,
     /// Time spent closing Iceberg DeltaWriters.
@@ -142,9 +131,6 @@ impl IcebergSinkMetrics {
                 .get_delete_on_drop_metric(labels.clone()),
             commit_failures: defs
                 .commit_failures
-                .get_delete_on_drop_metric(labels.clone()),
-            commit_conflicts: defs
-                .commit_conflicts
                 .get_delete_on_drop_metric(labels.clone()),
             commit_duration_seconds: defs
                 .commit_duration_seconds

--- a/src/storage/src/metrics/sink/iceberg.rs
+++ b/src/storage/src/metrics/sink/iceberg.rs
@@ -13,7 +13,7 @@ use mz_ore::{
     metric,
     metrics::{
         DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, HistogramVec, IntCounterVec,
-        MetricVisibility, UIntGaugeVec,
+        MetricTag, MetricVisibility, UIntGaugeVec,
     },
     stats::histogram_seconds_buckets,
 };
@@ -53,12 +53,14 @@ impl IcebergSinkMetricDefs {
                 help: "Number of data files written by the iceberg sink",
                 var_labels: ["sink_id", "worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             delete_files_written: registry.register(metric!(
                 name: "mz_sink_iceberg_delete_files_written",
                 help: "Number of delete files written by the iceberg sink",
                 var_labels: ["sink_id", "worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             stashed_rows: registry.register(metric!(
                 name: "mz_sink_iceberg_stashed_rows",
@@ -70,18 +72,21 @@ impl IcebergSinkMetricDefs {
                 help: "Number of snapshots committed by the iceberg sink",
                 var_labels: ["sink_id", "worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             commit_failures: registry.register(metric!(
                 name: "mz_sink_iceberg_commit_failures",
                 help: "Number of commit failures in the iceberg sink",
                 var_labels: ["sink_id", "worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             commit_conflicts: registry.register(metric!(
                 name: "mz_sink_iceberg_commit_conflicts",
                 help: "Number of commit conflicts in the iceberg sink",
                 var_labels: ["sink_id", "worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             commit_duration_seconds: registry.register(metric!(
                 name: "mz_sink_iceberg_commit_duration_seconds",
@@ -89,6 +94,7 @@ impl IcebergSinkMetricDefs {
                 var_labels: ["sink_id", "worker_id"],
                 buckets: histogram_seconds_buckets(0.001, 32.0),
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             writer_close_duration_seconds: registry.register(metric!(
                 name: "mz_sink_iceberg_writer_close_duration_seconds",

--- a/src/storage/src/metrics/sink/kafka.rs
+++ b/src/storage/src/metrics/sink/kafka.rs
@@ -11,7 +11,7 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    DeleteOnDropGauge, IntGaugeVec, MetricVisibility, MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropGauge, IntGaugeVec, MetricTag, MetricVisibility, MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::GlobalId;
 use prometheus::core::{AtomicI64, AtomicU64};
@@ -102,6 +102,7 @@ impl KafkaSinkMetricDefs {
                 help: "The number of messages awaiting transmission across all brokers.",
                 var_labels: ["sink_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             rdkafka_waitresp_cnt: registry.register(metric!(
                 name: "mz_sink_rdkafka_waitresp_cnt",
@@ -120,6 +121,7 @@ impl KafkaSinkMetricDefs {
                 help: "The total number of transmission errors across all brokers.",
                 var_labels: ["sink_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             rdkafka_txretries: registry.register(metric!(
                 name: "mz_sink_rdkafka_txretries",
@@ -137,6 +139,7 @@ impl KafkaSinkMetricDefs {
                        attempts, and name resolution failures across all brokers.",
                 var_labels: ["sink_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             rdkafka_disconnects: registry.register(metric!(
                 name: "mz_sink_rdkafka_disconnects",
@@ -144,6 +147,7 @@ impl KafkaSinkMetricDefs {
                       network, the load balancer, or something else across all brokers.",
                 var_labels: ["sink_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             outstanding_progress_records: registry.register(metric!(
                 name: "mz_sink_oustanding_progress_records",

--- a/src/storage/src/metrics/source.rs
+++ b/src/storage/src/metrics/source.rs
@@ -16,7 +16,7 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    DeleteOnDropCounter, DeleteOnDropGauge, IntCounter, IntCounterVec, IntGaugeVec,
+    DeleteOnDropCounter, DeleteOnDropGauge, IntCounter, IntCounterVec, IntGaugeVec, MetricTag,
     MetricVisibility, MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::GlobalId;
@@ -78,6 +78,7 @@ impl GeneralSourceMetricDefs {
                 help: "A counter representing how many times we have failed to commit offsets for a source",
                 var_labels: ["source_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Source],
             )),
             progress: registry.register(metric!(
                 name: "mz_source_progress",

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -29,8 +29,8 @@ use std::time::Instant;
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    DeleteOnDropCounter, DeleteOnDropGauge, IntCounterVec, IntGaugeVec, MetricVisibility,
-    MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropCounter, DeleteOnDropGauge, IntCounterVec, IntGaugeVec, MetricTag,
+    MetricVisibility, MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::statistics::{Gauge, SinkStatisticsUpdate, SourceStatisticsUpdate};
@@ -79,6 +79,7 @@ impl SourceStatisticsMetricDefs {
                 help: "The number of raw messages the worker has received from upstream.",
                 var_labels: ["source_id", "worker_id", "parent_source_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Source],
             )),
             updates_staged: registry.register(metric!(
                 name: "mz_source_updates_staged",
@@ -95,6 +96,7 @@ impl SourceStatisticsMetricDefs {
                 help: "The number of bytes worth of messages the worker has received from upstream. The way the bytes are counted is source-specific.",
                 var_labels: ["source_id", "worker_id", "parent_source_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Source],
             )),
             bytes_indexed: registry.register(metric!(
                 name: "mz_source_bytes_indexed",
@@ -121,12 +123,14 @@ impl SourceStatisticsMetricDefs {
                 help: "The total number of _values_ (source-defined unit) present in upstream.",
                 var_labels: ["source_id", "worker_id", "shard_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Source],
             )),
             offset_committed: registry.register(metric!(
                 name: "mz_source_offset_committed",
                 help: "The total number of _values_ (source-defined unit) we have fully processed, and storage and committed.",
                 var_labels: ["source_id", "worker_id", "shard_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Source],
             )),
             snapshot_records_known: registry.register(metric!(
                 name: "mz_source_snapshot_records_known",
@@ -291,12 +295,14 @@ impl SinkStatisticsMetricDefs {
                 help: "The number of bytes staged but possibly not committed to the sink.",
                 var_labels: ["sink_id", "worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
             bytes_committed: registry.register(metric!(
                 name: "mz_sink_bytes_committed",
                 help: "The number of bytes committed to the sink.",
                 var_labels: ["sink_id", "worker_id"],
                 visibility: MetricVisibility::Public,
+                tags: [MetricTag::Sink],
             )),
         }
     }


### PR DESCRIPTION
Add an optional `tags` property for documentation purposes. Currently we only show tags for "public" metrics given for the appendix entire list, the set is so large that it's hard to find the right taxonomy while also avoiding duplicate metrics. Also it's not too useful to categorize here given the appendix is most likely going to be used for referenceRemove these sections if your commit already has a good description!

### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
