### PR TITLE
adapter: reject writes in read-only txn after a constant peek

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1264,7 +1264,6 @@ impl TransactionStatus {
 
     /// Checks whether the current state of this transaction allows writes
     /// (adding write ops).
-    /// transaction
     pub fn allows_writes(&self) -> bool {
         match self {
             TransactionStatus::Started(Transaction { ops, access, .. })
@@ -1273,10 +1272,12 @@ impl TransactionStatus {
                 match ops {
                     TransactionOps::None => access != &Some(TransactionAccessMode::ReadOnly),
                     TransactionOps::Peeks { determination, .. } => {
-                        // If-and-only-if peeks thus far do not have a timestamp
-                        // (i.e. they are constant), we can switch to a write
-                        // transaction.
-                        !determination.timestamp_context.contains_timestamp()
+                        // We can switch a peek-only transaction to a write
+                        // transaction only if the peeks thus far are constant
+                        // (i.e. they do not have a timestamp) and the
+                        // transaction is not explicitly marked read-only.
+                        access != &Some(TransactionAccessMode::ReadOnly)
+                            && !determination.timestamp_context.contains_timestamp()
                     }
                     TransactionOps::Subscribe => false,
                     TransactionOps::Writes(_) => true,
@@ -1360,12 +1361,20 @@ impl TransactionStatus {
                                 *requires_linearization = add_requires_linearization;
                             }
                         }
-                        // Iff peeks thus far do not have a timestamp (i.e.
-                        // they are constant), we can switch to a write
-                        // transaction.
+                        // If the peeks thus far are constant (i.e. they do not
+                        // have a timestamp), writes can follow and switch the
+                        // transaction to a write transaction. But a read-only
+                        // transaction must still reject the write. Without that
+                        // check the write would silently turn a read-only
+                        // transaction into a write transaction, and a later
+                        // write would then trip the assert in the `Writes` arm
+                        // below.
                         writes @ TransactionOps::Writes(..)
                             if !determination.timestamp_context.contains_timestamp() =>
                         {
+                            if matches!(access, Some(TransactionAccessMode::ReadOnly)) {
+                                return Err(AdapterError::ReadOnlyTransaction);
+                            }
                             *ops = writes;
                         }
                         _ => return Err(AdapterError::ReadOnlyTransaction),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -4628,6 +4628,7 @@ impl AstDisplay for TransactionMode {
 }
 impl_display!(TransactionMode);
 
+/// The access mode of a transaction, as specified by the `BEGIN ...` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TransactionAccessMode {
     ReadOnly,

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -614,3 +614,45 @@ DataRow {"fields":["1"]}
 DataRow {"fields":["2"]}
 CommandComplete {"tag":"SELECT 2"}
 ReadyForQuery {"status":"I"}
+
+# Regression test for SQL-373: a constant peek must not let a COPY (a write)
+# sneak into a read-only transaction. The constant SELECT turns the
+# transaction's ops into a constant Peeks. The COPY used to be wrongly
+# accepted, switching the transaction into a write transaction, and a later
+# write then tripped an assertion and panicked. The COPY must be rejected.
+send
+Query {"query": "BEGIN READ ONLY; SELECT 1"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"T"}
+
+# The COPY is a write and must be rejected with a read-only error (25006),
+# moving the explicit transaction into the failed state.
+send
+Query {"query": "COPY t FROM STDIN"}
+CopyData "1\n"
+CopyDone
+----
+
+until err_field_typs=CM
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text"]}
+ErrorResponse {"fields":[{"typ":"C","value":"25006"},{"typ":"M","value":"transaction in read-only mode"}]}
+ReadyForQuery {"status":"E"}
+
+send
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -482,6 +482,32 @@ INSERT INTO t (a) VALUES (1)
 statement ok
 ROLLBACK
 
+## A constant peek must not let a write sneak into a read-only transaction.
+## Regression test for SQL-373 and SQL-374: the constant SELECT used to switch
+## the transaction into a write transaction, so the INSERT was wrongly accepted.
+## A following second write then panicked (SQL-373), and a single write even
+## committed and persisted data (SQL-374). The write must be rejected, and
+## committing the transaction must not persist anything.
+
+statement ok
+BEGIN TRANSACTION READ ONLY
+
+query I
+SELECT 1
+----
+1
+
+statement error transaction in read-only mode
+INSERT INTO t (a) VALUES (42424242)
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM t WHERE a = 42424242
+----
+0
+
 ## BEGIN does not lose READ ONLY bit
 
 statement ok


### PR DESCRIPTION
Fixes SQL-373
Fixes SQL-374

A read-only transaction whose ops were a constant peek, for example after running `SELECT 1`, wrongly accepted a following write and switched the transaction into a write transaction. A second write then tripped the `assert!(!matches!(access, ReadOnly))` in `add_ops` and panicked (SQL-373). With only a single write, the staged write even committed and persisted data, so a read-only transaction silently performed a write (SQL-374). These are the same root cause; SQL-374 is marked a duplicate of SQL-373.

Both `allows_writes` and the constant-peek-to-write transition in `add_ops` treated a constant peek as write-eligible without checking the access mode. They now reject the write in a read-only transaction, matching the existing None-to-Writes check. `allows_writes` gates the INSERT and implicit read-then-write paths. The `add_ops` check additionally covers COPY FROM STDIN, which stages writes without going through `allows_writes`.

Adds a sqllogictest regression test for the INSERT path that also asserts nothing is committed, and a pgtest for the COPY path.
