### PR TITLE
persist: skip GC rollup invariant assert under active GC

### DIFF
--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -273,7 +273,8 @@ where
             rollups_to_remove_from_state,
         );
 
-        let mut states = if GC_USE_ACTIVE_GC.get(&machine.applier.cfg) {
+        let use_active_gc = GC_USE_ACTIVE_GC.get(&machine.applier.cfg);
+        let mut states = if use_active_gc {
             let diffs = machine
                 .applier
                 .state_versions
@@ -398,28 +399,42 @@ where
             .gc_seqno_held_parts
             .set(u64::cast_from(seqno_held_parts));
 
-        // verify that the "current" state (as of `fetch_all_live_states`) contains
-        // a rollup to the earliest state we fetched. this invariant isn't affected
-        // by the GC work we just performed, but it is a property of GC correctness
-        // overall / is a convenient place to run the assertion.
-        let valid_pre_gc_state = states
-            .state()
-            .collections
-            .rollups
-            .contains_key(&initial_seqno);
+        // verify that the current state contains a rollup to the earliest state
+        // we fetched. this invariant isn't affected by the GC work we just
+        // performed, but it is a property of GC correctness overall / is a
+        // convenient place to run the assertion.
+        //
+        // The check is only meaningful when `states` was built from
+        // `fetch_all_live_states`, where iterating to the end leaves
+        // `states.state()` at the genuine current state. Under active GC we only
+        // fetch diffs through `seqno_since`, so `states.state()` is the
+        // reconstructed state at `seqno_since`, not the current state. A rollup's
+        // entry is inserted into the rollups map by the `add_rollup` transition
+        // at a seqno strictly greater than the seqno it rolls up; when
+        // `seqno_since` precedes that insertion the reconstructed state legitimately
+        // lacks the entry and this check would false-fire. The active-GC path
+        // already validates the same invariant against fresh data when it resolves
+        // the rollup for `initial_seqno` above.
+        if !use_active_gc {
+            let valid_pre_gc_state = states
+                .state()
+                .collections
+                .rollups
+                .contains_key(&initial_seqno);
 
-        // this should never be true in the steady-state, but may be true the
-        // first time GC runs after fixing any correctness bugs related to our
-        // state version invariants. we'll make it an error so we can track
-        // any violations in Sentry, but opt not to panic because the root
-        // cause of the violation cannot be from this GC run (in fact, this
-        // GC run, assuming it's correct, should have fixed the violation!)
-        soft_assert_or_log!(
-            valid_pre_gc_state,
-            "earliest state fetched during GC did not have corresponding rollup: rollups = {:?}, state seqno = {}",
-            states.state().collections.rollups,
-            initial_seqno
-        );
+            // this should never be true in the steady-state, but may be true the
+            // first time GC runs after fixing any correctness bugs related to our
+            // state version invariants. we'll make it an error so we can track
+            // any violations in Sentry, but opt not to panic because the root
+            // cause of the violation cannot be from this GC run (in fact, this
+            // GC run, assuming it's correct, should have fixed the violation!)
+            soft_assert_or_log!(
+                valid_pre_gc_state,
+                "earliest state fetched during GC did not have corresponding rollup: rollups = {:?}, state seqno = {}",
+                states.state().collections.rollups,
+                initial_seqno
+            );
+        }
 
         report_step_timing(
             &machine

--- a/src/persist-client/tests/machine/regression_gc_active_rollup_assert
+++ b/src/persist-client/tests/machine/regression_gc_active_rollup_assert
@@ -1,0 +1,64 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for PER-10. Under active GC, gc_and_truncate reconstructs
+# state only through `seqno_since` (via `fetch_live_diffs_through`), so the
+# post-GC invariant check sees the state at `seqno_since` rather than the
+# current state. A rollup's entry in the rollups map is inserted by the
+# `add_rollup` transition at a seqno strictly greater than the seqno it rolls
+# up. When `seqno_since` lands below that insertion point, the reconstructed
+# state legitimately lacks its own rollup entry and the tail soft-assert
+# ("earliest state fetched during GC did not have corresponding rollup")
+# false-fires, aborting the persist worker in instrumented builds.
+
+dyncfg
+persist_gc_use_active_gc true
+persist_inline_writes_single_max_bytes 0
+----
+ok
+
+write-batch output=b0 lower=0 upper=1
+k1 0 1
+----
+parts=1 len=1
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [1]
+
+# Roll up state v2 and register it. The rollup blob captures state as of v2,
+# whose rollups map does not yet reference v2 — that entry is only inserted by
+# this `add-rollup`, landing at v3.
+write-rollup output=v2
+----
+state=v2 diffs=[v1, v3)
+
+add-rollup input=v2
+----
+v3
+
+consensus-scan from_seqno=v1
+----
+seqno=v1 batches= rollups=v0
+seqno=v2 batches=b0 rollups=v0
+seqno=v3 batches=b0 rollups=v0,v2
+
+# Truncate v1 out of band so the earliest live diff becomes v2 — a rollup-keyed
+# seqno whose rollups-map entry was only inserted at v3. This mirrors an
+# overlapping GC process having already truncated Consensus.
+consensus-truncate to_seqno=v2
+----
+Some(2)
+
+# Active GC to v2. The earliest live diff is v2, gc_rollups has a rollup for it,
+# but the state reconstructed at v2 has rollups={v0} (the v2 entry arrives at
+# v3). On the buggy code the tail soft-assert false-fires here.
+gc to_seqno=v2
+----
+v4 batch_parts=0 rollups=0 truncated= state_rollups=v0


### PR DESCRIPTION
## Summary

The soft-assert at the tail of `gc_and_truncate` (\"earliest state fetched during GC did not have corresponding rollup\") checks that `states.state()` references a rollup for the earliest fetched seqno. That premise holds only when `states` was built from `fetch_all_live_states`, where iterating to the end leaves `states.state()` at the genuine current state.

Under active GC (`persist_gc_use_active_gc`, on by default in CI for versions after v0.143.0-dev) GC instead fetches diffs only through `seqno_since`, so `states.state()` is the reconstructed state at `seqno_since`, **not** the current state. A rollup's entry is inserted into the rollups map by the `add_rollup` transition at a seqno strictly greater than the seqno it rolls up. When `seqno_since` precedes that insertion, the reconstructed state legitimately lacks its own rollup entry and the assert false-fires.

The check is a `soft_assert_or_log!`, so production only logs to Sentry — the impact is a recurring **test blocker** (Antithesis, nightly, Long Workload Replay), not a customer-facing crash. The PER-16 `add_rollup` fix (#36740) addressed an adjacent but distinct invariant and did not stop this.

## Fix

Gate the check to the classic path, where it is sound. The active-GC path already validates the same invariant against fresh data when it resolves the rollup for the earliest seqno (the early-returns at the top of that branch), so the tripwire is preserved on the classic path for any genuine regression.

## Tests

Adds the datadriven regression test `tests/machine/regression_gc_active_rollup_assert`, which reproduces the panic under active GC on the unfixed code and passes with the fix.

Fixes database-issues#10092, PER-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)