### PR TITLE
transform: cancel union branches exposed by physical RelationCSE

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -111,6 +111,7 @@ def get_minimal_system_parameters(
         "enable_statement_lifecycle_logging": "true",
         "enable_storage_introspection_logs": "true",
         "enable_compute_temporal_bucketing": "true",
+        "enable_union_cancellation_after_relation_cse": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
@@ -276,6 +277,11 @@ def get_variable_system_parameters(
         ),
         VariableSystemParameter(
             "enable_simplify_from_less_existence",
+            "true",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
+            "enable_union_cancellation_after_relation_cse",
             "true",
             ["true", "false"],
         ),

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -118,6 +118,7 @@ def get_minimal_system_parameters(
         "enable_storage_introspection_logs": "true",
         "enable_compute_error_distinct": "true",
         "enable_compute_temporal_bucketing": "true",
+        "enable_union_cancellation_after_relation_cse": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
@@ -294,6 +295,11 @@ def get_variable_system_parameters(
         ),
         VariableSystemParameter(
             "enable_simplify_from_less_existence",
+            "true",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
+            "enable_union_cancellation_after_relation_cse",
             "true",
             ["true", "false"],
         ),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1845,6 +1845,9 @@ class FlipFlagsAction(Action):
             "false",
         ]
         self.flags_with_values["enable_case_literal_transform"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_union_cancellation_after_relation_cse"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_cast_elimination"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_fixed_correlated_cte_lowering"] = (
             BOOLEAN_FLAG_VALUES

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3015,6 +3015,9 @@ class FlipFlagsAction(Action):
             "false",
         ]
         self.flags_with_values["enable_case_literal_transform"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_union_cancellation_after_relation_cse"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_cast_elimination"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_fixed_correlated_cte_lowering"] = (
             BOOLEAN_FLAG_VALUES

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -122,6 +122,8 @@ optimizer_feature_flags!({
     // See the feature flag of the same name.
     enable_projection_pushdown_after_relation_cse: bool,
     // See the feature flag of the same name.
+    enable_union_cancellation_after_relation_cse: bool,
+    // See the feature flag of the same name.
     enable_less_reduce_in_eqprop: bool,
     // See the feature flag of the same name.
     enable_dequadratic_eqprop_map: bool,

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -74,6 +74,7 @@ Broker
 Brokers
 By
 Bytes
+Cancellation
 Capture
 Cardinality
 Cascade

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2430,6 +2430,7 @@ pub enum ClusterFeatureName {
     EnableLetrecFixpointAnalysis,
     EnableJoinPrioritizeArranged,
     EnableProjectionPushdownAfterRelationCse,
+    EnableUnionCancellationAfterRelationCse,
 }
 
 impl WithOptionName for ClusterFeatureName {
@@ -2446,7 +2447,8 @@ impl WithOptionName for ClusterFeatureName {
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableJoinPrioritizeArranged
-            | Self::EnableProjectionPushdownAfterRelationCse => false,
+            | Self::EnableProjectionPushdownAfterRelationCse
+            | Self::EnableUnionCancellationAfterRelationCse => false,
         }
     }
 }
@@ -4107,6 +4109,7 @@ pub enum ExplainPlanOptionName {
     EnableJoinPrioritizeArranged,
     EnableProjectionPushdownAfterRelationCse,
     EnableFixedCorrelatedCteLowering,
+    EnableUnionCancellationAfterRelationCse,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -4144,7 +4147,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableJoinPrioritizeArranged
             | Self::EnableProjectionPushdownAfterRelationCse
-            | Self::EnableFixedCorrelatedCteLowering => false,
+            | Self::EnableFixedCorrelatedCteLowering
+            | Self::EnableUnionCancellationAfterRelationCse => false,
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2506,6 +2506,7 @@ pub enum ClusterFeatureName {
     EnableLetrecFixpointAnalysis,
     EnableJoinPrioritizeArranged,
     EnableProjectionPushdownAfterRelationCse,
+    EnableUnionCancellationAfterRelationCse,
 }
 
 impl WithOptionName for ClusterFeatureName {
@@ -2522,7 +2523,8 @@ impl WithOptionName for ClusterFeatureName {
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableJoinPrioritizeArranged
-            | Self::EnableProjectionPushdownAfterRelationCse => false,
+            | Self::EnableProjectionPushdownAfterRelationCse
+            | Self::EnableUnionCancellationAfterRelationCse => false,
         }
     }
 }
@@ -4191,6 +4193,7 @@ pub enum ExplainPlanOptionName {
     EnableJoinPrioritizeArranged,
     EnableProjectionPushdownAfterRelationCse,
     EnableFixedCorrelatedCteLowering,
+    EnableUnionCancellationAfterRelationCse,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -4228,7 +4231,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableJoinPrioritizeArranged
             | Self::EnableProjectionPushdownAfterRelationCse
-            | Self::EnableFixedCorrelatedCteLowering => false,
+            | Self::EnableFixedCorrelatedCteLowering
+            | Self::EnableUnionCancellationAfterRelationCse => false,
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4868,6 +4868,11 @@ generate_extracted_config!(
         EnableProjectionPushdownAfterRelationCse,
         Option<bool>,
         Default(None)
+    ),
+    (
+        EnableUnionCancellationAfterRelationCse,
+        Option<bool>,
+        Default(None)
     )
 );
 
@@ -5010,6 +5015,7 @@ pub fn plan_create_cluster_inner(
             enable_letrec_fixpoint_analysis,
             enable_join_prioritize_arranged,
             enable_projection_pushdown_after_relation_cse,
+            enable_union_cancellation_after_relation_cse,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
@@ -5020,6 +5026,7 @@ pub fn plan_create_cluster_inner(
             enable_letrec_fixpoint_analysis,
             enable_join_prioritize_arranged,
             enable_projection_pushdown_after_relation_cse,
+            enable_union_cancellation_after_relation_cse,
             ..Default::default()
         };
 
@@ -5140,6 +5147,7 @@ pub fn unplan_create_cluster(
                 enable_letrec_fixpoint_analysis,
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
+                enable_union_cancellation_after_relation_cse,
                 enable_less_reduce_in_eqprop: _,
                 enable_dequadratic_eqprop_map: _,
                 enable_eq_classes_withholding_errors: _,
@@ -5163,6 +5171,7 @@ pub fn unplan_create_cluster(
                 enable_letrec_fixpoint_analysis,
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
+                enable_union_cancellation_after_relation_cse,
             };
             let features = features_extracted.into_values(scx.catalog);
             let availability_zones = if availability_zones.is_empty() {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5047,6 +5047,11 @@ generate_extracted_config!(
         EnableProjectionPushdownAfterRelationCse,
         Option<bool>,
         Default(None)
+    ),
+    (
+        EnableUnionCancellationAfterRelationCse,
+        Option<bool>,
+        Default(None)
     )
 );
 
@@ -5190,6 +5195,7 @@ pub fn plan_create_cluster_inner(
             enable_letrec_fixpoint_analysis,
             enable_join_prioritize_arranged,
             enable_projection_pushdown_after_relation_cse,
+            enable_union_cancellation_after_relation_cse,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
@@ -5200,6 +5206,7 @@ pub fn plan_create_cluster_inner(
             enable_letrec_fixpoint_analysis,
             enable_join_prioritize_arranged,
             enable_projection_pushdown_after_relation_cse,
+            enable_union_cancellation_after_relation_cse,
             ..Default::default()
         };
 
@@ -5326,6 +5333,7 @@ pub fn unplan_create_cluster(
                 enable_letrec_fixpoint_analysis,
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
+                enable_union_cancellation_after_relation_cse,
                 enable_less_reduce_in_eqprop: _,
                 enable_dequadratic_eqprop_map: _,
                 enable_eq_classes_withholding_errors: _,
@@ -5349,6 +5357,7 @@ pub fn unplan_create_cluster(
                 enable_letrec_fixpoint_analysis,
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
+                enable_union_cancellation_after_relation_cse,
             };
             let features = features_extracted.into_values(scx.catalog);
             let availability_zones = if availability_zones.is_empty() {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -582,6 +582,11 @@ generate_extracted_config!(
         EnableFixedCorrelatedCteLowering,
         Option<bool>,
         Default(None)
+    ),
+    (
+        EnableUnionCancellationAfterRelationCse,
+        Option<bool>,
+        Default(None)
     )
 );
 
@@ -634,6 +639,8 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_join_prioritize_arranged: v.enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse: v
                     .enable_projection_pushdown_after_relation_cse,
+                enable_union_cancellation_after_relation_cse: v
+                    .enable_union_cancellation_after_relation_cse,
                 enable_less_reduce_in_eqprop: Default::default(),
                 enable_dequadratic_eqprop_map: Default::default(),
                 enable_eq_classes_withholding_errors: Default::default(),

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -579,6 +579,11 @@ generate_extracted_config!(
         EnableFixedCorrelatedCteLowering,
         Option<bool>,
         Default(None)
+    ),
+    (
+        EnableUnionCancellationAfterRelationCse,
+        Option<bool>,
+        Default(None)
     )
 );
 
@@ -631,6 +636,8 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_join_prioritize_arranged: v.enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse: v
                     .enable_projection_pushdown_after_relation_cse,
+                enable_union_cancellation_after_relation_cse: v
+                    .enable_union_cancellation_after_relation_cse,
                 enable_less_reduce_in_eqprop: Default::default(),
                 enable_dequadratic_eqprop_map: Default::default(),
                 enable_eq_classes_withholding_errors: Default::default(),

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2243,6 +2243,13 @@ feature_flags!(
         scope: ParameterScope::Cluster,
     },
     {
+        name: enable_union_cancellation_after_relation_cse,
+        desc: "Run UnionBranchCancellation one more time after the last RelationCSE.",
+        default: true,
+        enable_for_item_parsing: false,
+        scope: ParameterScope::Cluster,
+    },
+    {
         name: enable_less_reduce_in_eqprop,
         desc: "Run MSE::reduce in EquivalencePropagation only if reduce_expr changed something.",
         default: true,
@@ -2352,6 +2359,8 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_join_prioritize_arranged: vars.enable_join_prioritize_arranged(),
             enable_projection_pushdown_after_relation_cse: vars
                 .enable_projection_pushdown_after_relation_cse(),
+            enable_union_cancellation_after_relation_cse: vars
+                .enable_union_cancellation_after_relation_cse(),
             enable_less_reduce_in_eqprop: vars.enable_less_reduce_in_eqprop(),
             enable_dequadratic_eqprop_map: vars.enable_dequadratic_eqprop_map(),
             enable_eq_classes_withholding_errors: vars.enable_eq_classes_withholding_errors(),
@@ -2397,6 +2406,7 @@ mod tests {
             reoptimize_imported_views,
             enable_join_prioritize_arranged,
             enable_projection_pushdown_after_relation_cse,
+            enable_union_cancellation_after_relation_cse,
             enable_less_reduce_in_eqprop,
             enable_dequadratic_eqprop_map,
             enable_fast_path_plan_insights,
@@ -2429,6 +2439,7 @@ mod tests {
         let _ = reoptimize_imported_views; // no corresponding var
         set_var!(enable_join_prioritize_arranged);
         set_var!(enable_projection_pushdown_after_relation_cse);
+        set_var!(enable_union_cancellation_after_relation_cse);
         set_var!(enable_less_reduce_in_eqprop);
         set_var!(enable_dequadratic_eqprop_map);
         set_var!(enable_fast_path_plan_insights);

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2286,6 +2286,13 @@ feature_flags!(
         scope: ParameterScope::Cluster,
     },
     {
+        name: enable_union_cancellation_after_relation_cse,
+        desc: "Run UnionBranchCancellation one more time after the last RelationCSE.",
+        default: true,
+        enable_for_item_parsing: false,
+        scope: ParameterScope::Cluster,
+    },
+    {
         name: enable_less_reduce_in_eqprop,
         desc: "Run MSE::reduce in EquivalencePropagation only if reduce_expr changed something.",
         default: true,
@@ -2395,6 +2402,8 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_join_prioritize_arranged: vars.enable_join_prioritize_arranged(),
             enable_projection_pushdown_after_relation_cse: vars
                 .enable_projection_pushdown_after_relation_cse(),
+            enable_union_cancellation_after_relation_cse: vars
+                .enable_union_cancellation_after_relation_cse(),
             enable_less_reduce_in_eqprop: vars.enable_less_reduce_in_eqprop(),
             enable_dequadratic_eqprop_map: vars.enable_dequadratic_eqprop_map(),
             enable_eq_classes_withholding_errors: vars.enable_eq_classes_withholding_errors(),
@@ -2446,6 +2455,7 @@ mod tests {
             reoptimize_imported_views,
             enable_join_prioritize_arranged,
             enable_projection_pushdown_after_relation_cse,
+            enable_union_cancellation_after_relation_cse,
             enable_less_reduce_in_eqprop,
             enable_dequadratic_eqprop_map,
             enable_fast_path_plan_insights,
@@ -2478,6 +2488,7 @@ mod tests {
         let _ = reoptimize_imported_views; // no corresponding var
         set_var!(enable_join_prioritize_arranged);
         set_var!(enable_projection_pushdown_after_relation_cse);
+        set_var!(enable_union_cancellation_after_relation_cse);
         set_var!(enable_less_reduce_in_eqprop);
         set_var!(enable_dequadratic_eqprop_map);
         set_var!(enable_fast_path_plan_insights);

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -877,6 +877,12 @@ impl Optimizer {
             Box::new(CanonicalizeMfp),
             // Identifies common relation subexpressions.
             Box::new(cse::relation_cse::RelationCSE::new(false)),
+            // `RelationCSE` can deduplicate two branches of a union into a shared `Get`, which
+            // first exposes the `union(get, negate(get), ...)` shape that the logical passes never
+            // saw. Run `UnionBranchCancellation` here so these branches cancel; the trailing
+            // `fold_constants_fixpoint` then fuses the resulting empty constants and drops the now
+            // unused binding.
+            Box::new(UnionBranchCancellation),
             // `RelationCSE` can create new points of interest for `ProjectionPushdown`: If an MFP
             // is cut in half by `RelationCSE`, then we'd like to push projections behind the new
             // Get as much as possible. This is because a fork in the plan involves copying the

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -877,12 +877,29 @@ impl Optimizer {
             Box::new(CanonicalizeMfp),
             // Identifies common relation subexpressions.
             Box::new(cse::relation_cse::RelationCSE::new(false)),
-            // `RelationCSE` can deduplicate two branches of a union into a shared `Get`, which
-            // first exposes the `union(get, negate(get), ...)` shape that the logical passes never
-            // saw. Run `UnionBranchCancellation` here so these branches cancel; the trailing
-            // `fold_constants_fixpoint` then fuses the resulting empty constants and drops the now
-            // unused binding.
-            Box::new(UnionBranchCancellation),
+            // `UnionBranchCancellation` only cancels two branches that are direct siblings of the
+            // same `Union` and literally structurally equal (see `compare_branches`); a
+            // `Get x` under a `Map` sibling to a `Union` nested one level down does not qualify,
+            // even if that nested union contains a matching `Negate (Get x)`.
+            //
+            // In `fixpoint_physical_01` above, `LiteralLifting` can hoist a `Map` literal that was
+            // wrapping *both* branches of such a union out of the union entirely, turning
+            // `union(map(k, x), map(k, union(negate(x), y)))` into `map(k, union(x, union(negate(x), y)))`.
+            // A later `FoldConstants` pass (in the same fixpoint) then flattens the resulting
+            // union-of-union into one flat union, making `x` and `negate(x)` siblings for the first
+            // time. `LiteralLifting` also runs in the logical optimizer's `fixpoint_logical_02`, but
+            // `logical_cleanup_pass` (which runs after cross-view normalization, closer to where this
+            // shape tends to arise) never repeats it, so no earlier `UnionBranchCancellation` call
+            // gets a chance to see the flattened form. Run it again here, after the last `RelationCSE`,
+            // so the trailing `fold_constants_fixpoint` can fuse the resulting empty constants and
+            // drop the now-unused binding.
+            //
+            // Gated behind a flag because this generalizes beyond `LiteralLifting`: any transform
+            // that can make two union branches syntactically equal only after running once more
+            // late in the pipeline could expose the same gap, and we haven't enumerated those; see
+            // database-issues#5225.
+            Box::new(UnionBranchCancellation);
+                if ctx.features.enable_union_cancellation_after_relation_cse,
             // `RelationCSE` can create new points of interest for `ProjectionPushdown`: If an MFP
             // is cut in half by `RelationCSE`, then we'd like to push projections behind the new
             // Get as much as possible. This is because a fork in the plan involves copying the

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -885,19 +885,16 @@ impl Optimizer {
             // In `fixpoint_physical_01` above, `LiteralLifting` can hoist a `Map` literal that was
             // wrapping *both* branches of such a union out of the union entirely, turning
             // `union(map(k, x), map(k, union(negate(x), y)))` into `map(k, union(x, union(negate(x), y)))`.
-            // A later `FoldConstants` pass (in the same fixpoint) then flattens the resulting
-            // union-of-union into one flat union, making `x` and `negate(x)` siblings for the first
-            // time. `LiteralLifting` also runs in the logical optimizer's `fixpoint_logical_02`, but
+            // Flattening that union-of-union is what makes `x` and `negate(x)` direct siblings, so
+            // run `UnionFusion` first to establish the flat shape `UnionBranchCancellation` needs.
+            // `LiteralLifting` also runs in the logical optimizer's `fixpoint_logical_02`, but
             // `logical_cleanup_pass` (which runs after cross-view normalization, closer to where this
             // shape tends to arise) never repeats it, so no earlier `UnionBranchCancellation` call
-            // gets a chance to see the flattened form. Run it again here, after the last `RelationCSE`,
-            // so the trailing `fold_constants_fixpoint` can fuse the resulting empty constants and
-            // drop the now-unused binding.
-            //
-            // Gated behind a flag because this generalizes beyond `LiteralLifting`: any transform
-            // that can make two union branches syntactically equal only after running once more
-            // late in the pipeline could expose the same gap, and we haven't enumerated those; see
-            // database-issues#5225.
+            // gets a chance to see the flattened form. Run it again here, after the last
+            // `RelationCSE`, so the trailing `fold_constants_fixpoint` can fuse the resulting empty
+            // constants and drop the now-unused binding.
+            Box::new(fusion::union::Union);
+                if ctx.features.enable_union_cancellation_after_relation_cse,
             Box::new(UnionBranchCancellation);
                 if ctx.features.enable_union_cancellation_after_relation_cse,
             // `RelationCSE` can create new points of interest for `ProjectionPushdown`: If an MFP

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -284,6 +284,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_simplify_from_less_existence
     enable_simplify_quantified_comparisons
     enable_time_at_time_zone
+    enable_union_cancellation_after_relation_cse
     enable_unlimited_retain_history
     enable_will_distinct_propagation
     enable_with_ordinality_legacy_fallback

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -1176,10 +1176,6 @@ WHERE EXISTS (SELECT FROM c AS ref_7 WHERE EXISTS (SELECT ref_0."?column?" AS c2
 Explained Query:
   With
     cte l0 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          ReadStorage materialize.public.c // { arity: 1 }
-    cte l1 =
       Union // { arity: 1 }
         Project (#2) // { arity: 1 }
           Map (null) // { arity: 3 }
@@ -1195,21 +1191,17 @@ Explained Query:
         implementation
           %0[×] » %1[×]
         ArrangeBy keys=[[]] // { arity: 0 }
-          Union // { arity: 0 }
-            Get l0 // { arity: 0 }
-            Negate // { arity: 0 }
-              Get l0 // { arity: 0 }
-            Constant // { arity: 0 }
-              - ()
+          Constant // { arity: 0 }
+            - ()
         ArrangeBy keys=[[]] // { arity: 1 }
           Union // { arity: 1 }
-            Get l1 // { arity: 1 }
+            Get l0 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Distinct project=[] // { arity: 0 }
                     Project () // { arity: 0 }
-                      Get l1 // { arity: 1 }
+                      Get l0 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
 

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -29,6 +29,9 @@ select x from (select x, 1/a from (select 2 as x), t);
 # A `dummy` used to occur in the following plan before putting an extra call to `ProjectionPushdown` after the `Demand`
 # call in the physical optimizer, because at the time of the first `Demand` call, the column that is later dummied in
 # the second call is still being used in a join constraint, but this join is then eliminated by `RedundantJoin`.
+#
+# This query also exercises `UnionBranchCancellation` running again after the final `RelationCSE`: it folds a
+# `union(get l0, negate(get l0), constant)` left behind by the earlier passes into the fast path below.
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR
 select

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -87,27 +87,10 @@ from
 where true
 limit coalesce(43, 120);
 ----
-Explained Query:
+Explained Query (fast path):
   Finish limit=43 output=[#0..=#3]
-    With
-      cte l0 =
-        Distinct project=[] // { arity: 0 }
-          TopK limit=13 // { arity: 0 }
-            Filter error("timestamp out of range") // { arity: 0 }
-              Project () // { arity: 0 }
-                ReadIndex on=mz_columns mz_columns_ind=[*** full scan ***] // { arity: 8 }
-    Return // { arity: 4 }
-      Map (833564499, null, null, 2024-12-18 12:54:29.994 UTC) // { arity: 4 }
-        TopK limit=90 // { arity: 0 }
-          Union // { arity: 0 }
-            Get l0 // { arity: 0 }
-            Negate // { arity: 0 }
-              Get l0 // { arity: 0 }
-            Constant // { arity: 0 }
-              - ()
-
-Used Indexes:
-  - mz_catalog.mz_columns_ind (*** full scan ***)
+    Constant
+      - (833564499, null, null, 2024-12-18 12:54:29.994 UTC)
 
 Target cluster: mz_catalog_server
 

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -32,6 +32,10 @@ select x from (select x, 1/a from (select 2 as x), t);
 #
 # This query also exercises `UnionBranchCancellation` running again after the final `RelationCSE`: it folds a
 # `union(get l0, negate(get l0), constant)` left behind by the earlier passes into the fast path below.
+#
+# NOTE: That cancellation collapses the whole query to a constant fast path, so this query no longer exercises the
+# `dummy` scenario described in the first paragraph. It is kept for the `UnionBranchCancellation` coverage, and the
+# original `dummy` coverage would need a different query.
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR
 select


### PR DESCRIPTION
`UnionBranchCancellation` cancels two branches only when they are direct siblings of the same `Union` and structurally equal (see `compare_branches`).
A `Get x` sitting under a `Map` next to a `Union` one level down does not qualify, even when that nested union holds a matching `Negate (Get x)`.
The transform ran only in the logical optimizer and the logical cleanup pass, so a plan that reaches the flat sibling shape later kept the cancellable union all the way into the optimized plan.

The shape becomes cancellable inside `fixpoint_physical_01`.
`LiteralLifting` hoists a literal `Map` that wrapped *both* branches out of the union, turning `union(map(k, x), map(k, union(negate(x), y)))` into `map(k, union(x, union(negate(x), y)))`, and flattening that union-of-union makes `x` and `negate(x)` siblings for the first time.
`LiteralLifting` also runs in `fixpoint_logical_02`, but `logical_cleanup_pass` never repeats it, so no earlier `UnionBranchCancellation` call gets to see the flattened form.
The transform logic is correct; the gap is pipeline coverage.

This change runs `fusion::union::Union` followed by `UnionBranchCancellation` after the final `RelationCSE` in the physical optimizer.
The explicit union fusion establishes the flat shape on purpose instead of relying on `FoldConstants`, which flattens a union-of-union only as a side effect of decomposing a `Union` and rebuilding it with `union_many`.
The trailing `fold_constants_fixpoint` then fuses the resulting empty constants and `NormalizeLets` drops the now unused binding.
Both calls sit behind `enable_union_cancellation_after_relation_cse`, cluster-scoped and default on, so the optimization can be switched off for a user who hits an unexpected regression.
Cleanup of the flag is tracked in [STG-41](https://linear.app/materializeinc/issue/STG-41).

The motivating cases are a query in `test/sqllogictest/joins.slt` and the second query in `test/sqllogictest/transform/demand.slt`, both of which previously left `union(get l0, negate(get l0), constant)` in the plan and now fold to a constant fast path.
The `demand.slt` query no longer reaches a plan that could carry a `dummy`, so it stops covering the scenario its first comment paragraph describes; the comment now records that.

Every `test/sqllogictest` file containing `EXPLAIN` (137 files, excluding the upstream `sqlite` and `cockroach` trees) passes unchanged apart from those two goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
