### PR TITLE
Instrument stuck persist blob reads and reclock snapshot hydration

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -444,7 +444,12 @@ pub(crate) async fn fetch_batch_part_blob<T>(
     let blob_key = part.key.complete(shard_id);
     let value = retry_external(&metrics.retries.external.fetch_batch_get, || async {
         shard_metrics.blob_gets.inc();
-        blob.get(&blob_key).await
+        // Name the blob in the error. A GET stuck retrying forever surfaces only in the retry log
+        // (see `retry_external`), which prints the error, so without this the log cannot say which
+        // blob, and thus which shard, is wedged.
+        blob.get(&blob_key)
+            .await
+            .map_err(|err| err.context(format!("blob {blob_key}")))
     })
     .instrument(get_span.clone())
     .await

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -31,7 +31,7 @@ use mz_persist_types::{Codec, Codec64};
 use semver::Version;
 use timely::PartialOrder;
 use timely::progress::{Antichain, Timestamp};
-use tracing::{Instrument, debug, info, trace_span};
+use tracing::{Instrument, debug, info, trace_span, warn};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES;
@@ -1169,6 +1169,12 @@ pub(crate) fn next_listen_batch_retry_params(cfg: &ConfigSet) -> RetryParameters
 
 pub const INFO_MIN_ATTEMPTS: usize = 3;
 
+/// Attempts after which a still-failing retry loop escalates from INFO to WARN.
+/// `retry_external` always uses the persist backoff (clamped at 16s), so this
+/// is roughly five minutes of continuous failure: well past transient retries,
+/// and a sign the operation (e.g. a blob whose GET never returns) is wedged.
+pub const WARN_MIN_ATTEMPTS: usize = 30;
+
 pub async fn retry_external<R, F, WorkFn>(metrics: &RetryMetrics, mut work_fn: WorkFn) -> R
 where
     F: std::future::Future<Output = Result<R, ExternalError>>,
@@ -1187,7 +1193,15 @@ where
                 return x;
             }
             Err(err) => {
-                if retry.attempt() >= INFO_MIN_ATTEMPTS {
+                if retry.attempt() >= WARN_MIN_ATTEMPTS {
+                    warn!(
+                        "external operation {} has failed {} times, retrying in {:?}: {}",
+                        metrics.name,
+                        retry.attempt(),
+                        retry.next_sleep(),
+                        err.display_with_causes()
+                    );
+                } else if retry.attempt() >= INFO_MIN_ATTEMPTS {
                     info!(
                         "external operation {} failed, retrying in {:?}: {}",
                         metrics.name,

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -148,6 +148,14 @@ impl Determinate {
     pub fn new(inner: anyhow::Error) -> Self {
         Determinate { inner }
     }
+
+    /// Adds context to the wrapped error. Mirrors [`anyhow::Error::context`].
+    pub fn context<C>(self, context: C) -> Self
+    where
+        C: fmt::Display + Send + Sync + 'static,
+    {
+        Determinate::new(self.inner.context(context))
+    }
 }
 
 /// An error coming from an underlying durability system (e.g. s3) indicating
@@ -163,6 +171,14 @@ impl Indeterminate {
     /// Exposed for testing.
     pub fn new(inner: anyhow::Error) -> Self {
         Indeterminate { inner }
+    }
+
+    /// Adds context to the wrapped error. Mirrors [`anyhow::Error::context`].
+    pub fn context<C>(self, context: C) -> Self
+    where
+        C: fmt::Display + Send + Sync + 'static,
+    {
+        Indeterminate::new(self.inner.context(context))
     }
 }
 
@@ -216,6 +232,22 @@ impl ExternalError {
     pub fn is_timeout(&self) -> bool {
         // Gross...
         self.to_string().contains("timeout")
+    }
+
+    /// Adds context to the underlying error, preserving the determinate vs
+    /// indeterminate classification. Mirrors [`anyhow::Error::context`].
+    ///
+    /// Callers use this to record which resource an operation was acting on
+    /// (e.g. the blob key being fetched) so the error names it everywhere it is
+    /// displayed.
+    pub fn context<C>(self, context: C) -> Self
+    where
+        C: fmt::Display + Send + Sync + 'static,
+    {
+        match self {
+            ExternalError::Determinate(e) => ExternalError::Determinate(e.context(context)),
+            ExternalError::Indeterminate(e) => ExternalError::Indeterminate(e.context(context)),
+        }
     }
 }
 

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use differential_dataflow::lattice::Lattice;
@@ -153,12 +153,29 @@ where
             "{operator}({id}) {worker_id}/{worker_count} initializing PersistHandle"
         );
 
+        // Own the operator name: the snapshot stream below outlives this call.
+        let operator = operator.to_string();
+
         use futures::stream;
         let events = stream::once(async move {
+            // Bracket the snapshot read. It is the first thing polled and the
+            // point that wedges if the blob store can't serve a batch part, so a
+            // "reading" with no matching "read" pins the stall to the read here.
+            tracing::info!(
+                ?as_of,
+                "{operator}({id}) {worker_id}/{worker_count} reading remap snapshot"
+            );
+            let snapshot_start = Instant::now();
             let updates = read_handle
                 .snapshot_and_fetch(as_of.clone())
                 .await
                 .expect("since <= as_of asserted");
+            tracing::info!(
+                ?as_of,
+                update_count = updates.len(),
+                elapsed = ?snapshot_start.elapsed(),
+                "{operator}({id}) {worker_id}/{worker_count} read remap snapshot"
+            );
             let snapshot = stream::once(std::future::ready(ListenEvent::Updates(updates)));
 
             let listener = read_handle


### PR DESCRIPTION
### Motivation

While investigating DB-64 (a 0dt cutover that hung in `Initializing`), the
root cause was a persist blob `GET` that failed forever against the blob
store, which meant a source never hydrated and the caught-up gate never
opened. Diagnosing it required hand-correlating ~125 MB of service logs,
because none of the layers involved surfaced *why* the read was stuck:

- the blob GET error (`indeterminate: s3 get body err: ...`) named no blob, so
  the retry log that prints it could not say which shard/blob, and thus which
  collection, was wedged;
- a forever-retrying read produced only a steady stream of identical INFO
  lines, never anything louder;
- the source's reclock follower logged "initializing PersistHandle" and then
  nothing, so a source blocked in the snapshot read stalled silently.

This PR adds diagnostic instrumentation so the next occurrence is obvious from
the logs. It does **not** change the cutover behavior: refusing to promote
until everything has caught up is correct and load-bearing, and these changes
only make a stuck gate self-explaining.

### Description

Three independent changes (one per commit):

1. **`persist: name the blob in errors from a stuck fetch`** - the blob GET
   error carried no identifier, so the retry log (which prints the error)
   couldn't name the blob. Add `ExternalError::context`, mirroring
   `anyhow::Error::context`, which adds context while preserving the
   determinate/indeterminate classification, and use it in the batch-part fetch
   to attach the blob key (shard + writer + part). The key then shows up
   wherever the error is displayed, including the retry log, with no plumbing
   through the generic retry helper. Putting it on the error rather than a span
   matters because persist keeps these hot-path fetch spans at debug level, so
   at the default INFO filter the span is never entered and its fields never
   reach the log (verified, see below).

2. **`persist: escalate stuck external-operation retries to WARN`** -
   `retry_external` retries every `ExternalError` forever (backoff clamped at
   16s) and logs at INFO. Escalate to WARN once a loop has failed for many
   attempts. The retry stream already tracks the per-loop attempt count and the
   backoff is fixed, so an attempt threshold maps to a known duration: 30
   attempts is roughly five minutes of continuous failure. The threshold is
   high so transient slowness and ordinary contention stay at INFO. The blob
   from change 1 rides in the error, so an escalated GET names the exact blob.

3. **`storage: log progress around the reclock remap snapshot read`** -
   bracket the remap-shard snapshot read in the reclock follower with INFO
   logs. A "reading remap snapshot" with no following "read remap snapshot"
   pinpoints a source wedged in that read. Scoped to the snapshot boundary on
   purpose: it is the observed dark spot and has full source context, whereas
   the generic reclock sync loop lacks the source id and would be noisier.

### Verification

`cargo fmt` and `cargo check` for `mz-persist`, `mz-persist-client`, and
`mz-storage`.

The span-vs-error question was checked against the actual failing run and with
standalone probes. The failing run's 125 MB of logs contain only INFO and WARN
lines (zero DEBUG), and the retry log there reads
`... timely{name="compute" worker_id=0}: ...: external operation fetch_batch::get failed ...`
with no `fetch_batch::get{...}` span in the context, confirming the debug span
is not entered at INFO, so attaching span fields would not have surfaced
anything. Reconstructing the error chain confirms the chosen approach renders
`external operation fetch_batch::get failed, retrying in 16s: indeterminate: blob <shard>/<writer>/<part>: s3 get body err: ...`,
i.e. the blob is named on the existing log line, while every other
`retry_external` caller is unchanged.
