### PR TITLE
console: only surface auth errors from active sign-in attempts

### DIFF
--- a/console/src/components/Alert.tsx
+++ b/console/src/components/Alert.tsx
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+import { CloseIcon } from "@chakra-ui/icons";
 import {
   Box,
   BoxProps,
@@ -14,6 +15,7 @@ import {
   ButtonProps,
   Heading,
   HStack,
+  IconButton,
   StackProps,
   Text,
   useTheme,
@@ -36,6 +38,8 @@ export interface AlertProps extends BoxProps {
   showButton?: boolean;
   buttonText?: string;
   buttonProps?: ButtonProps & Partial<LinkProps>;
+  /** When set, renders a dismiss (X) button that calls this on click. */
+  onClose?: () => void;
 }
 
 function getColorScheme(
@@ -72,6 +76,7 @@ export const Alert = forwardRef(
       showButton = false,
       buttonText = "View details",
       buttonProps = {},
+      onClose,
       ...props
     }: AlertProps,
     ref,
@@ -128,6 +133,16 @@ export const Alert = forwardRef(
                   {buttonText}
                 </Button>
               </Box>
+            ) : null}
+            {onClose ? (
+              <IconButton
+                aria-label="Dismiss"
+                icon={<CloseIcon boxSize={3} />}
+                variant="ghost"
+                size="sm"
+                color={colors.foreground.secondary}
+                onClick={onClose}
+              />
             ) : null}
           </HStack>
         </Box>

--- a/console/src/platform/auth/Login.tsx
+++ b/console/src/platform/auth/Login.tsx
@@ -21,7 +21,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useMutation } from "@tanstack/react-query";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
@@ -197,10 +197,21 @@ const SsoLoginLink = () => {
 };
 
 export const Login = () => {
-  const [searchParams] = useSearchParams();
   const { data: auth, error: oidcInitializationError } = useOidcManagerQuery();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const oidcError = searchParams.get(LOGIN_ERROR_PARAM);
+  // Surface the one-shot auth error from the redirect, then strip it from the
+  // URL so it doesn't reappear on refresh or back navigation.
+  const [oidcError, setOidcError] = useState<string | null>(() =>
+    searchParams.get(LOGIN_ERROR_PARAM),
+  );
+
+  useEffect(() => {
+    if (!searchParams.has(LOGIN_ERROR_PARAM)) return;
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete(LOGIN_ERROR_PARAM);
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   return (
     <AuthLayout>
@@ -210,7 +221,13 @@ export const Login = () => {
             <MaterializeLogo height="12" />
           </HStack>
           {oidcError && (
-            <Alert variant="error" minWidth="100%" message={oidcError} mb="4" />
+            <Alert
+              variant="error"
+              minWidth="100%"
+              message={oidcError}
+              mb="4"
+              onClose={() => setOidcError(null)}
+            />
           )}
           {oidcInitializationError && (
             <Alert


### PR DESCRIPTION
Auth errors were sticky on the login page across refresh and back navigation. Clear out the url param and make the error banner dismissable 
<img width="2690" height="1402" alt="image" src="https://github.com/user-attachments/assets/c3c34caf-3736-4f7b-97fc-534a221ce51a" />

Fixes [CNS-88](https://linear.app/materializeinc/issue/CNS-88/sso-error-persisting-on-page-reload)
