### PR TITLE
catalog: bump mz_cluster_replicas builtin migration for 26.31.0-dev

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -536,7 +536,6 @@ steps:
           ]
     agents:
       queue: hetzner-x86-64-4cpu-8gb
-    skip: "https://linear.app/materializeinc/issues/SQL-420"
 
   - id: source-sink-errors
     label: "S&S error reporting"

--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -237,6 +237,15 @@ static MIGRATIONS: LazyLock<Vec<MigrationStep>> = LazyLock::new(|| {
             MZ_CATALOG_SCHEMA,
             "mz_system_privileges",
         ),
+        // The mz_cluster_replicas MV definition changed in 26.31.0-dev (the
+        // `availability_zone` column now aggregates the durable
+        // `availability_zones` list).
+        MigrationStep::replacement(
+            "26.31.0-dev.0",
+            CatalogItemType::MaterializedView,
+            MZ_CATALOG_SCHEMA,
+            "mz_cluster_replicas",
+        ),
     ]
 });
 


### PR DESCRIPTION
Caused by #37107

Closes SQL-420

The reason we only noticed this so late is the auto dev version migration I added to make it easier to bump versions in staging, I'll disable that for CI in a separate PR.