### PR TITLE
tests: Reenable two tests disabled because of RTR bug

### DIFF
--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -18,6 +18,7 @@ import time
 from materialize import buildkite
 from materialize.data_ingest.executor import (
     KafkaExecutor,
+    KafkaRoundtripExecutor,
     MySqlExecutor,
 )
 from materialize.data_ingest.workload import *  # noqa: F401 F403
@@ -115,9 +116,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "sql-server",
     )
 
-    # TODO: Reenable KafkaRoundtripExecutor when https://linear.app/materializeinc/issue/SS-303 is fixed
     # TODO: Reenable SqlServerExecutor when https://linear.app/materializeinc/issue/SS-291 is fixed
-    executor_classes = [MySqlExecutor, KafkaExecutor]
+    executor_classes = [MySqlExecutor, KafkaExecutor, KafkaRoundtripExecutor]
 
     with c.override(
         # Fixed port so that we keep the same port after restarting Mz in disruptions

--- a/test/kafka-rtr/mzcompose.py
+++ b/test/kafka-rtr/mzcompose.py
@@ -43,9 +43,6 @@ def workflow_default(c: Composition) -> None:
     def process(name: str) -> None:
         if name == "default":
             return
-        # TODO: Reenable when https://linear.app/materializeinc/issue/SS-303 is fixed
-        if name == "multithreaded":
-            return
         with c.test_case(name):
             c.workflow(name)
 


### PR DESCRIPTION
https://linear.app/materializeinc/issue/SS-303/rtr-data-ingest-test-keeps-flaking-comparing-against-pgexecutor-failed

Test run: https://buildkite.com/materialize/nightly/builds/16853