### PR TITLE
[SS-319] hydrating Iceberg sinks should immediately mint a batch for `as_of`

### DIFF
--- a/src/storage/src/sink/iceberg.rs
+++ b/src/storage/src/sink/iceberg.rs
@@ -1281,35 +1281,39 @@ where
                         }
                     }
 
-                    // We only start minting after we've reached as_of and resume_upper to avoid
-                    // minting batches that would be immediately skipped.
+                    // If we aren't hydrating from a source snapshot (i.e. resume_upper = minimum),
+                    // don't mint batches until the frontier advances to where there's data.
+                    // N.B. When resume_upper = minimum, this condition cannot be satisfied.
                     if PartialOrder::less_than(&observed_frontier, &resume_upper)
-                        || PartialOrder::less_than(&observed_frontier, &as_of)
                     {
                         continue;
                     }
 
-                    let mut batch_descriptions = vec![];
-                    let mut current_upper = observed_frontier.clone();
-                    let current_upper_ts = current_upper.as_option().expect("frontier not empty").clone();
+                    let (batch_lower, current_upper_ts) =
+                    if *resume_upper == [Timestamp::minimum()] {
+                        // We're hydrating from the source snapshot.
+                        // Start from a batch that just contains 'as_of'.
+                        let batch_lower = as_of.clone();
+                        let batch_upper_ts = as_of.as_option().expect("as_of not empty").clone().step_forward();
 
-                    // Create a catch-up batch from the later of resume_upper or as_of to current frontier.
-                    // We use the later of the two because:
-                    // - For fresh sinks: resume_upper = minimum, as_of = actual timestamp, data starts at as_of
-                    // - For resuming: as_of <= resume_upper (enforced by overcompaction check), data starts at resume_upper
-                    let batch_lower = if PartialOrder::less_than(&resume_upper, &as_of) {
-                        as_of.clone()
+                        (batch_lower, batch_upper_ts)
                     } else {
-                        resume_upper.clone()
+                        // We are a resuming sink. Data (ergo, batches) starts at 'resume_upper'.
+                        // N.B. When resuming, as_of <= resume_upper (enforced by overcompaction check).
+                        let batch_lower = resume_upper.clone();
+                        let mut batch_upper_ts = observed_frontier.as_option().expect("frontier not empty").clone();
+                        if batch_lower == Antichain::from_elem(batch_upper_ts) {
+                            // We enforce that 'batch_upper = observed_frontier' is not less than 'resume_upper'.
+                            // But they could be equal. Make sure the first batch includes at least one timestamp.
+                            batch_upper_ts = batch_upper_ts.step_forward();
+                        }
+
+                        (batch_lower, batch_upper_ts)
                     };
 
-                    if batch_lower == current_upper {
-                        // Snapshot! as_of is exactly at the frontier. We still need to mint
-                        // a batch to create the snapshot, so we step the upper forward by one.
-                        current_upper = Antichain::from_elem(current_upper_ts.step_forward());
-                    }
+                    let mut batch_descriptions = vec![];
 
-                    let batch_description = (batch_lower.clone(), current_upper.clone());
+                    let mut current_upper = Antichain::from_elem(current_upper_ts);
                     debug!(
                         ?sink_id,
                         %name_for_logging,
@@ -1323,7 +1327,8 @@ where
                         batch_lower.pretty(),
                         current_upper.pretty()
                     );
-                    batch_descriptions.push(batch_description);
+                    batch_descriptions.push((batch_lower.clone(), current_upper.clone()));
+
                     // Mint initial future batch descriptions at configurable intervals
                     for i in 1..INITIAL_DESCRIPTIONS_TO_MINT {
                         let duration_millis = commit_interval.as_millis()

--- a/test/canary-environment/README.md
+++ b/test/canary-environment/README.md
@@ -99,13 +99,13 @@ the split clusters are new), so the `USAGE` grants are reapplied on every
   granted in the testdrive block of `workflow_create`, since mz-deploy has no
   cluster-grant modifier and doesn't manage those schemas.
 
-**TODO: Reenable when SS-282 is fixed.** The Iceberg sinks are currently
-disabled because they OOM the `qa_canary_environment_sinks` cluster during
-hydration. The ten model sinks are renamed to `*.sql.disabled` (mz-deploy only
-reads `*.sql`, so it skips them) and the two testdrive `public_table.table_mv`
-Iceberg sinks are commented out. Only the Kafka sinks are active. To re-enable,
-rename the `.sql.disabled` files back to `.sql` and uncomment the testdrive
-sinks in `mzcompose.py`.
+**Iceberg sinks: AWS/S3-Tables enabled, GCS still disabled.** The five
+S3-Tables model sinks and the `public_table.table_mv_iceberg_sink` testdrive
+sink are active. The five `*_gcs_iceberg_sink` model sinks remain
+`*.sql.disabled` (mz-deploy only reads `*.sql`, so it skips them) and the
+`table_mv_gcs_iceberg_sink` testdrive sink is left out of `mzcompose.py`. To
+re-enable a GCS sink, rename its `.sql.disabled` file back to `.sql` (and add
+the testdrive sink back to `mzcompose.py`).
 
 ## What `mz-deploy` does not manage
 

--- a/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/customer_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/customer_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK mysql_wmr_iceberg_sink
+CREATE SINK customer_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_mysql_cdc.mysql_wmr
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'mysql_wmr')
+    FROM qa_canary_environment.public_loadgen_sources.customer_tbl
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'customer')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (a_name, b_name) NOT ENFORCED
+    KEY (key)
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/sales_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/sales_iceberg_sink.sql
@@ -7,7 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
 CREATE SINK sales_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
     FROM qa_canary_environment.public_loadgen_sources.sales_tbl

--- a/test/canary-environment/models/qa_canary_environment/public_mysql_cdc_sources/mysql_wmr_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_mysql_cdc_sources/mysql_wmr_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK tpch_q18_iceberg_sink
+CREATE SINK mysql_wmr_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_tpch.tpch_q18
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'tpch_18')
+    FROM qa_canary_environment.public_mysql_cdc.mysql_wmr
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'mysql_wmr')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (c_custkey) NOT ENFORCED
+    KEY (a_name, b_name) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/models/qa_canary_environment/public_pg_cdc_sources/pg_relationships_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_pg_cdc_sources/pg_relationships_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK customer_iceberg_sink
+CREATE SINK pg_relationships_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_loadgen_sources.customer_tbl
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'customer')
+    FROM qa_canary_environment.public_pg_cdc_sources.pg_relationships
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'pg_relationships')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (key)
+    KEY (a, b) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/models/qa_canary_environment/public_tpch_sources/tpch_q18_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_tpch_sources/tpch_q18_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK pg_relationships_iceberg_sink
+CREATE SINK tpch_q18_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_pg_cdc_sources.pg_relationships
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'pg_relationships')
+    FROM qa_canary_environment.public_tpch.tpch_q18
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'tpch_18')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (a, b) NOT ENFORCED
+    KEY (c_custkey) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -439,11 +439,17 @@ def workflow_create(c: Composition, parser: WorkflowArgumentParser) -> None:
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION public.csr_connection
               ENVELOPE DEBEZIUM
 
-            # TODO: Reenable when SS-282 is fixed
-            # The public_table.table_mv Iceberg sinks (table_mv_iceberg_sink,
-            # table_mv_gcs_iceberg_sink) are disabled — the Iceberg sinks OOM the
-            # sinks cluster during hydration. See the disabled .sql.disabled
-            # sink models under models/ for the rest.
+            > CREATE SINK IF NOT EXISTS public_table.table_mv_iceberg_sink
+              IN CLUSTER qa_canary_environment_sinks
+              FROM public_table.table_mv
+              INTO ICEBERG CATALOG CONNECTION public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'table_mv')
+              USING AWS CONNECTION public.qa_canary_aws_connection
+              MODE APPEND
+              WITH (COMMIT INTERVAL = '60s')
+
+            # The GCS Iceberg sink (table_mv_gcs_iceberg_sink) stays disabled, as
+            # do the *_gcs_iceberg_sink.sql.disabled model sinks. Only the
+            # AWS/S3-Tables Iceberg sinks are enabled.
 
             # Seed data for the loadgen product/category tables (created by `apply`).
             > DELETE FROM public_loadgen_sources.product_category


### PR DESCRIPTION
Hydrating Iceberg sinks currently wait until after they've read the entire source snapshot to mint a batch description and start writing. This means they accumulate the entire source snapshot in memory.

This PR allows Iceberg sinks to immediately mint a batch description for the source snapshot so they can flush to the writer instead of accumulating everything in memory.