### PR TITLE
console: scope the materialization-lag subqueries to the requested objects

### DIFF
--- a/console/src/api/materialize/cluster/materializationLag.ts
+++ b/console/src/api/materialize/cluster/materializationLag.ts
@@ -50,13 +50,22 @@ export const buildMaterializationLagQuery = ({
             .as("objects"),
         )
         .leftJoin(
-          qb.selectFrom("mz_hydration_statuses").selectAll().as("hs"),
+          // Scope to the requested objects. Otherwise this scans hydration for
+          // every object in the environment and only the join discards the rest.
+          qb
+            .selectFrom("mz_hydration_statuses")
+            .selectAll()
+            .where("object_id", "in", objectIds)
+            .as("hs"),
           "hs.object_id",
           "objects.id",
         )
         .leftJoin(
           // Get the latest lag values for each object.
           // We use a temporal filter of 5 minutes because the lag values for all objects are updated every minute.
+          // Scope to the requested objects so the per-object Top-1 reads via the
+          // object_id index instead of computing latest-lag for every object in
+          // the environment and discarding all but these in the join.
           qb
             .selectFrom("mz_wallclock_global_lag_recent_history")
             .select(["object_id", "lag"])
@@ -68,6 +77,7 @@ export const buildMaterializationLagQuery = ({
               ">=",
               sql<Date>`mz_now()`,
             )
+            .where("object_id", "in", objectIds)
             .as("ml"),
           "ml.object_id",
           "objects.id",


### PR DESCRIPTION
`buildMaterializationLagQuery` is parameterized by `objectIds` (called from the cluster-detail IndexList / LargestMaintainedQueries views), but its two `LEFT JOIN` subqueries are computed for the **whole environment** and only narrowed by the join:

- the hydration subquery scans all of `mz_hydration_statuses`;
- the lag subquery takes a per-object Top-1 (`DISTINCT ON (object_id)`, latest) over `mz_wallclock_global_lag_recent_history` for **every object**.

This pushes `object_id IN (objectIds)` into both subqueries so the lag Top-1 reads via the `object_id` index instead of computing latest-lag for every object and discarding all but the requested ones in the join.

### Plan evidence (`EXPLAIN` on `mz_catalog_server`)

The lag read changes from a full scan to a lookup:

- **before**: `mz_wallclock_global_lag_recent_history_ind (*** full scan ***)`, Top-1 over the whole relation.
- **after**: Top-1 above `Differential Join … » mz_wallclock_global_lag_recent_history[object_id]`; `mz_wallclock_global_lag_recent_history_ind (lookup)`.

(The hydration read stays a cheap full scan — it's a small current-state relation — so the win comes from the lag lookup.)

### Measured (synthetic fleet, lag shadow indexed on `object_id` like prod)

Single-worker bench cluster, 20 objects/cluster; `objectIds` = one cluster's objects. p50 ms, old → new ("concurrency N" = N page loads at once):

| clusters (objects) | 1 | 4 | 16 | 32 |
|---|---|---|---|---|
| 25 (500)   | 33 → 49 | 60 → 58 | 177 → 149 | 345 → 296 |
| 100 (2000) | 50 → 45 | 129 → 80 | 483 → 244 | 985 → 510 |
| 200 (4000) | 74 → 53 | 225 → 111 | 885 → 366 | 1767 → 797 |

The win scales with environment size: OLD grows with the total object count (single-user 33 → 74 ms across 500 → 4000 objects), NEW stays flatter (49 → 53 ms). At 200 clusters it's ~1.4× single-user and **~2.2–2.4× under concurrency** (saving ~1 s on a busy large environment).

**Trade-off, stated plainly:** at small fleets NEW is a slight single-user regression (33 → 49 ms — the `IN`-lookup's fixed overhead only beats a cheap full scan once the environment is large enough; crossover ~100 clusters / 2000 objects). Both are sub-100 ms there, so the regression is negligible in absolute terms, and the gain is concentrated exactly where the query is actually slow. Output is unchanged (verified row-for-row). Console-only; no DB change.
