### PR TITLE
expr: simplify `p OR NOT(p)` and `p AND NOT(p)` in MirScalarExpr::reduce

### DIFF
--- a/src/expr/src/scalar/reduce/variadic.rs
+++ b/src/expr/src/scalar/reduce/variadic.rs
@@ -164,6 +164,7 @@ pub(super) fn reduce_call_variadic(
             // Note: It's important that we have called `flatten_associative` above.
             e.undistribute_and_or();
             e.reduce_and_canonicalize_and_or();
+            reduce_complement_and_or(e, column_types);
         }
         VariadicFunc::TimezoneTimeVariadic(_)
             if exprs[0].is_literal() && exprs[2].is_literal_ok() =>
@@ -186,6 +187,47 @@ pub(super) fn reduce_call_variadic(
             };
         }
         _ => {}
+    }
+}
+
+/// Collapses an `AND`/`OR` that contains a complementary pair of operands, i.e.
+/// some operand `p` together with `NOT(p)`: `p OR NOT(p)` is `true` and
+/// `p AND NOT(p)` is `false`.
+///
+/// The rewrite fires only when `p` is guaranteed to evaluate to `true` or
+/// `false`. Under three-valued logic a `NULL` operand makes both `p` and
+/// `NOT(p)` `NULL`, so the call evaluates to `NULL` rather than its zero, and an
+/// erroring operand makes both error, so the call errors. We therefore require
+/// `p` to be non-nullable and infallible. When it is, the pair forces the
+/// call's zero (`true` for `OR`, `false` for `AND`), which then dominates every
+/// other operand regardless of their nulls or errors (the zero short-circuits
+/// past both), so the whole call collapses to that zero.
+///
+/// Assumes the operands have been canonicalized by
+/// [`MirScalarExpr::reduce_and_canonicalize_and_or`], which pushes `NOT` inward
+/// so that `p` and `NOT(p)` appear in this syntactic form.
+fn reduce_complement_and_or(e: &mut MirScalarExpr, column_types: &[ReprColumnType]) {
+    let MirScalarExpr::CallVariadic {
+        func: func @ (VariadicFunc::And(_) | VariadicFunc::Or(_)),
+        exprs,
+    } = e
+    else {
+        return;
+    };
+    let has_complement = exprs.iter().any(|operand| {
+        let MirScalarExpr::CallUnary {
+            func: UnaryFunc::Not(_),
+            expr: inner,
+        } = operand
+        else {
+            return false;
+        };
+        // `inner` is the un-negated `p`. The pair only forces the zero if `p`
+        // itself is also an operand and can never be `NULL` or an error.
+        !inner.typ(column_types).nullable && !inner.could_error() && exprs.contains(&**inner)
+    });
+    if has_complement {
+        *e = func.zero_of_and_or();
     }
 }
 

--- a/src/expr/src/scalar/reduce/variadic.rs
+++ b/src/expr/src/scalar/reduce/variadic.rs
@@ -9,6 +9,7 @@
 
 //! Post-order rewrites for `CallVariadic` nodes.
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::mem;
 
@@ -156,6 +157,7 @@ pub(super) fn reduce_call_variadic(
             // Note: It's important that we have called `flatten_associative` above.
             e.undistribute_and_or();
             e.reduce_and_canonicalize_and_or();
+            reduce_complement_and_or(e, column_types);
         }
         VariadicFunc::TimezoneTimeVariadic(_)
             if exprs[0].is_literal() && exprs[2].is_literal_ok() =>
@@ -178,6 +180,108 @@ pub(super) fn reduce_call_variadic(
             };
         }
         _ => {}
+    }
+}
+
+/// Collapses an `AND`/`OR` that contains a complementary pair of operands, i.e.
+/// some operand `p` together with the negation of `p`: `p OR NOT(p)` is `true`
+/// and `p AND NOT(p)` is `false`.
+///
+/// The rewrite fires only when `p` is guaranteed to evaluate to `true` or
+/// `false`. Under three-valued logic a `NULL` operand makes both `p` and its
+/// negation `NULL`, so the call evaluates to `NULL` rather than its zero, and an
+/// erroring operand makes both error, so the call errors. We therefore require
+/// `p` to be non-nullable and infallible, which its negation then is as well.
+/// When it is, the pair forces the call's zero (`true` for `OR`, `false` for
+/// `AND`), and `And`/`Or` evaluation returns that zero as soon as it sees it,
+/// discarding the nulls and errors of the remaining operands. The whole call
+/// therefore collapses to the zero.
+///
+/// NOTE: an operand that is a *literal* error never reaches this rule: the
+/// generic error fold in [`reduce_call_variadic`] turns the whole call into that
+/// error first, even though evaluation would have returned the zero.
+///
+/// The operands are already reduced, so the negation of `p` appears in the
+/// canonical form that `reduce` produces for `NOT(p)`, which is what
+/// [`negation_of`] reconstructs.
+fn reduce_complement_and_or(e: &mut MirScalarExpr, column_types: &[ReprColumnType]) {
+    let MirScalarExpr::CallVariadic {
+        func: func @ (VariadicFunc::And(_) | VariadicFunc::Or(_)),
+        exprs,
+    } = e
+    else {
+        return;
+    };
+    // `reduce_and_canonicalize_and_or` above sorted `exprs`, so a negation can
+    // be located with a binary search rather than a linear scan per operand,
+    // which would make this rule quadratic in the operand count. Should that
+    // ordering ever break, the search only fails to find an operand that is
+    // present, costing a missed simplification and never a wrong one.
+    debug_assert!(
+        exprs.is_sorted(),
+        "reduce_and_canonicalize_and_or leaves the operands sorted"
+    );
+    let contains = |target: &MirScalarExpr| exprs.binary_search(target).is_ok();
+    let has_complement = exprs.iter().any(|operand| {
+        // A negation has the same nullability and fallibility as what it
+        // negates, so testing one side of the pair covers both. For a nested
+        // `AND`/`OR` this also covers every child, since both properties are
+        // the disjunction over the children.
+        if operand.typ(column_types).nullable || operand.could_error() {
+            return false;
+        }
+        match operand {
+            // De Morgan's law distributes the negation of a nested `AND`/`OR`
+            // over its children, and `flatten_associative` then merges the
+            // result into this operand list. The negation is therefore present
+            // as one negated child per child of `operand`, not as a single
+            // operand.
+            MirScalarExpr::CallVariadic {
+                func: inner_func,
+                exprs: inner_exprs,
+            } if *inner_func == func.switch_and_or() => {
+                !inner_exprs.is_empty()
+                    && inner_exprs
+                        .iter()
+                        .all(|child| negation_of(child).is_some_and(|neg| contains(&neg)))
+            }
+            _ => negation_of(operand).is_some_and(|neg| contains(&neg)),
+        }
+    });
+    if has_complement {
+        *e = func.zero_of_and_or();
+    }
+}
+
+/// The negation of an already-reduced boolean expression, in the form `reduce`
+/// leaves `NOT(e)` in: a `NOT` cancels against `e`'s own `NOT`, and a
+/// comparison flips to its opposite comparison. Both rewrites happen in
+/// `reduce_pre` before this expression's parent is visited.
+///
+/// Returns `None` for a nested `AND`/`OR`, whose negation De Morgan's law
+/// spreads over several expressions rather than leaving a single one.
+///
+/// Flipping a comparison is only exact on non-`NULL` inputs, so callers must
+/// establish that `e` is non-nullable.
+fn negation_of(e: &MirScalarExpr) -> Option<Cow<'_, MirScalarExpr>> {
+    match e {
+        MirScalarExpr::CallUnary {
+            func: UnaryFunc::Not(_),
+            expr,
+        } => Some(Cow::Borrowed(expr)),
+        MirScalarExpr::CallBinary { func, expr1, expr2 } => Some(Cow::Owned(match func.negate() {
+            Some(negated) => MirScalarExpr::CallBinary {
+                func: negated,
+                expr1: expr1.clone(),
+                expr2: expr2.clone(),
+            },
+            None => e.clone().not(),
+        })),
+        MirScalarExpr::CallVariadic {
+            func: VariadicFunc::And(_) | VariadicFunc::Or(_),
+            ..
+        } => None,
+        _ => Some(Cow::Owned(e.clone().not())),
     }
 }
 

--- a/src/expr/tests/spec/reduce.spec
+++ b/src/expr/tests/spec/reduce.spec
@@ -703,3 +703,138 @@ types (integer?, integer?, integer?)
 (#0 = #1)
 ((#0 + 1) < 2147483647)
 ((#0 + 1) < #2)
+
+# Complementary-pair collapse: `p OR NOT(p)` --> true and `p AND NOT(p)` -->
+# false, but only when `p` is non-nullable and infallible.
+
+# Non-nullable, infallible `p`: collapses.
+reduce
+types (boolean)
+(#0 OR not(#0))
+----
+true
+
+reduce
+types (boolean)
+(#0 AND not(#0))
+----
+false
+
+# Extra operands do not block the collapse: the forced zero dominates them.
+reduce
+types (boolean, boolean)
+or(#0, not(#0), #1)
+----
+true
+
+reduce
+types (boolean, boolean)
+and(#0, not(#0), #1)
+----
+false
+
+# The dominance holds even when the extra operand is nullable or fallible: the
+# forced zero short-circuits past both.
+reduce
+types (boolean, boolean?)
+or(#0, not(#0), #1)
+----
+true
+
+reduce
+types (boolean, text)
+or(#0, not(#0), cast_string_to_bool(#1))
+----
+true
+
+# Nullable `p`: `NULL OR NOT(NULL)` is NULL, not true, so no collapse.
+reduce
+types (boolean?)
+(#0 OR not(#0))
+----
+(#0 OR NOT(#0))
+
+reduce
+types (boolean?)
+(#0 AND not(#0))
+----
+(#0 AND NOT(#0))
+
+# Fallible `p`: if `p` errors, both `p` and `NOT(p)` error, so the call errors
+# rather than evaluating to its zero. No collapse even though `p` is
+# non-nullable.
+reduce
+types (text)
+(cast_string_to_bool(#0) OR not(cast_string_to_bool(#0)))
+----
+(NOT(text_to_boolean(#0)) OR text_to_boolean(#0))
+
+# The negation is matched in the canonical form `reduce` leaves it in, so a
+# comparison pair collapses too: `reduce` rewrites `NOT(#0 = 5)` to `#0 != 5`.
+reduce
+types (integer)
+or((#0 = 5::integer), not((#0 = 5::integer)))
+----
+true
+
+reduce
+types (integer)
+and((#0 = 5::integer), not((#0 = 5::integer)))
+----
+false
+
+# Ordered comparisons flip too, but only in the argument order they were
+# written in: `reduce` canonically orders the arguments of `=` and `!=` only.
+reduce
+types (integer, integer)
+or((#0 < #1), not((#0 < #1)))
+----
+true
+
+reduce
+types (integer, integer)
+or((#0 < #1), (#1 <= #0))
+----
+((#0 < #1) OR (#1 <= #0))
+
+# Nullable comparison: no collapse.
+reduce
+types (integer?)
+or((#0 = 5::integer), not((#0 = 5::integer)))
+----
+((#0 = 5) OR (#0 != 5))
+
+# Fallible comparison: no collapse.
+reduce
+types (integer)
+or((div_int32(1::integer, #0) = 1::integer), not((div_int32(1::integer, #0) = 1::integer)))
+----
+((1 = (1 / #0)) OR (1 != (1 / #0)))
+
+# De Morgan's law spreads the negation of a nested AND/OR over its children, so
+# the complement is a negated child per child rather than a single operand.
+reduce
+types (boolean, boolean)
+or((#0 AND #1), not((#0 AND #1)))
+----
+true
+
+reduce
+types (boolean, boolean)
+and((#0 OR #1), not((#0 OR #1)))
+----
+false
+
+# Nullable children: no collapse.
+reduce
+types (boolean?, boolean?)
+or((#0 AND #1), not((#0 AND #1)))
+----
+(NOT(#0) OR NOT(#1) OR (#0 AND #1))
+
+# Only part of the spread negation is present, which is not a tautology.
+reduce
+types (boolean, boolean)
+or((#0 AND #1), not(#0))
+----
+(NOT(#0) OR (#0 AND #1))

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -947,3 +947,57 @@ canonicalize
 (#0 = #1)
 ((#0 + 1) < 2147483647)
 ((#0 + 1) < #2)
+
+# Complementary-pair collapse: `p OR NOT(p)` --> true and `p AND NOT(p)` -->
+# false, but only when `p` is non-nullable and infallible.
+
+# Non-nullable, infallible `p`: collapses.
+reduce
+(call_variadic or [#0 (call_unary not #0)])
+[(bool false)]
+----
+true
+
+reduce
+(call_variadic and [#0 (call_unary not #0)])
+[(bool false)]
+----
+false
+
+# Extra operands do not block the collapse: the forced zero dominates them.
+reduce
+(call_variadic or [#0 (call_unary not #0) #1])
+[(bool false) (bool false)]
+----
+true
+
+reduce
+(call_variadic and [#0 (call_unary not #0) #1])
+[(bool false) (bool false)]
+----
+false
+
+# Nullable `p`: `NULL OR NOT(NULL)` is NULL, not true, so no collapse.
+reduce
+(call_variadic or [#0 (call_unary not #0)])
+[bool]
+----
+(#0 OR NOT(#0))
+
+reduce
+(call_variadic and [#0 (call_unary not #0)])
+[bool]
+----
+(#0 AND NOT(#0))
+
+# Fallible `p`: if `p` errors, both `p` and `NOT(p)` error, so the call errors
+# rather than evaluating to its zero. No collapse even though `p` is
+# non-nullable.
+reduce
+(call_variadic or [
+    (call_unary cast_string_to_bool #0)
+    (call_unary not (call_unary cast_string_to_bool #0))
+])
+[(string false)]
+----
+(NOT(text_to_boolean(#0)) OR text_to_boolean(#0))

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -8330,17 +8330,14 @@ Explained Query:
           Project: #0..=#2, #4
             →Read l27
     cte l29 =
-      →Differential Join %1:mz_hydration_statuses[#0{object_id}, #1{replica_id}] » %0:l28[#2{hydration_object_id}, #3{id}]
-        →Arrange (#2{hydration_object_id}, #3{id})
-          →Fused with Child Map/Filter/Project
-            Filter: (#3{id}) IS NOT NULL
-              →Read l28
-        →Arranged mz_internal.mz_hydration_statuses
+      →Arrange (#2{hydration_object_id}, #3{id})
+        →Fused with Child Map/Filter/Project
+          Filter: (#3{id}) IS NOT NULL
+            →Read l28
     cte l30 =
-      →Fused with Child Map/Filter/Project
-        Project: #0..=#4
-        Map: (#1) IS NULL
-          →Read l28
+      →Differential Join %1:mz_hydration_statuses[#0{object_id}, #1{replica_id}] » %0:l29[#2{hydration_object_id}, #3{id}]
+        →Arranged l29
+        →Arranged mz_internal.mz_hydration_statuses
     cte l31 =
       →Differential Join %0:l23[#0{object_name}] » %1[#0{object_name}]
         after %1:
@@ -8348,10 +8345,7 @@ Explained Query:
           Filter: ((#7 AND #8) OR (NOT(#7) AND NOT(#8) AND (#1{cluster} = #4{cluster})))
           Map: (#1{cluster}) IS NULL, (#4{cluster}) IS NULL
         →Arrange (#0{object_name})
-          →Fused with Child Map/Filter/Project
-            Filter: (#4 OR NOT(#4))
-            Map: (#1{cluster}) IS NULL
-              →Read l23
+          →Stream l23
         →Arrange (#0{object_name})
           →Map/Filter/Project
             Project: #0, #1, #4, #5
@@ -8370,25 +8364,18 @@ Explained Query:
                       Map: null
                         →Consolidating Union
                           →Negate Diffs
-                            →Differential Join %1[#0, #1] » %0:l30[#2{hydration_object_id}, #3{id}]
-                              →Arrange (#2{hydration_object_id}, #3{id})
-                                →Fused with Child Map/Filter/Project
-                                  Project: #0..=#3
-                                  Filter: (#3{id}) IS NOT NULL AND (#4 OR NOT(#4))
-                                    →Read l30
+                            →Differential Join %1[#0, #1] » %0:l29[#2{hydration_object_id}, #3{id}]
+                              →Arranged l29
                               →Distinct GroupAggregate
                                 →Fused with Child Map/Filter/Project
                                   Project: #2, #3
-                                    →Read l29
+                                    →Read l30
                           →Fused with Child Map/Filter/Project
                             Project: #0, #1, #3
-                            Filter: (#4 OR NOT(#4))
-                              →Read l30
+                              →Read l28
                     →Fused with Child Map/Filter/Project
                       Project: #0, #1, #3, #4
-                      Filter: (#5 OR NOT(#5))
-                      Map: (#1) IS NULL
-                        →Read l29
+                        →Read l30
   →Return
     →Map/Filter/Project
       Project: #0..=#3, #6

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -9555,17 +9555,14 @@ Explained Query:
           Project: #0..=#2, #4
             →Read l35
     cte l37 =
-      →Differential Join %1:mz_hydration_statuses[#0{object_id}, #1{replica_id}] » %0:l36[#2{hydration_object_id}, #3{id}]
-        →Arrange (#2{hydration_object_id}, #3{id})
-          →Fused with Child Map/Filter/Project
-            Filter: (#3{id}) IS NOT NULL
-              →Read l36
-        →Arranged mz_internal.mz_hydration_statuses
+      →Arrange (#2{hydration_object_id}, #3{id})
+        →Fused with Child Map/Filter/Project
+          Filter: (#3{id}) IS NOT NULL
+            →Read l36
     cte l38 =
-      →Fused with Child Map/Filter/Project
-        Project: #0..=#4
-        Map: (#1) IS NULL
-          →Read l36
+      →Differential Join %1:mz_hydration_statuses[#0{object_id}, #1{replica_id}] » %0:l37[#2{hydration_object_id}, #3{id}]
+        →Arranged l37
+        →Arranged mz_internal.mz_hydration_statuses
     cte l39 =
       →Differential Join %0:l31[#0{object_name}] » %1[#0{object_name}]
         after %1:
@@ -9573,10 +9570,7 @@ Explained Query:
           Filter: ((#7 AND #8) OR (NOT(#7) AND NOT(#8) AND (#1{cluster} = #4{cluster})))
           Map: (#1{cluster}) IS NULL, (#4{cluster}) IS NULL
         →Arrange (#0{object_name})
-          →Fused with Child Map/Filter/Project
-            Filter: (#4 OR NOT(#4))
-            Map: (#1{cluster}) IS NULL
-              →Read l31
+          →Stream l31
         →Arrange (#0{object_name})
           →Map/Filter/Project
             Project: #0, #1, #4, #5
@@ -9595,25 +9589,18 @@ Explained Query:
                       Map: null
                         →Consolidating Union
                           →Negate Diffs
-                            →Differential Join %1[#0, #1] » %0:l38[#2{hydration_object_id}, #3{id}]
-                              →Arrange (#2{hydration_object_id}, #3{id})
-                                →Fused with Child Map/Filter/Project
-                                  Project: #0..=#3
-                                  Filter: (#3{id}) IS NOT NULL AND (#4 OR NOT(#4))
-                                    →Read l38
+                            →Differential Join %1[#0, #1] » %0:l37[#2{hydration_object_id}, #3{id}]
+                              →Arranged l37
                               →Distinct GroupAggregate
                                 →Fused with Child Map/Filter/Project
                                   Project: #2, #3
-                                    →Read l37
+                                    →Read l38
                           →Fused with Child Map/Filter/Project
                             Project: #0, #1, #3
-                            Filter: (#4 OR NOT(#4))
-                              →Read l38
+                              →Read l36
                     →Fused with Child Map/Filter/Project
                       Project: #0, #1, #3, #4
-                      Filter: (#5 OR NOT(#5))
-                      Map: (#1) IS NULL
-                        →Read l37
+                        →Read l38
     cte l40 =
       →Union
         →Stream l39


### PR DESCRIPTION
The AND/OR canonicalizer in `MirScalarExpr::reduce` deduplicates operands, short-circuits on a literal zero, and drops units, but never recognized a complementary pair of operands.
As a result `#4 OR NOT(#4)` survived to the final plan unsimplified.
This lives in the shared scalar reducer, so it affected every consumer of `MapFilterProject` optimization rather than a single query path.

A complementary pair only forces the call's zero (`true` for `OR`, `false` for `AND`) when the operand is guaranteed to evaluate to `true` or `false`.
Under SQL's three-valued logic a `NULL` operand makes both halves of the pair `NULL`, so the call evaluates to `NULL` rather than its zero, and an erroring operand makes both error, so the call errors.
The new `reduce_complement_and_or` therefore fires only when the operand is non-nullable and infallible.
When it does, `And`/`Or` evaluation returns the forced zero as soon as it reaches it and discards the remaining operands' nulls and errors, so the entire call collapses to that zero.

Matching the pair syntactically requires knowing what `reduce` already did to the negation.
`reduce_pre` cancels double negations, flips a comparison to its opposite so that `NOT(a = b)` becomes `a != b`, and applies De Morgan's law to a nested `AND`/`OR`, whose result `flatten_associative` then merges into the enclosing operand list.
`negation_of` reconstructs that canonical form, so the rule covers a plain `p`/`NOT(p)` pair, a comparison pair such as `a = 5 OR a != 5`, and a nested conjunction whose negation was spread across siblings, as in `(a AND b) OR NOT(a) OR NOT(b)`.

Recognition stays sensitive to how a predicate is spelled, because it compares operands structurally.
`reduce` canonically orders the arguments of `=` and `!=` only, so `a < b OR a >= b` collapses while the equivalent `a < b OR b <= a` does not.

An operand that is a *literal* error never reaches the rule: the generic error fold in `reduce_call_variadic` turns the whole call into that error first, even though evaluation would have returned the zero.
That fold predates this change and is left alone here.

`catalog_server_explain.slt` is regenerated: a builtin view's `(#1 IS NULL) OR NOT(#1 IS NULL)` filter now collapses, dropping the tautology and its now-dead `IS NULL` maps and letting two CTEs share one arrangement.
