### PR TITLE
SS-16: AWS Glue Schema Registry documentation

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -30,8 +30,9 @@ certificates) can be specified as plain `text`, or also stored as secrets.
 An Amazon Web Services (AWS) connection provides Materialize with access to an
 Identity and Access Management (IAM) user or role in your AWS account. You can
 use AWS connections to perform [bulk exports to Amazon S3](/serve-results/s3/),
-perform [authentication with an Amazon MSK cluster](#kafka-aws-connection), or
-perform [authentication with an Amazon RDS MySQL database](#mysql-aws-connection).
+perform [authentication with an Amazon MSK cluster](#kafka-aws-connection),
+perform [authentication with an Amazon RDS MySQL database](#mysql-aws-connection),
+or [authenticate to an AWS Glue Schema Registry](#aws-glue-schema-registry).
 
 {{% include-syntax file="examples/create_connection" example="syntax-aws" %}}
 
@@ -438,7 +439,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 
 ##### Default connections {#kafka-privatelink-default}
 
-[Redpanda Cloud](/ingest-data/redpanda/redpanda-cloud/)) does not require
+[Redpanda Cloud](/ingest-data/redpanda/redpanda-cloud/) does not require
 listing every broker individually. In this case, you should specify a
 PrivateLink connection and the port of the bootstrap server instead.
 
@@ -617,6 +618,71 @@ CREATE CONNECTION csr_ssh TO CONFLUENT SCHEMA REGISTRY (
 
 {{< /tab >}}
 {{< /tabs >}}
+
+### AWS Glue Schema Registry
+
+{{< private-preview />}}
+
+An AWS Glue Schema Registry connection establishes a link to an [AWS Glue Schema
+Registry]. You can use AWS Glue Schema Registry connections in the `FORMAT`
+clause of [`CREATE SOURCE`] statements to decode Avro-encoded messages whose
+schemas are managed in AWS Glue.
+
+The connection authenticates to AWS through a separate [AWS connection](#aws),
+which supplies the credentials and region. See [AWS](#aws) for how to grant
+Materialize access to your AWS account.
+
+#### Syntax {#glue-syntax}
+
+{{% include-syntax file="examples/create_connection" example="syntax-glue" %}}
+
+#### Examples {#glue-example}
+
+```mzsql
+CREATE CONNECTION aws_conn TO AWS (
+    ASSUME ROLE ARN = 'arn:aws:iam::123456789000:role/MaterializeGlue'
+);
+
+CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_conn,
+    REGISTRY = 'default-registry'
+);
+```
+
+#### Permissions {#glue-permissions}
+
+The IAM role assumed by the [AWS connection](#aws) must be allowed to read
+schemas from the registry. Materialize uses the following AWS Glue actions:
+
+| Action | When it is used |
+|--------|-----------------|
+| `glue:GetRegistry` | At connection creation, to validate the connection. Only required when `VALIDATE` is `true` (the default). |
+| `glue:GetSchemaVersion` | When a source is created, to pin the schema, and at runtime, to fetch the writer schema for each new schema version encountered. Always required. |
+
+A least-privilege policy scoped to a single registry looks like:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "glue:GetRegistry",
+                "glue:GetSchemaVersion"
+            ],
+            "Resource": [
+                "arn:aws:glue:<region>:<account>:registry/<registry-name>",
+                "arn:aws:glue:<region>:<account>:schema/<registry-name>/*"
+            ]
+        }
+    ]
+}
+```
+
+If you create the connection with `WITH (VALIDATE = false)`, you can omit
+`glue:GetRegistry` and grant only `glue:GetSchemaVersion`. For details on
+creating and authorizing the AWS connection, see [AWS](#aws).
 
 ### MySQL
 
@@ -1016,6 +1082,7 @@ Connection type             | Validated by default |
 AWS                         |                      |
 Kafka                       | ✓                    |
 Confluent Schema Registry   | ✓                    |
+AWS Glue Schema Registry    | ✓                    |
 MySQL                       | ✓                    |
 PostgreSQL                  | ✓                    |
 SSH Tunnel                  |                      |
@@ -1046,6 +1113,7 @@ The privileges required to execute this statement are:
 
 [AWS PrivateLink]: https://aws.amazon.com/privatelink/
 [Confluent Schema Registry]: https://docs.confluent.io/platform/current/schema-registry/index.html#sr-overview
+[AWS Glue Schema Registry]: https://docs.aws.amazon.com/glue/latest/dg/schema-registry.html
 [Kafka]: https://kafka.apache.org
 [MySQL]: https://www.mysql.com/
 [PostgreSQL]: https://www.postgresql.org

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -42,14 +42,37 @@ in the source.
 
 {{% include-syntax file="examples/create_source_kafka" example="syntax-avro" %}}
 
+#### Schema registries
+
+Materialize can retrieve Avro schemas from either of two schema registries,
+selected by the `USING` clause:
+
+- **[Confluent Schema Registry](/sql/create-connection/#confluent-schema-registry)**
+  (`USING CONFLUENT SCHEMA REGISTRY`): schemas are looked up by topic using the
+  `TopicNameStrategy`, and the message's embedded schema ID resolves the writer
+  schema at decode time.
+
+- **[AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry)**
+  (`USING AWS GLUE SCHEMA REGISTRY`) {{< private-preview-inline />}}: schemas are
+  looked up by the `SCHEMA NAME` you provide, and the message's embedded schema
+  version ID resolves the writer schema at decode time. Each `FORMAT AVRO USING
+  AWS GLUE` clause resolves a single schema. To decode keys and values from
+  different schemas (for example, under `ENVELOPE UPSERT` or `ENVELOPE
+  DEBEZIUM`), you must specify `KEY FORMAT ... VALUE FORMAT ...` explicitly.
 
 #### Schema versioning
 
-The _latest_ schema is retrieved using the [`TopicNameStrategy`](https://docs.confluent.io/current/schema-registry/serdes-develop/index.html) strategy at the time the `CREATE SOURCE` statement is issued.
+The schema is resolved when the `CREATE SOURCE` statement is issued. With
+[Confluent Schema Registry](/sql/create-connection/#confluent-schema-registry),
+the _latest_ schema is retrieved using the
+[`TopicNameStrategy`](https://docs.confluent.io/current/schema-registry/serdes-develop/index.html)
+strategy. With [AWS Glue Schema
+Registry](/sql/create-connection/#aws-glue-schema-registry), the latest version
+of the schema named by `SCHEMA NAME` is retrieved.
 
 #### Schema evolution
 
-As long as the writer schema changes in a [compatible way](https://avro.apache.org/docs/++version++/specification/#schema-resolution), Materialize will continue using the original reader schema definition by mapping values from the new to the old schema version. To use the new version of the writer schema in Materialize, you need to **drop and recreate** the source.
+As long as the writer schema changes in a [compatible way](https://avro.apache.org/docs/++version++/specification/#schema-resolution), Materialize will continue using the original reader schema definition by mapping values from the new to the old schema version. To use the new version of the writer schema in Materialize, you need to **drop and recreate** the source. This applies to both Confluent Schema Registry and AWS Glue Schema Registry.
 
 #### Name collision
 
@@ -798,6 +821,29 @@ an SSH bastion server to accept connections from Materialize, check [this guide]
 {{< /tab >}}
 {{< /tabs >}}
 
+#### AWS Glue Schema Registry
+
+{{< private-preview />}}
+
+An [AWS Glue Schema Registry connection](/sql/create-connection/#aws-glue-schema-registry)
+authenticates through a separate [AWS connection](/sql/create-connection/#aws),
+which supplies the credentials and region:
+
+```mzsql
+CREATE CONNECTION aws_connection TO AWS (
+    ASSUME ROLE ARN = 'arn:aws:iam::123456789000:role/MaterializeGlue'
+);
+
+CREATE CONNECTION glue_connection TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_connection,
+    REGISTRY = 'default-registry'
+);
+```
+
+The AWS connection must be allowed to read schemas from the registry. See
+[Permissions](/sql/create-connection/#glue-permissions) for the required IAM
+actions.
+
 ### Creating a source
 
 {{< tabs tabID="1" >}}
@@ -809,6 +855,16 @@ an SSH bastion server to accept connections from Materialize, check [this guide]
 CREATE SOURCE avro_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection;
+```
+
+**Using AWS Glue Schema Registry** {{< private-preview-inline />}}
+
+```mzsql
+CREATE SOURCE avro_source
+  FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_connection (
+    SCHEMA NAME = 'test_schema'
+  );
 ```
 
 {{< /tab >}}

--- a/doc/user/data/examples/create_connection.yml
+++ b/doc/user/data/examples/create_connection.yml
@@ -359,6 +359,38 @@
         |-------|-------|-------------|
         | `VALIDATE` | `boolean` | Whether [connection validation](#connection-validation) should be performed on connection creation. Default: `true`. |
 
+- name: "syntax-glue"
+  code: |
+    CREATE CONNECTION <connection_name> TO AWS GLUE SCHEMA REGISTRY (
+        AWS CONNECTION = <aws_connection_name>,
+        REGISTRY = '<registry_name>'
+    )
+    [WITH (<with_options>)];
+  syntax_elements:
+    - name: "`<connection_name>`"
+      description: |
+        A name for the connection.
+    - name: "`AWS CONNECTION`"
+      description: |
+        *Value:* object name. Required.
+
+        The name of an [AWS connection](#aws) that provides the credentials
+        Materialize uses to authenticate to AWS Glue. The Schema Registry's
+        region is taken from this connection.
+    - name: "`REGISTRY`"
+      description: |
+        *Value:* `text`. Required.
+
+        The name of the AWS Glue Schema Registry to read schemas from (for
+        example, `default-registry`). Must not be empty.
+    - name: "`WITH (<with_options>)`"
+      description: |
+        The following `<with_options>` are supported:
+
+        | Field | Value | Description |
+        |-------|-------|-------------|
+        | `VALIDATE` | `boolean` | Whether [connection validation](#connection-validation) should be performed on connection creation. Default: `true`. |
+
 - name: "syntax-mysql"
   code: |
     CREATE CONNECTION <connection_name> TO MYSQL (

--- a/doc/user/data/examples/create_source_kafka.yml
+++ b/doc/user/data/examples/create_source_kafka.yml
@@ -8,9 +8,13 @@
       [, START OFFSET ( <partition_offset> [, ...] ) ]
       [, START TIMESTAMP <timestamp> ]
     )
-    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>
-      [KEY STRATEGY <key_strategy>]
-      [VALUE STRATEGY <value_strategy>]
+    FORMAT AVRO
+        USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>
+          [KEY STRATEGY <key_strategy>]
+          [VALUE STRATEGY <value_strategy>]
+      | USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name> (
+          SCHEMA NAME = '<schema_name>'
+        )
     [INCLUDE
         KEY [AS <name>]
       | PARTITION [AS <name>]
@@ -54,7 +58,23 @@
         Optional. Use the specified value to set `START OFFSET` based on the Kafka timestamp. Negative values will be interpreted as relative to the current system time in milliseconds (e.g. `-1000` means 1000 ms ago). See [Time-based offsets](#time-based-offsets) for details.
     - name: "`<csr_connection_name>`"
       description: |
-        The Confluent Schema Registry connection to use in the source.
+        The [Confluent Schema Registry connection](/sql/create-connection/#confluent-schema-registry)
+        to use in the source. Applies to both the key and value.
+    - name: "`<glue_connection_name>` (**SCHEMA NAME** `'<schema_name>'`)"
+      description: |
+        ***Private preview.** This feature is under active development.*
+
+        Decode Avro messages using a schema managed in AWS Glue Schema
+        Registry. `<glue_connection_name>` is the [AWS Glue Schema Registry
+        connection](/sql/create-connection/#aws-glue-schema-registry), and
+        `SCHEMA NAME` (**required**) is the name of the schema to read from
+        the connection's registry. The schema is pinned at the time the
+        source is created.
+
+        A single `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` clause resolves
+        one schema. To set the key and value independently (for example,
+        under `ENVELOPE UPSERT` or `ENVELOPE DEBEZIUM`), specify `KEY FORMAT
+        ... VALUE FORMAT ...` explicitly.
     - name: "**KEY STRATEGY** `<key_strategy>`"
       description: |
         Optional. Define how an Avro reader schema will be chosen for the
@@ -473,6 +493,7 @@
     -- AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <conn_name>
     --     [KEY STRATEGY <strategy>]
     --     [VALUE STRATEGY <strategy>]
+    -- | AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_conn_name> (SCHEMA NAME = '<schema_name>')
     -- | CSV WITH <num> COLUMNS DELIMITED BY <char>
     -- | JSON | TEXT | BYTES
     -- | PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION <conn_name>
@@ -520,10 +541,10 @@
         Optional. Use the specified value to set `START OFFSET` based on the Kafka timestamp. Negative values will be interpreted as relative to the current system time in milliseconds (e.g. `-1000` means 1000 ms ago). See [Time-based offsets](#time-based-offsets) for details.
     - name: "**KEY FORMAT** `<key_format_spec>`"
       description: |
-        **Required.** Set the key encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `JSON`, `PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `PROTOBUF MESSAGE '<message_name>' USING SCHEMA '<schema_bytes>'`, `TEXT`, `BYTES`.
+        **Required.** Set the key encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name> (SCHEMA NAME = '<schema_name>')`, `JSON`, `PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `PROTOBUF MESSAGE '<message_name>' USING SCHEMA '<schema_bytes>'`, `TEXT`, `BYTES`.
     - name: "**VALUE FORMAT** `<value_format_spec>`"
       description: |
-        **Required.** Set the value encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `JSON`, `PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `PROTOBUF MESSAGE '<message_name>' USING SCHEMA '<schema_bytes>'`, `TEXT`, `BYTES`. By default, the message key is decoded using the same format as the message value.
+        **Required.** Set the value encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name> (SCHEMA NAME = '<schema_name>')`, `JSON`, `PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `PROTOBUF MESSAGE '<message_name>' USING SCHEMA '<schema_bytes>'`, `TEXT`, `BYTES`. By default, the message key is decoded using the same format as the message value.
     - name: "**INCLUDE** `<include_option>`"
       description: |
         Optional. If specified, include the additional information as column(s) in the table. The following `<include_option>`s are supported:


### PR DESCRIPTION
Updates user documentation with new AWS Glue schema registry `CONNECTION` and `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax.


This also fixes an unrelated syntax error on `create-connection.md:442`.