### PR TITLE
adapter: fix priority inversion that pins the coordinator on linearize_reads

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -174,7 +174,7 @@ use thiserror::Error;
 use timely::progress::{Antichain, Timestamp as _};
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
-use tokio::sync::{OwnedMutexGuard, mpsc, oneshot, watch};
+use tokio::sync::{Notify, OwnedMutexGuard, mpsc, oneshot, watch};
 use tokio::time::{Interval, MissedTickBehavior};
 use tracing::{Instrument, Level, Span, debug, info, info_span, span, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -1863,6 +1863,11 @@ pub struct Coordinator {
 
     /// Channel for strict serializable reads ready to commit.
     strict_serializable_reads_tx: mpsc::UnboundedSender<(ConnectionId, PendingReadTxn)>,
+
+    /// Signals that pending strict serializable reads should be re-checked
+    /// because the timestamp oracle may have advanced. Awaited below group commit
+    /// in [`Coordinator::serve`]; see that branch for the ordering rationale.
+    linearize_reads_notify: Arc<Notify>,
 
     /// Mechanism for totally ordering write and read timestamps, so that all reads
     /// reflect exactly the set of writes that precede them, and no writes that follow.
@@ -3819,6 +3824,16 @@ impl Coordinator {
 
             let message_batch = self.metrics.message_batch.clone();
 
+            // A persisted `Notified` future for the linearize re-check signal.
+            // It must outlive a single loop iteration and be re-`set` only after
+            // it completes: a fresh `notified()` per iteration could drop a
+            // wakeup that arrives while a higher-priority branch wins the same
+            // poll, stranding pending reads. Keeping it pinned across iterations
+            // leaves it registered, so no wakeup is lost.
+            let linearize_reads_notify = Arc::clone(&self.linearize_reads_notify);
+            let linearize_reads_notified = linearize_reads_notify.notified();
+            tokio::pin!(linearize_reads_notified);
+
             loop {
                 // Before adding a branch to this select loop, please ensure that the branch is
                 // cancellation safe and add a comment explaining why. You can refer here for more
@@ -3928,6 +3943,20 @@ impl Coordinator {
                             messages.push(Message::GroupCommitInitiate(span, None));
                         }
                     },
+                    // Re-check pending strict serializable reads. Deliberately
+                    // placed below the group commit branches above: a re-check
+                    // only makes a read ready if the timestamp oracle has
+                    // advanced, and the oracle only advances via group commit, so
+                    // this must never win over (and thereby starve) group commit.
+                    // `Notify` coalesces re-arms into a single wakeup, so even
+                    // when a pending read sits just behind the oracle (re-armed
+                    // sub-millisecond), the lower branches (including the idle
+                    // watchdog) stay reachable. See the pin above for why the
+                    // future is persisted rather than recreated per iteration.
+                    () = linearize_reads_notified.as_mut() => {
+                        linearize_reads_notified.set(linearize_reads_notify.notified());
+                        messages.push(Message::LinearizeReads);
+                    }
                     // `tick()` on `Interval` is cancel-safe:
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                     // Receive a single command.
@@ -4953,6 +4982,7 @@ pub fn serve(
                     internal_cmd_tx,
                     group_commit_tx,
                     strict_serializable_reads_tx,
+                    linearize_reads_notify: Arc::new(Notify::new()),
                     global_timelines: timestamp_oracles,
                     transient_id_gen: Arc::new(TransientIdGen::new()),
                     active_conns: BTreeMap::new(),

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -11,6 +11,7 @@
 //! messages from various sources (ex: controller, clients, background tasks, etc).
 
 use std::collections::{BTreeMap, BTreeSet, btree_map};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::FutureExt;
@@ -1126,16 +1127,13 @@ impl Coordinator {
         }
 
         if !self.pending_linearize_read_txns.is_empty() {
-            // Cap wait time to 1s.
+            // Cap wait time to 1s, then signal a re-check. `serve` awaits this
+            // below group commit; see its linearize branch for why.
             let remaining_ms = std::cmp::min(shortest_wait, Duration::from_millis(1_000));
-            let internal_cmd_tx = self.internal_cmd_tx.clone();
+            let linearize_reads_notify = Arc::clone(&self.linearize_reads_notify);
             task::spawn(|| "deferred_read_txns", async move {
                 tokio::time::sleep(remaining_ms).await;
-                // It is not an error for this task to be running after `internal_cmd_rx` is dropped.
-                let result = internal_cmd_tx.send(Message::LinearizeReads);
-                if let Err(e) = result {
-                    warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-                }
+                linearize_reads_notify.notify_one();
             });
         }
     }


### PR DESCRIPTION
`message_linearize_reads` re-checks strict serializable reads whose chosen timestamp is ahead of the oracle by re-arming on the high-priority internal command channel, which the biased coordinator select polls above the group commit that advances the oracle.

Under sustained strict serializable load this is a self-sustaining priority inversion: the re-arm starves group commit, the oracle read timestamp freezes, the reads never become ready, and the re-arm spins forever. Group commit stops, the read-timestamp `SELECT` saturates the oracle, and the coordinator is reported stuck on `linearize_reads` until clients disconnect and drain the pending reads.

Signal the re-check via a dedicated `tokio::sync::Notify` that `serve` awaits below the group commit branches, so group commit always advances the oracle and the waiting reads retire instead of spinning. Re-check timing is otherwise unchanged; pacing it down is left to #37317.

No automated test: this is a scheduling/priority bug that's hard to unit-test. Observable signals that it stays fixed are the absence of the `coordinator stuck for … last_message_kind: linearize_reads` warning, and the requeued (`false`) bucket of the `linearize_message_seconds` histogram staying low (reads linearize on first check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)