### PR TITLE
[SS-319, SS-282] hydrating Iceberg sinks should immediately mint a batch for `as_of`

### DIFF
--- a/src/storage/src/sink/iceberg.rs
+++ b/src/storage/src/sink/iceberg.rs
@@ -1223,6 +1223,25 @@ where
             // It's "sortedness" is derived from the monotonicity of batch descriptions,
             // and the fact that we only ever push new descriptions to the back and pop from the front.
             let mut minted_batches = VecDeque::new();
+
+            // Once we start seeing new data, we'll roll everything into a single catch-up commit
+            // before beginning the steady state commit interval.
+            let catchup_start = if *resume_upper == [Timestamp::minimum()] {
+                // If we're hydrating from a source snapshot, we immediately emit the snapshot's batch description.
+                let batch_upper = Antichain::from_elem(
+                    as_of.as_option().expect("as_of not empty").step_forward());
+                let batch = (as_of.clone(), batch_upper.clone());
+                minted_batches.push_back(batch.clone());
+                batch_desc_output.give(&capset[0], batch);
+                capset.downgrade(batch_upper.clone());
+
+                // The "catch-up" batch starts at the end of the snapshot batch.
+                batch_upper
+            } else {
+                // If we're resuming, the "catch-up" batch starts at the start of data, i.e. resume_upper.
+                resume_upper.clone()
+            };
+
             loop {
                 if let Some(event) = input.next().await {
                     match event {
@@ -1258,7 +1277,7 @@ where
                         // initialization. For example, a loadgen source configured for a finite
                         // dataset may emit all rows at time t and then immediately close. If we
                         // saw any data, synthesize an upper one tick past the maximum timestamp
-                        // so we can mint a snapshot batch and commit it.
+                        // so we can mint a catch-up batch and commit it.
                         if let Some(max_ts) = max_seen_ts.as_ref() {
                             let synthesized_upper =
                                 Antichain::from_elem(max_ts.step_forward());
@@ -1281,49 +1300,31 @@ where
                         }
                     }
 
-                    // We only start minting after we've reached as_of and resume_upper to avoid
-                    // minting batches that would be immediately skipped.
-                    if PartialOrder::less_than(&observed_frontier, &resume_upper)
-                        || PartialOrder::less_than(&observed_frontier, &as_of)
+                    // Don't make empty commits while we wait ^for the first data to be ready.
+                    // (^for the frontier to indicate there _could_ be data ready)
+                    if !PartialOrder::less_than(&catchup_start, &observed_frontier)
                     {
                         continue;
                     }
 
                     let mut batch_descriptions = vec![];
                     let mut current_upper = observed_frontier.clone();
-                    let current_upper_ts = current_upper.as_option().expect("frontier not empty").clone();
-
-                    // Create a catch-up batch from the later of resume_upper or as_of to current frontier.
-                    // We use the later of the two because:
-                    // - For fresh sinks: resume_upper = minimum, as_of = actual timestamp, data starts at as_of
-                    // - For resuming: as_of <= resume_upper (enforced by overcompaction check), data starts at resume_upper
-                    let batch_lower = if PartialOrder::less_than(&resume_upper, &as_of) {
-                        as_of.clone()
-                    } else {
-                        resume_upper.clone()
-                    };
-
-                    if batch_lower == current_upper {
-                        // Snapshot! as_of is exactly at the frontier. We still need to mint
-                        // a batch to create the snapshot, so we step the upper forward by one.
-                        current_upper = Antichain::from_elem(current_upper_ts.step_forward());
-                    }
-
-                    let batch_description = (batch_lower.clone(), current_upper.clone());
+                    let current_upper_ts = observed_frontier.as_option().expect("frontier not empty").clone();
                     debug!(
                         ?sink_id,
                         %name_for_logging,
-                        batch_lower = %batch_lower.pretty(),
+                        batch_lower = %catchup_start.pretty(),
                         current_upper = %current_upper.pretty(),
                         "iceberg mint initializing (catch-up batch)"
                     );
                     debug!(
                         "{}: creating catch-up batch [{}, {})",
                         name_for_logging,
-                        batch_lower.pretty(),
+                        catchup_start.pretty(),
                         current_upper.pretty()
                     );
-                    batch_descriptions.push(batch_description);
+                    batch_descriptions.push((catchup_start.clone(), current_upper.clone()));
+
                     // Mint initial future batch descriptions at configurable intervals
                     for i in 1..INITIAL_DESCRIPTIONS_TO_MINT {
                         let duration_millis = commit_interval.as_millis()

--- a/test/canary-environment/README.md
+++ b/test/canary-environment/README.md
@@ -99,13 +99,13 @@ the split clusters are new), so the `USAGE` grants are reapplied on every
   granted in the testdrive block of `workflow_create`, since mz-deploy has no
   cluster-grant modifier and doesn't manage those schemas.
 
-**TODO: Reenable when SS-282 is fixed.** The Iceberg sinks are currently
-disabled because they OOM the `qa_canary_environment_sinks` cluster during
-hydration. The ten model sinks are renamed to `*.sql.disabled` (mz-deploy only
-reads `*.sql`, so it skips them) and the two testdrive `public_table.table_mv`
-Iceberg sinks are commented out. Only the Kafka sinks are active. To re-enable,
-rename the `.sql.disabled` files back to `.sql` and uncomment the testdrive
-sinks in `mzcompose.py`.
+**Iceberg sinks: AWS/S3-Tables enabled, GCS still disabled.** The five
+S3-Tables model sinks and the `public_table.table_mv_iceberg_sink` testdrive
+sink are active. The five `*_gcs_iceberg_sink` model sinks remain
+`*.sql.disabled` (mz-deploy only reads `*.sql`, so it skips them) and the
+`table_mv_gcs_iceberg_sink` testdrive sink is left out of `mzcompose.py`. To
+re-enable a GCS sink, rename its `.sql.disabled` file back to `.sql` (and add
+the testdrive sink back to `mzcompose.py`).
 
 ## What `mz-deploy` does not manage
 

--- a/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/customer_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/customer_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK mysql_wmr_iceberg_sink
+CREATE SINK customer_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_mysql_cdc.mysql_wmr
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'mysql_wmr')
+    FROM qa_canary_environment.public_loadgen_sources.customer_tbl
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'customer')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (a_name, b_name) NOT ENFORCED
+    KEY (key)
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/sales_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/sales_iceberg_sink.sql
@@ -7,7 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
 CREATE SINK sales_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
     FROM qa_canary_environment.public_loadgen_sources.sales_tbl

--- a/test/canary-environment/models/qa_canary_environment/public_mysql_cdc_sources/mysql_wmr_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_mysql_cdc_sources/mysql_wmr_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK tpch_q18_iceberg_sink
+CREATE SINK mysql_wmr_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_tpch.tpch_q18
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'tpch_18')
+    FROM qa_canary_environment.public_mysql_cdc.mysql_wmr
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'mysql_wmr')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (c_custkey) NOT ENFORCED
+    KEY (a_name, b_name) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/models/qa_canary_environment/public_pg_cdc_sources/pg_relationships_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_pg_cdc_sources/pg_relationships_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK customer_iceberg_sink
+CREATE SINK pg_relationships_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_loadgen_sources.customer_tbl
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'customer')
+    FROM qa_canary_environment.public_pg_cdc_sources.pg_relationships
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'pg_relationships')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (key)
+    KEY (a, b) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/models/qa_canary_environment/public_tpch_sources/tpch_q18_iceberg_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_tpch_sources/tpch_q18_iceberg_sink.sql
@@ -7,12 +7,11 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
--- TODO: Reenable when SS-282 is fixed
-CREATE SINK pg_relationships_iceberg_sink
+CREATE SINK tpch_q18_iceberg_sink
     IN CLUSTER qa_canary_environment_sinks
-    FROM qa_canary_environment.public_pg_cdc_sources.pg_relationships
-    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'pg_relationships')
+    FROM qa_canary_environment.public_tpch.tpch_q18
+    INTO ICEBERG CATALOG CONNECTION qa_canary_environment.public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'tpch_18')
     USING AWS CONNECTION qa_canary_environment.public.qa_canary_aws_connection
-    KEY (a, b) NOT ENFORCED
+    KEY (c_custkey) NOT ENFORCED
     MODE UPSERT
     WITH (COMMIT INTERVAL = '60s');

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -439,11 +439,17 @@ def workflow_create(c: Composition, parser: WorkflowArgumentParser) -> None:
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION public.csr_connection
               ENVELOPE DEBEZIUM
 
-            # TODO: Reenable when SS-282 is fixed
-            # The public_table.table_mv Iceberg sinks (table_mv_iceberg_sink,
-            # table_mv_gcs_iceberg_sink) are disabled — the Iceberg sinks OOM the
-            # sinks cluster during hydration. See the disabled .sql.disabled
-            # sink models under models/ for the rest.
+            > CREATE SINK IF NOT EXISTS public_table.table_mv_iceberg_sink
+              IN CLUSTER qa_canary_environment_sinks
+              FROM public_table.table_mv
+              INTO ICEBERG CATALOG CONNECTION public.qa_canary_iceberg_catalog (NAMESPACE = 'qa_canary_environment', TABLE = 'table_mv')
+              USING AWS CONNECTION public.qa_canary_aws_connection
+              MODE APPEND
+              WITH (COMMIT INTERVAL = '60s')
+
+            # The GCS Iceberg sink (table_mv_gcs_iceberg_sink) stays disabled, as
+            # do the *_gcs_iceberg_sink.sql.disabled model sinks. Only the
+            # AWS/S3-Tables Iceberg sinks are enabled.
 
             # Seed data for the loadgen product/category tables (created by `apply`).
             > DELETE FROM public_loadgen_sources.product_category

--- a/test/iceberg/empty-source.td
+++ b/test/iceberg/empty-source.td
@@ -1,0 +1,65 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# A fresh Iceberg sink whose input finishes without producing any rows
+# is expected to commit an empty snapshot.
+# N.B. It would also be correct to make zero commits in this case.
+#      The important part is that the sink doesn't break.
+
+> CREATE SECRET empty_access_key_secret AS '${arg.s3-access-key}'
+
+> CREATE CONNECTION empty_polaris TO ICEBERG CATALOG (
+    CATALOG TYPE = 'REST',
+    URL = 'http://polaris:8181/api/catalog',
+    CREDENTIAL = 'root:root',
+    WAREHOUSE = 'default_catalog',
+    SCOPE = 'PRINCIPAL_ROLE:ALL'
+  );
+
+# A finite COUNTER generator with AS OF == UP TO produces zero rows and then
+# closes its frontier (data at offset >= UP TO is dropped; the generator
+# terminates at UP TO). This gives the sink a fresh input that closes having
+# seen no data.
+> CREATE SOURCE counter_src FROM LOAD GENERATOR COUNTER (AS OF 5, UP TO 5);
+
+> CREATE TABLE counter_tbl FROM SOURCE counter_src;
+
+> SELECT count(*) FROM counter_tbl
+0
+
+> CREATE SINK empty_demo
+    FROM counter_tbl
+    INTO ICEBERG CATALOG CONNECTION empty_polaris (
+        NAMESPACE 'default_namespace',
+        TABLE 'empty_source_table'
+    )
+    MODE APPEND
+    WITH (COMMIT INTERVAL '1s');
+
+# The sink must not stall or error.
+> SELECT error IS NULL FROM mz_internal.mz_sink_statuses WHERE name = 'empty_demo'
+true
+
+# Iceberg sinks commit asynchronously; wait for at least one commit interval.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
+
+$ duckdb-execute name=empty_iceberg
+CREATE SECRET s3_secret_empty (TYPE S3, KEY_ID 'tduser', SECRET '${arg.s3-access-key}', ENDPOINT '${arg.aws-endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'minio');
+SET unsafe_enable_version_guessing = true;
+
+# We successfully made our one commit. And it is empty.
+# A stalled sink would never have committed anything.
+$ duckdb-query name=empty_iceberg
+SELECT count(*) = 1 FROM iceberg_snapshots('s3://test-bucket/default_namespace/empty_source_table')
+true
+
+# The table should hold no data.
+$ duckdb-query name=empty_iceberg
+SELECT count(*) FROM iceberg_scan('s3://test-bucket/default_namespace/empty_source_table')
+0

--- a/test/iceberg/mzcompose.py
+++ b/test/iceberg/mzcompose.py
@@ -105,6 +105,18 @@ def workflow_mode_append(c: Composition) -> None:
     )
 
 
+def workflow_empty_source(c: Composition) -> None:
+    """A fresh Iceberg sink whose input closes after producing zero rows
+    commits one empty snapshot instead of stalling or erroring."""
+    key = _setup(c)
+
+    c.run_testdrive_files(
+        f"--var=s3-access-key={key}",
+        "--var=aws-endpoint=minio:9000",
+        "empty-source.td",
+    )
+
+
 def _polaris_get(table_url: str, access_token: str) -> dict:
     """GET table metadata from Polaris REST API (always returns latest)."""
     req = urllib.request.Request(


### PR DESCRIPTION
Hydrating Iceberg sinks currently wait until after they've read the entire source snapshot to mint a batch description and start writing. This means they accumulate the entire source snapshot in memory.

This PR allows Iceberg sinks to immediately mint a batch description for the source snapshot so they can flush to the writer instead of accumulating everything in memory.

----
_Notes:_

- This always mints a batch description for the source snapshot. If there's no data _and_ the input stream closes, we're now making an empty batch instead of no batches.
- This needs to run through QA Canary to see if it fixes SS-319/SS-282.