### PR TITLE
[SS-193] Fix issue where copy into doesn't respect target table's numeric precision

### DIFF
--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -1200,9 +1200,8 @@ mod tests {
     }
 
     /// Regression test for SS-193: when the destination column declares a
-    /// `max_scale`, the reader must round the decoded value to that scale
-    /// rather than preserving the source file's scale. This mirrors the
-    /// assignment-cast path so `COPY FROM PARQUET` agrees with `INSERT`.
+    /// `max_scale`, the reader should round the decoded value to that scale
+    /// rather than preserving the source file's scale.
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
     fn decimal_applies_destination_max_scale() {
@@ -1256,24 +1255,13 @@ mod tests {
         assert_eq!(num.0, expected, "Decimal256 did not round to max_scale");
     }
 
-    /// Rescaling the decoded value to the destination's `max_scale` (SS-193)
-    /// can push it past numeric's maximum precision: a higher scale appends
-    /// fractional digits, so a value with many integer digits that decodes
-    /// cleanly at a low scale overflows `NUMERIC_DATUM_MAX_PRECISION` (39) at a
-    /// high scale. The reader must surface that as an error rather than
-    /// silently truncating or panicking. Demonstrates that the *same* source
-    /// value can decode at one destination scale and fail at a larger one.
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
     fn decimal_rescale_to_higher_scale_overflows() {
         use mz_repr::adt::numeric::NumericMaxScale;
 
-        // A 33-digit integer (10^33 - 1). The source column has scale 0, so the
-        // parquet file stores this integer verbatim.
         let value: i128 = 10_i128.pow(33) - 1;
 
-        // Build the source array fresh per reader: `ArrowReader::new` consumes
-        // the `StructArray`.
         let build_batch = || {
             let mut dec128 = arrow::array::Decimal128Builder::new();
             dec128 = dec128.with_precision_and_scale(38, 0).unwrap();
@@ -1298,9 +1286,7 @@ mod tests {
                 .finish()
         };
 
-        // Lower scale (2): 33 integer digits + 2 fractional digits = 35
-        // significant digits, within the 39-digit limit, so the value decodes
-        // successfully and is rescaled to scale 2.
+        // Test working case with supportable scale then broken case.
         let reader = ArrowReader::new(&desc_with_scale(2), build_batch()).unwrap();
         let mut row = Row::default();
         reader
@@ -1311,16 +1297,12 @@ mod tests {
         rescale(&mut expected, 2).unwrap();
         assert_eq!(num.0, expected, "value did not rescale to scale 2");
 
-        // Higher scale (8): 33 + 8 = 41 significant digits exceeds the 39-digit
-        // maximum precision, so the same value now errors out instead of
-        // decoding.
         let reader = ArrowReader::new(&desc_with_scale(8), build_batch()).unwrap();
         let mut row = Row::default();
         let err = reader
             .read(0, &mut row)
             .expect_err("value must overflow at destination scale 8");
-        // `ArrowReader::read` wraps the column error with the row index, so
-        // check the full chain rather than just the top-level message.
+
         assert!(
             format!("{err:#}").contains("exceed maximum precision"),
             "unexpected error: {err:#}",

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -30,7 +30,7 @@ use mz_ore::cast::CastFrom;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::jsonb::JsonbPacker;
-use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::numeric::{Numeric, rescale};
 use mz_repr::adt::range::{Range, RangeLowerBound, RangeUpperBound};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{Datum, RelationDesc, Row, RowPacker, SharedRow, SqlScalarType};
@@ -188,8 +188,7 @@ fn scalar_type_and_array_to_reader(
         (SqlScalarType::Float64, DataType::Float64) => {
             Ok(ColReader::Float64(downcast_array::<Float64Array>(array)))
         }
-        // TODO(cf3): Consider the max_scale for numeric.
-        (SqlScalarType::Numeric { .. }, DataType::Decimal128(precision, scale)) => {
+        (SqlScalarType::Numeric { max_scale }, DataType::Decimal128(precision, scale)) => {
             use num_traits::Pow;
 
             let base = Numeric::from(10);
@@ -209,10 +208,10 @@ fn scalar_type_and_array_to_reader(
                 array,
                 scale_factor,
                 precision,
+                max_scale: (*max_scale).map(|s| s.into_u8()),
             })
         }
-        // TODO(cf3): Consider the max_scale for numeric.
-        (SqlScalarType::Numeric { .. }, DataType::Decimal256(precision, scale)) => {
+        (SqlScalarType::Numeric { max_scale }, DataType::Decimal256(precision, scale)) => {
             use num_traits::Pow;
 
             let base = Numeric::from(10);
@@ -232,6 +231,7 @@ fn scalar_type_and_array_to_reader(
                 array,
                 scale_factor,
                 precision,
+                max_scale: (*max_scale).map(|s| s.into_u8()),
             })
         }
         (SqlScalarType::Bytes, DataType::Binary) => {
@@ -489,11 +489,15 @@ enum ColReader {
         array: Decimal128Array,
         scale_factor: Numeric,
         precision: usize,
+        /// The destination column's declared scale, if constrained.
+        max_scale: Option<u8>,
     },
     Decimal256 {
         array: Decimal256Array,
         scale_factor: Numeric,
         precision: usize,
+        /// The destination column's declared scale, if constrained.
+        max_scale: Option<u8>,
     },
 
     Binary(arrow::array::BinaryArray),
@@ -609,21 +613,34 @@ impl ColReader {
                 array,
                 scale_factor,
                 precision,
-            } => array.is_valid(idx).then(|| array.value(idx)).map(|x| {
-                // Create a Numeric from our i128 with precision.
-                let mut ctx = dec::Context::<Numeric>::default();
-                ctx.set_precision(*precision).expect("checked before");
-                let mut num = ctx.from_i128(x);
+                max_scale,
+            } => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|x| {
+                    // Create a Numeric from our i128 with precision.
+                    let mut ctx = dec::Context::<Numeric>::default();
+                    ctx.set_precision(*precision).expect("checked before");
+                    let mut num = ctx.from_i128(x);
 
-                // Scale the number.
-                ctx.div(&mut num, scale_factor);
+                    // Scale the number.
+                    ctx.div(&mut num, scale_factor);
 
-                Datum::Numeric(OrderedDecimal(num))
-            }),
+                    // Round to the destination column's declared scale, matching
+                    // the assignment-cast path so COPY FROM agrees with INSERT
+                    // (SS-193).
+                    if let Some(max_scale) = max_scale {
+                        rescale(&mut num, *max_scale)?;
+                    }
+
+                    Ok::<_, anyhow::Error>(Datum::Numeric(OrderedDecimal(num)))
+                })
+                .transpose()?,
             ColReader::Decimal256 {
                 array,
                 scale_factor,
                 precision,
+                max_scale,
             } => array
                 .is_valid(idx)
                 .then(|| array.value(idx))
@@ -641,6 +658,13 @@ impl ColReader {
 
                     // Scale the number.
                     ctx.div(&mut num, scale_factor);
+
+                    // Round to the destination column's declared scale, matching
+                    // the assignment-cast path so COPY FROM agrees with INSERT
+                    // (SS-193).
+                    if let Some(max_scale) = max_scale {
+                        rescale(&mut num, *max_scale)?;
+                    }
 
                     Ok::<_, anyhow::Error>(Datum::Numeric(OrderedDecimal(num)))
                 })
@@ -1181,6 +1205,134 @@ mod tests {
         reader.read(2, &mut rnd_row).unwrap();
         let num = rnd_row.into_element().unwrap_numeric();
         assert_eq!(num.0, Numeric::from(100000000.009f64));
+    }
+
+    /// Regression test for SS-193: when the destination column declares a
+    /// `max_scale`, the reader must round the decoded value to that scale
+    /// rather than preserving the source file's scale. This mirrors the
+    /// assignment-cast path so `COPY FROM PARQUET` agrees with `INSERT`.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
+    fn decimal_applies_destination_max_scale() {
+        use mz_repr::adt::numeric::NumericMaxScale;
+
+        // Destination column is numeric(10, 2): scale 2.
+        let desc = RelationDesc::builder()
+            .with_column(
+                "a",
+                SqlScalarType::Numeric {
+                    max_scale: Some(NumericMaxScale::try_from(2_i64).unwrap()),
+                }
+                .nullable(true),
+            )
+            .finish();
+
+        let expected = Numeric::from(10.45f64);
+
+        // The source files carry scale-3 values (10.447) that don't round
+        // evenly to the destination's scale 2.
+        let mut dec128 = arrow::array::Decimal128Builder::new();
+        dec128 = dec128.with_precision_and_scale(12, 3).unwrap();
+        dec128.append_value(10447);
+        let dec128 = dec128.finish();
+        #[allow(clippy::as_conversions)]
+        let batch128 = StructArray::from(vec![(
+            Arc::new(Field::new("a", dec128.data_type().clone(), true)),
+            Arc::new(dec128) as arrow::array::ArrayRef,
+        )]);
+
+        let reader = ArrowReader::new(&desc, batch128).unwrap();
+        let mut rnd_row = Row::default();
+        reader.read(0, &mut rnd_row).unwrap();
+        let num = rnd_row.into_element().unwrap_numeric();
+        assert_eq!(num.0, expected, "Decimal128 did not round to max_scale");
+
+        let mut dec256 = arrow::array::Decimal256Builder::new();
+        dec256 = dec256.with_precision_and_scale(12, 3).unwrap();
+        dec256.append_value(arrow::datatypes::i256::from(10447));
+        let dec256 = dec256.finish();
+        #[allow(clippy::as_conversions)]
+        let batch256 = StructArray::from(vec![(
+            Arc::new(Field::new("a", dec256.data_type().clone(), true)),
+            Arc::new(dec256) as arrow::array::ArrayRef,
+        )]);
+
+        let reader = ArrowReader::new(&desc, batch256).unwrap();
+        let mut rnd_row = Row::default();
+        reader.read(0, &mut rnd_row).unwrap();
+        let num = rnd_row.into_element().unwrap_numeric();
+        assert_eq!(num.0, expected, "Decimal256 did not round to max_scale");
+    }
+
+    /// Rescaling the decoded value to the destination's `max_scale` (SS-193)
+    /// can push it past numeric's maximum precision: a higher scale appends
+    /// fractional digits, so a value with many integer digits that decodes
+    /// cleanly at a low scale overflows `NUMERIC_DATUM_MAX_PRECISION` (39) at a
+    /// high scale. The reader must surface that as an error rather than
+    /// silently truncating or panicking. Demonstrates that the *same* source
+    /// value can decode at one destination scale and fail at a larger one.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
+    fn decimal_rescale_to_higher_scale_overflows() {
+        use mz_repr::adt::numeric::NumericMaxScale;
+
+        // A 33-digit integer (10^33 - 1). The source column has scale 0, so the
+        // parquet file stores this integer verbatim.
+        let value: i128 = 10_i128.pow(33) - 1;
+
+        // Build the source array fresh per reader: `ArrowReader::new` consumes
+        // the `StructArray`.
+        let build_batch = || {
+            let mut dec128 = arrow::array::Decimal128Builder::new();
+            dec128 = dec128.with_precision_and_scale(38, 0).unwrap();
+            dec128.append_value(value);
+            let dec128 = dec128.finish();
+            #[allow(clippy::as_conversions)]
+            StructArray::from(vec![(
+                Arc::new(Field::new("a", dec128.data_type().clone(), true)),
+                Arc::new(dec128) as arrow::array::ArrayRef,
+            )])
+        };
+
+        let desc_with_scale = |scale: i64| {
+            RelationDesc::builder()
+                .with_column(
+                    "a",
+                    SqlScalarType::Numeric {
+                        max_scale: Some(NumericMaxScale::try_from(scale).unwrap()),
+                    }
+                    .nullable(true),
+                )
+                .finish()
+        };
+
+        // Lower scale (2): 33 integer digits + 2 fractional digits = 35
+        // significant digits, within the 39-digit limit, so the value decodes
+        // successfully and is rescaled to scale 2.
+        let reader = ArrowReader::new(&desc_with_scale(2), build_batch()).unwrap();
+        let mut row = Row::default();
+        reader
+            .read(0, &mut row)
+            .expect("value must decode at destination scale 2");
+        let num = row.into_element().unwrap_numeric();
+        let mut expected = Numeric::try_from(value).unwrap();
+        rescale(&mut expected, 2).unwrap();
+        assert_eq!(num.0, expected, "value did not rescale to scale 2");
+
+        // Higher scale (8): 33 + 8 = 41 significant digits exceeds the 39-digit
+        // maximum precision, so the same value now errors out instead of
+        // decoding.
+        let reader = ArrowReader::new(&desc_with_scale(8), build_batch()).unwrap();
+        let mut row = Row::default();
+        let err = reader
+            .read(0, &mut row)
+            .expect_err("value must overflow at destination scale 8");
+        // `ArrowReader::read` wraps the column error with the row index, so
+        // check the full chain rather than just the top-level message.
+        assert!(
+            format!("{err:#}").contains("exceed maximum precision"),
+            "unexpected error: {err:#}",
+        );
     }
 
     /// Regression test for database-issues#11330: when a Parquet file authored

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -208,7 +208,7 @@ fn scalar_type_and_array_to_reader(
                 array,
                 scale_factor,
                 precision,
-                max_scale: (*max_scale).map(|s| s.into_u8()),
+                destination_max_scale: (*max_scale).map(|s| s.into_u8()),
             })
         }
         (SqlScalarType::Numeric { max_scale }, DataType::Decimal256(precision, scale)) => {
@@ -231,7 +231,7 @@ fn scalar_type_and_array_to_reader(
                 array,
                 scale_factor,
                 precision,
-                max_scale: (*max_scale).map(|s| s.into_u8()),
+                destination_max_scale: (*max_scale).map(|s| s.into_u8()),
             })
         }
         (SqlScalarType::Bytes, DataType::Binary) => {
@@ -489,15 +489,13 @@ enum ColReader {
         array: Decimal128Array,
         scale_factor: Numeric,
         precision: usize,
-        /// The destination column's declared scale, if constrained.
-        max_scale: Option<u8>,
+        destination_max_scale: Option<u8>,
     },
     Decimal256 {
         array: Decimal256Array,
         scale_factor: Numeric,
         precision: usize,
-        /// The destination column's declared scale, if constrained.
-        max_scale: Option<u8>,
+        destination_max_scale: Option<u8>,
     },
 
     Binary(arrow::array::BinaryArray),
@@ -613,7 +611,7 @@ impl ColReader {
                 array,
                 scale_factor,
                 precision,
-                max_scale,
+                destination_max_scale,
             } => array
                 .is_valid(idx)
                 .then(|| array.value(idx))
@@ -626,11 +624,8 @@ impl ColReader {
                     // Scale the number.
                     ctx.div(&mut num, scale_factor);
 
-                    // Round to the destination column's declared scale, matching
-                    // the assignment-cast path so COPY FROM agrees with INSERT
-                    // (SS-193).
-                    if let Some(max_scale) = max_scale {
-                        rescale(&mut num, *max_scale)?;
+                    if let Some(destination_max_scale) = destination_max_scale {
+                        rescale(&mut num, *destination_max_scale)?;
                     }
 
                     Ok::<_, anyhow::Error>(Datum::Numeric(OrderedDecimal(num)))
@@ -640,7 +635,7 @@ impl ColReader {
                 array,
                 scale_factor,
                 precision,
-                max_scale,
+                destination_max_scale,
             } => array
                 .is_valid(idx)
                 .then(|| array.value(idx))
@@ -659,11 +654,8 @@ impl ColReader {
                     // Scale the number.
                     ctx.div(&mut num, scale_factor);
 
-                    // Round to the destination column's declared scale, matching
-                    // the assignment-cast path so COPY FROM agrees with INSERT
-                    // (SS-193).
-                    if let Some(max_scale) = max_scale {
-                        rescale(&mut num, *max_scale)?;
+                    if let Some(destination_max_scale) = destination_max_scale {
+                        rescale(&mut num, *destination_max_scale)?;
                     }
 
                     Ok::<_, anyhow::Error>(Datum::Numeric(OrderedDecimal(num)))

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -331,7 +331,7 @@ http
 {"queries":[{"query":"select $1::decimal+2 as col","params":["nan"]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[["NaN"]],"desc":{"columns":[{"name":"col","type_oid":1700,"type_len":-1,"type_mod":2555947}]},"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[["NaN"]],"desc":{"columns":[{"name":"col","type_oid":1700,"type_len":-1,"type_mod":-1}]},"notices":[]}]}
 
 # Null string value parameters
 http

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -1257,13 +1257,10 @@ impl From<&SqlScalarType> for Type {
             },
             SqlScalarType::Uuid => Type::Uuid,
             SqlScalarType::Numeric { max_scale } => Type::Numeric {
-                constraints: Some(NumericConstraints {
+                constraints: max_scale.map(|max_scale| NumericConstraints {
                     max_precision: i32::from(NUMERIC_DATUM_MAX_PRECISION),
-                    max_scale: match max_scale {
-                        Some(max_scale) => i32::from(max_scale.into_u8()),
-                        None => i32::from(NUMERIC_DATUM_MAX_PRECISION),
-                    },
-                }),
+                    max_scale: i32::from(max_scale.into_u8())
+                })
             },
             SqlScalarType::RegClass => Type::RegClass,
             SqlScalarType::RegProc => Type::RegProc,

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -1259,8 +1259,8 @@ impl From<&SqlScalarType> for Type {
             SqlScalarType::Numeric { max_scale } => Type::Numeric {
                 constraints: max_scale.map(|max_scale| NumericConstraints {
                     max_precision: i32::from(NUMERIC_DATUM_MAX_PRECISION),
-                    max_scale: i32::from(max_scale.into_u8())
-                })
+                    max_scale: i32::from(max_scale.into_u8()),
+                }),
             },
             SqlScalarType::RegClass => Type::RegClass,
             SqlScalarType::RegProc => Type::RegProc,

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -938,13 +938,6 @@ impl Value {
 }
 
 /// Rescales `n` to the scale required by `constraints`, if any.
-///
-/// `COPY ... FROM` and parameter input decode values directly through
-/// `pgrepr`, bypassing the planner's assignment-cast path, so the destination's
-/// declared scale must be applied here. This mirrors the `(Numeric, Numeric)`
-/// assignment cast, which is itself just a [`rescale`] (see `AdjustNumericScale`
-/// in `mz-expr`). Shared by the text, CSV, and binary decode paths so they all
-/// agree on the value stored for a given typed numeric.
 fn rescale_numeric(
     mut n: OrderedDecimal<mz_repr_numeric::Numeric>,
     constraints: Option<&NumericConstraints>,

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -13,6 +13,7 @@ use std::{io, str};
 
 use bytes::{BufMut, BytesMut};
 use chrono::{DateTime, NaiveDateTime, NaiveTime, Utc};
+use dec::OrderedDecimal;
 use itertools::Itertools;
 use mz_ore::cast::ReinterpretCast;
 use mz_pgrepr_consts::oid::TYPE_INT2_OID;
@@ -22,6 +23,7 @@ use mz_repr::adt::char;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::jsonb::JsonbRef;
 use mz_repr::adt::mz_acl_item::{AclItem, MzAclItem};
+use mz_repr::adt::numeric::{self as mz_repr_numeric, NumericMaxScale, rescale};
 use mz_repr::adt::pg_legacy_name::NAME_MAX_BYTES;
 use mz_repr::adt::range::{Range, RangeInner};
 use mz_repr::adt::timestamp::CheckedTimestamp;
@@ -30,7 +32,7 @@ use mz_repr::{Datum, RowArena, RowPacker, RowRef, SqlRelationType, SqlScalarType
 use postgres_types::{FromSql, IsNull, ToSql, Type as PgType};
 use uuid::Uuid;
 
-use crate::types::{UINT2, UINT4, UINT8};
+use crate::types::{NumericConstraints, UINT2, UINT4, UINT8};
 use crate::value::error::IntoDatumError;
 use crate::{Interval, Jsonb, Numeric, Type, UInt2, UInt4, UInt8};
 
@@ -711,7 +713,10 @@ impl Value {
                 },
             )?),
             Type::Name => Value::Name(strconv::parse_pg_legacy_name(s)),
-            Type::Numeric { .. } => Value::Numeric(Numeric(strconv::parse_numeric(s)?)),
+            Type::Numeric { constraints } => Value::Numeric(Numeric(rescale_numeric(
+                strconv::parse_numeric(s)?,
+                constraints.as_ref(),
+            )?)),
             Type::Oid | Type::RegClass | Type::RegProc | Type::RegType => {
                 Value::Oid(strconv::parse_oid(s)?)
             }
@@ -815,7 +820,10 @@ impl Value {
                 })?;
             }
             Type::Name => packer.push(Datum::String(&strconv::parse_pg_legacy_name(s))),
-            Type::Numeric { .. } => packer.push(Datum::Numeric(strconv::parse_numeric(s)?)),
+            Type::Numeric { constraints } => packer.push(Datum::Numeric(rescale_numeric(
+                strconv::parse_numeric(s)?,
+                constraints.as_ref(),
+            )?)),
             Type::Oid | Type::RegClass | Type::RegProc | Type::RegType => {
                 packer.push(Datum::UInt32(strconv::parse_oid(s)?))
             }
@@ -887,7 +895,13 @@ impl Value {
                 }
                 Ok(Value::Name(s))
             }
-            Type::Numeric { .. } => Numeric::from_sql(ty.inner(), raw).map(Value::Numeric),
+            Type::Numeric { constraints } => {
+                let n = Numeric::from_sql(ty.inner(), raw)?;
+                Ok(Value::Numeric(Numeric(rescale_numeric(
+                    n.0,
+                    constraints.as_ref(),
+                )?)))
+            }
             Type::Oid | Type::RegClass | Type::RegProc | Type::RegType => {
                 u32::from_sql(ty.inner(), raw).map(Value::Oid)
             }
@@ -921,6 +935,27 @@ impl Value {
             Type::AclItem => Err("aclitem has no binary encoding".into()),
         }
     }
+}
+
+/// Rescales `n` to the scale required by `constraints`, if any.
+///
+/// `COPY ... FROM` and parameter input decode values directly through
+/// `pgrepr`, bypassing the planner's assignment-cast path, so the destination's
+/// declared scale must be applied here. This mirrors the `(Numeric, Numeric)`
+/// assignment cast, which is itself just a [`rescale`] (see `AdjustNumericScale`
+/// in `mz-expr`). Shared by the text, CSV, and binary decode paths so they all
+/// agree on the value stored for a given typed numeric.
+fn rescale_numeric(
+    mut n: OrderedDecimal<mz_repr_numeric::Numeric>,
+    constraints: Option<&NumericConstraints>,
+) -> Result<OrderedDecimal<mz_repr_numeric::Numeric>, Box<dyn Error + Sync + Send>> {
+    if let Some(constraints) = constraints {
+        rescale(
+            &mut n.0,
+            NumericMaxScale::try_from(i64::from(constraints.max_scale()))?.into_u8(),
+        )?;
+    }
+    Ok(n)
 }
 
 fn encode_element(buf: &mut BytesMut, elem: Option<&Value>, ty: &Type) -> Result<(), io::Error> {
@@ -1019,5 +1054,38 @@ mod tests {
             decoded_int_array.map_err(|e| e.to_string()).unwrap_err(),
             "invalid input syntax for type array: Specifying array lower bounds is not supported: \"[0:0]={t}\"".to_string()
         );
+    }
+
+    /// Decoding a numeric must round it to the destination's declared scale,
+    /// and the text and binary paths must agree. `COPY ... FROM` relies on the
+    /// text/CSV side of this (SS-193); binary parameters rely on the binary
+    /// side. `COPY ... FORMAT BINARY` is unsupported, so the binary path is
+    /// exercised here rather than via mzcompose.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // numeric/decimal contexts unsupported under miri
+    fn decode_numeric_applies_destination_scale() {
+        // A `numeric(10, 2)` destination: scale 2.
+        let ty = Type::from(&SqlScalarType::Numeric {
+            max_scale: Some(NumericMaxScale::try_from(2_i64).unwrap()),
+        });
+        let expected = strconv::parse_numeric("10.45").unwrap();
+
+        // Encode an over-scale value (10.447, scale 3) to binary, then decode
+        // it back through the scale-2 type.
+        let input = Value::Numeric(Numeric(strconv::parse_numeric("10.447").unwrap()));
+        let mut buf = BytesMut::new();
+        input
+            .encode_binary(&ty, &mut buf)
+            .expect("encoding 10.447 as numeric must succeed");
+        let Value::Numeric(Numeric(binary)) = Value::decode_binary(&ty, &buf).unwrap() else {
+            panic!("decode_binary of a numeric must yield Value::Numeric");
+        };
+        assert_eq!(binary, expected, "binary decode did not rescale to scale 2");
+
+        // The text path must agree with the binary path.
+        let Value::Numeric(Numeric(text)) = Value::decode_text(&ty, b"10.447").unwrap() else {
+            panic!("decode_text of a numeric must yield Value::Numeric");
+        };
+        assert_eq!(text, expected, "text decode did not rescale to scale 2");
     }
 }

--- a/test/copy/mzcompose.py
+++ b/test/copy/mzcompose.py
@@ -19,6 +19,7 @@ import random
 import string
 import threading
 import time
+from decimal import Decimal
 from io import BytesIO, StringIO
 from textwrap import dedent
 
@@ -456,6 +457,32 @@ def workflow_test_github_9627(c: Composition):
         after = int(result[0][0])
 
         assert before < after, f"read frontier is stuck, {before} >= {after}"
+
+
+def workflow_test_ss_193(c: Composition):
+    """
+    Regression test for SS-193 where COPYing to a table from STDIN would
+    store values without rounding them to the destination column's scale.
+
+    The same rounding must also apply to the COPY FROM parquet path, so we
+    additionally round-trip scale-3 values through a parquet file on S3 and
+    assert they are rounded to the destination column's scale on read.
+    """
+    c.up("materialized")
+    conn = c.sql_connection()
+    with conn.cursor() as cur:
+        cur.execute("CREATE TABLE numbers_with_precision (a DECIMAL(10, 2), b NUMERIC(10, 2))")
+        with cur.copy("COPY numbers_with_precision FROM STDIN") as copy:
+            copy.write('10.447\t10.447\n')
+        with cur.copy("COPY numbers_with_precision FROM STDIN (FORMAT CSV)") as copy:
+            copy.write('10.447,10.447\n')
+
+        cur.execute("SELECT a, b FROM numbers_with_precision")
+        rows = cur.fetchall()
+        assert rows == [
+            (Decimal('10.45'), Decimal('10.45')),
+            (Decimal('10.45'), Decimal('10.45'))
+        ], f"COPY FROM did not round values to the column scale: {rows}"
 
 
 def workflow_copy_from_ssrf_redirect(c: Composition) -> None:

--- a/test/copy/mzcompose.py
+++ b/test/copy/mzcompose.py
@@ -464,11 +464,12 @@ def workflow_test_ss_193(c: Composition):
     Regression test for SS-193 where COPYing to a table from STDIN would
     store values without rounding them to the destination column's scale.
 
-    The same rounding must also apply to the COPY FROM parquet path, so we
-    additionally round-trip scale-3 values through a parquet file on S3 and
-    assert they are rounded to the destination column's scale on read.
+    The same rounding must also apply to the COPY FROM S3 paths, so we
+    additionally round-trip scale-3 values through both a CSV and a parquet
+    file on S3 and assert they are rounded to the destination column's scale
+    on read.
     """
-    c.up("materialized")
+    c.up("materialized", "minio")
     conn = c.sql_connection()
     with conn.cursor() as cur:
         cur.execute("CREATE TABLE numbers_with_precision (a DECIMAL(10, 2), b NUMERIC(10, 2))")
@@ -482,7 +483,45 @@ def workflow_test_ss_193(c: Composition):
         assert rows == [
             (Decimal('10.45'), Decimal('10.45')),
             (Decimal('10.45'), Decimal('10.45'))
-        ], f"COPY FROM did not round values to the column scale: {rows}"
+        ], f"COPY FROM STDIN did not round values to the column scale: {rows}"
+
+        # Round-trip scale-3 values through CSV and parquet files on S3 and
+        # assert COPY FROM rounds them to the destination column's scale on read.
+        cur.execute("CREATE SECRET minio_secret AS 'minioadmin'")
+        cur.execute(
+            """
+            CREATE CONNECTION aws_conn TO AWS (
+                ACCESS KEY ID = 'minioadmin',
+                SECRET ACCESS KEY = SECRET minio_secret,
+                ENDPOINT = 'http://minio:9000/',
+                REGION = 'us-east-1'
+            )
+            """
+        )
+
+        # Source carries scale-3 values that don't round evenly to scale 2.
+        cur.execute("CREATE TABLE numbers_scale3 (a DECIMAL(10, 3), b NUMERIC(10, 3))")
+        cur.execute("INSERT INTO numbers_scale3 VALUES (10.447, 10.447)")
+
+        for format in ["csv", "parquet"]:
+            cur.execute(
+                f"COPY (SELECT a, b FROM numbers_scale3) "
+                f"TO 's3://copytos3/test/ss_193/{format}' "
+                f"WITH (AWS CONNECTION = aws_conn, FORMAT = '{format}')"
+            )
+            cur.execute(
+                f"CREATE TABLE numbers_from_{format} (a DECIMAL(10, 2), b NUMERIC(10, 2))"
+            )
+            cur.execute(
+                f"COPY INTO numbers_from_{format} "
+                f"FROM 's3://copytos3/test/ss_193/{format}' "
+                f"(FORMAT {format.upper()}, AWS CONNECTION = aws_conn)"
+            )
+            cur.execute(f"SELECT a, b FROM numbers_from_{format}")
+            rows = cur.fetchall()
+            assert rows == [
+                (Decimal('10.45'), Decimal('10.45'))
+            ], f"COPY FROM {format} did not round values to the column scale: {rows}"
 
 
 def workflow_copy_from_ssrf_redirect(c: Composition) -> None:

--- a/test/copy/mzcompose.py
+++ b/test/copy/mzcompose.py
@@ -503,21 +503,23 @@ def workflow_test_ss_193(c: Composition):
         cur.execute("CREATE TABLE numbers_scale3 (a DECIMAL(10, 3), b NUMERIC(10, 3))")
         cur.execute("INSERT INTO numbers_scale3 VALUES (10.447, 10.447)")
 
+        # The dynamic SQL below is encoded to bytes so it satisfies psycopg's
+        # LiteralString-typed query parameter.
         for format in ["csv", "parquet"]:
             cur.execute(
                 f"COPY (SELECT a, b FROM numbers_scale3) "
                 f"TO 's3://copytos3/test/ss_193/{format}' "
-                f"WITH (AWS CONNECTION = aws_conn, FORMAT = '{format}')"
+                f"WITH (AWS CONNECTION = aws_conn, FORMAT = '{format}')".encode()
             )
             cur.execute(
-                f"CREATE TABLE numbers_from_{format} (a DECIMAL(10, 2), b NUMERIC(10, 2))"
+                f"CREATE TABLE numbers_from_{format} (a DECIMAL(10, 2), b NUMERIC(10, 2))".encode()
             )
             cur.execute(
                 f"COPY INTO numbers_from_{format} "
                 f"FROM 's3://copytos3/test/ss_193/{format}' "
-                f"(FORMAT {format.upper()}, AWS CONNECTION = aws_conn)"
+                f"(FORMAT {format.upper()}, AWS CONNECTION = aws_conn)".encode()
             )
-            cur.execute(f"SELECT a, b FROM numbers_from_{format}")
+            cur.execute(f"SELECT a, b FROM numbers_from_{format}".encode())
             rows = cur.fetchall()
             assert rows == [
                 (Decimal("10.45"), Decimal("10.45"))

--- a/test/copy/mzcompose.py
+++ b/test/copy/mzcompose.py
@@ -489,11 +489,11 @@ def workflow_test_ss_193(c: Composition):
 
         # Round-trip scale-3 values through CSV and parquet files on S3 and
         # assert COPY FROM rounds them to the destination column's scale on read.
-        cur.execute("CREATE SECRET minio_secret AS 'minioadmin'")
+        cur.execute("CREATE SECRET aws_secret_ss_193 AS 'minioadmin'")
         cur.execute("""
-            CREATE CONNECTION aws_conn TO AWS (
+            CREATE CONNECTION aws_conn_ss_193 TO AWS (
                 ACCESS KEY ID = 'minioadmin',
-                SECRET ACCESS KEY = SECRET minio_secret,
+                SECRET ACCESS KEY = SECRET aws_secret_ss_193,
                 ENDPOINT = 'http://minio:9000/',
                 REGION = 'us-east-1'
             )
@@ -509,7 +509,7 @@ def workflow_test_ss_193(c: Composition):
             cur.execute(
                 f"COPY (SELECT a, b FROM numbers_scale3) "
                 f"TO 's3://copytos3/test/ss_193/{format}' "
-                f"WITH (AWS CONNECTION = aws_conn, FORMAT = '{format}')".encode()
+                f"WITH (AWS CONNECTION = aws_conn_ss_193, FORMAT = '{format}')".encode()
             )
             cur.execute(
                 f"CREATE TABLE numbers_from_{format} (a DECIMAL(10, 2), b NUMERIC(10, 2))".encode()
@@ -517,7 +517,7 @@ def workflow_test_ss_193(c: Composition):
             cur.execute(
                 f"COPY INTO numbers_from_{format} "
                 f"FROM 's3://copytos3/test/ss_193/{format}' "
-                f"(FORMAT {format.upper()}, AWS CONNECTION = aws_conn)".encode()
+                f"(FORMAT {format.upper()}, AWS CONNECTION = aws_conn_ss_193)".encode()
             )
             cur.execute(f"SELECT a, b FROM numbers_from_{format}".encode())
             rows = cur.fetchall()

--- a/test/copy/mzcompose.py
+++ b/test/copy/mzcompose.py
@@ -472,32 +472,32 @@ def workflow_test_ss_193(c: Composition):
     c.up("materialized", "minio")
     conn = c.sql_connection()
     with conn.cursor() as cur:
-        cur.execute("CREATE TABLE numbers_with_precision (a DECIMAL(10, 2), b NUMERIC(10, 2))")
+        cur.execute(
+            "CREATE TABLE numbers_with_precision (a DECIMAL(10, 2), b NUMERIC(10, 2))"
+        )
         with cur.copy("COPY numbers_with_precision FROM STDIN") as copy:
-            copy.write('10.447\t10.447\n')
+            copy.write("10.447\t10.447\n")
         with cur.copy("COPY numbers_with_precision FROM STDIN (FORMAT CSV)") as copy:
-            copy.write('10.447,10.447\n')
+            copy.write("10.447,10.447\n")
 
         cur.execute("SELECT a, b FROM numbers_with_precision")
         rows = cur.fetchall()
         assert rows == [
-            (Decimal('10.45'), Decimal('10.45')),
-            (Decimal('10.45'), Decimal('10.45'))
+            (Decimal("10.45"), Decimal("10.45")),
+            (Decimal("10.45"), Decimal("10.45")),
         ], f"COPY FROM STDIN did not round values to the column scale: {rows}"
 
         # Round-trip scale-3 values through CSV and parquet files on S3 and
         # assert COPY FROM rounds them to the destination column's scale on read.
         cur.execute("CREATE SECRET minio_secret AS 'minioadmin'")
-        cur.execute(
-            """
+        cur.execute("""
             CREATE CONNECTION aws_conn TO AWS (
                 ACCESS KEY ID = 'minioadmin',
                 SECRET ACCESS KEY = SECRET minio_secret,
                 ENDPOINT = 'http://minio:9000/',
                 REGION = 'us-east-1'
             )
-            """
-        )
+            """)
 
         # Source carries scale-3 values that don't round evenly to scale 2.
         cur.execute("CREATE TABLE numbers_scale3 (a DECIMAL(10, 3), b NUMERIC(10, 3))")
@@ -520,7 +520,7 @@ def workflow_test_ss_193(c: Composition):
             cur.execute(f"SELECT a, b FROM numbers_from_{format}")
             rows = cur.fetchall()
             assert rows == [
-                (Decimal('10.45'), Decimal('10.45'))
+                (Decimal("10.45"), Decimal("10.45"))
             ], f"COPY FROM {format} did not round values to the column scale: {rows}"
 
 

--- a/test/sqllogictest/pg_catalog_attribute.slt
+++ b/test/sqllogictest/pg_catalog_attribute.slt
@@ -100,7 +100,7 @@ SELECT atttypid, attname, atttypmod FROM pg_attribute WHERE attrelid = (SELECT o
 1186  c_interval  -1
 1187  c__interval  -1
 1231  c__numeric  -1
-1700  c_numeric  2555947
+1700  c_numeric  -1
 2950  c_uuid  -1
 2951  c__uuid  -1
 3802  c_jsonb  -1


### PR DESCRIPTION
### Motivation

Dennis filed an issue flagging a test failure in the iceberg sink where we failed to output the decimal value "62912915282.360725" to an iceberg sink where we expected precision of 3. The issue appears to be upstream, where the data being sinked doesn't match the schema.

For parallel_workload it appears we use `COPY`.

Issue https://linear.app/materializeinc/issue/SS-193/iceberg-failed-to-convert-row-to-recordbatch-failed-to-add-insert-row

### Description

I added some tests for `COPY` behavior that failed initially and now pass, covering default and CSV input via STDIN and Parquet. Generally trying to mirror existing insert behavior that ultimately calls rescale.

### Verification

I've compared the results for the basic tab-separated `COPY` command to postgres and confirmed that postgres rounds while materialize currently doesn't.

I've added some testdrive tests and unit tests to prevent future regressions and explore edge cases like numbers overflowing max precision on rescale that wouldn't have before.

Note: There are a variety of other types that may have similar issues, i.e. timestamp max precision, which I'm thinking I'll file a separate follow-up issue on.

###  Potential Gotchas

The fivetran sink uses the constraints from `Type::Numeric`, so would end up creating a `DECIMAL` with no options, see https://github.com/MaterializeInc/materialize/blob/4229f003472695da7f0fb9c8c1f2aecc3fa8e39e/src/fivetran-destination/src/utils.rs#L94. I think DECIMAL in the SDK maps to fivetran's BIGDECIMAL and so should be more correct by default.
