### PR TITLE
adapter: linearize timestamp off the coordinator loop for EXPLAIN TIMESTAMP and SUBSCRIBE

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1611,12 +1611,15 @@ impl std::ops::DerefMut for ExecuteContext {
     }
 }
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct ExecuteContextInner {
     tx: ClientTransmitter<ExecuteResponse>,
     internal_cmd_tx: mpsc::UnboundedSender<Message>,
     session: Session,
     extra: ExecuteContextGuard,
+    #[derivative(Debug = "ignore")]
+    response_barriers: Vec<BuiltinTableAppendNotify>,
 }
 
 impl ExecuteContext {
@@ -1647,6 +1650,7 @@ impl ExecuteContext {
                 tx,
                 session,
                 extra,
+                response_barriers: Vec::new(),
                 internal_cmd_tx,
             }
             .into(),
@@ -1674,7 +1678,12 @@ impl ExecuteContext {
             internal_cmd_tx,
             session,
             extra,
+            response_barriers,
         } = *self.inner;
+        assert!(
+            response_barriers.is_empty(),
+            "cannot split ExecuteContext while response barriers are pending"
+        );
         (tx, internal_cmd_tx, session, extra)
     }
 
@@ -1686,24 +1695,23 @@ impl ExecuteContext {
             internal_cmd_tx,
             session,
             extra,
+            response_barriers,
         } = *self.inner;
-        let reason = if extra.is_trivial() {
-            None
+        if response_barriers.is_empty() {
+            retire_execution_context(tx, internal_cmd_tx, session, extra, result);
         } else {
-            Some((&result).into())
-        };
-        tx.send(result, session);
-        if let Some(reason) = reason {
-            // Retire the guard to get the inner ExecuteContextExtra without triggering auto-retire
-            let extra = extra.defuse();
-            if let Err(e) = internal_cmd_tx.send(Message::RetireExecute {
-                otel_ctx: OpenTelemetryContext::obtain(),
-                data: extra,
-                reason,
-            }) {
-                warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-            }
+            spawn(|| "execute_context::retire_after_response_barriers", async move {
+                for barrier in response_barriers {
+                    barrier.await;
+                }
+                retire_execution_context(tx, internal_cmd_tx, session, extra, result);
+            });
         }
+    }
+
+    /// Delays sending this statement's response until `barrier` resolves.
+    pub(crate) fn delay_response_until(&mut self, barrier: BuiltinTableAppendNotify) {
+        self.response_barriers.push(barrier);
     }
 
     pub fn extra(&self) -> &ExecuteContextGuard {
@@ -1712,6 +1720,31 @@ impl ExecuteContext {
 
     pub fn extra_mut(&mut self) -> &mut ExecuteContextGuard {
         &mut self.extra
+    }
+}
+
+fn retire_execution_context(
+    tx: ClientTransmitter<ExecuteResponse>,
+    internal_cmd_tx: mpsc::UnboundedSender<Message>,
+    session: Session,
+    extra: ExecuteContextGuard,
+    result: Result<ExecuteResponse, AdapterError>,
+) {
+    let reason = if extra.is_trivial() {
+        None
+    } else {
+        Some((&result).into())
+    };
+    tx.send(result, session);
+    if let Some(reason) = reason {
+        let extra = extra.defuse();
+        if let Err(e) = internal_cmd_tx.send(Message::RetireExecute {
+            otel_ctx: OpenTelemetryContext::obtain(),
+            data: extra,
+            reason,
+        }) {
+            warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+        }
     }
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -804,6 +804,7 @@ pub struct CreateViewExplain {
 pub enum ExplainTimestampStage {
     Optimize(ExplainTimestampOptimize),
     RealTimeRecency(ExplainTimestampRealTimeRecency),
+    LinearizeTimestamp(ExplainTimestampLinearizeTimestamp),
     Finish(ExplainTimestampFinish),
 }
 
@@ -824,7 +825,7 @@ pub struct ExplainTimestampRealTimeRecency {
 }
 
 #[derive(Debug)]
-pub struct ExplainTimestampFinish {
+pub struct ExplainTimestampLinearizeTimestamp {
     validity: PlanValidity,
     format: ExplainFormat,
     optimized_plan: OptimizedMirRelationExpr,
@@ -832,6 +833,23 @@ pub struct ExplainTimestampFinish {
     source_ids: BTreeSet<GlobalId>,
     when: QueryWhen,
     real_time_recency_ts: Option<Timestamp>,
+}
+
+#[derive(Debug)]
+pub struct ExplainTimestampFinish {
+    validity: PlanValidity,
+    format: ExplainFormat,
+    cluster_id: ClusterId,
+    source_ids: BTreeSet<GlobalId>,
+    when: QueryWhen,
+    real_time_recency_ts: Option<Timestamp>,
+    /// The timeline context derived in the preceding `LinearizeTimestamp`
+    /// stage, carried forward so it stays consistent with `oracle_read_ts`.
+    timeline_context: TimelineContext,
+    /// The linearized read timestamp, read off the coordinator loop in the
+    /// preceding `LinearizeTimestamp` stage. `None` when no linearized read is
+    /// needed.
+    oracle_read_ts: Option<Timestamp>,
 }
 
 #[derive(Debug)]
@@ -970,6 +988,7 @@ pub struct CreateMaterializedViewExplain {
 #[derive(Debug)]
 pub enum SubscribeStage {
     OptimizeMir(SubscribeOptimizeMir),
+    LinearizeTimestamp(SubscribeLinearizeTimestamp),
     TimestampOptimizeLir(SubscribeTimestampOptimizeLir),
     Finish(SubscribeFinish),
     Explain(SubscribeExplain),
@@ -989,6 +1008,20 @@ pub struct SubscribeOptimizeMir {
 }
 
 #[derive(Debug)]
+pub struct SubscribeLinearizeTimestamp {
+    validity: PlanValidity,
+    plan: plan::SubscribePlan,
+    timeline: TimelineContext,
+    optimizer: optimize::subscribe::Optimizer,
+    global_mir_plan: optimize::subscribe::GlobalMirPlan<optimize::subscribe::Unresolved>,
+    dependency_ids: BTreeSet<GlobalId>,
+    replica_id: Option<ReplicaId>,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPLAIN for this statement.
+    explain_ctx: ExplainContext,
+}
+
+#[derive(Debug)]
 pub struct SubscribeTimestampOptimizeLir {
     validity: PlanValidity,
     plan: plan::SubscribePlan,
@@ -997,6 +1030,10 @@ pub struct SubscribeTimestampOptimizeLir {
     global_mir_plan: optimize::subscribe::GlobalMirPlan<optimize::subscribe::Unresolved>,
     dependency_ids: BTreeSet<GlobalId>,
     replica_id: Option<ReplicaId>,
+    /// The linearized read timestamp, read off the coordinator loop in the
+    /// preceding `LinearizeTimestamp` stage. `None` when no linearized read is
+    /// needed.
+    oracle_read_ts: Option<Timestamp>,
     /// An optional context set iff the state machine is initiated from
     /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1700,12 +1700,15 @@ impl ExecuteContext {
         if response_barriers.is_empty() {
             retire_execution_context(tx, internal_cmd_tx, session, extra, result);
         } else {
-            spawn(|| "execute_context::retire_after_response_barriers", async move {
-                for barrier in response_barriers {
-                    barrier.await;
-                }
-                retire_execution_context(tx, internal_cmd_tx, session, extra, result);
-            });
+            spawn(
+                || "execute_context::retire_after_response_barriers",
+                async move {
+                    for barrier in response_barriers {
+                        barrier.await;
+                    }
+                    retire_execution_context(tx, internal_cmd_tx, session, extra, result);
+                },
+            );
         }
     }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1645,12 +1645,22 @@ impl ExecuteContext {
         session: Session,
         extra: ExecuteContextGuard,
     ) -> Self {
+        Self::from_parts_with_response_barriers(tx, internal_cmd_tx, session, extra, Vec::new())
+    }
+
+    pub fn from_parts_with_response_barriers(
+        tx: ClientTransmitter<ExecuteResponse>,
+        internal_cmd_tx: mpsc::UnboundedSender<Message>,
+        session: Session,
+        extra: ExecuteContextGuard,
+        response_barriers: Vec<BuiltinTableAppendNotify>,
+    ) -> Self {
         Self {
             inner: ExecuteContextInner {
                 tx,
                 session,
                 extra,
-                response_barriers: Vec::new(),
+                response_barriers,
                 internal_cmd_tx,
             }
             .into(),
@@ -1664,7 +1674,8 @@ impl ExecuteContext {
     /// the coordinator and the pgwire layer. As part of any such
     /// protocol, we must ensure that the `ExecuteContextGuard`
     /// (possibly wrapped in a new `ExecuteContext`) is passed back to the coordinator for
-    /// eventual retirement.
+    /// eventual retirement. The returned response barriers must stay attached
+    /// to the user-visible response path.
     pub fn into_parts(
         self,
     ) -> (
@@ -1672,6 +1683,7 @@ impl ExecuteContext {
         mpsc::UnboundedSender<Message>,
         Session,
         ExecuteContextGuard,
+        Vec<BuiltinTableAppendNotify>,
     ) {
         let ExecuteContextInner {
             tx,
@@ -1680,11 +1692,7 @@ impl ExecuteContext {
             extra,
             response_barriers,
         } = *self.inner;
-        assert!(
-            response_barriers.is_empty(),
-            "cannot split ExecuteContext while response barriers are pending"
-        );
-        (tx, internal_cmd_tx, session, extra)
+        (tx, internal_cmd_tx, session, extra, response_barriers)
     }
 
     /// Retire the execution, by sending a message to the coordinator.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -189,7 +189,8 @@ use crate::config::{
     SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig,
 };
 use crate::coord::appends::{
-    BuiltinTableAppendNotify, DeferredOp, GroupCommitPermit, PendingWriteTxn,
+    BuiltinTableAppendCompletion, BuiltinTableAppendNotify, DeferredOp, GroupCommitPermit,
+    PendingWriteTxn,
 };
 use crate::coord::caught_up::CaughtUpCheckContext;
 use crate::coord::cluster_scheduling::SchedulingDecision;
@@ -1721,8 +1722,8 @@ impl ExecuteContext {
     }
 
     /// Delays sending this statement's response until `barrier` resolves.
-    pub(crate) fn delay_response_until(&mut self, barrier: BuiltinTableAppendNotify) {
-        self.response_barriers.push(barrier);
+    pub(crate) fn delay_response_until(&mut self, barrier: BuiltinTableAppendCompletion) {
+        self.response_barriers.push(barrier.into_notify());
     }
 
     pub fn extra(&self) -> &ExecuteContextGuard {

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -737,6 +737,21 @@ pub struct BuiltinTableAppend<'a> {
 /// wait for it to complete, while other long running tasks are concurrently executing.
 pub type BuiltinTableAppendNotify = Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>>;
 
+/// Completion handle for a builtin-table append response barrier.
+pub struct BuiltinTableAppendCompletion {
+    notify: BuiltinTableAppendNotify,
+}
+
+impl BuiltinTableAppendCompletion {
+    pub fn new(notify: BuiltinTableAppendNotify) -> Self {
+        Self { notify }
+    }
+
+    pub fn into_notify(self) -> BuiltinTableAppendNotify {
+        self.notify
+    }
+}
+
 impl<'a> BuiltinTableAppend<'a> {
     /// Submit a write to a system table to be executed during the next group commit. This method
     /// __does not__ trigger a group commit.

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -727,6 +727,11 @@ pub struct BuiltinTableAppend<'a> {
 
 /// `Future` that notifies when a builtin table write has completed.
 ///
+/// Callers that expose completion of an operation whose builtin-table write is
+/// user-observable should await this future before sending that completion. It
+/// is safe to drop the future only when the caller does not provide such an
+/// ordering guarantee, or when the future is known to resolve immediately.
+///
 /// Note: builtin table writes need to talk to persist, which can take 100s of milliseconds. This
 /// type allows you to execute a builtin table write, e.g. via [`BuiltinTableAppend::execute`], and
 /// wait for it to complete, while other long running tasks are concurrently executing.

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -835,19 +835,6 @@ impl<'a> BuiltinTableAppend<'a> {
 
         (Box::pin(rx.map(|_| ())), Some(write_ts))
     }
-
-    /// Submit a write to a system table, blocking until complete.
-    ///
-    /// Note: if possible you should use the `execute(...)` method, which returns a `Future` that
-    /// can be `await`-ed concurrently with other tasks.
-    ///
-    /// Note: When in read-only mode, this will buffer the update and the
-    /// returned future will resolve immediately, without the update actually
-    /// having been written.
-    pub async fn blocking(self, updates: Vec<BuiltinTableUpdate>) {
-        let (notify, _) = self.execute(updates).await;
-        notify.await;
-    }
 }
 
 /// Returns two sides of a "channel" that can be used to notify the coordinator when we want a

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -959,8 +959,10 @@ impl Coordinator {
             }
 
             if !active_compute_sinks_to_drop.is_empty() {
-                self.retire_compute_sinks(active_compute_sinks_to_drop)
-                    .await;
+                let retire_notify = self.retire_compute_sinks(active_compute_sinks_to_drop).await;
+                if let Some(ctx) = ctx {
+                    ctx.delay_response_until(retire_notify);
+                }
             }
 
             if !peeks_to_drop.is_empty() {

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -959,7 +959,9 @@ impl Coordinator {
             }
 
             if !active_compute_sinks_to_drop.is_empty() {
-                let retire_notify = self.retire_compute_sinks(active_compute_sinks_to_drop).await;
+                let retire_notify = self
+                    .retire_compute_sinks(active_compute_sinks_to_drop)
+                    .await;
                 if let Some(ctx) = ctx {
                     ctx.delay_response_until(retire_notify);
                 }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -346,6 +346,8 @@ impl Coordinator {
                     // Part of the Command::Commit contract is that the Coordinator guarantees that
                     // it has cleared its transaction state for the connection.
                     let retire_notify = self.clear_connection(&conn_id).await;
+                    // `sequence_plan` has already handled the client response.
+                    // This call only satisfies the internal cleanup contract.
                     drop(retire_notify);
                 }
 
@@ -1932,6 +1934,8 @@ impl Coordinator {
         self.cancel_pending_peeks(&conn_id);
         self.cancel_pending_watchsets(&conn_id);
         let retire_notify = self.cancel_compute_sinks_for_conn(&conn_id).await;
+        // SQL cancellation has no success response to delay. Each subscribe
+        // still waits for its own retraction before it observes retirement.
         drop(retire_notify);
         self.cancel_cluster_reconfigurations_for_conn(&conn_id)
             .await;
@@ -1958,6 +1962,8 @@ impl Coordinator {
         // We do not need to call clear_transaction here because there are no side effects to run
         // based on any session transaction state.
         let retire_notify = self.clear_connection(&conn_id).await;
+        // Termination has no statement response to delay. Each subscribe still
+        // waits for its own retraction before it observes retirement.
         drop(retire_notify);
 
         self.drop_temp_items(&conn_id).await;

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -345,7 +345,8 @@ impl Coordinator {
                         .await;
                     // Part of the Command::Commit contract is that the Coordinator guarantees that
                     // it has cleared its transaction state for the connection.
-                    self.clear_connection(&conn_id).await;
+                    let retire_notify = self.clear_connection(&conn_id).await;
+                    drop(retire_notify);
                 }
 
                 Command::CatalogSnapshot { tx } => {
@@ -1930,7 +1931,8 @@ impl Coordinator {
 
         self.cancel_pending_peeks(&conn_id);
         self.cancel_pending_watchsets(&conn_id);
-        self.cancel_compute_sinks_for_conn(&conn_id).await;
+        let retire_notify = self.cancel_compute_sinks_for_conn(&conn_id).await;
+        drop(retire_notify);
         self.cancel_cluster_reconfigurations_for_conn(&conn_id)
             .await;
         self.cancel_pending_copy(&conn_id);
@@ -1955,7 +1957,8 @@ impl Coordinator {
 
         // We do not need to call clear_transaction here because there are no side effects to run
         // based on any session transaction state.
-        self.clear_connection(&conn_id).await;
+        let retire_notify = self.clear_connection(&conn_id).await;
+        drop(retire_notify);
 
         self.drop_temp_items(&conn_id).await;
         // Only call catalog_mut() if a temporary schema actually exists for this connection.

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -471,7 +471,7 @@ impl Coordinator {
                         statement_logging_id,
                         self.internal_cmd_tx.clone(),
                     );
-                    let result = self
+                    match self
                         .implement_subscribe(
                             &mut ctx_extra,
                             df_desc,
@@ -483,8 +483,21 @@ impl Coordinator {
                             read_holds,
                             plan,
                         )
-                        .await;
-                    let _ = tx.send(result);
+                        .await
+                    {
+                        Ok((resp, write_notify)) => {
+                            // Wait for the `mz_subscriptions` bookkeeping write to be durable
+                            // off the coordinator loop before responding, so we don't block
+                            // the loop on a group commit.
+                            task::spawn(|| "execute_subscribe::await_bookkeeping", async move {
+                                write_notify.await;
+                                let _ = tx.send(Ok(resp));
+                            });
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(e));
+                        }
+                    }
                 }
 
                 Command::CopyToPreflight {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -486,9 +486,9 @@ impl Coordinator {
                         .await
                     {
                         Ok((resp, write_notify)) => {
-                            // Wait for the `mz_subscriptions` bookkeeping write to be durable
-                            // off the coordinator loop before responding, so we don't block
-                            // the loop on a group commit.
+                            // Wait for the `mz_subscriptions` bookkeeping write off the
+                            // coordinator loop before returning the `SUBSCRIBE` response to
+                            // the subscribing session.
                             task::spawn(|| "execute_subscribe::await_bookkeeping", async move {
                                 write_notify.await;
                                 let _ = tx.send(Ok(resp));

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -772,7 +772,10 @@ impl Coordinator {
 
     /// Cancels all active compute sinks for the identified connection.
     #[mz_ore::instrument(level = "debug")]
-    pub(crate) async fn cancel_compute_sinks_for_conn(&mut self, conn_id: &ConnectionId) {
+    pub(crate) async fn cancel_compute_sinks_for_conn(
+        &mut self,
+        conn_id: &ConnectionId,
+    ) -> BuiltinTableAppendNotify {
         self.retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Canceled)
             .await
     }
@@ -793,7 +796,7 @@ impl Coordinator {
         &mut self,
         conn_id: &ConnectionId,
         reason: ActiveComputeSinkRetireReason,
-    ) {
+    ) -> BuiltinTableAppendNotify {
         let drop_sinks = self
             .active_conns
             .get_mut(conn_id)
@@ -802,8 +805,7 @@ impl Coordinator {
             .iter()
             .map(|sink_id| (*sink_id, reason.clone()))
             .collect();
-        let retire_notify = self.retire_compute_sinks(drop_sinks).await;
-        drop(retire_notify);
+        self.retire_compute_sinks(drop_sinks).await
     }
 
     /// Cleans pending cluster reconfiguraiotns for the identified connection

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -52,7 +52,7 @@ use tracing::{Instrument, Level, event, info_span, warn};
 use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
 use crate::catalog::{DropObjectInfo, Op, ReplicaCreateDropReason, TransactionResult};
 use crate::coord::Coordinator;
-use crate::coord::appends::BuiltinTableAppendNotify;
+use crate::coord::appends::{BuiltinTableAppendCompletion, BuiltinTableAppendNotify};
 use crate::coord::catalog_implications::parsed_state_updates::ParsedStateUpdate;
 use crate::session::{Session, Transaction, TransactionOps};
 use crate::telemetry::{EventDetails, SegmentClientExt};
@@ -701,7 +701,7 @@ impl Coordinator {
     pub async fn retire_compute_sinks(
         &mut self,
         mut reasons: BTreeMap<GlobalId, ActiveComputeSinkRetireReason>,
-    ) -> BuiltinTableAppendNotify {
+    ) -> BuiltinTableAppendCompletion {
         let sink_ids = reasons.keys().cloned();
         let to_retire: Vec<_> = self
             .drop_compute_sinks(sink_ids)
@@ -728,9 +728,9 @@ impl Coordinator {
             }
             let _ = done_tx.send(());
         });
-        Box::pin(async move {
+        BuiltinTableAppendCompletion::new(Box::pin(async move {
             let _ = done_rx.await;
-        })
+        }))
     }
 
     /// Drops all pending replicas for a set of clusters
@@ -775,7 +775,7 @@ impl Coordinator {
     pub(crate) async fn cancel_compute_sinks_for_conn(
         &mut self,
         conn_id: &ConnectionId,
-    ) -> BuiltinTableAppendNotify {
+    ) -> BuiltinTableAppendCompletion {
         self.retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Canceled)
             .await
     }
@@ -796,7 +796,7 @@ impl Coordinator {
         &mut self,
         conn_id: &ConnectionId,
         reason: ActiveComputeSinkRetireReason,
-    ) -> BuiltinTableAppendNotify {
+    ) -> BuiltinTableAppendCompletion {
         let drop_sinks = self
             .active_conns
             .get_mut(conn_id)

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -638,7 +638,10 @@ impl Coordinator {
     /// sink was known to the controller. It is the caller's responsibility to
     /// retire the returned sink. Consider using `retire_compute_sinks` instead.
     #[must_use]
-    pub async fn drop_compute_sink(&mut self, sink_id: GlobalId) -> Option<ActiveComputeSink> {
+    pub async fn drop_compute_sink(
+        &mut self,
+        sink_id: GlobalId,
+    ) -> Option<(ActiveComputeSink, BuiltinTableAppendNotify)> {
         self.drop_compute_sinks([sink_id]).await.remove(&sink_id)
     }
 
@@ -647,18 +650,20 @@ impl Coordinator {
     /// For each sink that exists, the coordinator and controller's state
     /// associated with the sink is removed.
     ///
-    /// Returns a map containing the controller's state for each sink that was
-    /// removed. It is the caller's responsibility to retire the returned sinks.
-    /// Consider using `retire_compute_sinks` instead.
+    /// Returns a map from sink id to the controller's state for the sink and a notify that
+    /// resolves once the sink's `mz_subscriptions` retraction is durable (see
+    /// `remove_active_compute_sink`). It is the caller's responsibility to await the notify
+    /// off the coordinator loop and then retire the returned sinks. Consider using
+    /// `retire_compute_sinks` instead.
     #[must_use]
     pub async fn drop_compute_sinks(
         &mut self,
         sink_ids: impl IntoIterator<Item = GlobalId>,
-    ) -> BTreeMap<GlobalId, ActiveComputeSink> {
+    ) -> BTreeMap<GlobalId, (ActiveComputeSink, BuiltinTableAppendNotify)> {
         let mut by_id = BTreeMap::new();
         let mut by_cluster: BTreeMap<_, Vec<_>> = BTreeMap::new();
         for sink_id in sink_ids {
-            let sink = match self.remove_active_compute_sink(sink_id).await {
+            let (sink, write_notify) = match self.remove_active_compute_sink(sink_id).await {
                 None => {
                     // This can happen due to a race condition: an internal
                     // subscribe may be cleaned up via its own message while
@@ -667,14 +672,14 @@ impl Coordinator {
                     tracing::debug!(%sink_id, "drop_compute_sinks: sink already removed");
                     continue;
                 }
-                Some(sink) => sink,
+                Some(entry) => entry,
             };
 
             by_cluster
                 .entry(sink.cluster_id())
                 .or_default()
                 .push(sink_id);
-            by_id.insert(sink_id, sink);
+            by_id.insert(sink_id, (sink, write_notify));
         }
         for (cluster_id, ids) in by_cluster {
             let compute = &mut self.controller.compute;
@@ -697,12 +702,30 @@ impl Coordinator {
         mut reasons: BTreeMap<GlobalId, ActiveComputeSinkRetireReason>,
     ) {
         let sink_ids = reasons.keys().cloned();
-        for (id, sink) in self.drop_compute_sinks(sink_ids).await {
-            let reason = reasons
-                .remove(&id)
-                .expect("all returned IDs are in `reasons`");
-            sink.retire(reason);
-        }
+        let to_retire: Vec<_> = self
+            .drop_compute_sinks(sink_ids)
+            .await
+            .into_iter()
+            .map(|(id, (sink, write_notify))| {
+                let reason = reasons
+                    .remove(&id)
+                    .expect("all returned IDs are in `reasons`");
+                (sink, write_notify, reason)
+            })
+            .collect();
+
+        // Retire off the coordinator loop. We wait for each `mz_subscriptions` retraction
+        // to be durable before telling the client the sink is gone, so a client that
+        // observes the retirement and then queries `mz_subscriptions` does not see the
+        // stale row. The wait must not happen on the loop: that would block every other
+        // session on the group-commit oracle round trip, which is the whole point of
+        // deferring the write.
+        task::spawn(|| "retire_compute_sinks", async move {
+            for (sink, write_notify, reason) in to_retire {
+                write_notify.await;
+                sink.retire(reason);
+            }
+        });
     }
 
     /// Drops all pending replicas for a set of clusters

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -696,11 +696,12 @@ impl Coordinator {
     /// Retires a batch of sinks with disparate reasons for retirement.
     ///
     /// Each sink identified in `reasons` is dropped (see `drop_compute_sinks`),
-    /// then retired with its corresponding reason.
+    /// then retired with its corresponding reason. Returns a notify that resolves
+    /// once all `mz_subscriptions` retractions are durable and the sinks are retired.
     pub async fn retire_compute_sinks(
         &mut self,
         mut reasons: BTreeMap<GlobalId, ActiveComputeSinkRetireReason>,
-    ) {
+    ) -> BuiltinTableAppendNotify {
         let sink_ids = reasons.keys().cloned();
         let to_retire: Vec<_> = self
             .drop_compute_sinks(sink_ids)
@@ -715,17 +716,21 @@ impl Coordinator {
             .collect();
 
         // Retire off the coordinator loop. We wait for each `mz_subscriptions` retraction
-        // to be durable before telling the client the sink is gone, so a client that
-        // observes the retirement and then queries `mz_subscriptions` does not see the
-        // stale row. The wait must not happen on the loop: that would block every other
-        // session on the group-commit oracle round trip, which is the whole point of
-        // deferring the write.
+        // before telling the subscribing client that the sink is gone. The returned notify
+        // lets statements that caused the retirement also wait before sending their response.
+        // The wait must not happen on the loop, since that would block every other session
+        // on the group-commit oracle round trip.
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
         task::spawn(|| "retire_compute_sinks", async move {
             for (sink, write_notify, reason) in to_retire {
                 write_notify.await;
                 sink.retire(reason);
             }
+            let _ = done_tx.send(());
         });
+        Box::pin(async move {
+            let _ = done_rx.await;
+        })
     }
 
     /// Drops all pending replicas for a set of clusters
@@ -797,7 +802,8 @@ impl Coordinator {
             .iter()
             .map(|sink_id| (*sink_id, reason.clone()))
             .collect();
-        self.retire_compute_sinks(drop_sinks).await;
+        let retire_notify = self.retire_compute_sinks(drop_sinks).await;
+        drop(retire_notify);
     }
 
     /// Cleans pending cluster reconfiguraiotns for the identified connection

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -683,6 +683,8 @@ impl Coordinator {
                                 sink_id => ActiveComputeSinkRetireReason::Finished,
                             })
                             .await;
+                        // `retire_compute_sinks` waits before sending the terminal
+                        // SUBSCRIBE response. There is no separate statement response here.
                         drop(retire_notify);
                     }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -678,10 +678,11 @@ impl Coordinator {
                 {
                     let finished = active_subscribe.process_response(response);
                     if finished {
-                        self.retire_compute_sinks(btreemap! {
+                        let retire_notify = self.retire_compute_sinks(btreemap! {
                             sink_id => ActiveComputeSinkRetireReason::Finished,
                         })
                         .await;
+                        drop(retire_notify);
                     }
 
                     soft_assert_or_log!(

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -678,10 +678,11 @@ impl Coordinator {
                 {
                     let finished = active_subscribe.process_response(response);
                     if finished {
-                        let retire_notify = self.retire_compute_sinks(btreemap! {
-                            sink_id => ActiveComputeSinkRetireReason::Finished,
-                        })
-                        .await;
+                        let retire_notify = self
+                            .retire_compute_sinks(btreemap! {
+                                sink_id => ActiveComputeSinkRetireReason::Finished,
+                            })
+                            .await;
                         drop(retire_notify);
                     }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -699,7 +699,7 @@ impl Coordinator {
             }
             ControllerResponse::CopyToResponse(sink_id, response) => {
                 match self.drop_compute_sink(sink_id).await {
-                    Some(ActiveComputeSink::CopyTo(active_copy_to)) => {
+                    Some((ActiveComputeSink::CopyTo(active_copy_to), _write_notify)) => {
                         active_copy_to.retire_with_response(response);
                     }
                     _ => {

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -1446,10 +1446,7 @@ impl crate::coord::Coordinator {
         };
 
         // Add metadata for the new COPY TO. CopyTo returns a `ready` future, so it is safe to drop.
-        drop(
-            self.add_active_compute_sink(sink_id, ActiveComputeSink::CopyTo(active_copy_to))
-                .await,
-        );
+        drop(self.add_active_compute_sink(sink_id, ActiveComputeSink::CopyTo(active_copy_to)));
 
         // Try to ship the dataflow. We handle errors gracefully because dependencies might have
         // disappeared during sequencing.

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -543,7 +543,8 @@ impl Coordinator {
                 }
                 Plan::DiscardAll => {
                     let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
-                        self.clear_transaction(ctx.session_mut()).await;
+                        let (_, retire_notify) = self.clear_transaction(ctx.session_mut()).await;
+                        ctx.delay_response_until(retire_notify);
                         self.drop_temp_items(ctx.session().conn_id()).await;
                         ctx.session_mut().reset();
                         Ok(ExecuteResponse::DiscardedAll)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -604,18 +604,32 @@ impl Coordinator {
                 Plan::Execute(plan) => {
                     match self.sequence_execute(ctx.session_mut(), plan) {
                         Ok(portal_name) => {
-                            let (tx, _, session, extra) = ctx.into_parts();
-                            self.internal_cmd_tx
-                                .send(Message::Command(
-                                    OpenTelemetryContext::obtain(),
-                                    Command::Execute {
-                                        portal_name,
-                                        session,
-                                        tx: tx.take(),
-                                        outer_ctx_extra: Some(extra),
+                            let (tx, _, session, extra, response_barriers) = ctx.into_parts();
+                            let command = Message::Command(
+                                OpenTelemetryContext::obtain(),
+                                Command::Execute {
+                                    portal_name,
+                                    session,
+                                    tx: tx.take(),
+                                    outer_ctx_extra: Some(extra),
+                                },
+                            );
+                            if response_barriers.is_empty() {
+                                self.internal_cmd_tx
+                                    .send(command)
+                                    .expect("sending to self.internal_cmd_tx cannot fail");
+                            } else {
+                                let internal_cmd_tx = self.internal_cmd_tx.clone();
+                                mz_ore::task::spawn(
+                                    || "execute_after_response_barriers",
+                                    async move {
+                                        for barrier in response_barriers {
+                                            barrier.await;
+                                        }
+                                        let _ = internal_cmd_tx.send(command);
                                     },
-                                ))
-                                .expect("sending to self.internal_cmd_tx cannot fail");
+                                );
+                            }
                         }
                         Err(err) => ctx.retire(Err(err)),
                     };
@@ -702,7 +716,7 @@ impl Coordinator {
         params: Params,
     ) {
         // Put the session into single statement implicit so anything can execute.
-        let (tx, internal_cmd_tx, mut session, extra) = ctx.into_parts();
+        let (tx, internal_cmd_tx, mut session, extra, response_barriers) = ctx.into_parts();
         assert!(matches!(session.transaction(), TransactionStatus::Default));
         session.start_transaction_single_stmt(self.now_datetime());
         let conn_id = session.conn_id().unhandled();
@@ -710,7 +724,13 @@ impl Coordinator {
         // Execute the saved statement in a temp transmitter so we can run COMMIT.
         let (sub_tx, sub_rx) = oneshot::channel();
         let sub_ct = ClientTransmitter::new(sub_tx, self.internal_cmd_tx.clone());
-        let sub_ctx = ExecuteContext::from_parts(sub_ct, internal_cmd_tx, session, extra);
+        let sub_ctx = ExecuteContext::from_parts_with_response_barriers(
+            sub_ct,
+            internal_cmd_tx,
+            session,
+            extra,
+            response_barriers,
+        );
         self.handle_execute_inner(stmt, params, sub_ctx).await;
 
         // The response can need off-thread processing. Wait for it elsewhere so the coordinator can

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -65,6 +65,7 @@ use mz_sql::plan::{
 };
 use mz_sql::pure::{PurifiedSourceExport, generate_subsource_statements};
 use mz_storage_types::sinks::StorageSinkDesc;
+use mz_timestamp_oracle::TimestampOracle;
 // Import `plan` module, but only import select elements to avoid merge conflicts on use statements.
 use mz_sql::plan::{
     AlterConnectionAction, AlterConnectionPlan, CreateSourcePlanBundle, ExplainSinkSchemaPlan,
@@ -146,6 +147,30 @@ macro_rules! return_if_err {
 }
 
 pub(super) use return_if_err;
+
+fn spawn_linearized_read_ts<S>(
+    oracle: Option<Arc<dyn TimestampOracle<Timestamp> + Send + Sync>>,
+    name: &'static str,
+    build_stage: impl FnOnce(Option<Timestamp>) -> S + Send + 'static,
+) -> StageResult<Box<S>>
+where
+    S: Send + 'static,
+{
+    match oracle {
+        Some(oracle) => {
+            let span = Span::current();
+            StageResult::Handle(mz_ore::task::spawn(
+                move || name,
+                async move {
+                    let oracle_read_ts = oracle.read_ts().await;
+                    Ok(Box::new(build_stage(Some(oracle_read_ts))))
+                }
+                .instrument(span),
+            ))
+        }
+        None => StageResult::Immediate(Box::new(build_stage(None))),
+    }
+}
 
 struct DropOps {
     ops: Vec<catalog::Op>,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2206,7 +2206,8 @@ impl Coordinator {
         ctx: &mut ExecuteContext,
         action: EndTransactionAction,
     ) -> Result<(Option<TransactionOps>, Option<WriteLocks>), AdapterError> {
-        let txn = self.clear_transaction(ctx.session_mut()).await;
+        let (txn, retire_notify) = self.clear_transaction(ctx.session_mut()).await;
+        ctx.delay_response_until(retire_notify);
 
         if let EndTransactionAction::Commit = action {
             if let (Some(mut ops), write_lock_guards) = txn.into_ops_and_lock_guard() {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2824,7 +2824,7 @@ impl Coordinator {
 
         let (peek_tx, peek_rx) = oneshot::channel();
         let peek_client_tx = ClientTransmitter::new(peek_tx, self.internal_cmd_tx.clone());
-        let (tx, _, session, extra) = ctx.into_parts();
+        let (tx, _, session, extra, response_barriers) = ctx.into_parts();
         // We construct a new execute context for the peek, with a trivial (`Default::default()`)
         // execution context, because this peek does not directly correspond to an execute,
         // and so we don't need to take any action on its retirement.
@@ -2877,8 +2877,13 @@ impl Coordinator {
                     session,
                     otel_ctx,
                 }) => {
-                    let ctx =
-                        ExecuteContext::from_parts(tx, internal_cmd_tx.clone(), session, extra);
+                    let ctx = ExecuteContext::from_parts_with_response_barriers(
+                        tx,
+                        internal_cmd_tx.clone(),
+                        session,
+                        extra,
+                        response_barriers,
+                    );
                     otel_ctx.attach_as_parent();
                     ctx.retire(Err(e));
                     return;
@@ -2886,7 +2891,13 @@ impl Coordinator {
                 // It is not an error for these results to be ready after `peek_client_tx` has been dropped.
                 Err(e) => return warn!("internal_cmd_rx dropped before we could send: {:?}", e),
             };
-            let mut ctx = ExecuteContext::from_parts(tx, internal_cmd_tx.clone(), session, extra);
+            let mut ctx = ExecuteContext::from_parts_with_response_barriers(
+                tx,
+                internal_cmd_tx.clone(),
+                session,
+                extra,
+                response_barriers,
+            );
             let mut timeout_dur = *ctx.session().vars().statement_timeout();
 
             // Timeout of 0 is equivalent to "off", meaning we will wait "forever."

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -69,17 +69,24 @@ impl Coordinator {
         // CopyData/CopyDone exchange. URL/S3 sources stage a one-shot ingestion
         // server-side and fall through to the rest of this function.
         if let CopyFromSource::Stdin = plan.source {
-            let (tx, _, session, ctx_extra) = ctx.into_parts();
-            tx.send(
-                Ok(ExecuteResponse::CopyFrom {
-                    target_id: plan.target_id,
-                    target_name: plan.target_name,
-                    columns: plan.columns,
-                    params: plan.params,
-                    ctx_extra,
-                }),
-                session,
-            );
+            let (tx, _, session, ctx_extra, response_barriers) = ctx.into_parts();
+            let response = Ok(ExecuteResponse::CopyFrom {
+                target_id: plan.target_id,
+                target_name: plan.target_name,
+                columns: plan.columns,
+                params: plan.params,
+                ctx_extra,
+            });
+            if response_barriers.is_empty() {
+                tx.send(response, session);
+            } else {
+                mz_ore::task::spawn(|| "copy_from_stdin_after_response_barriers", async move {
+                    for barrier in response_barriers {
+                        barrier.await;
+                    }
+                    tx.send(response, session);
+                });
+            }
             return;
         }
 

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -21,7 +21,7 @@ use mz_sql::plan::{self};
 use mz_sql::session::metadata::SessionMetadata;
 use tracing::{Instrument, Span};
 
-use crate::coord::sequencer::inner::return_if_err;
+use crate::coord::sequencer::inner::{return_if_err, spawn_linearized_read_ts};
 use crate::coord::timestamp_selection::{TimestampDetermination, TimestampSource};
 use crate::coord::{
     Coordinator, ExplainTimestampFinish, ExplainTimestampLinearizeTimestamp,
@@ -268,22 +268,11 @@ impl Coordinator {
             })
         };
 
-        match oracle {
-            Some(oracle) => {
-                // We ship the timestamp oracle off to an async task, so that we
-                // don't block the main task while we wait.
-                let span = Span::current();
-                Ok(StageResult::Handle(mz_ore::task::spawn(
-                    || "explain timestamp linearize timestamp",
-                    async move {
-                        let oracle_read_ts = oracle.read_ts().await;
-                        Ok(Box::new(build_stage(Some(oracle_read_ts))))
-                    }
-                    .instrument(span),
-                )))
-            }
-            None => Ok(StageResult::Immediate(Box::new(build_stage(None)))),
-        }
+        Ok(spawn_linearized_read_ts(
+            oracle,
+            "explain timestamp linearize timestamp",
+            build_stage,
+        ))
     }
 
     pub(crate) fn explain_timestamp(

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -16,7 +16,7 @@ use mz_controller_types::ClusterId;
 use mz_expr::CollectionPlan;
 use mz_ore::instrument;
 use mz_repr::explain::ExplainFormat;
-use mz_repr::{Datum, Row};
+use mz_repr::{Datum, Row, Timestamp};
 use mz_sql::plan::{self};
 use mz_sql::session::metadata::SessionMetadata;
 use tracing::{Instrument, Span};
@@ -24,8 +24,9 @@ use tracing::{Instrument, Span};
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::timestamp_selection::{TimestampDetermination, TimestampSource};
 use crate::coord::{
-    Coordinator, ExplainTimestampFinish, ExplainTimestampOptimize, ExplainTimestampRealTimeRecency,
-    ExplainTimestampStage, Message, PlanValidity, StageResult, Staged, TargetCluster,
+    Coordinator, ExplainTimestampFinish, ExplainTimestampLinearizeTimestamp,
+    ExplainTimestampOptimize, ExplainTimestampRealTimeRecency, ExplainTimestampStage, Message,
+    PlanValidity, StageResult, Staged, TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::optimize::{self, Optimize};
@@ -39,6 +40,7 @@ impl Staged for ExplainTimestampStage {
         match self {
             ExplainTimestampStage::Optimize(stage) => &mut stage.validity,
             ExplainTimestampStage::RealTimeRecency(stage) => &mut stage.validity,
+            ExplainTimestampStage::LinearizeTimestamp(stage) => &mut stage.validity,
             ExplainTimestampStage::Finish(stage) => &mut stage.validity,
         }
     }
@@ -55,10 +57,13 @@ impl Staged for ExplainTimestampStage {
                     .explain_timestamp_real_time_recency(ctx.session(), stage)
                     .await
             }
-            ExplainTimestampStage::Finish(stage) => {
+            ExplainTimestampStage::LinearizeTimestamp(stage) => {
                 coord
-                    .explain_timestamp_finish(ctx.session_mut(), stage)
+                    .explain_timestamp_linearize_timestamp(ctx.session(), stage)
                     .await
+            }
+            ExplainTimestampStage::Finish(stage) => {
+                coord.explain_timestamp_finish(ctx.session_mut(), stage)
             }
         }
     }
@@ -190,22 +195,24 @@ impl Coordinator {
                     async move {
                         let real_time_recency_ts =
                             Coordinator::await_real_time_recent_timestamp(catalog, fut).await?;
-                        let stage = ExplainTimestampStage::Finish(ExplainTimestampFinish {
-                            validity,
-                            format,
-                            optimized_plan,
-                            cluster_id,
-                            source_ids,
-                            when,
-                            real_time_recency_ts: Some(real_time_recency_ts),
-                        });
+                        let stage = ExplainTimestampStage::LinearizeTimestamp(
+                            ExplainTimestampLinearizeTimestamp {
+                                validity,
+                                format,
+                                optimized_plan,
+                                cluster_id,
+                                source_ids,
+                                when,
+                                real_time_recency_ts: Some(real_time_recency_ts),
+                            },
+                        );
                         Ok(Box::new(stage))
                     }
                     .instrument(span),
                 )))
             }
             None => Ok(StageResult::Immediate(Box::new(
-                ExplainTimestampStage::Finish(ExplainTimestampFinish {
+                ExplainTimestampStage::LinearizeTimestamp(ExplainTimestampLinearizeTimestamp {
                     validity,
                     format,
                     optimized_plan,
@@ -215,6 +222,67 @@ impl Coordinator {
                     real_time_recency_ts: None,
                 }),
             ))),
+        }
+    }
+
+    /// Possibly linearize a timestamp from a `TimestampOracle`, off the
+    /// coordinator loop.
+    #[instrument]
+    async fn explain_timestamp_linearize_timestamp(
+        &self,
+        session: &Session,
+        ExplainTimestampLinearizeTimestamp {
+            validity,
+            format,
+            optimized_plan,
+            cluster_id,
+            source_ids,
+            when,
+            real_time_recency_ts,
+        }: ExplainTimestampLinearizeTimestamp,
+    ) -> Result<StageResult<Box<ExplainTimestampStage>>, AdapterError> {
+        let mut timeline_context = self
+            .catalog()
+            .validate_timeline_context(source_ids.iter().copied())?;
+        if matches!(timeline_context, TimelineContext::TimestampIndependent)
+            && optimized_plan.contains_temporal()
+        {
+            // If the source IDs are timestamp independent but the query contains temporal functions,
+            // then the timeline context needs to be upgraded to timestamp dependent. This is
+            // required because `source_ids` doesn't contain functions.
+            timeline_context = TimelineContext::TimestampDependent;
+        }
+
+        let oracle = self.linearized_read_ts_oracle(session, &timeline_context, &when);
+
+        let build_stage = move |oracle_read_ts: Option<Timestamp>| {
+            ExplainTimestampStage::Finish(ExplainTimestampFinish {
+                validity,
+                format,
+                cluster_id,
+                source_ids,
+                when,
+                real_time_recency_ts,
+                timeline_context,
+                oracle_read_ts,
+            })
+        };
+
+        match oracle {
+            Some(oracle) => {
+                // We ship the timestamp oracle off to an async task, so that we
+                // don't block the main task while we wait.
+                let span = Span::current();
+                Ok(StageResult::Handle(mz_ore::task::spawn(
+                    || "explain timestamp linearize timestamp",
+                    async move {
+                        let oracle_read_ts = oracle.read_ts().await;
+                        Ok(Box::new(build_stage(Some(oracle_read_ts))))
+                    }
+                    .instrument(span),
+                )))
+            }
+            None => Ok(StageResult::Immediate(Box::new(build_stage(None)))),
         }
     }
 
@@ -285,17 +353,18 @@ impl Coordinator {
     }
 
     #[instrument]
-    async fn explain_timestamp_finish(
+    fn explain_timestamp_finish(
         &mut self,
         session: &mut Session,
         ExplainTimestampFinish {
             validity: _,
             format,
-            optimized_plan,
             cluster_id,
             source_ids,
             when,
             real_time_recency_ts,
+            timeline_context,
+            oracle_read_ts,
         }: ExplainTimestampFinish,
     ) -> Result<StageResult<Box<ExplainTimestampStage>>, AdapterError> {
         let id_bundle = self
@@ -309,19 +378,6 @@ impl Coordinator {
                 return Err(AdapterError::Unsupported("EXPLAIN TIMESTAMP AS DOT"));
             }
         };
-        let mut timeline_context = self
-            .catalog()
-            .validate_timeline_context(source_ids.iter().copied())?;
-        if matches!(timeline_context, TimelineContext::TimestampIndependent)
-            && optimized_plan.contains_temporal()
-        {
-            // If the source IDs are timestamp independent but the query contains temporal functions,
-            // then the timeline context needs to be upgraded to timestamp dependent. This is
-            // required because `source_ids` doesn't contain functions.
-            timeline_context = TimelineContext::TimestampDependent;
-        }
-
-        let oracle_read_ts = self.oracle_read_ts(session, &timeline_context, &when).await;
 
         let determination = self.sequence_peek_timestamp(
             session,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -36,9 +36,7 @@ use crate::coord::peek::{self, PeekDataflowPlan, PeekPlan, PlannedPeek};
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::sequencer::{check_log_reads, emit_optimizer_notices, eval_copy_to_uri};
 use crate::coord::timeline::{TimelineContext, timedomain_for};
-use crate::coord::timestamp_selection::{
-    TimestampContext, TimestampDetermination, TimestampProvider,
-};
+use crate::coord::timestamp_selection::{TimestampContext, TimestampDetermination};
 use crate::coord::{
     Coordinator, CopyToContext, ExecuteContext, ExplainContext, ExplainPlanContext, Message,
     PeekStage, PeekStageCopyTo, PeekStageExplainPlan, PeekStageExplainPushdown, PeekStageFinish,
@@ -389,10 +387,7 @@ impl Coordinator {
             explain_ctx,
         }: PeekStageLinearizeTimestamp,
     ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
-        let isolation_level = session.vars().transaction_isolation().clone();
-        let timeline = Coordinator::get_timeline(&timeline_context);
-        let needs_linearized_read_ts =
-            Coordinator::needs_linearized_read_ts(&isolation_level, &plan.when);
+        let oracle = self.linearized_read_ts_oracle(session, &timeline_context, &plan.when);
 
         let build_stage = move |oracle_read_ts: Option<Timestamp>| PeekStageRealTimeRecency {
             validity,
@@ -406,10 +401,8 @@ impl Coordinator {
             explain_ctx,
         };
 
-        match timeline {
-            Some(timeline) if needs_linearized_read_ts => {
-                let oracle = self.get_timestamp_oracle(&timeline);
-
+        match oracle {
+            Some(oracle) => {
                 // We ship the timestamp oracle off to an async task, so that we
                 // don't block the main task while we wait.
 
@@ -425,7 +418,7 @@ impl Coordinator {
                     .instrument(span),
                 )))
             }
-            Some(_) | None => {
+            None => {
                 let stage = build_stage(None);
                 let stage = PeekStage::RealTimeRecency(stage);
                 Ok(StageResult::Immediate(Box::new(stage)))

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -953,10 +953,7 @@ impl Coordinator {
             depends_on: source_ids,
         };
         // Add metadata for the new COPY TO. CopyTo returns a `ready` future, so it is safe to drop.
-        drop(
-            self.add_active_compute_sink(sink_id, ActiveComputeSink::CopyTo(active_copy_to))
-                .await,
-        );
+        drop(self.add_active_compute_sink(sink_id, ActiveComputeSink::CopyTo(active_copy_to)));
 
         // Ship dataflow.
         self.ship_dataflow(df_desc, cluster_id, target_replica)

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -33,7 +33,7 @@ use crate::active_compute_sink::{ActiveComputeSink, ActiveCopyTo};
 use crate::command::ExecuteResponse;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::{self, PeekDataflowPlan, PeekPlan, PlannedPeek};
-use crate::coord::sequencer::inner::return_if_err;
+use crate::coord::sequencer::inner::{return_if_err, spawn_linearized_read_ts};
 use crate::coord::sequencer::{check_log_reads, emit_optimizer_notices, eval_copy_to_uri};
 use crate::coord::timeline::{TimelineContext, timedomain_for};
 use crate::coord::timestamp_selection::{TimestampContext, TimestampDetermination};
@@ -401,29 +401,11 @@ impl Coordinator {
             explain_ctx,
         };
 
-        match oracle {
-            Some(oracle) => {
-                // We ship the timestamp oracle off to an async task, so that we
-                // don't block the main task while we wait.
-
-                let span = Span::current();
-                Ok(StageResult::Handle(mz_ore::task::spawn(
-                    || "linearize timestamp",
-                    async move {
-                        let oracle_read_ts = oracle.read_ts().await;
-                        let stage = build_stage(Some(oracle_read_ts));
-                        let stage = PeekStage::RealTimeRecency(stage);
-                        Ok(Box::new(stage))
-                    }
-                    .instrument(span),
-                )))
-            }
-            None => {
-                let stage = build_stage(None);
-                let stage = PeekStage::RealTimeRecency(stage);
-                Ok(StageResult::Immediate(Box::new(stage)))
-            }
-        }
+        Ok(spawn_linearized_read_ts(
+            oracle,
+            "linearize timestamp",
+            move |oracle_read_ts| PeekStage::RealTimeRecency(build_stage(oracle_read_ts)),
+        ))
     }
 
     /// Determine a read timestamp and create appropriate read holds.

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 use crate::active_compute_sink::{ActiveComputeSink, ActiveSubscribe};
 use crate::command::ExecuteResponse;
 use crate::coord::appends::BuiltinTableAppendNotify;
-use crate::coord::sequencer::inner::return_if_err;
+use crate::coord::sequencer::inner::{return_if_err, spawn_linearized_read_ts};
 use crate::coord::sequencer::{check_log_reads, emit_optimizer_notices};
 use crate::coord::{
     Coordinator, ExplainContext, ExplainPlanContext, Message, PlanValidity, StageResult, Staged,
@@ -360,22 +360,11 @@ impl Coordinator {
             })
         };
 
-        match oracle {
-            Some(oracle) => {
-                // We ship the timestamp oracle off to an async task, so that we
-                // don't block the main task while we wait.
-                let span = Span::current();
-                Ok(StageResult::Handle(mz_ore::task::spawn(
-                    || "subscribe linearize timestamp",
-                    async move {
-                        let oracle_read_ts = oracle.read_ts().await;
-                        Ok(Box::new(build_stage(Some(oracle_read_ts))))
-                    }
-                    .instrument(span),
-                )))
-            }
-            None => Ok(StageResult::Immediate(Box::new(build_stage(None)))),
-        }
+        Ok(spawn_linearized_read_ts(
+            oracle,
+            "subscribe linearize timestamp",
+            build_stage,
+        ))
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -16,6 +16,7 @@ use mz_compute_types::plan::LirRelationExpr;
 use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_repr::GlobalId;
+use mz_repr::Timestamp;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
 use mz_sql::plan::{self, QueryWhen, SubscribeFrom};
@@ -23,7 +24,7 @@ use mz_sql::session::metadata::SessionMetadata;
 use std::collections::BTreeSet;
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
-use tracing::Span;
+use tracing::{Instrument, Span};
 use uuid::Uuid;
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveSubscribe};
@@ -32,8 +33,8 @@ use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::sequencer::{check_log_reads, emit_optimizer_notices};
 use crate::coord::{
     Coordinator, ExplainContext, ExplainPlanContext, Message, PlanValidity, StageResult, Staged,
-    SubscribeExplain, SubscribeFinish, SubscribeOptimizeMir, SubscribeStage,
-    SubscribeTimestampOptimizeLir, TargetCluster,
+    SubscribeExplain, SubscribeFinish, SubscribeLinearizeTimestamp, SubscribeOptimizeMir,
+    SubscribeStage, SubscribeTimestampOptimizeLir, TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
@@ -49,6 +50,7 @@ impl Staged for SubscribeStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             SubscribeStage::OptimizeMir(stage) => &mut stage.validity,
+            SubscribeStage::LinearizeTimestamp(stage) => &mut stage.validity,
             SubscribeStage::TimestampOptimizeLir(stage) => &mut stage.validity,
             SubscribeStage::Finish(stage) => &mut stage.validity,
             SubscribeStage::Explain(stage) => &mut stage.validity,
@@ -62,6 +64,11 @@ impl Staged for SubscribeStage {
     ) -> Result<StageResult<Box<Self>>, AdapterError> {
         match self {
             SubscribeStage::OptimizeMir(stage) => coord.subscribe_optimize_mir(stage),
+            SubscribeStage::LinearizeTimestamp(stage) => {
+                coord
+                    .subscribe_linearize_timestamp(ctx.session(), stage)
+                    .await
+            }
             SubscribeStage::TimestampOptimizeLir(stage) => {
                 coord.subscribe_timestamp_optimize_lir(ctx, stage).await
             }
@@ -303,21 +310,71 @@ impl Coordinator {
                             .map(|id| catalog.resolve_item_id(&id)),
                     );
 
-                    let stage =
-                        SubscribeStage::TimestampOptimizeLir(SubscribeTimestampOptimizeLir {
-                            validity,
-                            plan,
-                            timeline,
-                            optimizer,
-                            global_mir_plan,
-                            dependency_ids,
-                            replica_id,
-                            explain_ctx,
-                        });
+                    let stage = SubscribeStage::LinearizeTimestamp(SubscribeLinearizeTimestamp {
+                        validity,
+                        plan,
+                        timeline,
+                        optimizer,
+                        global_mir_plan,
+                        dependency_ids,
+                        replica_id,
+                        explain_ctx,
+                    });
                     Ok(Box::new(stage))
                 })
             },
         )))
+    }
+
+    /// Possibly linearize a timestamp from a `TimestampOracle`, off the
+    /// coordinator loop.
+    #[instrument]
+    async fn subscribe_linearize_timestamp(
+        &self,
+        session: &Session,
+        SubscribeLinearizeTimestamp {
+            validity,
+            plan,
+            timeline,
+            optimizer,
+            global_mir_plan,
+            dependency_ids,
+            replica_id,
+            explain_ctx,
+        }: SubscribeLinearizeTimestamp,
+    ) -> Result<StageResult<Box<SubscribeStage>>, AdapterError> {
+        let oracle = self.linearized_read_ts_oracle(session, &timeline, &plan.when);
+
+        let build_stage = move |oracle_read_ts: Option<Timestamp>| {
+            SubscribeStage::TimestampOptimizeLir(SubscribeTimestampOptimizeLir {
+                validity,
+                plan,
+                timeline,
+                optimizer,
+                global_mir_plan,
+                dependency_ids,
+                replica_id,
+                oracle_read_ts,
+                explain_ctx,
+            })
+        };
+
+        match oracle {
+            Some(oracle) => {
+                // We ship the timestamp oracle off to an async task, so that we
+                // don't block the main task while we wait.
+                let span = Span::current();
+                Ok(StageResult::Handle(mz_ore::task::spawn(
+                    || "subscribe linearize timestamp",
+                    async move {
+                        let oracle_read_ts = oracle.read_ts().await;
+                        Ok(Box::new(build_stage(Some(oracle_read_ts))))
+                    }
+                    .instrument(span),
+                )))
+            }
+            None => Ok(StageResult::Immediate(Box::new(build_stage(None)))),
+        }
     }
 
     #[instrument]
@@ -332,13 +389,14 @@ impl Coordinator {
             global_mir_plan,
             dependency_ids,
             replica_id,
+            oracle_read_ts,
             explain_ctx,
         }: SubscribeTimestampOptimizeLir,
     ) -> Result<StageResult<Box<SubscribeStage>>, AdapterError> {
         let plan::SubscribePlan { when, .. } = &plan;
 
-        // Timestamp selection
-        let oracle_read_ts = self.oracle_read_ts(ctx.session(), &timeline, when).await;
+        // Timestamp selection. The linearized read timestamp was already
+        // obtained off the coordinator loop in the preceding stage.
         let bundle = &global_mir_plan.id_bundle(optimizer.cluster_id());
         let (determination, read_holds) = self.determine_timestamp(
             ctx.session(),

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -87,7 +87,10 @@ impl Staged for SubscribeStage {
     }
 
     fn cancel_enabled(&self) -> bool {
-        true
+        // `Finish` installs the sink before it waits for the builtin-table write
+        // off-loop. If cancellation won during that wait, the active sink would
+        // outlive the canceled execution.
+        !matches!(self, SubscribeStage::Finish(_))
     }
 }
 
@@ -515,9 +518,9 @@ impl Coordinator {
                 plan,
             )
             .await?;
-        // Wait for the `mz_subscriptions` bookkeeping write to be durable off the
-        // coordinator loop, then respond. This keeps the introspection table
-        // synchronously consistent without blocking the loop on a group commit.
+        // Wait for the `mz_subscriptions` bookkeeping write off the coordinator
+        // loop before returning the `SUBSCRIBE` response to the subscribing
+        // session.
         let span = Span::current();
         Ok(StageResult::HandleRetire(mz_ore::task::spawn(
             || "subscribe_finish::await_bookkeeping",
@@ -574,8 +577,8 @@ impl Coordinator {
         // `mz_subscriptions` write is deferred to a group commit (see
         // `add_active_compute_sink`) rather than committed inline, so it does not block
         // the coordinator loop on a timestamp-oracle round trip. We hand the notify back
-        // so the caller can wait for the write to be durable off the loop before
-        // responding, keeping `mz_subscriptions` synchronously consistent.
+        // so the caller can wait before returning the `SUBSCRIBE` response to the
+        // subscribing session.
         let write_notify =
             self.add_active_compute_sink(sink_id, ActiveComputeSink::Subscribe(active_subscribe));
         self.ship_dataflow(df_desc, cluster_id, replica_id).await;

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -29,6 +29,7 @@ use uuid::Uuid;
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveSubscribe};
 use crate::command::ExecuteResponse;
+use crate::coord::appends::BuiltinTableAppendNotify;
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::sequencer::{check_log_reads, emit_optimizer_notices};
 use crate::coord::{
@@ -512,7 +513,7 @@ impl Coordinator {
             .txn_read_holds
             .remove(&conn_id)
             .expect("must have previously installed read holds");
-        let resp = self
+        let (resp, write_notify) = self
             .implement_subscribe(
                 ctx.extra_mut(),
                 df_desc,
@@ -525,7 +526,18 @@ impl Coordinator {
                 plan,
             )
             .await?;
-        Ok(StageResult::Response(resp))
+        // Wait for the `mz_subscriptions` bookkeeping write to be durable off the
+        // coordinator loop, then respond. This keeps the introspection table
+        // synchronously consistent without blocking the loop on a group commit.
+        let span = Span::current();
+        Ok(StageResult::HandleRetire(mz_ore::task::spawn(
+            || "subscribe_finish::await_bookkeeping",
+            async move {
+                write_notify.await;
+                Ok(resp)
+            }
+            .instrument(span),
+        )))
     }
 
     #[instrument]
@@ -540,7 +552,7 @@ impl Coordinator {
         session_uuid: Uuid,
         read_holds: ReadHolds,
         plan: plan::SubscribePlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
+    ) -> Result<(ExecuteResponse, BuiltinTableAppendNotify), AdapterError> {
         let sink_id = df_desc.sink_id();
 
         let (tx, rx) = mpsc::unbounded_channel();
@@ -569,16 +581,15 @@ impl Coordinator {
         };
         active_subscribe.initialize();
 
-        // Add metadata for the new SUBSCRIBE.
-        let write_notify_fut = self
-            .add_active_compute_sink(sink_id, ActiveComputeSink::Subscribe(active_subscribe))
-            .await;
-        // Ship dataflow.
-        let ship_dataflow_fut = self.ship_dataflow(df_desc, cluster_id, replica_id);
-
-        // Both adding metadata for the new SUBSCRIBE and shipping the underlying dataflow, send
-        // requests to external services, which can take time, so we run them concurrently.
-        let ((), ()) = futures::future::join(write_notify_fut, ship_dataflow_fut).await;
+        // Register bookkeeping for the new SUBSCRIBE and ship its dataflow. The
+        // `mz_subscriptions` write is deferred to a group commit (see
+        // `add_active_compute_sink`) rather than committed inline, so it does not block
+        // the coordinator loop on a timestamp-oracle round trip. We hand the notify back
+        // so the caller can wait for the write to be durable off the loop before
+        // responding, keeping `mz_subscriptions` synchronously consistent.
+        let write_notify =
+            self.add_active_compute_sink(sink_id, ActiveComputeSink::Subscribe(active_subscribe));
+        self.ship_dataflow(df_desc, cluster_id, replica_id).await;
 
         // Explicitly drop read holds, just to make it obvious what's happening.
         drop(read_holds);
@@ -595,7 +606,7 @@ impl Coordinator {
                 resp: Box::new(resp),
             },
         };
-        Ok(resp)
+        Ok((resp, write_notify))
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -249,7 +249,7 @@ impl Coordinator {
     ///
     /// This is a low-level method. The caller is responsible for installing the
     /// sink in the controller.
-    pub(crate) async fn add_active_compute_sink(
+    pub(crate) fn add_active_compute_sink(
         &mut self,
         id: GlobalId,
         active_sink: ActiveComputeSink,
@@ -273,7 +273,13 @@ impl Coordinator {
                     );
                     let update = self.catalog().state().resolve_builtin_table_update(update);
 
-                    self.builtin_table_update().execute(vec![update]).await.0
+                    // Defer the introspection-row write to a group commit instead of
+                    // committing it inline. An inline `execute` would block the coordinator
+                    // loop on a timestamp-oracle round trip and stall every other session.
+                    // The caller waits for this write to be durable off the loop (see
+                    // `implement_subscribe`), so `mz_subscriptions` stays synchronously
+                    // consistent without blocking the loop.
+                    self.builtin_table_update().defer(vec![update])
                 } else {
                     // Internal subscribes skip the builtin table update.
                     Box::pin(std::future::ready(()))
@@ -300,14 +306,22 @@ impl Coordinator {
 
     /// Removes coordinator bookkeeping for an active compute sink.
     ///
+    /// Returns the removed sink together with a notify that resolves once the
+    /// `mz_subscriptions` retraction is durable. The retraction is deferred to a group
+    /// commit rather than committed inline, which would block the coordinator loop on a
+    /// timestamp-oracle round trip. Callers should await the notify off the loop before
+    /// retiring the sink to the client, so a client that observes the retirement does not
+    /// then see a stale `mz_subscriptions` row. The notify is already resolved for sinks
+    /// that write no introspection row (internal subscribes and COPY TO).
+    ///
     /// This is a low-level method. The caller is responsible for dropping the
     /// sink from the controller. Consider calling `drop_compute_sink` or
-    /// `retire_compute_sink` instead.
+    /// `retire_compute_sinks` instead.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn remove_active_compute_sink(
         &mut self,
         id: GlobalId,
-    ) -> Option<ActiveComputeSink> {
+    ) -> Option<(ActiveComputeSink, BuiltinTableAppendNotify)> {
         if let Some(sink) = self.active_compute_sinks.remove(&id) {
             let user = self.active_conns()[sink.connection_id()].user();
             let session_type = metrics::session_type_label_value(user);
@@ -318,32 +332,42 @@ impl Coordinator {
                 .drop_sinks
                 .remove(&id);
 
-            match &sink {
+            let write_notify: BuiltinTableAppendNotify = match &sink {
                 ActiveComputeSink::Subscribe(active_subscribe) => {
-                    // Skip builtin table update for internal subscribes
-                    if !active_subscribe.internal {
+                    // Internal subscribes write no introspection row.
+                    let notify = if !active_subscribe.internal {
                         let update = self.catalog().state().pack_subscribe_update(
                             id,
                             active_subscribe,
                             Diff::MINUS_ONE,
                         );
                         let update = self.catalog().state().resolve_builtin_table_update(update);
-                        self.builtin_table_update().blocking(vec![update]).await;
-                    }
+                        // Defer the retraction to a group commit, for the same reason we
+                        // defer the insert (see `add_active_compute_sink`): committing inline
+                        // would block the coordinator loop. The caller awaits this off the
+                        // loop before retiring the sink to the client.
+                        self.builtin_table_update().defer(vec![update])
+                    } else {
+                        Box::pin(std::future::ready(()))
+                    };
 
                     self.metrics
                         .active_subscribes
                         .with_label_values(&[session_type])
                         .dec();
+
+                    notify
                 }
                 ActiveComputeSink::CopyTo(_) => {
                     self.metrics
                         .active_copy_tos
                         .with_label_values(&[session_type])
                         .dec();
+
+                    Box::pin(std::future::ready(()))
                 }
-            }
-            Some(sink)
+            };
+            Some((sink, write_notify))
         } else {
             None
         }

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -204,21 +204,34 @@ impl Coordinator {
 
     /// Handle removing in-progress transaction state regardless of the end action
     /// of the transaction.
-    pub(crate) async fn clear_transaction(&mut self, session: &mut Session) -> TransactionStatus {
+    ///
+    /// Returns a notify that resolves once any `mz_subscriptions` retractions
+    /// caused by cleanup are durable.
+    pub(crate) async fn clear_transaction(
+        &mut self,
+        session: &mut Session,
+    ) -> (TransactionStatus, BuiltinTableAppendNotify) {
         // This function is *usually* called when transactions end, but it can fail to be called in
         // some cases (for example if the session's role id was dropped, then we return early and
         // don't go through the normal sequence_end_transaction path). The `Command::Commit` handler
         // and `AdapterClient::end_transaction` protect against this by each executing their parts
         // of this function. Thus, if this function changes, ensure that the changes are propogated
         // to either of those components.
-        self.clear_connection(session.conn_id()).await;
-        session.clear_transaction()
+        let retire_notify = self.clear_connection(session.conn_id()).await;
+        (session.clear_transaction(), retire_notify)
     }
 
     /// Clears coordinator state for a connection.
-    pub(crate) async fn clear_connection(&mut self, conn_id: &ConnectionId) {
+    ///
+    /// Returns a notify that resolves once any `mz_subscriptions` retractions
+    /// caused by cleanup are durable.
+    pub(crate) async fn clear_connection(
+        &mut self,
+        conn_id: &ConnectionId,
+    ) -> BuiltinTableAppendNotify {
         self.connection_cancel_watches.remove(conn_id);
-        self.retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Finished)
+        let retire_notify = self
+            .retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Finished)
             .await;
         self.retire_cluster_reconfigurations_for_conn(conn_id).await;
 
@@ -243,6 +256,8 @@ impl Coordinator {
                 let _ = self.internal_cmd_tx.send(Message::DeferredStatementReady);
             }
         }
+
+        retire_notify
     }
 
     /// Adds coordinator bookkeeping for an active compute sink.

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -21,7 +21,7 @@ use mz_sql_parser::ast::{Raw, Statement};
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
 use crate::catalog::Catalog;
-use crate::coord::appends::BuiltinTableAppendNotify;
+use crate::coord::appends::{BuiltinTableAppendCompletion, BuiltinTableAppendNotify};
 use crate::coord::{Coordinator, Message};
 use crate::session::{Session, StateRevision, TransactionStatus};
 use crate::util::describe;
@@ -210,7 +210,7 @@ impl Coordinator {
     pub(crate) async fn clear_transaction(
         &mut self,
         session: &mut Session,
-    ) -> (TransactionStatus, BuiltinTableAppendNotify) {
+    ) -> (TransactionStatus, BuiltinTableAppendCompletion) {
         // This function is *usually* called when transactions end, but it can fail to be called in
         // some cases (for example if the session's role id was dropped, then we return early and
         // don't go through the normal sequence_end_transaction path). The `Command::Commit` handler
@@ -228,7 +228,7 @@ impl Coordinator {
     pub(crate) async fn clear_connection(
         &mut self,
         conn_id: &ConnectionId,
-    ) -> BuiltinTableAppendNotify {
+    ) -> BuiltinTableAppendCompletion {
         self.connection_cancel_watches.remove(conn_id);
         let retire_notify = self
             .retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Finished)

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -276,9 +276,8 @@ impl Coordinator {
                     // Defer the introspection-row write to a group commit instead of
                     // committing it inline. An inline `execute` would block the coordinator
                     // loop on a timestamp-oracle round trip and stall every other session.
-                    // The caller waits for this write to be durable off the loop (see
-                    // `implement_subscribe`), so `mz_subscriptions` stays synchronously
-                    // consistent without blocking the loop.
+                    // `implement_subscribe` waits for this write before returning the
+                    // `SUBSCRIBE` response to the subscribing session.
                     self.builtin_table_update().defer(vec![update])
                 } else {
                     // Internal subscribes skip the builtin table update.
@@ -309,10 +308,9 @@ impl Coordinator {
     /// Returns the removed sink together with a notify that resolves once the
     /// `mz_subscriptions` retraction is durable. The retraction is deferred to a group
     /// commit rather than committed inline, which would block the coordinator loop on a
-    /// timestamp-oracle round trip. Callers should await the notify off the loop before
-    /// retiring the sink to the client, so a client that observes the retirement does not
-    /// then see a stale `mz_subscriptions` row. The notify is already resolved for sinks
-    /// that write no introspection row (internal subscribes and COPY TO).
+    /// timestamp-oracle round trip. Callers that expose completion of the retirement
+    /// should wait on the notify off the loop before responding. The notify is already
+    /// resolved for sinks that write no introspection row (internal subscribes and COPY TO).
     ///
     /// This is a low-level method. The caller is responsible for dropping the
     /// sink from the controller. Consider calling `drop_compute_sink` or
@@ -344,8 +342,8 @@ impl Coordinator {
                         let update = self.catalog().state().resolve_builtin_table_update(update);
                         // Defer the retraction to a group commit, for the same reason we
                         // defer the insert (see `add_active_compute_sink`): committing inline
-                        // would block the coordinator loop. The caller awaits this off the
-                        // loop before retiring the sink to the client.
+                        // would block the coordinator loop. Callers that expose the
+                        // retirement wait on the notify off the loop before responding.
                         self.builtin_table_update().defer(vec![update])
                     } else {
                         Box::pin(std::future::ready(()))

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -10,6 +10,7 @@
 //! Logic for selecting timestamps for various operations on collections.
 
 use std::fmt;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -22,6 +23,7 @@ use mz_repr::{GlobalId, Timestamp, TimestampManipulation};
 use mz_sql::plan::QueryWhen;
 use mz_sql::session::vars::IsolationLevel;
 use mz_storage_types::sources::Timeline;
+use mz_timestamp_oracle::TimestampOracle;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp as _};
 
@@ -645,26 +647,30 @@ pub trait TimestampProvider {
 }
 
 impl Coordinator {
-    pub(crate) async fn oracle_read_ts(
+    /// Returns the timestamp oracle to obtain a linearized read timestamp from,
+    /// if the given isolation level and `when` require one, and `None`
+    /// otherwise.
+    ///
+    /// The caller must perform the `read_ts()` round-trip off the coordinator
+    /// loop, in a spawned task. The oracle backing store can be slow, so doing
+    /// the read inline would wedge every other session until it returns. See
+    /// `peek_linearize_timestamp` for the canonical use of this helper.
+    pub(crate) fn linearized_read_ts_oracle(
         &self,
         session: &Session,
         timeline_ctx: &TimelineContext,
         when: &QueryWhen,
-    ) -> Option<Timestamp> {
-        let isolation_level = session.vars().transaction_isolation().clone();
+    ) -> Option<Arc<dyn TimestampOracle<Timestamp> + Send + Sync>> {
+        let isolation_level = session.vars().transaction_isolation();
         let timeline = Coordinator::get_timeline(timeline_ctx);
-        let needs_linearized_read_ts =
-            Coordinator::needs_linearized_read_ts(&isolation_level, when);
+        let needs_linearized_read_ts = Coordinator::needs_linearized_read_ts(isolation_level, when);
 
-        let oracle_read_ts = match timeline {
+        match timeline {
             Some(timeline) if needs_linearized_read_ts => {
-                let timestamp_oracle = self.get_timestamp_oracle(&timeline);
-                Some(timestamp_oracle.read_ts().await)
+                Some(self.get_timestamp_oracle(&timeline))
             }
             Some(_) | None => None,
-        };
-
-        oracle_read_ts
+        }
     }
 
     /// Determines the timestamp for a query, acquires read holds that ensure the

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2206,26 +2206,17 @@ def workflow_test_mz_subscriptions(c: Composition) -> None:
         We explicitly don't check the `GlobalId`, as how that is
         allocated is an implementation detail and might change in the
         future.
-
-        The `mz_subscriptions` row is written in the background (not committed
-        synchronously when the SUBSCRIBE starts or stops), so we let testdrive
-        retry the query until the table reflects the expected state.
         """
-        expected_rows = "".join(
-            f"{role} {cluster} {table}\n" for role, cluster, table in expected
-        )
-        c.testdrive(
-            args=["--no-reset"],
-            input=dedent("""
-                > SELECT r.name, c.name, t.name
-                  FROM mz_internal.mz_subscriptions s
-                    JOIN mz_internal.mz_sessions e ON (e.id = s.session_id)
-                    JOIN mz_roles r ON (r.id = e.role_id)
-                    JOIN mz_clusters c ON (c.id = s.cluster_id)
-                    JOIN mz_tables t ON (t.id = s.referenced_object_ids[1])
-                  ORDER BY s.created_at
-                """) + expected_rows,
-        )
+        output = c.sql_query("""
+            SELECT r.name, c.name, t.name
+            FROM mz_internal.mz_subscriptions s
+              JOIN mz_internal.mz_sessions e ON (e.id = s.session_id)
+              JOIN mz_roles r ON (r.id = e.role_id)
+              JOIN mz_clusters c ON (c.id = s.cluster_id)
+              JOIN mz_tables t ON (t.id = s.referenced_object_ids[1])
+            ORDER BY s.created_at
+            """)
+        assert output == expected, f"expected: {expected}, got: {output}"
 
     subscribe1 = start_subscribe("t1", "quickstart")
     check_mz_subscriptions([("materialize", "quickstart", "t1")])

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2206,17 +2206,26 @@ def workflow_test_mz_subscriptions(c: Composition) -> None:
         We explicitly don't check the `GlobalId`, as how that is
         allocated is an implementation detail and might change in the
         future.
+
+        The `mz_subscriptions` row is written in the background (not committed
+        synchronously when the SUBSCRIBE starts or stops), so we let testdrive
+        retry the query until the table reflects the expected state.
         """
-        output = c.sql_query("""
-            SELECT r.name, c.name, t.name
-            FROM mz_internal.mz_subscriptions s
-              JOIN mz_internal.mz_sessions e ON (e.id = s.session_id)
-              JOIN mz_roles r ON (r.id = e.role_id)
-              JOIN mz_clusters c ON (c.id = s.cluster_id)
-              JOIN mz_tables t ON (t.id = s.referenced_object_ids[1])
-            ORDER BY s.created_at
-            """)
-        assert output == expected, f"expected: {expected}, got: {output}"
+        expected_rows = "".join(
+            f"{role} {cluster} {table}\n" for role, cluster, table in expected
+        )
+        c.testdrive(
+            args=["--no-reset"],
+            input=dedent("""
+                > SELECT r.name, c.name, t.name
+                  FROM mz_internal.mz_subscriptions s
+                    JOIN mz_internal.mz_sessions e ON (e.id = s.session_id)
+                    JOIN mz_roles r ON (r.id = e.role_id)
+                    JOIN mz_clusters c ON (c.id = s.cluster_id)
+                    JOIN mz_tables t ON (t.id = s.referenced_object_ids[1])
+                  ORDER BY s.created_at
+                """) + expected_rows,
+        )
 
     subscribe1 = start_subscribe("t1", "quickstart")
     check_mz_subscriptions([("materialize", "quickstart", "t1")])


### PR DESCRIPTION
### Motivation

Since we keep hitting `environmentd` stalls, this is one of the proactive
fixes from the SQL-42x batch.

`EXPLAIN TIMESTAMP` and `SUBSCRIBE` performed their linearized
timestamp-oracle read (`oracle.read_ts().await`) **inline on the
single-threaded coordinator loop** (`explain_timestamp.rs` and
`subscribe.rs`). The oracle backing store can be slow, and an inline await
parks the loop, so a slow oracle wedged **every other session** for the whole
round-trip. The peek path does not have this problem: it does the read in its
own `LinearizeTimestamp` stage that spawns the round-trip off the loop
(`peek_linearize_timestamp`).

The issue includes a reproducer (`coord-oracle-latency`) that routes only the
timestamp-oracle connection through toxiproxy and injects latency. With the
old code, `k` concurrent `EXPLAIN TIMESTAMP`s serialize on the loop and scale
~`k`x the single-call latency (measured: 1x ≈ 500ms, 8x ≈ 8.7s at 500ms
injected latency). A normal peek reads off the loop and batches.

### What this does

Make `EXPLAIN TIMESTAMP` and `SUBSCRIBE` follow the existing peek pattern.
Each gains a `LinearizeTimestamp` stage that spawns the `read_ts()`
round-trip off the coordinator loop and threads the resulting
`oracle_read_ts` forward as plain data. The subsequent stages
(`determine_timestamp` / `sequence_peek_timestamp` and the read-hold
bookkeeping) stay on the loop and consume that value unchanged, so timestamp
selection is identical, just no longer blocking the loop.

The "should we linearize, and against which oracle" decision that was
duplicated across the inline `oracle_read_ts` helper and
`peek_linearize_timestamp` is factored into a single
`Coordinator::linearized_read_ts_oracle` helper that returns the oracle to
read from, if any. All three spawn sites (peek, subscribe, explain timestamp)
now share that helper and a small `spawn_linearized_read_ts` wrapper, so a
future change to how the read is spawned lands in one place.

`SUBSCRIBE` bookkeeping in `mz_subscriptions` is also moved off-loop. The
coordinator installs the sink and defers the builtin-table append to a group
commit, then waits for the append in a spawned task before returning the
`SUBSCRIBE` response to the subscribing session. Retractions follow the same
pattern: the sink is removed from coordinator/controller state on the loop, but
responses that observe the retirement wait off the loop until the
`mz_subscriptions` retraction is durable. That includes the subscribing
client's terminal message, statements like `ROLLBACK` that end the subscribe
transaction, and DDL statements that cause subscribes to retire. The response
barriers are carried through execution paths that split and rebuild
`ExecuteContext`, so nested execution paths preserve the same ordering. The
coordinator can continue processing unrelated work while those barriers wait.

### Correctness

This is **timing-neutral with respect to strict serializability**: the
linearized read still happens during the query's real-time interval (after
arrival, before response), against the same backing oracle. It is the same
call the peek path already makes off the loop. No caching or shared-atomic
shortcut is introduced (see the rejected optimizations in
`doc/developer/guide-adapter.md`). Read holds are still acquired on the loop
in the stage that runs after the spawned read returns, matching peek. The new
spawned reads are cancelable via the existing `cancel_enabled`/`handle_spawn`
wiring, also matching peek.

### Tests

No new tests in this PR. Correctness of timestamp selection for `EXPLAIN
TIMESTAMP` and `SUBSCRIBE` is covered by the existing functional suites. The
issue's `coord-oracle-latency` reproducer is a manual latency diagnostic (its
assertion is written to detect the *bug*, i.e. on-loop serialization); I'd
like to discuss whether to add an inverted-assertion version as a benchmark,
since latency assertions in a multi-container mzcompose tend to be flaky in
CI.

Fixes SQL-425


---

### Local verification (reproducer)

Ran the issue's setup locally: `environmentd` with catalog/persist direct on CockroachDB and the **timestamp oracle routed through toxiproxy** with 500ms injected latency. Built `main` and this branch from the same tree and compared.

**EXPLAIN TIMESTAMP (the issue's clean signal):** clear improvement.

| metric (8 concurrent, 500ms oracle latency) | main | this branch |
|---|---|---|
| wall time | 4079ms (~7.9x of 1x) | 1390ms (~2.7x) |
| `read_ts` backing batches for 8 reads | n/a | 8 ops -> **2 batches** (reads now overlap/batch) |
| **victim** `SELECT 1` latency while 8 sessions hammer it | **~26 s** | **~3.5 s** |

The "victim" row is the direct test of the headline symptom ("every *other* session stalls"): a constant `SELECT 1` (no oracle read) on a separate connection. On `main` the coordinator loop is wedged by the inline oracle reads and the victim stalls ~26s; with the fix the read is off-loop and the victim recovers to ~3.5s.

**Scope note / separate issue.** The reproducer also shows that statements which actually *read data* (`SELECT` peeks, and `SUBSCRIBE`) still stall the coordinator under a slow oracle through a **different** on-loop cost (frontier advancement / dataflow lifecycle), independent of the linearized read this PR moves off-loop:

- `SELECT` peek victim stall ~8.5s (this path was already off-loop for the read and is unchanged by this PR).
- `SUBSCRIBE` victim stall ~24.7s on both `main` and this branch.

This matches the issue's own note that "peeks have their own on-loop oracle costs too." This PR fixes the specific defect it names (the inline linearized read for EXPLAIN TIMESTAMP and SUBSCRIBE) and is fully effective for EXPLAIN TIMESTAMP. The broader "data reads stall the coordinator under a slow oracle" cost affects peeks too and should be tracked as a separate follow-up rather than folded in here.



