### PR TITLE
self-managed releases: Fix bumping terraform by ignoring rc versions

### DIFF
--- a/doc/user/data/self_managed/latest_versions.yml
+++ b/doc/user/data/self_managed/latest_versions.yml
@@ -1,7 +1,7 @@
-terraform_gcp_version: v0.8.37
-terraform_azure_version: v0.8.36
-terraform_aws_version: v0.8.36
-terraform_helm_version: v0.1.71
+terraform_gcp_version: v0.8.38
+terraform_azure_version: v0.8.37
+terraform_aws_version: v0.8.37
+terraform_helm_version: v0.1.72
 operator_helm_chart_version: v26.30.1
 orchestratord_version: v26.30.1
 environmentd_version: v26.30.1

--- a/misc/helm-charts/publish.sh
+++ b/misc/helm-charts/publish.sh
@@ -145,8 +145,7 @@ if ! is_truthy "$CI_DRY_RUN"; then
     exit 1
   fi
 
-  # sort -V doesn't do a proper semver sort, have to manually fix that, v26.0.0~rc.6 is considered to be less than v26.0.0
-  HIGHEST_HELM_CHART_VERSION=$(echo "$YAML" | yq '.entries["materialize-operator"][].version' | grep -v beta | sed "s/-rc\./~rc./" | sort -V | tail -n 1)
+  HIGHEST_HELM_CHART_VERSION=$(echo "$YAML" | yq '.entries["materialize-operator"][].version' | grep -v beta | grep -v -- '-rc\.' | sort -V | tail -n 1)
 
   if [ "$HIGHEST_HELM_CHART_VERSION" != "$BUILDKITE_TAG" ]; then
     echo "--- Higher helm-chart version $HIGHEST_HELM_CHART_VERSION > $BUILDKITE_TAG has already been released, not bumping terraform versions"


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/37278

Noticed by @kay-kim in https://materializeinc.slack.com/archives/C07PN7KSB0T/p1782494689094189