### PR TITLE
console: push cluster filter down in replica utilization history query

### DIFF
--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
@@ -46,17 +46,26 @@ export function buildReplicaUtilizationHistoryQuery({
   const dateBinOrigin = sql.lit("1970-01-01");
 
   let query = queryBuilder
-    .with("replica_history", (qb) =>
-      qb
+    .with("replica_history", (qb) => {
+      let history = qb
         .selectFrom("mz_cluster_replica_history")
-        .select(["replica_id", "cluster_id", "size"])
-        // We need to union the current set of cluster replicas since mz_cluster_replica_history doesn't account for system clusters
-        .union(
-          qb
-            .selectFrom("mz_cluster_replicas")
-            .select(["id as replica_id", "cluster_id", "size"]),
-        ),
-    )
+        .select(["replica_id", "cluster_id", "size"]);
+      // We need to union the current set of cluster replicas since mz_cluster_replica_history doesn't account for system clusters
+      let current = qb
+        .selectFrom("mz_cluster_replicas")
+        .select(["id as replica_id", "cluster_id", "size"]);
+      // Push the cluster filter into both UNION branches up front. Otherwise it
+      // only enters at the final join and the optimizer can't push it into the
+      // shared `replica_utilization_history_binned` CTE, so the metrics
+      // aggregate and all five Top-1 passes run over the whole fleet and only
+      // the last step discards other clusters. Filtering here scopes the heavy
+      // work to the requested cluster(s).
+      if (clusterIds !== undefined && clusterIds.length > 0) {
+        history = history.where("cluster_id", "in", clusterIds);
+        current = current.where("cluster_id", "in", clusterIds);
+      }
+      return history.union(current);
+    })
     .with("replica_name_history", (qb) =>
       qb
         .selectFrom("mz_cluster_replica_name_history")
@@ -128,13 +137,11 @@ export function buildReplicaUtilizationHistoryQuery({
         ]),
     )
     .with("replica_utilization_history_binned", (qb) => {
+      // Read the per-sample rollup directly. replica_metrics_history is already
+      // derived from replica_history, so joining replica_history here would be
+      // redundant and could fan out if a replica ever had two sizes.
       let cte = qb
-        .selectFrom("replica_history as r")
-        .innerJoin(
-          "replica_metrics_history as m",
-          "m.replica_id",
-          "r.replica_id",
-        )
+        .selectFrom("replica_metrics_history as m")
         .select([
           "m.occurred_at",
           "m.replica_id",
@@ -296,6 +303,13 @@ export function buildReplicaUtilizationHistoryQuery({
         // NOTE(SangJunBak): Given processes should share the same state, we can just take the statuses of the first process.
         .where("process_id", "=", "0")
         .where("status", "=", "offline")
+        // Restrict the offline scan to the replicas we're charting. When a
+        // cluster filter is set, replica_history is already scoped to it, so
+        // this turns a full status-history scan into a lookup; when it isn't,
+        // replica_history is the whole fleet and this is a no-op.
+        .where("rsh.replica_id", "in", (eb) =>
+          eb.selectFrom("replica_history").select("replica_id"),
+        )
         .where(
           "occurred_at",
           ">=",
@@ -410,10 +424,6 @@ export function buildReplicaUtilizationHistoryQuery({
       "replica_history.size",
     ])
     .orderBy("bucketStart");
-
-  if (clusterIds !== undefined && clusterIds.length > 0) {
-    query = query.where("replica_history.cluster_id", "in", clusterIds);
-  }
 
   if (replicaId) {
     query = query.where("max_memory.replica_id", "=", replicaId);


### PR DESCRIPTION
The cluster-detail page recomputes the whole-fleet replica-utilization rollup on every load and only filters to the viewed cluster at the very end. Because the `cluster_id` predicate enters at the final join, the optimizer can't push it into the shared `replica_utilization_history_binned` CTE that the five Top-1 argmax CTEs all read — so the metrics aggregate and all five Top-1 passes run over every replica in the deployment before the last step discards other clusters.

This pushes the filter to the front:

- filter `replica_history` to the cluster in both UNION branches, so the predicate reaches the source reads instead of the final join;
- restrict the offline-event scan to that replica set (a full status-history scan becomes a lookup);
- drop the redundant `replica_history` re-join in the binned CTE (the rollup is already derived from it, and it could fan out on a replica that ever had two sizes).

Output is unchanged — verified row-for-row against the original query on synthetic fleets. Only execution differs: `EXPLAIN` shows the `cluster_id` filter pushed down to the `replica_history` source reads, with the five Top-1 passes now scoped to one cluster.

Console-only; no catalog or index changes. On a synthetic single-worker fleet (matching `mz_catalog_server`) the per-cluster page-load p50 drops ~8–15× and, unlike before, no longer grows with total fleet size:

| clusters | old p50 (1 viewer) | new p50 (1 viewer) | speedup |
|---|---|---|---|
| 25 | 3.7 s | 0.48 s | 7.7× |
| 100 | 14.8 s | 1.2 s | 12.4× |
| 200 | 29.3 s | 2.2 s | 13.0× |

The gain widens with concurrent viewers and with fleet size. In production the win is larger still: these synthetic tables are unindexed, whereas `mz_cluster_replica_metrics_history` / `mz_cluster_replica_status_history` are indexed on `replica_id`, so the pushed-down replica set turns the residual full scans into lookups.
