### PR TITLE
GSR: additional test coverage

### DIFF
--- a/test/aws-glue-schema-registry/glue-schema-registry-restart.td
+++ b/test/aws-glue-schema-registry/glue-schema-registry-restart.td
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Companion to glue-schema-registry.td, run AFTER the workflow restarts
+# Materialize. Tests that the Glue interaction survives a restart, not the Avro
+# decode (covered elsewhere):
+#
+#   - glue_conn and the pre-restart simple_source/simple_table rehydrate from
+#     the catalog.
+#   - A table planned post-restart re-runs purification (GetSchemaVersion by
+#     name, cold caches) and decodes the pre-restart records.
+#
+# consistent_seed pins the topic name to the one glue-schema-registry.td used.
+
+$ set simple-schema-name=mz-test-schema
+
+# Pre-restart table rehydrates from persist, no Glue call. Confirms the catalog
+# object survived.
+> SELECT a, b FROM simple_table ORDER BY a
+1 hello
+2 world
+42 glue
+
+# A table planned post-restart re-resolves its schema against the registry
+# (GetSchemaVersion by name) and decodes the pre-restart topic contents.
+> CREATE SOURCE simple_source_after_restart
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+> CREATE TABLE simple_table_after_restart FROM SOURCE simple_source_after_restart (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${simple-schema-name}')
+  ENVELOPE NONE
+
+> SELECT a, b FROM simple_table_after_restart ORDER BY a
+1 hello
+2 world
+42 glue

--- a/test/aws-glue-schema-registry/glue-schema-registry-runtime-errors.td
+++ b/test/aws-glue-schema-registry/glue-schema-registry-runtime-errors.td
@@ -1,0 +1,114 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Companion to glue-schema-registry.td. Exercises the two runtime (decode-time)
+# Glue error paths, distinct from the planning-time paths the other scripts
+# cover. Moto-only, needs toxiproxy fronting moto for Materialize.
+
+# ---------------------------------------------------------------------------
+# Permanent: a record framed with a UUID in no registry. The per-UUID
+# writer-schema fetch returns NotFound, cached as a permanent decode error. The
+# table's reader schema (by name) resolves fine, only the writer UUID is bogus.
+# ---------------------------------------------------------------------------
+
+$ set notfound-schema={
+    "type": "record",
+    "name": "row",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "string"}
+    ]
+  }
+
+$ kafka-create-topic topic=notfound partitions=1
+
+# Bytes are valid Avro, but decode never reaches them: the writer-schema lookup
+# for this never-registered UUID fails first.
+$ kafka-ingest format=avro topic=notfound glue-schema-version-id=00000000-0000-0000-0000-0000000000ff schema=${notfound-schema} timestamp=1
+{"a": 1, "b": "x"}
+
+> CREATE SOURCE notfound_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-notfound-${testdrive.seed}')
+
+> CREATE TABLE notfound_table FROM SOURCE notfound_source (REFERENCE "testdrive-notfound-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'mz-test-schema')
+  ENVELOPE NONE
+
+! SELECT * FROM notfound_table
+contains:not found
+
+# ---------------------------------------------------------------------------
+# Transient: a record with an uncached but real UUID arrives while the registry
+# is unreachable. The fetch error is transient (source halts and retries), not
+# a permanent decode error, so the record decodes once connectivity returns.
+# Mis-caching it as permanent would hang this script.
+#
+# The source runs on its own cluster so its halt/retry loop does not churn the
+# other sources (which would re-fetch on restart).
+# ---------------------------------------------------------------------------
+
+$ set transient-schema={
+    "type": "record",
+    "name": "transient_row",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {"name": "v", "type": "string"}
+    ]
+  }
+
+# Registered directly against moto (testdrive bypasses toxiproxy), so the UUID
+# exists even while Materialize's path to the registry is cut below.
+$ glue-create-schema registry=${arg.registry-name} name=mz-transient-schema set-version-id-var=transient-version-id schema=${transient-schema}
+
+$ kafka-create-topic topic=transient partitions=1
+
+> CREATE CLUSTER glue_transient_cluster SIZE 'scale=1,workers=1'
+
+> CREATE SOURCE transient_source
+  IN CLUSTER glue_transient_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-transient-${testdrive.seed}')
+
+> CREATE TABLE transient_table FROM SOURCE transient_source (REFERENCE "testdrive-transient-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = 'mz-transient-schema')
+  ENVELOPE NONE
+
+> SELECT count(*) FROM transient_table
+0
+
+# Cut Materialize's link to the registry.
+$ http-request method=POST url=http://toxiproxy:8474/proxies/glue content-type=application/json
+{
+  "name": "glue",
+  "listen": "0.0.0.0:5000",
+  "upstream": "moto:5000",
+  "enabled": false
+}
+
+# Publish a record whose schema UUID the source has not cached yet.
+$ kafka-ingest format=avro topic=transient glue-schema-version-id=${transient-version-id} schema=${transient-schema} timestamp=1
+{"id": 1, "v": "survives-outage"}
+
+# Confirm the source actually hit the outage (rather than racing past it),
+# proving the transient path is exercised, not a lucky post-restore fetch.
+> SELECT count(*) > 0 FROM mz_internal.mz_source_statuses
+  WHERE name = 'transient_source' AND error IS NOT NULL
+true
+
+# Restore connectivity. The retried fetch succeeds and the record decodes.
+$ http-request method=POST url=http://toxiproxy:8474/proxies/glue content-type=application/json
+{
+  "name": "glue",
+  "listen": "0.0.0.0:5000",
+  "upstream": "moto:5000",
+  "enabled": true
+}
+
+> SELECT id, v FROM transient_table
+1 survives-outage

--- a/test/aws-glue-schema-registry/glue-schema-registry-unreachable.td
+++ b/test/aws-glue-schema-registry/glue-schema-registry-unreachable.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Run after the workflow kills moto, so the Glue backend is unreachable. Both
+# Glue-touching planning paths must fail cleanly. Moto-only.
+
+$ set simple-schema-name=mz-test-schema
+
+# Connection validation pings GetRegistry: transport error, not NotFound.
+! CREATE CONNECTION glue_conn_unreachable TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_conn,
+    REGISTRY = '${arg.registry-name}'
+  )
+contains:failed to validate AWS Glue Schema Registry connection
+
+# Table purification pings GetSchemaVersion. The source itself needs no Glue.
+> CREATE SOURCE unreachable_source
+  IN CLUSTER quickstart
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-simple-${testdrive.seed}')
+
+! CREATE TABLE unreachable_table FROM SOURCE unreachable_source (REFERENCE "testdrive-simple-${testdrive.seed}")
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (SCHEMA NAME = '${simple-schema-name}')
+  ENVELOPE NONE
+contains:Glue schema lookup failed

--- a/test/aws-glue-schema-registry/glue-schema-registry.td
+++ b/test/aws-glue-schema-registry/glue-schema-registry.td
@@ -25,6 +25,15 @@
 # registries are created by the workflow (mzcompose.py); the schemas inside them
 # are registered here so the schema bodies live in exactly one place.
 #
+# Scenarios that need container-lifecycle or connectivity control live in
+# companion files the moto workflow runs after this one (all moto-only, since
+# we can't restart against or take down real AWS):
+# glue-schema-registry-restart.td (Glue connection/sources survive a
+# Materialize restart), glue-schema-registry-runtime-errors.td (decode-time
+# unknown-UUID and transient-outage paths), and
+# glue-schema-registry-unreachable.td (connection validation fails cleanly when
+# the registry backend is down).
+#
 # Cross-schema references (CSR's `VALUE REFERENCES (...)`) are *intentionally*
 # not exercised here: AWS Glue Schema Registry has no equivalent concept
 # (`RegisterSchemaVersion` takes one self-contained JSON blob; there is no

--- a/test/aws-glue-schema-registry/mzcompose.py
+++ b/test/aws-glue-schema-registry/mzcompose.py
@@ -33,11 +33,17 @@ from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.moto import Moto
 from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
 
 # Moto-mode constants. workflow_aws derives its own per-run names.
 MOTO_AWS_ACCESS_KEY_ID = "test"
 MOTO_AWS_SECRET_ACCESS_KEY = "test"
+# testdrive's AWS client talks to moto directly. Materialize goes through
+# toxiproxy so a test can sever its link to the registry without disturbing
+# testdrive's schema registration. With no toxic set toxiproxy is a transparent
+# passthrough, so the happy-path scripts are unaffected.
 MOTO_AWS_ENDPOINT_URL = "http://moto:5000"
+GLUE_PROXY_ENDPOINT_URL = "http://toxiproxy:5000"
 
 REGISTRY_NAME_BASE = "mz-test-registry"
 OTHER_REGISTRY_NAME_BASE = "mz-other-registry"
@@ -55,12 +61,13 @@ DEFAULT_SCHEMA_NAME_BASE = "mz-default-schema"
 
 SERVICES = [
     Moto(),
+    Toxiproxy(),
     Kafka(),
     Materialized(
-        depends_on=["moto"],
+        depends_on=["moto", "toxiproxy"],
         environment_extra=[
             f"AWS_REGION={DEFAULT_CLOUD_REGION}",
-            f"AWS_ENDPOINT_URL={MOTO_AWS_ENDPOINT_URL}",
+            f"AWS_ENDPOINT_URL={GLUE_PROXY_ENDPOINT_URL}",
             f"AWS_ACCESS_KEY_ID={MOTO_AWS_ACCESS_KEY_ID}",
             f"AWS_SECRET_ACCESS_KEY={MOTO_AWS_SECRET_ACCESS_KEY}",
         ],
@@ -68,6 +75,10 @@ SERVICES = [
     Testdrive(
         default_timeout="30s",
         no_reset=True,
+        # Pin the seed so topic names stay stable across the several testdrive
+        # invocations a single run makes (main script, post-restart script,
+        # ...). The restart script references topics the main script created.
+        consistent_seed=True,
         # Point testdrive's AWS client at moto so the `glue-create-schema`
         # action registers schemas in the same backend Materialize reads from.
         # workflow_aws overrides this to talk to real AWS.
@@ -124,6 +135,42 @@ def _cleanup_glue(
             print(f"warning: failed to delete default-registry schema: {e}")
 
 
+def _testdrive_var_args(
+    *,
+    registry_name: str,
+    other_registry_name: str,
+    nonexistent_registry_name: str,
+    default_schema_name: str,
+) -> list[str]:
+    """Build the `--var` args shared by every testdrive file in a run.
+
+    Only the resources whose names must be unique per run and are managed here,
+    the registries and the shared default-registry schema, are passed in.
+    In-registry schema names are constants defined in the scripts, and every
+    schema body + version UUID is produced there by `glue-create-schema`.
+    """
+    return [
+        f"--var=registry-name={registry_name}",
+        f"--var=other-registry-name={other_registry_name}",
+        f"--var=default-registry-name={DEFAULT_REGISTRY_NAME}",
+        f"--var=nonexistent-registry-name={nonexistent_registry_name}",
+        f"--var=default-schema-name={default_schema_name}",
+    ]
+
+
+def _configure_glue_proxy(c: Composition) -> None:
+    """Create the toxiproxy proxy that fronts moto for Materialize."""
+    c.testdrive(input="""
+$ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
+{
+  "name": "glue",
+  "listen": "0.0.0.0:5000",
+  "upstream": "moto:5000",
+  "enabled": true
+}
+""")
+
+
 def _run_testdrive(
     c: Composition,
     *,
@@ -133,22 +180,17 @@ def _run_testdrive(
     nonexistent_registry_name: str,
     default_schema_name: str,
 ) -> None:
+    var_args = _testdrive_var_args(
+        registry_name=registry_name,
+        other_registry_name=other_registry_name,
+        nonexistent_registry_name=nonexistent_registry_name,
+        default_schema_name=default_schema_name,
+    )
+
     # Bring up the AWS connection out-of-band so we can include SESSION TOKEN
     # only when present.
-    #
-    # Only the resources whose names must be unique per run and are managed here
-    # — the registries and the shared default-registry schema — are passed in.
-    # In-registry schema names are constants defined in the script, and every
-    # schema body + version UUID is produced there by `glue-create-schema`.
     c.testdrive(input=aws_conn_sql)
-    c.run_testdrive_files(
-        f"--var=registry-name={registry_name}",
-        f"--var=other-registry-name={other_registry_name}",
-        f"--var=default-registry-name={DEFAULT_REGISTRY_NAME}",
-        f"--var=nonexistent-registry-name={nonexistent_registry_name}",
-        f"--var=default-schema-name={default_schema_name}",
-        "glue-schema-registry.td",
-    )
+    c.run_testdrive_files(*var_args, "glue-schema-registry.td")
 
 
 def workflow_default(c: Composition) -> None:
@@ -178,7 +220,12 @@ def workflow_default(c: Composition) -> None:
         other_registry_name=OTHER_REGISTRY_NAME_BASE,
     )
 
-    c.up("kafka", "materialized")
+    c.up("toxiproxy", "kafka", "materialized")
+
+    # Insert toxiproxy between Materialize and moto. No toxic is set, so it is a
+    # transparent passthrough until the runtime-errors script cuts it. Created
+    # before any Materialize Glue call (the first is glue_conn's validate()).
+    _configure_glue_proxy(c)
 
     aws_conn_sql = f"""
 > CREATE SECRET aws_secret_access_key AS '{MOTO_AWS_SECRET_ACCESS_KEY}'
@@ -197,6 +244,34 @@ def workflow_default(c: Composition) -> None:
         nonexistent_registry_name="no-such-registry",
         default_schema_name=DEFAULT_SCHEMA_NAME_BASE,
     )
+
+    # The scenarios below need container-lifecycle or connectivity control, so
+    # they run here rather than inside the shared testdrive script. Moto-only:
+    # we can't restart against or take down real AWS, and all exercise
+    # Materialize-internal behavior moto reproduces faithfully.
+    var_args = _testdrive_var_args(
+        registry_name=REGISTRY_NAME_BASE,
+        other_registry_name=OTHER_REGISTRY_NAME_BASE,
+        nonexistent_registry_name="no-such-registry",
+        default_schema_name=DEFAULT_SCHEMA_NAME_BASE,
+    )
+
+    # Restart Materialize and confirm the Glue connection and sources rehydrate
+    # from the catalog and keep resolving + decoding against the registry. The
+    # pinned seed keeps the post-restart script pointed at the same topics.
+    c.kill("materialized")
+    c.up("materialized")
+    c.run_testdrive_files(*var_args, "glue-schema-registry-restart.td")
+
+    # Runtime (decode-time) error paths: a record with an unknown UUID is a
+    # permanent error, while a record arriving during a registry outage is
+    # transient and recovers. The script toggles the toxiproxy proxy itself.
+    c.run_testdrive_files(*var_args, "glue-schema-registry-runtime-errors.td")
+
+    # Registry-unreachable: kill the Glue backend, then confirm connection
+    # validation fails cleanly rather than hanging or panicking.
+    c.kill("moto")
+    c.run_testdrive_files(*var_args, "glue-schema-registry-unreachable.td")
 
 
 def workflow_aws(c: Composition) -> None:
@@ -313,6 +388,7 @@ def workflow_aws(c: Composition) -> None:
             Testdrive(
                 default_timeout="30s",
                 no_reset=True,
+                consistent_seed=True,
                 aws_region=region,
                 aws_endpoint=None,
                 aws_access_key_id=None,


### PR DESCRIPTION
Modifies the default workflow for Glue schema registry tests to include toxiproxy service and add tests to validate behavior given transient schema registry errors.  This only affects the moto based tests, not the AWS integration tests.