### PR TITLE
repr: canonicalize ranges from the declared element type, not the Datum tag

### DIFF
--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -727,7 +727,10 @@ impl LazyUnaryFunc for CastStringToRange {
                 .eval(&[Datum::String(elem_text)], temp_storage)
         })?;
 
-        range.canonicalize()?;
+        // Canonicalize using the target range's declared element type rather than
+        // the parsed bound's Datum tag (correct discrete-step width at the
+        // element type's boundary).
+        range.canonicalize_with_type(self.return_ty.unwrap_range_element_type())?;
 
         Ok(temp_storage.make_datum(|packer| {
             packer

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -591,7 +591,10 @@ impl EagerVariadicFunc for RangeCreate {
             RangeBound::new(upper, upper_inclusive),
         )));
 
-        range.canonicalize()?;
+        // Canonicalize using the range's declared element type rather than the
+        // bound's Datum tag, so the discrete-step width is correct at the
+        // element type's boundary (e.g. int4 vs int8).
+        range.canonicalize_with_type(&self.elem_type)?;
 
         Ok(temp_storage.make_datum(|row| {
             row.push_range(range).expect("errors already handled");

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -509,7 +509,38 @@ impl<'a, B: Copy + Ord> Range<B> {
 }
 
 impl<'a> Range<Datum<'a>> {
-    /// Canonicalize the range by PG's heuristics, which are:
+    /// Canonicalize the range, recovering the element type from a finite bound's
+    /// [`Datum`] tag.
+    ///
+    /// This is the legacy entry point. It exists only to keep callers that lack a
+    /// declared element type working; it isolates the historical tag-sniffing,
+    /// which is the residual coupling that communicating the element type
+    /// explicitly is meant to remove (see `RANGE_CANON_ANALYSIS.md`). Callers that
+    /// know the range's element [`SqlScalarType`] — range construction and range
+    /// casts — should call [`Range::canonicalize_with_type`] instead, so that
+    /// canonicalization does not depend on the runtime tag of the bound value.
+    ///
+    /// # Panics
+    /// - If the upper and lower bounds are finite and of different types.
+    pub fn canonicalize(&mut self) -> Result<(), InvalidRangeError> {
+        let elem_type = match &self.inner {
+            // Both bounds share a type (asserted in `canonicalize_with_type`), so a
+            // single finite bound's tag determines the element type.
+            Some(inner) => inner
+                .lower
+                .bound
+                .or(inner.upper.bound)
+                .map(range_elem_sql_type),
+            None => None,
+        };
+        // With no finite bound, canonicalization is element-type-independent (only
+        // the infinite-bound rule applies), so the element type is irrelevant.
+        let elem_type = elem_type.unwrap_or(SqlScalarType::Int64);
+        self.canonicalize_with_type(&elem_type)
+    }
+
+    /// Canonicalize the range by PG's heuristics, using the supplied element type
+    /// rather than inferring it from a bound's [`Datum`]. The heuristics are:
     /// - Infinite bounds are always exclusive
     /// - If type has step:
     ///  - Exclusive lower bounds are rewritten as inclusive += step
@@ -517,9 +548,16 @@ impl<'a> Range<Datum<'a>> {
     /// - Ranges are empty if lower >= upper after prev. step unless range type
     ///   does not have step and both bounds are inclusive
     ///
+    /// `elem_type` is the range's declared element type; it determines the
+    /// discrete step's width (e.g. `int4` vs `int8`), which is load-bearing at the
+    /// element type's boundary.
+    ///
     /// # Panics
     /// - If the upper and lower bounds are finite and of different types.
-    pub fn canonicalize(&mut self) -> Result<(), InvalidRangeError> {
+    pub fn canonicalize_with_type(
+        &mut self,
+        elem_type: &SqlScalarType,
+    ) -> Result<(), InvalidRangeError> {
         let (lower, upper) = match &mut self.inner {
             Some(inner) => (&mut inner.lower, &mut inner.upper),
             None => return Ok(()),
@@ -539,8 +577,8 @@ impl<'a> Range<Datum<'a>> {
             _ => {}
         };
 
-        lower.canonicalize()?;
-        upper.canonicalize()?;
+        lower.canonicalize(elem_type)?;
+        upper.canonicalize(elem_type)?;
 
         // The only way that you have two inclusive bounds with equal value are
         // if type does not have step.
@@ -554,6 +592,25 @@ impl<'a> Range<Datum<'a>> {
         }
 
         Ok(())
+    }
+}
+
+/// Recovers a range's element [`SqlScalarType`] from a bound's [`Datum`],
+/// reproducing the historical tag-based dispatch used by canonicalization.
+///
+/// This is the residual "type sniffing" that the type-communicated path removes;
+/// only the legacy [`Range::canonicalize`] shim relies on it. The continuous
+/// variants' parameters are irrelevant — those types have no discrete step and
+/// are never rewritten — so placeholder values are used.
+fn range_elem_sql_type(d: Datum) -> SqlScalarType {
+    match d {
+        Datum::Int32(_) => SqlScalarType::Int32,
+        Datum::Int64(_) => SqlScalarType::Int64,
+        Datum::Date(_) => SqlScalarType::Date,
+        Datum::Numeric(_) => SqlScalarType::Numeric { max_scale: None },
+        Datum::Timestamp(_) => SqlScalarType::Timestamp { precision: None },
+        Datum::TimestampTz(_) => SqlScalarType::TimestampTz { precision: None },
+        other => unreachable!("{other:?} is not a valid range element type"),
     }
 }
 
@@ -734,18 +791,22 @@ impl<'a, const UPPER: bool> RangeBound<Datum<'a>, UPPER> {
     /// Rewrite the bounds to the consistent format. This is absolutely
     /// necessary to perform the correct equality/comparison operations on
     /// types.
-    fn canonicalize(&mut self) -> Result<(), InvalidRangeError> {
+    fn canonicalize(&mut self, elem_type: &SqlScalarType) -> Result<(), InvalidRangeError> {
         Ok(match self.bound {
             None => {
                 self.inclusive = false;
             }
-            // Valid range types are defined in typeconv.rs:validate_range_element_type
-            Some(value) => match value {
-                d @ Datum::Int32(_) => self.canonicalize_inner::<i32>(d)?,
-                d @ Datum::Int64(_) => self.canonicalize_inner::<i64>(d)?,
-                d @ Datum::Date(_) => self.canonicalize_inner::<Date>(d)?,
-                Datum::Numeric(..) | Datum::Timestamp(..) | Datum::TimestampTz(..) => {}
-                d => unreachable!("{d:?} not yet supported in ranges"),
+            // Valid range element types are defined in
+            // typeconv.rs:validate_range_element_type. The discrete-step width is
+            // taken from the declared `elem_type`, not the bound's `Datum` tag.
+            Some(d) => match elem_type {
+                SqlScalarType::Int32 => self.canonicalize_inner::<i32>(d)?,
+                SqlScalarType::Int64 => self.canonicalize_inner::<i64>(d)?,
+                SqlScalarType::Date => self.canonicalize_inner::<Date>(d)?,
+                SqlScalarType::Numeric { .. }
+                | SqlScalarType::Timestamp { .. }
+                | SqlScalarType::TimestampTz { .. } => {}
+                other => unreachable!("{other:?} is not a valid range element type"),
             },
         })
     }

--- a/src/storage-types/src/sources/casts.rs
+++ b/src/storage-types/src/sources/casts.rs
@@ -347,7 +347,7 @@ impl CastFunc {
                 }))
             }
             CastFunc::CastStringToRange {
-                return_ty: _,
+                return_ty,
                 cast_expr,
             } => {
                 let mut range = strconv::parse_range(a, |elem_text| {
@@ -357,7 +357,9 @@ impl CastFunc {
                     };
                     cast_expr.eval(&[Datum::String(elem_text)], arena)
                 })?;
-                range.canonicalize()?;
+                // Canonicalize using the target range's declared element type
+                // rather than the parsed bound's Datum tag.
+                range.canonicalize_with_type(return_ty.unwrap_range_element_type())?;
                 Ok(arena.make_datum(|packer| {
                     packer
                         .push_range(range)


### PR DESCRIPTION
## What

Range canonicalization decided the discrete-step width by matching on the **bound's `Datum` tag** (`Datum::Int32` → `i32` step, `Datum::Int64` → `i64` step). The width is load-bearing at the element type's boundary: an `int4range` bound at `i32::MAX` must overflow on the `+1` step (→ `CanonicalizationOverflow`); at `i64` width it would not.

Depending on the value's runtime tag instead of the column's **declared** type is slop — it's only correct because today an `int4range` happens to store `Int32` bounds. It becomes an actual bug under the integer-unification work (#37262), where `Int32`/`Int64` collapse to a single `Datum::Int` and the tag no longer distinguishes `int4range` from `int8range`.

This threads the declared element `SqlScalarType` into canonicalization:

- New `Range::canonicalize_with_type(&SqlScalarType)` (and `RangeBound::canonicalize` takes the element type) drives the step width from the declared type.
- It's used at the sites that build a range from elements and know that type: the `range(...)` constructor (`RangeCreate`) and the text→range casts (`CastStringToRange`, in both `expr` and `storage-types`).
- The legacy `Range::canonicalize()` is kept as a thin shim that recovers the element type from a finite bound's tag (`range_elem_sql_type`) and delegates — **isolating the residual tag-sniffing in one clearly-marked place**.

Behavior-preserving on `main` (the tag and declared type agree wherever a bound is unwrapped); existing range tests pass. The value here is the refactor itself + unblocking the unification spike.

## The design question I'm flagging (not deciding here)

Canonicalization is genuinely *required* at construction (the three sites above, which have the declared type). It is also *incidentally* called on already-canonical values at sites that have **no** declared element type:

| Site | Has element type? | Required? |
|---|---|---|
| `RangeCreate` / `CastStringToRange` ×3 | yes (`elem_type` / `return_ty`) | yes — building from elements |
| `Row::push_range` | no (type-agnostic Row packing) | incidental — callers already canonicalize; decode paths feed it already-canonical data |
| `Range::difference` (internal) | no (bare `Datum` bounds) | incidental — operates on canonical inputs |
| `kafka.rs::decode_row` | partial | incidental, **on read** — carries `//XXX: why do we have to canonicalize on read?` |

Two ways to eliminate the tag-sniffing at the incidental sites:

- **(A) Canonicalize-on-write, trust-on-read** — remove canonicalization from `push_range`/read paths; require it (with type) only at construction. Cleanest, matches the kafka XXX, fully unblocks the spike. Risk: changes the public `push_range` contract and assumes every `push_range` input is already canonical (analysis says yes).
- **(B) Thread the element type through `push_range`** and its ~15 callers. Keeps canonicalization where it is, but pushes type into a deliberately type-agnostic layer.

I lean **(A)**, but it's a public-API/read-path behavior change that's the "where *should* canonicalization be required" call left open — so this PR keeps the incidental sites behavior-preserving and surfaces the decision rather than guessing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)