### PR TITLE
sql: reject `ALTER CLUSTER ... WITH (WAIT ...)` on unmanaged clusters

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -6264,7 +6264,7 @@ pub fn plan_alter_cluster(
                     }
                 }
                 false => {
-                    if !alter_strategy.is_none() {
+                    if !with_options.is_empty() {
                         sql_bail!("ALTER... WITH not supported for unmanaged clusters");
                     }
                     if availability_zones.is_some() {

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -424,6 +424,35 @@ ALTER CLUSTER foo set (SIZE 'scale=1,workers=4') WITH (WAIT UNTIL READY (TIMEOUT
 statement ok
 DROP CLUSTER foo
 
+# Regression: SQL-217. `WITH (WAIT ...)` must be rejected on unmanaged
+# clusters, both when the cluster is already unmanaged and when the same
+# statement transitions it from managed to unmanaged. Previously the WAIT
+# options were silently ignored.
+
+statement ok
+CREATE CLUSTER foo REPLICAS (r1 (SIZE 'scale=1,workers=1'))
+
+statement error ALTER\.\.\. WITH not supported for unmanaged clusters
+ALTER CLUSTER foo SET (REPLICAS ()) WITH (WAIT FOR '0s')
+
+statement error ALTER\.\.\. WITH not supported for unmanaged clusters
+ALTER CLUSTER foo SET (REPLICAS ()) WITH (WAIT UNTIL READY (TIMEOUT '0s', ON TIMEOUT 'COMMIT'))
+
+statement ok
+DROP CLUSTER foo
+
+statement ok
+CREATE CLUSTER foo (SIZE 'scale=1,workers=1')
+
+statement error ALTER\.\.\. WITH not supported for unmanaged clusters
+ALTER CLUSTER foo SET (MANAGED = false) WITH (WAIT FOR '0s')
+
+statement error ALTER\.\.\. WITH not supported for unmanaged clusters
+ALTER CLUSTER foo SET (MANAGED = false) WITH (WAIT UNTIL READY (TIMEOUT '0s', ON TIMEOUT 'COMMIT'))
+
+statement ok
+DROP CLUSTER foo
+
 # Regression: zero-downtime finalization (PR #28836) reads workload_class from
 # the catalog instead of the planned config, silently dropping the change.
 


### PR DESCRIPTION
Problem:
`ALTER CLUSTER c SET (MANAGED = false) WITH (WAIT FOR '...')` and the `WAIT UNTIL READY` variant were silently accepted: the WAIT options were parsed and then dropped without effect, contrary to the error other managed-only options produce ("not supported for unmanaged clusters").

Solution:
Validate the raw `with_options` in the unmanaged arm instead of the typed strategy. Any non-empty `WITH` clause on an unmanaged target now errors consistently with the sibling option checks.

Testing:
Added four cases to `test/sqllogictest/managed_cluster.slt` covering `WAIT FOR` and `WAIT UNTIL READY` against (a) an already-unmanaged cluster and (b) a managed->unmanaged transition

Fixes SQL-217.

