### PR TITLE
mz-debug CPU profiling

### DIFF
--- a/src/mz-debug/src/internal_http_dumper.rs
+++ b/src/mz-debug/src/internal_http_dumper.rs
@@ -10,29 +10,53 @@
 //! Dumps internal http debug information to files.
 use anyhow::{Context as AnyhowContext, Result};
 use futures::StreamExt;
+use futures::future::join_all;
 use k8s_openapi::api::core::v1::ServicePort;
+use reqwest::StatusCode;
 use reqwest::header::{HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::fs::{File, create_dir_all};
 use tokio::io::AsyncWriteExt;
 use tracing::{info, warn};
 use url::Url;
 
 use crate::kubectl_port_forwarder::{
-    KubectlPortForwarder, find_cluster_services, find_environmentd_service,
+    KubectlPortForwarder, ServiceInfo, find_cluster_services, find_environmentd_service,
 };
 use crate::{AuthMode, Context, EmulatorContext, PasswordAuthCredentials, SelfManagedContext};
 
-static HEAP_PROFILES_DIR: &str = "profiles";
+static PROFILES_DIR: &str = "profiles";
 static PROM_METRICS_DIR: &str = "prom_metrics";
 static PROM_METRICS_ENDPOINT: &str = "metrics";
 static ENVD_HEAP_PROFILE_ENDPOINT: &str = "prof/heap";
 static CLUSTERD_HEAP_PROFILE_ENDPOINT: &str = "heap";
+static ENVD_CPU_PROFILE_ENDPOINT: &str = "prof/cpu";
+static CLUSTERD_CPU_PROFILE_ENDPOINT: &str = "cpu";
+/// The endpoint for reading a service's profiling mode. Used to probe CPU
+/// profiling support and to verify memory profiling is active again after a
+/// CPU profile capture.
+static ENVD_PROF_MODE_ENDPOINT: &str = "prof/mode";
+static CLUSTERD_PROF_MODE_ENDPOINT: &str = "mode";
 /// The default port for the external HTTP endpoint.
 static DEFAULT_EXTERNAL_HTTP_PORT: i32 = 6877;
 /// The default port for the internal HTTP endpoint.
 static DEFAULT_INTERNAL_HTTP_PORT: i32 = 6878;
+
+/// The sampling frequency, in Hz, used when capturing CPU profiles. We avoid
+/// round numbers like 100 to reduce the chance of sampling in lockstep with
+/// periodic activity.
+static CPU_PROFILE_HZ: u32 = 99;
+/// Whether to merge per-thread stacks when capturing CPU profiles. We keep
+/// threads separate by default so that per-thread behavior is visible.
+static CPU_PROFILE_MERGE_THREADS: bool = false;
+/// The timeout for requests to a service's profiling mode endpoint.
+static PROF_MODE_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Extra time on top of the requested capture duration before the CPU profile
+/// request times out, covering profile conversion and transfer.
+static CPU_PROFILE_REQUEST_GRACE: Duration = Duration::from_secs(60);
 
 /// The label for the internal HTTP port.
 const INTERNAL_HTTP_PORT_LABEL: &str = "internal-http";
@@ -40,6 +64,7 @@ const INTERNAL_HTTP_PORT_LABEL: &str = "internal-http";
 // Even when not using TLS, the external HTTP port is labeled as "https".
 const EXTERNAL_HTTP_PORT_LABEL: &str = "https";
 
+#[derive(Debug, Clone, Copy)]
 enum ServiceType {
     Clusterd,
     Environmentd,
@@ -50,6 +75,48 @@ fn get_profile_endpoint(service_type: &ServiceType) -> &'static str {
         ServiceType::Clusterd => CLUSTERD_HEAP_PROFILE_ENDPOINT,
         ServiceType::Environmentd => ENVD_HEAP_PROFILE_ENDPOINT,
     }
+}
+
+fn get_cpu_profile_endpoint(service_type: &ServiceType) -> &'static str {
+    match service_type {
+        ServiceType::Clusterd => CLUSTERD_CPU_PROFILE_ENDPOINT,
+        ServiceType::Environmentd => ENVD_CPU_PROFILE_ENDPOINT,
+    }
+}
+
+fn get_prof_mode_endpoint(service_type: &ServiceType) -> &'static str {
+    match service_type {
+        ServiceType::Clusterd => CLUSTERD_PROF_MODE_ENDPOINT,
+        ServiceType::Environmentd => ENVD_PROF_MODE_ENDPOINT,
+    }
+}
+
+/// The body of a `POST` request to a service's CPU profile endpoint.
+#[derive(Serialize)]
+struct CpuProfileRequest {
+    /// How long, in seconds, to sample.
+    seconds: u64,
+    /// The sampling frequency in Hz.
+    hz: u32,
+    /// Whether to merge per-thread stacks.
+    merge_threads: bool,
+}
+
+/// The profiling mode reported by a service's profiling mode endpoint.
+#[derive(Deserialize)]
+struct ProfModeResponse {
+    cpu_active: bool,
+    memory_available: bool,
+    memory_active: bool,
+}
+
+/// Returns the HTTP status code of the innermost `reqwest` error in `err`'s
+/// chain, if any. Transport failures such as timeouts and connection errors
+/// carry no status.
+fn http_error_status(err: &anyhow::Error) -> Option<StatusCode> {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<reqwest::Error>())
+        .and_then(reqwest::Error::status)
 }
 
 #[derive(Debug, Clone)]
@@ -114,51 +181,70 @@ impl<'n> HttpDumpClient<'n> {
         }
     }
 
-    async fn dump_request_to_file(
+    /// Sends a request to `relative_url`, trying HTTPS first and falling back
+    /// to HTTP when the connection cannot be established. `build_request`
+    /// constructs the request for a given URL and basic auth is layered on top
+    /// when configured. Returns the response only if the server returned a
+    /// success status. The underlying `reqwest::Error` is preserved in the
+    /// error chain so that callers can inspect the HTTP status via
+    /// [`http_error_status`].
+    async fn send_with_fallback(
         &self,
         relative_url: &str,
-        headers: HeaderMap,
-        output_path: &Path,
-    ) -> Result<(), anyhow::Error> {
-        let create_request = |url: &Url| {
-            let mut request_builder = self
-                .http_client
-                .get(url.to_string())
-                .headers(headers.clone());
-
+        build_request: impl Fn(&Url) -> reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, anyhow::Error> {
+        let build_with_auth = |url: &Url| {
+            let request_builder = build_request(url);
             if let AuthMode::Password(PasswordAuthCredentials { username, password }) =
                 self.auth_mode
             {
-                request_builder = request_builder.basic_auth(&username, Some(&password));
+                request_builder.basic_auth(username, Some(password))
+            } else {
+                request_builder
             }
-
-            request_builder
         };
-        // Try HTTPS first, then fall back to HTTP if that fails
+        // Try HTTPS first, then fall back to HTTP if that fails.
         let mut url = Url::parse(&format!("https://{}", relative_url))
             .with_context(|| format!("Failed to parse URL: https://{}", relative_url))?;
 
-        let request = create_request(&url);
+        let mut response = build_with_auth(&url).send().await;
 
-        let mut response = request.send().await;
-
-        if response.is_err() {
-            // Fall back to HTTP if HTTPS fails
+        // Only fall back to HTTP when the connection could not be established,
+        // which is how an HTTP-only server answers an HTTPS attempt. Errors
+        // from a server we actually reached (including timeouts) must not
+        // trigger a second attempt, since requests may have side effects such
+        // as starting a CPU profile capture.
+        if response.as_ref().is_err_and(reqwest::Error::is_connect) {
             let _ = url.set_scheme("http");
-
-            response = create_request(&url).send().await;
+            response = build_with_auth(&url).send().await;
         }
 
         let response = response.with_context(|| format!("Failed to send request to {}", url))?;
 
-        if !response.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "Failed to get response from {}: {}",
-                url,
-                response.status()
-            ));
+        let status = response.status();
+        if !status.is_success() {
+            // Prefer `error_for_status` since it preserves the status code in
+            // the error chain for callers to inspect.
+            return match response.error_for_status() {
+                Err(err) => {
+                    Err(err).with_context(|| format!("Failed to get response from {}", url))
+                }
+                Ok(_) => Err(anyhow::anyhow!(
+                    "Failed to get response from {}: {}",
+                    url,
+                    status
+                )),
+            };
         }
 
+        Ok(response)
+    }
+
+    /// Streams the body of `response` to `output_path`.
+    async fn stream_response_to_file(
+        response: reqwest::Response,
+        output_path: &Path,
+    ) -> Result<(), anyhow::Error> {
         let mut file = File::create(output_path)
             .await
             .with_context(|| format!("Failed to create file: {}", output_path.display()))?;
@@ -178,9 +264,26 @@ impl<'n> HttpDumpClient<'n> {
         Ok(())
     }
 
+    async fn dump_request_to_file(
+        &self,
+        relative_url: &str,
+        headers: HeaderMap,
+        output_path: &Path,
+    ) -> Result<(), anyhow::Error> {
+        let response = self
+            .send_with_fallback(relative_url, |url| {
+                self.http_client
+                    .get(url.to_string())
+                    .headers(headers.clone())
+            })
+            .await?;
+
+        Self::stream_response_to_file(response, output_path).await
+    }
+
     /// Downloads and saves heap profile data
     pub async fn dump_heap_profile(&self, relative_url: &str, service_name: &str) -> Result<()> {
-        let output_dir = self.context.base_path.join(HEAP_PROFILES_DIR);
+        let output_dir = self.context.base_path.join(PROFILES_DIR);
         create_dir_all(&output_dir).await.with_context(|| {
             format!(
                 "Failed to create output directory: {}",
@@ -205,6 +308,70 @@ impl<'n> HttpDumpClient<'n> {
         .with_context(|| format!("Failed to dump heap profile to {}", output_path.display()))?;
 
         Ok(())
+    }
+
+    /// Captures a CPU profile from `relative_url` and saves it to disk.
+    ///
+    /// The server temporarily disables memory (heap) profiling while it
+    /// captures a CPU profile. See [`dump_cpu_profile_and_verify_memory`]
+    /// for how memory profiling is restored afterwards.
+    pub async fn dump_cpu_profile(
+        &self,
+        relative_url: &str,
+        service_name: &str,
+        duration_secs: u64,
+    ) -> Result<()> {
+        let output_dir = self.context.base_path.join(PROFILES_DIR);
+        create_dir_all(&output_dir).await.with_context(|| {
+            format!(
+                "Failed to create output directory: {}",
+                output_dir.display()
+            )
+        })?;
+        let output_path = output_dir.join(format!("{}.cpuprof.pprof.gz", service_name));
+
+        let request = CpuProfileRequest {
+            seconds: duration_secs,
+            hz: CPU_PROFILE_HZ,
+            merge_threads: CPU_PROFILE_MERGE_THREADS,
+        };
+        // The server samples for `duration_secs`, so give the request that
+        // long plus a fixed grace period before timing out.
+        let request_timeout =
+            Duration::from_secs(duration_secs).saturating_add(CPU_PROFILE_REQUEST_GRACE);
+
+        let response = self
+            .send_with_fallback(relative_url, |url| {
+                self.http_client
+                    .post(url.to_string())
+                    .timeout(request_timeout)
+                    .header("Accept", "application/octet-stream")
+                    .json(&request)
+            })
+            .await
+            .with_context(|| format!("Failed to capture CPU profile from {}", relative_url))?;
+
+        Self::stream_response_to_file(response, &output_path)
+            .await
+            .with_context(|| format!("Failed to dump CPU profile to {}", output_path.display()))?;
+
+        Ok(())
+    }
+
+    /// Reads the profiling mode of the target service.
+    async fn get_profiling_mode(&self, relative_url: &str) -> Result<ProfModeResponse> {
+        let response = self
+            .send_with_fallback(relative_url, |url| {
+                self.http_client
+                    .get(url.to_string())
+                    .timeout(PROF_MODE_REQUEST_TIMEOUT)
+            })
+            .await?;
+        let mode = response
+            .json::<ProfModeResponse>()
+            .await
+            .with_context(|| format!("Failed to parse profiling mode from {}", relative_url))?;
+        Ok(mode)
     }
 
     pub async fn dump_prometheus_metrics(
@@ -233,6 +400,99 @@ impl<'n> HttpDumpClient<'n> {
         .await?;
 
         Ok(())
+    }
+}
+
+/// Captures a CPU profile for a single service and verifies that memory
+/// profiling is active again afterwards.
+///
+/// The server temporarily disables memory (heap) profiling while it captures
+/// a CPU profile and restores the prior state itself when the capture ends,
+/// including when the capture fails or is cancelled. mz-debug therefore only
+/// observes the profiling mode and never modifies it. If memory profiling was
+/// active before the capture but is not active afterwards, that is reported
+/// for the operator to fix.
+///
+/// Errors are logged rather than propagated so that one failing service does
+/// not abort the others.
+async fn dump_cpu_profile_and_verify_memory(
+    dump_client: &HttpDumpClient<'_>,
+    cpu_endpoint: &str,
+    mode_endpoint: &str,
+    service_name: &str,
+    duration_secs: u64,
+) {
+    // Reading the mode also serves as a version probe. Servers that predate
+    // CPU profiling support have neither the profiling mode endpoint nor the
+    // CPU profile endpoint, so skip them without noise.
+    let prior_mode = match dump_client.get_profiling_mode(mode_endpoint).await {
+        Ok(mode) => Some(mode),
+        Err(e) if http_error_status(&e) == Some(StatusCode::NOT_FOUND) => {
+            info!(
+                "Service {} does not support CPU profiling. Skipping the CPU profile.",
+                service_name
+            );
+            return;
+        }
+        Err(e) => {
+            warn!(
+                "Failed to read the profiling mode of service {}: {:#}",
+                service_name, e
+            );
+            None
+        }
+    };
+
+    info!("Dumping CPU profile for service {}", service_name);
+    let capture_result = dump_client
+        .dump_cpu_profile(cpu_endpoint, service_name, duration_secs)
+        .await;
+    let capture_status = capture_result.as_ref().err().and_then(http_error_status);
+    if let Err(e) = &capture_result {
+        warn!(
+            "Failed to dump CPU profile for service {}: {:#}",
+            service_name, e
+        );
+    }
+    // If the capture endpoint does not exist, the capture never started and
+    // memory profiling was never disturbed.
+    if let Some(StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED) = capture_status {
+        return;
+    }
+
+    // Skip the verification when memory profiling was off or unavailable
+    // before the capture, there is nothing to restore then. An unknown prior
+    // mode still verifies, a spurious warning is better than silently leaving
+    // heap profiling off.
+    let memory_was_active = prior_mode
+        .as_ref()
+        .is_none_or(|mode| mode.memory_available && mode.memory_active);
+    if !memory_was_active {
+        return;
+    }
+
+    match dump_client.get_profiling_mode(mode_endpoint).await {
+        Ok(mode) if mode.memory_active => {}
+        Ok(mode) if mode.cpu_active => {
+            // Another capture is still running, possibly one this tool timed
+            // out on. The server restores memory profiling when it finishes.
+            info!(
+                "A CPU profile capture is still running on service {}. The service restores memory profiling when it finishes.",
+                service_name
+            );
+        }
+        Ok(_) => {
+            warn!(
+                "Memory profiling is not active on service {} after the CPU profile. Re-enable it by POSTing {{\"memory_active\": true}} to the service's profiling mode endpoint or via its /prof web UI.",
+                service_name
+            );
+        }
+        Err(e) => {
+            warn!(
+                "Failed to verify the profiling mode of service {} after the CPU profile: {:#}",
+                service_name, e
+            );
+        }
     }
 }
 
@@ -287,6 +547,34 @@ pub async fn dump_emulator_http_resources(
         }
     }
 
+    // Capture the CPU profile after memory profiling, since the capture
+    // temporarily disables memory profiling on the service.
+    if context.dump_cpu_profiles {
+        let resource_name = "environmentd".to_string();
+        let port = get_default_port(&emulator_context.http_connection_auth_mode).heap_profile_port;
+        let cpu_endpoint = format!(
+            "{}:{}/{}",
+            emulator_context.container_ip, port, ENVD_CPU_PROFILE_ENDPOINT
+        );
+        let mode_endpoint = format!(
+            "{}:{}/{}",
+            emulator_context.container_ip, port, ENVD_PROF_MODE_ENDPOINT
+        );
+
+        info!(
+            "Capturing CPU profile for {} seconds. Memory profiling is temporarily disabled during the capture and restored afterwards.",
+            context.cpu_profile_duration_secs
+        );
+        dump_cpu_profile_and_verify_memory(
+            &dump_task,
+            &cpu_endpoint,
+            &mode_endpoint,
+            &resource_name,
+            context.cpu_profile_duration_secs,
+        )
+        .await;
+    }
+
     Ok(())
 }
 
@@ -317,16 +605,17 @@ pub async fn dump_self_managed_http_resources(
     .await
     .with_context(|| "Failed to find environmentd service")?;
 
-    let services = cluster_services
+    let services: Vec<(&ServiceInfo, ServiceType)> = cluster_services
         .iter()
         .map(|service| (service, ServiceType::Clusterd))
         .chain(std::iter::once((
             &environmentd_service,
             ServiceType::Environmentd,
-        )));
+        )))
+        .collect();
 
-    // Scrape each service
-    for (service_info, service_type) in services {
+    // Scrape each service for heap profiles and prometheus metrics.
+    for &(service_info, service_type) in &services {
         let profiling_endpoint = get_profile_endpoint(&service_type);
         let heap_profile_port_label = get_port_labels(
             &self_managed_context.http_connection_auth_mode,
@@ -446,6 +735,84 @@ pub async fn dump_self_managed_http_resources(
                 );
             }
         }
+    }
+
+    // Capture CPU profiles after memory profiling, since each capture
+    // temporarily disables memory profiling on its service. The captures run
+    // in parallel, and a failure on one service does not abort the others.
+    if context.dump_cpu_profiles {
+        info!(
+            "Capturing CPU profiles for {} seconds. Memory profiling is temporarily disabled on each service during its capture and restored afterwards.",
+            context.cpu_profile_duration_secs
+        );
+
+        let cpu_profile_futures = services.iter().map(|&(service_info, service_type)| {
+            // The CPU and mode endpoints are served on the same port as the heap
+            // profile endpoint.
+            let port_label = get_port_labels(
+                &self_managed_context.http_connection_auth_mode,
+                &service_type,
+            )
+            .heap_profile_port_label;
+            let k8s_context = self_managed_context.k8s_context.clone();
+            let dump_task = &dump_task;
+            let duration_secs = context.cpu_profile_duration_secs;
+
+            async move {
+                let Some(port) = service_info
+                    .service_ports
+                    .iter()
+                    .find_map(|port_info| find_http_port_by_label(port_info, port_label))
+                else {
+                    warn!(
+                        "Failed to find HTTP port `{}` for CPU profiling of service {}",
+                        port_label, service_info.service_name
+                    );
+                    return;
+                };
+
+                let port_forwarder = KubectlPortForwarder {
+                    context: k8s_context,
+                    namespace: service_info.namespace.clone(),
+                    service_name: service_info.service_name.clone(),
+                    target_port: port.port,
+                };
+                let connection = match port_forwarder.spawn_port_forward().await {
+                    Ok(connection) => connection,
+                    Err(e) => {
+                        warn!(
+                            "Failed to spawn port forwarder for CPU profiling of service {}: {:#}",
+                            service_info.service_name, e
+                        );
+                        return;
+                    }
+                };
+
+                let cpu_endpoint = format!(
+                    "{}:{}/{}",
+                    connection.local_address,
+                    connection.local_port,
+                    get_cpu_profile_endpoint(&service_type)
+                );
+                let mode_endpoint = format!(
+                    "{}:{}/{}",
+                    connection.local_address,
+                    connection.local_port,
+                    get_prof_mode_endpoint(&service_type)
+                );
+
+                dump_cpu_profile_and_verify_memory(
+                    dump_task,
+                    &cpu_endpoint,
+                    &mode_endpoint,
+                    &service_info.service_name,
+                    duration_secs,
+                )
+                .await;
+            }
+        });
+
+        join_all(cpu_profile_futures).await;
     }
 
     Ok(())

--- a/src/mz-debug/src/internal_http_dumper.rs
+++ b/src/mz-debug/src/internal_http_dumper.rs
@@ -518,7 +518,7 @@ pub async fn dump_emulator_http_resources(
                     "{}:{}/{}",
                     emulator_context.container_ip,
                     get_default_port(&emulator_context.http_connection_auth_mode).heap_profile_port,
-                    ENVD_HEAP_PROFILE_ENDPOINT
+                    get_profile_endpoint(&ServiceType::Environmentd)
                 ),
                 &resource_name,
             )
@@ -554,11 +554,15 @@ pub async fn dump_emulator_http_resources(
         let port = get_default_port(&emulator_context.http_connection_auth_mode).heap_profile_port;
         let cpu_endpoint = format!(
             "{}:{}/{}",
-            emulator_context.container_ip, port, ENVD_CPU_PROFILE_ENDPOINT
+            emulator_context.container_ip,
+            port,
+            get_cpu_profile_endpoint(&ServiceType::Environmentd)
         );
         let mode_endpoint = format!(
             "{}:{}/{}",
-            emulator_context.container_ip, port, ENVD_PROF_MODE_ENDPOINT
+            emulator_context.container_ip,
+            port,
+            get_prof_mode_endpoint(&ServiceType::Environmentd)
         );
 
         info!(

--- a/src/mz-debug/src/main.rs
+++ b/src/mz-debug/src/main.rs
@@ -104,6 +104,19 @@ pub struct Args {
     /// If true, the tool will dump the prometheus metrics in Materialize.
     #[clap(long, default_value = "true", action = clap::ArgAction::Set, global = true)]
     dump_prometheus_metrics: bool,
+    /// If true, the tool will collect CPU profiles from Materialize. While a CPU
+    /// profile is captured, memory profiling is temporarily disabled on that
+    /// service and restored afterwards.
+    #[clap(long, default_value = "true", action = clap::ArgAction::Set, global = true)]
+    dump_cpu_profiles: bool,
+    /// How long, in seconds, to sample each CPU profile.
+    #[clap(
+        long,
+        default_value = "10",
+        value_parser = clap::value_parser!(u64).range(1..=3600),
+        global = true
+    )]
+    cpu_profile_duration_seconds: u64,
     /// The username to use to connect to Materialize,
     #[clap(long, env = "MZ_USERNAME", global = true)]
     mz_username: Option<String>,
@@ -194,6 +207,8 @@ pub struct Context {
     dump_system_catalog: bool,
     dump_heap_profiles: bool,
     dump_prometheus_metrics: bool,
+    dump_cpu_profiles: bool,
+    cpu_profile_duration_secs: u64,
 }
 
 #[tokio::main]
@@ -391,6 +406,8 @@ async fn initialize_context(
         dump_system_catalog: global_args.dump_system_catalog,
         dump_heap_profiles: global_args.dump_heap_profiles,
         dump_prometheus_metrics: global_args.dump_prometheus_metrics,
+        dump_cpu_profiles: global_args.dump_cpu_profiles,
+        cpu_profile_duration_secs: global_args.cpu_profile_duration_seconds,
     })
 }
 

--- a/src/prof-http/Cargo.toml
+++ b/src/prof-http/Cargo.toml
@@ -22,13 +22,16 @@ mappings.workspace = true
 mime.workspace = true
 mz-build-info = { path = "../build-info", default-features = false }
 mz-http-util = { path = "../http-util", default-features = false }
-mz-ore = { path = "../ore", default-features = false }
+mz-ore = { path = "../ore", default-features = false, features = ["panic"] }
 mz-prof = { path = "../prof", default-features = false }
 jemalloc_pprof = { workspace = true, optional = true }
 pprof_util.workspace = true
 serde.workspace = true
 tokio.workspace = true
-tracing = { workspace = true, optional = true }
+tracing.workspace = true
+
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 
 [build-dependencies]
 anyhow.workspace = true
@@ -42,7 +45,7 @@ default = []
 #
 # WARNING: For development use only! When enabled, may allow unrestricted read
 # access to the file system.
-dev-web = ["tracing"]
+dev-web = []
 # Whether to enable profiling features that depend on jemalloc.
 jemalloc = ["mz-prof/jemalloc", "jemalloc_pprof"]
 

--- a/src/prof-http/src/lib.rs
+++ b/src/prof-http/src/lib.rs
@@ -11,22 +11,26 @@
 
 use std::env;
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use askama::Template;
+use axum::Json;
 use axum::response::IntoResponse;
 use axum::routing::{self, Router};
 use cfg_if::cfg_if;
-use http::StatusCode;
+use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
+use http::{HeaderMap, HeaderValue, StatusCode};
 use mz_build_info::BuildInfo;
 use mz_prof::StackProfileExt;
 use pprof_util::{ProfStartTime, StackProfile};
+use serde::{Deserialize, Serialize};
 
 cfg_if! {
     if #[cfg(any(not(feature = "jemalloc"), miri))] {
-        use disabled::{handle_get, handle_post, handle_get_heap};
+        use disabled::{handle_get, handle_get_heap, handle_get_mode, handle_post, handle_post_mode};
     } else {
-        use enabled::{handle_get, handle_post, handle_get_heap};
+        use enabled::{handle_get, handle_get_heap, handle_get_mode, handle_post, handle_post_mode};
     }
 }
 
@@ -59,8 +63,132 @@ pub fn router(build_info: &'static BuildInfo) -> Router {
             "/",
             routing::post(move |form| handle_post(form, build_info)),
         )
+        .route("/cpu", routing::post(handle_post_cpu))
+        .route(
+            "/mode",
+            routing::get(handle_get_mode).post(handle_post_mode),
+        )
         .route("/heap", routing::get(handle_get_heap))
         .route("/static/{*path}", routing::get(handle_static))
+}
+
+static CPU_PROFILING_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// The maximum permitted CPU profile capture duration. A capture holds the
+/// jemalloc profiling control lock for its entire run, which blocks the heap
+/// profiling endpoints, so runaway requests must be bounded.
+const MAX_CPU_PROFILE_TIME_SECS: u64 = 3600;
+/// The maximum permitted CPU profile sampling frequency. Matches the limit
+/// enforced by `mz_prof::time::prof_time`.
+const MAX_CPU_PROFILE_HZ: u32 = 1_000_000;
+
+#[derive(Deserialize)]
+struct CpuProfileRequest {
+    seconds: u64,
+    hz: u32,
+    #[serde(default)]
+    merge_threads: bool,
+}
+
+/// A profiling mode update.
+#[derive(Debug, Deserialize)]
+struct ModeUpdateRequest {
+    memory_active: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct ModeResponse {
+    cpu_active: bool,
+    memory_available: bool,
+    memory_active: bool,
+}
+
+fn cpu_profiling_active() -> bool {
+    CPU_PROFILING_ACTIVE.load(Ordering::SeqCst)
+}
+
+struct CpuProfilingGuard;
+
+impl CpuProfilingGuard {
+    fn acquire() -> Result<Self, (StatusCode, String)> {
+        CPU_PROFILING_ACTIVE
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map_err(|_| {
+                (
+                    StatusCode::CONFLICT,
+                    "CPU profiling is already running".to_owned(),
+                )
+            })?;
+        Ok(Self)
+    }
+}
+
+impl Drop for CpuProfilingGuard {
+    fn drop(&mut self) {
+        CPU_PROFILING_ACTIVE.store(false, Ordering::SeqCst);
+    }
+}
+
+fn validate_cpu_profile_params(
+    time_secs: u64,
+    sample_freq: u32,
+) -> Result<(), (StatusCode, String)> {
+    if time_secs == 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "`seconds` must be greater than zero".to_owned(),
+        ));
+    }
+    if time_secs > MAX_CPU_PROFILE_TIME_SECS {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("`seconds` must be at most {MAX_CPU_PROFILE_TIME_SECS}"),
+        ));
+    }
+    if sample_freq == 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "`hz` must be greater than zero".to_owned(),
+        ));
+    }
+    if sample_freq > MAX_CPU_PROFILE_HZ {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("`hz` must be at most {MAX_CPU_PROFILE_HZ}"),
+        ));
+    }
+    Ok(())
+}
+
+fn cpu_pprof_response(mut stacks: StackProfile) -> impl IntoResponse {
+    // The sampler records raw runtime addresses. Attach the process memory
+    // mappings so that `to_pprof` can rebase addresses to be file-relative and
+    // offline tooling can symbolize them against the binary, like the heap
+    // profile path does via `parse_jeheap`.
+    if let Some(mappings) = mappings::MAPPINGS.as_ref() {
+        stacks.mappings = mappings.clone();
+    }
+    let pprof = stacks.to_pprof(("samples", "count"), ("cpu", "nanoseconds"), None);
+    (
+        HeaderMap::from_iter([
+            (
+                CONTENT_DISPOSITION,
+                HeaderValue::from_static("attachment; filename=\"cpu.pb.gz\""),
+            ),
+            (
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/octet-stream"),
+            ),
+        ]),
+        pprof,
+    )
+}
+
+async fn handle_post_cpu(
+    Json(request): Json<CpuProfileRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let stacks = capture_cpu_profile(request.merge_threads, request.seconds, request.hz).await?;
+    Ok(cpu_pprof_response(stacks))
 }
 
 #[allow(dead_code)]
@@ -86,28 +214,71 @@ pub struct FlamegraphTemplate<'a> {
     pub mzfg: &'a str,
 }
 
+/// Holds the jemalloc profiling control lock with memory profiling
+/// deactivated, restoring the prior state on drop.
+///
+/// Restoration lives in `Drop` so that it also runs when the capture future is
+/// cancelled, for example when the HTTP client disconnects mid-capture.
+#[cfg(all(feature = "jemalloc", not(miri)))]
+struct MemProfilingSuspendGuard {
+    ctl: tokio::sync::MutexGuard<'static, jemalloc_pprof::JemallocProfCtl>,
+    memory_was_active: bool,
+}
+
+#[cfg(all(feature = "jemalloc", not(miri)))]
+impl Drop for MemProfilingSuspendGuard {
+    fn drop(&mut self) {
+        if self.memory_was_active {
+            // There is no caller to report the error to during drop, so log
+            // instead. `GET /mode` exposes the resulting state.
+            if let Err(e) = self.ctl.activate() {
+                tracing::error!("failed to re-activate memory profiling after CPU profiling: {e}");
+            }
+        }
+    }
+}
+
 #[allow(dropping_copy_types)]
-async fn time_prof(
+async fn capture_cpu_profile(
     merge_threads: bool,
-    build_info: &'static BuildInfo,
     // the time in seconds to run the profiler for
     time_secs: u64,
     // the sampling frequency in Hz
     sample_freq: u32,
-) -> impl IntoResponse + use<> {
+) -> Result<StackProfile, (StatusCode, String)> {
+    validate_cpu_profile_params(time_secs, sample_freq)?;
+    let _cpu_profiling_guard = CpuProfilingGuard::acquire()?;
+    // Suspend memory profiling for the duration of the capture. The guard
+    // restores the prior state when dropped, which covers the success path,
+    // the error path, and cancellation. Holding the jemalloc control lock
+    // across the whole capture is what prevents anyone from re-activating
+    // memory profiling while the sampler runs.
     let ctl_lock;
     cfg_if! {
         if #[cfg(any(not(feature = "jemalloc"), miri))] {
             ctl_lock = ();
         } else {
-            ctl_lock = if let Some(ctl) = jemalloc_pprof::PROF_CTL.as_ref() {
-                let mut borrow = ctl.lock().await;
-                borrow.deactivate().map_err(|e| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-                })?;
-                Some(borrow)
-            } else {
-                None
+            ctl_lock = match jemalloc_pprof::PROF_CTL.as_ref() {
+                Some(ctl) => {
+                    // Acquire the jemalloc memory profiling control lock
+                    // to ensure that no other thread can re-activate memory profiling
+                    let mut borrow = ctl.lock().await;
+                    // Check if memory profiling is currently active
+                    let memory_was_active = borrow.activated();
+                    // If it is, deactivate it
+                    if memory_was_active {
+                        borrow.deactivate().map_err(|e| {
+                            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+                        })?;
+                    }
+                    // Return a guard where memory profiling is suspended and will be restored
+                    // when the guard is dropped
+                    Some(MemProfilingSuspendGuard {
+                        ctl: borrow,
+                        memory_was_active,
+                    })
+                }
+                None => None,
             };
         }
     }
@@ -118,8 +289,22 @@ async fn time_prof(
     }
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    // Fail with a compile error if we weren't holding the jemalloc lock.
+    // The sampler has stopped, so the guard may now restore memory profiling.
+    // Referencing `ctl_lock` here also fails with a compile error if we
+    // weren't holding the jemalloc lock across the capture.
     drop(ctl_lock);
+    Ok(stacks)
+}
+
+async fn time_prof(
+    merge_threads: bool,
+    build_info: &'static BuildInfo,
+    // the time in seconds to run the profiler for
+    time_secs: u64,
+    // the sampling frequency in Hz
+    sample_freq: u32,
+) -> impl IntoResponse + use<> {
+    let stacks = capture_cpu_profile(merge_threads, time_secs, sample_freq).await?;
     let (secs_s, freq_s) = (format!("{time_secs}"), format!("{sample_freq}"));
     Ok::<_, (StatusCode, String)>(flamegraph(
         stacks,
@@ -157,6 +342,7 @@ fn flamegraph<'a, 'b>(
 
 #[cfg(any(not(feature = "jemalloc"), miri))]
 mod disabled {
+    use axum::Json;
     use axum::extract::{Form, Query};
     use axum::response::IntoResponse;
     use http::StatusCode;
@@ -166,7 +352,10 @@ mod disabled {
 
     use mz_prof::ever_symbolized;
 
-    use super::{MemProfilingStatus, ProfTemplate, time_prof};
+    use super::{
+        MemProfilingStatus, ModeResponse, ModeUpdateRequest, ProfTemplate, cpu_profiling_active,
+        time_prof,
+    };
 
     #[derive(Deserialize)]
     pub struct ProfQuery {
@@ -230,6 +419,27 @@ mod disabled {
     }
 
     #[allow(clippy::unused_async)]
+    pub async fn handle_get_mode() -> Json<ModeResponse> {
+        Json(ModeResponse {
+            cpu_active: cpu_profiling_active(),
+            memory_available: false,
+            memory_active: false,
+        })
+    }
+
+    pub async fn handle_post_mode(
+        Json(request): Json<ModeUpdateRequest>,
+    ) -> Result<Json<ModeResponse>, (StatusCode, String)> {
+        if request.memory_active == Some(true) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "memory profiling is unavailable in this build".to_owned(),
+            ));
+        }
+        Ok(handle_get_mode().await)
+    }
+
+    #[allow(clippy::unused_async)]
     pub async fn handle_get_heap() -> Result<(), (StatusCode, String)> {
         Err((
             StatusCode::BAD_REQUEST,
@@ -243,6 +453,7 @@ mod enabled {
     use std::io::{BufReader, Read};
     use std::sync::Arc;
 
+    use axum::Json;
     use axum::extract::{Form, Query};
     use axum::response::IntoResponse;
     use axum_extra::TypedHeader;
@@ -260,7 +471,10 @@ mod enabled {
     use serde::Deserialize;
     use tokio::sync::Mutex;
 
-    use super::{MemProfilingStatus, ProfTemplate, flamegraph, time_prof};
+    use super::{
+        MemProfilingStatus, ModeResponse, ModeUpdateRequest, ProfTemplate, cpu_profiling_active,
+        flamegraph, time_prof,
+    };
 
     #[derive(Deserialize)]
     pub struct ProfForm {
@@ -444,6 +658,50 @@ mod enabled {
         }
     }
 
+    pub async fn handle_get_mode() -> Json<ModeResponse> {
+        let memory_active = current_memory_mode().await;
+        Json(mode_response(memory_active, prof_ctl().is_some()))
+    }
+
+    pub async fn handle_post_mode(
+        Json(request): Json<ModeUpdateRequest>,
+    ) -> Result<Json<ModeResponse>, (StatusCode, String)> {
+        if let Some(desired_memory_active) = request.memory_active {
+            // NOTE: This check is a fast fail. The guarantee that memory
+            // profiling cannot be activated mid-capture is the jemalloc
+            // control lock below, which a running capture holds for its
+            // entire duration.
+            if desired_memory_active && cpu_profiling_active() {
+                return Err((
+                    StatusCode::CONFLICT,
+                    "memory profiling cannot be activated while CPU profiling is running"
+                        .to_owned(),
+                ));
+            }
+            let prof_ctl = prof_ctl().ok_or_else(|| {
+                (
+                    StatusCode::FORBIDDEN,
+                    "memory profiling is unavailable in this build".to_owned(),
+                )
+            })?;
+            let mut borrow = prof_ctl.lock().await;
+            if desired_memory_active && !borrow.activated() {
+                borrow
+                    .activate()
+                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            } else if !desired_memory_active && borrow.activated() {
+                borrow
+                    .deactivate()
+                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            }
+            return Ok(Json(mode_response(borrow.activated(), true)));
+        }
+        Ok(Json(mode_response(
+            current_memory_mode().await,
+            prof_ctl().is_some(),
+        )))
+    }
+
     pub async fn handle_get_heap() -> Result<impl IntoResponse, (StatusCode, String)> {
         let mut prof_ctl = PROF_CTL.as_ref().unwrap().lock().await;
         require_profiling_activated(&prof_ctl)?;
@@ -477,5 +735,151 @@ mod enabled {
         } else {
             Err((StatusCode::FORBIDDEN, "heap profiling not activated".into()))
         }
+    }
+
+    async fn current_memory_mode() -> bool {
+        match prof_ctl() {
+            Some(prof_ctl) => prof_ctl.lock().await.activated(),
+            None => false,
+        }
+    }
+
+    fn prof_ctl() -> Option<Arc<Mutex<JemallocProfCtl>>> {
+        // NOTE: Dereferencing `PROF_CTL` panics when the linked jemalloc was
+        // built without profiling support, e.g. in test binaries that enable
+        // the `jemalloc` feature without configuring the allocator. Treat
+        // that as memory profiling being unavailable. `mz_ore`'s wrapper,
+        // unlike `std::panic::catch_unwind`, cooperates with our panic hook,
+        // which otherwise aborts the process.
+        mz_ore::panic::catch_unwind(|| PROF_CTL.as_ref().cloned())
+            .ok()
+            .flatten()
+    }
+
+    fn mode_response(memory_active: bool, memory_available: bool) -> ModeResponse {
+        ModeResponse {
+            cpu_active: cpu_profiling_active(),
+            memory_available,
+            memory_active,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Json;
+    use http::StatusCode;
+
+    use super::{
+        CpuProfileRequest, CpuProfilingGuard, MAX_CPU_PROFILE_TIME_SECS, ModeResponse,
+        ModeUpdateRequest, handle_get_mode, handle_post_cpu, handle_post_mode,
+    };
+
+    /// Serializes tests that acquire the process-global [`CpuProfilingGuard`],
+    /// since tests within one binary run concurrently.
+    static CPU_GUARD_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    fn expect_error(
+        result: Result<impl axum::response::IntoResponse, (StatusCode, String)>,
+        msg: &str,
+    ) -> StatusCode {
+        match result {
+            Ok(_) => panic!("{}", msg),
+            Err((status, _)) => status,
+        }
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn post_cpu_rejects_zero_seconds() {
+        let result = handle_post_cpu(Json(CpuProfileRequest {
+            seconds: 0,
+            hz: 99,
+            merge_threads: false,
+        }))
+        .await;
+        let status = expect_error(result, "zero-second capture must fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn post_cpu_rejects_zero_hz() {
+        let result = handle_post_cpu(Json(CpuProfileRequest {
+            seconds: 1,
+            hz: 0,
+            merge_threads: false,
+        }))
+        .await;
+        let status = expect_error(result, "zero-hz capture must fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn post_cpu_rejects_excessive_seconds() {
+        let result = handle_post_cpu(Json(CpuProfileRequest {
+            seconds: MAX_CPU_PROFILE_TIME_SECS + 1,
+            hz: 99,
+            merge_threads: false,
+        }))
+        .await;
+        let status = expect_error(result, "over-long capture must fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn post_cpu_conflicts_with_running_capture() {
+        let _lock = CPU_GUARD_LOCK.lock().await;
+        let _guard = CpuProfilingGuard::acquire().expect("no capture running");
+        let result = handle_post_cpu(Json(CpuProfileRequest {
+            seconds: 1,
+            hz: 99,
+            merge_threads: false,
+        }))
+        .await;
+        let status = expect_error(result, "concurrent capture must fail");
+        assert_eq!(status, StatusCode::CONFLICT);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn get_mode_reports_cpu_active_state() {
+        let _lock = CPU_GUARD_LOCK.lock().await;
+        let guard = CpuProfilingGuard::acquire().expect("no capture running");
+        let Json(ModeResponse { cpu_active, .. }) = handle_get_mode().await;
+        assert!(cpu_active);
+        drop(guard);
+        let Json(ModeResponse { cpu_active, .. }) = handle_get_mode().await;
+        assert!(!cpu_active);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn post_mode_without_memory_change_is_noop() {
+        let _lock = CPU_GUARD_LOCK.lock().await;
+        let _guard = CpuProfilingGuard::acquire().expect("no capture running");
+        let result = handle_post_mode(Json(ModeUpdateRequest {
+            memory_active: None,
+        }))
+        .await;
+        let _ = result.expect("mode update without a memory change must succeed");
+    }
+
+    #[cfg(any(not(feature = "jemalloc"), miri))]
+    #[mz_ore::test(tokio::test)]
+    async fn post_mode_rejects_memory_activation_when_unavailable() {
+        let result = handle_post_mode(Json(ModeUpdateRequest {
+            memory_active: Some(true),
+        }))
+        .await;
+        let (status, _) = result.expect_err("memory activation must fail without jemalloc");
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[cfg(all(feature = "jemalloc", not(miri)))]
+    #[mz_ore::test(tokio::test)]
+    async fn get_mode_handles_optional_memory_support() {
+        let Json(ModeResponse {
+            memory_available,
+            memory_active,
+            ..
+        }) = handle_get_mode().await;
+        assert!(!memory_active || memory_available);
     }
 }

--- a/src/prof-http/src/lib.rs
+++ b/src/prof-http/src/lib.rs
@@ -882,4 +882,76 @@ mod tests {
         }) = handle_get_mode().await;
         assert!(!memory_active || memory_available);
     }
+
+    /// End-to-end check of the memory-profiling lifecycle around a CPU capture:
+    /// memory profiling starts active, is suspended for the duration of a
+    /// capture (during which it cannot be re-activated), and is restored once
+    /// the capture finishes.
+    #[cfg(all(feature = "jemalloc", not(miri)))]
+    #[mz_ore::test(tokio::test)]
+    async fn cpu_capture_suspends_then_restores_memory_profiling() {
+        use super::{capture_cpu_profile, cpu_profiling_active};
+
+        let _lock = CPU_GUARD_LOCK.lock().await;
+
+        // Without a profiling-enabled jemalloc there is nothing to suspend, so
+        // the behavior under test does not exist here. Skip loudly rather than
+        // fail, so narrow local builds do not report a spurious failure.
+        let Json(ModeResponse {
+            memory_available, ..
+        }) = handle_get_mode().await;
+        if !memory_available {
+            eprintln!(
+                "skipping cpu_capture_suspends_then_restores_memory_profiling: \
+                 jemalloc memory profiling is unavailable in this build"
+            );
+            return;
+        }
+
+        // (a) Memory profiling on, CPU profiling off.
+        let Json(before) = handle_post_mode(Json(ModeUpdateRequest {
+            memory_active: Some(true),
+        }))
+        .await
+        .expect("memory activation must succeed");
+        assert!(before.memory_active, "memory profiling should start active");
+        assert!(!before.cpu_active, "cpu profiling should start inactive");
+
+        // (b) Run a capture on its own task so we can observe the live state
+        // while it holds the jemalloc control lock. `GET /mode` reads that lock
+        // and would block until the capture finished, so we observe through the
+        // lock-free CPU atomic and the fast-fail `POST /mode` path instead.
+        let capture =
+            mz_ore::task::spawn(|| "cpu-capture-test", capture_cpu_profile(false, 1, 100));
+        while !cpu_profiling_active() && !capture.is_finished() {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            cpu_profiling_active(),
+            "the capture should have activated cpu profiling"
+        );
+        // Memory profiling is suspended: re-activating it is rejected while the
+        // capture holds the control lock.
+        let conflict = handle_post_mode(Json(ModeUpdateRequest {
+            memory_active: Some(true),
+        }))
+        .await;
+        assert_eq!(
+            expect_error(conflict, "memory activation must be rejected mid-capture"),
+            StatusCode::CONFLICT,
+        );
+
+        // (c) Once the capture finishes, memory profiling is restored and CPU
+        // profiling is off.
+        let _ = capture.await.expect("cpu capture must succeed");
+        let Json(after) = handle_get_mode().await;
+        assert!(
+            !after.cpu_active,
+            "cpu profiling should be inactive after the capture"
+        );
+        assert!(
+            after.memory_active,
+            "memory profiling should be restored after the capture"
+        );
+    }
 }

--- a/src/prof-http/src/lib.rs
+++ b/src/prof-http/src/lib.rs
@@ -23,6 +23,8 @@ use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use http::{HeaderMap, HeaderValue, StatusCode};
 use mz_build_info::BuildInfo;
 use mz_prof::StackProfileExt;
+#[cfg(all(feature = "jemalloc", not(miri)))]
+use mz_prof::jemalloc::JemallocProfCtlExt;
 use pprof_util::{ProfStartTime, StackProfile};
 use serde::{Deserialize, Serialize};
 
@@ -214,8 +216,12 @@ pub struct FlamegraphTemplate<'a> {
     pub mzfg: &'a str,
 }
 
-/// Holds the jemalloc profiling control lock with memory profiling
-/// deactivated, restoring the prior state on drop.
+/// Holds the jemalloc profiling control lock with memory profiling paused,
+/// restoring the prior state on drop.
+///
+/// Pauses rather than deactivates memory profiling: deactivation calls
+/// jemalloc's `prof.reset`, which discards the heap profile accumulated so far.
+/// See [`JemallocProfCtlExt::pause`].
 ///
 /// Restoration lives in `Drop` so that it also runs when the capture future is
 /// cancelled, for example when the HTTP client disconnects mid-capture.
@@ -231,8 +237,8 @@ impl Drop for MemProfilingSuspendGuard {
         if self.memory_was_active {
             // There is no caller to report the error to during drop, so log
             // instead. `GET /mode` exposes the resulting state.
-            if let Err(e) = self.ctl.activate() {
-                tracing::error!("failed to re-activate memory profiling after CPU profiling: {e}");
+            if let Err(e) = self.ctl.resume() {
+                tracing::error!("failed to resume memory profiling after CPU profiling: {e}");
             }
         }
     }
@@ -262,12 +268,14 @@ async fn capture_cpu_profile(
                 Some(ctl) => {
                     // Acquire the jemalloc memory profiling control lock
                     // to ensure that no other thread can re-activate memory profiling
-                    let mut borrow = ctl.lock().await;
+                    let borrow = ctl.lock().await;
                     // Check if memory profiling is currently active
                     let memory_was_active = borrow.activated();
-                    // If it is, deactivate it
+                    // If it is, pause it. Pause rather than deactivate: the
+                    // latter calls jemalloc's `prof.reset`, which would discard
+                    // the heap profile accumulated so far.
                     if memory_was_active {
-                        borrow.deactivate().map_err(|e| {
+                        borrow.pause().map_err(|e| {
                             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
                         })?;
                     }

--- a/src/prof/src/jemalloc.rs
+++ b/src/prof/src/jemalloc.rs
@@ -22,7 +22,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::{MetricsRegistry, UIntGauge};
 use pprof_util::ProfStartTime;
-use tikv_jemalloc_ctl::{epoch, stats};
+use tikv_jemalloc_ctl::{epoch, raw, stats};
 
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
@@ -45,6 +45,26 @@ pub struct JemallocStats {
 pub trait JemallocProfCtlExt {
     fn dump_stats(&mut self, json_format: bool) -> anyhow::Result<String>;
     fn stats(&self) -> anyhow::Result<JemallocStats>;
+
+    /// Pauses allocation sampling by clearing jemalloc's `prof.active` mallctl.
+    ///
+    /// Unlike [`JemallocProfCtl::deactivate`], this leaves `prof.reset`
+    /// untouched, so the profile accumulated so far and the profiling metadata
+    /// (start time, sample rate) survive. Pair with [`resume`](Self::resume) to
+    /// keep extending the same profile. Use this to briefly stop sampling, for
+    /// example while capturing a CPU profile, without discarding the heap
+    /// profile collected so far. A caller that intends to start a fresh profile
+    /// wants [`JemallocProfCtl::deactivate`] instead.
+    ///
+    /// Takes `&self` deliberately: pausing does not touch the tracked metadata,
+    /// only the global mallctl.
+    fn pause(&self) -> anyhow::Result<()>;
+
+    /// Resumes allocation sampling by setting jemalloc's `prof.active` mallctl.
+    ///
+    /// The counterpart to [`pause`](Self::pause). Sampling continues into the
+    /// profile that `pause` preserved.
+    fn resume(&self) -> anyhow::Result<()>;
 }
 
 impl JemallocProfCtlExt for JemallocProfCtl {
@@ -59,6 +79,20 @@ impl JemallocProfCtlExt for JemallocProfCtl {
 
     fn stats(&self) -> anyhow::Result<JemallocStats> {
         JemallocStats::get()
+    }
+
+    fn pause(&self) -> anyhow::Result<()> {
+        // SAFETY: "prof.active" is documented as writable and taking a bool:
+        // http://jemalloc.net/jemalloc.3.html#prof.active
+        unsafe { raw::write(b"prof.active\0", false) }?;
+        Ok(())
+    }
+
+    fn resume(&self) -> anyhow::Result<()> {
+        // SAFETY: "prof.active" is documented as writable and taking a bool:
+        // http://jemalloc.net/jemalloc.3.html#prof.active
+        unsafe { raw::write(b"prof.active\0", true) }?;
+        Ok(())
     }
 }
 

--- a/src/prof/src/time.rs
+++ b/src/prof/src/time.rs
@@ -45,7 +45,16 @@ pub async unsafe fn prof_time(
         let thread_name;
         // No other known way to convert `*mut c_void` to `usize`.
         #[allow(clippy::as_conversions)]
-        let mut addrs: Vec<_> = f.frames.iter().map(|f| f.ip() as usize).collect();
+        let mut addrs: Vec<_> = f
+            .frames
+            .iter()
+            .map(|f| f.ip() as usize)
+            // Drop null instruction pointers. The sampler can emit `ip() == 0`
+            // for empty/unresolvable frames; downstream pprof conversion computes
+            // `addr - 1`, which underflows on 0 (panics in debug builds with
+            // overflow checks enabled, wraps to a bogus address in release).
+            .filter(|ip| *ip != 0)
+            .collect();
         addrs.reverse();
         // No other known way to convert `isize` to `f64`.
         #[allow(clippy::as_conversions)]

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -3749,10 +3749,11 @@ def workflow_test_profile_fetch(c: Composition) -> None:
     # Regression test for CLU-109: a sampling frequency of zero used to reach
     # pprof's `Timer::new`, which computes `1_000_000 / hz` and panicked with a
     # division by zero, crashing the whole process. It must now be rejected with
-    # a clean error response instead.
+    # a clean error response instead. Parameter validation catches it at the
+    # request boundary and returns a 400.
     test_post(
         {"action": "time_fg", "time_secs": "1", "hz": "0"},
-        make_check(500, "Sampling frequency must be greater than zero."),
+        make_check(400, "`hz` must be greater than zero"),
     )
 
     # Deactivate memory profiling.

--- a/test/mz-debug/mzcompose.py
+++ b/test/mz-debug/mzcompose.py
@@ -8,8 +8,10 @@
 # by the Apache License, Version 2.0.
 
 """
-Basic test for mz-debug
+E2E tests for mz-debug
 """
+
+import urllib.request
 
 from materialize import spawn
 from materialize.mzcompose.composition import (
@@ -20,15 +22,118 @@ from materialize.mzcompose.composition import (
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz_debug import MzDebug
 
+# The internal HTTP port of `materialized`, which serves the unauthenticated
+# `/prof` profiling endpoints (heap, cpu, mode).
+INTERNAL_HTTP_PORT = 6878
+
 SERVICES = [
     Materialized(
         ports=[
             "6875:6875",
             "6877:6877",
+            f"{INTERNAL_HTTP_PORT}:{INTERNAL_HTTP_PORT}",
         ]
     ),
     MzDebug(),
 ]
+
+
+def _heap_profile_inuse(port: int) -> tuple[int, int]:
+    """Dumps the jemalloc heap profile and returns
+    `(total in-use sampled bytes, number of sampled stacks)`.
+
+    The `dump_jeheap` action returns the raw jemalloc profile in `jeprof` text
+    format. Each sampled stack is a line starting with `@` followed by a
+    `t*: <objs>: <bytes> [...]` line whose `<bytes>` is the in-use bytes charged
+    to that stack. The leading global `t*:` summary line has no preceding `@`
+    and is therefore ignored, so stacks are not double counted.
+    """
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/prof/",
+        data=b"action=dump_jeheap",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            # The internal listener runs with no authenticator, but the
+            # profiling route group still requires an authenticated identity.
+            # `mz_system` is accepted on the internal listener without a
+            # password.
+            "x-materialize-user": "mz_system",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        text = response.read().decode("utf-8", "replace")
+
+    total_bytes = 0
+    num_stacks = 0
+    pending_stack = False
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("@"):
+            pending_stack = True
+            num_stacks += 1
+        elif pending_stack and line.startswith("t*:"):
+            # Format: `t*: <objs>: <bytes> [<cum objs>: <cum bytes>]`.
+            total_bytes += int(line.split()[2])
+            pending_stack = False
+    return total_bytes, num_stacks
+
+
+def _assert_cpu_capture_preserves_heap_profile(
+    c: Composition, container_id: str
+) -> None:
+    """
+    Asserts that a CPU profile capture reset heap profiling.
+    """
+    # Plant long-lived allocations in environmentd's heap. Each view definition
+    # embeds a ~512 KiB literal that the catalog holds verbatim. We stay under
+    # the 1 MiB statement-batch limit and well above jemalloc's 512 KiB average
+    # sampling interval so that the allocations are reliably sampled.
+    ballast = "x" * (512 * 1024)
+    for i in range(16):
+        c.sql(
+            f"CREATE VIEW heap_ballast_{i} AS SELECT '{ballast}'::text AS c",
+            print_statement=False,
+        )
+
+    before_bytes, before_stacks = _heap_profile_inuse(INTERNAL_HTTP_PORT)
+    print(
+        f"heap profile before CPU capture: {before_bytes} bytes across {before_stacks} stacks"
+    )
+    # Sanity check: profiling must have captured the planted ballast, otherwise
+    # the comparison below is meaningless and could pass spuriously.
+    assert before_bytes >= 1_000_000, (
+        f"expected the planted allocations to show up in the heap profile, "
+        f"only saw {before_bytes} bytes across {before_stacks} stacks"
+    )
+
+    # Capture a CPU profile
+    spawn.runv(
+        [
+            "./mz-debug",
+            "emulator",
+            "--docker-container-id",
+            container_id,
+            "--dump-cpu-profiles=true",
+            "--dump-heap-profiles=false",
+            "--dump-prometheus-metrics=false",
+            "--dump-system-catalog=false",
+            "--dump-docker=false",
+            "--cpu-profile-duration-seconds=1",
+        ]
+    )
+
+    # Assert that the new heap profile has at least as many stacks as the previous one.
+    after_bytes, after_stacks = _heap_profile_inuse(INTERNAL_HTTP_PORT)
+    print(
+        f"heap profile after CPU capture: {after_bytes} bytes across {after_stacks} stacks"
+    )
+    assert after_bytes >= before_bytes // 2, (
+        "CPU profile capture reset the accumulated heap profile: "
+        f"{before_bytes} bytes / {before_stacks} stacks before, "
+        f"{after_bytes} bytes / {after_stacks} stacks after. "
+        "The capture must suspend memory profiling without calling prof.reset."
+    )
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -38,6 +143,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if container_id is None:
         raise ValueError("Failed to get materialized container ID")
 
+    # Assert that the CPU capture doesn't reset heap profiling.
+    _assert_cpu_capture_preserves_heap_profile(c, container_id)
+
+    # Smoke test: a full `mz-debug` run against the emulator completes without
+    # error.
     spawn.runv(
         [
             "./mz-debug",


### PR DESCRIPTION
**Extend profiling APIs with CPU profiling support and wire it into mz-debug**

**Extend the profiling HTTP APIs with /cpu and /mode routes.**

- /cpu turns on CPU profiling. Before, users could only turn it on via a webpage. CPU and memory profiling cannot be turned on at the same time, because doing so can cause deadlocks (see https://github.com/MaterializeInc/materialize/pull/3922 for more context). Before starting CPU profiling, we turn off memory profiling, then create a drop guard for the remainder of the CPU profiling execution that ensures memory profiling is turned back to its previous state after a drop.
- /mode returns what profiling is enabled and allows users to turn memory profiling on/off.

**Add a test asserting that CPU profiling disables memory profiling.**

Implement CPU profiling in mz-debug: using the new APIs, scrape CPU profiles from each service, also logging if memory profiling is still disabled afterwards. This shouldn't be the case usually, but can happen if for whatever reason, activate on jemalloc fails.

**Fix an underflow bug found while testing that caused a panic.**

**Update the regression test.**

Reuse endpoint functions for the emulator: make the code more consistent by reusing what we already use to branch clusterd and environmentd services for the emulator.
### Motivation

For many self managed customers, we've had to manually tell users to go to some webpage to scrape CPU profiles which is too much TOIL. This feature now also gets CPU profiles along with memory profiles, default to 10 seconds.

### Verification

Created some unit tests and manually tested via my personal kind environment.