### PR TITLE
console: push the entity filter down in the lag-history query

### DIFF
--- a/console/src/api/materialize/freshness/lagHistory.ts
+++ b/console/src/api/materialize/freshness/lagHistory.ts
@@ -68,6 +68,25 @@ export function buildLagHistoryQuery(
         lagHistoryQuery = lagHistoryQuery.where("object_id", "like", "u%");
       }
 
+      // Push the entity filter to the source read, before the bin + Top-1.
+      // Otherwise the cluster/object filter only enters at the final join (the
+      // `lag_history` CTE), so the Top-1 over `lag_history_binned` runs over
+      // every object in the environment and the join discards the rest. Applied
+      // here it scopes the Top-1 to the requested objects via the
+      // mz_wallclock_global_lag_recent_history object_id index.
+      if (clusterId) {
+        lagHistoryQuery = lagHistoryQuery.where("object_id", "in", (eb) =>
+          eb
+            .selectFrom("mz_objects")
+            .select("id")
+            .where("cluster_id", "=", clusterId),
+        );
+      }
+
+      if (objectIds) {
+        lagHistoryQuery = lagHistoryQuery.where("object_id", "in", objectIds);
+      }
+
       if (lookback.type === "getLatest") {
         // Temporal filter of 2 minutes since the latest will always be within the last minute.
         // This is an optimation to do work on less records.
@@ -132,14 +151,6 @@ export function buildLagHistoryQuery(
           "lag_history.object_id",
           "object_names.id",
         );
-
-      if (clusterId) {
-        cteQuery = cteQuery.where("clusters.id", "=", clusterId);
-      }
-
-      if (objectIds) {
-        cteQuery = cteQuery.where("object_id", "in", objectIds);
-      }
 
       // orderBy and distinctOn inherently gives us the latest max lag per ID since it takes the first row by group
       // using the order specified.


### PR DESCRIPTION
The lag-history query (freshness UI) bins per-object wallclock lag and takes a Top-1 (max lag) per `(bucket, object)`, then joins `mz_objects`/`mz_clusters`/names and only *then* applies the cluster/object filter. Because the filter enters at that final join, the optimizer can't push it into the shared `lag_history_binned` CTE, so the `DISTINCT ON` Top-1 runs over **every object in the environment** and the join discards all but the requested ones.

When a `clusterId` or `objectIds` filter is set, this pushes it into the `lag_history_with_temporal_filter` CTE, before the bin + Top-1:

- `clusterId` → `object_id IN (SELECT id FROM mz_objects WHERE cluster_id = ?)`
- `objectIds` → `object_id IN (?)` directly

`mz_wallclock_global_lag_recent_history` is indexed on `object_id`, so the restricted set becomes a key lookup and the Top-1 only processes the requested objects. The unscoped (environment-wide / `groupByCluster`) path is unchanged. Output is identical; only the filter placement moves.

### Plan evidence (`EXPLAIN` on `mz_catalog_server`)

The lag read goes from a full index scan to a differential-join lookup:

- **before**: `Consolidating Monotonic Top1` over the whole relation; `mz_wallclock_global_lag_recent_history_ind (*** full scan ***)`.
- **after**: Top-1 sits above `Differential Join … » mz_wallclock_global_lag_recent_history[object_id]`; `mz_wallclock_global_lag_recent_history_ind (differential join)`.

### Measured (synthetic fleet, lag shadow indexed on `object_id` like prod)

Single-worker bench cluster (matches `mz_catalog_server`), 10 objects/cluster, ad-hoc peeks. "Concurrency N" = N cluster pages loaded simultaneously (closed-loop; p50 ≈ time each viewer waits). p50 ms.

**OLD (filter after Top-1, full scan):**

| clusters (objects) | 1 | 4 | 16 | 32 |
|---|---|---|---|---|
| 25 (250)   | 70.2 | 253.0 | 1024.1 | 2056.0 |
| 100 (1000) | 249.7 | 979.1 | 3884.9 | 7709.5 |
| 200 (2000) | 481.6 | 1889.4 | 7613.5 | 15244.1 |

**NEW (pushdown → lookup):**

| clusters (objects) | 1 | 4 | 16 | 32 |
|---|---|---|---|---|
| 25 (250)   | 25.4 | 37.3 | 123.8 | 262.5 |
| 100 (1000) | 25.6 | 42.0 | 138.6 | 286.6 |
| 200 (2000) | 26.8 | 49.3 | 160.6 | 338.8 |

**Speedup (old/new p50):**

| clusters | 1 | 4 | 16 | 32 |
|---|---|---|---|---|
| 25  | 2.8× | 6.8× | 8.3× | 7.8× |
| 100 | 9.8× | 23.3× | 28.0× | 26.9× |
| 200 | 18.0× | 38.3× | 47.4× | 45.0× |

**NEW is flat with fleet size** (the lookup touches only the one cluster's objects); OLD scales linearly with the environment's object count and degrades hard under concurrency (15.2 s p50 at 200 clusters / 32 viewers vs 339 ms for NEW). Console-only; no DB change. Same shape as the replica-utilization pushdown.