### PR TITLE
ci: Stop using dedicated cargo test agents

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -246,7 +246,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-x86-64-dedi-32cpu-128gb-cargo-test
+          queue: hetzner-x86-64-dedi-48cpu-192gb
         coverage: skip
         sanitizer: skip
 
@@ -289,7 +289,7 @@ steps:
           composition: cargo-test
           ci-builder: stable
     agents:
-      queue: hetzner-x86-64-dedi-32cpu-128gb-cargo-test
+      queue: hetzner-x86-64-dedi-48cpu-192gb
 
   - id: testdrive
     label: "Testdrive"


### PR DESCRIPTION
Cheaper. Works together with https://github.com/MaterializeInc/i2/pull/3428