### PR TITLE
clusterd-test-driver: add metrics and drop-dataflow verbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6448,6 +6448,7 @@ dependencies = [
  "mz-service",
  "mz-storage-types",
  "mz-transform",
+ "reqwest 0.12.28",
  "serde",
  "tempfile",
  "timely",

--- a/src/clusterd-test-driver/Cargo.toml
+++ b/src/clusterd-test-driver/Cargo.toml
@@ -45,6 +45,9 @@ mz-storage-types = { path = "../storage-types" }
 # `implementation` defaults to `Unimplemented`); the default path lowers faithfully
 # without it.
 mz-transform = { path = "../transform" }
+# Scrapes clusterd's Prometheus `/metrics` endpoint for the `metrics` command (the
+# observable behind the CLU-131 reproduction).
+reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 timely.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/src/clusterd-test-driver/src/lib.rs
+++ b/src/clusterd-test-driver/src/lib.rs
@@ -15,6 +15,7 @@ pub mod ctp;
 pub mod data;
 pub mod dataflow;
 pub mod driver;
+pub mod metrics;
 pub mod persist_host;
 pub mod responses;
 pub mod script;

--- a/src/clusterd-test-driver/src/metrics.rs
+++ b/src/clusterd-test-driver/src/metrics.rs
@@ -1,0 +1,153 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Scraping clusterd's Prometheus `/metrics` endpoint.
+//!
+//! The driver speaks the compute protocol but does not see the replica's internal
+//! state. Some behaviors are only observable through clusterd's own metrics, so this
+//! module reads the Prometheus text endpoint clusterd's internal HTTP server exposes
+//! and sums named series for the `metrics` command to assert on.
+//!
+//! The motivating use case is the persist-sink correction buffer (CLU-131): a
+//! read-only materialized-view sink holds a roughly full-MV-size correction buffer
+//! that a read-write sink consolidates to ~0. The live buffer occupancy is not a
+//! gauge; it is the difference of two monotonic counters,
+//! `mz_persist_sink_correction_insertions_total - …_deletions_total`, which the
+//! `metrics` command expresses with its `minus` operand.
+
+use anyhow::Context;
+use mz_ore::cast::CastLossy;
+
+/// Fetch the raw Prometheus text body from a clusterd `/metrics` URL.
+pub async fn fetch(metrics_url: &str) -> anyhow::Result<String> {
+    reqwest::get(metrics_url)
+        .await
+        .with_context(|| format!("scraping clusterd metrics at {metrics_url}"))?
+        .error_for_status()
+        .context("clusterd metrics endpoint returned an error status")?
+        .text()
+        .await
+        .context("reading clusterd metrics body")
+}
+
+/// Sum the values of every series of `name` in a Prometheus text `body`, optionally
+/// restricted to series carrying a `select` label (`(label, value)`).
+///
+/// Summing across series gives a process-wide total over all label combinations
+/// (e.g. per-worker series), which is the natural quantity to assert on. A metric
+/// absent from the body sums to 0: a counter's family is registered lazily on first
+/// use, so before the relevant code path runs the line is simply not present. Values
+/// are emitted by the Prometheus text encoder as (possibly floating-point) numbers;
+/// the counters and gauges of interest are integral, so a lossy cast back to `u64`
+/// recovers the count.
+pub fn sum_metric(body: &str, name: &str, select: Option<(&str, &str)>) -> anyhow::Result<u64> {
+    let mut total: u64 = 0;
+    for line in body.lines() {
+        // Skip `# HELP`/`# TYPE` comment lines.
+        if line.starts_with('#') {
+            continue;
+        }
+        // A sample line is `series value` (mz's encoder emits no trailing
+        // timestamp), where `series` is `name` or `name{labels}` with no unquoted
+        // whitespace, so the value is the final whitespace-separated token.
+        let Some((series, value)) = line.rsplit_once(char::is_whitespace) else {
+            continue;
+        };
+        if !series_matches(series, name, select) {
+            continue;
+        }
+        let parsed: f64 = value
+            .parse()
+            .with_context(|| format!("metric {name} value {value:?} is not a number"))?;
+        total += u64::cast_lossy(parsed);
+    }
+    Ok(total)
+}
+
+/// Whether a Prometheus `series` token (`name` or `name{labels}`) is named `name`
+/// and, when `select` is given, carries that exact `label="value"` pair.
+fn series_matches(series: &str, name: &str, select: Option<(&str, &str)>) -> bool {
+    let (series_name, labels) = match series.split_once('{') {
+        Some((n, rest)) => (n, rest.strip_suffix('}').unwrap_or(rest)),
+        None => (series, ""),
+    };
+    if series_name != name {
+        return false;
+    }
+    match select {
+        None => true,
+        // Labels are `k1="v1",k2="v2"`; match one entry exactly.
+        Some((key, value)) => {
+            let needle = format!("{key}=\"{value}\"");
+            labels.split(',').any(|entry| entry.trim() == needle)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BODY: &str = "\
+# HELP mz_persist_sink_correction_insertions_total The cumulative insertions.
+# TYPE mz_persist_sink_correction_insertions_total counter
+mz_persist_sink_correction_insertions_total 200000
+mz_persist_sink_correction_deletions_total 199950
+mz_persist_sink_correction_capacity_increases_total 4096
+mz_persist_sink_correction_max_per_sink_worker_len_updates{worker_id=\"0\"} 60000
+mz_persist_sink_correction_max_per_sink_worker_len_updates{worker_id=\"1\"} 40000
+";
+
+    /// A counter is read by exact name, comment lines are skipped, an absent metric
+    /// sums to 0, and a name that is a prefix of another metric does not match it.
+    #[mz_ore::test]
+    fn sums_unlabeled_counters() {
+        assert_eq!(
+            sum_metric(BODY, "mz_persist_sink_correction_insertions_total", None).unwrap(),
+            200000
+        );
+        assert_eq!(
+            sum_metric(BODY, "mz_persist_sink_correction_deletions_total", None).unwrap(),
+            199950
+        );
+        // Absent metric sums to zero.
+        assert_eq!(
+            sum_metric(BODY, "mz_persist_sink_absent_total", None).unwrap(),
+            0
+        );
+    }
+
+    /// Multiple label series of one metric sum to a process-wide total, and a label
+    /// selector restricts to a single series.
+    #[mz_ore::test]
+    fn sums_and_selects_labeled_series() {
+        let name = "mz_persist_sink_correction_max_per_sink_worker_len_updates";
+        assert_eq!(sum_metric(BODY, name, None).unwrap(), 100000);
+        assert_eq!(
+            sum_metric(BODY, name, Some(("worker_id", "0"))).unwrap(),
+            60000
+        );
+        assert_eq!(
+            sum_metric(BODY, name, Some(("worker_id", "1"))).unwrap(),
+            40000
+        );
+        // A selector that matches no series sums to zero.
+        assert_eq!(sum_metric(BODY, name, Some(("worker_id", "2"))).unwrap(), 0);
+    }
+
+    /// A float-encoded counter value casts back to its integral count.
+    #[mz_ore::test]
+    fn casts_float_encoded_value() {
+        let body = "mz_persist_sink_correction_deletions_total 12345.0\n";
+        assert_eq!(
+            sum_metric(body, "mz_persist_sink_correction_deletions_total", None).unwrap(),
+            12345
+        );
+    }
+}

--- a/src/clusterd-test-driver/src/script.rs
+++ b/src/clusterd-test-driver/src/script.rs
@@ -426,6 +426,16 @@ pub enum Command {
         /// The new read frontier.
         frontier: u64,
     },
+    /// Drop a dataflow by sending `AllowCompaction` with the empty frontier, the
+    /// canonical way to drop a compute collection (it signals external readers want
+    /// nothing from it ever again). Distinct from `allow-compaction`, which advances
+    /// the read frontier to a finite timestamp; the empty frontier instead removes
+    /// the dataflow. It relaxes only read capabilities, so it does not seal the
+    /// collection's output shard.
+    DropDataflow {
+        /// The dropped collection's global id.
+        id: u64,
+    },
     /// Take a collection out of read-only mode via `AllowWrites`, letting its
     /// persist sink begin writing. Every dataflow starts read-only; indexes,
     /// subscribes, and peeks work regardless, but a materialized-view sink withholds
@@ -536,6 +546,39 @@ pub enum Command {
         #[serde(default)]
         updates: Vec<ConfigSetting>,
     },
+    /// Assert on a clusterd Prometheus metric scraped from its `/metrics` endpoint.
+    ///
+    /// `metric` is summed across all of its label series (a process-wide total),
+    /// optionally restricted to a single `select` label and optionally with a second
+    /// metric `minus` subtracted, so a counter difference can be expressed. The
+    /// assertion is level-triggered: the command polls until the value satisfies the
+    /// bounds (or the timeout elapses), so it doubles as a wait.
+    ///
+    /// The motivating use is the persist-sink correction buffer (CLU-131): its live
+    /// occupancy is `mz_persist_sink_correction_insertions_total` with
+    /// `minus=mz_persist_sink_correction_deletions_total`. A read-only MV sink holds a
+    /// roughly full-MV-size buffer (`min` large); a read-write sink under continuous
+    /// load consolidates it small (`max` small). With a bound, the golden output
+    /// states the satisfied bound, so it is independent of the exact value.
+    Metrics {
+        /// The metric name to sum.
+        metric: String,
+        /// An optional second metric whose sum is subtracted from `metric`'s.
+        #[serde(default)]
+        minus: Option<String>,
+        /// An optional `label=value` restricting the summed series.
+        #[serde(default)]
+        select: Option<String>,
+        /// Wait until the value is at least this much.
+        #[serde(default)]
+        min: Option<u64>,
+        /// Wait until the value is at most this much.
+        #[serde(default)]
+        max: Option<u64>,
+        /// Timeout in seconds; defaults to `DEFAULT_TIMEOUT_SECS`.
+        #[serde(default)]
+        timeout_secs: Option<u64>,
+    },
     /// Drop the current connection and reconnect, sending only `Hello`. Re-issue
     /// `create_instance`, replay the dataflows the replica should keep, then
     /// `initialization_complete` to close the reconciliation window.
@@ -575,6 +618,8 @@ pub struct ScriptState {
     mv_outputs: BTreeMap<u64, CollectionMetadata>,
     /// Next ephemeral id for the count sugar's dataflows.
     next_internal: u64,
+    /// clusterd's Prometheus `/metrics` URL, scraped by the `metrics` command.
+    metrics_url: String,
 }
 
 impl ScriptState {
@@ -591,6 +636,7 @@ impl ScriptState {
             indexes: BTreeMap::new(),
             mv_outputs: BTreeMap::new(),
             next_internal: INTERNAL_ID_BASE,
+            metrics_url: crate::target::metrics_url(),
         })
     }
 
@@ -812,6 +858,16 @@ impl ScriptState {
                 self.driver.send(ComputeCommand::AllowCompaction {
                     id: GlobalId::User(id),
                     frontier: Antichain::from_elem(Timestamp::from(frontier)),
+                })?;
+                Ok("ok".to_string())
+            }
+            Command::DropDataflow { id } => {
+                // The empty frontier is the canonical drop signal (see the command
+                // doc). It relaxes read capabilities, so the dataflow is removed
+                // without sealing its output shard.
+                self.driver.send(ComputeCommand::AllowCompaction {
+                    id: GlobalId::User(id),
+                    frontier: Antichain::new(),
                 })?;
                 Ok("ok".to_string())
             }
@@ -1059,6 +1115,57 @@ impl ScriptState {
                     .await?;
                 Ok(render_updates(&updates))
             }
+            Command::Metrics {
+                metric,
+                minus,
+                select,
+                min,
+                max,
+                timeout_secs,
+            } => {
+                let timeout = Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
+                let select = select
+                    .as_deref()
+                    .map(|s| {
+                        s.split_once('=').ok_or_else(|| {
+                            anyhow::anyhow!("select must be `label=value`, got {s:?}")
+                        })
+                    })
+                    .transpose()?;
+                let satisfied =
+                    |v: u64| min.map_or(true, |m| v >= m) && max.map_or(true, |m| v <= m);
+                // Level-triggered: poll until the value meets the bounds, so the
+                // command waits out a metric rising (`min`) or falling (`max`). The
+                // body is fetched once per poll so `metric` and `minus` are read from
+                // a single consistent snapshot.
+                let mut last = 0;
+                let polled = tokio::time::timeout(timeout, async {
+                    loop {
+                        let body = crate::metrics::fetch(&self.metrics_url).await?;
+                        let mut value = crate::metrics::sum_metric(&body, &metric, select)?;
+                        if let Some(minus) = &minus {
+                            value = value
+                                .saturating_sub(crate::metrics::sum_metric(&body, minus, select)?);
+                        }
+                        last = value;
+                        if satisfied(value) {
+                            return Ok::<_, anyhow::Error>(value);
+                        }
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                    }
+                })
+                .await;
+                match polled {
+                    Ok(result) => {
+                        let value = result?;
+                        Ok(describe_metric(min, max, value))
+                    }
+                    Err(_) => anyhow::bail!(
+                        "metric value {last} did not satisfy {} in time",
+                        describe_metric(min, max, last)
+                    ),
+                }
+            }
             Command::CreateInstance {
                 expiration_offset,
                 arrangement_dictionary_compression,
@@ -1168,6 +1275,20 @@ fn render_rows(rows: &[Row]) -> String {
         .collect();
     lines.sort();
     lines.join("\n")
+}
+
+/// Render a `metrics` reading. With a bound, render the satisfied bound as
+/// deterministic golden text independent of the exact value (`value >= N`,
+/// `value <= N`, `N <= value <= M`). With no bound, it is a point read, so render the
+/// raw value (`value = N`) for exploration; that line is not deterministic across
+/// runs and is meant for `REWRITE`, not a golden assertion.
+fn describe_metric(min: Option<u64>, max: Option<u64>, value: u64) -> String {
+    match (min, max) {
+        (Some(min), Some(max)) => format!("{min} <= value <= {max}"),
+        (Some(min), None) => format!("value >= {min}"),
+        (None, Some(max)) => format!("value <= {max}"),
+        (None, None) => format!("value = {value}"),
+    }
 }
 
 /// Convert an optional `up_to` timestamp into a sink's exclusive upper antichain;

--- a/src/clusterd-test-driver/src/target.rs
+++ b/src/clusterd-test-driver/src/target.rs
@@ -37,6 +37,16 @@ pub fn compute_addr() -> String {
     std::env::var("CLUSTERD_COMPUTE_ADDR").unwrap_or_else(|_| "127.0.0.1:2101".to_string())
 }
 
+/// The clusterd Prometheus metrics endpoint, from `CLUSTERD_METRICS_URL`. Defaults
+/// to clusterd's internal HTTP server on localhost (`127.0.0.1:6878`, the clap
+/// default of `--internal-http-listen-addr`), which the local `run-local.py` runner
+/// uses unchanged. An mzcompose run, where clusterd is a separate container, must
+/// set this to that container's address (e.g. `http://clusterd:6878/metrics`).
+pub fn metrics_url() -> String {
+    std::env::var("CLUSTERD_METRICS_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:6878/metrics".to_string())
+}
+
 /// Whether an end-to-end test should run: true only when a target address was
 /// explicitly provided. Integration tests skip when unset to keep `cargo test`
 /// green without a running clusterd.

--- a/src/clusterd-test-driver/src/text.rs
+++ b/src/clusterd-test-driver/src/text.rs
@@ -472,6 +472,9 @@ fn parse_command(input: &str) -> anyhow::Result<Command> {
             id: req_u64(&args, "id")?,
             frontier: req_u64(&args, "frontier")?,
         },
+        "drop-dataflow" => Command::DropDataflow {
+            id: req_u64(&args, "id")?,
+        },
         "allow-writes" => Command::AllowWrites {
             id: req_u64(&args, "id")?,
         },
@@ -493,6 +496,17 @@ fn parse_command(input: &str) -> anyhow::Result<Command> {
         "await-subscribe" => Command::AwaitSubscribe {
             id: req_u64(&args, "id")?,
             up_to: req_u64(&args, "up-to")?,
+            timeout_secs: opt_u64(&args, "timeout-secs")?,
+        },
+        "metrics" => Command::Metrics {
+            metric: flags
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow!("metrics needs a metric name"))?,
+            minus: opt_string(&args, "minus"),
+            select: opt_string(&args, "select"),
+            min: opt_u64(&args, "min")?,
+            max: opt_u64(&args, "max")?,
             timeout_secs: opt_u64(&args, "timeout-secs")?,
         },
         "create-dataflow" => parse_create_dataflow(&args, &flags, body)?,
@@ -748,6 +762,49 @@ mod tests {
                 timeout_secs: Some(5),
             }
         );
+    }
+
+    /// `drop-dataflow` parses its id.
+    #[mz_ore::test]
+    fn parses_drop_dataflow() {
+        assert_eq!(
+            parse_command("drop-dataflow id=2001").unwrap(),
+            Command::DropDataflow { id: 2001 }
+        );
+    }
+
+    /// `metrics` parses its metric name (a bare token), optional `minus`/`select`
+    /// operands, bounds, and timeout.
+    #[mz_ore::test]
+    fn parses_metrics() {
+        assert_eq!(
+            parse_command(
+                "metrics mz_persist_sink_correction_insertions_total \
+                 minus=mz_persist_sink_correction_deletions_total min=100000 timeout-secs=120"
+            )
+            .unwrap(),
+            Command::Metrics {
+                metric: "mz_persist_sink_correction_insertions_total".to_string(),
+                minus: Some("mz_persist_sink_correction_deletions_total".to_string()),
+                select: None,
+                min: Some(100000),
+                max: None,
+                timeout_secs: Some(120),
+            }
+        );
+        assert_eq!(
+            parse_command("metrics my_metric select=worker_id=0 max=1000").unwrap(),
+            Command::Metrics {
+                metric: "my_metric".to_string(),
+                minus: None,
+                select: Some("worker_id=0".to_string()),
+                min: None,
+                max: Some(1000),
+                timeout_secs: None,
+            }
+        );
+        // A metric name is required.
+        assert!(parse_command("metrics min=1").is_err());
     }
 
     /// A file splits into stanzas, preserving comments and blanks, and round-trips

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -276,7 +276,7 @@ where
         sink_id,
         persist_api.clone(),
         as_of.clone(),
-        read_only_rx,
+        read_only_rx.clone(),
         desired,
     );
 
@@ -287,6 +287,7 @@ where
         desired,
         persist,
         descs.clone(),
+        read_only_rx,
         Rc::clone(&compute_state.worker_config),
     );
 
@@ -781,6 +782,7 @@ mod write {
         desired: DesiredStreams<'s>,
         persist: PersistStreams<'s>,
         descs: DescsStream<'s>,
+        mut read_only_rx: watch::Receiver<bool>,
         worker_config: Rc<ConfigSet>,
     ) -> (BatchesStream<'s>, PressOnDropButton) {
         let scope = desired.ok.scope();
@@ -832,6 +834,7 @@ mod write {
 
             let writer = persist_api.open_writer().await;
             let sink_metrics = persist_api.open_metrics().await;
+            let read_only = *read_only_rx.borrow_and_update();
             let mut state = State::new(
                 sink_id,
                 worker_id,
@@ -839,6 +842,7 @@ mod write {
                 sink_metrics,
                 channel_logging,
                 as_of,
+                read_only,
                 &worker_config,
             );
             let mut correction_logger = correction_logger;
@@ -913,6 +917,14 @@ mod write {
                             Event::Progress(_frontier) => None,
                         }
                     }
+                    // Track read-only mode so the forced consolidation stops re-arming once
+                    // writes are allowed and the batch-write path takes over.
+                    Ok(()) = read_only_rx.changed(), if state.read_only => {
+                        if !*read_only_rx.borrow_and_update() {
+                            state.set_read_only(false);
+                        }
+                        None
+                    }
                     // All inputs are exhausted, so we can shut down.
                     else => return,
                 };
@@ -953,9 +965,13 @@ mod write {
         ///
         /// Normally we force a consolidation whenever we write a batch, but there are periods
         /// (like read-only mode) when that doesn't happen, and we need to manually force
-        /// consolidation instead. Currently this is only used to ensure we quickly get rid of the
-        /// snapshot updates.
+        /// consolidation instead. In read-only mode this is re-armed after each firing so it
+        /// keeps sweeping forward as the frontiers advance (see `maybe_force_consolidation`).
         force_consolidation_after: Option<Antichain<Timestamp>>,
+        /// Whether the sink is in read-only mode. While read-only the `write` operator mints no
+        /// batches, so the batch-write path never sweeps `consolidate_before(upper)` forward; the
+        /// forced consolidation stands in for it and is re-armed as long as this holds.
+        read_only: bool,
     }
 
     impl State {
@@ -966,6 +982,7 @@ mod write {
             metrics: SinkMetrics,
             logging: Option<ChannelLogging>,
             as_of: Antichain<Timestamp>,
+            read_only: bool,
             worker_config: &ConfigSet,
         ) -> Self {
             let worker_metrics = metrics.for_worker(worker_id);
@@ -991,6 +1008,7 @@ mod write {
                 persist_frontiers: OkErr::new_frontiers(),
                 batch_description: None,
                 force_consolidation_after,
+                read_only,
             };
 
             // Immediately advance the persist frontier tracking to the `as_of`.
@@ -1080,9 +1098,26 @@ mod write {
                 self.corrections.ok.consolidate_at_since();
                 self.corrections.err.consolidate_at_since();
 
-                // Remove the consolidation request, now that we have fulfilled it.
-                self.force_consolidation_after = None;
+                // In read-only mode the sink mints no batches, so the batch-write path never
+                // sweeps `consolidate_before(upper)` forward and a single forced consolidation
+                // only covers the band below the `since` at the moment it fires, leaving the
+                // forward region uncancelled for the whole read-only window (CLU-131). Re-arm at
+                // the current persist frontier so the forced consolidation keeps sweeping forward
+                // as `desired`/`persist` advance. Once writes are allowed, the batch-write path
+                // takes over and we disarm.
+                self.force_consolidation_after = if self.read_only {
+                    Some(persist_frontier.to_owned())
+                } else {
+                    None
+                };
             }
+        }
+
+        /// Update read-only mode. While read-only the forced consolidation re-arms itself; once
+        /// writes are allowed the still-armed request fires one final time and then disarms, after
+        /// which the batch-write path drives consolidation.
+        fn set_read_only(&mut self, read_only: bool) {
+            self.read_only = read_only;
         }
 
         fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -111,7 +111,7 @@ pub(super) fn persist_sink<'s>(
         sink_id,
         persist_api.clone(),
         as_of.clone(),
-        read_only_rx,
+        read_only_rx.clone(),
         desired,
     );
 
@@ -127,6 +127,7 @@ pub(super) fn persist_sink<'s>(
         desired,
         persist,
         descs.clone(),
+        read_only_rx,
         Rc::clone(&compute_state.worker_config),
     );
 
@@ -572,6 +573,7 @@ mod write {
         desired: DesiredStreams<'s>,
         persist: PersistStreams<'s>,
         descs: DescsStream<'s>,
+        mut read_only_rx: watch::Receiver<bool>,
         worker_config: Rc<ConfigSet>,
     ) -> BatchesStream<'s> {
         let scope = desired.ok.scope();
@@ -693,16 +695,35 @@ mod write {
             .abort_on_drop()
         };
 
+        // In read-only mode, wake the operator when writes are allowed so the forced
+        // consolidation stops re-arming and the `WriteBatch` path takes over promptly. Without
+        // this the operator only learns of the transition on its next input activation, which an
+        // idle sink may not get for a while.
+        let read_only_watch_handle = (*read_only_rx.borrow()).then(|| {
+            let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
+            let mut rx = read_only_rx.clone();
+            mz_ore::task::spawn(
+                || operator_name(sink_id, "write::read_only_watch"),
+                async move {
+                    let _ = rx.changed().await;
+                    let _ = sync_activator.activate();
+                },
+            )
+            .abort_on_drop()
+        });
+
         builder.build(move |capabilities| {
             // We will use the data capabilities from the `descs` input to produce output, so no
             // need to hold onto the initial capabilities.
             drop(capabilities);
 
+            let read_only = *read_only_rx.borrow_and_update();
             let mut state = State::new(
                 sink_id,
                 worker_id,
                 as_of,
                 advance_persist_frontiers_at_startup,
+                read_only,
             );
 
             // Whether a batch write is currently in flight in the Tokio task.
@@ -714,8 +735,9 @@ mod write {
             let mut correction_logger = correction_logger;
 
             move |frontiers| {
-                // Keep task handle alive so it is aborted when the operator is dropped.
+                // Keep task handles alive so they are aborted when the operator is dropped.
                 let _ = &write_task_handle;
+                let _ = &read_only_watch_handle;
 
                 // Acknowledge activation so the Tokio task can activate us again.
                 activation_ack.ack();
@@ -758,6 +780,14 @@ mod write {
                 {
                     batch.persist_frontier = Some(state.persist_frontiers.frontier().to_owned());
                 }
+                // Track read-only mode so the forced consolidation stops re-arming once writes
+                // are allowed and the `WriteBatch` path takes over driving consolidation.
+                if state.read_only && read_only_rx.has_changed().unwrap_or(false) {
+                    if !*read_only_rx.borrow_and_update() {
+                        state.set_read_only(false);
+                    }
+                }
+
                 if state.should_force_consolidation() {
                     batch.force_consolidation = true;
                 }
@@ -897,9 +927,13 @@ mod write {
         ///
         /// Normally we force a consolidation whenever we write a batch, but there are periods
         /// (like read-only mode) when that doesn't happen, and we need to manually force
-        /// consolidation instead. Currently this is only used to ensure we quickly get rid of the
-        /// snapshot updates.
+        /// consolidation instead. In read-only mode this is re-armed after each firing so it
+        /// keeps sweeping forward as the frontiers advance (see `should_force_consolidation`).
         force_consolidation_after: Option<Antichain<Timestamp>>,
+        /// Whether the sink is in read-only mode. While read-only the `write` operator mints no
+        /// batches, so the `WriteBatch` path never sweeps `consolidate_before(upper)` forward;
+        /// the forced consolidation stands in for it and is re-armed as long as this holds.
+        read_only: bool,
     }
 
     impl State {
@@ -908,6 +942,7 @@ mod write {
             worker_id: usize,
             as_of: Antichain<Timestamp>,
             advance_persist_frontiers_at_startup: bool,
+            read_only: bool,
         ) -> Self {
             // Force a consolidation of corrections after the snapshot updates have been fully
             // processed, to ensure we get rid of those as quickly as possible.
@@ -920,6 +955,7 @@ mod write {
                 persist_frontiers: OkErr::new_frontiers(),
                 batch_description: None,
                 force_consolidation_after,
+                read_only,
             };
 
             // Immediately advance the persist frontier tracking to the `as_of`.
@@ -1011,11 +1047,29 @@ mod write {
                 && PartialOrder::less_than(request, persist_frontier)
             {
                 self.trace("requesting correction consolidation");
-                self.force_consolidation_after = None;
+                // In read-only mode the sink mints no batches, so the `WriteBatch` path never
+                // sweeps `consolidate_before(upper)` forward and a single forced consolidation
+                // only covers the band below the `since` at the moment it fires, leaving the
+                // forward region uncancelled for the whole read-only window (CLU-131). Re-arm at
+                // the current persist frontier so the forced consolidation keeps sweeping forward
+                // as `desired`/`persist` advance, mirroring the read-write path. Once writes are
+                // allowed, the `WriteBatch` path takes over and we disarm.
+                self.force_consolidation_after = if self.read_only {
+                    Some(persist_frontier.to_owned())
+                } else {
+                    None
+                };
                 true
             } else {
                 false
             }
+        }
+
+        /// Update read-only mode. While read-only the forced consolidation re-arms itself; once
+        /// writes are allowed the still-armed request fires one final time and then disarms, after
+        /// which the `WriteBatch` path drives consolidation.
+        fn set_read_only(&mut self, read_only: bool) {
+            self.read_only = read_only;
         }
 
         fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -2000,6 +2000,190 @@ def workflow_materialized_view_correction_pruning(c: Composition) -> None:
         )
 
 
+def workflow_materialized_view_read_only_correction_pruning(
+    c: Composition,
+) -> None:
+    """
+    Verify that a read-only replica's materialized-view sink consolidates its
+    correction buffer instead of retaining one record per write made during the
+    read-only window — the memory blow-up of CLU-131 (a factor in the INC-1095
+    OOM).
+
+    During a 0dt upgrade the new generation hydrates read-only while the old
+    generation keeps writing. A read-only sink mints no batches, so the
+    `WriteBatch` path that drives `consolidate_before` forward never runs, and the
+    `desired`/`persist` pairs for each forward write are never cancelled: the
+    correction buffer grows by roughly one record per written row and stays
+    resident for the whole read-only window. The fix re-arms the forced
+    consolidation in read-only mode, so the buffer is swept per batch and stays
+    near zero. The pre-existing single-INSERT `materialized_view_correction_pruning`
+    scenario only exercises the snapshot, which the one-shot consolidation already
+    handles, so it cannot catch this; the forward writes below are what expose it.
+
+    The replica is unorchestrated and runs inside the mz_new container.
+    environmentd's federated /metrics does not surface it, so we scrape the
+    replica's own clusterd internal HTTP socket.
+    """
+
+    c.down(destroy_volumes=True)
+    c.up("mz_old")
+
+    c.sql(
+        "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    initial_rows = 1_000
+    batch_rows = 10_000
+    forward_rows = 300_000
+    payload_bytes = 1_024
+    memory_growth_bound_bytes = 384 * 1024**2
+
+    c.sql(
+        f"""
+         CREATE TABLE t (a int, payload text);
+         INSERT INTO t
+           SELECT g, repeat('x', {payload_bytes})
+           FROM generate_series(1, {initial_rows}) AS g;
+         CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+         SELECT * FROM mv LIMIT 1;
+         """,
+        service="mz_old",
+    )
+
+    # Boot the new generation read-only and hydrate the MV there. It is never
+    # promoted, so it stays read-only for the whole test.
+    c.up("mz_new")
+    c.sql("SELECT * FROM mv LIMIT 1", service="mz_new")
+
+    def replica_metrics_addr() -> str:
+        # The read-only replica is unorchestrated and runs inside the mz_new
+        # container; environmentd's federated /metrics does not surface it, so we
+        # hit the replica's own clusterd internal HTTP unix socket, whose path it
+        # logs at startup. Match any generation and take the latest.
+        logs = c.invoke("logs", "mz_new", capture=True).stdout
+        addr = None
+        for line in logs.splitlines():
+            if (
+                "cluster-u1-replica-u1-gen-" in line
+                and "mz_clusterd: serving internal HTTP server on" in line
+            ):
+                addr = line.split(" ")[-1]
+        if addr is None:
+            raise RuntimeError("no clusterd internal HTTP socket found in mz_new logs")
+        return addr
+
+    def anon_bytes() -> int:
+        # Anonymous (heap) memory of the mz_new container from the cgroup, where
+        # the correction buffer lives. cgroup v2 reports `anon`; v1 `total_rss`
+        # or `rss`.
+        return int(
+            c.exec(
+                "mz_new",
+                "sh",
+                "-lc",
+                r"""awk '$1=="anon" || $1=="total_rss" || $1=="rss" { print $2; exit }' \
+                    /sys/fs/cgroup/memory.stat 2>/dev/null || \
+                    awk '$1=="anon" || $1=="total_rss" || $1=="rss" { print $2; exit }' \
+                    /sys/fs/cgroup/memory/memory.stat""",
+                capture=True,
+            ).stdout
+        )
+
+    def mib(value: int) -> str:
+        return f"{value / 1024**2:.1f} MiB"
+
+    def correction_metrics() -> tuple[int, int]:
+        resp = c.exec(
+            "mz_new",
+            "curl",
+            "-s",
+            "--unix-socket",
+            replica_metrics_addr(),
+            "http:/prof/metrics",
+            capture=True,
+        ).stdout
+
+        insertions = deletions = 0
+        for line in resp.splitlines():
+            if line.startswith("#"):
+                continue
+            if line.startswith("mz_persist_sink_correction_insertions_total"):
+                insertions += int(float(line.rsplit(maxsplit=1)[-1]))
+            elif line.startswith("mz_persist_sink_correction_deletions_total"):
+                deletions += int(float(line.rsplit(maxsplit=1)[-1]))
+        return (insertions, deletions)
+
+    # Wait for the read-only generation to process and prune the initial snapshot
+    # before measuring the memory baseline. The snapshot is small enough not to
+    # matter for RSS, but this preserves the older test's signal.
+    insertions = deletions = 0
+    for _ in range(30):
+        insertions, deletions = correction_metrics()
+        if insertions >= initial_rows and insertions - deletions == 0:
+            break
+        time.sleep(1)
+    else:
+        raise AssertionError(
+            f"snapshot correction buffer did not consolidate: {insertions=}, "
+            f"{deletions=}, net={insertions - deletions}"
+        )
+
+    baseline_anon = anon_bytes()
+
+    # The old generation writes meaningful volume while mz_new stays read-only.
+    # Wide payloads make the retained correction buffer visible in anonymous RSS:
+    # on an unfixed build the desired and persist halves retain roughly
+    # `2 * forward_rows * payload_bytes`, while the fixed build keeps at most a
+    # small batch resident before forced consolidation drains it.
+    for lo in range(initial_rows + 1, initial_rows + forward_rows + 1, batch_rows):
+        hi = min(lo + batch_rows - 1, initial_rows + forward_rows)
+        c.sql(
+            f"""
+            INSERT INTO t
+              SELECT g, repeat('x', {payload_bytes})
+              FROM generate_series({lo}, {hi}) AS g;
+            """,
+            service="mz_old",
+        )
+        _wait_for_mz_count(c, "SELECT count(*) FROM mv", hi, "mz_old")
+        time.sleep(1)
+
+    # The read-only sink must consolidate the forward writes away rather than
+    # retain one record per written row. With the fix the buffer holds at most a
+    # batch or so in flight; before it, `insertions - deletions` stays near
+    # `forward_rows` (CLU-131) and the wide rows push mz_new's anonymous memory
+    # hundreds of MiB above baseline.
+    correction_bound = batch_rows * 4
+    memory_ceiling = baseline_anon + memory_growth_bound_bytes
+    for _ in range(150):
+        insertions, deletions = correction_metrics()
+        settled_anon = anon_bytes()
+        if (
+            insertions >= forward_rows
+            and insertions - deletions < correction_bound
+            and settled_anon <= memory_ceiling
+        ):
+            break
+        time.sleep(1)
+
+    net = insertions - deletions
+    memory_growth = settled_anon - baseline_anon
+    if (
+        insertions < forward_rows
+        or net >= correction_bound
+        or settled_anon > memory_ceiling
+    ):
+        raise AssertionError(
+            f"read-only correction buffer did not consolidate: {insertions=}, "
+            f"{deletions=}, net={net} (bound {correction_bound}, "
+            f"forward_rows {forward_rows}, memory_growth={mib(memory_growth)}, "
+            f"memory_bound={mib(memory_growth_bound_bytes)}); CLU-131"
+        )
+
+
 def setup(c: Composition) -> None:
     # Make sure cluster is owned by the system so it doesn't get dropped
     # between testdrive runs.

--- a/test/clusterd-test-driver/mzcompose.py
+++ b/test/clusterd-test-driver/mzcompose.py
@@ -51,6 +51,10 @@ class HeadlessDriver(Service):
                 "mzbuild": "clusterd-test-driver",
                 "environment": [
                     "CLUSTERD_COMPUTE_ADDR=clusterd:2101",
+                    # clusterd's internal HTTP server, exposed by the Clusterd
+                    # service on 6878, serves the Prometheus `/metrics` the
+                    # `metrics` command scrapes.
+                    "CLUSTERD_METRICS_URL=http://clusterd:6878/metrics",
                     f"PERSIST_BLOB_URL={minio_blob_uri()}",
                     f"PERSIST_CONSENSUS_URL={CONSENSUS_URI}",
                     "DRIVER_PUBSUB_BIND=0.0.0.0:6879",
@@ -94,6 +98,7 @@ SCRIPTS = [
     "subscribe.spec",
     "join.spec",
     "index_and_mv.spec",
+    "clu_131.spec",
 ]
 
 

--- a/test/clusterd-test-driver/scripts/clu_131.spec
+++ b/test/clusterd-test-driver/scripts/clu_131.spec
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# CLU-131 regression test: a read-only materialized-view sink must not retain a
+# full-MV-size correction buffer.
+#
+# The scenario reproduces the 0dt configuration in which the bug appears: the output
+# shard `mv` already holds the MV at spread timestamps (the old generation wrote it
+# over time), and a read-only sink recomputes the same rows from a single-timestamp
+# source. The recomputed `desired` collapses to t=0 while the `persist` read-back
+# replays at the original spread timestamps, so the two halves are the same rows at
+# different times and cancel only when a consolidation pass re-times them together.
+#
+# A read-only sink mints no batches, so before the fix its only consolidation was the
+# one-shot `consolidate_at_since` = `consolidate_before(since + 1)`, which covers only
+# the band at or below the `since` when it happened to fire. The forward region (the
+# spread persist beyond t=0) survived uncancelled: the sink held ~one full copy of the
+# MV for the whole read-only window. The exact residual was timing-dependent (it
+# hinged on the `since` value at the instant the one-shot fired), so before the fix
+# this assertion failed intermittently with a value in the hundreds of thousands.
+#
+# The fix re-arms the forced consolidation in read-only mode so it keeps sweeping
+# `consolidate_before` forward as the frontiers advance, mirroring the read-write
+# path. The buffer is therefore consolidated down to a few thousand records,
+# deterministically. The defaults exercise the affected path
+# (`enable_compute_sync_mv_sink` and `enable_compute_correction_v2` both on).
+create-instance
+----
+ok
+
+initialization-complete
+----
+ok
+
+# The old generation's accumulated output: the MV at spread timestamps 0..9.
+write-spread shard=mv count=100000 n-ts=10
+----
+wrote 100000
+
+# The read-only sink's source: the same rows at a single timestamp, so the recomputed
+# `desired` snapshot collapses to t=0 while `persist` (mv) replays at 0..9.
+write-single-ts shard=src ts=0 count=100000
+----
+wrote 100000
+
+# A read-only MV sink recomputing `desired` from `src` and reading `mv` back. It is
+# never given allow-writes, so it stays read-only and mints no batches. `as_of=0`
+# holds `since` low, the configuration that exposed the bug.
+create-dataflow name=reader as-of=0
+  import source=1100 shard=src upper=1
+  build id=2100
+    Get u1100
+  export kind=materialized-view sink=2101 on=2100 shard=mv
+----
+ok
+
+schedule id=2101
+----
+ok
+
+# The read-only correction buffer stays small: the re-armed forced consolidation
+# sweeps the spread persist away instead of leaving ~one full MV uncancelled. Live
+# occupancy is the difference of the two correction counters. `metrics` polls until it
+# settles. (Before the fix this returned a full-MV-size value, intermittently.)
+metrics mz_persist_sink_correction_insertions_total minus=mz_persist_sink_correction_deletions_total max=15000 timeout-secs=120
+----
+value <= 15000


### PR DESCRIPTION
Adds two verbs to the headless clusterd test driver, plus a regression scenario.

`metrics <metric> [minus=<metric>] [select=<label>=<value>] [min=N] [max=N] [timeout-secs=N]` scrapes clusterd's Prometheus `/metrics`, sums a metric across its label series (optional label filter, optional subtraction of a second metric), and polls level-triggered until the value satisfies the bounds.

`drop-dataflow id=N` drops a compute collection via `AllowCompaction` with the empty frontier, distinct from the numeric `allow-compaction`.

`clu_131.spec` uses both verbs to reproduce the read-only MV sink correction-buffer behavior over a spread-timestamp output shard.

Stacked on #37233: the first commit is that PR's fix and drops out of this diff once it merges. `clu_131.spec` asserts the fixed behavior, so this must merge after #37233.
