### PR TITLE
Redact secrets from mz_statement_execution_history error messages

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -37,7 +37,7 @@ use mz_repr::{Diff, GlobalId, SqlScalarType, Timestamp};
 use mz_sql::ast::{
     AlterConnectionAction, AlterConnectionStatement, AlterSinkAction, AlterSourceAction, AstInfo,
     ConstantVisitor, CopyRelation, CopyStatement, CreateSourceOptionName, Raw, Statement,
-    SubscribeStatement,
+    StatementKind, SubscribeStatement,
 };
 use mz_sql::catalog::RoleAttributesRaw;
 use mz_sql::names::{Aug, PartialItemName, ResolvedIds};
@@ -1382,12 +1382,17 @@ impl Coordinator {
                             }
                         }
 
-                        // Redact literals (e.g. `CREATE SECRET` values) so that
-                        // secret material does not leak into the error message,
-                        // which is persisted in `mz_statement_execution_history`.
-                        return ctx.retire(Err(AdapterError::OperationProhibitsTransaction(
-                            stmt.to_ast_string_redacted(),
-                        )));
+                        // For statements that can carry sensitive material, redact
+                        // literals so they don't leak into the error message, which
+                        // is persisted in `mz_statement_execution_history` (matching
+                        // how their SQL text is redacted). Other statements keep
+                        // their literals for a clearer error.
+                        let op = if StatementKind::from(&*stmt).is_sensitive() {
+                            stmt.to_ast_string_redacted()
+                        } else {
+                            stmt.to_string()
+                        };
+                        return ctx.retire(Err(AdapterError::OperationProhibitsTransaction(op)));
                     }
                 }
             }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1382,8 +1382,11 @@ impl Coordinator {
                             }
                         }
 
+                        // Redact literals (e.g. `CREATE SECRET` values) so that
+                        // secret material does not leak into the error message,
+                        // which is persisted in `mz_statement_execution_history`.
                         return ctx.retire(Err(AdapterError::OperationProhibitsTransaction(
-                            stmt.to_string(),
+                            stmt.to_ast_string_redacted(),
                         )));
                     }
                 }

--- a/src/adapter/src/coord/sequencer/inner/secret.rs
+++ b/src/adapter/src/coord/sequencer/inner/secret.rs
@@ -150,8 +150,21 @@ impl Coordinator {
             session,
             catalog_state: self.catalog().state(),
         };
-        style.prep_scalar_expr(secret_as)?;
-        let evaled = secret_as.eval(&[], &temp_storage)?;
+        // Preparing and evaluating the secret expression can fail with an error
+        // that embeds the value being evaluated (e.g. a `bytea` parse error quotes
+        // its input). That value is the secret itself, so we discard the underlying
+        // error and surface a vague message, to avoid including the secret in the
+        // statement log (or some other log file somewhere). We wrap both calls,
+        // rather than just the ones that leak today, so a future error added to
+        // either is covered by default.
+        let secret_eval_err =
+            || AdapterError::Unstructured(anyhow::anyhow!("could not evaluate secret value"));
+        style
+            .prep_scalar_expr(secret_as)
+            .map_err(|_| secret_eval_err())?;
+        let evaled = secret_as
+            .eval(&[], &temp_storage)
+            .map_err(|_| secret_eval_err())?;
 
         if evaled == Datum::Null {
             coord_bail!("secret value can not be null");
@@ -177,10 +190,9 @@ impl Coordinator {
         // `SecretsReader::read_string` will panic if the secret contains
         // invalid UTF-8.
         if std::str::from_utf8(payload).is_err() {
-            // Intentionally produce a vague error message (rather than
-            // including the invalid bytes, for example), to avoid including
-            // secret material in the error message, which might end up in a log
-            // file somewhere.
+            // Similarly to above, intentionally produce a vague error message
+            // (rather than  including the invalid bytes, for example), to avoid
+            // including secret material in the error message.
             coord_bail!("secret value must be valid UTF-8");
         }
 

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -21,6 +21,7 @@ use mz_repr::adt::timestamp::TimestampLike;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_sql::plan::Params;
 use mz_sql::session::metadata::SessionMetadata;
+use mz_sql_parser::ast::StatementKind;
 use mz_storage_client::controller::IntrospectionType;
 use qcell::QCell;
 use rand::SeedableRng;
@@ -300,8 +301,9 @@ impl Coordinator {
         logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
     ) {
         let logging = session.qcell_rw(&*logging);
-        if let PreparedStatementLoggingInfo::StillToLog { .. } = logging {
-            *logging = PreparedStatementLoggingInfo::AlreadyLogged { uuid };
+        if let PreparedStatementLoggingInfo::StillToLog { kind, .. } = logging {
+            let kind = *kind;
+            *logging = PreparedStatementLoggingInfo::AlreadyLogged { uuid, kind };
         }
     }
 
@@ -327,7 +329,7 @@ impl Coordinator {
         let logging = session.qcell_ro(&*logging);
 
         match logging {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => (None, *uuid),
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid, .. } => (None, *uuid),
             PreparedStatementLoggingInfo::StillToLog {
                 sql,
                 redacted_sql,
@@ -485,7 +487,19 @@ impl Coordinator {
                 ),
                 StatementEndedExecutionReason::Canceled => ("canceled", None, None, None, None),
                 StatementEndedExecutionReason::Errored { error } => {
-                    ("error", Some(error.as_str()), None, None, None)
+                    // Backstop for SQL-435: `CREATE SECRET`/`ALTER SECRET` errors
+                    // can embed secret material (the rejected statement text, or a
+                    // value-bearing eval error). The per-site fixes redact the known
+                    // cases, but we never persist an unredacted error for these
+                    // kinds, regardless of which error variant fired. The client
+                    // still receives the real error over pgwire.
+                    let error = match began_record.kind {
+                        Some(StatementKind::CreateSecret | StatementKind::AlterSecret) => {
+                            "<error redacted for secret statement>"
+                        }
+                        _ => error.as_str(),
+                    };
+                    ("error", Some(error), None, None, None)
                 }
                 StatementEndedExecutionReason::Aborted => ("aborted", None, None, None, None),
             };
@@ -660,6 +674,7 @@ impl Coordinator {
             .config()
             .build_info
             .human_version(None);
+        let kind = session.qcell_ro(logging).kind();
         let record = create_began_execution_record(
             execution_uuid,
             ps_uuid,
@@ -668,6 +683,7 @@ impl Coordinator {
             session,
             began_at,
             build_info_version,
+            kind,
         );
 
         // `mz_statement_execution_history`

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -21,7 +21,6 @@ use mz_repr::adt::timestamp::TimestampLike;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_sql::plan::Params;
 use mz_sql::session::metadata::SessionMetadata;
-use mz_sql_parser::ast::StatementKind;
 use mz_storage_client::controller::IntrospectionType;
 use qcell::QCell;
 use rand::SeedableRng;
@@ -493,11 +492,10 @@ impl Coordinator {
                     // cases, but we never persist an unredacted error for these
                     // kinds, regardless of which error variant fired. The client
                     // still receives the real error over pgwire.
-                    let error = match began_record.kind {
-                        Some(StatementKind::CreateSecret | StatementKind::AlterSecret) => {
-                            "<error redacted for secret statement>"
-                        }
-                        _ => error.as_str(),
+                    let error = if began_record.kind.is_some_and(|kind| kind.is_secret()) {
+                        "<error redacted for secret statement>"
+                    } else {
+                        error.as_str()
                     };
                     ("error", Some(error), None, None, None)
                 }

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -76,6 +76,9 @@ pub struct StatementBeganExecutionRecord {
     pub transaction_id: TransactionId,
     pub transient_index_id: Option<GlobalId>,
     pub mz_version: String,
+    /// The kind of statement being executed, if known. Used to redact
+    /// `error_message` for kinds that can carry secret material.
+    pub kind: Option<StatementKind>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -280,7 +283,10 @@ pub enum PreparedStatementLoggingInfo {
     /// The statement has already been logged; we don't need to log it
     /// again if a future execution hits the sampling rate; we merely
     /// need to reference the corresponding UUID.
-    AlreadyLogged { uuid: Uuid },
+    AlreadyLogged {
+        uuid: Uuid,
+        kind: Option<StatementKind>,
+    },
     /// The statement has not yet been logged; if a future execution
     /// hits the sampling rate, we need to log it at that point.
     StillToLog {
@@ -307,6 +313,15 @@ pub enum PreparedStatementLoggingInfo {
 }
 
 impl PreparedStatementLoggingInfo {
+    /// The kind of the prepared statement, if known. Available regardless of
+    /// whether the statement has already been logged.
+    pub fn kind(&self) -> Option<StatementKind> {
+        match self {
+            PreparedStatementLoggingInfo::StillToLog { kind, .. } => *kind,
+            PreparedStatementLoggingInfo::AlreadyLogged { kind, .. } => *kind,
+        }
+    }
+
     /// Constructor for the [`PreparedStatementLoggingInfo::StillToLog`] variant that ensures SQL
     /// statements are properly redacted.
     pub fn still_to_log<A: AstInfo>(
@@ -490,7 +505,7 @@ impl StatementLoggingFrontend {
         let logging_ref = session.qcell_ro(&*logging);
 
         match logging_ref {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => (None, *uuid),
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid, .. } => (None, *uuid),
             PreparedStatementLoggingInfo::StillToLog {
                 sql,
                 redacted_sql,
@@ -563,8 +578,9 @@ impl StatementLoggingFrontend {
         logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
     ) {
         let logging = session.qcell_rw(&*logging);
-        if let PreparedStatementLoggingInfo::StillToLog { .. } = logging {
-            *logging = PreparedStatementLoggingInfo::AlreadyLogged { uuid };
+        if let PreparedStatementLoggingInfo::StillToLog { kind, .. } = logging {
+            let kind = *kind;
+            *logging = PreparedStatementLoggingInfo::AlreadyLogged { uuid, kind };
         }
     }
 
@@ -656,6 +672,11 @@ impl StatementLoggingFrontend {
             return None;
         }
 
+        // Capture the statement kind for the began-execution record, before
+        // `record_prepared_statement_as_logged` transitions the logging info to
+        // `AlreadyLogged`.
+        let kind = session.qcell_ro(logging).kind();
+
         // Get prepared statement info.
         let (prepared_statement_event, ps_uuid) =
             self.get_prepared_statement_info(session, logging);
@@ -678,6 +699,7 @@ impl StatementLoggingFrontend {
             session,
             began_at,
             self.build_info_human_version.clone(),
+            kind,
         );
 
         // Build rows to calculate cost for throttling
@@ -793,6 +815,7 @@ pub(crate) fn create_began_execution_record(
     session: &Session,
     began_at: EpochMillis,
     build_info_version: String,
+    kind: Option<StatementKind>,
 ) -> StatementBeganExecutionRecord {
     let params = serialize_params(params);
     StatementBeganExecutionRecord {
@@ -816,6 +839,7 @@ pub(crate) fn create_began_execution_record(
                 9999999
             }),
         mz_version: build_info_version,
+        kind,
         // These are not known yet; we'll fill them in later.
         cluster_id: None,
         cluster_name: None,
@@ -889,6 +913,8 @@ pub(crate) fn pack_statement_execution_inner(
         transaction_id,
         transient_index_id,
         mz_version,
+        // Not packed into a column; only used to redact `error_message`.
+        kind: _,
     } = record;
 
     let cluster = cluster_id.map(|id| id.to_string());

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -334,17 +334,12 @@ impl PreparedStatementLoggingInfo {
     ) -> Self {
         let kind = stmt.map(StatementKind::from);
         let sql = match kind {
-            // Always redact SQL statements that may contain sensitive information.
-            // CREATE SECRET and ALTER SECRET statements can contain secret values, so we redact them.
-            // INSERT, UPDATE, and EXECUTE statements can include large amounts of user data, so we redact them for both
-            // data privacy and to avoid logging excessive data.
-            Some(
-                StatementKind::CreateSecret
-                | StatementKind::AlterSecret
-                | StatementKind::Insert
-                | StatementKind::Update
-                | StatementKind::Execute,
-            ) => stmt.map(|s| s.to_ast_string_redacted()).unwrap_or_default(),
+            // Redact the SQL text of statements that can carry sensitive material:
+            // secret values (`CREATE`/`ALTER SECRET`), or bulk/PII user data
+            // (`INSERT`/`UPDATE`/`EXECUTE`). See `StatementKind::is_sensitive`.
+            Some(kind) if kind.is_sensitive() => {
+                stmt.map(|s| s.to_ast_string_redacted()).unwrap_or_default()
+            }
             _ => raw_sql,
         };
 

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -54,7 +54,7 @@ http
 {"query":"create view v1 as select 1; create view v2 as select 1"}
 ----
 200 OK
-{"results":[{"error":{"message":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block","code":"25001"},"notices":[]}]}
+{"results":[{"error":{"message":"CREATE VIEW v1 AS SELECT '<REDACTED>' cannot be run inside a transaction block","code":"25001"},"notices":[]}]}
 
 # Syntax errors fail the request.
 http

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -54,7 +54,7 @@ http
 {"query":"create view v1 as select 1; create view v2 as select 1"}
 ----
 200 OK
-{"results":[{"error":{"message":"CREATE VIEW v1 AS SELECT '<REDACTED>' cannot be run inside a transaction block","code":"25001"},"notices":[]}]}
+{"results":[{"error":{"message":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block","code":"25001"},"notices":[]}]}
 
 # Syntax errors fail the request.
 http

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -199,6 +199,31 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
 }
 impl_display_t!(Statement);
 
+impl StatementKind {
+    /// Whether this kind of statement can carry secret values, i.e. `CREATE
+    /// SECRET` or `ALTER SECRET`. Such secret material must never be persisted
+    /// verbatim (e.g. in `mz_statement_execution_history`), not even in error
+    /// messages.
+    pub fn is_secret(&self) -> bool {
+        matches!(
+            self,
+            StatementKind::CreateSecret | StatementKind::AlterSecret
+        )
+    }
+
+    /// Whether this kind of statement can carry sensitive material that we
+    /// redact from logged SQL text (and error messages): secret values, or
+    /// bulk/PII user data in `INSERT`/`UPDATE`/`EXECUTE`. A superset of
+    /// [`Self::is_secret`].
+    pub fn is_sensitive(&self) -> bool {
+        self.is_secret()
+            || matches!(
+                self,
+                StatementKind::Insert | StatementKind::Update | StatementKind::Execute
+            )
+    }
+}
+
 /// A static str for each statement kind
 pub fn statement_kind_label_value(kind: StatementKind) -> &'static str {
     match kind {

--- a/test/cluster/statement-logging/statement-logging.td
+++ b/test/cluster/statement-logging/statement-logging.td
@@ -292,6 +292,17 @@ ROLLBACK
 > SELECT sql FROM mz_internal.mz_recent_activity_log WHERE statement_type = 'alter_secret';
 "ALTER SECRET my_super_secret AS '<REDACTED>'"
 
+# Backstop for SQL-435: a failed secret statement must never persist its real
+# error in `error_message`, which could embed the value through some path the
+# per-site redactions don't cover. The client still receives the real error, but
+# the logged `error_message` is a fixed placeholder.
+
+! CREATE SECRET leaky_secret AS '\xNOTHEXsupersecret'
+contains: could not evaluate secret value
+
+> SELECT error_message FROM mz_internal.mz_recent_activity_log WHERE statement_type = 'create_secret' AND finished_status = 'error';
+"<error redacted for secret statement>"
+
 # Test that UPDATE redacts values.
 
 > RESET cluster

--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -188,3 +188,15 @@ SELECT 1;
 CREATE SECRET leaked AS 'super-sensitive-api-key';
 ----
 db error: ERROR: CREATE SECRET leaked AS '<REDACTED>' cannot be run inside a transaction block
+
+# Regression test for SQL-435: when evaluating the secret value fails (here, an
+# invalid `bytea` literal), the error must not echo the value back, since it is
+# persisted in mz_statement_execution_history. A vague message is used instead.
+statement error could not evaluate secret value
+CREATE SECRET leaked AS '\xNOTHEXsupersecret';
+
+# Regression test for SQL-435: preparing the secret value (not just evaluating
+# it) can fail too, here because mz_now() is unavailable when creating a secret.
+# That path is wrapped as well, so it yields the vague message.
+statement error could not evaluate secret value
+CREATE SECRET prep_fail AS mz_now()::text::bytea;

--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -179,3 +179,12 @@ DROP SCHEMA to_be_dropped CASCADE
 # Secret validation
 statement error secret value must be valid UTF-8
 CREATE SECRET invalid_cert AS '\x80';
+
+# Regression test for SQL-435: a secret statement rejected for running inside a
+# transaction block must not echo its value back in the error, which is
+# persisted in mz_statement_execution_history. The value must be `<REDACTED>`.
+simple
+SELECT 1;
+CREATE SECRET leaked AS 'super-sensitive-api-key';
+----
+db error: ERROR: CREATE SECRET leaked AS '<REDACTED>' cannot be run inside a transaction block

--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -142,7 +142,7 @@ SELECT 1;
 INSERT INTO t VALUES (1) RETURNING 0;
 COMMIT;
 ----
-db error: ERROR: INSERT INTO t VALUES (1) RETURNING 0 cannot be run inside a transaction block
+db error: ERROR: INSERT INTO t VALUES ('<REDACTED>') RETURNING '<REDACTED>' cannot be run inside a transaction block
 
 # Regression for non-constant VALUES
 # VALUES cannot contain a query that references a table.
@@ -152,7 +152,7 @@ BEGIN;
 INSERT INTO t1 VALUES((SELECT x FROM t1 LIMIT 1));
 COMMIT;
 ----
-db error: ERROR: INSERT INTO t1 VALUES ((SELECT x FROM t1 LIMIT 1)) cannot be run inside a transaction block
+db error: ERROR: INSERT INTO t1 VALUES ((SELECT x FROM t1 LIMIT '<REDACTED>')) cannot be run inside a transaction block
 
 # VALUES can contain a subselect with no table references.
 simple
@@ -172,7 +172,7 @@ BEGIN;
 INSERT INTO t1 VALUES((SELECT 1 ORDER BY (SELECT x FROM t1 LIMIT 1)));
 COMMIT;
 ----
-db error: ERROR: INSERT INTO t1 VALUES ((SELECT 1 ORDER BY (SELECT x FROM t1 LIMIT 1))) cannot be run inside a transaction block
+db error: ERROR: INSERT INTO t1 VALUES ((SELECT '<REDACTED>' ORDER BY (SELECT x FROM t1 LIMIT '<REDACTED>'))) cannot be run inside a transaction block
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
### Motivation

Fixes SQL-435. A `CREATE SECRET` / `ALTER SECRET` whose execution failed could store the secret value verbatim in `mz_internal.mz_statement_execution_history.error_message`. For example, running `CREATE SECRET leaked AS '...'` inside a transaction block returned (and logged) an error containing the full statement text, secret included.

**Severity: low.**
- The leaked `error_message` is only accessible with the `mz_monitor` role. The redacted history views available to broader roles (`mz_monitor_redacted`, `mz_support`, `mz_analytics`) already exclude `error_message`.
- To actually leak a secret, an attacker would have to get a privileged user to run some very weird commands (a secret statement crafted to fail with a value-bearing error).

Still worth fixing, since secret values are otherwise never readable, even by `mz_monitor` (the SQL text is redacted to `'<REDACTED>'` everywhere else).

### Description

Three commits, defense in depth:

1. **adapter: redact secrets in OperationProhibitsTransaction error** — When a secret statement is rejected for running inside a transaction block, the error embedded the full statement via `stmt.to_string()`. It now renders with `to_ast_string_redacted()`, so the value shows as `'<REDACTED>'`.
2. **adapter: don't leak secret value in CREATE/ALTER SECRET errors** — Evaluating the secret expression in `extract_secret` could fail with an error quoting the value (e.g. a `bytea` parse error). Failures from both the prepare and eval steps are now mapped to a vague message.
3. **adapter: redact error_message for secret statements as a backstop** — The error surface feeding `error_message` is large and `Display` for AST nodes is unredacted, so a future error could regress this. As a backstop, an unredacted `error_message` is never persisted for `CREATE SECRET`/`ALTER SECRET`; a fixed placeholder is stored instead. The client still receives the real error over pgwire.

### Verification

- `test/sqllogictest/secret.slt`: redaction of the transaction-block error and the eval/prep failures.
- `test/cluster/statement-logging/statement-logging.td`: a failed secret statement's persisted `error_message` is the placeholder. Ran `bin/mzcompose --find cluster run statement-logging`, passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
