### PR TITLE
Refactor delta joins to demote demuxing

### DIFF
--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -13,8 +13,7 @@
 
 #![allow(clippy::op_ref)]
 
-use std::collections::{BTreeMap, BTreeSet};
-
+use std::collections::BTreeSet;
 use std::rc::Rc;
 
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
@@ -59,56 +58,29 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             // Collects error streams for the ambient scope.
             let mut inner_errs = Vec::new();
 
-            // Deduplicate the error streams of multiply used arrangements.
-            let mut err_dedup = BTreeSet::new();
-
             // Our plan is to iterate through each input relation, and attempt
             // to find a plan that maximally uses existing keys (better: uses
             // existing arrangements, to which we have access).
             let mut join_results = Vec::new();
 
-            // First let's prepare the input arrangements we will need.
-            // This reduces redundant imports, and simplifies the dataflow structure.
-            // As the arrangements are all shared, it should not dramatically improve
-            // the efficiency, but the dataflow simplification is worth doing.
-            let mut arrangements = BTreeMap::new();
-            for path_plan in join_plan.path_plans.iter() {
-                for stage_plan in path_plan.stage_plans.iter() {
-                    let lookup_idx = stage_plan.lookup_relation;
-                    let lookup_key = stage_plan.lookup_key.clone();
-                    arrangements
-                        .entry((lookup_idx, lookup_key.clone()))
-                        .or_insert_with(|| {
-                            match inputs[lookup_idx]
-                                .arrangement(&lookup_key)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                        lookup_idx, lookup_key,
-                                    )
-                                }) {
-                                ArrangementFlavor::Local(oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Ok(oks.enter_region(inner))
-                                }
-                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Err(oks.enter_region(inner))
-                                }
-                            }
-                        });
-                }
+            // An input bundle may carry collections no delta path consumes: arrangements keyed
+            // differently than any lookup, or a raw collection. Entering a collection into a region
+            // does work proportional to its data, so we prune each bundle to the arrangements some
+            // path reads before bringing it into `inner`.
+            let mut arrangements = vec![BTreeSet::new(); inputs.len()];
+            for path_plan in &join_plan.path_plans {
+                record_path_arrangements(
+                    &mut arrangements,
+                    path_plan.source_relation,
+                    &path_plan.source_key,
+                    &path_plan.stage_plans,
+                );
             }
+            let inputs = inputs
+                .iter()
+                .enumerate()
+                .map(|(index, cb)| prune_bundle(cb, &arrangements[index]).enter_region(inner))
+                .collect::<Vec<_>>();
 
             for path_plan in join_plan.path_plans {
                 // Deconstruct the stages of the path plan.
@@ -138,40 +110,36 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     // available information to determine the filtering and logic that we can apply, and
                     // introduce that in to the `lookup` logic to cause it to happen in that operator.
 
+                    // Prune each bundle to just the arrangements this path looks up before entering
+                    // the path's region, for the reason noted at the join's region entry above.
+                    let mut path_arrangements = vec![BTreeSet::new(); inputs.len()];
+                    record_path_arrangements(
+                        &mut path_arrangements,
+                        source_relation,
+                        &source_key,
+                        &stage_plans,
+                    );
+                    let bundles = inputs
+                        .iter()
+                        .enumerate()
+                        .map(|(index, cb)| {
+                            prune_bundle(cb, &path_arrangements[index]).enter_region(region)
+                        })
+                        .collect::<Vec<_>>();
+
                     // Collects error streams for the region scope. Concats before leaving.
                     let mut region_errs = Vec::with_capacity(inputs.len());
 
-                    // Ensure this input is rendered, and extract its update stream.
-                    let val = arrangements
-                        .get(&(source_relation, source_key))
-                        .expect("Arrangement promised by the planner is absent!");
-                    let as_of = self.as_of_frontier.clone();
-                    let update_stream = match val {
-                        Ok(local) => {
-                            let arranged = local.clone().enter_region(region);
-                            let (update_stream, err_stream) =
-                                build_update_stream::<_, RowRowAgent<_, _>>(
-                                    arranged,
-                                    as_of,
-                                    source_relation,
-                                    initial_closure,
-                                );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                        Err(trace) => {
-                            let arranged = trace.clone().enter_region(region);
-                            let (update_stream, err_stream) =
-                                build_update_stream::<_, RowRowEnter<_, _, _>>(
-                                    arranged,
-                                    as_of,
-                                    source_relation,
-                                    initial_closure,
-                                );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                    };
+                    // Form the initial stream of updates that will hydrate the delta path.
+                    let (update_stream, err_stream) = build_update_stream(
+                        &bundles[source_relation],
+                        self.as_of_frontier.clone(),
+                        source_key,
+                        source_relation,
+                        initial_closure,
+                    );
+                    region_errs.push(err_stream);
+
                     // Promote `time` to a datum element.
                     //
                     // The `half_join` operator manipulates as "data" a pair `(data, time)`,
@@ -198,57 +166,18 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                         // updates with less or equal `time`, and otherwise we present only updates
                         // with strictly less `time`.
                         //
-                        // We need to write the logic twice, as there are two types of arrangement
-                        // we might have: either dataflow-local or an imported trace.
-                        let (oks, errs) =
-                            match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
-                                Ok(local) => {
-                                    if source_relation < lookup_relation {
-                                        build_halfjoin::<_, RowRowAgent<_, _>, _>(
-                                            update_stream,
-                                            local.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                            Rc::clone(&self.config_set),
-                                        )
-                                    } else {
-                                        build_halfjoin::<_, RowRowAgent<_, _>, _>(
-                                            update_stream,
-                                            local.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                            Rc::clone(&self.config_set),
-                                        )
-                                    }
-                                }
-                                Err(trace) => {
-                                    if source_relation < lookup_relation {
-                                        build_halfjoin::<_, RowRowEnter<_, _, _>, _>(
-                                            update_stream,
-                                            trace.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                            Rc::clone(&self.config_set),
-                                        )
-                                    } else {
-                                        build_halfjoin::<_, RowRowEnter<_, _, _>, _>(
-                                            update_stream,
-                                            trace.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                            Rc::clone(&self.config_set),
-                                        )
-                                    }
-                                }
-                            };
+                        // We require demuxing over the two flavors of arrangement and over the
+                        // relative order of the inputs. Both are handled inside `build_halfjoin`.
+                        let (oks, errs) = build_halfjoin(
+                            update_stream,
+                            stream_key,
+                            stream_thinning,
+                            &bundles[lookup_relation],
+                            lookup_key,
+                            source_relation < lookup_relation,
+                            closure,
+                            Rc::clone(&self.config_set),
+                        );
                         update_stream = oks;
                         region_errs.push(errs);
                     }
@@ -313,6 +242,112 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     }
 }
 
+/// Records, into `arrangements`, the arrangement keys a single delta path reads from each input:
+/// the `source_key` for the seed relation and each stage's `lookup_key`.
+fn record_path_arrangements(
+    arrangements: &mut [BTreeSet<Vec<LirScalarExpr>>],
+    source_relation: usize,
+    source_key: &[LirScalarExpr],
+    stage_plans: &[DeltaStagePlan],
+) {
+    arrangements[source_relation].insert(source_key.to_vec());
+    for stage_plan in stage_plans {
+        arrangements[stage_plan.lookup_relation].insert(stage_plan.lookup_key.clone());
+    }
+}
+
+/// Retains only the arrangements of `bundle` keyed by `keys`, dropping every other collection
+/// (including the raw collection, which no delta path reads while every source is arranged).
+fn prune_bundle<'scope, T: RenderTimestamp>(
+    bundle: &CollectionBundle<'scope, T>,
+    keys: &BTreeSet<Vec<LirScalarExpr>>,
+) -> CollectionBundle<'scope, T> {
+    CollectionBundle {
+        collection: None,
+        arranged: bundle
+            .arranged
+            .iter()
+            .filter(|(key, _)| keys.contains(*key))
+            .map(|(key, flavor)| (key.clone(), flavor.clone()))
+            .collect(),
+    }
+}
+
+/// Constructs a `half_join` against the arrangement held by a collection bundle.
+///
+/// This wrapper demuxes over the two flavors of arrangement (dataflow-local or imported trace)
+/// that the bundle might hold for `lookup_key`, dispatching to the generic [`build_halfjoin_trace`]
+/// for each. `source_precedes_lookup` selects the tie-breaking comparison: `le` if the source
+/// relation precedes the lookup relation in the total order on relations, otherwise `lt`.
+fn build_halfjoin<'scope, T>(
+    updates: VecCollection<'scope, T, (Row, T), Diff>,
+    prev_key: Vec<LirScalarExpr>,
+    prev_thinning: Vec<usize>,
+    bundle: &CollectionBundle<'scope, T>,
+    lookup_key: Vec<LirScalarExpr>,
+    source_precedes_lookup: bool,
+    closure: JoinClosure,
+    config_set: Rc<ConfigSet>,
+) -> (
+    VecCollection<'scope, T, (Row, T), Diff>,
+    VecCollection<'scope, T, DataflowErrorSer, Diff>,
+)
+where
+    T: RenderTimestamp,
+{
+    match bundle.arrangement(&lookup_key) {
+        Some(ArrangementFlavor::Local(oks, errs)) => {
+            let (oks, errs2) = if source_precedes_lookup {
+                build_halfjoin_trace::<_, RowRowAgent<_, _>, _>(
+                    updates,
+                    oks,
+                    prev_key,
+                    prev_thinning,
+                    |t1, t2| t1.le(t2),
+                    closure,
+                    config_set,
+                )
+            } else {
+                build_halfjoin_trace::<_, RowRowAgent<_, _>, _>(
+                    updates,
+                    oks,
+                    prev_key,
+                    prev_thinning,
+                    |t1, t2| t1.lt(t2),
+                    closure,
+                    config_set,
+                )
+            };
+            (oks, errs2.concat(errs.as_collection(|k, _v| k.clone())))
+        }
+        Some(ArrangementFlavor::Trace(_, oks, errs)) => {
+            let (oks, errs2) = if source_precedes_lookup {
+                build_halfjoin_trace::<_, RowRowEnter<_, _, _>, _>(
+                    updates,
+                    oks,
+                    prev_key,
+                    prev_thinning,
+                    |t1, t2| t1.le(t2),
+                    closure,
+                    config_set,
+                )
+            } else {
+                build_halfjoin_trace::<_, RowRowEnter<_, _, _>, _>(
+                    updates,
+                    oks,
+                    prev_key,
+                    prev_thinning,
+                    |t1, t2| t1.lt(t2),
+                    closure,
+                    config_set,
+                )
+            };
+            (oks, errs2.concat(errs.as_collection(|k, _v| k.clone())))
+        }
+        None => panic!("Arrangement promised by the planner is absent!"),
+    }
+}
+
 /// Constructs a `half_join` from supplied arguments.
 ///
 /// This method exists to factor common logic from four code paths that are generic over the type of trace.
@@ -323,7 +358,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 /// the time of the update. This operator may manipulate `time` as part of this pair, but will not manipulate
 /// the time of the update. This is crucial for correctness, as the total order on times of updates is used
 /// to ensure that any two updates are matched at most once.
-fn build_halfjoin<'scope, T, Tr, CF>(
+fn build_halfjoin_trace<'scope, T, Tr, CF>(
     updates: VecCollection<'scope, T, (Row, T), Diff>,
     trace: Arranged<'scope, Tr>,
     prev_key: Vec<LirScalarExpr>,
@@ -603,12 +638,52 @@ where
     }
 }
 
+/// Builds the initial update stream of a delta path from a collection bundle.
+///
+/// Demuxes over the two flavors of arrangement the bundle might hold for `source_key`, dispatching
+/// to the generic [`build_update_stream_trace`] for each.
+fn build_update_stream<'scope, T>(
+    bundle: &CollectionBundle<'scope, T>,
+    as_of: Antichain<mz_repr::Timestamp>,
+    source_key: Vec<LirScalarExpr>,
+    source_relation: usize,
+    initial_closure: JoinClosure,
+) -> (
+    VecCollection<'scope, T, Row, Diff>,
+    VecCollection<'scope, T, DataflowErrorSer, Diff>,
+)
+where
+    T: RenderTimestamp,
+{
+    match bundle.arrangement(&source_key) {
+        Some(ArrangementFlavor::Local(oks, errs)) => {
+            let (oks, errs2) = build_update_stream_trace::<_, RowRowAgent<_, _>>(
+                oks,
+                as_of,
+                source_relation,
+                initial_closure,
+            );
+            (oks, errs2.concat(errs.as_collection(|k, _v| k.clone())))
+        }
+        Some(ArrangementFlavor::Trace(_, oks, errs)) => {
+            let (oks, errs2) = build_update_stream_trace::<_, RowRowEnter<_, _, _>>(
+                oks,
+                as_of,
+                source_relation,
+                initial_closure,
+            );
+            (oks, errs2.concat(errs.as_collection(|k, _v| k.clone())))
+        }
+        None => panic!("Arrangement promised by the planner is absent!"),
+    }
+}
+
 /// Builds the beginning of the update stream of a delta path.
 ///
 /// At start-up time only the delta path for the first relation sees updates, since any updates fed to the
 /// other delta paths would be discarded anyway due to the tie-breaking logic that avoids double-counting
 /// updates happening at the same time on different relations.
-fn build_update_stream<'scope, T, Tr>(
+fn build_update_stream_trace<'scope, T, Tr>(
     trace: Arranged<'scope, Tr>,
     as_of: Antichain<mz_repr::Timestamp>,
     source_relation: usize,


### PR DESCRIPTION
Re-organize delta join rendering to consolidate arrangement-flavor "demuxing" outside the main body of the join.
The flavor demux (dataflow-local vs imported trace) and the relation ordering now live inside `build_halfjoin` and `build_update_stream`, which take a `CollectionBundle` and dispatch internally to the generic `*_trace` helpers.
This prepares for `Collection` hydration of delta join paths, which the existing code is overly specific about.

Recreation of the refactor commit from #26843 (by @frankmcsherry) onto current `main`.

One behavior note: this drops the per-arrangement error-stream dedup. An arrangement's error stream is now concatenated once per use rather than once overall. This is benign because error collections are consumed by non-emptiness, and retractions scale symmetrically, but it is not byte-identical.

The follow-up that adds `Collection` hydration for single-time SELECT paths stacks on this branch.

Part of CPU-178: https://linear.app/materializeinc/issue/CPU-178
