### PR TITLE
environmentd: make webhook request size limit configurable via dyncfg

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -221,6 +221,14 @@ pub const MCP_MAX_RESPONSE_SIZE: Config<usize> = Config::new(
     "Maximum size in bytes of MCP tool response content. Responses exceeding this limit are rejected with an error telling the agent to narrow its query.",
 );
 
+/// Maximum allowed size in bytes for the body of a webhook source request.
+/// Requests with a larger body are rejected with `413 Payload Too Large`.
+pub const WEBHOOK_MAX_REQUEST_SIZE: Config<usize> = Config::new(
+    "webhook_max_request_size",
+    5 * 1024 * 1024,
+    "Maximum allowed size in bytes for the body of a webhook source request.",
+);
+
 /// Number of user IDs to pre-allocate in a batch. Pre-allocating IDs avoids
 /// a persist write + oracle call per DDL statement.
 pub const USER_ID_POOL_BATCH_SIZE: Config<u32> = Config::new(
@@ -298,6 +306,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_MCP_DEVELOPER_QUERY_TOOL)
         .add(&ENABLE_PUBLIC_METRICS_ENDPOINT)
         .add(&MCP_MAX_RESPONSE_SIZE)
+        .add(&WEBHOOK_MAX_REQUEST_SIZE)
         .add(&USER_ID_POOL_BATCH_SIZE)
         .add(&CONSOLE_OIDC_CLIENT_ID)
         .add(&CONSOLE_OIDC_SCOPES)

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -80,6 +80,7 @@ use mz_auth::Authenticated;
 use mz_auth::password::Password;
 use mz_authenticator::Authenticator;
 use mz_controller::ReplicaHttpLocator;
+use mz_dyncfg::ConfigSet;
 use mz_frontegg_auth::Error as FronteggError;
 use mz_http_util::DynamicFilterTarget;
 use mz_ore::cast::u64_to_usize;
@@ -183,6 +184,10 @@ pub struct HttpConfig {
     pub routes_enabled: HttpRoutesEnabled,
     /// Locator for cluster replica HTTP addresses, used for proxying requests.
     pub replica_http_locator: Arc<ReplicaHttpLocator>,
+    /// Live dyncfg set, cheaply readable on the webhook hot path. A clone of the
+    /// process-wide [`ConfigSet`] that shares its inner atomics, so reads reflect
+    /// runtime updates without a coordinator round-trip.
+    pub dyncfg: ConfigSet,
 }
 
 #[derive(Debug, Clone)]
@@ -206,6 +211,7 @@ pub struct WsState {
 pub struct WebhookState {
     adapter_client_rx: Delayed<mz_adapter::Client>,
     webhook_cache: WebhookAppenderCache,
+    dyncfg: ConfigSet,
 }
 
 #[derive(Clone, Debug)]
@@ -241,6 +247,7 @@ impl HttpServer {
             internal_route_config,
             routes_enabled,
             replica_http_locator,
+            dyncfg,
         }: HttpConfig,
     ) -> HttpServer {
         let tls_enabled = tls.is_some();
@@ -346,6 +353,7 @@ impl HttpServer {
                 .with_state(WebhookState {
                     adapter_client_rx: adapter_client_rx.clone(),
                     webhook_cache,
+                    dyncfg: dyncfg.clone(),
                 })
                 .layer(
                     tower_http::decompression::RequestDecompressionLayer::new()

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use mz_adapter::{AppendWebhookError, AppendWebhookResponse, WebhookAppenderCache};
+use mz_adapter_types::dyncfgs::WEBHOOK_MAX_REQUEST_SIZE;
 use mz_ore::cast::CastFrom;
 use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::str::StrExt;
@@ -21,6 +22,7 @@ use mz_repr::{Datum, Diff, Row, RowPacker, SqlScalarType};
 use mz_sql::plan::{WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders};
 use mz_storage_types::controller::StorageError;
 
+use axum::body::{Body, to_bytes};
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use bytes::Bytes;
@@ -33,11 +35,22 @@ pub async fn handle_webhook(
     State(WebhookState {
         adapter_client_rx,
         webhook_cache,
+        dyncfg,
     }): State<WebhookState>,
     Path((database, schema, name)): Path<(String, String, String)>,
     headers: http::HeaderMap,
-    body: Bytes,
+    body: Body,
 ) -> impl IntoResponse {
+    // Bound the (decompressed) request body to the configured limit. We read the
+    // limit from the live dyncfg set on every request, which is just an atomic
+    // load. Using the `Body` extractor instead of `Bytes` means the global
+    // `DefaultBodyLimit` does not apply here, so this is the sole limit for
+    // webhook requests.
+    let limit = WEBHOOK_MAX_REQUEST_SIZE.get(&dyncfg);
+    let body = to_bytes(body, limit)
+        .await
+        .map_err(|_| WebhookError::RequestTooLarge { limit })?;
+
     let adapter_client = adapter_client_rx.clone().await.expect("sender not dropped");
     // Collect headers into a map, while converting them into strings.
     let mut headers_s = BTreeMap::new();
@@ -322,6 +335,8 @@ pub enum WebhookError {
     SecretMissing,
     #[error("headers of request were invalid: {0}")]
     InvalidHeaders(String),
+    #[error("request body exceeds the maximum allowed size of {limit} bytes")]
+    RequestTooLarge { limit: usize },
     #[error("failed to deserialize body as {ty:?}: {msg}")]
     InvalidBody { ty: SqlScalarType, msg: String },
     #[error("failed to validate the request")]
@@ -386,6 +401,9 @@ impl IntoResponse for WebhookError {
             }
             e @ WebhookError::InvalidHeaders(_) => {
                 (StatusCode::UNAUTHORIZED, e.to_string()).into_response()
+            }
+            e @ WebhookError::RequestTooLarge { .. } => {
+                (StatusCode::PAYLOAD_TOO_LARGE, e.to_string()).into_response()
             }
             e @ WebhookError::Unavailable => {
                 (StatusCode::SERVICE_UNAVAILABLE, e.to_string()).into_response()

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -420,6 +420,10 @@ impl Listeners {
                 internal_route_config: Arc::clone(&internal_route_config),
                 routes_enabled: listener.config.routes.clone(),
                 replica_http_locator: Arc::clone(&config.controller.replica_http_locator),
+                // Clone the live dyncfg set (shares inner atomics) so the webhook
+                // handler can read its request-size limit without a coordinator
+                // round-trip.
+                dyncfg: mz_dyncfg::ConfigSet::clone(config.catalog_config.persist_clients.cfg()),
             };
             http_listener_handles.insert(name.clone(), listener.serve_http(http_config).await);
         }

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -600,3 +600,31 @@ SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-
 > DROP TABLE webhook_as_table;
 
 $ check-shard-tombstone shard-id=${webhook-table-shard-id}
+
+# The maximum webhook request body size is configurable at runtime via the
+# `webhook_max_request_size` dyncfg, and read live on every request.
+
+> CREATE SOURCE webhook_request_size FROM WEBHOOK BODY FORMAT TEXT;
+
+# Shrink the limit; a body larger than the limit is rejected with 413.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET webhook_max_request_size = 5
+
+$ webhook-append name=webhook_request_size status=413
+this body is larger than five bytes
+
+# Raise the limit; the same body is now accepted, proving the dyncfg is read
+# live without a restart.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET webhook_max_request_size = 1048576
+
+$ webhook-append name=webhook_request_size
+this body is larger than five bytes
+
+> SELECT * FROM webhook_request_size;
+"this body is larger than five bytes"
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET webhook_max_request_size
+
+> DROP SOURCE webhook_request_size;


### PR DESCRIPTION
## Motivation

Webhook source requests are hardcoded to a **5 MiB** body size limit, enforced globally for all environmentd HTTP routes by an Axum `DefaultBodyLimit` layer (`src/environmentd/src/http.rs`). Operators have no way to raise it for webhook sources that legitimately need to accept larger payloads.

## What this does

Introduces the `webhook_max_request_size` dyncfg (default 5 MiB) that bounds the size of a webhook request body, read **live on every request**. Other HTTP routes (SQL API, WebSocket, etc.) keep the existing 5 MiB `MAX_REQUEST_SIZE`. Oversized requests are rejected with `413 Payload Too Large`.

### Reading the limit cheaply

The webhook handler is deliberately coordinator-free in steady state (it caches the appender via `WebhookAppenderCache`), so reading the limit must not add a coordinator round-trip. Rather than `get_system_vars().await` (which sends a command to the coordinator and awaits a reply), the handler reads a clone of the process-wide live `ConfigSet` carried on the shared `PersistClientCache`. Cloning a `ConfigSet` shares its inner atomics, so reads are O(1) atomic loads that reflect runtime updates. The storage controller already applies the full set of dyncfg updates to that `ConfigSet` via `apply_from`, and `catalog_config.persist_clients` / `controller.persist_clients` are the same `Arc<PersistClientCache>`, so updates are visible to the webhook's clone.

### Enforcement

The handler's body extractor switches from `Bytes` (which silently inherits the global `DefaultBodyLimit`) to `axum::body::Body`, collected via `to_bytes(body, limit)`. Because the handler runs *inside* the request-decompression layer, the limit applies to the **decompressed** body, preserving today's decompression-bomb protection. A `from_fn` middleware would have been forced outside decompression by Axum's body-type plumbing (limiting only the compressed wire size), which is why enforcement lives in the handler.

## Testing

Adds a case to `test/testdrive/webhook.td` that shrinks the limit and confirms a larger body is rejected with `413`, then raises the limit and confirms the same body is accepted without a restart — proving the dyncfg is read live per request.

## Release note

This release will allow the maximum webhook request body size to be configured at runtime via the `webhook_max_request_size` system parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)