### PR TITLE
sql: require target ownership for CREATE REPLACEMENT MATERIALIZED VIEW

### DIFF
--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -672,9 +672,15 @@ fn generate_rbac_requirements(
             if_not_exists: _,
             ambiguous_columns: _,
         }) => RbacRequirements {
+            // `CREATE REPLACEMENT MATERIALIZED VIEW ... FOR <target>` requires ownership of the
+            // target, mirroring `ALTER ... APPLY REPLACEMENT` and `CREATE INDEX`, which require
+            // ownership of the item they act on. `replace` is the separate `CREATE OR REPLACE`
+            // target. Both are optional and independent, so require ownership of whichever are set.
             ownership: replace
-                .map(|id| vec![ObjectId::Item(id)])
-                .unwrap_or_default(),
+                .iter()
+                .chain(materialized_view.replacement_target.iter())
+                .map(|id| ObjectId::Item(*id))
+                .collect(),
             privileges: vec![
                 (
                     SystemObjectId::Object(name.qualifiers.clone().into()),

--- a/test/sqllogictest/replacement-materialized-views.slt
+++ b/test/sqllogictest/replacement-materialized-views.slt
@@ -237,3 +237,99 @@ simple conn=test_role,user=test_role
 SELECT * FROM mv
 ----
 COMPLETE 0
+
+
+# Regression test: authorization to CREATE a replacement against another role's
+# materialized view.
+#
+# CREATE [REPLACEMENT] MATERIALIZED VIEW ... FOR <target> must require ownership of
+# <target>, mirroring ALTER ... APPLY REPLACEMENT and CREATE INDEX, which both
+# require ownership of the item they act on. Without that check a role needs only
+# CREATE on a schema and a cluster it can use, plus USAGE on the target's schema to
+# name it, and can stage a replacement for another role's materialized view. At
+# most one replacement may exist per target, so that locks the owner out of the
+# replacement workflow on their own object, and the owner cannot drop the squatted
+# replacement because it is owned by the other role.
+#
+# The ownership requirement is enforced by the Plan::CreateMaterializedView arm of
+# generate_rbac_requirements in src/sql/src/rbac.rs, which includes
+# materialized_view.replacement_target in its ownership requirement.
+
+# RBAC enforcement is the premise of this test. It is on by default, but set it
+# explicitly so the test stays meaningful if that default ever changes.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks = true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE victim;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA victim_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA attacker_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SCHEMA victim_schema OWNER TO victim;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SCHEMA attacker_schema OWNER TO attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE, USAGE ON CLUSTER quickstart TO victim;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE, USAGE ON CLUSTER quickstart TO attacker;
+----
+COMPLETE 0
+
+# The attacker gets only enough access to name the target, not to read it.
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA victim_schema TO attacker;
+----
+COMPLETE 0
+
+# The victim owns a materialized view in its own schema.
+simple conn=victim,user=victim
+CREATE TABLE victim_schema.t (a int, b int);
+----
+COMPLETE 0
+
+simple conn=victim,user=victim
+CREATE MATERIALIZED VIEW victim_schema.victim_mv AS SELECT a, b FROM victim_schema.t;
+----
+COMPLETE 0
+
+# The attacker reconstructs the target's output schema in its own table. The
+# column names and types are world-readable in the system catalog, so this needs
+# no read of the victim's data.
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.t2 (a int, b int);
+----
+COMPLETE 0
+
+# The attacker has no ownership, SELECT, or USAGE on victim_mv, so staging a
+# replacement for it must be rejected with an ownership error on the target.
+simple conn=attacker,user=attacker
+CREATE REPLACEMENT MATERIALIZED VIEW attacker_schema.rp FOR victim_schema.victim_mv AS SELECT a, b FROM attacker_schema.t2;
+----
+db error: ERROR: must be owner of MATERIALIZED VIEW materialize.victim_schema.victim_mv


### PR DESCRIPTION
### Motivation

`CREATE [REPLACEMENT] MATERIALIZED VIEW ... FOR <target>` performed no
authorization check on `<target>`. A role with `CREATE`/`USAGE` on a cluster and
its own schema, plus `USAGE` on the target's schema to name it, could stage a
replacement for another role's materialized view without owning or reading it.
Since at most one replacement may exist per target, this locks the owner out of
the replacement workflow on their own object, and they can't drop the squatted
replacement because it's owned by the other role.

Low severity: it needs an authenticated role with those privileges, exposes none
of the target's data, and only blocks the replacement workflow on the target.

Fixes SQL-436.

### Description

The `Plan::CreateMaterializedView` arm of `generate_rbac_requirements` required
ownership only for `replace` (the `CREATE OR REPLACE` target), not for the
`FOR <target>` replacement target. Fold the replacement target into the
ownership requirement, mirroring `ALTER ... APPLY REPLACEMENT` and `CREATE INDEX`.

### Verification

New regression test in `test/sqllogictest/replacement-materialized-views.slt`:
an attacker role with only enough access to name a victim's materialized view is
now rejected with `must be owner of MATERIALIZED VIEW ...`. Verified by CI.
