### PR TITLE
SS-16: testdrive infrastructure for AWS Glue schema registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8759,6 +8759,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "aws-credential-types",
+ "aws-sdk-glue",
  "aws-sdk-sts",
  "aws-types",
  "byteorder",

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -796,6 +796,29 @@ The schema to use
 
 For data that contains a key, the schema of the key
 
+##### `confluent-wire-format=(true|false)`
+
+For `format=avro`, whether to frame each message with the Confluent Schema
+Registry wire format (a magic byte followed by a 4-byte schema ID). Defaults to
+`true`, unless `glue-schema-version-id` is set (in which case it defaults to
+`false`, and setting it to `true` is an error). Set to `false` to emit a bare
+Avro datum with no framing.
+
+##### `references=subject[,subject...]`
+
+For `format=avro` with `confluent-wire-format`, a comma-separated list of
+Confluent Schema Registry subjects that the schema references. Transitive
+references are resolved automatically. Not supported with
+`glue-schema-version-id`. `key-references` is the equivalent for the key schema.
+
+##### `glue-schema-version-id=UUID`
+
+For `format=avro`, frame each message with the AWS Glue Schema Registry wire
+format (header byte `0x03`, a compression byte, then the given 16-byte
+schema-version UUID) instead of the Confluent format. Mutually exclusive with
+`confluent-wire-format=true` and with `references`. `key-glue-schema-version-id`
+is the equivalent for the key schema.
+
 ##### `key-terminator=str`
 
 For data provided as `format=bytes key-format=bytes`, the separator between the key and the data in the test
@@ -919,6 +942,56 @@ defined at the schema registry. Also waits for the kafka topic to exist.
 
 This action is useful to fortify tests that expect an external party, e.g.
 Debezium, to upload a particular schema.
+
+## Actions on AWS Glue Schema Registry
+
+#### `$ glue-create-schema name=... [registry=...] [set-version-id-var=VAR] [schema=...] [data-format=avro] [compatibility=backward]`
+
+Register a schema in AWS Glue Schema Registry and, optionally, stash the
+returned schema-version UUID in a testdrive variable.
+
+The schema definition is taken from the `schema` argument when present (typically
+a `${...}` reference to a schema defined with `$ set`), otherwise from the
+command body.
+
+The recommended pattern keeps each schema body in exactly one place: define it
+once as a pretty-printed `$ set` variable, then reference that variable both here
+(to register the schema) and in `kafka-ingest` (to frame records with the
+returned version id):
+
+```
+$ set my-schema={
+    "type": "record", "name": "row",
+    "fields": [{"name": "a", "type": "long"}]
+  }
+
+$ glue-create-schema registry=my-registry name=my-schema set-version-id-var=my-version-id schema=${my-schema}
+
+$ kafka-ingest format=avro topic=my-topic glue-schema-version-id=${my-version-id} schema=${my-schema}
+{"a": 1}
+```
+
+Arguments:
+
+* The required `name` argument is the schema name.
+* The optional `registry` argument is the registry name. Omit it to target
+  Glue's implicit default registry (`default-registry`).
+* The optional `set-version-id-var` argument names a testdrive variable to
+  receive the returned `SchemaVersionId`. Omit it when the schema is referenced
+  only by name (e.g. a negative test that registers a schema just to be
+  rejected).
+* The optional `schema` argument supplies the schema definition; if absent, the
+  command body is used.
+* The optional `data-format` argument is one of `avro` (default), `json`, or
+  `protobuf`.
+* The optional `compatibility` argument defaults to `backward`.
+
+Registering a name that already exists registers a *new version* of that schema
+rather than failing — which is how schema-evolution tests register v2 atop v1.
+
+This action talks to whatever AWS Glue endpoint testdrive's AWS client is
+configured for (e.g. moto in CI, or real AWS); see the `Testdrive` mzcompose
+service's `aws_*` parameters.
 
 ## Actions on REST services
 

--- a/misc/python/materialize/mzcompose/services/moto.py
+++ b/misc/python/materialize/mzcompose/services/moto.py
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.mzcompose.service import (
+    Service,
+)
+
+
+class Moto(Service):
+    """A `moto_server` container that mocks AWS services.
+
+    Used for testing AWS surfaces that LocalStack Community doesn't cover
+    (notably Glue / Glue Schema Registry).
+    """
+
+    def __init__(
+        self,
+        name: str = "moto",
+        image: str = "motoserver/moto:5.2.1",
+        port: int = 5000,
+    ) -> None:
+        super().__init__(
+            name=name,
+            config={
+                "image": image,
+                "init": True,
+                "ports": [port],
+                "healthcheck": {
+                    "test": [
+                        "CMD-SHELL",
+                        f"python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:{port}/moto-api/\")'",
+                    ],
+                    "interval": "1s",
+                    "start_period": "30s",
+                },
+            },
+        )

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 async-compression.workspace = true
 async-trait.workspace = true
 aws-credential-types.workspace = true
+aws-sdk-glue.workspace = true
 aws-sdk-sts.workspace = true
 aws-types.workspace = true
 arrow.workspace = true

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -9,7 +9,14 @@
 
 MZFROM ubuntu-base
 
-RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends postgresql-client && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends ca-certificates postgresql-client && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# testdrive's AWS client uses vendored OpenSSL, which looks for the trust store
+# in its compiled-in default dir (/usr/local/ssl/certs) rather than where
+# `ca-certificates` installs it. Point it at the system bundle so TLS to real
+# AWS (e.g. Glue/STS in the aws-glue-schema-registry `aws` workflow) verifies.
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs
 
 # Install the Protobuf compiler from protobuf-src.
 COPY protobuf-bin /usr/local/bin/

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -64,6 +64,7 @@ pub mod consistency;
 mod duckdb;
 mod file;
 mod fivetran;
+mod glue;
 mod http;
 mod kafka;
 mod mysql;
@@ -875,6 +876,7 @@ impl Run for PosCommand {
                     }
                     "file-append" => file::run_append(builtin, state).await,
                     "file-delete" => file::run_delete(builtin, state).await,
+                    "glue-create-schema" => glue::run_create_schema(builtin, state).await,
                     "http-request" => http::run_request(builtin, state).await,
                     "kafka-add-partitions" => kafka::run_add_partitions(builtin, state).await,
                     "kafka-create-topic" => kafka::run_create_topic(builtin, state).await,

--- a/src/testdrive/src/action/glue.rs
+++ b/src/testdrive/src/action/glue.rs
@@ -1,0 +1,146 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::{Context, anyhow, bail};
+use aws_sdk_glue::types::{Compatibility, DataFormat, RegistryId, SchemaId};
+
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+/// Register a schema in AWS Glue Schema Registry and stash its version UUID in a
+/// testdrive variable.
+///
+/// This keeps a single source of truth in the `.td` file: define the schema
+/// once as a pretty-printed `$ set` variable, then reference it both here (to
+/// register it) and in `kafka-ingest` (to encode records) — so the body is
+/// never written twice.
+///
+/// ```text
+/// $ set my-schema={
+///     "type": "record", "name": "row",
+///     "fields": [{"name": "a", "type": "long"}]
+///   }
+///
+/// $ glue-create-schema registry=my-registry name=my-schema set-version-id-var=my-version-id schema=${my-schema}
+/// ```
+///
+/// Arguments:
+///   * `name` (required): the schema name.
+///   * `schema` (required unless given as the command body): the schema
+///     definition. Typically a `${...}` reference to a `$ set` variable.
+///   * `set-version-id-var` (optional): testdrive variable to receive the
+///     returned `SchemaVersionId`. Omit when the schema is referenced only by
+///     name (e.g. a negative test that registers a schema just to be rejected).
+///   * `registry` (optional): registry name. Omit to target Glue's implicit
+///     default registry.
+///   * `data-format` (optional, default `avro`): one of `avro`, `json`,
+///     `protobuf`.
+///   * `compatibility` (optional, default `backward`).
+///
+/// If a schema with this name already exists, a new version is registered
+/// instead — which is how schema-evolution tests register v2 atop v1.
+pub async fn run_create_schema(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let name = cmd.args.string("name")?;
+    let version_id_var = cmd.args.opt_string("set-version-id-var");
+    let registry = cmd.args.opt_string("registry");
+    let schema_arg = cmd.args.opt_string("schema");
+    let data_format = match cmd
+        .args
+        .opt_string("data-format")
+        .unwrap_or_else(|| "avro".into())
+        .to_lowercase()
+        .as_str()
+    {
+        "avro" => DataFormat::Avro,
+        "json" => DataFormat::Json,
+        "protobuf" => DataFormat::Protobuf,
+        other => bail!("unknown data-format: {}", other),
+    };
+    let compatibility = match cmd
+        .args
+        .opt_string("compatibility")
+        .unwrap_or_else(|| "backward".into())
+        .to_lowercase()
+        .as_str()
+    {
+        "backward" => Compatibility::Backward,
+        "backward_all" => Compatibility::BackwardAll,
+        "forward" => Compatibility::Forward,
+        "forward_all" => Compatibility::ForwardAll,
+        "full" => Compatibility::Full,
+        "full_all" => Compatibility::FullAll,
+        "none" => Compatibility::None,
+        "disabled" => Compatibility::Disabled,
+        other => bail!("unknown compatibility: {}", other),
+    };
+    cmd.args.done()?;
+
+    // The schema definition comes from the `schema=` argument (typically a
+    // `${...}` reference to a `$ set` variable) or, failing that, the command
+    // body.
+    let definition = match schema_arg {
+        Some(schema) => schema,
+        None => cmd.input.join("\n"),
+    };
+    if definition.trim().is_empty() {
+        bail!("glue-create-schema requires a `schema=` argument or a schema definition body");
+    }
+
+    println!(
+        "Registering Glue schema {:?} (registry {:?})...",
+        name,
+        registry.as_deref().unwrap_or("<default>"),
+    );
+
+    let glue = aws_sdk_glue::Client::new(&state.aws_config);
+
+    let mut create = glue
+        .create_schema()
+        .schema_name(&name)
+        .data_format(data_format)
+        .compatibility(compatibility)
+        .schema_definition(&definition);
+    if let Some(registry) = &registry {
+        create = create.registry_id(RegistryId::builder().registry_name(registry).build());
+    }
+
+    let version_id = match create.send().await {
+        Ok(resp) => resp.schema_version_id().map(|s| s.to_string()),
+        Err(err) => {
+            // The schema already exists — register a new version of it. This is
+            // the schema-evolution path (v2 atop v1).
+            let svc = err.into_service_error();
+            if svc.is_already_exists_exception() {
+                let mut schema_id = SchemaId::builder().schema_name(&name);
+                if let Some(registry) = &registry {
+                    schema_id = schema_id.registry_name(registry);
+                }
+                let resp = glue
+                    .register_schema_version()
+                    .schema_id(schema_id.build())
+                    .schema_definition(&definition)
+                    .send()
+                    .await
+                    .context("registering new Glue schema version")?;
+                resp.schema_version_id().map(|s| s.to_string())
+            } else {
+                return Err(anyhow::Error::new(svc).context("creating Glue schema"));
+            }
+        }
+    };
+    if let Some(var) = version_id_var {
+        let version_id =
+            version_id.ok_or_else(|| anyhow!("Glue did not return a schema version id"))?;
+        state.cmd_vars.insert(var, version_id);
+    }
+    Ok(ControlFlow::Continue)
+}

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -21,6 +21,7 @@ use rdkafka::message::{Header, OwnedHeaders};
 use rdkafka::producer::FutureRecord;
 use serde::de::DeserializeOwned;
 use tokio::fs;
+use uuid::Uuid;
 
 use crate::action::{self, ControlFlow, State};
 use crate::format::avro::{self, Schema};
@@ -160,6 +161,10 @@ enum Format {
     Avro {
         schema: String,
         confluent_wire_format: bool,
+        /// If set, override the wire format with AWS Glue Schema Registry framing
+        /// using the given schema-version UUID. Mutually exclusive with
+        /// `confluent_wire_format=true`.
+        glue_schema_version_id: Option<Uuid>,
         /// Schema references (subject names) for Confluent Schema Registry
         references: Vec<String>,
     },
@@ -182,6 +187,10 @@ enum Transcoder {
     ConfluentAvro {
         schema: Schema,
         schema_id: i32,
+    },
+    GlueAvro {
+        schema: Schema,
+        schema_version_id: Uuid,
     },
     Protobuf {
         message: MessageDescriptor,
@@ -224,6 +233,26 @@ impl Transcoder {
                     // https://docs.confluent.io/3.3.0/schema-registry/docs/serializer-formatter.html#wire-format
                     out.write_u8(0).unwrap();
                     out.write_i32::<NetworkEndian>(*schema_id).unwrap();
+                    out.extend(avro::to_avro_datum(schema, val)?);
+                    Ok(Some(out))
+                } else {
+                    Ok(None)
+                }
+            }
+            Transcoder::GlueAvro {
+                schema,
+                schema_version_id,
+            } => {
+                if let Some(val) = Self::decode_json(row)? {
+                    let val = avro::from_json(&val, schema.top_node())?;
+                    let mut out = vec![];
+                    // AWS Glue Schema Registry wire format:
+                    // byte 0   = 0x03 (header version)
+                    // byte 1   = compression byte (0x00 = none)
+                    // bytes 2..18 = 16-byte schema-version UUID
+                    out.write_u8(0x03).unwrap();
+                    out.write_u8(0x00).unwrap();
+                    out.extend_from_slice(schema_version_id.as_bytes());
                     out.extend(avro::to_avro_datum(schema, val)?);
                     Ok(Some(out))
                 } else {
@@ -303,16 +332,30 @@ pub async fn run_ingest(
     let schema_id_var = cmd.args.opt_parse("set-schema-id-var")?;
     let key_schema_id_var = cmd.args.opt_parse("set-key-schema-id-var")?;
     let format = match cmd.args.string("format")?.as_str() {
-        "avro" => Format::Avro {
-            schema: cmd.args.string("schema")?,
-            confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true),
-            // TODO (maz): update README!
-            references: cmd
+        "avro" => {
+            let glue_schema_version_id = cmd
                 .args
-                .opt_string("references")
-                .map(|s| s.split(',').map(|s| s.to_string()).collect())
-                .unwrap_or_default(),
-        },
+                .opt_string("glue-schema-version-id")
+                .map(|s| Uuid::parse_str(&s).context("parsing glue-schema-version-id as UUID"))
+                .transpose()?;
+            let confluent_wire_format_explicit = cmd.args.opt_bool("confluent-wire-format")?;
+            if glue_schema_version_id.is_some() && confluent_wire_format_explicit == Some(true) {
+                bail!("confluent-wire-format=true is incompatible with glue-schema-version-id");
+            }
+            // Default: confluent unless Glue framing is requested.
+            let confluent_wire_format =
+                confluent_wire_format_explicit.unwrap_or_else(|| glue_schema_version_id.is_none());
+            Format::Avro {
+                schema: cmd.args.string("schema")?,
+                confluent_wire_format,
+                glue_schema_version_id,
+                references: cmd
+                    .args
+                    .opt_string("references")
+                    .map(|s| s.split(',').map(|s| s.to_string()).collect())
+                    .unwrap_or_default(),
+            }
+        }
         "protobuf" => {
             let descriptor_file = cmd.args.string("descriptor-file")?;
             let message = cmd.args.string("message")?;
@@ -331,17 +374,33 @@ pub async fn run_ingest(
     };
     let mut key_schema = cmd.args.opt_string("key-schema");
     let key_format = match cmd.args.opt_string("key-format").as_deref() {
-        Some("avro") => Some(Format::Avro {
-            schema: key_schema.take().ok_or_else(|| {
-                anyhow!("key-schema parameter required when key-format is present")
-            })?,
-            confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true),
-            references: cmd
+        Some("avro") => {
+            let key_glue_schema_version_id = cmd
                 .args
-                .opt_string("key-references")
-                .map(|s| s.split(',').map(|s| s.to_string()).collect())
-                .unwrap_or_default(),
-        }),
+                .opt_string("key-glue-schema-version-id")
+                .map(|s| Uuid::parse_str(&s).context("parsing key-glue-schema-version-id as UUID"))
+                .transpose()?;
+            let confluent_wire_format_explicit = cmd.args.opt_bool("confluent-wire-format")?;
+            if key_glue_schema_version_id.is_some() && confluent_wire_format_explicit == Some(true)
+            {
+                bail!("confluent-wire-format=true is incompatible with key-glue-schema-version-id");
+            }
+            // Default: confluent unless Glue framing is requested.
+            let confluent_wire_format = confluent_wire_format_explicit
+                .unwrap_or_else(|| key_glue_schema_version_id.is_none());
+            Some(Format::Avro {
+                schema: key_schema.take().ok_or_else(|| {
+                    anyhow!("key-schema parameter required when key-format is present")
+                })?,
+                confluent_wire_format,
+                glue_schema_version_id: key_glue_schema_version_id,
+                references: cmd
+                    .args
+                    .opt_string("key-references")
+                    .map(|s| s.split(',').map(|s| s.to_string()).collect())
+                    .unwrap_or_default(),
+            })
+        }
         Some("protobuf") => {
             let descriptor_file = cmd.args.string("key-descriptor-file")?;
             let message = cmd.args.string("key-message")?;
@@ -425,8 +484,16 @@ pub async fn run_ingest(
             match fmt {
                 Format::Avro {
                     confluent_wire_format,
+                    glue_schema_version_id,
                     ..
-                } => Some(*confluent_wire_format),
+                } => {
+                    // Glue framing is its own wire format — don't compare against CSR.
+                    if glue_schema_version_id.is_some() {
+                        None
+                    } else {
+                        Some(*confluent_wire_format)
+                    }
+                }
                 Format::Protobuf {
                     confluent_wire_format,
                     ..
@@ -550,8 +617,20 @@ async fn make_transcoder(
         Format::Avro {
             schema,
             confluent_wire_format,
+            glue_schema_version_id,
             references,
         } => {
+            if let Some(schema_version_id) = glue_schema_version_id {
+                if !references.is_empty() {
+                    bail!("schema references are not supported with glue-schema-version-id");
+                }
+                let schema = avro::parse_schema(&schema, &[])
+                    .with_context(|| format!("parsing avro schema: {}", schema))?;
+                return Ok(Transcoder::GlueAvro {
+                    schema,
+                    schema_version_id,
+                });
+            }
             if confluent_wire_format {
                 // Build references list by fetching each subject from the registry.
                 // Start with immediate references and automatically resolve transitive ones.


### PR DESCRIPTION
New infra to support AWS glue schema registry testing

- moto service in mzcompose for emulating AWS Glue schema registry
- new testdrive action: `glue-create-schema`
- update testdrive action `kafka-ingest`: add `glue-schema-version-id` + `key-glue-schema-version-id` to frame messages with the Glue wire format
- updates `testdrive.md` with new syntax (including schema references, which was a TODO in the code)
- update testdrive image to include ca-certificate bundle to run against AWS

E2E tests in https://github.com/MaterializeInc/materialize/pull/36795
successful AWS run: https://buildkite.com/materialize/nightly/builds/16870#019ef793-be09-4037-9ad0-de4b464ce648