### PR TITLE
adapter: gate 0dt cutover on sustained replica health

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -105,6 +105,9 @@ def get_minimal_system_parameters(
         "grpc_client_http2_keep_alive_timeout": "5s",
         "ore_overflowing_behavior": "panic",
         "unsafe_enable_table_keys": "true",
+        # Keep the 0dt stability soak out of the critical path for tests. The
+        # production default is much higher. Dedicated workflows override this.
+        "with_0dt_caught_up_check_stability_period": "0s",
         "with_0dt_deployment_max_wait": "1800s",
         # End of list (ordered by name)
     }
@@ -645,6 +648,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "with_0dt_caught_up_check_allowed_lag",
     "with_0dt_caught_up_check_cutoff",
     "enable_0dt_caught_up_replica_status_check",
+    "enable_0dt_caught_up_stability_check",
     "plan_insights_notice_fast_path_clusters_optimize_duration",
     "enable_expression_cache",
     "mz_metrics_lgalloc_map_refresh_interval",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1858,6 +1858,8 @@ class FlipFlagsAction(Action):
             "enable_0dt_caught_up_check",
             "with_0dt_caught_up_check_allowed_lag",
             "with_0dt_caught_up_check_cutoff",
+            "with_0dt_caught_up_check_stability_period",
+            "enable_0dt_caught_up_stability_check",
             "enable_statement_lifecycle_logging",
             "enable_introspection_subscribes",
             "plan_insights_notice_fast_path_clusters_optimize_duration",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -65,6 +65,18 @@ pub const ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK: Config<bool> = Config::new(
     "Enable checking for crash/OOM-looping replicas during 0dt caught-up checks. Emergency break-glass flag to disable this feature if needed.",
 );
 
+pub const ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK: Config<bool> = Config::new(
+    "enable_0dt_caught_up_stability_check",
+    true,
+    "Require clusters to stay caught-up and healthy for a stability period before being considered ready during 0dt deployments. Emergency break-glass flag to disable this feature if needed.",
+);
+
+pub const WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD: Config<Duration> = Config::new(
+    "with_0dt_caught_up_check_stability_period",
+    Duration::from_secs(10 * 60), // 10 minutes
+    "How long a cluster must continuously be caught-up and have all replicas healthy before it is considered ready to cut over during a 0dt deployment.",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -310,6 +322,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG)
         .add(&WITH_0DT_CAUGHT_UP_CHECK_CUTOFF)
         .add(&ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK)
+        .add(&ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK)
+        .add(&WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&ENABLE_FRONTEND_SUBSCRIBES)

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -68,7 +68,7 @@ pub const ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK: Config<bool> = Config::new(
 pub const ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK: Config<bool> = Config::new(
     "enable_0dt_caught_up_stability_check",
     true,
-    "Require clusters to stay caught-up and healthy for a stability period before being considered ready during 0dt deployments. Emergency break-glass flag to disable this feature if needed.",
+    "Require clusters to stay caught-up and healthy for a stability period before being considered ready during 0dt deployments. Emergency break-glass flag: disabling reverts to treating a caught-up cluster as ready with no replica-health requirement, which differs from setting the stability period to zero (a zero period still requires all replicas to be healthy).",
 );
 
 pub const WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD: Config<Duration> = Config::new(

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -65,6 +65,9 @@ pub const ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK: Config<bool> = Config::new(
     "Enable checking for crash/OOM-looping replicas during 0dt caught-up checks. Emergency break-glass flag to disable this feature if needed.",
 );
 
+// TODO(aljoscha): Remove this break-glass flag after a couple of releases, once
+// the sustained-health gate has proven itself in production. It only exists as a
+// fleet-wide automatic revert to the prior "caught-up implies ready" behavior.
 pub const ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK: Config<bool> = Config::new(
     "enable_0dt_caught_up_stability_check",
     true,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1712,6 +1712,7 @@ impl ClusterReplicaStatuses {
             .map(|process_id| {
                 let status = ClusterReplicaProcessStatus {
                     status: ClusterStatus::Offline(Some(OfflineReason::Initializing)),
+                    restart_count: 0,
                     time: time.clone(),
                 };
                 (u64::cast_from(process_id), status)
@@ -4895,6 +4896,7 @@ pub fn serve(
                 CaughtUpCheckContext {
                     trigger,
                     exclude_collections,
+                    cluster_stability: BTreeMap::new(),
                 }
             });
 

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -41,7 +41,7 @@ use mz_adapter_types::dyncfgs::{
 };
 use mz_catalog::builtin::{MZ_CLUSTER_REPLICA_FRONTIERS, MZ_CLUSTER_REPLICA_STATUS_HISTORY};
 use mz_catalog::memory::objects::Cluster;
-use mz_controller::clusters::ClusterStatus;
+use mz_controller::clusters::{ClusterStatus, ProcessId};
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_orchestrator::OfflineReason;
 use mz_ore::channel::trigger::Trigger;
@@ -109,17 +109,20 @@ pub struct ClusterStabilityState {
     /// `Instant`. We only ever compare these orchestrator times against each
     /// other, so orchestrator/environmentd clock skew doesn't matter.
     last_status_change: Option<DateTime<Utc>>,
-    /// Sum of replica-process restart counts observed on the previous tick.
+    /// Restart count per replica process observed on the previous tick.
     ///
-    /// Any change resets the streak: an increase means a restart, a decrease
-    /// means a process was recreated. The restart count survives gaps in the
-    /// orchestrator watch, so it catches restarts the status stream can drop.
-    last_restart_total: Option<u64>,
+    /// Any difference from this tick resets the streak: an increased count means
+    /// a restart, a decreased one means the process was recreated, and an added
+    /// or removed key means replica/process churn. Restart counts survive gaps
+    /// in the orchestrator watch, so they catch restarts the status stream can
+    /// drop. We track them per process rather than as a cluster-wide sum so that
+    /// offsetting changes across processes can't cancel out and hide a restart.
+    last_restart_counts: Option<BTreeMap<(ReplicaId, ProcessId), u64>>,
 }
 
 /// A point-in-time view of a cluster's replica health, derived from the
 /// in-memory mirror of orchestrator-reported replica statuses.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct ClusterHealthSnapshot {
     /// True iff the cluster has replicas and every process of every replica is
     /// `Online`. We deliberately require all replicas to be healthy, so we only
@@ -127,8 +130,13 @@ struct ClusterHealthSnapshot {
     all_healthy: bool,
     /// Max status-change time across all of the cluster's replica processes.
     max_status_change: Option<DateTime<Utc>>,
-    /// Sum of restart counts across all of the cluster's replica processes.
-    restart_total: u64,
+    /// Restart count per replica process.
+    ///
+    /// Kept per process rather than summed: restart counts are not monotonic (a
+    /// recreated process resets to zero), so a cluster-wide sum could cancel
+    /// offsetting changes across processes and hide a restart. Comparing the
+    /// whole map between ticks also catches replica/process churn.
+    restart_counts: BTreeMap<(ReplicaId, ProcessId), u64>,
 }
 
 /// Why a caught-up cluster is being held back by the stability gate on a given
@@ -185,13 +193,18 @@ impl ClusterStabilityState {
         // to be reliable on its own:
         //
         //   - `all_healthy` is a point-in-time check, independent of ordering.
-        //   - a change in `restart_total` is the durable signal: k8s reports
-        //     restart counts monotonically and they survive gaps in the
-        //     orchestrator watch, so they catch restarts the status stream drops.
-        //   - `max_status_change` advancing is only a best-effort flap detector:
-        //     status `time` is overwritten without enforcing monotonicity, so an
-        //     out-of-order event could lower the max and hide a flap. The restart
-        //     counter is the belt-and-suspenders for exactly that gap.
+        //   - a change in the per-process `restart_counts` is the durable signal:
+        //     k8s reports restart counts and they survive gaps in the orchestrator
+        //     watch, so they catch restarts the status stream drops. We compare
+        //     the whole map, never a cluster-wide sum: restart counts are not
+        //     monotonic (a recreated process resets to zero), so a sum could
+        //     cancel offsetting changes across processes and hide a restart.
+        //   - `max_status_change` advancing is a best-effort flap detector. A
+        //     cluster-wide max is enough here, unlike the restart counts, because
+        //     any status change stamps `process.time` at ~now, so a flap pushes
+        //     the max past the previous tick's value. It can still miss a flap if
+        //     an out-of-order event reports an older time, which is why the
+        //     restart counts are the belt-and-suspenders.
         //
         // We only compare the orchestrator-supplied times against each other, so
         // clock skew between the orchestrator and environmentd doesn't matter.
@@ -200,8 +213,9 @@ impl ClusterStabilityState {
             _ => false,
         };
         let restarted = self
-            .last_restart_total
-            .is_some_and(|prev| prev != snapshot.restart_total);
+            .last_restart_counts
+            .as_ref()
+            .is_some_and(|prev| prev != &snapshot.restart_counts);
 
         let good = snapshot.all_healthy && !status_flapped && !restarted;
 
@@ -211,7 +225,7 @@ impl ClusterStabilityState {
             None
         };
         self.last_status_change = snapshot.max_status_change;
-        self.last_restart_total = Some(snapshot.restart_total);
+        self.last_restart_counts = Some(snapshot.restart_counts.clone());
 
         let stable_for_ms = self.stable_since.map(|since| now.saturating_sub(since));
         let ready = stable_for_ms.is_some_and(|elapsed| elapsed >= period_ms);
@@ -420,7 +434,9 @@ impl Coordinator {
                             stable_for_ms = ?observation.stable_for_ms,
                             required_period_ms = stability_period_ms,
                             max_status_change = ?snapshot.max_status_change,
-                            restart_total = snapshot.restart_total,
+                            // Summed only for a readable log line. The gate
+                            // compares the per-process map, not this total.
+                            restart_total = snapshot.restart_counts.values().sum::<u64>(),
                             "cluster is caught up but not yet stable for the required period"
                         );
                     }
@@ -447,33 +463,31 @@ impl Coordinator {
             .try_get_cluster_statuses(cluster_id)
             .filter(|replicas| !replicas.is_empty())
         else {
-            // A cluster with no replica statuses is treated as not healthy. We
-            // spell the snapshot out rather than deriving `Default` so the
-            // "no replicas means unhealthy" choice is explicit at the use site.
+            // A cluster with no replica statuses is treated as not healthy.
             return ClusterHealthSnapshot {
                 all_healthy: false,
                 max_status_change: None,
-                restart_total: 0,
+                restart_counts: BTreeMap::new(),
             };
         };
 
         let mut all_healthy = true;
         let mut max_status_change = None;
-        let mut restart_total: u64 = 0;
-        for processes in replicas.values() {
+        let mut restart_counts = BTreeMap::new();
+        for (replica_id, processes) in replicas {
             if ClusterReplicaStatuses::cluster_replica_status(processes) != ClusterStatus::Online {
                 all_healthy = false;
             }
-            for process in processes.values() {
+            for (process_id, process) in processes {
                 max_status_change = max_status_change.max(Some(process.time));
-                restart_total = restart_total.saturating_add(process.restart_count);
+                restart_counts.insert((*replica_id, *process_id), process.restart_count);
             }
         }
 
         ClusterHealthSnapshot {
             all_healthy,
             max_status_change,
-            restart_total,
+            restart_counts,
         }
     }
 
@@ -863,13 +877,14 @@ impl Coordinator {
 mod tests {
     use super::*;
 
-    /// Builds a health snapshot. `change_secs` is the max status-change time as
-    /// a unix-second offset, `restarts` the summed restart count.
+    /// Builds a health snapshot with all restarts attributed to a single
+    /// replica process. `change_secs` is the max status-change time as a
+    /// unix-second offset, `restarts` that process's restart count.
     fn snapshot(all_healthy: bool, change_secs: i64, restarts: u64) -> ClusterHealthSnapshot {
         ClusterHealthSnapshot {
             all_healthy,
             max_status_change: DateTime::from_timestamp(change_secs, 0),
-            restart_total: restarts,
+            restart_counts: BTreeMap::from([((ReplicaId::User(1), 0), restarts)]),
         }
     }
 
@@ -966,6 +981,31 @@ mod tests {
                 .observe(&snapshot(true, 100, 4), 2500, period_ms)
                 .ready
         );
+    }
+
+    #[mz_ore::test]
+    fn offsetting_restart_changes_reset_streak() {
+        // Two processes whose restart counts move in opposite directions by the
+        // same amount. A cluster-wide sum would be unchanged and miss the
+        // restart, but the per-process map differs, so the streak resets.
+        let period_ms = 1000;
+        let mut state = ClusterStabilityState::default();
+
+        let r = ReplicaId::User(1);
+        let snapshot = |a: u64, b: u64| ClusterHealthSnapshot {
+            all_healthy: true,
+            max_status_change: DateTime::from_timestamp(100, 0),
+            restart_counts: BTreeMap::from([((r, 0u64), a), ((r, 1u64), b)]),
+        };
+
+        // Start a streak with per-process counts summing to 2.
+        assert!(!state.observe(&snapshot(1, 1), 0, period_ms).ready);
+        // One process restarts (+1) while the other is recreated (-1). The sum
+        // is still 2, but the per-process map changed: reset.
+        assert!(!state.observe(&snapshot(2, 0), 1000, period_ms).ready);
+        // A clean streak from here.
+        assert!(!state.observe(&snapshot(2, 0), 1500, period_ms).ready);
+        assert!(state.observe(&snapshot(2, 0), 2500, period_ms).ready);
     }
 
     #[mz_ore::test]

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -13,16 +13,19 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use differential_dataflow::lattice::Lattice as _;
 use futures::StreamExt;
 use itertools::Itertools;
 use mz_adapter_types::dyncfgs::{
-    ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK, WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG,
-    WITH_0DT_CAUGHT_UP_CHECK_CUTOFF,
+    ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK, ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK,
+    WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG, WITH_0DT_CAUGHT_UP_CHECK_CUTOFF,
+    WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD,
 };
 use mz_catalog::builtin::{MZ_CLUSTER_REPLICA_FRONTIERS, MZ_CLUSTER_REPLICA_STATUS_HISTORY};
 use mz_catalog::memory::objects::Cluster;
-use mz_controller_types::ReplicaId;
+use mz_controller::clusters::ClusterStatus;
+use mz_controller_types::{ClusterId, ReplicaId};
 use mz_orchestrator::OfflineReason;
 use mz_ore::channel::trigger::Trigger;
 use mz_ore::now::EpochMillis;
@@ -30,7 +33,7 @@ use mz_repr::{GlobalId, Timestamp};
 use timely::PartialOrder;
 use timely::progress::{Antichain, Timestamp as _};
 
-use crate::coord::Coordinator;
+use crate::coord::{ClusterReplicaStatuses, Coordinator};
 
 /// Context needed to check whether clusters/collections are caught up.
 #[derive(Debug)]
@@ -43,17 +46,120 @@ pub struct CaughtUpCheckContext {
     /// When a caught up check is performed as part of a 0dt upgrade, it makes sense to exclude
     /// collections of newly added builtin objects, as these might not hydrate in read-only mode.
     pub exclude_collections: BTreeSet<GlobalId>,
+    /// Per-cluster state for the stability gate, retained across checks.
+    ///
+    /// Only genuinely caught-up clusters have an entry. Entries are dropped as
+    /// soon as a cluster stops being caught-up, so the streak restarts from
+    /// scratch when it becomes caught-up again.
+    pub cluster_stability: BTreeMap<ClusterId, ClusterStabilityState>,
+}
+
+/// How a cluster relates to the 0dt caught-up check on a given tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClusterCaughtUpStatus {
+    /// Genuinely hydrated and within lag. Subject to the stability gate.
+    CaughtUp,
+    /// Excluded by the existing checks (no replicas, or hopelessly behind with
+    /// only crash/OOM-looping replicas). Does not block readiness and is not
+    /// health-gated, so we keep ignoring clusters that are already unhealthy in
+    /// the leader environment.
+    Ignored,
+    /// Not yet caught up. Blocks readiness.
+    NotCaughtUp,
+}
+
+/// Per-cluster state for the stability gate, retained across caught-up checks.
+///
+/// The gate requires a cluster to stay caught-up and fully healthy for a
+/// configurable period before we report it ready. A point-in-time check isn't
+/// enough: a crash-looping replica can momentarily look hydrated and healthy, so
+/// we'd cut over right into a crash. We therefore track health over time here.
+#[derive(Debug, Default, Clone)]
+pub struct ClusterStabilityState {
+    /// Wall-clock time (environmentd's `now()`) at which the current
+    /// uninterrupted caught-up-and-healthy streak began. `None` while the
+    /// cluster isn't currently in such a streak.
+    ///
+    /// We anchor the window with environmentd's clock so the configured period
+    /// means real wall-clock seconds, independent of orchestrator event times.
+    stable_since: Option<EpochMillis>,
+    /// Max replica-process status-change time observed on the previous tick.
+    ///
+    /// Used to detect status transitions that happened and resolved between two
+    /// ticks (a fast flap we'd otherwise miss by only sampling the current
+    /// status). Compared only against itself, so orchestrator/environmentd clock
+    /// skew doesn't matter.
+    last_status_change: Option<DateTime<Utc>>,
+    /// Sum of replica-process restart counts observed on the previous tick.
+    ///
+    /// Any change resets the streak: an increase means a restart, a decrease
+    /// means a process was recreated. The restart count survives gaps in the
+    /// orchestrator watch, so it catches restarts the status stream can drop.
+    last_restart_total: Option<u64>,
+}
+
+/// A point-in-time view of a cluster's replica health, derived from the
+/// in-memory mirror of orchestrator-reported replica statuses.
+#[derive(Debug, Clone, Copy)]
+struct ReplicaHealthSnapshot {
+    /// True iff the cluster has replicas and every process of every replica is
+    /// `Online`. We deliberately require all replicas to be healthy, so we only
+    /// cut over when the new environment is fully healthy.
+    all_healthy: bool,
+    /// Max status-change time across all of the cluster's replica processes.
+    max_status_change: Option<DateTime<Utc>>,
+    /// Sum of restart counts across all of the cluster's replica processes.
+    restart_total: u64,
+}
+
+impl ClusterStabilityState {
+    /// Folds in the latest health snapshot and returns whether the cluster has
+    /// now been continuously caught-up and healthy for at least `period_ms`.
+    ///
+    /// A cluster is "good" on a tick only if all its replicas are currently
+    /// healthy and nothing changed since the previous tick (no status flap, no
+    /// restart). Any disruption resets the streak, so a crash-looping replica can
+    /// never accumulate the required stable time.
+    fn observe(
+        &mut self,
+        snapshot: &ReplicaHealthSnapshot,
+        now: EpochMillis,
+        period_ms: u64,
+    ) -> bool {
+        // We only compare the orchestrator-supplied times against each other, so
+        // clock skew between the orchestrator and environmentd doesn't matter.
+        let status_flapped = match (self.last_status_change, snapshot.max_status_change) {
+            (Some(prev), Some(cur)) => cur > prev,
+            _ => false,
+        };
+        let restarted = self
+            .last_restart_total
+            .is_some_and(|prev| prev != snapshot.restart_total);
+
+        let good = snapshot.all_healthy && !status_flapped && !restarted;
+
+        self.stable_since = if good {
+            self.stable_since.or(Some(now))
+        } else {
+            None
+        };
+        self.last_status_change = snapshot.max_status_change;
+        self.last_restart_total = Some(snapshot.restart_total);
+
+        self.stable_since
+            .is_some_and(|since| now.saturating_sub(since) >= period_ms)
+    }
 }
 
 impl Coordinator {
     /// Checks that all clusters/collections are caught up. If so, this will
-    /// trigger `self.catchup_check.trigger`.
+    /// trigger `self.caught_up_check.trigger`.
     ///
     /// This method is a no-op when the trigger has already been fired.
     pub async fn maybe_check_caught_up(&mut self) {
-        let Some(ctx) = &self.caught_up_check else {
+        if self.caught_up_check.is_none() {
             return;
-        };
+        }
 
         let replica_frontier_item_id = self
             .catalog()
@@ -148,26 +254,127 @@ impl Coordinator {
             BTreeSet::new()
         };
 
-        let caught_up = self
-            .clusters_caught_up(
+        let stability_check_enabled =
+            ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK.get(self.catalog().system_config().dyncfgs());
+        let stability_period =
+            WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD.get(self.catalog().system_config().dyncfgs());
+        let stability_period_ms: u64 = stability_period
+            .as_millis()
+            .try_into()
+            .expect("must fit into u64");
+
+        // We clone the exclude set so we don't hold a borrow of `caught_up_check`
+        // across the classification, which lets us update the per-cluster
+        // stability state on it (mutably) afterwards.
+        let exclude_collections = self
+            .caught_up_check
+            .as_ref()
+            .expect("known to exist")
+            .exclude_collections
+            .clone();
+
+        let classification = self
+            .classify_clusters(
                 allowed_lag.into(),
                 cutoff.into(),
                 now.into(),
                 &live_collection_frontiers,
-                &ctx.exclude_collections,
+                &exclude_collections,
                 &problematic_replicas,
             )
             .await;
 
-        tracing::info!(%caught_up, "checked caught-up status of collections");
+        // Read the health snapshots for genuinely caught-up clusters now, while we
+        // only hold a shared borrow of `self`. We update the stability state in a
+        // separate, mutable pass below.
+        let health: BTreeMap<ClusterId, ReplicaHealthSnapshot> = classification
+            .iter()
+            .filter(|(_, status)| **status == ClusterCaughtUpStatus::CaughtUp)
+            .map(|(&cluster_id, _)| (cluster_id, self.cluster_replica_health(cluster_id)))
+            .collect();
 
-        if caught_up {
+        let ctx = self.caught_up_check.as_mut().expect("known to exist");
+
+        // Drop stability state for clusters that are no longer genuinely caught
+        // up, so the streak restarts from scratch when they become caught-up
+        // again.
+        ctx.cluster_stability.retain(|cluster_id, _| {
+            classification.get(cluster_id) == Some(&ClusterCaughtUpStatus::CaughtUp)
+        });
+
+        let mut all_ready = true;
+        for (&cluster_id, status) in &classification {
+            match status {
+                ClusterCaughtUpStatus::Ignored => {}
+                ClusterCaughtUpStatus::NotCaughtUp => {
+                    all_ready = false;
+                }
+                ClusterCaughtUpStatus::CaughtUp => {
+                    if !stability_check_enabled {
+                        continue;
+                    }
+                    let snapshot = health.get(&cluster_id).expect("computed above");
+                    let state = ctx.cluster_stability.entry(cluster_id).or_default();
+                    let ready = state.observe(snapshot, now, stability_period_ms);
+                    if !ready {
+                        all_ready = false;
+                        tracing::info!(
+                            %cluster_id,
+                            all_healthy = snapshot.all_healthy,
+                            "cluster is caught up but not yet stable for the required period"
+                        );
+                    }
+                }
+            }
+        }
+
+        tracing::info!(%all_ready, "checked caught-up status of clusters");
+
+        if all_ready {
             let ctx = self.caught_up_check.take().expect("known to exist");
             ctx.trigger.fire();
         }
     }
 
-    /// Returns whether all clusters are considered caught-up.
+    /// Reads the current health of a cluster's replicas from the in-memory
+    /// mirror of orchestrator-reported statuses.
+    ///
+    /// A cluster with no replica status entries (e.g. a freshly created cluster
+    /// whose statuses haven't been initialized) is reported as not healthy.
+    fn cluster_replica_health(&self, cluster_id: ClusterId) -> ReplicaHealthSnapshot {
+        let Some(replicas) = self
+            .cluster_replica_statuses
+            .try_get_cluster_statuses(cluster_id)
+            .filter(|replicas| !replicas.is_empty())
+        else {
+            return ReplicaHealthSnapshot {
+                all_healthy: false,
+                max_status_change: None,
+                restart_total: 0,
+            };
+        };
+
+        let mut all_healthy = true;
+        let mut max_status_change = None;
+        let mut restart_total: u64 = 0;
+        for processes in replicas.values() {
+            if ClusterReplicaStatuses::cluster_replica_status(processes) != ClusterStatus::Online {
+                all_healthy = false;
+            }
+            for process in processes.values() {
+                max_status_change = max_status_change.max(Some(process.time));
+                restart_total = restart_total.saturating_add(process.restart_count);
+            }
+        }
+
+        ReplicaHealthSnapshot {
+            all_healthy,
+            max_status_change,
+            restart_total,
+        }
+    }
+
+    /// Classifies every cluster for the caught-up check.
     ///
     /// Informally, a cluster is considered caught-up if it is at least as healthy as its
     /// counterpart in the leader environment. To determine that, we use the following rules:
@@ -182,10 +389,12 @@ impl Coordinator {
     ///      health in the read-only environment either.
     ///  (4) On a cluster that is crash-looping, all collections are ignored.
     ///
-    /// For this check, zero-replica clusters are always considered caught up. Their collections
-    /// would never normally be considered caught up but it's clearly intentional that they have no
-    /// replicas.
-    async fn clusters_caught_up(
+    /// A cluster that is caught-up only because it has no replicas, or because it is hopelessly
+    /// behind with only crash/OOM-looping replicas (rule 4), is reported as
+    /// [`ClusterCaughtUpStatus::Ignored`] rather than [`ClusterCaughtUpStatus::CaughtUp`]. The
+    /// caller does not health-gate ignored clusters, so we keep ignoring clusters that are already
+    /// unhealthy in the leader environment.
+    async fn classify_clusters(
         &self,
         allowed_lag: Timestamp,
         cutoff: Timestamp,
@@ -193,10 +402,10 @@ impl Coordinator {
         live_frontiers: &BTreeMap<GlobalId, Antichain<Timestamp>>,
         exclude_collections: &BTreeSet<GlobalId>,
         problematic_replicas: &BTreeSet<ReplicaId>,
-    ) -> bool {
-        let mut result = true;
+    ) -> BTreeMap<ClusterId, ClusterCaughtUpStatus> {
+        let mut result = BTreeMap::new();
         for cluster in self.catalog().clusters() {
-            let caught_up = self
+            let status = self
                 .collections_caught_up(
                     cluster,
                     allowed_lag.clone(),
@@ -206,31 +415,29 @@ impl Coordinator {
                     exclude_collections,
                     problematic_replicas,
                 )
-                .await;
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!(
+                        "unexpected error while checking if cluster {} caught up: {e:#}",
+                        cluster.id
+                    );
+                    ClusterCaughtUpStatus::NotCaughtUp
+                });
 
-            let caught_up = caught_up.unwrap_or_else(|e| {
-                tracing::error!(
-                    "unexpected error while checking if cluster {} caught up: {e:#}",
-                    cluster.id
-                );
-                false
-            });
-
-            if !caught_up {
-                result = false;
-
-                // We continue with our loop instead of breaking out early, so
-                // that we log all non-caught up clusters.
+            if status == ClusterCaughtUpStatus::NotCaughtUp {
+                // We log all non-caught-up clusters instead of breaking out early.
                 tracing::info!("cluster {} is not caught up", cluster.id);
             }
+
+            result.insert(cluster.id, status);
         }
 
         result
     }
 
-    /// Returns whether the given cluster is considered caught-up.
+    /// Classifies the given cluster for the caught-up check.
     ///
-    /// See [`Coordinator::clusters_caught_up`] for details.
+    /// See [`Coordinator::classify_clusters`] for details.
     async fn collections_caught_up(
         &self,
         cluster: &Cluster,
@@ -240,9 +447,9 @@ impl Coordinator {
         live_frontiers: &BTreeMap<GlobalId, Antichain<Timestamp>>,
         exclude_collections: &BTreeSet<GlobalId>,
         problematic_replicas: &BTreeSet<ReplicaId>,
-    ) -> Result<bool, anyhow::Error> {
+    ) -> Result<ClusterCaughtUpStatus, anyhow::Error> {
         if cluster.replicas().next().is_none() {
-            return Ok(true);
+            return Ok(ClusterCaughtUpStatus::Ignored);
         }
 
         // Check if all replicas in this cluster are crash/OOM-looping. As long
@@ -324,7 +531,7 @@ impl Coordinator {
                      checks",
                     cluster.id
                 );
-                return Ok(true);
+                return Ok(ClusterCaughtUpStatus::Ignored);
             } else if beyond_all_hope {
                 tracing::info!(
                     ?live_write_frontier,
@@ -398,7 +605,11 @@ impl Coordinator {
             }
         }
 
-        Ok(all_caught_up)
+        Ok(if all_caught_up {
+            ClusterCaughtUpStatus::CaughtUp
+        } else {
+            ClusterCaughtUpStatus::NotCaughtUp
+        })
     }
 
     /// Analyzes replica status history to detect replicas that are
@@ -542,5 +753,82 @@ impl Coordinator {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a health snapshot. `change_secs` is the max status-change time as
+    /// a unix-second offset, `restarts` the summed restart count.
+    fn snapshot(all_healthy: bool, change_secs: i64, restarts: u64) -> ReplicaHealthSnapshot {
+        ReplicaHealthSnapshot {
+            all_healthy,
+            max_status_change: DateTime::from_timestamp(change_secs, 0),
+            restart_total: restarts,
+        }
+    }
+
+    #[mz_ore::test]
+    fn stability_requires_sustained_health() {
+        let period_ms = 1000;
+        let mut state = ClusterStabilityState::default();
+
+        // The first healthy observation starts the streak but isn't yet stable.
+        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms));
+        // Still within the period.
+        assert!(!state.observe(&snapshot(true, 100, 0), 500, period_ms));
+        // Past the period: ready.
+        assert!(state.observe(&snapshot(true, 100, 0), 1000, period_ms));
+    }
+
+    #[mz_ore::test]
+    fn unhealthy_resets_streak() {
+        let period_ms = 1000;
+        let mut state = ClusterStabilityState::default();
+
+        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms));
+        // A currently-unhealthy observation resets the streak.
+        assert!(!state.observe(&snapshot(false, 100, 0), 500, period_ms));
+        // Healthy again, but the clock restarts from here.
+        assert!(!state.observe(&snapshot(true, 100, 0), 600, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 0), 1599, period_ms));
+        assert!(state.observe(&snapshot(true, 100, 0), 1600, period_ms));
+    }
+
+    #[mz_ore::test]
+    fn status_flap_between_ticks_resets_streak() {
+        let period_ms = 1000;
+        let mut state = ClusterStabilityState::default();
+
+        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms));
+        // Currently healthy, but the status-change time advanced, so a flap
+        // happened and resolved between ticks: reset.
+        assert!(!state.observe(&snapshot(true, 200, 0), 1000, period_ms));
+        // A clean streak from here.
+        assert!(!state.observe(&snapshot(true, 200, 0), 1500, period_ms));
+        assert!(state.observe(&snapshot(true, 200, 0), 2500, period_ms));
+    }
+
+    #[mz_ore::test]
+    fn restart_between_ticks_resets_streak() {
+        let period_ms = 1000;
+        let mut state = ClusterStabilityState::default();
+
+        assert!(!state.observe(&snapshot(true, 100, 3), 0, period_ms));
+        // Healthy with the same status-change time, but the restart count went
+        // up: a restart happened and recovered between ticks, which the status
+        // alone would miss. Reset.
+        assert!(!state.observe(&snapshot(true, 100, 4), 1000, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 4), 1500, period_ms));
+        assert!(state.observe(&snapshot(true, 100, 4), 2500, period_ms));
+    }
+
+    #[mz_ore::test]
+    fn zero_period_ready_on_first_healthy_tick() {
+        let mut state = ClusterStabilityState::default();
+        // With a zero period a single clean, healthy observation is enough.
+        assert!(state.observe(&snapshot(true, 100, 0), 0, 0));
     }
 }

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -9,6 +9,23 @@
 
 //! Support for checking whether clusters/collections are caught up during a 0dt
 //! deployment.
+//!
+//! During a zero-downtime upgrade the new `environmentd` boots read-only and
+//! reports "ready to promote" once its clusters have caught up with the leader
+//! generation. [`Coordinator::maybe_check_caught_up`] runs that check on an
+//! interval (see `with_0dt_deployment_caught_up_check_interval`). We call one
+//! such run a "tick", and the term is used throughout this module.
+//!
+//! A point-in-time caught-up check is not enough on its own: a crash- or
+//! OOM-looping replica can momentarily look hydrated and caught-up, and cutting
+//! over right then drops us straight into a crashing replica. On top of the
+//! per-tick caught-up classification we therefore run a stability gate. Once a
+//! cluster is genuinely caught-up it must stay caught-up and have all replicas
+//! healthy for a configurable period before we report it ready. Any disruption
+//! (a replica not `Online`, a status flap between ticks, or a replica restart)
+//! resets the streak, so a crash-looping replica never accumulates the required
+//! stable time. [`ClusterStabilityState`] holds the per-cluster gate state
+//! across ticks.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
@@ -87,8 +104,10 @@ pub struct ClusterStabilityState {
     ///
     /// Used to detect status transitions that happened and resolved between two
     /// ticks (a fast flap we'd otherwise miss by only sampling the current
-    /// status). Compared only against itself, so orchestrator/environmentd clock
-    /// skew doesn't matter.
+    /// status). This is an orchestrator-supplied timestamp (`process.time`), not
+    /// a locally measured one, which is why it's a `DateTime` and not an
+    /// `Instant`. We only ever compare these orchestrator times against each
+    /// other, so orchestrator/environmentd clock skew doesn't matter.
     last_status_change: Option<DateTime<Utc>>,
     /// Sum of replica-process restart counts observed on the previous tick.
     ///
@@ -101,7 +120,7 @@ pub struct ClusterStabilityState {
 /// A point-in-time view of a cluster's replica health, derived from the
 /// in-memory mirror of orchestrator-reported replica statuses.
 #[derive(Debug, Clone, Copy)]
-struct ReplicaHealthSnapshot {
+struct ClusterHealthSnapshot {
     /// True iff the cluster has replicas and every process of every replica is
     /// `Online`. We deliberately require all replicas to be healthy, so we only
     /// cut over when the new environment is fully healthy.
@@ -112,11 +131,13 @@ struct ReplicaHealthSnapshot {
     restart_total: u64,
 }
 
-/// Why the stability gate is (not) satisfied for a cluster on a given tick.
+/// Why a caught-up cluster is being held back by the stability gate on a given
+/// tick.
 ///
-/// Recorded so we can log why a caught-up cluster is being held back.
+/// Only ever set when the cluster is not yet ready, so there is no "stable"
+/// variant. Recorded so we can log the cause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StabilityReason {
+enum StabilityBlocker {
     /// Not all replicas are currently `Online`.
     NotHealthy,
     /// A status change happened and resolved between two ticks.
@@ -126,8 +147,6 @@ enum StabilityReason {
     /// Currently caught-up and healthy, but the streak hasn't reached the
     /// required period yet.
     WithinPeriod,
-    /// Caught-up and healthy for at least the required period.
-    Stable,
 }
 
 /// Outcome of folding one health snapshot into a [`ClusterStabilityState`].
@@ -139,15 +158,15 @@ struct StabilityObservation {
     /// How long the current uninterrupted streak has lasted, in milliseconds.
     /// `None` when the cluster is not currently in a streak (this tick reset it).
     stable_for_ms: Option<u64>,
-    /// Why the gate is (not) satisfied, for logging.
-    reason: StabilityReason,
+    /// Why the cluster is being held back, for logging. `None` once it's ready.
+    blocked_by: Option<StabilityBlocker>,
 }
 
 impl ClusterStabilityState {
     /// Folds in the latest health snapshot and returns an observation: whether
     /// the cluster has now been continuously caught-up and healthy for at least
-    /// `period_ms`, how long the current streak has lasted, and why the gate is
-    /// (not) satisfied.
+    /// `period_ms`, how long the current streak has lasted, and (when not ready)
+    /// what is holding it back.
     ///
     /// A cluster is "good" on a tick only if all its replicas are currently
     /// healthy and nothing changed since the previous tick (no status flap, no
@@ -155,7 +174,7 @@ impl ClusterStabilityState {
     /// never accumulate the required stable time.
     fn observe(
         &mut self,
-        snapshot: &ReplicaHealthSnapshot,
+        snapshot: &ClusterHealthSnapshot,
         now: EpochMillis,
         period_ms: u64,
     ) -> StabilityObservation {
@@ -197,22 +216,22 @@ impl ClusterStabilityState {
         let stable_for_ms = self.stable_since.map(|since| now.saturating_sub(since));
         let ready = stable_for_ms.is_some_and(|elapsed| elapsed >= period_ms);
 
-        let reason = if ready {
-            StabilityReason::Stable
+        let blocked_by = if ready {
+            None
         } else if !snapshot.all_healthy {
-            StabilityReason::NotHealthy
+            Some(StabilityBlocker::NotHealthy)
         } else if status_flapped {
-            StabilityReason::StatusFlapped
+            Some(StabilityBlocker::StatusFlapped)
         } else if restarted {
-            StabilityReason::Restarted
+            Some(StabilityBlocker::Restarted)
         } else {
-            StabilityReason::WithinPeriod
+            Some(StabilityBlocker::WithinPeriod)
         };
 
         StabilityObservation {
             ready,
             stable_for_ms,
-            reason,
+            blocked_by,
         }
     }
 }
@@ -354,10 +373,10 @@ impl Coordinator {
         // Read the health snapshots for genuinely caught-up clusters now, while we
         // only hold a shared borrow of `self`. We update the stability state in a
         // separate, mutable pass below.
-        let health: BTreeMap<ClusterId, ReplicaHealthSnapshot> = classification
+        let health: BTreeMap<ClusterId, ClusterHealthSnapshot> = classification
             .iter()
             .filter(|(_, status)| **status == ClusterCaughtUpStatus::CaughtUp)
-            .map(|(&cluster_id, _)| (cluster_id, self.cluster_replica_health(cluster_id)))
+            .map(|(&cluster_id, _)| (cluster_id, self.cluster_health(cluster_id)))
             .collect();
 
         let ctx = self.caught_up_check.as_mut().expect("known to exist");
@@ -396,7 +415,7 @@ impl Coordinator {
                         all_ready = false;
                         tracing::info!(
                             %cluster_id,
-                            reason = ?observation.reason,
+                            reason = ?observation.blocked_by,
                             all_healthy = snapshot.all_healthy,
                             stable_for_ms = ?observation.stable_for_ms,
                             required_period_ms = stability_period_ms,
@@ -422,13 +441,16 @@ impl Coordinator {
     ///
     /// A cluster with no replica status entries (e.g. a freshly created cluster
     /// whose statuses haven't been initialized) is reported as not healthy.
-    fn cluster_replica_health(&self, cluster_id: ClusterId) -> ReplicaHealthSnapshot {
+    fn cluster_health(&self, cluster_id: ClusterId) -> ClusterHealthSnapshot {
         let Some(replicas) = self
             .cluster_replica_statuses
             .try_get_cluster_statuses(cluster_id)
             .filter(|replicas| !replicas.is_empty())
         else {
-            return ReplicaHealthSnapshot {
+            // A cluster with no replica statuses is treated as not healthy. We
+            // spell the snapshot out rather than deriving `Default` so the
+            // "no replicas means unhealthy" choice is explicit at the use site.
+            return ClusterHealthSnapshot {
                 all_healthy: false,
                 max_status_change: None,
                 restart_total: 0,
@@ -448,7 +470,7 @@ impl Coordinator {
             }
         }
 
-        ReplicaHealthSnapshot {
+        ClusterHealthSnapshot {
             all_healthy,
             max_status_change,
             restart_total,
@@ -843,8 +865,8 @@ mod tests {
 
     /// Builds a health snapshot. `change_secs` is the max status-change time as
     /// a unix-second offset, `restarts` the summed restart count.
-    fn snapshot(all_healthy: bool, change_secs: i64, restarts: u64) -> ReplicaHealthSnapshot {
-        ReplicaHealthSnapshot {
+    fn snapshot(all_healthy: bool, change_secs: i64, restarts: u64) -> ClusterHealthSnapshot {
+        ClusterHealthSnapshot {
             all_healthy,
             max_status_change: DateTime::from_timestamp(change_secs, 0),
             restart_total: restarts,

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -112,9 +112,42 @@ struct ReplicaHealthSnapshot {
     restart_total: u64,
 }
 
+/// Why the stability gate is (not) satisfied for a cluster on a given tick.
+///
+/// Recorded so we can log why a caught-up cluster is being held back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StabilityReason {
+    /// Not all replicas are currently `Online`.
+    NotHealthy,
+    /// A status change happened and resolved between two ticks.
+    StatusFlapped,
+    /// A replica process restarted between two ticks.
+    Restarted,
+    /// Currently caught-up and healthy, but the streak hasn't reached the
+    /// required period yet.
+    WithinPeriod,
+    /// Caught-up and healthy for at least the required period.
+    Stable,
+}
+
+/// Outcome of folding one health snapshot into a [`ClusterStabilityState`].
+#[derive(Debug, Clone, Copy)]
+struct StabilityObservation {
+    /// Whether the cluster has now been continuously caught-up and healthy for
+    /// at least the required period.
+    ready: bool,
+    /// How long the current uninterrupted streak has lasted, in milliseconds.
+    /// `None` when the cluster is not currently in a streak (this tick reset it).
+    stable_for_ms: Option<u64>,
+    /// Why the gate is (not) satisfied, for logging.
+    reason: StabilityReason,
+}
+
 impl ClusterStabilityState {
-    /// Folds in the latest health snapshot and returns whether the cluster has
-    /// now been continuously caught-up and healthy for at least `period_ms`.
+    /// Folds in the latest health snapshot and returns an observation: whether
+    /// the cluster has now been continuously caught-up and healthy for at least
+    /// `period_ms`, how long the current streak has lasted, and why the gate is
+    /// (not) satisfied.
     ///
     /// A cluster is "good" on a tick only if all its replicas are currently
     /// healthy and nothing changed since the previous tick (no status flap, no
@@ -125,7 +158,22 @@ impl ClusterStabilityState {
         snapshot: &ReplicaHealthSnapshot,
         now: EpochMillis,
         period_ms: u64,
-    ) -> bool {
+    ) -> StabilityObservation {
+        // NOTE: We don't assume orchestrator status events arrive in order or
+        // that every process of a cluster reports within the same tick. The
+        // snapshot reflects whatever the in-memory mirror holds right now, and
+        // the three checks below are deliberately redundant so no single one has
+        // to be reliable on its own:
+        //
+        //   - `all_healthy` is a point-in-time check, independent of ordering.
+        //   - a change in `restart_total` is the durable signal: k8s reports
+        //     restart counts monotonically and they survive gaps in the
+        //     orchestrator watch, so they catch restarts the status stream drops.
+        //   - `max_status_change` advancing is only a best-effort flap detector:
+        //     status `time` is overwritten without enforcing monotonicity, so an
+        //     out-of-order event could lower the max and hide a flap. The restart
+        //     counter is the belt-and-suspenders for exactly that gap.
+        //
         // We only compare the orchestrator-supplied times against each other, so
         // clock skew between the orchestrator and environmentd doesn't matter.
         let status_flapped = match (self.last_status_change, snapshot.max_status_change) {
@@ -146,8 +194,26 @@ impl ClusterStabilityState {
         self.last_status_change = snapshot.max_status_change;
         self.last_restart_total = Some(snapshot.restart_total);
 
-        self.stable_since
-            .is_some_and(|since| now.saturating_sub(since) >= period_ms)
+        let stable_for_ms = self.stable_since.map(|since| now.saturating_sub(since));
+        let ready = stable_for_ms.is_some_and(|elapsed| elapsed >= period_ms);
+
+        let reason = if ready {
+            StabilityReason::Stable
+        } else if !snapshot.all_healthy {
+            StabilityReason::NotHealthy
+        } else if status_flapped {
+            StabilityReason::StatusFlapped
+        } else if restarted {
+            StabilityReason::Restarted
+        } else {
+            StabilityReason::WithinPeriod
+        };
+
+        StabilityObservation {
+            ready,
+            stable_for_ms,
+            reason,
+        }
     }
 }
 
@@ -258,10 +324,11 @@ impl Coordinator {
             ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK.get(self.catalog().system_config().dyncfgs());
         let stability_period =
             WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD.get(self.catalog().system_config().dyncfgs());
-        let stability_period_ms: u64 = stability_period
-            .as_millis()
-            .try_into()
-            .expect("must fit into u64");
+        // Cap rather than panic on an absurdly large configured duration. A
+        // period of u64::MAX milliseconds means "effectively never auto-ready",
+        // which is the safe, conservative outcome: we won't cut over on our own,
+        // and an operator can still force it via skip-catchup.
+        let stability_period_ms = u64::try_from(stability_period.as_millis()).unwrap_or(u64::MAX);
 
         // We clone the exclude set so we don't hold a borrow of `caught_up_check`
         // across the classification, which lets us update the per-cluster
@@ -310,17 +377,31 @@ impl Coordinator {
                     all_ready = false;
                 }
                 ClusterCaughtUpStatus::CaughtUp => {
+                    // Break-glass: when disabled, a caught-up cluster is
+                    // immediately ready, with no replica-health requirement,
+                    // i.e. the behavior from before this gate existed. We keep it
+                    // as a config-level, fleet-wide revert. Operators can already
+                    // force a single cutover via skip-catchup/promote, but this
+                    // flag restores prior auto-cutover behavior across all
+                    // environments without per-deploy manual intervention or a
+                    // code release, mirroring
+                    // `enable_0dt_caught_up_replica_status_check`.
                     if !stability_check_enabled {
                         continue;
                     }
                     let snapshot = health.get(&cluster_id).expect("computed above");
                     let state = ctx.cluster_stability.entry(cluster_id).or_default();
-                    let ready = state.observe(snapshot, now, stability_period_ms);
-                    if !ready {
+                    let observation = state.observe(snapshot, now, stability_period_ms);
+                    if !observation.ready {
                         all_ready = false;
                         tracing::info!(
                             %cluster_id,
+                            reason = ?observation.reason,
                             all_healthy = snapshot.all_healthy,
+                            stable_for_ms = ?observation.stable_for_ms,
+                            required_period_ms = stability_period_ms,
+                            max_status_change = ?snapshot.max_status_change,
+                            restart_total = snapshot.restart_total,
                             "cluster is caught up but not yet stable for the required period"
                         );
                     }
@@ -776,11 +857,15 @@ mod tests {
         let mut state = ClusterStabilityState::default();
 
         // The first healthy observation starts the streak but isn't yet stable.
-        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms).ready);
         // Still within the period.
-        assert!(!state.observe(&snapshot(true, 100, 0), 500, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 0), 500, period_ms).ready);
         // Past the period: ready.
-        assert!(state.observe(&snapshot(true, 100, 0), 1000, period_ms));
+        assert!(
+            state
+                .observe(&snapshot(true, 100, 0), 1000, period_ms)
+                .ready
+        );
     }
 
     #[mz_ore::test]
@@ -788,13 +873,25 @@ mod tests {
         let period_ms = 1000;
         let mut state = ClusterStabilityState::default();
 
-        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms).ready);
         // A currently-unhealthy observation resets the streak.
-        assert!(!state.observe(&snapshot(false, 100, 0), 500, period_ms));
+        assert!(
+            !state
+                .observe(&snapshot(false, 100, 0), 500, period_ms)
+                .ready
+        );
         // Healthy again, but the clock restarts from here.
-        assert!(!state.observe(&snapshot(true, 100, 0), 600, period_ms));
-        assert!(!state.observe(&snapshot(true, 100, 0), 1599, period_ms));
-        assert!(state.observe(&snapshot(true, 100, 0), 1600, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 0), 600, period_ms).ready);
+        assert!(
+            !state
+                .observe(&snapshot(true, 100, 0), 1599, period_ms)
+                .ready
+        );
+        assert!(
+            state
+                .observe(&snapshot(true, 100, 0), 1600, period_ms)
+                .ready
+        );
     }
 
     #[mz_ore::test]
@@ -802,13 +899,25 @@ mod tests {
         let period_ms = 1000;
         let mut state = ClusterStabilityState::default();
 
-        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 0), 0, period_ms).ready);
         // Currently healthy, but the status-change time advanced, so a flap
         // happened and resolved between ticks: reset.
-        assert!(!state.observe(&snapshot(true, 200, 0), 1000, period_ms));
+        assert!(
+            !state
+                .observe(&snapshot(true, 200, 0), 1000, period_ms)
+                .ready
+        );
         // A clean streak from here.
-        assert!(!state.observe(&snapshot(true, 200, 0), 1500, period_ms));
-        assert!(state.observe(&snapshot(true, 200, 0), 2500, period_ms));
+        assert!(
+            !state
+                .observe(&snapshot(true, 200, 0), 1500, period_ms)
+                .ready
+        );
+        assert!(
+            state
+                .observe(&snapshot(true, 200, 0), 2500, period_ms)
+                .ready
+        );
     }
 
     #[mz_ore::test]
@@ -816,19 +925,31 @@ mod tests {
         let period_ms = 1000;
         let mut state = ClusterStabilityState::default();
 
-        assert!(!state.observe(&snapshot(true, 100, 3), 0, period_ms));
+        assert!(!state.observe(&snapshot(true, 100, 3), 0, period_ms).ready);
         // Healthy with the same status-change time, but the restart count went
         // up: a restart happened and recovered between ticks, which the status
         // alone would miss. Reset.
-        assert!(!state.observe(&snapshot(true, 100, 4), 1000, period_ms));
-        assert!(!state.observe(&snapshot(true, 100, 4), 1500, period_ms));
-        assert!(state.observe(&snapshot(true, 100, 4), 2500, period_ms));
+        assert!(
+            !state
+                .observe(&snapshot(true, 100, 4), 1000, period_ms)
+                .ready
+        );
+        assert!(
+            !state
+                .observe(&snapshot(true, 100, 4), 1500, period_ms)
+                .ready
+        );
+        assert!(
+            state
+                .observe(&snapshot(true, 100, 4), 2500, period_ms)
+                .ready
+        );
     }
 
     #[mz_ore::test]
     fn zero_period_ready_on_first_healthy_tick() {
         let mut state = ClusterStabilityState::default();
         // With a zero period a single clean, healthy observation is enough.
-        assert!(state.observe(&snapshot(true, 100, 0), 0, 0));
+        assert!(state.observe(&snapshot(true, 100, 0), 0, 0).ready);
     }
 }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -971,47 +971,69 @@ impl Coordinator {
 
         // It is possible that we receive a status update for a replica that has
         // already been dropped from the catalog. Just ignore these events.
-        let Some(replica_statues) = self
+        let Some(replica_statuses) = self
             .cluster_replica_statuses
             .try_get_cluster_replica_statuses(event.cluster_id, event.replica_id)
         else {
             return;
         };
 
-        if event.status != replica_statues[&event.process_id].status {
-            if !self.controller.read_only() {
-                let offline_reason = match event.status {
-                    ClusterStatus::Online => None,
-                    ClusterStatus::Offline(None) => None,
-                    ClusterStatus::Offline(Some(reason)) => Some(reason.to_string()),
-                };
-                let row = Row::pack_slice(&[
-                    Datum::String(&event.replica_id.to_string()),
-                    Datum::UInt64(event.process_id),
-                    Datum::String(event.status.as_kebab_case_str()),
-                    Datum::from(offline_reason.as_deref()),
-                    Datum::TimestampTz(event.time.try_into().expect("must fit")),
-                ]);
-                self.controller.storage.append_introspection_updates(
-                    IntrospectionType::ReplicaStatusHistory,
-                    vec![(row, Diff::ONE)],
-                );
-            }
+        let old_process_status = &replica_statuses[&event.process_id];
+        let status_changed = event.status != old_process_status.status;
+        let restart_count_changed = event.restart_count != old_process_status.restart_count;
 
-            let old_replica_status =
-                ClusterReplicaStatuses::cluster_replica_status(replica_statues);
+        // We mirror the restart count in memory even when only it changes (and the
+        // status stays the same), so the 0dt caught-up check can detect replica
+        // restarts it would otherwise miss by only sampling the status. The status
+        // history and the status-changed notice are keyed on the status itself, so
+        // we only touch those when the status actually changes.
+        //
+        // NOTE: The 0dt stability gate detects flaps by watching a process's
+        // status-change `time` advance between checks. That only works because we
+        // freeze `time` on no-op events, i.e. we return early here instead of
+        // rewriting the record when neither the status nor the restart count
+        // changed.
+        if !status_changed && !restart_count_changed {
+            return;
+        }
 
-            let new_process_status = ClusterReplicaProcessStatus {
-                status: event.status,
-                time: event.time,
+        if status_changed && !self.controller.read_only() {
+            let offline_reason = match event.status {
+                ClusterStatus::Online => None,
+                ClusterStatus::Offline(None) => None,
+                ClusterStatus::Offline(Some(reason)) => Some(reason.to_string()),
             };
-            self.cluster_replica_statuses.ensure_cluster_status(
-                event.cluster_id,
-                event.replica_id,
-                event.process_id,
-                new_process_status,
+            let row = Row::pack_slice(&[
+                Datum::String(&event.replica_id.to_string()),
+                Datum::UInt64(event.process_id),
+                Datum::String(event.status.as_kebab_case_str()),
+                Datum::from(offline_reason.as_deref()),
+                Datum::TimestampTz(event.time.try_into().expect("must fit")),
+            ]);
+            self.controller.storage.append_introspection_updates(
+                IntrospectionType::ReplicaStatusHistory,
+                vec![(row, Diff::ONE)],
             );
+        }
 
+        // Capture the rolled-up replica status before the update so we can tell
+        // whether the user-visible status changed. Only needed for the notice.
+        let old_replica_status = status_changed
+            .then(|| ClusterReplicaStatuses::cluster_replica_status(replica_statuses));
+
+        let new_process_status = ClusterReplicaProcessStatus {
+            status: event.status,
+            restart_count: event.restart_count,
+            time: event.time,
+        };
+        self.cluster_replica_statuses.ensure_cluster_status(
+            event.cluster_id,
+            event.replica_id,
+            event.process_id,
+            new_process_status,
+        );
+
+        if let Some(old_replica_status) = old_replica_status {
             let cluster = self.catalog().get_cluster(event.cluster_id);
             let replica = cluster.replica(event.replica_id).expect("Replica exists");
             let new_replica_status = self

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -540,6 +540,10 @@ impl From<ClusterReplica> for durable::ClusterReplica {
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct ClusterReplicaProcessStatus {
     pub status: ClusterStatus,
+    /// Cumulative restart count of the process, mirrored from the orchestrator.
+    /// See [`mz_orchestrator::ServiceEvent::restart_count`].
+    pub restart_count: u64,
+    /// Time of the most recent change to `status` or `restart_count`.
     pub time: DateTime<Utc>,
 }
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -398,6 +398,9 @@ pub struct ClusterEvent {
     pub replica_id: ReplicaId,
     pub process_id: ProcessId,
     pub status: ClusterStatus,
+    /// Cumulative restart count of the process, propagated from the orchestrator.
+    /// See [`mz_orchestrator::ServiceEvent::restart_count`].
+    pub restart_count: u64,
     pub time: DateTime<Utc>,
 }
 
@@ -636,6 +639,7 @@ impl Controller {
                 replica_id,
                 process_id: event.process_id,
                 status: event.status,
+                restart_count: event.restart_count,
                 time: event.time,
             };
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2990,7 +2990,13 @@ async fn test_leader_promotion_mixed_code_version() {
         .unsafe_mode()
         .data_directory(tmpdir.path())
         .with_deploy_generation(1)
-        .with_code_version(this_version);
+        .with_code_version(this_version)
+        // The caught-up stability gate would otherwise hold the new version in
+        // read-only for the production default period before it reports ready.
+        .with_system_parameter_default(
+            "with_0dt_caught_up_check_stability_period".to_string(),
+            "0s".to_string(),
+        );
 
     // Query a server at the current version before we start a second server.
     let server_this = harness.clone().start().await;

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -1342,6 +1342,22 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 })
                 .unwrap_or(false);
 
+            // Sum the per-container restart counts to get a per-process (per-pod)
+            // restart count. This is cumulative and survives gaps in the watch
+            // stream, so it lets consumers detect restarts they'd otherwise miss
+            // by only sampling the ready/not-ready status.
+            let restart_count = pod
+                .status
+                .as_ref()
+                .and_then(|status| status.container_statuses.as_ref())
+                .map(|container_statuses| {
+                    container_statuses
+                        .iter()
+                        .map(|cs| u64::try_from(cs.restart_count).unwrap_or(0))
+                        .sum()
+                })
+                .unwrap_or(0);
+
             let (pod_ready, last_probe_time) = pod
                 .status
                 .and_then(|status| status.conditions)
@@ -1364,6 +1380,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 service_id,
                 process_id,
                 status,
+                restart_count,
                 time: DateTime::from_timestamp_nanos(
                     time.as_nanosecond().try_into().expect("must fit"),
                 ),

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -379,8 +379,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                         service_id: service_id.clone(),
                         process_id: u64::cast_from(process_id),
                         status: process_state.status.into(),
-                        // The process orchestrator does not track restart counts.
-                        restart_count: 0,
+                        restart_count: process_state.restart_count,
                         time: process_state.status_time,
                     });
                 }
@@ -698,6 +697,7 @@ impl OrchestratorWorker {
                     _handle: handle.abort_on_drop(),
                     status: ProcessStatus::NotReady,
                     status_time: Utc::now(),
+                    restart_count: 0,
                     labels: labels.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
                     tcp_proxy_addrs,
                 });
@@ -1149,14 +1149,21 @@ impl ProcessStateUpdater {
             return;
         };
         let status_time = Utc::now();
+        // Count each transition to NotReady as a restart. The process
+        // orchestrator always relaunches a process that exits, so a death is a
+        // restart. This is monotonic for a given `ProcessState` and changes on
+        // every restart, which is what the 0dt caught-up check needs. It only
+        // resets to zero if the whole service is dropped and recreated.
+        if matches!(status, ProcessStatus::NotReady) {
+            process_state.restart_count += 1;
+        }
         process_state.status = status;
         process_state.status_time = status_time;
         let _ = self.service_event_tx.send(ServiceEvent {
             service_id: self.id.to_string(),
             process_id: u64::cast_from(self.i),
             status: status.into(),
-            // The process orchestrator does not track restart counts.
-            restart_count: 0,
+            restart_count: process_state.restart_count,
             time: status_time,
         });
     }
@@ -1167,6 +1174,9 @@ struct ProcessState {
     _handle: AbortOnDropHandle<()>,
     status: ProcessStatus,
     status_time: DateTime<Utc>,
+    /// Number of times this process has died and been relaunched. Monotonic for
+    /// the lifetime of this `ProcessState`. See [`ProcessStateUpdater::update_state`].
+    restart_count: u64,
     labels: BTreeMap<String, String>,
     tcp_proxy_addrs: BTreeMap<String, SocketAddr>,
 }

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -379,6 +379,8 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                         service_id: service_id.clone(),
                         process_id: u64::cast_from(process_id),
                         status: process_state.status.into(),
+                        // The process orchestrator does not track restart counts.
+                        restart_count: 0,
                         time: process_state.status_time,
                     });
                 }
@@ -1153,6 +1155,8 @@ impl ProcessStateUpdater {
             service_id: self.id.to_string(),
             process_id: u64::cast_from(self.i),
             status: status.into(),
+            // The process orchestrator does not track restart counts.
+            restart_count: 0,
             time: status_time,
         });
     }

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -93,6 +93,11 @@ pub struct ServiceEvent {
     pub service_id: String,
     pub process_id: u64,
     pub status: ServiceStatus,
+    /// Cumulative number of times the underlying process has restarted, as
+    /// reported by the orchestrator. Monotonic for the lifetime of a process,
+    /// but can reset (e.g. when a pod is recreated). Orchestrators that don't
+    /// track restarts report 0.
+    pub restart_count: u64,
     pub time: DateTime<Utc>,
 }
 

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -12,6 +12,7 @@ Explicit deterministic tests for read-only mode and zero downtime deploys (same
 version, no upgrade).
 """
 
+import json
 import time
 from datetime import datetime, timedelta
 from textwrap import dedent
@@ -2865,6 +2866,148 @@ def workflow_stuck_collection(c: Composition) -> None:
     )
 
     c.up("mz_new")
+    c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+    c.promote_mz("mz_new")
+    c.await_mz_deployment_status(DeploymentStatus.IS_LEADER, "mz_new", sleep_time=None)
+
+
+def workflow_caught_up_stability(c: Composition) -> None:
+    """Verify the 0dt caught-up stability gate end-to-end.
+
+    With a non-trivial stability period, a healthy deployment must still reach
+    ReadyToPromote (the gate does not deadlock healthy clusters) and can be
+    promoted to leader. The gate's reset-on-unhealthy behavior is hard to
+    reproduce deterministically here, so it is covered by adapter unit tests
+    that drive synthetic replica-health transitions directly.
+    """
+
+    c.down(destroy_volumes=True)
+
+    c.up("mz_old")
+
+    # Require clusters to stay caught-up and healthy for a while before we cut
+    # over. mz_new reads this from the shared catalog.
+    c.sql(
+        "ALTER SYSTEM SET with_0dt_caught_up_check_stability_period = '20s'",
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    c.sql(
+        """
+        CREATE TABLE t (a int);
+        CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+        CREATE INDEX mv_idx ON mv (a);
+        INSERT INTO t VALUES (1), (2), (3);
+        """,
+        service="mz_old",
+    )
+
+    c.up("mz_new")
+    c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+    c.promote_mz("mz_new")
+    c.await_mz_deployment_status(DeploymentStatus.IS_LEADER, "mz_new", sleep_time=None)
+
+
+def _leader_status(c: Composition, mz_service: str) -> str:
+    """Reads the current leader-promotion status of *mz_service*."""
+    return json.loads(
+        c.exec(
+            mz_service,
+            "curl",
+            "-s",
+            "localhost:6878/api/leader/status",
+            capture=True,
+            silent=True,
+        ).stdout
+    )["status"]
+
+
+def workflow_caught_up_stability_crash_loop(c: Composition) -> None:
+    """Verify the stability gate blocks cutover while a replica crash-loops.
+
+    A cluster with two replicas hosts a materialized view. One of mz_new's
+    replicas is repeatedly killed while the other stays healthy, so the cluster
+    keeps hydrating and counts as caught-up. Because it is caught-up, a
+    point-in-time check would see it ready and cut over into the crashing
+    replica. The stability gate must refuse while any replica is unhealthy, and
+    report ready only once the killed replica recovers and stays healthy for the
+    stability period.
+    """
+
+    c.down(destroy_volumes=True)
+
+    c.up("mz_old")
+
+    c.sql(
+        "ALTER SYSTEM SET with_0dt_caught_up_check_stability_period = '15s'",
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    c.sql(
+        """
+        CREATE CLUSTER crashy SIZE 'scale=1,workers=1', REPLICATION FACTOR 2;
+        CREATE TABLE t (a int);
+        CREATE MATERIALIZED VIEW mv IN CLUSTER crashy AS SELECT * FROM t;
+        CREATE INDEX mv_idx IN CLUSTER crashy ON mv (a);
+        INSERT INTO t VALUES (1), (2), (3);
+        """,
+        service="mz_old",
+    )
+
+    # Target a single replica of `crashy` so the cluster stays caught-up on the
+    # other one. Replica IDs come from the shared catalog, so they match across
+    # generations. We kill the matching child process inside mz_new's container.
+    replica_id = c.sql_query(
+        "SELECT r.id FROM mz_cluster_replicas r JOIN mz_clusters c ON c.id = r.cluster_id "
+        "WHERE c.name = 'crashy' ORDER BY r.name LIMIT 1",
+        service="mz_old",
+    )[0][0]
+
+    c.up("mz_new")
+
+    # SIGKILL the replica's clusterd repeatedly. The process orchestrator
+    # relaunches it ~5s later, producing Online/Offline flapping. SIGKILL is not
+    # classified as a crash, so it's safe with the default propagate_crashes.
+    crash_until = time.time() + 60
+
+    def crash_loop() -> None:
+        while time.time() < crash_until:
+            c.exec(
+                "mz_new",
+                "bash",
+                "-c",
+                f"ps aux | grep -v grep | grep -w 'replica_id={replica_id}' "
+                f"| awk '{{print $2}}' | xargs -r kill -9 || true",
+            )
+            time.sleep(3)
+
+    crasher = Thread(target=crash_loop)
+    crasher.start()
+    try:
+        # While a replica is crash-looping, mz_new must never report ready. The
+        # surviving replica hydrates the tiny view within seconds, so the cluster
+        # is caught-up almost immediately. Without the gate, mz_new would promote
+        # within a check interval. The status endpoint may not answer in the
+        # first moments after boot, so we only assert once we read a status.
+        deadline = time.time() + 45
+        while time.time() < deadline:
+            try:
+                status = _leader_status(c, "mz_new")
+            except Exception:
+                time.sleep(2)
+                continue
+            assert (
+                status == DeploymentStatus.INITIALIZING.value
+            ), f"mz_new reached status {status} while a replica was crash-looping"
+            time.sleep(2)
+    finally:
+        crasher.join()
+
+    # The replica recovers. After the stability period mz_new becomes ready.
     c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
     c.promote_mz("mz_new")
     c.await_mz_deployment_status(DeploymentStatus.IS_LEADER, "mz_new", sleep_time=None)

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -224,6 +224,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     default_timestamp_interval
     disallow_unmaterializable_functions_as_of
     enable_0dt_caught_up_replica_status_check
+    enable_0dt_caught_up_stability_check
     enable_0dt_deployment_panic_after_timeout
     enable_alter_table_add_column
     enable_binary_date_bin
@@ -417,6 +418,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     webhooks_secrets_caching_ttl_secs
     with_0dt_caught_up_check_allowed_lag
     with_0dt_caught_up_check_cutoff
+    with_0dt_caught_up_check_stability_period
     with_0dt_deployment_ddl_check_interval
     """.split())
 


### PR DESCRIPTION
### Motivation

During a zero-downtime upgrade, the new `environmentd` boots read-only and
reports "ready to promote" once its clusters look caught-up. The caught-up
check was a point-in-time check, so a crash/OOM-looping replica that briefly
reached a hydrated, caught-up state could trip the check, and we would cut over
right into a crashing replica.

The existing OOM-loop detection reads `mz_cluster_replica_status_history`, which
in read-only mode reflects the leader's (old version's) replicas, not the new
version's own replicas. The new version's replica health only lives in the
in-memory mirror fed by the orchestrator watch.

Implements https://linear.app/materializeinc/issue/SQL-416

### Description

Adds a per-cluster stability gate to the 0dt caught-up check. Once a cluster is
genuinely caught-up, it must stay caught-up and have all replicas healthy for a
configurable period before we report ready. Any disruption resets the streak,
so a crash-looping replica never accumulates the required stable time.

- Classify clusters three ways: `CaughtUp` (health-gated), `Ignored`
  (zero-replica, or hopelessly behind with only looping replicas, which
  preserves the existing behavior of ignoring clusters already unhealthy in the
  leader), and `NotCaughtUp`.
- Detect disruptions from the in-memory mirror three ways: a replica not
  currently `Online`, the per-process status-change time advancing between
  ticks (a flap that resolved between samples), and per-process restart counts
  changing. Restart counts are newly plumbed from the orchestrator
  (`ServiceEvent` to `ClusterEvent` to `ClusterReplicaProcessStatus`) because
  they survive gaps in the orchestrator watch that the status stream can drop.
  We track them per `(replica, process)` rather than as a cluster-wide sum, so
  offsetting changes across processes (one restarting while another is
  recreated) can't cancel out and hide a restart. Kubernetes reports
  per-container restart counts. The process orchestrator now tracks its own
  counts by treating each process death as a restart.
- All new gate state lives in the caught-up check task. The only out-of-band
  change is mirroring the restart count, which `message_cluster_event` now
  records even when the rolled-up status is unchanged (without writing the
  status history or firing notices for restart-only changes).
- New dyncfgs `with_0dt_caught_up_check_stability_period` (default 10min) and
  `enable_0dt_caught_up_stability_check` (break-glass). The mzcompose test
  default is `0s` so the existing 0dt suite isn't slowed; dedicated workflows
  set a real period.

Points worth discussing in review:

- **Default period of 10 minutes** is a starting point, open to bikeshedding.
  It is bounded by `with_0dt_deployment_max_wait`, so the gate cannot wedge a
  deploy forever.
- **User-facing effect**: a healthy 0dt deploy now waits the stability period
  after catching up before promoting (previously seconds). Tunable via the new
  dyncfg.
- **`all_healthy` is a new cutover policy**, active whenever the check is
  enabled (including tests at period `0s`): a `CaughtUp` cluster now also
  requires every replica to be `Online`. A cluster hydrated on one replica with
  another permanently down no longer promotes until `max_wait`. This is
  intentional.
- The change spans several areas (adapter, controller, catalog, orchestrator),
  because the restart-count signal is only meaningful together with its
  consumer. Happy to split if reviewers prefer.

### Verification

- Adapter unit tests for the gate state machine (`ClusterStabilityState::observe`):
  sustained-health promotes, a currently-unhealthy tick resets, a sub-tick
  status flap resets, a restart-count bump with unchanged status resets,
  offsetting per-process restart changes that net to zero still reset the
  streak, and the zero-period case.
- Two `test/0dt` mzcompose workflows:
  - `workflow_caught_up_stability`: a healthy deploy with a real stability
    period still reaches `ReadyToPromote` and `IsLeader` (no deadlock).
  - `workflow_caught_up_stability_crash_loop`: a two-replica cluster where one
    of mz_new's replicas is SIGKILL-looped while the other stays healthy. The
    cluster is caught-up via the survivor, so a point-in-time check would
    promote, but the gate keeps mz_new in `Initializing` until the killed
    replica recovers and stays healthy for the period.
- `cargo fmt`, `cargo check`, `cargo clippy`, and `bin/lint-test-flags` pass
  locally.

