### PR TITLE
edu-53: docs for developer mcp connect via oauth flow

### DIFF
--- a/doc/user/content/headless/mcp-endpoint-baseurl-replacements.md
+++ b/doc/user/content/headless/mcp-endpoint-baseurl-replacements.md
@@ -1,0 +1,10 @@
+---
+headless: true
+---
+
+Update the `<baseURL>` placeholder with your value:
+
+| Deployment   |  `<baseURL>`                                                     |
+|--------------| ------------------------------------------------------------------|
+| **Cloud**        | Replace with your value |
+| **Self-Managed** | Replace with your value |

--- a/doc/user/content/headless/mcp-endpoint-config-replacements.md
+++ b/doc/user/content/headless/mcp-endpoint-config-replacements.md
@@ -6,13 +6,6 @@ Update the `<baseURL>` and `<mcp-token>` placeholders with your values:
 
 | Deployment   |  `<baseURL>`                                                     |  `<mcp-token>`              |
 |--------------| ------------------------------------------------------------------| -------------------------------|
-| **Cloud**        | Replace with your value (format: `https://<region-id>.materialize.cloud`)  | Replace with your value       |
-| **Self-Managed** | Replace with your value (format: `http://<host>:6876`) | Replace with your value       |
+| **Cloud**        | Replace with your value | Replace with your value |
+| **Self-Managed** | Replace with your value | Replace with your value |
 | **Emulator**     | `http://localhost:6876` | Replace with your value |
-
-{{< tip >}}
-
-For **Cloud**, you can get the full MCP URL directly from the Console's
-**Connect** modal.
-
-{{< /tip >}}

--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -23,12 +23,36 @@ products over HTTP. You can connect an MCP-compatible client (such as Claude
 Code, Claude Desktop, or Cursor) to the MCP server and ask the agent to discover
 and query your data products using either natural language or SQL:
 
-- *Via `materialize-agent`: What data products can I query?*
 - *SELECT * FROM mcp_product_performance LIMIT 5;*
 - *What's the `total_revenue` for product 42?*
 - *Perform a Pareto analysis on my products.*
 
+## Connection methods
+
+There are two ways to authenticate to the `materialize-agent` MCP server. Your
+method determines whether you need to set up a dedicated agent query
+environment:
+
+- **OAuth** (Available for **Cloud** and for **Self-Managed** using
+  [SSO](/security/self-managed/sso/)): Your MCP client signs you in through your
+  browser. The agent connects as **your user role** with your existing
+  privileges. You can **skip the environment setup** and go to [Method 1:
+  OAuth](#method-1-oauth).
+
+- **Token-based** (Available for **Cloud**, **Self-Managed**, and the
+  **Emulator**): You provide Base64-encoded credentials (the MCP token) to the
+  client. The agent connects as a dedicated, least-privilege **service account**
+  (i.e., a separate login role acting as a service account). [Set up the agent
+  query environment and data
+  products](#set-up-the-agent-query-environment-and-data-products) first and
+  then go to [Method 2: Token-based
+  authentication](#method-2-token-based-authentication).
+
 ## Set up the agent query environment and data products
+
+*This setup is required only for the **token-based** connection method. If
+you're using OAuth, you can skip to [Connect to the MCP
+server](#connect-to-the-mcp-server).*
 
 {{< note >}}
 
@@ -229,9 +253,171 @@ exists.
      For objects that already exist, use [`GRANT SELECT ON <object> TO
      mcp_agent`](/sql/grant-privilege/).
 
-## Create the specific agent role
+## Connect to the MCP server
 
-For your specific agent, create the role with which the agent will connect.
+Connect using [OAuth](#method-1-oauth) or [token-based
+authentication](#method-2-token-based-authentication), as described in
+[Connection methods](#connection-methods).
+
+### Method 1: OAuth
+
+{{< note >}}
+
+The OAuth method is available for **Cloud** and for **Self-Managed** using
+[SSO](/security/self-managed/sso/).
+{{< /note >}}
+
+With OAuth, the agent connects as **your user role** with your existing
+privileges. It is **not** confined to a dedicated [agent query
+environment](#set-up-the-agent-query-environment-and-data-products) and can read
+anything your user can. You do **not** need to set up the agent query
+environment to connect this way.
+
+{{< tip >}}
+
+If you have [set up the agent query environment and data
+products](#set-up-the-agent-query-environment-and-data-products), you can
+optionally grant the `mcp_agent` functional role to your user. This grants
+access to the curated data products if your user does not already have the
+necessary privileges.
+
+```mzsql
+GRANT mcp_agent TO <your_user>;
+```
+
+{{< /tip >}}
+
+To limit what the agent can reach, set
+[`restrict_to_user_objects`](/integrations/mcp-server/mcp-agent-tools/#restrict-to-user-objects)
+on your role (this excludes the system catalog only). For a confined,
+least-privilege agent, use a token-based [service
+account](#method-2-token-based-authentication) instead.
+
+#### Step 1. Get your MCP server URL
+
+To connect, the MCP-compatible client needs the `materialize-agent` MCP server
+URL: `<baseURL>/api/mcp/agent`.
+
+{{< tabs >}}
+
+{{< tab "Cloud" >}}
+
+1. Log in to the [Materialize Console](https://console.materialize.com/).
+
+1. Click the **Connect** link (lower-left corner) to open the **Connect** modal
+   and click on the **MCP Server** tab.
+
+1. In the **Connect your client** section, click on the **Agent** tab.
+
+   You can find your `materialize-agent` MCP server URL
+   `<baseURL>/api/mcp/agent` as part of the code block.
+
+   If using Claude Code as your MCP-compatible client, you can copy the code
+   block wholesale for the next step.
+
+{{< /tab >}}
+
+{{< tab "Self-Managed" >}}
+
+Self-Managed deployments using OAuth require SSO, which uses TLS. Get your MCP
+server URL from the Materialize Console:
+
+1. Log in via the Materialize Console.
+
+1. Click the **Connect** link (lower-left corner) to open the **Connect** modal
+   and click on the **MCP Server** tab.
+
+1. In the **Connect your client** section, click on the **Agent** tab.
+
+   You can find your `materialize-agent` MCP server URL
+   `<baseURL>/api/mcp/agent` as part of the code block.
+
+   If using Claude Code as your MCP-compatible client, you can copy the code
+   block wholesale for the next step.
+
+{{< /tab >}}
+{{< /tabs >}}
+
+#### Step 2. Configure your MCP client
+
+In the following, replace `<baseURL>` with the MCP server URL from [Step
+1](#step-1-get-your-mcp-server-url). For Cloud, the base URL has the format
+`https://<region-id>.materialize.cloud`.
+
+{{< tabs >}}
+{{< tab "Claude Code" >}}
+
+1. Add the `materialize-agent` MCP server as [local-scoped
+   server](https://code.claude.com/docs/en/mcp#local-scope) (i.e., the
+   configurations are stored in `~/.claude.json`):
+
+   ```sh
+   claude mcp add --transport http "materialize-agent" \
+     "<baseURL>/api/mcp/agent"
+   ```
+
+1. Restart Claude Code. On first connection, your browser opens to complete
+   sign-in and connect.
+
+1. Upon successful connection, you can [Start querying](#start-querying).
+
+{{< /tab >}}
+
+{{< tab "Claude Desktop/Chrome" >}}
+
+To configure Claude Desktop/Chrome, add a custom connector. The exact steps
+depend on your Claude plan; for example:
+
+- **Organization settings** → **Connectors** → **Add** → **Custom** → **Web**,
+  or
+- **Customize** → **Connectors** → **+** → **Add custom connector**.
+
+Refer to the [Add a custom
+connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp#h_3d1a65aded)
+section of the [Get started with custom connectors using Remote
+MCP](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp#h_3d1a65aded)
+guide to get the exact steps for your plan. For the **Remote MCP server URL**
+field, enter your `materialize-agent` MCP server URL.
+
+For additional information, including network requirements and security and
+privacy concerns, see the [Get started with custom connectors using Remote
+MCP](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
+article.
+
+{{< /tab >}}
+
+{{< tab "Cursor" >}}
+
+1. Add the `materialize-agent` MCP server entry to your local MCP settings
+   file (`~/.cursor/mcp.json`).
+   - When merging into an existing `mcpServers` object, remember to add commas
+     between entries.
+   - If the `mcpServers` field does not already exist, add it as well.
+
+   ```json {hl_lines="3-5"}
+   {
+     "mcpServers": {
+       "materialize-agent": {
+         "url": "<baseURL>/api/mcp/agent"
+       }
+     }
+   }
+   ```
+
+1. Restart Cursor. On first connection, your browser opens to complete sign-in
+   and connect.
+
+1. Upon successful connection, you can [Start querying](#start-querying).
+
+{{< /tab >}}
+{{< /tabs >}}
+
+### Method 2: Token-based authentication
+
+#### Step 1. Create the specific agent role
+
+For your specific agent, create the dedicated role with which the agent will
+connect.
 
 {{< tabs >}}
 
@@ -383,14 +569,12 @@ For your specific agent, create the role with which the agent will connect.
 
 {{< /tabs >}}
 
-## Connect to the MCP server
-
-### Step 1. Get connection details
+#### Step 2. Get connection details
 
 When connecting to the MCP server, the MCP-compatible client needs:
 
 - The Base64-encoded `user:password` credentials (i.e., the MCP token) of your
-  [agent](#create-the-specific-agent-role).
+  [agent](#step-1-create-the-specific-agent-role).
 
 - The `materialize-agent` MCP server URL: `<baseURL>/api/mcp/agent`.
 
@@ -401,18 +585,18 @@ When connecting to the MCP server, the MCP-compatible client needs:
 1. Log in to the Materialize Console.
 
 1. Go to **App Passwords** and for the [service account created
-   `my_agent`](#create-the-specific-agent-role), click
+   `my_agent`](#step-1-create-the-specific-agent-role), click
    **Connect**.
 
 1. Click on the **MCP Server** tab.
 
 1. In the **Get your MCP token** section[^1],
-   - If using [`my_agent`](#create-the-specific-agent-role), use the **MCP
+   - If using [`my_agent`](#step-1-create-the-specific-agent-role), use the **MCP
      Token** that was returned when you created the service account. You can
      skip to the next step.
 
    - Otherwise, you can:
-     - [Create a different service account](#create-the-specific-agent-role) and
+     - [Create a different service account](#step-1-create-the-specific-agent-role) and
        use the generated MCP token; or
 
      - Use an existing service account, Base64 encoding the `role:password` to
@@ -491,7 +675,7 @@ When connecting to the MCP server, the MCP-compatible client needs:
 
 {{< /tabs >}}
 
-### Step 2. Configure your MCP client
+#### Step 3. Configure your MCP client
 
 {{< warning >}}
 When saving your credentials or other sensitive information in a config file, do

--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -33,20 +33,20 @@ There are two ways to authenticate to the `materialize-agent` MCP server. Your
 method determines whether you need to set up a dedicated agent query
 environment:
 
-- **OAuth** (Available for **Cloud** and for **Self-Managed** using
-  [SSO](/security/self-managed/sso/)): Your MCP client signs you in through your
+- **OAuth**: Starting in v26.30, your MCP client can sign you in through your
   browser. The agent connects as **your user role** with your existing
   privileges. You can **skip the environment setup** and go to [Method 1:
-  OAuth](#method-1-oauth).
+  OAuth](#method-1-oauth). Available for **Cloud** and for **Self-Managed**
+  using [SSO](/security/self-managed/sso/).
 
-- **Token-based** (Available for **Cloud**, **Self-Managed**, and the
-  **Emulator**): You provide Base64-encoded credentials (the MCP token) to the
+- **Token-based**: You provide Base64-encoded credentials (the MCP token) to the
   client. The agent connects as a dedicated, least-privilege **service account**
   (i.e., a separate login role acting as a service account). [Set up the agent
   query environment and data
   products](#set-up-the-agent-query-environment-and-data-products) first and
   then go to [Method 2: Token-based
-  authentication](#method-2-token-based-authentication).
+  authentication](#method-2-token-based-authentication). Available for
+  **Cloud**, **Self-Managed**, and the **Emulator**
 
 ## Set up the agent query environment and data products
 
@@ -260,6 +260,8 @@ authentication](#method-2-token-based-authentication), as described in
 [Connection methods](#connection-methods).
 
 ### Method 1: OAuth
+
+*Available starting in v26.30*
 
 {{< note >}}
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -28,13 +28,30 @@ language questions like:
 
 ## Connect to the MCP server
 
-### Step 1. Get connection details
+There are two ways to authenticate to the `materialize-developer` MCP server:
 
-When connecting to the MCP server, the MCP-compatible client needs:
+- **OAuth** (recommended): Your MCP client signs you in through your browser; no
+  token to generate or store. Available for **Cloud** and for **Self-Managed**
+  [using SSO](/security/self-managed/sso/).
 
-- The Base64-encoded `user:password` credentials (i.e., the MCP token).
+- **Token-based**: You provide Base64-encoded credentials (the MCP token) to the
+  client. Available for **Cloud**, **Self-Managed**, and the **Emulator**.
 
-- The `materialize-developer` MCP server URL: `<baseURL>/api/mcp/developer`.
+### Method 1: OAuth (recommended)
+
+{{< note >}}
+
+The OAuth method is available for **Cloud** and for **Self-Managed** deployments
+using [SSO](/security/self-managed/sso/). For the **Emulator** (or Self-Managed
+not using SSO), use [Method 2: Token-based
+authentication](#method-2-token-based-authentication).
+
+{{< /note >}}
+
+#### Step 1. Get your MCP server URL
+
+To connect, the MCP-compatible client needs the `materialize-developer` MCP
+server URL: `<baseURL>/api/mcp/developer`.
 
 {{< tabs >}}
 
@@ -43,23 +60,6 @@ When connecting to the MCP server, the MCP-compatible client needs:
 1. Log in to the [Materialize Console](https://console.materialize.com/).
 1. Click the **Connect** link (lower-left corner) to open the **Connect** modal
    and click on the **MCP Server** tab.
-
-   ![Image of MCP tab in the Console's Connect
-   modal](/images/console/console-connect-mcp.png "Materialize Connect modal,
-   MCP Server tab")
-
-1. To get your base64-encoded token:
-   - If you want to create a new personal app password to use, click on the
-     **Generate personal MCP token** to generate a new personal app token for
-     the MCP Server. **Copy the token** as you will use the token to connect.
-     Once you navigate away, the token will not display again.
-
-   - If using an existing personal app password, manually generate the
-     base64-encoded token.
-
-     ```bash
-     printf '<user>:<app_password>' | base64 -w0
-     ```
 
 1. In the **Connect your client** section, click on the **Developer** tab.
 
@@ -70,9 +70,151 @@ When connecting to the MCP server, the MCP-compatible client needs:
    block wholesale for the next step.
 
 {{< /tab >}}
+
 {{< tab "Self-Managed" >}}
 
-1. You can connect using either an existing or new login role with password.
+Self-Managed deployments using OAuth require SSO, which uses TLS. Get your MCP
+server URL from the Materialize Console:
+
+1. Log in via the Materialize Console.
+1. Click the **Connect** link (lower-left corner) to open the **Connect** modal
+   and click on the **MCP Server** tab.
+
+1. In the **Connect your client** section, click on the **Developer** tab.
+
+   You can find your `materialize-developer` MCP server URL
+   `<baseURL>/api/mcp/developer` as part of the code block.
+
+   If using Claude Code as your MCP-compatible client, you can copy the code
+   block wholesale for the next step.
+
+{{< /tab >}}
+{{< /tabs >}}
+
+#### Step 2. Configure your MCP client
+
+Once you have your `materialize-developer` MCP server URL, you can configure
+your MCP client. The `materialize-developer` MCP server URL has the form:
+`<baseURL>/api/mcp/developer`.
+
+{{< tabs >}}
+{{< tab "Claude Code" >}}
+
+1. Add the `materialize-developer` MCP server as [local-scoped
+   server](https://code.claude.com/docs/en/mcp#local-scope) (i.e., the
+   configurations are stored in `~/.claude.json`):
+
+   ```sh
+   claude mcp add --transport http materialize-developer \
+     <baseURL>/api/mcp/developer
+   ```
+
+   {{% include-headless "/headless/mcp-endpoint-baseurl-replacements" %}}
+
+1. Restart Claude Code. On first connection, your browser opens to complete
+   sign-in and connect.
+
+1. Upon successful connection, you can [Start asking
+   questions](#start-asking-questions).
+
+{{< /tab >}}
+
+{{< tab "Claude Desktop/Chrome" >}}
+
+To configure Claude Desktop/Chrome, add a custom connector. The exact steps
+depend on your Claude plan; for example:
+
+- **Organization settings** → **Connectors** → **Add** → **Custom** → **Web**,
+  or
+- **Customize** → **Connectors** → **+** → **Add custom connector**.
+
+Refer to the [Add a custom
+connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp#h_3d1a65aded)
+section of the [Get started with custom connectors using Remote
+MCP](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp#h_3d1a65aded)
+guide to get the exact steps for your plan. For the **Remote MCP server URL**
+field, enter your `materialize-developer` MCP server URL.
+
+For additional information, including network requirements and security and
+privacy concerns, see the [Get started with custom connectors using Remote
+MCP](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
+article.
+
+{{< /tab >}}
+
+{{< tab "Cursor" >}}
+
+1. Add the `materialize-developer` MCP server entry to your local MCP settings
+   file (`~/.cursor/mcp.json`).
+   - When merging into an existing `mcpServers` object, remember to add commas
+     between entries.
+   - If the `mcpServers` field does not already exist, add it as well.
+
+   ```json {hl_lines="3-5"}
+   {
+     "mcpServers": {
+       "materialize-developer": {
+         "url": "<baseURL>/api/mcp/developer"
+       }
+     }
+   }
+   ```
+
+   {{% include-headless "/headless/mcp-endpoint-baseurl-replacements" %}}
+
+1. Restart Cursor. On first connection, your browser opens to complete sign-in
+   and connect.
+
+1. Upon successful connection, you can [Start asking
+   questions](#start-asking-questions).
+
+{{< /tab >}}
+{{< /tabs >}}
+
+### Method 2: Token-based authentication
+
+When connecting to the MCP server, the MCP-compatible client needs:
+
+- The Base64-encoded credentials (i.e., the MCP token).
+
+- The `materialize-developer` MCP server URL: `<baseURL>/api/mcp/developer`.
+
+#### Step 1. Get your MCP token
+
+{{< tabs >}}
+
+{{< tab "Cloud" >}}
+
+The MCP token is your base64-encoded credentials. Prefer using a personal app
+password over encoding your account credentials as the token is only
+base64-encoded and not encrypted.
+
+1. Log in to the [Materialize Console](https://console.materialize.com/).
+
+1. Get your base64-encoded token for your personal app.
+
+   - If you already have an MCP token for your personal app, copy the token.
+   - If you want to create a new personal app password to use, the MCP token is
+     generated when you create the new app password (**Create New** → **App
+     Password**). **Copy the token** as you will use the token to connect.
+     Once you navigate away, the token will not display again.
+
+   - If using an existing personal app password, manually generate the
+     base64-encoded token.
+
+     ```bash
+     printf '<user>:<app_password>' | base64 -w0
+     ```
+
+{{< /tab >}}
+{{< tab "Self-Managed" >}}
+
+The MCP token is your base64-encoded credentials. Prefer using a separate role's
+login credentials over encoding your own credentials as the token is only
+base64-encoded and not encrypted.
+
+1. For the MCP token, you can use either an existing or new app login role with
+   password.
 
    - To use an existing login role with password, go to the next step.
    - To create a new login role with password:
@@ -88,38 +230,6 @@ When connecting to the MCP server, the MCP-compatible client needs:
    printf 'my_dev_agent:<your_app_password>' | base64
    ```
 
-1. Find your deployment's host name to determine your `materialize-developer`
-   MCP URL:
-
-   ```
-   http://<host>:6876/api/mcp/developer
-   ```
-
-   - For your Self-Managed Materialize deployment in AWS/GCP/Azure, the `<host>`
-     is the load balancer address. If [deployed
-     viaTerraform](/self-managed-deployments/installation/#install-using-terraform-modules),run
-     the Terraform output command for your cloud provider:
-
-     ```bash
-     # AWS
-     terraform output -raw nlb_dns_name
-
-     # GCP
-     terraform output -raw balancerd_load_balancer_ip
-
-     # Azure
-     terraform output -raw balancerd_load_balancer_ip
-     ```
-
-   - For local
-     [kind](/self-managed-deployments/installation/install-on-local-kind/)
-     clusters, use port forwarding and use `localhost` for `<host>`:
-
-     ```bash
-     kubectl port-forward svc/<instance-name>-balancerd 6876:6876 -n materialize-environment
-     ```
-
-
 {{< /tab >}}
 
 {{< tab "Emulator" >}}
@@ -134,24 +244,115 @@ specific AI agent or use the default `materialize` user:
    CREATE ROLE my_dev_agent;
    ```
 
-1. Encode your agent role's credentials `<role>:<password>` in Base64 to create
-   the MCP token (the Emulator does not support passwords):
+1. Base64-encode your agent role's credentials `<role>:<password>` to create the
+   MCP token (the Emulator does not support passwords):
 
    ```bash
    printf 'my_dev_agent:' | base64
    ```
 
-1. For the Emulator, you will use `http://localhost:6876` as the `<baseURL>`
-   portion of the MCP URL:
-
-   ```
-   <baseURL>/api/mcp/developer
-   ```
-
 {{< /tab >}}
 {{< /tabs >}}
 
-### Step 2. Configure your MCP client
+#### Step 2. Get your MCP server URL
+
+To connect, the MCP-compatible client needs the `materialize-developer` MCP
+server URL: `<baseURL>/api/mcp/developer`.
+
+{{< tabs >}}
+
+{{< tab "Cloud" >}}
+
+1. Log in to the [Materialize Console](https://console.materialize.com/).
+1. Click the **Connect** link (lower-left corner) to open the **Connect** modal
+   and click on the **MCP Server** tab.
+
+1. In the **Connect your client** section, click on the **Developer** tab.
+
+   You can find your `materialize-developer` MCP server URL
+   `<baseURL>/api/mcp/developer` as part of the code block.
+
+   If using Claude Code as your MCP-compatible client, you can copy the code
+   block wholesale for the next step.
+
+{{< /tab >}}
+
+{{< tab "Self-Managed" >}}
+
+{{< tabs >}}
+{{< tab "Deployment using TLS" >}}
+**If your Self-Managed deployment is using TLS**:
+
+1. Log in via the Materialize Console.
+1. Click the **Connect** link (lower-left corner) to open the **Connect** modal
+   and click on the **MCP Server** tab.
+
+1. In the **Connect your client** section, click on the **Developer** tab.
+
+   You can find your `materialize-developer` MCP server URL
+   `<baseURL>/api/mcp/developer` as part of the code block.
+
+   If using Claude Code as your MCP-compatible client, you can copy the code
+   block wholesale for the next step.
+
+{{< /tab >}}
+{{< tab "Deployment not using TLS" >}}
+**If your Self-Managed deployment is not using TLS**:
+
+1. Find your deployment's host name to determine your `materialize-developer`
+   MCP URL:
+
+   - For your Self-Managed Materialize deployment in AWS/GCP/Azure, the hostname
+     is the load balancer address. If [deployed via
+     Terraform](/self-managed-deployments/installation/#install-using-terraform-modules),
+     run the Terraform output command for your cloud provider:
+
+     ```bash
+     # AWS
+     terraform output -raw nlb_dns_name
+
+     # GCP
+     terraform output -raw balancerd_load_balancer_ip
+
+     # Azure
+     terraform output -raw balancerd_load_balancer_ip
+     ```
+
+   - For local
+     [kind](/self-managed-deployments/installation/install-on-local-kind/)
+     clusters,
+     use port forwarding and `localhost` is your hostname:
+
+     ```bash
+     kubectl port-forward svc/<instance-name>-balancerd 6876:6876 -n materialize-environment
+     ```
+
+1. Determine the value of your MCP URL using your hostname:
+
+   ```
+   http://<host>:6876/api/mcp/developer
+   ```
+
+   where `http://<host>:6876` is your base URL.
+
+{{< /tab >}}
+{{< /tabs >}}
+{{< /tab >}}
+{{< tab "Emulator" >}}
+
+For the Emulator, your MCP URL is:
+
+```
+http://localhost:6876/api/mcp/developer
+```
+
+where `http://localhost:6876` is your base URL.
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+#### Step 3. Configure your MCP client
 
 {{< warning >}}
 When saving your credentials or other sensitive information in a config file, do
@@ -174,6 +375,9 @@ When saving your credentials or other sensitive information in a config file, do
    {{% include-headless "/headless/mcp-endpoint-config-replacements" %}}
 
 1. Restart Claude Code to pick up the new setting.
+
+1. Upon successful connection, you can [Start asking
+   questions](#start-asking-questions).
 
 {{< /tab >}}
 
@@ -204,6 +408,9 @@ When saving your credentials or other sensitive information in a config file, do
 
 1. Restart Claude Desktop to pick up the new setting.
 
+1. Upon successful connection, you can [Start asking
+   questions](#start-asking-questions).
+
 {{< /tab >}}
 
 {{< tab "Cursor" >}}
@@ -230,6 +437,9 @@ When saving your credentials or other sensitive information in a config file, do
    {{% include-headless "/headless/mcp-endpoint-config-replacements" %}}
 
 1. Restart Cursor to pick up the new setting.
+
+1. Upon successful connection, you can [Start asking
+   questions](#start-asking-questions).
 
 {{< /tab >}}
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -30,14 +30,16 @@ language questions like:
 
 There are two ways to authenticate to the `materialize-developer` MCP server:
 
-- **OAuth** (recommended): Your MCP client signs you in through your browser; no
-  token to generate or store. Available for **Cloud** and for **Self-Managed**
-  [using SSO](/security/self-managed/sso/).
+- **OAuth**: Starting in v26.30, your MCP client can sign you in through your
+  browser; no token to generate or store. Available for **Cloud** and for
+  **Self-Managed** [using SSO](/security/self-managed/sso/).
 
 - **Token-based**: You provide Base64-encoded credentials (the MCP token) to the
   client. Available for **Cloud**, **Self-Managed**, and the **Emulator**.
 
-### Method 1: OAuth (recommended)
+### Method 1: OAuth
+
+*Available starting in v26.30*
 
 {{< note >}}
 


### PR DESCRIPTION
https://preview.materialize.com/materialize/37287/integrations/mcp-server/mcp-developer/
https://preview.materialize.com/materialize/37287/integrations/mcp-server/mcp-agent/
- This commit only has the updates to dev MCP server for Oauth.
- Added second commit with the updates to agent MCP server for oauth.
- ~~For the agent MCP server, until we support SCIM, I'm only aware of the user journey where we want people to use- a service app/account (so that the role is restricted) and I didn't know how that is to be handled. Let me know if this differs from your understanding.  Am coming into this a little cold ... so, my understanding may be out of date. (I have the agent MCP server (Cloud only) changes locally)~~
- Also, am so happy that no content change overlaps with https://github.com/MaterializeInc/materialize/pull/36955#event-27148098189
