### PR TITLE
timestamp-oracle: add statement_timeout knob

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -550,6 +550,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "crdb_keepalives_idle",
     "crdb_keepalives_interval",
     "crdb_keepalives_retries",
+    "pg_timestamp_oracle_statement_timeout",
     "persist_use_critical_since_txn",
     "use_global_txn_cache_source",
     "persist_batch_builder_max_outstanding_parts",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1577,6 +1577,13 @@ class FlipFlagsAction(Action):
             "'1h'",
             "'7d'",
         ]
+        # Keep these generous: a tight timeout would abort the oracle's own
+        # queries (they are retried, but it adds noise). "0s" leaves it unset.
+        self.flags_with_values["pg_timestamp_oracle_statement_timeout"] = [
+            "'0s'",
+            "'30s'",
+            "'60s'",
+        ]
         # Note: it's not safe to re-enable this flag after writing with `persist_validate_part_bounds_on_write`,
         # since those new-style parts may fail our old-style validation.
         self.flags_with_values["persist_validate_part_bounds_on_read"] = ["FALSE"]

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -267,6 +267,16 @@ pub const CATALOG_INFO_METRICS_RECONCILE_INTERVAL: Config<Duration> = Config::ne
     "How frequently to reconcile the catalog `*_info` metrics with the catalog. A zero duration disables reconciliation.",
 );
 
+/// Server-side `statement_timeout` to set on Postgres/CRDB connections used by
+/// the Postgres/CRDB timestamp oracle. A zero value leaves the statement
+/// timeout unset.
+pub const PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT: Config<Duration> = Config::new(
+    "pg_timestamp_oracle_statement_timeout",
+    crate::timestamp_oracle::DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT,
+    "The server-side statement timeout to set on Postgres/CRDB connections used by the \
+    Postgres/CRDB timestamp oracle. A value of zero leaves the statement timeout unset.",
+);
+
 /// Adds the full set of all adapter `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -304,4 +314,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ARRANGEMENT_SIZE_HISTORY_COLLECTION_INTERVAL)
         .add(&ARRANGEMENT_SIZE_HISTORY_RETENTION_PERIOD)
         .add(&CATALOG_INFO_METRICS_RECONCILE_INTERVAL)
+        .add(&PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT)
 }

--- a/src/adapter-types/src/timestamp_oracle.rs
+++ b/src/adapter-types/src/timestamp_oracle.rs
@@ -35,3 +35,8 @@ pub const DEFAULT_PG_TIMESTAMP_ORACLE_KEEPALIVES_INTERVAL: Duration = Duration::
 
 /// Default value for `DynamicConfig::pg_connection_pool_keepalives_retries`.
 pub const DEFAULT_PG_TIMESTAMP_ORACLE_KEEPALIVES_RETRIES: u32 = 5;
+
+/// Default value for `DynamicConfig::pg_statement_timeout`.
+///
+/// A value of zero is a sentinel that means "do not set a statement timeout".
+pub const DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT: Duration = Duration::from_secs(0);

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -9,6 +9,7 @@
 
 use std::time::Duration;
 
+use mz_adapter_types::dyncfgs::PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT;
 use mz_compute_client::protocol::command::ComputeParameters;
 use mz_orchestrator::scheduling_config::{ServiceSchedulingConfig, ServiceTopologySpreadConfig};
 use mz_ore::cast::CastFrom;
@@ -180,7 +181,7 @@ pub fn timestamp_oracle_config(config: &SystemVars) -> TimestampOracleParameters
         pg_connection_pool_keepalives_idle: Some(config.crdb_keepalives_idle()),
         pg_connection_pool_keepalives_interval: Some(config.crdb_keepalives_interval()),
         pg_connection_pool_keepalives_retries: Some(config.crdb_keepalives_retries()),
-        pg_statement_timeout: Some(config.pg_timestamp_oracle_statement_timeout()),
+        pg_statement_timeout: Some(PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT.get(config.dyncfgs())),
     }
 }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -180,6 +180,7 @@ pub fn timestamp_oracle_config(config: &SystemVars) -> TimestampOracleParameters
         pg_connection_pool_keepalives_idle: Some(config.crdb_keepalives_idle()),
         pg_connection_pool_keepalives_interval: Some(config.crdb_keepalives_interval()),
         pg_connection_pool_keepalives_retries: Some(config.crdb_keepalives_retries()),
+        pg_statement_timeout: Some(config.pg_timestamp_oracle_statement_timeout()),
     }
 }
 

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -607,6 +607,11 @@ impl PostgresClientKnobs for PersistConfig {
     fn keepalives_retries(&self) -> u32 {
         CRDB_KEEPALIVES_RETRIES.get(self)
     }
+
+    fn statement_timeout(&self) -> Duration {
+        // Persist consensus does not use a server-side statement timeout.
+        Duration::ZERO
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary, Serialize, Deserialize)]

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -232,6 +232,10 @@ impl PostgresConsensusConfig {
             fn keepalives_retries(&self) -> u32 {
                 5
             }
+
+            fn statement_timeout(&self) -> Duration {
+                Duration::ZERO
+            }
         }
 
         let dyncfg = ConfigSet::default().add(&USE_POSTGRES_TUNED_QUERIES);

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -21,6 +21,7 @@
 pub mod error;
 pub mod metrics;
 
+use std::fmt::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -60,6 +61,9 @@ pub trait PostgresClientKnobs: std::fmt::Debug + Send + Sync {
     fn keepalives_interval(&self) -> Duration;
     /// Maximum number of TCP keepalive probes that will be sent before dropping a connection.
     fn keepalives_retries(&self) -> u32;
+    /// Server-side `statement_timeout` to set on each connection. A value of
+    /// zero is a sentinel that means "do not set a statement timeout".
+    fn statement_timeout(&self) -> Duration;
 }
 
 /// Configuration for creating a [PostgresClient].
@@ -128,6 +132,7 @@ impl PostgresClient {
         let last_ttl_connection = AtomicU64::new(0);
         let connections_created = config.metrics.connpool_connections_created.clone();
         let ttl_reconnections = config.metrics.connpool_ttl_reconnections.clone();
+        let knobs = Arc::clone(&config.knobs);
         let builder = Pool::builder(manager);
         let builder = match config.knobs.connection_pool_max_wait() {
             None => builder,
@@ -137,15 +142,31 @@ impl PostgresClient {
             .max_size(config.knobs.connection_pool_max_size())
             .post_create(Hook::async_fn(move |client, _| {
                 connections_created.inc();
+                let knobs = Arc::clone(&knobs);
                 Box::pin(async move {
                     debug!("opened new consensus postgres connection");
+                    let mut setup = String::from(
+                        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+                    );
+                    // A zero `statement_timeout` is our sentinel for "leave it
+                    // unset". We only emit the `SET` when non-zero so we don't
+                    // override a timeout configured out of band.
+                    let statement_timeout = knobs.statement_timeout();
+                    if !statement_timeout.is_zero() {
+                        // A bare integer value for `statement_timeout` is
+                        // interpreted as milliseconds.
+                        write!(
+                            setup,
+                            "; SET statement_timeout = {}",
+                            statement_timeout.as_millis()
+                        )
+                        .expect("writing to a String never fails");
+                    }
                     // This hook must return `tokio_postgres::Error`; using
                     // `mz_postgres_util` wrappers would change the error type.
                     #[allow(clippy::disallowed_methods)]
                     client
-                        .batch_execute(
-                        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE",
-                    )
+                        .batch_execute(&setup)
                         .await
                         .map_err(|e| HookError::Abort(HookErrorCause::Backend(e)))
                 })

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1297,7 +1297,6 @@ impl SystemVars {
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER,
-            &PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT,
             &USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION,
             &FORCE_SOURCE_TABLE_SYNTAX,
             &OPTIMIZER_E2E_LATENCY_WARNING_THRESHOLD,
@@ -2282,11 +2281,6 @@ impl SystemVars {
         *self.expect_value(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER)
     }
 
-    /// Returns the `pg_timestamp_oracle_statement_timeout` configuration parameter.
-    pub fn pg_timestamp_oracle_statement_timeout(&self) -> Duration {
-        *self.expect_value(&PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT)
-    }
-
     /// Returns the `user_storage_managed_collections_batch_duration` configuration parameter.
     pub fn user_storage_managed_collections_batch_duration(&self) -> Duration {
         *self.expect_value(&USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION)
@@ -2396,7 +2390,6 @@ pub fn is_timestamp_oracle_config_var(name: &str) -> bool {
         || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT.name()
         || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL.name()
         || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER.name()
-        || name == PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT.name()
         || name == CRDB_CONNECT_TIMEOUT.name()
         || name == CRDB_TCP_USER_TIMEOUT.name()
         || name == CRDB_KEEPALIVES_IDLE.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1297,6 +1297,7 @@ impl SystemVars {
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER,
+            &PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT,
             &USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION,
             &FORCE_SOURCE_TABLE_SYNTAX,
             &OPTIMIZER_E2E_LATENCY_WARNING_THRESHOLD,
@@ -2281,6 +2282,11 @@ impl SystemVars {
         *self.expect_value(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER)
     }
 
+    /// Returns the `pg_timestamp_oracle_statement_timeout` configuration parameter.
+    pub fn pg_timestamp_oracle_statement_timeout(&self) -> Duration {
+        *self.expect_value(&PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT)
+    }
+
     /// Returns the `user_storage_managed_collections_batch_duration` configuration parameter.
     pub fn user_storage_managed_collections_batch_duration(&self) -> Duration {
         *self.expect_value(&USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION)
@@ -2390,6 +2396,7 @@ pub fn is_timestamp_oracle_config_var(name: &str) -> bool {
         || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT.name()
         || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL.name()
         || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER.name()
+        || name == PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT.name()
         || name == CRDB_CONNECT_TIMEOUT.name()
         || name == CRDB_TCP_USER_TIMEOUT.name()
         || name == CRDB_KEEPALIVES_IDLE.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2395,6 +2395,7 @@ pub fn is_timestamp_oracle_config_var(name: &str) -> bool {
         || name == CRDB_KEEPALIVES_IDLE.name()
         || name == CRDB_KEEPALIVES_INTERVAL.name()
         || name == CRDB_KEEPALIVES_RETRIES.name()
+        || name == mz_adapter_types::dyncfgs::PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT.name()
 }
 
 /// Returns whether the named variable is a cluster scheduling config

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -19,6 +19,7 @@ use derivative::Derivative;
 use mz_adapter_types::timestamp_oracle::{
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
+    DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT,
 };
 use mz_dyncfg::ParameterScope;
 use mz_ore::cast::{self, CastFrom};
@@ -683,6 +684,15 @@ pub static PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: VarDefinition = VarD
     "pg_timestamp_oracle_connection_pool_ttl_stagger",
     value!(Duration; DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER),
     "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
+    false,
+);
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_statement_timeout`.
+pub static PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT: VarDefinition = VarDefinition::new(
+    "pg_timestamp_oracle_statement_timeout",
+    value!(Duration; DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT),
+    "The server-side statement timeout to set on Postgres/CRDB connections used by the \
+    Postgres/CRDB timestamp oracle. A value of zero leaves the statement timeout unset.",
     false,
 );
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -19,7 +19,6 @@ use derivative::Derivative;
 use mz_adapter_types::timestamp_oracle::{
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
-    DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT,
 };
 use mz_dyncfg::ParameterScope;
 use mz_ore::cast::{self, CastFrom};
@@ -684,15 +683,6 @@ pub static PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: VarDefinition = VarD
     "pg_timestamp_oracle_connection_pool_ttl_stagger",
     value!(Duration; DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER),
     "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
-    false,
-);
-
-/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_statement_timeout`.
-pub static PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT: VarDefinition = VarDefinition::new(
-    "pg_timestamp_oracle_statement_timeout",
-    value!(Duration; DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT),
-    "The server-side statement timeout to set on Postgres/CRDB connections used by the \
-    Postgres/CRDB timestamp oracle. A value of zero leaves the statement timeout unset.",
     false,
 );
 

--- a/src/timestamp-oracle/src/postgres_oracle.rs
+++ b/src/timestamp-oracle/src/postgres_oracle.rs
@@ -28,7 +28,8 @@ use mz_adapter_types::timestamp_oracle::{
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL,
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER, DEFAULT_PG_TIMESTAMP_ORACLE_KEEPALIVES_IDLE,
     DEFAULT_PG_TIMESTAMP_ORACLE_KEEPALIVES_INTERVAL,
-    DEFAULT_PG_TIMESTAMP_ORACLE_KEEPALIVES_RETRIES, DEFAULT_PG_TIMESTAMP_ORACLE_TCP_USER_TIMEOUT,
+    DEFAULT_PG_TIMESTAMP_ORACLE_KEEPALIVES_RETRIES, DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT,
+    DEFAULT_PG_TIMESTAMP_ORACLE_TCP_USER_TIMEOUT,
 };
 use mz_ore::error::ErrorExt;
 use mz_ore::instrument;
@@ -260,6 +261,11 @@ pub struct DynamicConfig {
     /// The maximum number of TCP keepalive probes that will be sent before
     /// dropping a Postgres/CRDB connection.
     pg_connection_pool_keepalives_retries: AtomicU32,
+
+    /// The server-side `statement_timeout` to set on each Postgres/CRDB
+    /// connection. A zero value is a sentinel that means "do not set a
+    /// statement timeout".
+    pg_statement_timeout: RwLock<Duration>,
 }
 
 impl Default for DynamicConfig {
@@ -293,6 +299,7 @@ impl Default for DynamicConfig {
             pg_connection_pool_keepalives_retries: AtomicU32::new(
                 DEFAULT_PG_TIMESTAMP_ORACLE_KEEPALIVES_RETRIES,
             ),
+            pg_statement_timeout: RwLock::new(DEFAULT_PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT),
         }
     }
 }
@@ -356,6 +363,10 @@ impl DynamicConfig {
         self.pg_connection_pool_keepalives_retries
             .load(Self::LOAD_ORDERING)
     }
+
+    fn statement_timeout(&self) -> Duration {
+        *self.pg_statement_timeout.read().expect("lock poisoned")
+    }
 }
 
 impl PostgresClientKnobs for PostgresTimestampOracleConfig {
@@ -394,6 +405,10 @@ impl PostgresClientKnobs for PostgresTimestampOracleConfig {
     fn keepalives_retries(&self) -> u32 {
         self.dynamic.keepalives_retries()
     }
+
+    fn statement_timeout(&self) -> Duration {
+        self.dynamic.statement_timeout()
+    }
 }
 
 /// Updates to values in [`PostgresTimestampOracleConfig`].
@@ -429,6 +444,8 @@ pub struct TimestampOracleParameters {
     pub pg_connection_pool_keepalives_interval: Option<Duration>,
     /// Configures `DynamicConfig::pg_connection_pool_keepalives_retries`.
     pub pg_connection_pool_keepalives_retries: Option<u32>,
+    /// Configures `DynamicConfig::pg_statement_timeout`.
+    pub pg_statement_timeout: Option<Duration>,
 }
 
 impl TimestampOracleParameters {
@@ -446,6 +463,7 @@ impl TimestampOracleParameters {
             pg_connection_pool_keepalives_idle: self_pg_connection_pool_keepalives_idle,
             pg_connection_pool_keepalives_interval: self_pg_connection_pool_keepalives_interval,
             pg_connection_pool_keepalives_retries: self_pg_connection_pool_keepalives_retries,
+            pg_statement_timeout: self_pg_statement_timeout,
         } = self;
         let Self {
             pg_connection_pool_max_size: other_pg_connection_pool_max_size,
@@ -457,6 +475,7 @@ impl TimestampOracleParameters {
             pg_connection_pool_keepalives_idle: other_pg_connection_pool_keepalives_idle,
             pg_connection_pool_keepalives_interval: other_pg_connection_pool_keepalives_interval,
             pg_connection_pool_keepalives_retries: other_pg_connection_pool_keepalives_retries,
+            pg_statement_timeout: other_pg_statement_timeout,
         } = other;
         if let Some(v) = other_pg_connection_pool_max_size {
             *self_pg_connection_pool_max_size = Some(v);
@@ -485,6 +504,9 @@ impl TimestampOracleParameters {
         if let Some(v) = other_pg_connection_pool_keepalives_retries {
             *self_pg_connection_pool_keepalives_retries = Some(v);
         }
+        if let Some(v) = other_pg_statement_timeout {
+            *self_pg_statement_timeout = Some(v);
+        }
     }
 
     /// Applies the parameter values to the given in-memory config object.
@@ -506,6 +528,7 @@ impl TimestampOracleParameters {
             pg_connection_pool_keepalives_idle,
             pg_connection_pool_keepalives_interval,
             pg_connection_pool_keepalives_retries,
+            pg_statement_timeout,
         } = self;
         if let Some(pg_connection_pool_max_size) = pg_connection_pool_max_size {
             cfg.dynamic
@@ -574,6 +597,14 @@ impl TimestampOracleParameters {
                 *pg_connection_pool_keepalives_retries,
                 DynamicConfig::STORE_ORDERING,
             );
+        }
+        if let Some(pg_statement_timeout) = pg_statement_timeout {
+            let mut timeout = cfg
+                .dynamic
+                .pg_statement_timeout
+                .write()
+                .expect("lock poisoned");
+            *timeout = *pg_statement_timeout;
         }
     }
 }

--- a/src/timestamp-oracle/src/postgres_oracle.rs
+++ b/src/timestamp-oracle/src/postgres_oracle.rs
@@ -1069,4 +1069,52 @@ mod tests {
 
         Ok(())
     }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn test_postgres_statement_timeout() -> Result<(), anyhow::Error> {
+        let config = match PostgresTimestampOracleConfig::new_for_test() {
+            Some(config) => config,
+            None => {
+                info!(
+                    "{} env not set: skipping test that uses external service",
+                    PostgresTimestampOracleConfig::EXTERNAL_TESTS_POSTGRES_URL
+                );
+                return Ok(());
+            }
+        };
+
+        // With the default config, the statement timeout is unset (the zero
+        // sentinel), so a query that outlives a short sleep still completes.
+        let no_timeout_client = PostgresClient::open(config.clone().into())?;
+        let conn = no_timeout_client.get_connection().await?;
+        pg_batch_execute(&conn, "SELECT pg_sleep(0.1)")
+            .await
+            .expect("query should not be aborted when no statement timeout is set");
+        drop(conn);
+
+        // Apply a short statement timeout through the dynamic-config path. New
+        // connections set it via the per-session setup hook.
+        TimestampOracleParameters {
+            pg_statement_timeout: Some(Duration::from_millis(100)),
+            ..Default::default()
+        }
+        .apply(&config);
+
+        let timeout_client = PostgresClient::open(config.clone().into())?;
+        let conn = timeout_client.get_connection().await?;
+
+        // A query that sleeps for much longer than the statement timeout must
+        // be aborted by the server.
+        let err = pg_batch_execute(&conn, "SELECT pg_sleep(5)")
+            .await
+            .expect_err("query should have been aborted by the statement timeout");
+        assert_eq!(
+            err.code(),
+            Some(&SqlState::QUERY_CANCELED),
+            "unexpected error, expected a statement timeout: {err:?}"
+        );
+
+        Ok(())
+    }
 }

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -362,6 +362,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     pg_timestamp_oracle_connection_pool_max_wait
     pg_timestamp_oracle_connection_pool_ttl
     pg_timestamp_oracle_connection_pool_ttl_stagger
+    pg_timestamp_oracle_statement_timeout
     plan_insights_notice_fast_path_clusters_optimize_duration
     postgres_fetch_slot_resume_lsn_interval
     privatelink_status_update_quota_per_minute


### PR DESCRIPTION
Adds a dynamic `pg_timestamp_oracle_statement_timeout` system variable that sets a server-side `statement_timeout` on the Postgres/CRDB connections used by the timestamp oracle.
A value of zero is a sentinel that leaves the statement timeout unset, which is the default, so behavior is unchanged unless an operator opts in.

Without a statement-level timeout, an oracle query that the backing database accepts but never answers (for example, blocked on a lock) leaves the client awaiting forever.
The existing TCP keepalive and user-timeout knobs do not help, because the connection is healthy and only the server-side query is stuck.
Since the batching oracle serializes all `read_ts` calls through a single in-flight query, one stuck query blocks every read and wedges the coordinator on `linearize_reads`.

A server-side `statement_timeout` turns the hang into an error, which the oracle's existing retry loop handles by retrying on a fresh connection, breaking the wedge.
The timeout is applied via the per-session connection setup hook, so it is scoped to the oracle's own connections and does not affect persist consensus queries sharing the same database.

The knob is wired through the same LaunchDarkly path as the other timestamp oracle connection-pool parameters.

### Release notes

This release adds the `pg_timestamp_oracle_statement_timeout` system variable, which bounds how long timestamp oracle queries against the backing database may run before being aborted and retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)