### PR TITLE
CLO-108 cloud-resources: Set app.kubernetes.io/name on environmentd resources

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -799,6 +799,10 @@ pub mod v1alpha1 {
                 ),
             ])
         }
+
+        fn app_name(&self) -> Option<&str> {
+            Some("environmentd")
+        }
     }
 
     impl From<v1::Materialize> for Materialize {


### PR DESCRIPTION
The orchestratord controller down-converts every Materialize CR to v1alpha1::Materialize to build the environmentd StatefulSet, Services, and ConfigMap. Those objects flow through managed_resource_meta, which derives app.kubernetes.io/name (and the legacy app label) from app_name(). The v1alpha1::Materialize impl never overrode app_name(), so it fell back to the trait default of None and the label was dropped, even though the v1 impl set it to Some("environmentd").

Override app_name() on v1alpha1::Materialize to mirror v1, delivering app.kubernetes.io/name=environmentd on environmentd resource objects and turning the new RecommendedK8sLabels orchestratord test green.

Follow-up to https://github.com/MaterializeInc/materialize/pull/37086, which caused test failures: https://buildkite.com/materialize/nightly/builds/16887

New test run: https://buildkite.com/materialize/nightly/builds/16888