### PR TITLE
SS-16: FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY purification and planning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8214,6 +8214,7 @@ dependencies = [
  "mz-arrow-util",
  "mz-audit-log",
  "mz-auth",
+ "mz-aws-glue-schema-registry",
  "mz-build-info",
  "mz-ccsr",
  "mz-cloud-provider",

--- a/src/aws-glue-schema-registry/src/client.rs
+++ b/src/aws-glue-schema-registry/src/client.rs
@@ -239,6 +239,17 @@ impl DataFormat {
             _ => DataFormat::Unknown(format.as_str().to_string()),
         }
     }
+
+    /// Returns the canonical Glue data-format string (`AVRO`, `JSON`,
+    /// `PROTOBUF`), or the raw SDK-reported value for `Unknown`.
+    pub fn as_str(&self) -> &str {
+        match self {
+            DataFormat::Avro => "AVRO",
+            DataFormat::Json => "JSON",
+            DataFormat::Protobuf => "PROTOBUF",
+            DataFormat::Unknown(s) => s,
+        }
+    }
 }
 
 /// Lifecycle status of a Glue schema version.

--- a/src/aws-glue-schema-registry/src/lib.rs
+++ b/src/aws-glue-schema-registry/src/lib.rs
@@ -51,7 +51,7 @@ mod client;
 mod config;
 
 pub use client::{
-    Client, GetRegistryError, GetSchemaVersionError, Registry, RegistryLifecycleStatus,
+    Client, DataFormat, GetRegistryError, GetSchemaVersionError, Registry, RegistryLifecycleStatus,
     SchemaVersion, SchemaVersionLifecycleStatus,
 };
 pub use config::ClientConfig;

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -176,6 +176,11 @@ pub enum AvroSchema<T: AstInfo> {
     Glue {
         connection: T::ItemName,
         with_options: Vec<GlueAvroOption<T>>,
+        /// Normally populated during purification by fetching the named
+        /// schema's latest version from AWS Glue. The grammar also accepts a
+        /// user-written `SEED VALUE SCHEMA`, so this may be set on input; it is
+        /// not the intended authoring path, but it is not rejected.
+        seed: Option<GlueAvroSeed>,
     },
 }
 
@@ -200,6 +205,7 @@ impl<T: AstInfo> AstDisplay for AvroSchema<T> {
             Self::Glue {
                 connection,
                 with_options,
+                seed,
             } => {
                 f.write_str("USING AWS GLUE SCHEMA REGISTRY CONNECTION ");
                 f.write_node(connection);
@@ -207,6 +213,10 @@ impl<T: AstInfo> AstDisplay for AvroSchema<T> {
                     f.write_str(" (");
                     f.write_node(&display::comma_separated(with_options));
                     f.write_str(")");
+                }
+                if let Some(seed) = seed {
+                    f.write_str(" ");
+                    f.write_node(seed);
                 }
             }
         }
@@ -458,6 +468,35 @@ impl AstDisplay for CsrSeedAvro {
     }
 }
 impl_display!(CsrSeedAvro);
+
+/// Resolved reader schema for a single `AvroSchema::Glue` FORMAT clause.
+///
+/// Glue resolves exactly one named schema per FORMAT clause, so this holds a
+/// single schema rather than a key/value pair. This differs from
+/// [`CsrSeedAvro`], where one `FORMAT AVRO USING CONFLUENT ...` clause can seed
+/// both key and value. Under Glue, the key and value are expressed as separate
+/// `KEY FORMAT ... VALUE FORMAT ...` clauses, each carrying its own
+/// `GlueAvroSeed`; the field is named `value_schema` because, for a single
+/// clause, it is decoded as that clause's value (a bare `FORMAT` clause, or the
+/// value side of a `KEY FORMAT/VALUE FORMAT` pair) — and a `KEY FORMAT` clause
+/// reuses the same schema as its key.
+///
+/// Glue schemas also have no references (each schema-version is a single
+/// self-contained definition), so unlike [`CsrSeedAvro`] there is no references
+/// vector.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GlueAvroSeed {
+    pub value_schema: String,
+}
+
+impl AstDisplay for GlueAvroSeed {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("SEED VALUE SCHEMA '");
+        f.write_node(&display::escape_single_quote_string(&self.value_schema));
+        f.write_str("'");
+    }
+}
+impl_display!(GlueAvroSeed);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CsrSeedProtobuf {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2215,9 +2215,21 @@ impl<'a> Parser<'a> {
             } else {
                 vec![]
             };
+            // SEED VALUE SCHEMA '<json>' is normally emitted by purification
+            // and re-parsed when persisted create_sql is reloaded. A user may
+            // also write it directly; that is accepted here (purification trusts
+            // a pre-populated seed), though it is not the intended path.
+            let seed = if self.parse_keyword(SEED) {
+                self.expect_keywords(&[VALUE, SCHEMA])?;
+                let value_schema = self.parse_literal_string()?;
+                Some(GlueAvroSeed { value_schema })
+            } else {
+                None
+            };
             AvroSchema::Glue {
                 connection,
                 with_options,
+                seed,
             }
         } else if self.parse_keyword(SCHEMA) {
             self.prev_token();

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -3656,23 +3656,34 @@ DROP NETWORK POLICY IF EXISTS q
 =>
 DropObjects(DropObjectsStatement { object_type: NetworkPolicy, if_exists: true, names: [NetworkPolicy(Ident("q"))], cascade: false })
 
-# AWS Glue Schema Registry — Avro source format. Parser-only; the planner
-# rejects this variant with a "not yet implemented" error until the
-# follow-up PR.
+# AWS Glue Schema Registry — Avro source format. `seed: None` here reflects
+# the unpurified AST; purification fetches the schema and fills it in. The
+# round-trip parses `SEED VALUE SCHEMA '...'` (also accepted if written
+# directly).
 
 parse-statement
 CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema')
 ----
 CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema')
 =>
-CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("my-schema"))) }] }))), envelope: None })
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("my-schema"))) }], seed: None }))), envelope: None })
+
+# Round-trip of a purified statement: the `SEED VALUE SCHEMA` clause that
+# purification emits must re-parse so persisted `create_sql` reloads. Parallels
+# the Confluent `SEED VALUE SCHEMA` case above; Glue has a value schema only.
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema') SEED VALUE SCHEMA '{"some": "schema"}'
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema') SEED VALUE SCHEMA '{"some": "schema"}'
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("my-schema"))) }], seed: Some(GlueAvroSeed { value_schema: "{\"some\": \"schema\"}" }) }))), envelope: None })
 
 parse-statement
 CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn
 ----
 CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn
 =>
-CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [] }))), envelope: None })
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [], seed: None }))), envelope: None })
 
 parse-statement
 CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY
@@ -3686,4 +3697,15 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING A
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'my-schema') ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("my-schema"))) }] }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("my-schema"))) }], seed: None }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
+
+# Round-trip of a purified UPSERT statement: KEY FORMAT and VALUE FORMAT are
+# purified independently, so each Glue clause carries its own `SEED VALUE
+# SCHEMA`. This is the persisted `create_sql` shape for UPSERT/DEBEZIUM, which
+# require explicit KEY FORMAT + VALUE FORMAT under Glue.
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) KEY FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'key-schema') SEED VALUE SCHEMA '{"k": "key"}' VALUE FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'val-schema') SEED VALUE SCHEMA '{"v": "value"}' ENVELOPE UPSERT
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = bar) KEY FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'key-schema') SEED VALUE SCHEMA '{"k": "key"}' VALUE FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'val-schema') SEED VALUE SCHEMA '{"v": "value"}' ENVELOPE UPSERT
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("bar")])), with_options: [], include_metadata: [], format: Some(KeyValue { key: Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("key-schema"))) }], seed: Some(GlueAvroSeed { value_schema: "{\"k\": \"key\"}" }) }), value: Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: SchemaName, value: Some(Value(String("val-schema"))) }], seed: Some(GlueAvroSeed { value_schema: "{\"v\": \"value\"}" }) }) }), envelope: Some(Upsert { value_decode_err_policy: [] }) })

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -34,6 +34,7 @@ mz-arrow-util = { path = "../arrow-util" }
 mz-adapter-types = { path = "../adapter-types" }
 mz-audit-log = { path = "../audit-log" }
 mz-auth = { path = "../auth" }
+mz-aws-glue-schema-registry = { path = "../aws-glue-schema-registry" }
 mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-provider = { path = "../cloud-provider", default-features = false }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -42,8 +42,8 @@ use crate::plan::plan_utils::JoinSide;
 use crate::plan::scope::ScopeItem;
 use crate::plan::typeconv::CastContext;
 use crate::pure::error::{
-    CsrPurificationError, IcebergSinkPurificationError, KafkaSinkPurificationError,
-    KafkaSourcePurificationError, LoadGeneratorSourcePurificationError,
+    CsrPurificationError, GluePurificationError, IcebergSinkPurificationError,
+    KafkaSinkPurificationError, KafkaSourcePurificationError, LoadGeneratorSourcePurificationError,
     MySqlSourcePurificationError, PgSourcePurificationError, SqlServerSourcePurificationError,
 };
 use crate::session::vars::VarError;
@@ -276,6 +276,7 @@ pub enum PlanError {
     IcebergSinkPurification(IcebergSinkPurificationError),
     LoadGeneratorSourcePurification(LoadGeneratorSourcePurificationError),
     CsrPurification(CsrPurificationError),
+    GluePurification(GluePurificationError),
     MySqlSourcePurification(MySqlSourcePurificationError),
     SqlServerSourcePurificationError(SqlServerSourcePurificationError),
     UseTablesForSources(String),
@@ -371,6 +372,7 @@ impl PlanError {
             Self::KafkaSourcePurification(e) => e.detail(),
             Self::LoadGeneratorSourcePurification(e) => e.detail(),
             Self::CsrPurification(e) => e.detail(),
+            Self::GluePurification(e) => e.detail(),
             Self::KafkaSinkPurification(e) => e.detail(),
             Self::IcebergSinkPurification(e) => e.detail(),
             Self::SubsourceNameConflict {
@@ -475,6 +477,7 @@ impl PlanError {
             Self::KafkaSourcePurification(e) => e.hint(),
             Self::LoadGeneratorSourcePurification(e) => e.hint(),
             Self::CsrPurification(e) => e.hint(),
+            Self::GluePurification(e) => e.hint(),
             Self::KafkaSinkPurification(e) => e.hint(),
             Self::UnknownColumn { table, similar, .. } => {
                 let suffix = "Make sure to surround case sensitive names in double quotes.";
@@ -803,6 +806,7 @@ impl fmt::Display for PlanError {
             Self::KafkaSinkPurification(e) => write!(f, "KAFKA sink validation: {}", e),
             Self::IcebergSinkPurification(e) => write!(f, "ICEBERG sink validation: {}", e),
             Self::CsrPurification(e) => write!(f, "CONFLUENT SCHEMA REGISTRY validation: {}", e),
+            Self::GluePurification(e) => write!(f, "AWS GLUE SCHEMA REGISTRY validation: {}", e),
             Self::MySqlSourcePurification(e) => write!(f, "MYSQL source validation: {}", e),
             Self::SqlServerSourcePurificationError(e) => write!(f, "SQL SERVER source validation: {}", e),
             Self::UseTablesForSources(command) => write!(f, "{command} not supported; use CREATE TABLE .. FROM SOURCE instead"),
@@ -1010,6 +1014,12 @@ impl From<KafkaSinkPurificationError> for PlanError {
 impl From<IcebergSinkPurificationError> for PlanError {
     fn from(e: IcebergSinkPurificationError) -> Self {
         PlanError::IcebergSinkPurification(e)
+    }
+}
+
+impl From<GluePurificationError> for PlanError {
+    fn from(e: GluePurificationError) -> Self {
+        PlanError::GluePurification(e)
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -68,22 +68,23 @@ use mz_sql_parser::ast::{
     CreateWebhookSourceStatement, CsrConfigOption, CsrConfigOptionName, CsrConnection,
     CsrConnectionAvro, CsrConnectionProtobuf, CsrSeedProtobuf, CsvColumns, DeferredItemName,
     DocOnIdentifier, DocOnSchema, DropObjectsStatement, DropOwnedStatement, Expr, Format,
-    FormatSpecifier, IcebergSinkConfigOption, Ident, IfExistsBehavior, IndexOption,
-    IndexOptionName, KafkaSinkConfigOption, KeyConstraint, LoadGeneratorOption,
-    LoadGeneratorOptionName, MaterializedViewOption, MaterializedViewOptionName, MySqlConfigOption,
-    MySqlConfigOptionName, NetworkPolicyOption, NetworkPolicyOptionName,
-    NetworkPolicyRuleDefinition, NetworkPolicyRuleOption, NetworkPolicyRuleOptionName,
-    PgConfigOption, PgConfigOptionName, ProtobufSchema, QualifiedReplica, RefreshAtOptionValue,
-    RefreshEveryOptionValue, RefreshOptionValue, ReplicaDefinition, ReplicaOption,
-    ReplicaOptionName, RoleAttribute, SetRoleVar, SourceErrorPolicy, SourceIncludeMetadata,
-    SqlServerConfigOption, SqlServerConfigOptionName, Statement, TableConstraint,
-    TableFromSourceColumns, TableFromSourceOption, TableFromSourceOptionName, TableOption,
-    TableOptionName, UnresolvedDatabaseName, UnresolvedItemName, UnresolvedObjectName,
-    UnresolvedSchemaName, Value, ViewDefinition, WithOptionValue,
+    FormatSpecifier, GlueAvroOption, GlueAvroOptionName, IcebergSinkConfigOption, Ident,
+    IfExistsBehavior, IndexOption, IndexOptionName, KafkaSinkConfigOption, KeyConstraint,
+    LoadGeneratorOption, LoadGeneratorOptionName, MaterializedViewOption,
+    MaterializedViewOptionName, MySqlConfigOption, MySqlConfigOptionName, NetworkPolicyOption,
+    NetworkPolicyOptionName, NetworkPolicyRuleDefinition, NetworkPolicyRuleOption,
+    NetworkPolicyRuleOptionName, PgConfigOption, PgConfigOptionName, ProtobufSchema,
+    QualifiedReplica, RefreshAtOptionValue, RefreshEveryOptionValue, RefreshOptionValue,
+    ReplicaDefinition, ReplicaOption, ReplicaOptionName, RoleAttribute, SetRoleVar,
+    SourceErrorPolicy, SourceIncludeMetadata, SqlServerConfigOption, SqlServerConfigOptionName,
+    Statement, TableConstraint, TableFromSourceColumns, TableFromSourceOption,
+    TableFromSourceOptionName, TableOption, TableOptionName, UnresolvedDatabaseName,
+    UnresolvedItemName, UnresolvedObjectName, UnresolvedSchemaName, Value, ViewDefinition,
+    WithOptionValue,
 };
 use mz_sql_parser::ident;
 use mz_sql_parser::parser::StatementParseResult;
-use mz_storage_types::connections::inline::{ConnectionAccess, ReferencedConnection};
+use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::connections::{Connection, KafkaTopicOptions};
 use mz_storage_types::sinks::{
     IcebergSinkConnection, KafkaIdStyle, KafkaSinkConnection, KafkaSinkFormat, KafkaSinkFormatType,
@@ -2296,6 +2297,8 @@ fn source_sink_cluster_config<'a, 'ctx>(
 
 generate_extracted_config!(AvroSchemaOption, (ConfluentWireFormat, bool, Default(true)));
 
+generate_extracted_config!(GlueAvroOption, (SchemaName, String));
+
 #[derive(Debug)]
 pub struct Schema {
     pub key_schema: Option<String>,
@@ -2304,8 +2307,10 @@ pub struct Schema {
     pub key_reference_schemas: Vec<String>,
     /// Reference schemas for the value schema, in dependency order.
     pub value_reference_schemas: Vec<String>,
-    pub csr_connection: Option<<ReferencedConnection as ConnectionAccess>::Csr>,
-    pub confluent_wire_format: bool,
+    /// Wire-format dispatch and the registry connection to fetch writer
+    /// schemas from. Built directly by each `AvroSchema` variant rather
+    /// than reconstructed from a (csr_connection, bool) pair downstream.
+    pub wire_format: WireFormat<ReferencedConnection>,
 }
 
 fn get_encoding_inner(
@@ -2320,8 +2325,7 @@ fn get_encoding_inner(
                 value_schema,
                 key_reference_schemas,
                 value_reference_schemas,
-                csr_connection,
-                confluent_wire_format,
+                wire_format,
             } = match schema {
                 // TODO(jldlaughlin): we need a way to pass in primary key information
                 // when building a source from a string or file.
@@ -2333,14 +2337,17 @@ fn get_encoding_inner(
                         confluent_wire_format,
                         ..
                     } = with_options.clone().try_into()?;
-
+                    let wire_format = if confluent_wire_format {
+                        WireFormat::Confluent { registry: None }
+                    } else {
+                        WireFormat::None
+                    };
                     Schema {
                         key_schema: None,
                         value_schema: schema.clone(),
                         key_reference_schemas: vec![],
                         value_reference_schemas: vec![],
-                        csr_connection: None,
-                        confluent_wire_format,
+                        wire_format,
                     }
                 }
                 AvroSchema::Csr {
@@ -2357,7 +2364,7 @@ fn get_encoding_inner(
                         Connection::Csr(_) => item.id(),
                         _ => {
                             sql_bail!(
-                                "{} is not a schema registry connection",
+                                "{} is not a Confluent Schema Registry connection",
                                 scx.catalog
                                     .resolve_full_name(item.name())
                                     .to_string()
@@ -2372,35 +2379,49 @@ fn get_encoding_inner(
                             value_schema: seed.value_schema.clone(),
                             key_reference_schemas: seed.key_reference_schemas.clone(),
                             value_reference_schemas: seed.value_reference_schemas.clone(),
-                            csr_connection: Some(csr_connection),
-                            confluent_wire_format: true,
+                            wire_format: WireFormat::Confluent {
+                                registry: Some(csr_connection),
+                            },
                         }
                     } else {
                         sql_bail!("Avro CSR seed resolution has not been performed")
                     }
                 }
-                AvroSchema::Glue { .. } => {
-                    sql_bail!(
-                        "FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY is not yet \
-                         implemented"
-                    )
-                }
-            };
+                AvroSchema::Glue {
+                    connection,
+                    with_options: _,
+                    seed,
+                } => {
+                    let item = scx.get_item_by_resolved_name(connection)?;
+                    let glue_connection = match item.connection()? {
+                        Connection::GlueSchemaRegistry(_) => item.id(),
+                        _ => {
+                            sql_bail!(
+                                "{} is not an AWS Glue Schema Registry connection",
+                                scx.catalog
+                                    .resolve_full_name(item.name())
+                                    .to_string()
+                                    .quoted()
+                            )
+                        }
+                    };
 
-            // Map the legacy (csr_connection, confluent_wire_format) pair to
-            // the unified `WireFormat`. `(Some, false)` is unreachable in
-            // practice (the planner only sets `confluent_wire_format = false`
-            // on inline schemas, which never carry a CSR connection) but is
-            // rejected explicitly here to keep the invariant local.
-            let wire_format = match (csr_connection.clone(), confluent_wire_format) {
-                (None, false) => WireFormat::None,
-                (None, true) => WireFormat::Confluent { registry: None },
-                (Some(c), true) => WireFormat::Confluent { registry: Some(c) },
-                (Some(_), false) => {
-                    sql_bail!(
-                        "internal error: AVRO source has CSR connection but \
-                         CONFLUENT WIRE FORMAT = false"
-                    )
+                    // `SCHEMA NAME` requiredness is enforced during
+                    // purification, which also populates `seed`. By the time
+                    // planning runs the option is guaranteed present.
+                    let Some(seed) = seed else {
+                        sql_bail!("Avro Glue seed resolution has not been performed");
+                    };
+
+                    Schema {
+                        key_schema: None,
+                        value_schema: seed.value_schema.clone(),
+                        key_reference_schemas: vec![],
+                        value_reference_schemas: vec![],
+                        wire_format: WireFormat::Glue {
+                            registry: Some(glue_connection),
+                        },
+                    }
                 }
             };
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -42,13 +42,14 @@ use mz_sql_parser::ast::{
     CreateSinkStatement, CreateSourceOptionName, CreateSubsourceOption, CreateSubsourceOptionName,
     CreateTableFromSourceStatement, CsrConfigOption, CsrConfigOptionName, CsrConnection,
     CsrSeedAvro, CsrSeedProtobuf, CsrSeedProtobufSchema, DeferredItemName, DocOnIdentifier,
-    DocOnSchema, Expr, Function, FunctionArgs, Ident, KafkaSourceConfigOption,
-    KafkaSourceConfigOptionName, LoadGenerator, LoadGeneratorOption, LoadGeneratorOptionName,
-    MaterializedViewOption, MaterializedViewOptionName, MySqlConfigOption, MySqlConfigOptionName,
-    PgConfigOption, PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy,
-    RefreshAtOptionValue, RefreshEveryOptionValue, RefreshOptionValue, SourceEnvelope,
-    SqlServerConfigOption, SqlServerConfigOptionName, Statement, TableFromSourceColumns,
-    TableFromSourceOption, TableFromSourceOptionName, UnresolvedItemName,
+    DocOnSchema, Expr, Function, FunctionArgs, GlueAvroOption, GlueAvroSeed, Ident,
+    KafkaSourceConfigOption, KafkaSourceConfigOptionName, LoadGenerator, LoadGeneratorOption,
+    LoadGeneratorOptionName, MaterializedViewOption, MaterializedViewOptionName, MySqlConfigOption,
+    MySqlConfigOptionName, PgConfigOption, PgConfigOptionName, RawItemName,
+    ReaderSchemaSelectionStrategy, RefreshAtOptionValue, RefreshEveryOptionValue,
+    RefreshOptionValue, SourceEnvelope, SqlServerConfigOption, SqlServerConfigOptionName,
+    Statement, TableFromSourceColumns, TableFromSourceOption, TableFromSourceOptionName,
+    UnresolvedItemName,
 };
 use mz_sql_server_util::desc::SqlServerTableDesc;
 use mz_storage_types::configuration::StorageConfiguration;
@@ -2312,11 +2313,20 @@ async fn purify_source_format_single(
                 .await?
             }
             AvroSchema::InlineSchema { .. } => {}
-            AvroSchema::Glue { .. } => {
-                sql_bail!(
-                    "FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY is not yet \
-                     implemented"
-                );
+            AvroSchema::Glue {
+                connection,
+                with_options,
+                seed,
+            } => {
+                purify_glue_connection_avro(
+                    catalog,
+                    options,
+                    connection,
+                    with_options,
+                    seed,
+                    storage_configuration,
+                )
+                .await?
             }
         },
         Format::Protobuf(schema) => match schema {
@@ -2535,6 +2545,103 @@ async fn purify_csr_connection_avro(
         })
     }
 
+    Ok(())
+}
+
+async fn purify_glue_connection_avro(
+    catalog: &dyn SessionCatalog,
+    options: &SourceFormatOptions,
+    connection: &ResolvedItemName,
+    with_options: &[GlueAvroOption<Aug>],
+    seed: &mut Option<GlueAvroSeed>,
+    storage_configuration: &StorageConfiguration,
+) -> Result<(), PlanError> {
+    use crate::pure::error::GluePurificationError;
+    let SourceFormatOptions::Kafka { .. } = options else {
+        sql_bail!("AWS Glue Schema Registry is only supported with Kafka sources")
+    };
+
+    let scx = StatementContext::new(None, &*catalog);
+    let item = scx.get_item_by_resolved_name(connection)?;
+    let full_name = scx.catalog.resolve_full_name(item.name());
+    // Structural validation below runs unconditionally — even when a seed is
+    // already present. The seed is not proof the rest of the statement is
+    // well-formed: the grammar accepts a user-written `SEED VALUE SCHEMA`, so a
+    // seeded statement may have arrived straight from a user rather than from
+    // our own re-parsed `create_sql`. Only the Glue *fetch* is safe to skip
+    // when seeded; the connection-type and `SCHEMA NAME` checks are not.
+    let Connection::GlueSchemaRegistry(gsr_connection) = item.connection()? else {
+        return Err(GluePurificationError::NotGlueConnection(full_name).into());
+    };
+
+    // Pull `SCHEMA NAME` out of the option bag. Required. Use the shared
+    // extractor (rather than a hand-rolled match) so non-string values get a
+    // proper "invalid value" error instead of being silently dropped.
+    let crate::plan::statement::ddl::GlueAvroOptionExtracted { schema_name, .. } =
+        with_options.to_vec().try_into()?;
+    let schema_name = schema_name.ok_or(GluePurificationError::MissingSchemaName)?;
+
+    if seed.is_some() {
+        // The schema is already pinned — either we purified this statement
+        // before and re-parsed it from persisted create_sql, or a user supplied
+        // the seed directly. Either way the reader schema is fixed, so skip the
+        // Glue lookup. (The structural checks above still ran.)
+        return Ok(());
+    }
+    let gsr_connection = gsr_connection.into_inline_connection(catalog);
+
+    // Build the SDK config the same way the storage decoder does at runtime
+    // — same auth, region, and endpoint override resolution.
+    let enforce_external_addresses = mz_storage_types::dyncfgs::ENFORCE_EXTERNAL_ADDRESSES
+        .get(storage_configuration.config_set());
+    let sdk_config = gsr_connection
+        .aws_connection
+        .connection
+        .load_sdk_config(
+            &storage_configuration.connection_context,
+            gsr_connection.aws_connection.connection_id,
+            // We are in a normal tokio context during purification.
+            InTask::No,
+            enforce_external_addresses,
+        )
+        .await
+        .map_err(|e| GluePurificationError::LoadSdkConfigError(Arc::new(e)))?;
+    let glue_client = mz_aws_glue_schema_registry::ClientConfig::new(sdk_config).build();
+
+    let version = glue_client
+        .get_schema_version_latest_by_name(&gsr_connection.registry_name, &schema_name)
+        .await
+        .map_err(|e| GluePurificationError::SchemaLookupError {
+            registry: gsr_connection.registry_name.clone(),
+            schema: schema_name.clone(),
+            cause: Arc::new(e),
+        })?;
+    // The runtime decode path only handles Avro; reject other formats at
+    // planning time so the failure mode is a clear SQL error, not a
+    // permanent decode error on every record.
+    match &version.data_format {
+        Some(mz_aws_glue_schema_registry::DataFormat::Avro) => {}
+        other => {
+            return Err(GluePurificationError::UnsupportedDataFormat {
+                registry: gsr_connection.registry_name.clone(),
+                schema: schema_name.clone(),
+                format: other
+                    .as_ref()
+                    .map(|f| f.as_str().to_string())
+                    .unwrap_or_else(|| "<unspecified>".to_string()),
+            }
+            .into());
+        }
+    }
+    let value_schema =
+        version
+            .definition
+            .ok_or_else(|| GluePurificationError::EmptyDefinition {
+                registry: gsr_connection.registry_name.clone(),
+                schema: schema_name.clone(),
+            })?;
+
+    *seed = Some(GlueAvroSeed { value_schema });
     Ok(())
 }
 

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -280,6 +280,51 @@ impl CsrPurificationError {
     }
 }
 
+/// Logical errors detectable during purification for AWS Glue Schema Registry.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum GluePurificationError {
+    #[error("{0} is not an AWS GLUE SCHEMA REGISTRY CONNECTION")]
+    NotGlueConnection(FullItemName),
+    #[error("SCHEMA NAME option is required")]
+    MissingSchemaName,
+    #[error("loading AWS SDK configuration failed")]
+    LoadSdkConfigError(Arc<anyhow::Error>),
+    #[error("Glue schema lookup failed (registry {registry:?}, schema {schema:?})")]
+    SchemaLookupError {
+        registry: String,
+        schema: String,
+        #[source]
+        cause: Arc<mz_aws_glue_schema_registry::GetSchemaVersionError>,
+    },
+    #[error("Glue schema {schema:?} in registry {registry:?} has no definition")]
+    EmptyDefinition { registry: String, schema: String },
+    #[error(
+        "Glue schema {schema:?} in registry {registry:?} uses unsupported data format {format}; only AVRO is supported"
+    )]
+    UnsupportedDataFormat {
+        registry: String,
+        schema: String,
+        format: String,
+    },
+}
+
+impl GluePurificationError {
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            Self::LoadSdkConfigError(e) => Some(e.to_string_with_causes()),
+            Self::SchemaLookupError { cause, .. } => Some(cause.to_string_with_causes()),
+            Self::NotGlueConnection(_)
+            | Self::MissingSchemaName
+            | Self::EmptyDefinition { .. }
+            | Self::UnsupportedDataFormat { .. } => None,
+        }
+    }
+
+    pub fn hint(&self) -> Option<String> {
+        None
+    }
+}
+
 /// Logical errors detectable during purification for a MySQL SOURCE.
 #[derive(Debug, thiserror::Error)]
 pub enum MySqlSourcePurificationError {

--- a/src/storage-types/src/wire_format.rs
+++ b/src/storage-types/src/wire_format.rs
@@ -24,9 +24,8 @@
 //!   ingest Confluent-framed bytes without an attached CSR connection
 //!   (the schema id is read but the schema is not fetched).
 //! * [`WireFormat::Glue`] — AWS Glue Schema Registry framing
-//!   (magic byte + UUID schema-version id). Not yet wired to the planner, so
-//!   currently unconstructable from SQL — defined here so the in-memory shape
-//!   is stable while the rest of the support lands.
+//!   (magic byte + UUID schema-version id). Constructable from SQL on the
+//!   source side; sinks do not yet support Glue and remain Confluent-only.
 
 use mz_repr::GlobalId;
 use serde::{Deserialize, Serialize};

--- a/src/storage/src/decode.rs
+++ b/src/storage/src/decode.rs
@@ -356,9 +356,6 @@ async fn get_decoder(
             reference_schemas,
             wire_format,
         }) => {
-            // Only the Confluent variant is reachable from SQL today; Glue
-            // is not yet wired to the planner.
-
             let writer_schemas = match wire_format {
                 WireFormat::None => WriterSchemaProvider::None,
                 WireFormat::Confluent { registry } => {


### PR DESCRIPTION
Implements the purification and planning for `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY`. Purification now generates the seed schemas (captured when the source is created). E2E tests (including those run against AWS) are in the [next commit](https://github.com/MaterializeInc/materialize/pull/36795).

Note: AWS Glue doesn't have an equivalent to CSR's `TopicNameStrategy` ( which uses `topic`-key and `topic`-value to resolve key and value schema names). Users can still specify `KEY FORMAT` / `VALUE FORMAT` separately, which will allow Glue registered schemas to be used in both places. 

The main changes are in ddl.rs and pure.rs.