### PR TITLE
mz-deploy: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "mz-deploy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "annotate-snippets",
  "async-stream",

--- a/doc/user/content/manage/mz-deploy/_index.md
+++ b/doc/user/content/manage/mz-deploy/_index.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 {{< warning >}}
-`mz-deploy` is a v0.1 release and is not yet recommended for production use.
+`mz-deploy` is a v0.2 release and is not yet recommended for production use.
 {{< /warning >}}
 
 `mz-deploy` is a CLI that manages your Materialize deployment from plain SQL

--- a/doc/user/content/manage/mz-deploy/get-started.md
+++ b/doc/user/content/manage/mz-deploy/get-started.md
@@ -10,7 +10,7 @@ menu:
 ---
 
 {{< warning >}}
-`mz-deploy` is a v0.1 release and is not yet recommended for production use.
+`mz-deploy` is a v0.2 release and is not yet recommended for production use.
 {{< /warning >}}
 
 `mz-deploy` is a deployment tool that gives you compile-time validation, unit

--- a/src/mz-deploy/Cargo.toml
+++ b/src/mz-deploy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-deploy"
 description = "Declarative SQL project tooling for Materialize: compile, test, deploy."
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Bump the `mz-deploy` crate version from `0.1.0` to `0.2.0`.

This updates:
- `version` in `src/mz-deploy/Cargo.toml` (and the matching `Cargo.lock` entry)
- The version called out in the user-facing docs (`manage/mz-deploy/_index.md` and `get-started.md`), which previously read "v0.1 release"

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)