### PR TITLE
kafka-rtr tests: Unflake CI

### DIFF
--- a/test/kafka-rtr/simple/verify-rtr.td
+++ b/test/kafka-rtr/simple/verify-rtr.td
@@ -60,18 +60,11 @@ A,B,0
 
 # Demo materialized views built on sources obey RTR.
 
-> SET REAL_TIME_RECENCY TO FALSE
-
 $ kafka-ingest topic=input_1 format=bytes repeat=500000
 A,B,0
 
 $ kafka-ingest topic=input_2 format=bytes repeat=500000
 A,B,0
-
-> SELECT sum < 4000207 FROM sum;
-true
-
-> SET REAL_TIME_RECENCY TO TRUE
 
 > SELECT sum FROM sum;
 4000207


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/126690#019eff67-3a8a-4b1d-8848-502e48213e8c

There is no reason non-RTR couldn't randomly get the correct result already