### PR TITLE
sqllogictest: mask churning global ID in case_literal test

### DIFF
--- a/test/sqllogictest/transform/case_literal.slt
+++ b/test/sqllogictest/transform/case_literal.slt
@@ -242,6 +242,8 @@ FROM t WHERE y = 'null'
 0
 
 # Verify JSON serialization of a CaseLiteral plan succeeds.
+# The global ID churns across runs, so replace it with a placeholder.
+replace ("User": )\d+  ${1}<ID>
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT
@@ -264,7 +266,7 @@ FROM t
                 "Get": {
                   "id": {
                     "Global": {
-                      "User": 1
+                      "User": <ID>
                     }
                   },
                   "typ": {
@@ -388,7 +390,7 @@ FROM t
   "sources": [
     {
       "id": {
-        "User": 1
+        "User": <ID>
       },
       "op": null
     }


### PR DESCRIPTION
The JSON `EXPLAIN` output in `test/sqllogictest/transform/case_literal.slt` embeds the global ID of table `t`.
That ID depends on how many catalog objects precede it, so it churns whenever unrelated tests or migrations shift the allocation, producing spurious diffs like `"User": 22` vs `"User": 1`.

This registers a `replace` directive that substitutes `"User": <num>` with a `<ID>` placeholder in the actual output before comparison, and updates the expected output to match.
The plan structure is still fully asserted; only the unstable ID is masked.
