### PR TITLE
adapter: Route COPY TO to the targeted replica

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -697,6 +697,7 @@ pub struct PeekStageCopyTo {
     optimizer: optimize::copy_to::Optimizer,
     global_lir_plan: optimize::copy_to::GlobalLirPlan,
     optimization_finished_at: EpochMillis,
+    target_replica: Option<ReplicaId>,
     source_ids: BTreeSet<GlobalId>,
 }
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -657,6 +657,7 @@ impl Coordinator {
                                 optimizer,
                                 global_lir_plan,
                                 optimization_finished_at,
+                                target_replica,
                                 source_ids,
                             })
                         }
@@ -931,6 +932,7 @@ impl Coordinator {
             optimizer,
             global_lir_plan,
             optimization_finished_at,
+            target_replica,
             source_ids,
         }: PeekStageCopyTo,
     ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
@@ -964,7 +966,8 @@ impl Coordinator {
         );
 
         // Ship dataflow.
-        self.ship_dataflow(df_desc, cluster_id, None).await;
+        self.ship_dataflow(df_desc, cluster_id, target_replica)
+            .await;
 
         let span = Span::current();
         Ok(StageResult::HandleRetire(mz_ore::task::spawn(


### PR DESCRIPTION
`COPY TO` shipped its dataflow with a hardcoded `None` target replica, so it ignored the session's `cluster_replica` setting and ran on an arbitrary replica. Thread the `target_replica` already resolved by the peek sequencer through `PeekStageCopyTo` into `ship_dataflow`, so `COPY TO` honors `SET cluster_replica` like regular `SELECT` peeks do.