### PR TITLE
Scoped feature flags: consolidate eval helpers + ALTER e2e

### DIFF
--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -337,6 +337,37 @@ pub struct ReplicaEvalContext {
     pub replica: ReplicaScopeContext,
 }
 
+impl ReplicaEvalContext {
+    /// Builds the eval context for a replica owned by `cluster`. The owning
+    /// cluster's scope context supplies both the cluster-free pass and the
+    /// replica's cluster attributes (id, name, builtin flag), so the caller
+    /// passes it once rather than restating those fields.
+    pub(crate) fn for_replica(
+        cluster_id: ClusterId,
+        cluster: ClusterScopeContext,
+        replica_id: ReplicaId,
+        name: String,
+        size: String,
+        size_family: String,
+    ) -> Self {
+        let replica = ReplicaScopeContext {
+            id: replica_id.to_string(),
+            name,
+            is_builtin: cluster.is_builtin,
+            size,
+            size_family,
+            cluster_id: cluster.id.clone(),
+            cluster_name: cluster.name.clone(),
+        };
+        ReplicaEvalContext {
+            cluster_id,
+            replica_id,
+            cluster,
+            replica,
+        }
+    }
+}
+
 /// The identity of a single live cluster, used to evaluate cluster-coherent
 /// scoped parameters in [`SystemParameterFrontend::pull_cluster_overrides`].
 #[derive(Clone, Debug)]

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -344,6 +344,37 @@ pub struct ReplicaEvalContext {
     pub replica: ReplicaScopeContext,
 }
 
+impl ReplicaEvalContext {
+    /// Builds the eval context for a replica owned by `cluster`. The owning
+    /// cluster's scope context supplies both the cluster-free pass and the
+    /// replica's cluster attributes (id, name, builtin flag), so the caller
+    /// passes it once rather than restating those fields.
+    pub(crate) fn for_replica(
+        cluster_id: ClusterId,
+        cluster: ClusterScopeContext,
+        replica_id: ReplicaId,
+        name: String,
+        size: String,
+        size_family: String,
+    ) -> Self {
+        let replica = ReplicaScopeContext {
+            id: replica_id.to_string(),
+            name,
+            is_builtin: cluster.is_builtin,
+            size,
+            size_family,
+            cluster_id: cluster.id.clone(),
+            cluster_name: cluster.name.clone(),
+        };
+        ReplicaEvalContext {
+            cluster_id,
+            replica_id,
+            cluster,
+            replica,
+        }
+    }
+}
+
 /// The identity of a single live cluster, used to evaluate cluster-coherent
 /// scoped parameters in [`SystemParameterFrontend::pull_cluster_overrides`].
 #[derive(Clone, Debug)]
@@ -504,6 +535,19 @@ pub struct ClusterScopeContext {
     pub name: String,
     /// Whether the cluster is a builtin (system) cluster.
     pub is_builtin: bool,
+}
+
+impl ClusterScopeContext {
+    /// Builds the scope context for `cluster_id`, whose id namespace also
+    /// decides the builtin flag. The single derivation keeps create-time and
+    /// steady-state evaluation from disagreeing on a cluster's attributes.
+    pub(crate) fn for_cluster(cluster_id: ClusterId, name: String) -> Self {
+        ClusterScopeContext {
+            id: cluster_id.to_string(),
+            name,
+            is_builtin: cluster_id.is_system(),
+        }
+    }
 }
 
 /// Identity of a replica, used to build a `replica` context kind for

--- a/src/adapter/src/config/sync.rs
+++ b/src/adapter/src/config/sync.rs
@@ -186,16 +186,8 @@ pub(crate) fn evaluate_scoped_parameters(
     // The synced parameters, partitioned by scope class. The scope declaration
     // bounds evaluation to exactly the flags in use: an environment with no
     // scoped flags evaluates neither pass.
-    let replica_param_names: Vec<&'static str> = system_config
-        .iter_synced()
-        .filter(|var| var.scope() == ParameterScope::Replica)
-        .map(|var| var.name())
-        .collect();
-    let cluster_param_names: Vec<&'static str> = system_config
-        .iter_synced()
-        .filter(|var| var.scope() == ParameterScope::Cluster)
-        .map(|var| var.name())
-        .collect();
+    let replica_param_names = system_config.synced_param_names_in_scope(ParameterScope::Replica);
+    let cluster_param_names = system_config.synced_param_names_in_scope(ParameterScope::Cluster);
 
     let replica = if replica_param_names.is_empty() {
         Default::default()

--- a/src/adapter/src/config/sync.rs
+++ b/src/adapter/src/config/sync.rs
@@ -19,9 +19,9 @@ use tokio::time;
 use crate::Client;
 use crate::catalog::Catalog;
 use crate::config::{
-    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
-    ScopedParameters, ScopedParametersScope, SynchronizedParameters, SystemParameterBackend,
-    SystemParameterFrontend, SystemParameterSyncConfig,
+    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ScopedParameters,
+    ScopedParametersScope, SynchronizedParameters, SystemParameterBackend, SystemParameterFrontend,
+    SystemParameterSyncConfig,
 };
 
 /// Run a loop that periodically pulls system parameters defined in the
@@ -149,16 +149,8 @@ pub(crate) fn evaluate_scoped_parameters(
     // The synced parameters, partitioned by scope class. The scope declaration
     // bounds evaluation to exactly the flags in use: an environment with no
     // scoped flags evaluates neither pass.
-    let replica_param_names: Vec<&'static str> = system_config
-        .iter_synced()
-        .filter(|var| var.scope() == ParameterScope::Replica)
-        .map(|var| var.name())
-        .collect();
-    let cluster_param_names: Vec<&'static str> = system_config
-        .iter_synced()
-        .filter(|var| var.scope() == ParameterScope::Cluster)
-        .map(|var| var.name())
-        .collect();
+    let replica_param_names = system_config.synced_param_names_in_scope(ParameterScope::Replica);
+    let cluster_param_names = system_config.synced_param_names_in_scope(ParameterScope::Cluster);
 
     let replica = if replica_param_names.is_empty() {
         Default::default()
@@ -187,11 +179,7 @@ fn build_cluster_eval_contexts(
         .filter(|cluster| filter.is_none_or(|f| f.contains(&cluster.id)))
         .map(|cluster| ClusterEvalContext {
             cluster_id: cluster.id,
-            cluster: ClusterScopeContext {
-                id: cluster.id.to_string(),
-                name: cluster.name.clone(),
-                is_builtin: cluster.id.is_system(),
-            },
+            cluster: ClusterScopeContext::for_cluster(cluster.id, cluster.name.clone()),
         })
         .collect()
 }
@@ -211,12 +199,7 @@ fn build_replica_eval_contexts(
 
     let mut contexts = Vec::new();
     for cluster in catalog.clusters() {
-        let is_builtin = cluster.id.is_system();
-        let cluster_ctx = ClusterScopeContext {
-            id: cluster.id.to_string(),
-            name: cluster.name.clone(),
-            is_builtin,
-        };
+        let cluster_ctx = ClusterScopeContext::for_cluster(cluster.id, cluster.name.clone());
         for replica in cluster.replicas() {
             if filter.is_some_and(|f| !f.contains(&replica.replica_id)) {
                 continue;
@@ -225,21 +208,14 @@ fn build_replica_eval_contexts(
             let ReplicaLocation::Managed(location) = &replica.config.location else {
                 continue;
             };
-            let replica_ctx = ReplicaScopeContext {
-                id: replica.replica_id.to_string(),
-                name: replica.name.clone(),
-                is_builtin,
-                size: location.size.clone(),
-                size_family: location.allocation.family().to_string(),
-                cluster_id: cluster.id.to_string(),
-                cluster_name: cluster.name.clone(),
-            };
-            contexts.push(ReplicaEvalContext {
-                cluster_id: cluster.id,
-                replica_id: replica.replica_id,
-                cluster: cluster_ctx.clone(),
-                replica: replica_ctx,
-            });
+            contexts.push(ReplicaEvalContext::for_replica(
+                cluster.id,
+                cluster_ctx.clone(),
+                replica.replica_id,
+                replica.name.clone(),
+                location.size.clone(),
+                location.allocation.family().to_string(),
+            ));
         }
     }
     contexts

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2117,16 +2117,10 @@ impl Coordinator {
 
         // Partition the synced parameters by scope class, as the sync loop does,
         // so we evaluate exactly the flags in use at each scope.
-        let replica_param_names: Vec<&'static str> = system_config
-            .iter_synced()
-            .filter(|var| var.scope() == ParameterScope::Replica)
-            .map(|var| var.name())
-            .collect();
-        let cluster_param_names: Vec<&'static str> = system_config
-            .iter_synced()
-            .filter(|var| var.scope() == ParameterScope::Cluster)
-            .map(|var| var.name())
-            .collect();
+        let replica_param_names =
+            system_config.synced_param_names_in_scope(ParameterScope::Replica);
+        let cluster_param_names =
+            system_config.synced_param_names_in_scope(ParameterScope::Cluster);
 
         let params = SynchronizedParameters::new(system_config.clone());
         let mut evaluated = ScopedParameters::default();

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2311,16 +2311,10 @@ impl Coordinator {
 
         // Partition the synced parameters by scope class, as the sync loop does,
         // so we evaluate exactly the flags in use at each scope.
-        let replica_param_names: Vec<&'static str> = system_config
-            .iter_synced()
-            .filter(|var| var.scope() == ParameterScope::Replica)
-            .map(|var| var.name())
-            .collect();
-        let cluster_param_names: Vec<&'static str> = system_config
-            .iter_synced()
-            .filter(|var| var.scope() == ParameterScope::Cluster)
-            .map(|var| var.name())
-            .collect();
+        let replica_param_names =
+            system_config.synced_param_names_in_scope(ParameterScope::Replica);
+        let cluster_param_names =
+            system_config.synced_param_names_in_scope(ParameterScope::Cluster);
 
         let params = SynchronizedParameters::new(system_config.clone());
         let mut evaluated = ScopedParameters::default();

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -41,9 +41,7 @@ use tracing::{Instrument, Span, debug};
 use super::return_if_err;
 use crate::AdapterError::AlterClusterWhilePendingReplicas;
 use crate::catalog::{self, Op, ReplicaCreateDropReason};
-use crate::config::{
-    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
-};
+use crate::config::{ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext};
 use crate::coord::{
     AlterCluster, AlterClusterFinalize, AlterClusterWaitForHydrated, ClusterStage, Coordinator,
     Message, PlanValidity, StageResult, Staged,
@@ -748,20 +746,14 @@ impl Coordinator {
                 *session.current_role_id(),
                 ReplicaCreateDropReason::Manual,
             )?;
-            replica_ctxs.push(ReplicaEvalContext {
+            replica_ctxs.push(ReplicaEvalContext::for_replica(
                 cluster_id,
+                cluster_ctx.clone(),
                 replica_id,
-                cluster: cluster_ctx.clone(),
-                replica: ReplicaScopeContext {
-                    id: replica_id.to_string(),
-                    name: replica_name,
-                    is_builtin: cluster_id.is_system(),
-                    size: size.clone(),
-                    size_family,
-                    cluster_id: cluster_id.to_string(),
-                    cluster_name: cluster_name.clone(),
-                },
-            });
+                replica_name,
+                size.clone(),
+                size_family,
+            ));
         }
 
         // Fold the new cluster's cluster-coherent and the replicas' replica-local
@@ -992,20 +984,14 @@ impl Coordinator {
             // Only orchestrated (managed-location) replicas have a size and size
             // family, so only they carry replica-local overrides.
             if let ReplicaLocation::Managed(location) = &config.location {
-                replica_ctxs.push(ReplicaEvalContext {
-                    cluster_id: id,
+                replica_ctxs.push(ReplicaEvalContext::for_replica(
+                    id,
+                    cluster_ctx.clone(),
                     replica_id,
-                    cluster: cluster_ctx.clone(),
-                    replica: ReplicaScopeContext {
-                        id: replica_id.to_string(),
-                        name: replica_name.clone(),
-                        is_builtin: id.is_system(),
-                        size: location.size.clone(),
-                        size_family: location.allocation.family().to_string(),
-                        cluster_id: id.to_string(),
-                        cluster_name: cluster_name.clone(),
-                    },
-                });
+                    replica_name.clone(),
+                    location.size.clone(),
+                    location.allocation.family().to_string(),
+                ));
             }
 
             ops.push(catalog::Op::CreateClusterReplica {
@@ -1153,24 +1139,18 @@ impl Coordinator {
         // Build the replica's eval context from the plan before `config` moves
         // into the op. Only managed replicas have a size (and size family).
         let replica_ctx = match &config.location {
-            ReplicaLocation::Managed(location) => Some(ReplicaEvalContext {
+            ReplicaLocation::Managed(location) => Some(ReplicaEvalContext::for_replica(
                 cluster_id,
-                replica_id,
-                cluster: ClusterScopeContext {
+                ClusterScopeContext {
                     id: cluster_id.to_string(),
                     name: cluster_name.clone(),
                     is_builtin,
                 },
-                replica: ReplicaScopeContext {
-                    id: replica_id.to_string(),
-                    name: name.to_string(),
-                    is_builtin,
-                    size: location.size.clone(),
-                    size_family: location.allocation.family().to_string(),
-                    cluster_id: cluster_id.to_string(),
-                    cluster_name,
-                },
-            }),
+                replica_id,
+                name.to_string(),
+                location.size.clone(),
+                location.allocation.family().to_string(),
+            )),
             ReplicaLocation::Unmanaged(_) => None,
         };
 
@@ -1385,20 +1365,14 @@ impl Coordinator {
                             owner_id,
                             reason.clone(),
                         )?;
-                        replica_ctxs.push(ReplicaEvalContext {
+                        replica_ctxs.push(ReplicaEvalContext::for_replica(
                             cluster_id,
+                            cluster_ctx.clone(),
                             replica_id,
-                            cluster: cluster_ctx.clone(),
-                            replica: ReplicaScopeContext {
-                                id: replica_id.to_string(),
-                                name: replica_name,
-                                is_builtin: cluster_id.is_system(),
-                                size: new_size.clone(),
-                                size_family,
-                                cluster_id: cluster_id.to_string(),
-                                cluster_name: cluster_ctx.name.clone(),
-                            },
-                        });
+                            replica_name,
+                            new_size.clone(),
+                            size_family,
+                        ));
                     }
                 }
                 AlterClusterPlanStrategy::For(_) | AlterClusterPlanStrategy::UntilReady { .. } => {
@@ -1421,20 +1395,14 @@ impl Coordinator {
                             owner_id,
                             reason.clone(),
                         )?;
-                        replica_ctxs.push(ReplicaEvalContext {
+                        replica_ctxs.push(ReplicaEvalContext::for_replica(
                             cluster_id,
+                            cluster_ctx.clone(),
                             replica_id,
-                            cluster: cluster_ctx.clone(),
-                            replica: ReplicaScopeContext {
-                                id: replica_id.to_string(),
-                                name: replica_name,
-                                is_builtin: cluster_id.is_system(),
-                                size: new_size.clone(),
-                                size_family,
-                                cluster_id: cluster_id.to_string(),
-                                cluster_name: cluster_ctx.name.clone(),
-                            },
-                        });
+                            replica_name,
+                            new_size.clone(),
+                            size_family,
+                        ));
                     }
                     finalization_needed = NeedsFinalization::Yes;
                 }
@@ -1475,20 +1443,14 @@ impl Coordinator {
                     owner_id,
                     reason.clone(),
                 )?;
-                replica_ctxs.push(ReplicaEvalContext {
+                replica_ctxs.push(ReplicaEvalContext::for_replica(
                     cluster_id,
+                    cluster_ctx.clone(),
                     replica_id,
-                    cluster: cluster_ctx.clone(),
-                    replica: ReplicaScopeContext {
-                        id: replica_id.to_string(),
-                        name: replica_name,
-                        is_builtin: cluster_id.is_system(),
-                        size: new_size.clone(),
-                        size_family,
-                        cluster_id: cluster_id.to_string(),
-                        cluster_name: cluster_ctx.name.clone(),
-                    },
-                });
+                    replica_name,
+                    new_size.clone(),
+                    size_family,
+                ));
             }
         }
 

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -55,9 +55,7 @@ use mz_adapter_types::dyncfgs::{
 use super::return_if_err;
 use crate::AdapterError::AlterClusterWhilePendingReplicas;
 use crate::catalog::{self, Op, ReplicaCreateDropReason};
-use crate::config::{
-    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
-};
+use crate::config::{ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext};
 use crate::coord::{
     AlterCluster, AlterClusterAwaitReconfiguration, AlterClusterFinalize,
     AlterClusterWaitForHydrated, ClusterReplicaStatuses, ClusterStage, Coordinator, Message,
@@ -1365,21 +1363,18 @@ impl Coordinator {
             .allocate_replica_ids(cluster_id, u64::from(replication_factor), id_ts)
             .await?;
 
-        let cluster_ctx = ClusterScopeContext {
-            id: cluster_id.to_string(),
-            name: cluster_name.clone(),
-            is_builtin: cluster_id.is_system(),
-        };
+        let cluster_ctx = ClusterScopeContext::for_cluster(cluster_id, cluster_name.clone());
 
         let mut replica_ctxs = Vec::new();
         for (replica_id, replica_name) in replica_ids
             .into_iter()
             .zip_eq((0..replication_factor).map(managed_cluster_replica_name))
         {
-            let size_family = self.create_managed_cluster_replica_op(
+            replica_ctxs.push(self.create_managed_cluster_replica_op(
                 cluster_id,
+                &cluster_ctx,
                 replica_id,
-                replica_name.clone(),
+                replica_name,
                 &compute,
                 &size,
                 &mut ops,
@@ -1391,21 +1386,7 @@ impl Coordinator {
                 false,
                 *session.current_role_id(),
                 ReplicaCreateDropReason::Manual,
-            )?;
-            replica_ctxs.push(ReplicaEvalContext {
-                cluster_id,
-                replica_id,
-                cluster: cluster_ctx.clone(),
-                replica: ReplicaScopeContext {
-                    id: replica_id.to_string(),
-                    name: replica_name,
-                    is_builtin: cluster_id.is_system(),
-                    size: size.clone(),
-                    size_family,
-                    cluster_id: cluster_id.to_string(),
-                    cluster_name: cluster_name.clone(),
-                },
-            });
+            )?);
         }
 
         // Fold the new cluster's cluster-coherent and the replicas' replica-local
@@ -1427,9 +1408,13 @@ impl Coordinator {
         Ok(ExecuteResponse::CreatedCluster)
     }
 
+    /// Pushes the op that creates a managed replica of `cluster_id` and returns
+    /// the replica's scoped-parameter eval context, so the caller can fold the
+    /// replica's overrides into the same transaction.
     fn create_managed_cluster_replica_op(
         &self,
         cluster_id: ClusterId,
+        cluster: &ClusterScopeContext,
         replica_id: ReplicaId,
         name: String,
         compute: &mz_sql::plan::ComputeReplicaConfig,
@@ -1439,7 +1424,7 @@ impl Coordinator {
         pending: bool,
         owner_id: RoleId,
         reason: ReplicaCreateDropReason,
-    ) -> Result<String, AdapterError> {
+    ) -> Result<ReplicaEvalContext, AdapterError> {
         let location = mz_catalog::durable::ReplicaLocation::Managed {
             // Concretized below from the cluster config; this intermediate value
             // is discarded, so the list is left empty here.
@@ -1474,19 +1459,25 @@ impl Coordinator {
             },
         };
 
-        // The caller pre-allocates `replica_id` out-of-band via the durable
-        // allocator, so nothing allocates a replica id in-apply.
-        //
-        // Extract the size family before `config` moves into the op, for the
-        // replica's scoped eval context.
-        let size_family = match &config.location {
-            ReplicaLocation::Managed(location) => location.allocation.family().to_string(),
+        // Build the eval context before `config` moves into the op, so the size
+        // family comes from the concretized location rather than the plan.
+        let replica_ctx = match &config.location {
+            ReplicaLocation::Managed(location) => ReplicaEvalContext::for_replica(
+                cluster_id,
+                cluster.clone(),
+                replica_id,
+                name.clone(),
+                location.size.clone(),
+                location.allocation.family().to_string(),
+            ),
             // A managed replica always concretizes to a managed location.
             ReplicaLocation::Unmanaged(_) => {
                 unreachable!("managed cluster replica has a managed location")
             }
         };
 
+        // The caller pre-allocates `replica_id` out-of-band via the durable
+        // allocator, so nothing allocates a replica id in-apply.
         ops.push(catalog::Op::CreateClusterReplica {
             cluster_id,
             replica_id,
@@ -1495,7 +1486,7 @@ impl Coordinator {
             owner_id,
             reason,
         });
-        Ok(size_family)
+        Ok(replica_ctx)
     }
 
     fn ensure_valid_azs<'a, I: IntoIterator<Item = &'a String>>(
@@ -1562,11 +1553,7 @@ impl Coordinator {
             .allocate_replica_ids(id, u64::cast_from(replicas.len()), id_ts)
             .await?;
 
-        let cluster_ctx = ClusterScopeContext {
-            id: id.to_string(),
-            name: cluster_name.clone(),
-            is_builtin: id.is_system(),
-        };
+        let cluster_ctx = ClusterScopeContext::for_cluster(id, cluster_name.clone());
         let mut replica_ctxs = Vec::new();
 
         for (replica_id, (replica_name, replica_config)) in replica_ids.into_iter().zip_eq(replicas)
@@ -1642,20 +1629,14 @@ impl Coordinator {
             // Only orchestrated (managed-location) replicas have a size and size
             // family, so only they carry replica-local overrides.
             if let ReplicaLocation::Managed(location) = &config.location {
-                replica_ctxs.push(ReplicaEvalContext {
-                    cluster_id: id,
+                replica_ctxs.push(ReplicaEvalContext::for_replica(
+                    id,
+                    cluster_ctx.clone(),
                     replica_id,
-                    cluster: cluster_ctx.clone(),
-                    replica: ReplicaScopeContext {
-                        id: replica_id.to_string(),
-                        name: replica_name.clone(),
-                        is_builtin: id.is_system(),
-                        size: location.size.clone(),
-                        size_family: location.allocation.family().to_string(),
-                        cluster_id: id.to_string(),
-                        cluster_name: cluster_name.clone(),
-                    },
-                });
+                    replica_name.clone(),
+                    location.size.clone(),
+                    location.allocation.family().to_string(),
+                ));
             }
 
             ops.push(catalog::Op::CreateClusterReplica {
@@ -1883,7 +1864,6 @@ impl Coordinator {
         let owner_id = cluster.owner_id();
 
         let cluster_name = cluster.name.clone();
-        let is_builtin = cluster_id.is_system();
         // A replica name is only unique within its cluster, so the notice on the
         // `IF NOT EXISTS` path below has to name both.
         let qualified_name = format!("{cluster_name}.{name}");
@@ -1905,24 +1885,14 @@ impl Coordinator {
         // Build the replica's eval context from the plan before `config` moves
         // into the op. Only managed replicas have a size (and size family).
         let replica_ctx = match &config.location {
-            ReplicaLocation::Managed(location) => Some(ReplicaEvalContext {
+            ReplicaLocation::Managed(location) => Some(ReplicaEvalContext::for_replica(
                 cluster_id,
+                ClusterScopeContext::for_cluster(cluster_id, cluster_name.clone()),
                 replica_id,
-                cluster: ClusterScopeContext {
-                    id: cluster_id.to_string(),
-                    name: cluster_name.clone(),
-                    is_builtin,
-                },
-                replica: ReplicaScopeContext {
-                    id: replica_id.to_string(),
-                    name: name.to_string(),
-                    is_builtin,
-                    size: location.size.clone(),
-                    size_family: location.allocation.family().to_string(),
-                    cluster_id: cluster_id.to_string(),
-                    cluster_name,
-                },
-            }),
+                name.to_string(),
+                location.size.clone(),
+                location.allocation.family().to_string(),
+            )),
             ReplicaLocation::Unmanaged(_) => None,
         };
 
@@ -2184,11 +2154,7 @@ impl Coordinator {
         // must reach the controller before the recreated replica renders. Only
         // the replica scope is folded. The cluster already exists and its
         // cluster-scoped overrides are unaffected by this alter.
-        let cluster_ctx = ClusterScopeContext {
-            id: cluster_id.to_string(),
-            name: name.clone(),
-            is_builtin: cluster_id.is_system(),
-        };
+        let cluster_ctx = ClusterScopeContext::for_cluster(cluster_id, name.clone());
         let mut replica_ctxs = Vec::new();
 
         if controller_owns {
@@ -2233,10 +2199,11 @@ impl Coordinator {
                         let replica_id = new_replica_ids
                             .next()
                             .expect("pre-allocated enough replica ids");
-                        let size_family = self.create_managed_cluster_replica_op(
+                        replica_ctxs.push(self.create_managed_cluster_replica_op(
                             cluster_id,
+                            &cluster_ctx,
                             replica_id,
-                            replica_name.clone(),
+                            replica_name,
                             &compute,
                             new_size,
                             &mut ops,
@@ -2244,21 +2211,7 @@ impl Coordinator {
                             false,
                             owner_id,
                             reason.clone(),
-                        )?;
-                        replica_ctxs.push(ReplicaEvalContext {
-                            cluster_id,
-                            replica_id,
-                            cluster: cluster_ctx.clone(),
-                            replica: ReplicaScopeContext {
-                                id: replica_id.to_string(),
-                                name: replica_name,
-                                is_builtin: cluster_id.is_system(),
-                                size: new_size.clone(),
-                                size_family,
-                                cluster_id: cluster_id.to_string(),
-                                cluster_name: cluster_ctx.name.clone(),
-                            },
-                        });
+                        )?);
                     }
                 }
                 AlterClusterPlanStrategy::For(_) | AlterClusterPlanStrategy::UntilReady { .. } => {
@@ -2269,10 +2222,11 @@ impl Coordinator {
                         let replica_id = new_replica_ids
                             .next()
                             .expect("pre-allocated enough replica ids");
-                        let size_family = self.create_managed_cluster_replica_op(
+                        replica_ctxs.push(self.create_managed_cluster_replica_op(
                             cluster_id,
+                            &cluster_ctx,
                             replica_id,
-                            replica_name.clone(),
+                            replica_name,
                             &compute,
                             new_size,
                             &mut ops,
@@ -2280,21 +2234,7 @@ impl Coordinator {
                             true,
                             owner_id,
                             reason.clone(),
-                        )?;
-                        replica_ctxs.push(ReplicaEvalContext {
-                            cluster_id,
-                            replica_id,
-                            cluster: cluster_ctx.clone(),
-                            replica: ReplicaScopeContext {
-                                id: replica_id.to_string(),
-                                name: replica_name,
-                                is_builtin: cluster_id.is_system(),
-                                size: new_size.clone(),
-                                size_family,
-                                cluster_id: cluster_id.to_string(),
-                                cluster_name: cluster_ctx.name.clone(),
-                            },
-                        });
+                        )?);
                     }
                     finalization_needed = NeedsFinalization::Yes;
                 }
@@ -2321,10 +2261,11 @@ impl Coordinator {
                 let replica_id = new_replica_ids
                     .next()
                     .expect("pre-allocated enough replica ids");
-                let size_family = self.create_managed_cluster_replica_op(
+                replica_ctxs.push(self.create_managed_cluster_replica_op(
                     cluster_id,
+                    &cluster_ctx,
                     replica_id,
-                    replica_name.clone(),
+                    replica_name,
                     &compute,
                     new_size,
                     &mut ops,
@@ -2334,21 +2275,7 @@ impl Coordinator {
                     false,
                     owner_id,
                     reason.clone(),
-                )?;
-                replica_ctxs.push(ReplicaEvalContext {
-                    cluster_id,
-                    replica_id,
-                    cluster: cluster_ctx.clone(),
-                    replica: ReplicaScopeContext {
-                        id: replica_id.to_string(),
-                        name: replica_name,
-                        is_builtin: cluster_id.is_system(),
-                        size: new_size.clone(),
-                        size_family,
-                        cluster_id: cluster_id.to_string(),
-                        cluster_name: cluster_ctx.name.clone(),
-                    },
-                });
+                )?);
             }
         }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1425,6 +1425,16 @@ impl SystemVars {
         self.iter().filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name)
     }
 
+    /// Returns the names of synced parameters declared in the given scope. Used
+    /// to bound scoped feature-flag evaluation to the flags in use at each scope
+    /// boundary.
+    pub fn synced_param_names_in_scope(&self, scope: ParameterScope) -> Vec<&'static str> {
+        self.iter_synced()
+            .filter(|var| var.scope() == scope)
+            .map(|var| var.name())
+            .collect()
+    }
+
     /// Returns an iterator over the configuration parameters that can be overriden per-Session.
     pub fn iter_session(&self) -> impl Iterator<Item = &dyn Var> {
         self.vars

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1449,6 +1449,16 @@ impl SystemVars {
         self.iter().filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name)
     }
 
+    /// Returns the names of synced parameters declared in the given scope. Used
+    /// to bound scoped feature-flag evaluation to the flags in use at each scope
+    /// boundary.
+    pub fn synced_param_names_in_scope(&self, scope: ParameterScope) -> Vec<&'static str> {
+        self.iter_synced()
+            .filter(|var| var.scope() == scope)
+            .map(|var| var.name())
+            .collect()
+    }
+
     /// Returns an iterator over the configuration parameters that can be overriden per-Session.
     pub fn iter_session(&self) -> impl Iterator<Item = &dyn Var> {
         self.vars

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -592,6 +592,97 @@ def run_scoped_feature_flag_cases(
                     ]
                 )
             )
+
+            # Create-time resolution on ALTER: recreating a replica at a new size
+            # family must fold its replica-local override into the alter
+            # transaction, the same way CREATE does. `ld_alter` starts cc-family,
+            # so its replica gets the env-wide `enable_lgalloc=true` and records no
+            # override.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "CREATE CLUSTER ld_alter SIZE 'scale=1,workers=1'",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT count(*) FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter'",
+                        "0",
+                    ]
+                )
+            )
+            # `ALTER CLUSTER ... SET (SIZE ... legacy)` recreates the replica as
+            # legacy-family, where the rule serves `false`. The row appears
+            # immediately, before the (disabled) sync loop could write it, so it
+            # can only come from the alter-time fold. The recreated replica keeps
+            # the name `r1`.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "ALTER CLUSTER ld_alter SET (SIZE 'scale=1,workers=1,legacy')",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT cr.name, p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter'",
+                        "r1 false",
+                    ]
+                )
+            )
+
+            # Same fold on the zero-downtime path. `WITH (WAIT FOR ...)` creates
+            # the replacement replica as a pending replica (`r1-pending`) and then
+            # finalizes by renaming it to `r1`. The override is folded onto the
+            # pending replica at create time and is keyed by replica id, so it
+            # survives the rename. We assert on the value alone, not the replica
+            # name, since the row is recorded under the pending name first and the
+            # final name after finalization. The size family (the targeting axis
+            # here) is already correct on the pending replica, so this path is
+            # unaffected by the `-pending` name. Targeting `replica_name` for a
+            # render-frozen flag through a 0dt alter is the open policy question in
+            # DB-152, not covered here.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "CREATE CLUSTER ld_alter_zdt SIZE 'scale=1,workers=1'",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT count(*) FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter_zdt'",
+                        "0",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        "ALTER CLUSTER ld_alter_zdt SET (SIZE 'scale=1,workers=1,legacy') WITH (WAIT FOR '0s')",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter_zdt'",
+                        "false",
+                    ]
+                )
+            )
             c.stop("materialized")
     finally:
         for flag in (

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -533,6 +533,93 @@ def run_scoped_feature_flag_cases(
                     ]
                 )
             )
+
+            # Create-time resolution on ALTER: recreating a replica at a new size
+            # family must fold its replica-local override into the alter
+            # transaction, the same way CREATE does. `ld_alter` starts cc-family,
+            # so its replica gets the env-wide `enable_lgalloc=true` and records no
+            # override.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-execute connection=mz_system",
+                        "CREATE CLUSTER ld_alter SIZE 'scale=1,workers=1'",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT count(*) FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter'",
+                        "0",
+                    ]
+                )
+            )
+            # `ALTER CLUSTER ... SET (SIZE ... legacy)` recreates the replica as
+            # legacy-family, where the rule serves `false`. The row appears
+            # immediately, before the (disabled) sync loop could write it, so it
+            # can only come from the alter-time fold. The recreated replica keeps
+            # the name `r1`.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-execute connection=mz_system",
+                        "ALTER CLUSTER ld_alter SET (SIZE 'scale=1,workers=1,legacy')",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT cr.name, p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter'",
+                        "r1 false",
+                    ]
+                )
+            )
+
+            # Same fold on the zero-downtime path. `WITH (WAIT FOR ...)` creates
+            # the replacement replica as a pending replica (`r1-pending`) and then
+            # finalizes by renaming it to `r1`. The override is folded onto the
+            # pending replica at create time and is keyed by replica id, so it
+            # survives the rename. We assert on the value alone, not the replica
+            # name, since the row is recorded under the pending name first and the
+            # final name after finalization. The size family (the targeting axis
+            # here) is already correct on the pending replica, so this path is
+            # unaffected by the `-pending` name. Targeting `replica_name` for a
+            # render-frozen flag through a 0dt alter is the open policy question in
+            # DB-152, not covered here.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-execute connection=mz_system",
+                        "CREATE CLUSTER ld_alter_zdt SIZE 'scale=1,workers=1'",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT count(*) FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter_zdt'",
+                        "0",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-execute connection=mz_system",
+                        "ALTER CLUSTER ld_alter_zdt SET (SIZE 'scale=1,workers=1,legacy') WITH (WAIT FOR '0s')",
+                    ]
+                )
+            )
+            c.testdrive(
+                "\n".join(
+                    [
+                        f"> SELECT p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_alter_zdt'",
+                        "false",
+                    ]
+                )
+            )
             c.stop("materialized")
     finally:
         for flag in (


### PR DESCRIPTION
### Motivation

Follow-up cleanup for the scoped feature-flags stack, addressing the non-blocking items raised in the #37158 review. Closes [DB-151](https://linear.app/materializeinc/issue/DB-151).

### Description

* **Scope-partition helper.** Add `SystemVars::synced_param_names_in_scope`, replacing the duplicated `iter_synced().filter(scope).map(name)` partition in `evaluate_scoped_parameters` (sync loop) and `scoped_overrides_create_op` (create-time fold). The scope filter now has exactly one implementation.
* **Scope-context constructors.** Add `ClusterScopeContext::for_cluster` and `ReplicaEvalContext::for_replica`, which derive a cluster's and a replica's scope attributes from the ids and names the caller already holds. `for_replica` takes the owning cluster's scope context, so a replica's cluster attributes come from the same place the cluster pass reads them. Between them they replace the near-identical struct literals on the create-managed, create-unmanaged, standalone-create-replica, three `ALTER CLUSTER` recreate, and sync-loop paths: the builtin flag was derived as `cluster_id.is_system()` at five separate sites, and now has one derivation.
* **No `ClusterEvalContext` constructor.** Its three remaining literals just pair a typed `ClusterId` with a context the caller already built for the replica pass, so a constructor would either duplicate that context or force callers to reach back through the wrapper to hand it to the replicas.
* **Managed-create sites build no context by hand.** `create_managed_cluster_replica_op` returns the replica's eval context instead of its size family, which was only ever returned to build that context. The four managed-create call sites therefore no longer restate the replica's name, size, and size family as three loose strings, and they drop a `name.clone()` each. The size now comes from the concretized location instead of the plan; `concretize_replica_location` passes the size through verbatim, so the value is unchanged and matches what the sync loop evaluates in steady state.
* **ALTER e2e.** Add `ALTER CLUSTER … SET (SIZE … legacy)` cases to the `test/launchdarkly` workflow, covering both the config-changed drop-and-recreate path and the zero-downtime path (`WITH (WAIT FOR …)`). A cc-family cluster records no replica override; the alter recreates the replica as legacy-family, so the alter-time fold records `enable_lgalloc=false`. The 0dt case asserts on the value, not the replica name, because the pending replica is recorded under `r1-pending` before finalization renames it to `r1`. The `replica_name`-targeting gap on the 0dt path is tracked separately in [DB-152](https://linear.app/materializeinc/issue/DB-152).

Both refactors are behavior-preserving.

### Verification

The new launchdarkly cases need a live LaunchDarkly project, so they run in the nightly `launchdarkly` job rather than PR CI, same as the existing scoped cases. They mirror the proven create-time case. The refactor is covered by the existing cluster and alter-cluster tests in PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
