### PR TITLE
console: add oauth mcp connect instructions

### DIFF
--- a/console/src/components/ConnectInstructions.tsx
+++ b/console/src/components/ConnectInstructions.tsx
@@ -31,6 +31,8 @@ export interface ConnectInstructionsProps extends BoxProps {
   environmentdAddress?: string;
   /** Override the query params in the psql connection string. */
   psqlQueryParams?: string;
+  /** Self-managed deployment with OIDC enabled; gets the browser OAuth flow. */
+  oidcEnabled?: boolean;
   /** Pre-computed Base64 token for MCP configuration (cloud only). */
   mcpBase64Token?: string;
   /** Called when the active tab changes. */
@@ -44,6 +46,7 @@ export interface ConnectInstructionsProps extends BoxProps {
 const ConnectInstructions = ({
   user,
   onTabChange,
+  oidcEnabled,
   mcpBase64Token,
   onGenerateToken,
   isGeneratingToken,
@@ -134,6 +137,7 @@ const ConnectInstructions = ({
           children: (
             <McpConnectInstructions
               userStr={userStr}
+              oidcEnabled={oidcEnabled}
               mcpBase64Token={mcpBase64Token}
               onGenerateToken={onGenerateToken}
               isGeneratingToken={isGeneratingToken}

--- a/console/src/components/McpConnectInstructions.tsx
+++ b/console/src/components/McpConnectInstructions.tsx
@@ -21,7 +21,10 @@ import React from "react";
 
 import { useAppConfig } from "~/config/useAppConfig";
 import docUrls from "~/mz-doc-urls.json";
-import { currentEnvironmentState } from "~/store/environments";
+import {
+  currentEnvironmentState,
+  useEnvironmentGate,
+} from "~/store/environments";
 import { MaterializeTheme } from "~/theme";
 import { obfuscateSecret } from "~/utils/format";
 
@@ -34,6 +37,8 @@ import TextLink from "./TextLink";
 
 interface McpConnectInstructionsProps extends BoxProps {
   userStr: string;
+  /** Self-managed deployment with OIDC enabled; gets the browser OAuth flow. */
+  oidcEnabled?: boolean;
   /** Pre-computed Base64 token for MCP configuration (cloud only). */
   mcpBase64Token?: string;
   /** Callback to generate a new MCP token (creates an app password). */
@@ -44,6 +49,7 @@ interface McpConnectInstructionsProps extends BoxProps {
 
 const McpConnectInstructions = ({
   userStr,
+  oidcEnabled = false,
   mcpBase64Token,
   onGenerateToken,
   isGeneratingToken,
@@ -53,6 +59,13 @@ const McpConnectInstructions = ({
   const [currentEnvironment] = useAtom(currentEnvironmentState);
   const appConfig = useAppConfig();
   const isCloud = appConfig.mode === "cloud";
+  // Envs >= 26.30.0 advertise OAuth via RFC 9728, so MCP clients log in through
+  // the browser instead of using a Basic-auth token. Applies to cloud (Frontegg)
+  // and self-managed with OIDC. The version must match region-controller's gate
+  // for `--frontegg-oauth-issuer-url` (precedence >= 26.30.0). Older/pre-release
+  // envs, and self-managed without OIDC, stay on the token flow.
+  const oauthAvailable =
+    useEnvironmentGate("26.30.0") === true && (isCloud || oidcEnabled);
 
   const envAddress =
     currentEnvironment?.state === "enabled"
@@ -74,8 +87,80 @@ const McpConnectInstructions = ({
   const user = userStr || "<user>";
   const base64Command = `printf '${user}:<password>' | base64 -w0`;
 
-  const claudeCodeCliCommand = (ep: "agent" | "developer") =>
+  const oauthCommand = (ep: "agent" | "developer") =>
+    `claude mcp add --transport http "materialize-${ep}" \\\n  "${baseUrl}/api/mcp/${ep}"`;
+  const tokenCommand = (ep: "agent" | "developer") =>
     `claude mcp add --transport http "materialize-${ep}" \\\n  "${baseUrl}/api/mcp/${ep}" \\\n  --header "Authorization: Basic <mcp-token>"`;
+
+  // App-password / token acquisition steps, shared by every endpoint that
+  // offers the token method (the Agent tab always, the Developer tab only when
+  // OAuth is unavailable).
+  const tokenInstructions = (
+    <VStack alignItems="stretch" spacing="4">
+      {isCloud && onGenerateToken && (
+        <VStack alignItems="stretch" spacing="4">
+          <Text fontSize="sm" color={colors.foreground.secondary}>
+            Generate a new token:
+          </Text>
+          {isGeneratingToken ? (
+            <Flex alignItems="center" color={colors.foreground.secondary}>
+              <Spinner size="sm" mr={2} />
+              <Text fontSize="sm">Generating token...</Text>
+            </Flex>
+          ) : mcpBase64Token ? (
+            <VStack alignItems="stretch" spacing="1">
+              <SecretCopyableBox
+                label="mcpToken"
+                contents={mcpBase64Token}
+                obfuscatedContent={obfuscateSecret(mcpBase64Token)}
+                overflow="hidden"
+                minWidth={0}
+              />
+              <Text
+                fontSize="xs"
+                color={colors.foreground.secondary}
+                lineHeight="tall"
+              >
+                Copy this somewhere safe. Tokens cannot be displayed after
+                initial creation.
+              </Text>
+            </VStack>
+          ) : (
+            <>
+              <Button
+                onClick={onGenerateToken}
+                variant="primary"
+                size="sm"
+                alignSelf="flex-start"
+              >
+                Generate personal MCP token
+              </Button>
+              <Text fontSize="xs" color={colors.foreground.secondary}>
+                For service accounts, create a{" "}
+                <TextLink href="/access/app-passwords">
+                  service app password
+                </TextLink>{" "}
+                and Base64-encode it below.
+              </Text>
+            </>
+          )}
+        </VStack>
+      )}
+
+      <VStack alignItems="stretch" spacing="2">
+        {isCloud ? (
+          <Text fontSize="sm" color={colors.foreground.secondary}>
+            Or Base64-encode an existing app password:
+          </Text>
+        ) : (
+          <Text fontSize="sm" color={colors.foreground.secondary}>
+            Base64-encode your username and password:
+          </Text>
+        )}
+        <CopyableBox variant="default" contents={base64Command} />
+      </VStack>
+    </VStack>
+  );
 
   return (
     <VStack alignItems="stretch" spacing="6" p="6" {...props}>
@@ -85,75 +170,7 @@ const McpConnectInstructions = ({
       </Text>
 
       <VStack alignItems="stretch" spacing="4">
-        <Text textStyle="heading-xs">1. Get your MCP token</Text>
-
-        {isCloud && onGenerateToken && (
-          <VStack alignItems="stretch" spacing="4">
-            <Text fontSize="sm" color={colors.foreground.secondary}>
-              Generate a new token:
-            </Text>
-            {isGeneratingToken ? (
-              <Flex alignItems="center" color={colors.foreground.secondary}>
-                <Spinner size="sm" mr={2} />
-                <Text fontSize="sm">Generating token...</Text>
-              </Flex>
-            ) : mcpBase64Token ? (
-              <VStack alignItems="stretch" spacing="1">
-                <SecretCopyableBox
-                  label="mcpToken"
-                  contents={mcpBase64Token}
-                  obfuscatedContent={obfuscateSecret(mcpBase64Token)}
-                  overflow="hidden"
-                  minWidth={0}
-                />
-                <Text
-                  fontSize="xs"
-                  color={colors.foreground.secondary}
-                  lineHeight="tall"
-                >
-                  Copy this somewhere safe. Tokens cannot be displayed after
-                  initial creation.
-                </Text>
-              </VStack>
-            ) : (
-              <>
-                <Button
-                  onClick={onGenerateToken}
-                  variant="primary"
-                  size="sm"
-                  alignSelf="flex-start"
-                >
-                  Generate personal MCP token
-                </Button>
-                <Text fontSize="xs" color={colors.foreground.secondary}>
-                  For service accounts, create a{" "}
-                  <TextLink href="/access/app-passwords">
-                    service app password
-                  </TextLink>{" "}
-                  and Base64-encode it below.
-                </Text>
-              </>
-            )}
-          </VStack>
-        )}
-
-        <VStack alignItems="stretch" spacing="2">
-          {isCloud && (
-            <Text fontSize="sm" color={colors.foreground.secondary}>
-              Or Base64-encode an existing app password:
-            </Text>
-          )}
-          {!isCloud && (
-            <Text fontSize="sm" color={colors.foreground.secondary}>
-              Base64-encode your username and password:
-            </Text>
-          )}
-          <CopyableBox variant="default" contents={base64Command} />
-        </VStack>
-      </VStack>
-
-      <VStack alignItems="stretch" spacing="4">
-        <Text textStyle="heading-xs">2. Connect your client</Text>
+        <Text textStyle="heading-xs">Connect your client</Text>
         <Text fontSize="sm" color={colors.foreground.secondary}>
           See the{" "}
           <TextLink
@@ -172,32 +189,83 @@ const McpConnectInstructions = ({
             {
               title: "Agent",
               children: (
-                <VStack alignItems="stretch" spacing="3" p="4">
+                <VStack alignItems="stretch" spacing="4" p="4">
                   <Text fontSize="xs" color={colors.foreground.secondary}>
                     Expose real-time data products to AI agents via
-                    Materialize&apos;s built-in MCP endpoint.
+                    Materialize&apos;s built-in MCP endpoint. Used by both
+                    service accounts and signed-in users.
                   </Text>
-                  <CopyableBox
-                    variant="default"
-                    wrap
-                    contents={claudeCodeCliCommand("agent")}
-                  />
+
+                  {oauthAvailable && (
+                    <VStack alignItems="stretch" spacing="2">
+                      <Text textStyle="heading-xs">
+                        Sign in with your account
+                      </Text>
+                      <CopyableBox
+                        variant="default"
+                        wrap
+                        contents={oauthCommand("agent")}
+                      />
+                      <Text fontSize="xs" color={colors.foreground.secondary}>
+                        Your browser opens to sign in to Materialize.
+                      </Text>
+                    </VStack>
+                  )}
+
+                  <VStack alignItems="stretch" spacing="4">
+                    {oauthAvailable && (
+                      <Text textStyle="heading-xs">
+                        Or use a service account
+                      </Text>
+                    )}
+                    {tokenInstructions}
+                    <CopyableBox
+                      variant="default"
+                      wrap
+                      contents={tokenCommand("agent")}
+                    />
+                  </VStack>
                 </VStack>
               ),
             },
             {
               title: "Developer",
               children: (
-                <VStack alignItems="stretch" spacing="3" p="4">
+                <VStack alignItems="stretch" spacing="4" p="4">
                   <Text fontSize="xs" color={colors.foreground.secondary}>
                     Query Materialize system catalog tables for troubleshooting
                     and observability via the built-in MCP developer endpoint.
                   </Text>
-                  <CopyableBox
-                    variant="default"
-                    wrap
-                    contents={claudeCodeCliCommand("developer")}
-                  />
+
+                  {oauthAvailable ? (
+                    <VStack alignItems="stretch" spacing="2">
+                      <CopyableBox
+                        variant="default"
+                        wrap
+                        contents={oauthCommand("developer")}
+                      />
+                      <Text fontSize="xs" color={colors.foreground.secondary}>
+                        Your browser opens to sign in to Materialize. App
+                        passwords also work. See the{" "}
+                        <TextLink
+                          href={docUrls["/docs/integrations/mcp-server/"]}
+                          target="_blank"
+                        >
+                          documentation
+                        </TextLink>
+                        .
+                      </Text>
+                    </VStack>
+                  ) : (
+                    <VStack alignItems="stretch" spacing="4">
+                      {tokenInstructions}
+                      <CopyableBox
+                        variant="default"
+                        wrap
+                        contents={tokenCommand("developer")}
+                      />
+                    </VStack>
+                  )}
                 </VStack>
               ),
             },

--- a/console/src/components/OidcConnectModal.tsx
+++ b/console/src/components/OidcConnectModal.tsx
@@ -97,6 +97,7 @@ const OidcConnectModal = ({
               <ConnectInstructions
                 userStr={userStr}
                 environmentdAddress={sqlAddress}
+                oidcEnabled
               />
               <VStack alignItems="stretch" spacing={2}>
                 <Text textStyle="heading-xs">ID Token</Text>
@@ -118,7 +119,9 @@ const OidcConnectModal = ({
               tabs={[
                 {
                   title: "MCP Server",
-                  children: <McpConnectInstructions userStr={userStr} />,
+                  children: (
+                    <McpConnectInstructions userStr={userStr} oidcEnabled />
+                  ),
                   icon: <ConnectionIcon w="4" h="4" />,
                 },
               ]}


### PR DESCRIPTION
### Motivation
Adding oauth instructions for mcp connection in the console. Fixes [CNS-92](https://linear.app/materializeinc/issue/CNS-92/add-console-oauth-instructions-for-connect-modal) 
<img width="878" height="635" alt="image" src="https://github.com/user-attachments/assets/94203e63-ab4e-4b6f-a05f-d799b6b79440" />

Related to the cloud work: https://github.com/MaterializeInc/cloud/pull/12773