### PR TITLE
console: read indexed cluster utilization overview views per timeframe

### DIFF
--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
@@ -15,6 +15,95 @@ import { executeSqlV2, queryBuilder } from "~/api/materialize";
 
 import { fetchClusterDeploymentLineage } from "./clusterDeploymentLineage";
 
+/**
+ * The built-in, indexed views that pre-compute the cluster utilization overview
+ * at a fixed bucket size and retention window (defined in `builtin.rs` in
+ * MaterializeInc/materialize). The Console queries the finest
+ * (shortest-retention) view that still covers the requested time range, so each
+ * cluster page load is a cheap indexed lookup against `mz_catalog_server`
+ * rather than a full recompute of the rollup.
+ *
+ * Ordered finest-grained first so `selectClusterUtilizationOverviewView` returns
+ * the smallest covering view.
+ */
+export const CLUSTER_UTILIZATION_OVERVIEW_VIEWS = [
+  {
+    name: "mz_console_cluster_utilization_overview_3h",
+    bucketSizeMs: 60_000, // 1 minute
+    maxTimePeriodMinutes: 180, // 3 hours
+  },
+  {
+    name: "mz_console_cluster_utilization_overview_24h",
+    bucketSizeMs: 300_000, // 5 minutes
+    maxTimePeriodMinutes: 1440, // 24 hours
+  },
+  {
+    name: "mz_console_cluster_utilization_overview",
+    bucketSizeMs: 3_600_000, // 1 hour
+    maxTimePeriodMinutes: 20160, // 14 days
+  },
+] as const;
+
+export type ConsoleClusterUtilizationOverviewViewName =
+  (typeof CLUSTER_UTILIZATION_OVERVIEW_VIEWS)[number]["name"];
+
+export type ClusterUtilizationOverviewViewSelection = {
+  viewName: ConsoleClusterUtilizationOverviewViewName;
+  // The fixed bucket size of the selected view, in milliseconds. Callers should
+  // use this for rendering rather than their own bucketSizeMs, since the view
+  // dictates the bucket boundaries.
+  bucketSizeMs: number;
+};
+
+/**
+ * The first Materialize release that ships the `_3h`/`_24h` overview views and
+ * the 1h-bucket 14d view (DB PR). On environments older than this, only the
+ * pre-existing 8h/14d `mz_console_cluster_utilization_overview` view is
+ * available, so we gate on the version with `useEnvironmentGate` and fall back
+ * to the previous behavior.
+ *
+ * TODO(cluster-utilization-views): set to the actual release version once the
+ * DB PR merges; conservatively the next minor after the current dev line.
+ */
+export const CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION = "26.32.0-dev";
+
+// Legacy 14d view bucket size (8h) on environments predating the new views.
+const LEGACY_14D_BUCKET_SIZE_MS = 8 * 60 * 60 * 1000;
+// "Last 14 days" in the console's time-period options.
+const LAST_14_DAYS_MINUTES = 20160;
+
+/**
+ * Returns the indexed overview view that covers `timePeriodMinutes` with the
+ * finest available bucket size, or `undefined` if the range isn't served by a
+ * view (in which case the caller falls back to the ad-hoc
+ * `buildReplicaUtilizationHistoryQuery`).
+ *
+ * `hasNewViews` should come from
+ * `useEnvironmentGate(CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION)`. When false
+ * (older environment), only the "Last 14 days" range is served, by the
+ * pre-existing 8h view — matching the console's behavior before the new views.
+ */
+export function selectClusterUtilizationOverviewView(
+  timePeriodMinutes: number,
+  hasNewViews: boolean,
+): ClusterUtilizationOverviewViewSelection | undefined {
+  if (hasNewViews) {
+    const view = CLUSTER_UTILIZATION_OVERVIEW_VIEWS.find(
+      (v) => timePeriodMinutes <= v.maxTimePeriodMinutes,
+    );
+    return view
+      ? { viewName: view.name, bucketSizeMs: view.bucketSizeMs }
+      : undefined;
+  }
+  if (timePeriodMinutes === LAST_14_DAYS_MINUTES) {
+    return {
+      viewName: "mz_console_cluster_utilization_overview",
+      bucketSizeMs: LEGACY_14D_BUCKET_SIZE_MS,
+    };
+  }
+  return undefined;
+}
+
 export type ReplicaUtilizationHistoryParameters = {
   // Filter per cluster
   clusterIds?: string[];
@@ -27,8 +116,9 @@ export type ReplicaUtilizationHistoryParameters = {
   // Size of the time buckets in milliseconds
   bucketSizeMs: number;
 
-  // Whether to use the console cluster utilization overview view
-  shouldUseConsoleClusterUtilizationOverviewView?: boolean;
+  // When set, query this pre-materialized overview view instead of computing the
+  // rollup ad-hoc. Choose it with `selectClusterUtilizationOverviewView`.
+  consoleOverviewViewName?: ConsoleClusterUtilizationOverviewViewName;
 };
 // We have an equivalent query in `builtin.rs` in the MaterializeInc/materialize.
 // This should query should be kept in sync with `mz_console_cluster_utilization_overview`.
@@ -41,22 +131,31 @@ export function buildReplicaUtilizationHistoryQuery({
 }: ReplicaUtilizationHistoryParameters) {
   const bucketSizeMsSqlStr = sql.raw(`${bucketSizeMs}`);
   const startDateLit = sql.lit(startDate);
-  const endDateLit = sql.lit(startDate);
 
   const dateBinOrigin = sql.lit("1970-01-01");
 
+  const hasClusterFilter = clusterIds !== undefined && clusterIds.length > 0;
+
   let query = queryBuilder
-    .with("replica_history", (qb) =>
-      qb
+    // We push the cluster filter all the way down into replica_history so the
+    // entire rollup (metrics aggregation, per-bucket argmax, the multi-way join)
+    // only ever processes the target cluster's replicas. Otherwise the optimizer
+    // computes the whole fleet's metrics and discards all but one cluster at the
+    // very end. See the analysis in MaterializeInc/materialize builtin.rs.
+    .with("replica_history", (qb) => {
+      let history = qb
         .selectFrom("mz_cluster_replica_history")
-        .select(["replica_id", "cluster_id", "size"])
-        // We need to union the current set of cluster replicas since mz_cluster_replica_history doesn't account for system clusters
-        .union(
-          qb
-            .selectFrom("mz_cluster_replicas")
-            .select(["id as replica_id", "cluster_id", "size"]),
-        ),
-    )
+        .select(["replica_id", "cluster_id", "size"]);
+      // We need to union the current set of cluster replicas since mz_cluster_replica_history doesn't account for system clusters
+      let current = qb
+        .selectFrom("mz_cluster_replicas")
+        .select(["id as replica_id", "cluster_id", "size"]);
+      if (hasClusterFilter) {
+        history = history.where("cluster_id", "in", clusterIds);
+        current = current.where("cluster_id", "in", clusterIds);
+      }
+      return history.union(current);
+    })
     .with("replica_name_history", (qb) =>
       qb
         .selectFrom("mz_cluster_replica_name_history")
@@ -128,13 +227,12 @@ export function buildReplicaUtilizationHistoryQuery({
         ]),
     )
     .with("replica_utilization_history_binned", (qb) => {
+      // We read directly from replica_metrics_history rather than re-joining
+      // replica_history; every replica_id here already came from replica_history
+      // (that's how replica_metrics_history was built), so the join was
+      // redundant and could fan out a replica that changed size.
       let cte = qb
-        .selectFrom("replica_history as r")
-        .innerJoin(
-          "replica_metrics_history as m",
-          "m.replica_id",
-          "r.replica_id",
-        )
+        .selectFrom("replica_metrics_history as m")
         .select([
           "m.occurred_at",
           "m.replica_id",
@@ -172,7 +270,7 @@ export function buildReplicaUtilizationHistoryQuery({
           sql<Date>`
             date_bin(
               '${bucketSizeMsSqlStr} MILLISECONDS',
-              TIMESTAMP ${endDateLit},
+              TIMESTAMP ${sql.lit(endDate)},
               TIMESTAMP ${dateBinOrigin}
             )`,
         );
@@ -308,6 +406,16 @@ export function buildReplicaUtilizationHistoryQuery({
         )
         .groupBy(["bucket_start", "replica_id"]);
 
+      // Restrict the (otherwise full-scanned) status history to the target
+      // cluster's replicas. Because mz_cluster_replica_status_history is indexed
+      // on replica_id, this becomes a lookup rather than a scan of every
+      // replica's offline events across the whole deployment.
+      if (hasClusterFilter) {
+        cte = cte.where("replica_id", "in", (eb) =>
+          eb.selectFrom("replica_history").select("replica_id"),
+        );
+      }
+
       if (endDate) {
         cte = cte.where(
           (eb) =>
@@ -316,7 +424,7 @@ export function buildReplicaUtilizationHistoryQuery({
           sql<Date>`
             date_bin(
               '${bucketSizeMsSqlStr} MILLISECONDS',
-              TIMESTAMP ${endDateLit},
+              TIMESTAMP ${sql.lit(endDate)},
               TIMESTAMP ${dateBinOrigin}
             )`,
         );
@@ -411,9 +519,9 @@ export function buildReplicaUtilizationHistoryQuery({
     ])
     .orderBy("bucketStart");
 
-  if (clusterIds !== undefined && clusterIds.length > 0) {
-    query = query.where("replica_history.cluster_id", "in", clusterIds);
-  }
+  // NOTE: the cluster filter is already pushed into the replica_history CTE
+  // above, and the final `JOIN replica_history` restricts the output to that
+  // cluster's replicas, so no top-level cluster_id filter is needed here.
 
   if (replicaId) {
     query = query.where("max_memory.replica_id", "=", replicaId);
@@ -423,18 +531,23 @@ export function buildReplicaUtilizationHistoryQuery({
 }
 
 /**
- * This is an optimized version of buildReplicaUtilizationHistoryQuery
- * that uses a time period of 14 days and a bucket of 8 hours via a built-in index+view.
+ * An optimized version of buildReplicaUtilizationHistoryQuery that reads from
+ * one of the pre-materialized, indexed `mz_console_cluster_utilization_overview*`
+ * views instead of recomputing the rollup. `viewName` selects the bucket
+ * size / retention window (see `selectClusterUtilizationOverviewView`); each
+ * view is indexed on `cluster_id`, so filtering by cluster is an indexed lookup.
  */
 export function buildConsoleClusterUtilizationOverviewQuery({
+  viewName,
   clusterIds,
   replicaId,
 }: {
+  viewName: ConsoleClusterUtilizationOverviewViewName;
   clusterIds?: string[];
   replicaId?: string;
 }) {
   let query = queryBuilder
-    .selectFrom("mz_console_cluster_utilization_overview")
+    .selectFrom(viewName)
     .select([
       "bucket_start as bucketStart",
       "replica_id as replicaId",
@@ -553,8 +666,9 @@ export async function fetchReplicaUtilizationHistory({
     clusterIds: clusterIdsFilter,
   }).compile();
 
-  if (params.shouldUseConsoleClusterUtilizationOverviewView) {
+  if (params.consoleOverviewViewName) {
     utilizationQuery = buildConsoleClusterUtilizationOverviewQuery({
+      viewName: params.consoleOverviewViewName,
       clusterIds: clusterIdsFilter,
       replicaId: params.replicaId,
     }).compile();

--- a/console/src/platform/clusters/ClusterOverview.tsx
+++ b/console/src/platform/clusters/ClusterOverview.tsx
@@ -26,6 +26,10 @@ import { useParams } from "react-router-dom";
 
 import { MZ_PROBE_CLUSTER } from "~/api/materialize";
 import { Cluster } from "~/api/materialize/cluster/clusterList";
+import {
+  CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION,
+  selectClusterUtilizationOverviewView,
+} from "~/api/materialize/cluster/replicaUtilizationHistory";
 import Alert from "~/components/Alert";
 import ErrorBox from "~/components/ErrorBox";
 import { EventEmitterProvider } from "~/components/EventEmitter";
@@ -37,6 +41,7 @@ import { useFlags } from "~/hooks/useFlags";
 import { useTimePeriodMinutes } from "~/hooks/useTimePeriodSelect";
 import { MainContentContainer } from "~/layouts/BaseLayout";
 import { useAllClusters } from "~/store/allClusters";
+import { useEnvironmentGate } from "~/store/environments";
 import { MaterializeTheme } from "~/theme";
 import { assert } from "~/util";
 
@@ -77,10 +82,22 @@ const ClusterOverview = () => {
   });
   const [selectedReplica, setSelectedReplica] = React.useState("all");
 
-  const bucketSizeMs = React.useMemo(
-    () => Math.max(timePeriodMinutes * 1000, MIN_BUCKET_SIZE_MS),
-    [timePeriodMinutes],
-  );
+  const hasNewUtilizationViews =
+    useEnvironmentGate(CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION) ?? false;
+
+  // When the selected range is served by a pre-materialized overview view, the
+  // view's fixed bucket size dictates the boundaries; otherwise (ad-hoc query)
+  // we derive a bucket size from the range, clamped to the metric sample rate.
+  const bucketSizeMs = React.useMemo(() => {
+    const overviewView = selectClusterUtilizationOverviewView(
+      timePeriodMinutes,
+      hasNewUtilizationViews,
+    );
+    return (
+      overviewView?.bucketSizeMs ??
+      Math.max(timePeriodMinutes * 1000, MIN_BUCKET_SIZE_MS)
+    );
+  }, [timePeriodMinutes, hasNewUtilizationViews]);
 
   const replicaId = selectedReplica === "all" ? undefined : selectedReplica;
 

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -63,13 +63,15 @@ import {
   fetchClusterReplicasWithUtilization,
 } from "~/api/materialize/cluster/replicasWithUtilization";
 import {
+  CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION,
   fetchReplicaUtilizationHistory,
   ReplicaUtilizationHistoryParameters,
+  selectClusterUtilizationOverviewView,
 } from "~/api/materialize/cluster/replicaUtilizationHistory";
 import { fetchLagHistory } from "~/api/materialize/freshness/lagHistory";
 import { assertNoMoreThanOneRow } from "~/api/materialize/MoreThanOneRowError";
 import { DataPoint, GraphLineSeries } from "~/components/FreshnessGraph/types";
-import { DEFAULT_OPTIONS as TIME_PERIOD_OPTIONS } from "~/hooks/useTimePeriodSelect";
+import { useEnvironmentGate } from "~/store/environments";
 import { notNullOrUndefined, sumPostgresIntervalMs } from "~/util";
 import { sortLagInfo } from "~/utils/freshness";
 
@@ -441,9 +443,6 @@ export function useMaterializationLag(params: MaterializationLagParams) {
   });
 }
 
-type TimePeriodOptionValues =
-  (typeof TIME_PERIOD_OPTIONS)[keyof typeof TIME_PERIOD_OPTIONS];
-
 /**
  * Fetches a normalized table of an object, the lag between its direct parent, and
  * the lag between its source/table objects
@@ -452,30 +451,36 @@ export function useReplicaUtilizationHistory(
   params: ReplicaUtilizationHistoryFilters,
   queryOptions?: { enabled?: boolean },
 ) {
+  // Older environments only have the pre-existing 8h/14d overview view; gate the
+  // new per-timeframe views on the release that introduces them. The selected
+  // bucketSizeMs (in `params`) already reflects this, so the query key changes
+  // when the gate flips.
+  const hasNewViews =
+    useEnvironmentGate(CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION) ?? false;
   return useQuery({
-    queryKey: clusterQueryKeys.replicaUtilizationHistory(params),
+    queryKey: [
+      ...clusterQueryKeys.replicaUtilizationHistory(params),
+      hasNewViews,
+    ],
     refetchInterval: 20_000,
     enabled: queryOptions?.enabled,
     queryFn: async ({ queryKey, signal }) => {
-      const [, queryKeyParams] = queryKey;
-
       const endDate = new Date();
-      const startDate = subMinutes(endDate, queryKeyParams.timePeriodMinutes);
+      const startDate = subMinutes(endDate, params.timePeriodMinutes);
 
-      const last14DaysOptionValue: TimePeriodOptionValues = "Last 14 days";
-
-      const last14DaysTimePeriodMinutes = Number(
-        Object.entries(TIME_PERIOD_OPTIONS).find(
-          ([_, option]) => option === last14DaysOptionValue,
-        )?.[0],
+      // Use the finest pre-materialized overview view that covers the selected
+      // range; ranges not served by a view (e.g. 30 days, or any short range on
+      // an older environment) fall back to the ad-hoc query.
+      const overviewView = selectClusterUtilizationOverviewView(
+        params.timePeriodMinutes,
+        hasNewViews,
       );
 
       const data = await fetchReplicaUtilizationHistory({
         params: {
-          ...queryKeyParams,
+          ...params,
           startDate: startDate.toISOString(),
-          shouldUseConsoleClusterUtilizationOverviewView:
-            queryKeyParams.timePeriodMinutes === last14DaysTimePeriodMinutes,
+          consoleOverviewViewName: overviewView?.viewName,
         },
         queryKey,
         requestOptions: { signal },

--- a/console/src/platform/environment-overview/queries.ts
+++ b/console/src/platform/environment-overview/queries.ts
@@ -15,13 +15,17 @@ import {
   buildQueryKeyPart,
   buildRegionQueryKey,
 } from "~/api/buildQueryKeySchema";
-import { fetchReplicaUtilizationHistory } from "~/api/materialize/cluster/replicaUtilizationHistory";
+import {
+  CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION,
+  fetchReplicaUtilizationHistory,
+} from "~/api/materialize/cluster/replicaUtilizationHistory";
 import {
   ClusterReplicaDetails,
   fetchClusterDetails,
 } from "~/api/materialize/environment-overview/clusterDetails";
 import { fetchLagHistory } from "~/api/materialize/freshness/lagHistory";
 import { DataPoint } from "~/components/FreshnessGraph/types";
+import { useEnvironmentGate } from "~/store/environments";
 import { notNullOrUndefined, sumPostgresIntervalMs } from "~/util";
 import { sortLagInfo } from "~/utils/freshness";
 
@@ -51,11 +55,22 @@ const environmentOverviewQueryKeys = {
 };
 
 const UTILIZATION_LOOKBACK_DAYS = 14;
+// The 14-day overview view (mz_console_cluster_utilization_overview) is bucketed
+// by 1 hour on environments with the new views and 8 hours on older ones;
+// gap-filling and the query must align to the view's actual bucket size.
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 const EIGHT_HOURS_IN_MS = 8 * 60 * 60 * 1000;
 
 export function useClusterMemDiskUtilization() {
+  const bucketSizeMs =
+    (useEnvironmentGate(CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION) ?? false)
+      ? ONE_HOUR_IN_MS
+      : EIGHT_HOURS_IN_MS;
   return useSuspenseQuery({
-    queryKey: environmentOverviewQueryKeys.clusterMemDiskUtilization(),
+    queryKey: [
+      ...environmentOverviewQueryKeys.clusterMemDiskUtilization(),
+      bucketSizeMs,
+    ],
     queryFn: async ({ queryKey, signal }) => {
       const endDate = new Date();
 
@@ -69,9 +84,10 @@ export function useClusterMemDiskUtilization() {
           }),
           fetchReplicaUtilizationHistory({
             params: {
-              bucketSizeMs: EIGHT_HOURS_IN_MS,
+              bucketSizeMs,
               startDate: startDate.toISOString(),
-              shouldUseConsoleClusterUtilizationOverviewView: true,
+              consoleOverviewViewName:
+                "mz_console_cluster_utilization_overview",
             },
             queryKey,
             requestOptions: { signal },
@@ -210,7 +226,7 @@ export function useClusterMemDiskUtilization() {
           endMs: endDate.getTime(),
           minBucketStartMs: replicaUtilizationHistoryRes.minBucketStartMs,
           maxBucketEndMs: replicaUtilizationHistoryRes.maxBucketEndMs,
-          bucketSizeMs: EIGHT_HOURS_IN_MS,
+          bucketSizeMs,
         });
 
         if (buckets) {

--- a/console/types/materialize.d.ts
+++ b/console/types/materialize.d.ts
@@ -1047,6 +1047,12 @@ export interface MzConsoleClusterUtilizationOverview {
   size: string | null;
 }
 
+export type MzConsoleClusterUtilizationOverview24h =
+  MzConsoleClusterUtilizationOverview;
+
+export type MzConsoleClusterUtilizationOverview3h =
+  MzConsoleClusterUtilizationOverview;
+
 export interface MzDatabases {
   /**
    * Materialize's unique ID for the database.
@@ -4280,6 +4286,8 @@ export interface DB {
   mz_compute_operator_hydration_statuses_per_worker: MzComputeOperatorHydrationStatusesPerWorker;
   mz_connections: MzConnections;
   mz_console_cluster_utilization_overview: MzConsoleClusterUtilizationOverview;
+  mz_console_cluster_utilization_overview_24h: MzConsoleClusterUtilizationOverview24h;
+  mz_console_cluster_utilization_overview_3h: MzConsoleClusterUtilizationOverview3h;
   mz_databases: MzDatabases;
   mz_dataflow_addresses: MzDataflowAddresses;
   mz_dataflow_addresses_per_worker: MzDataflowAddressesPerWorker;


### PR DESCRIPTION
### Motivation

The cluster-detail page's replica-utilization graph recomputed the **whole-fleet** rollup ad-hoc for every timeframe except "Last 14 days". That recompute serializes on `mz_catalog_server` under concurrent users and its cost grows with the number of clusters in the deployment — it's the dominant offender in the cluster-detail k6 load test (`replicaUtilizationHistory`, p95 ~30s, degrading to replica OOM under load).

### What this does

Points the graph at the pre-materialized, per-cluster **indexed** overview views added in the companion catalog PR (#37307). A new `selectClusterUtilizationOverviewView` picks the finest view whose window covers the selected range:

| Timeframe | View | Bucket |
|---|---|---|
| ≤ 3h | `…_overview_3h` | 1 min |
| ≤ 24h | `…_overview_24h` | 5 min |
| ≤ 14d | `…_overview` | 1 hour |
| 30d | ad-hoc query | — |

so each load is an indexed lookup keyed on `cluster_id` instead of a recompute. In a local repro this turns the query from ~3.5–52 s (and OOM under concurrency) into a flat ~124 ms / 100+ qps regardless of fleet size or concurrent sessions.

### Version gating

Use of the new views is gated on the environment version via `useEnvironmentGate(CLUSTER_UTILIZATION_OVERVIEW_VIEWS_VERSION)`. Older environments keep today's exact behavior (ad-hoc for short ranges; the pre-existing 8-hour view for "Last 14 days"). **The gate version is a placeholder** (`26.32.0-dev`) — set it to the release that actually ships #37307 before un-drafting.

### Also in this PR

The remaining ad-hoc query (`buildReplicaUtilizationHistoryQuery`, used for the 30-day range and on older environments) is optimized to match: the cluster filter is pushed into `replica_history` so the rollup only processes the target cluster's replicas, the redundant `replica_history` re-join is removed, and the offline-events scan is restricted to the cluster's replicas (turning a full scan into an index lookup). Also fixes a latent bug where the optional `endDate` bound was built from `startDate`.

`types/materialize.d.ts` is hand-edited to add the new view types; regenerate with `yarn gen:types` against an environment that has the views.

### Tests

`yarn typecheck` and `yarn lint` pass; the existing `ClusterOverview` / `ClusterMetrics` component tests pass. The `replicaUtilizationHistory.test.sql.ts` integration test still exercises the (optimized) ad-hoc builder.

Depends on MaterializeInc/materialize#37307.