### PR TITLE
[metrics]: expose mz_arrangement_capacity_bytes natively from clusterd

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -164,6 +164,18 @@ metrics:
   visibility: public
   tags:
   - compute
+- name: mz_arrangement_size_bytes_added_total
+  help: Cumulative bytes added to arrangement heaps. Resident bytes is (added - removed). Undercounts allocator-internal fragmentation; do not treat as an authoritative memory total.
+  labels:
+  - worker_id
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_arrangement_size_bytes_removed_total
+  help: Cumulative bytes removed from arrangement heaps. Resident bytes is (added - removed). Includes the final retraction when an arrangement drops.
+  labels:
+  - worker_id
+  source: src/compute/src/metrics.rs
+  visibility: internal
 - name: mz_arrangement_sizes_collection_time_seconds_bucket
   help: Seconds to read mz_object_arrangement_sizes and prepare history-table updates for one snapshot.
   labels:

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -773,6 +773,7 @@ impl<'a> ActiveComputeState<'a> {
             self.timely_worker,
             &config,
             self.compute_state.metrics_registry.clone(),
+            self.compute_state.metrics.clone(),
             Rc::clone(&self.compute_state.worker_config),
             self.compute_state.workers_per_process,
             storage_log_reader,

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -301,12 +301,15 @@ pub(super) struct Return {
 /// * `event_queue`: The source to read compute log events from.
 /// * `compute_event_streams`: Additional compute event streams to absorb.
 /// * `shared_state`: Shared state between logging dataflow fragments.
+/// * `worker_metrics`: Per-worker projected Prometheus handles, including the
+///   arrangement-size adds/removes counters this dataflow updates.
 pub(super) fn construct<'scope>(
     scope: Scope<'scope, Timestamp>,
     activations: Rc<RefCell<Activations>>,
     config: &mz_compute_client::logging::LoggingConfig,
     event_queue: EventQueue<Column<(Duration, ComputeEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
+    worker_metrics: crate::metrics::WorkerMetrics,
 ) -> Return {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
 
@@ -399,6 +402,7 @@ pub(super) fn construct<'scope>(
                             state: &mut demux_state,
                             shared_state,
                             output: &mut output_sessions,
+                            worker_metrics: &worker_metrics,
                             logging_interval_ms,
                             time,
                         }
@@ -783,6 +787,8 @@ struct DemuxHandler<'a, 'b, 'c> {
     shared_state: &'a mut SharedLoggingState,
     /// Demux output sessions.
     output: &'a mut DemuxOutput<'b, 'c>,
+    /// Per-worker Prometheus handles updated alongside the introspection rows.
+    worker_metrics: &'a crate::metrics::WorkerMetrics,
     /// The logging interval specifying the time granularity for the updates.
     logging_interval_ms: u128,
     /// The current event time.
@@ -1130,6 +1136,22 @@ impl DemuxHandler<'_, '_, '_> {
         let datum = self.state.pack_arrangement_heap_size_update(operator_id);
         let diff = Diff::cast_from(delta_size);
         self.output.arrangement_heap_size.give((datum, ts, diff));
+
+        // Mirror the delta as two monotone counters: positive deltas grow
+        // `_added_total`, negative deltas grow `_removed_total`. Resident size
+        // at any point in time is `added - removed` across all workers in the
+        // replica. Two counters preserve activity that a single gauge would
+        // mask when adds and removes cancel within a single scrape interval.
+        let delta_i64 = diff.into_inner();
+        if delta_i64 > 0 {
+            self.worker_metrics
+                .arrangement_size_bytes_added_total
+                .inc_by(delta_i64.unsigned_abs());
+        } else if delta_i64 < 0 {
+            self.worker_metrics
+                .arrangement_size_bytes_removed_total
+                .inc_by(delta_i64.unsigned_abs());
+        }
     }
 
     /// Update the allocation capacity for an arrangement.
@@ -1235,6 +1257,19 @@ impl DemuxHandler<'_, '_, '_> {
             let size = self.state.pack_arrangement_heap_size_update(operator_id);
             let diff = -Diff::cast_from(state.size);
             self.output.arrangement_heap_size.give((size, ts, diff));
+
+            // Mirror the full-size retraction into the `_removed_total`
+            // counter. Without this, `added - removed` drifts upward by the
+            // size of every dropped arrangement instead of returning to the
+            // resident total. `state.size` is non-negative by construction
+            // (every prior delta passed through `handle_arrangement_heap_size`
+            // which keeps the running sum positive).
+            let size_at_drop = Diff::cast_from(state.size).into_inner().unsigned_abs();
+            if size_at_drop > 0 {
+                self.worker_metrics
+                    .arrangement_size_bytes_removed_total
+                    .inc_by(size_at_drop);
+            }
         }
         self.shared_state
             .arrangement_size_activators

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -34,6 +34,7 @@ use crate::arrangement::manager::TraceBundle;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::logging::compute::{ComputeEvent, ComputeEventBuilder};
 use crate::logging::{BatchLogger, EventQueue, SharedLoggingState};
+use crate::metrics::WorkerMetrics;
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder};
 
@@ -45,6 +46,7 @@ pub fn initialize(
     worker: &mut timely::worker::Worker,
     config: &LoggingConfig,
     metrics_registry: MetricsRegistry,
+    worker_metrics: WorkerMetrics,
     worker_config: Rc<ConfigSet>,
     workers_per_process: usize,
     storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
@@ -71,6 +73,7 @@ pub fn initialize(
         c_event_queue: EventQueue::new("c"),
         shared_state: Default::default(),
         metrics_registry,
+        worker_metrics,
         worker_config,
         workers_per_process,
         storage_log_reader,
@@ -110,6 +113,7 @@ struct LoggingContext<'a> {
     c_event_queue: EventQueue<Column<(Duration, ComputeEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
     metrics_registry: MetricsRegistry,
+    worker_metrics: WorkerMetrics,
     worker_config: Rc<ConfigSet>,
     workers_per_process: usize,
     /// Optional reader for storage timely logging events.
@@ -166,6 +170,7 @@ impl LoggingContext<'_> {
                 self.config,
                 self.c_event_queue.clone(),
                 Rc::clone(&self.shared_state),
+                self.worker_metrics.clone(),
             );
             collections.extend(compute_collections);
 

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -43,6 +43,12 @@ pub struct ComputeMetrics {
     // arrangements
     arrangement_maintenance_seconds_total: raw::CounterVec,
     arrangement_maintenance_active_info: raw::UIntGaugeVec,
+    // Per-worker monotone counters for arrangement heap size churn. Reconstruct
+    // the point-in-time resident size as (added - removed) at query time. Two
+    // monotone counters preserve activity that a single gauge would mask if the
+    // adds and removes happen between scrapes.
+    arrangement_size_bytes_added_total: raw::IntCounterVec,
+    arrangement_size_bytes_removed_total: raw::IntCounterVec,
 
     // timings
     //
@@ -145,6 +151,16 @@ impl ComputeMetrics {
             arrangement_maintenance_active_info: registry.register(metric!(
                 name: "mz_arrangement_maintenance_active_info",
                 help: "Whether maintenance is currently occuring.",
+                var_labels: ["worker_id"],
+            )),
+            arrangement_size_bytes_added_total: registry.register(metric!(
+                name: "mz_arrangement_size_bytes_added_total",
+                help: "Cumulative bytes added to arrangement heaps. Resident bytes is (added - removed). Undercounts allocator-internal fragmentation; do not treat as an authoritative memory total.",
+                var_labels: ["worker_id"],
+            )),
+            arrangement_size_bytes_removed_total: registry.register(metric!(
+                name: "mz_arrangement_size_bytes_removed_total",
+                help: "Cumulative bytes removed from arrangement heaps. Resident bytes is (added - removed). Includes the final retraction when an arrangement drops.",
                 var_labels: ["worker_id"],
             )),
             timely_step_duration_seconds: registry.register(metric!(
@@ -254,6 +270,12 @@ impl ComputeMetrics {
         let arrangement_maintenance_active_info = self
             .arrangement_maintenance_active_info
             .with_label_values(&[&worker]);
+        let arrangement_size_bytes_added_total = self
+            .arrangement_size_bytes_added_total
+            .with_label_values(&[&worker]);
+        let arrangement_size_bytes_removed_total = self
+            .arrangement_size_bytes_removed_total
+            .with_label_values(&[&worker]);
         let timely_step_duration_seconds = self
             .timely_step_duration_seconds
             .with_label_values(&[&worker]);
@@ -286,6 +308,8 @@ impl ComputeMetrics {
             metrics: self.clone(),
             arrangement_maintenance_seconds_total,
             arrangement_maintenance_active_info,
+            arrangement_size_bytes_added_total,
+            arrangement_size_bytes_removed_total,
             timely_step_duration_seconds,
             persist_peek_seconds,
             stashed_peek_seconds,
@@ -319,6 +343,11 @@ pub struct WorkerMetrics {
     /// to gain a sense that Materialize is stuck on maintenance before the
     /// maintenance completes
     pub(crate) arrangement_maintenance_active_info: UIntGauge,
+    /// Cumulative bytes added to arrangement heaps by this worker.
+    pub(crate) arrangement_size_bytes_added_total: IntCounter,
+    /// Cumulative bytes removed from arrangement heaps by this worker, including
+    /// the final retraction emitted when an arrangement drops.
+    pub(crate) arrangement_size_bytes_removed_total: IntCounter,
     /// Histogram of Timely step timings.
     pub(crate) timely_step_duration_seconds: Histogram,
     /// Histogram of persist peek durations.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -421,6 +421,117 @@ def workflow_test_github_4443(c: Composition) -> None:
         ), f"more dataflows than expected in replica history, got {replica_dataflow_count}"
 
 
+def workflow_test_arrangement_size_metric(c: Composition) -> None:
+    """
+    Assert that `mz_arrangement_size_bytes_added_total` and
+    `_removed_total` move together across a CREATE INDEX / DROP INDEX cycle.
+    Whatever bytes flow into `added_total` when the index is built must
+    flow into `removed_total` when it is dropped.
+    """
+
+    c.down(destroy_volumes=True)
+
+    with c.override(Clusterd(name="clusterd1", workers=1)):
+        c.up("materialized", "clusterd1")
+
+        c.sql(
+            "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true",
+            port=6877,
+            user="mz_system",
+        )
+        # Pin the index to clusterd1 so the counters scraped from clusterd1
+        # cover exactly the arrangements this test builds.
+        c.sql(
+            """
+            CREATE CLUSTER cluster1 REPLICAS (replica1 (
+                STORAGECTL ADDRESSES ['clusterd1:2100'],
+                STORAGE ADDRESSES ['clusterd1:2103'],
+                COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                COMPUTE ADDRESSES ['clusterd1:2102'],
+                WORKERS 1
+            ));
+            GRANT ALL ON CLUSTER cluster1 TO materialize;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+
+        cursor = c.sql_cursor(startup_params={"cluster": "cluster1"})
+        cursor.execute("CREATE TABLE t (a bigint)")
+        cursor.execute("INSERT INTO t SELECT generate_series(1, 1000000)")
+
+        # Floor on the index's resident size, well above background
+        # logging-dataflow churn.
+        INDEX_SIZE_FLOOR_BYTES = 1_000_000
+        WAIT_DEADLINE_SECONDS = 120
+        POLL_SECONDS = 0.2
+
+        def counter_totals() -> tuple[int, int]:
+            """Return (added_total, removed_total) summed across workers."""
+            out = c.exec(
+                "clusterd1", "curl", "localhost:6878/metrics", capture=True
+            ).stdout
+            added = sum(
+                int(float(l.split()[1]))
+                for l in out.splitlines()
+                if l.startswith("mz_arrangement_size_bytes_added_total")
+            )
+            removed = sum(
+                int(float(l.split()[1]))
+                for l in out.splitlines()
+                if l.startswith("mz_arrangement_size_bytes_removed_total")
+            )
+            return added, removed
+
+        def wait_until(predicate: Callable[[], bool], description: str) -> None:
+            deadline = time.time() + WAIT_DEADLINE_SECONDS
+            while time.time() < deadline:
+                if predicate():
+                    return
+                time.sleep(POLL_SECONDS)
+            raise AssertionError(
+                f"condition never observed within {WAIT_DEADLINE_SECONDS}s: "
+                f"{description}"
+            )
+
+        def index_hydrated() -> bool:
+            cursor.execute(
+                "SELECT bool_and(hydrated) "
+                "FROM mz_internal.mz_compute_hydration_statuses h "
+                "JOIN mz_objects o ON (h.object_id = o.id) "
+                "WHERE name = 'idx'"
+            )
+            row = cursor.fetchone()
+            return bool(row[0]) if row and row[0] is not None else False
+
+        cycles = 4
+        for cycle in range(cycles):
+            added_before, _ = counter_totals()
+
+            cursor.execute("CREATE INDEX idx ON t (a)")
+            wait_until(index_hydrated, f"cycle {cycle}: index hydrated")
+
+            added_after_build, removed_after_build = counter_totals()
+            assert added_after_build - added_before >= INDEX_SIZE_FLOOR_BYTES, (
+                f"cycle {cycle}: added_total grew by only "
+                f"{added_after_build - added_before} bytes during CREATE, "
+                f"below the {INDEX_SIZE_FLOOR_BYTES}-byte floor"
+            )
+
+            cursor.execute("DROP INDEX idx")
+            # The wait timing out IS the bug signal: removed_total only
+            # grows from background churn (kilobytes), never crosses the
+            # floor.
+            target_removed = removed_after_build + INDEX_SIZE_FLOOR_BYTES
+            wait_until(
+                lambda: counter_totals()[1] >= target_removed,
+                f"cycle {cycle}: removed_total reaches "
+                f"{target_removed} bytes after DROP. "
+                f"handle_arrangement_heap_size_operator_dropped is not "
+                f"advancing the removed counter on arrangement drop.",
+            )
+
+
 def workflow_test_github_4444(c: Composition) -> None:
     """
     Test that compute reconciliation does not produce empty frontiers.


### PR DESCRIPTION
Problem:
clusterd doesn't publish the dataflow metrics on its own /metrics endpoint. envd derives them by running SQL against the introspection collections and republishing the results

Solution:
Register a Prometheus gauge on clusterd's MetricsRegistry and update it from the same compute event handler that already feeds the introspection collection. The gauge reads the same delta_capacity that populates mz_arrangement_heap_capacity_raw, so the value matches what the dashboards show and skips the SQL hop.

Testing:
- unit tests in compute_process_metrics cover registration of the guage and carries the label, and the gauge accumulates
- manual tested end-to-end by booting environmentd and scraping each clusterd /metric

Partially implements SQL-191 (as it only implements one metric as an example)
