### PR TITLE
Docs: standarize docs for reading from a PG physical standby

### DIFF
--- a/doc/user/content/sql/create-source/postgres-v2.md
+++ b/doc/user/content/sql/create-source/postgres-v2.md
@@ -17,6 +17,8 @@ other_ref="[old reference page](/sql/create-source/postgres/)" include_blurb=tru
 {{% create-source-intro external_source="PostgreSQL" version="11+"
 create_table="/sql/create-table/" %}}
 
+PostgreSQL 16+ is required for connecting Materialize to a physical replica.
+
 ## Prerequisites
 
 {{% include-from-yaml data="postgres_source_details"
@@ -104,6 +106,11 @@ SELECT id, replication_slot FROM mz_internal.mz_postgres_sources;
 name="postgres-replication-slots-tip-list" %}}
 
 {{</ tip >}}
+
+### Reading from a physical standby
+
+{{% include-from-yaml data="postgres_source_details"
+name="postgres-physical-standby" %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -140,6 +140,11 @@ CREATE SOURCE mz_source
   FOR TABLES (schema1.table_1 AS s1_table_1, schema2_table_1 AS s2_table_1);
 ```
 
+### Reading from a physical standby
+
+{{% include-from-yaml data="postgres_source_details"
+name="postgres-physical-standby" %}}
+
 ### Monitoring source progress
 
 By default, PostgreSQL sources expose progress metadata as a subsource that you

--- a/doc/user/data/postgres_source_details.yml
+++ b/doc/user/data/postgres_source_details.yml
@@ -57,6 +57,21 @@
     unbounded disk space usage, make sure to use [`DROP
     SOURCE`](/sql/drop-source/) or manually delete the replication slot.
 
+- name: postgres-physical-standby
+  content: |
+    Materialize can replicate from a PostgreSQL physical standby (read
+    replica) instead of the primary, using logical decoding on the standby.
+    This requires **PostgreSQL 16+** on both the primary and the standby, since
+    earlier versions do not support creating logical replication slots on a
+    standby.
+
+    When the upstream is a standby, the replication slot is created on the
+    standby and Materialize only connects to the standby. Note that slot
+    creation on a standby can block until the primary emits a standby snapshot
+    (a `RUNNING_XACTS` WAL record). On an idle primary, run
+    [`SELECT pg_log_standby_snapshot()`](https://www.postgresql.org/docs/16/functions-admin.html#FUNCTIONS-SNAPSHOT-SYNCHRONIZATION)
+    on the primary to unblock source creation.
+
 - name: postgres-supported-types
   content: |
     Materialize natively supports the following PostgreSQL types (including the


### PR DESCRIPTION
`CREATE SOURCE` legacy syntax called out PG 16 requirement for configuring Materialize against a physical standby, but this was accidentally omitted from the new syntax page.

This also adds a common "Reading from physical standby" section to both pages with a short blurb and a helpful command for anyone that tries to set this up from scratch (e.g. in a POC or local test scenario).