### PR TITLE
adapter: rate-limit the linearize_reads backstop poll

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -288,6 +288,20 @@ pub const PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT: Config<Duration> = Config::new(
     Postgres/CRDB timestamp oracle. A value of zero leaves the statement timeout unset.",
 );
 
+/// Minimum interval between re-checks of pending strict serializable reads.
+///
+/// Advances made by this node are observed eagerly, so this does not bound their
+/// latency. It paces the backstop poll that observes advances made by other
+/// writers sharing the oracle. Lower it to reduce cross-writer linearization
+/// latency at the cost of more oracle traffic. Not load-bearing for starvation,
+/// which the coordinator select prevents structurally.
+pub const LINEARIZE_READS_MIN_INTERVAL: Config<Duration> = Config::new(
+    "linearize_reads_min_interval",
+    Duration::from_millis(100),
+    "Minimum interval between re-checks of strict serializable reads that are \
+    waiting for the timestamp oracle to advance.",
+);
+
 /// Whether per-cluster and per-replica scoped system parameters are evaluated.
 /// Off by default: the parameter sync loop evaluates no cluster/replica
 /// contexts and resolution falls back to the environment-wide value everywhere
@@ -338,5 +352,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ARRANGEMENT_SIZE_HISTORY_RETENTION_PERIOD)
         .add(&CATALOG_INFO_METRICS_RECONCILE_INTERVAL)
         .add(&PG_TIMESTAMP_ORACLE_STATEMENT_TIMEOUT)
+        .add(&LINEARIZE_READS_MIN_INTERVAL)
         .add(&ENABLE_SCOPED_SYSTEM_PARAMETERS)
 }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -107,6 +107,14 @@ impl Coordinator {
             }
             Message::AdvanceTimelines => {
                 self.advance_timelines().boxed_local().await;
+                // A group commit just advanced the oracle's read timestamp, which
+                // can make pending strict serializable reads ready. Retire them
+                // now rather than waiting for the backstop re-check. Only fires
+                // for advances this node makes; other writers' advances are
+                // observed by the poll in `message_linearize_reads`.
+                if !self.pending_linearize_read_txns.is_empty() {
+                    self.message_linearize_reads().boxed_local().await;
+                }
             }
             Message::ClusterEvent(event) => self.message_cluster_event(event).boxed_local().await,
             Message::CancelPendingPeeks { conn_id } => {
@@ -1127,12 +1135,18 @@ impl Coordinator {
         }
 
         if !self.pending_linearize_read_txns.is_empty() {
-            // Cap wait time to 1s, then signal a re-check. `serve` awaits this
-            // below group commit; see its linearize branch for why.
-            let remaining_ms = std::cmp::min(shortest_wait, Duration::from_millis(1_000));
+            // Pace the backstop re-check with `linearize_reads_min_interval`,
+            // capped at 1s. The poll observes advances by other writers; advances
+            // this node makes are handled eagerly (see `Message::AdvanceTimelines`).
+            // `serve` awaits the signal below group commit; see its linearize
+            // branch for the ordering.
+            let interval = mz_adapter_types::dyncfgs::LINEARIZE_READS_MIN_INTERVAL
+                .get(self.catalog().system_config().dyncfgs());
+            let cap = std::cmp::max(interval, Duration::from_millis(1_000));
+            let remaining = shortest_wait.clamp(interval, cap);
             let linearize_reads_notify = Arc::clone(&self.linearize_reads_notify);
             task::spawn(|| "deferred_read_txns", async move {
-                tokio::time::sleep(remaining_ms).await;
+                tokio::time::sleep(remaining).await;
                 linearize_reads_notify.notify_one();
             });
         }

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -285,6 +285,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     keep_n_privatelink_status_history_entries
     keep_n_sink_status_history_entries
     keep_n_source_status_history_entries
+    linearize_reads_min_interval
     log_filter_defaults
     max_copy_from_row_size
     max_network_policies


### PR DESCRIPTION
Reduces the timestamp-oracle traffic the linearize re-check generates while a strict serializable read waits for the oracle to advance:

* Retire pending reads eagerly when this node advances the oracle (via `AdvanceTimelines`), so the backstop poll no longer needs to be fast.
* Pace the poll with the new `linearize_reads_min_interval` dyncfg (default 100ms). It observes advances made by other writers sharing the oracle; lower it to trade oracle traffic for cross-writer linearization latency.

Not load-bearing for starvation, which the select ordering from #37316 (now merged) already prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)