### PR TITLE
adapter: apply group commits off the coordinator loop

### DIFF
--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -237,39 +237,21 @@ the change.
 
 ### The group committer is the single in-process writer to the txns shard
 
-All txns-shard writes (table appends from group commits, table registration
-and forgetting for DDL) flow through the group committer task
-(`src/adapter/src/coord/appends.rs`), one queue, applied one at a time at
-monotone oracle timestamps. Do not add a second path that sends commands to
-the persist table-write worker from anywhere else at runtime. The bootstrap
-path (`StorageController::register_table_collections`) is the one exception,
-safe only because nothing else runs during bootstrap.
-
-Two reasons this is load-bearing:
-
-- **The worker's command channel carries an implicit ordering contract.** An
-  append containing writes for a table must reach the worker before the forget
-  of that table, otherwise the worker has no registered shard to write to and
-  panics. When all commands came from the coordinator loop, loop serialization
-  provided this ordering for free. The moment appends moved off-loop into the
-  committer, a DROP TABLE forgetting directly from the loop could overtake a
-  staged INSERT sitting in the committer's queue (DROP takes no write locks,
-  so nothing else prevented it). Any off-loop sender reintroduces this race.
-  The fix is structural: one sender, one queue, ordering by construction.
-- **In-process txns-shard conflicts become impossible**, so an
-  `InvalidUppers` result from the worker means exactly one thing: another
-  process wrote the txns shard. The committer retries at a fresh oracle
-  timestamp, which is the correct protocol for concurrent `environmentd`
-  writers and needs no coordination beyond the oracle's monotonicity.
-
-Related: the catalog shard's write-conflict protocol lives in the
-compare-and-append itself (`commit_transaction` and `advance_upper` in
-`src/catalog/src/durable/persist.rs`). On an upper mismatch they classify the
-conflicting interval: zero raw updates is empty progress (safe to rebase over
-and retry), anything else is content from another writer and surfaces as the
-graceful `CatalogOutOfSync` error, on which the process restarts and rebuilds
-from durable state. Checks before the write (`ensure_not_out_of_sync`) are
-early-abort conveniences, not the enforcement.
+All txns-shard writes (group-commit appends, table registration and forgetting
+for DDL) go through the group committer task's queue, one at a time at
+monotone oracle timestamps. Do not add another runtime sender to the persist
+table-write worker. Queue order is load-bearing: an append to a table must
+reach the worker before that table's forget, or the worker has no registered
+shard to write to and panics, and only queue order provides this (DROP TABLE
+takes no write locks). Single-writer also makes in-process txns-shard
+conflicts impossible, so `InvalidUppers` from the worker always means another
+process wrote the shard, handled by retrying at a fresh oracle timestamp.
+Bootstrap's `register_table_collections` is the one exception, safe because
+nothing else runs during bootstrap. The catalog shard's analogous conflict
+protocol lives in the compare-and-append itself (`commit_transaction` and
+`advance_upper` in `src/catalog/src/durable/persist.rs`): empty progress is
+rebased over, foreign content surfaces as the graceful `CatalogOutOfSync`.
+Full protocol in the module docs of `src/adapter/src/coord/appends.rs`.
 
 ## Rejected Optimizations
 

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -235,6 +235,42 @@ keep the change invisible to session-visible catalog reads (name resolution,
 planning). Otherwise sessions serve stale catalogs where today they would see
 the change.
 
+### The group committer is the single in-process writer to the txns shard
+
+All txns-shard writes (table appends from group commits, table registration
+and forgetting for DDL) flow through the group committer task
+(`src/adapter/src/coord/appends.rs`), one queue, applied one at a time at
+monotone oracle timestamps. Do not add a second path that sends commands to
+the persist table-write worker from anywhere else at runtime. The bootstrap
+path (`StorageController::register_table_collections`) is the one exception,
+safe only because nothing else runs during bootstrap.
+
+Two reasons this is load-bearing:
+
+- **The worker's command channel carries an implicit ordering contract.** An
+  append containing writes for a table must reach the worker before the forget
+  of that table, otherwise the worker has no registered shard to write to and
+  panics. When all commands came from the coordinator loop, loop serialization
+  provided this ordering for free. The moment appends moved off-loop into the
+  committer, a DROP TABLE forgetting directly from the loop could overtake a
+  staged INSERT sitting in the committer's queue (DROP takes no write locks,
+  so nothing else prevented it). Any off-loop sender reintroduces this race.
+  The fix is structural: one sender, one queue, ordering by construction.
+- **In-process txns-shard conflicts become impossible**, so an
+  `InvalidUppers` result from the worker means exactly one thing: another
+  process wrote the txns shard. The committer retries at a fresh oracle
+  timestamp, which is the correct protocol for concurrent `environmentd`
+  writers and needs no coordination beyond the oracle's monotonicity.
+
+Related: the catalog shard's write-conflict protocol lives in the
+compare-and-append itself (`commit_transaction` and `advance_upper` in
+`src/catalog/src/durable/persist.rs`). On an upper mismatch they classify the
+conflicting interval: zero raw updates is empty progress (safe to rebase over
+and retry), anything else is content from another writer and surfaces as the
+graceful `CatalogOutOfSync` error, on which the process restarts and rebuilds
+from durable state. Checks before the write (`ensure_not_out_of_sync`) are
+early-abort conveniences, not the enforcement.
+
 ## Rejected Optimizations
 
 This section records specific optimizations that have been attempted and found

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -237,20 +237,45 @@ keep the change invisible to session-visible catalog reads (name resolution,
 planning). Otherwise sessions serve stale catalogs where today they would see
 the change.
 
-### Group commit ordering and handover
+### Group commits and generation handover
 
-All runtime txns-shard operations in a process use one FIFO group committer. This ordering prevents
-an append from overtaking table registration or forgetting. Bootstrap may write directly because no local
-commands run concurrently before this process serves.
+At runtime, one group committer per `environmentd` serializes txns-shard operations:
 
-Writable bootstrap fences the old catalog generation, then orders the system-table snapshot and
-reset after a txns-shard write. A stale write either lands before that barrier and is observed, or
-conflicts. Its retry takes a fresh timestamp from the shared oracle. That timestamp's advance
-frontier is above the stale catalog handle's cached upper, so catalog advancement reaches Persist
-and observes the fence before another txns write.
+```text
+append / register / forget -> FIFO group committer -> table-write worker -> txns shard
+```
 
-An `advance_upper` no-op only checks a fence already observed by that handle. It is not a general
-leadership check. The fresh retry's advance frontier forces the durable handover check.
+FIFO ordering prevents an append from overtaking table registration or forgetting. Bootstrap is
+the only local exception because it runs before the process serves.
+
+Each runtime command uses this protocol:
+
+```text
+shared oracle write timestamp -> advance catalog upper -> compare-and-append txns shard
+                                                       | conflict -> retry
+                                                       ` success  -> apply write to oracle
+```
+
+The successful timestamp is applied to the oracle only after the txns write is durable.
+
+On `environmentd` bootstrap in read/write mode:
+
+```text
+catalog fence -> set up and register tables -> txns write advances table uppers
+              -> snapshot and reset system tables -> start serving
+```
+
+The snapshots cannot complete until the txns write has advanced the table uppers. Therefore:
+
+```text
+pre-fence write before barrier -> ordered before the snapshot
+pre-fence write after barrier  -> `InvalidUppers` -> retry at a fresh timestamp
+                                -> catalog advance observes the fence -> old generation exits
+```
+
+A system-table write before the barrier is included in the reset. A user-table write remains
+visible to later reads. The retry's `advance_to` is above the stale catalog handle's cached upper,
+so its catalog check is durable. An `advance_upper` no-op only checks an already-observed fence.
 
 ## Rejected Optimizations
 

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -237,24 +237,20 @@ keep the change invisible to session-visible catalog reads (name resolution,
 planning). Otherwise sessions serve stale catalogs where today they would see
 the change.
 
-### The group committer is the single in-process writer to the txns shard
+### Group commit ordering and handover
 
-All txns-shard writes (group-commit appends, table registration and forgetting
-for DDL) go through the group committer task's queue, one at a time at
-monotone oracle timestamps. Do not add another runtime sender to the persist
-table-write worker. Queue order is load-bearing: an append to a table must
-reach the worker before that table's forget, or the worker has no registered
-shard to write to and panics, and only queue order provides this (DROP TABLE
-takes no write locks). Single-writer also makes in-process txns-shard
-conflicts impossible, so `InvalidUppers` from the worker always means another
-process wrote the shard, handled by retrying at a fresh oracle timestamp.
-Bootstrap is the one exception (`register_table_collections` and its direct
-table appends), safe because nothing else runs during bootstrap. The catalog
-shard's analogous conflict protocol lives in the compare-and-append itself
-(`commit_transaction` and
-`advance_upper` in `src/catalog/src/durable/persist.rs`): empty progress is
-rebased over, foreign content surfaces as the graceful `CatalogOutOfSync`.
-Full protocol in the module docs of `src/adapter/src/coord/appends.rs`.
+All runtime txns-shard operations in a process use one FIFO group committer. This ordering prevents
+an append from overtaking table registration or forgetting. Bootstrap may write directly because no local
+commands run concurrently before this process serves.
+
+Writable bootstrap fences the old catalog generation, then orders the system-table snapshot and
+reset after a txns-shard write. A stale write either lands before that barrier and is observed, or
+conflicts. Its retry takes a fresh timestamp from the shared oracle. That timestamp's advance
+frontier is above the stale catalog handle's cached upper, so catalog advancement reaches Persist
+and observes the fence before another txns write.
+
+An `advance_upper` no-op only checks a fence already observed by that handle. It is not a general
+leadership check. The fresh retry's advance frontier forces the durable handover check.
 
 ## Rejected Optimizations
 

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -213,7 +213,8 @@ compare-and-append. It is a time-of-check to time-of-use gap.
 
 - It is safe today only by the fragile accident that the coordinator loop does
   not yield between the check and the durable commit. Any await later inserted
-  between them, or any move of the check off the loop, reopens the race.
+  between them, or any move of the check off the coordinator loop, reopens
+  the race.
 - It does not hold across writers. Another `environmentd` that commits a
   conflicting change to the durable store between this node's in-memory check and
   its durable commit is not detected. The durable layer does not re-validate a
@@ -222,7 +223,8 @@ compare-and-append. It is a time-of-check to time-of-use gap.
 
 If you need conflict detection, evaluate the precondition atomically with the
 commit, a real compare-and-append against the durable store. A check that merely
-precedes the write on the loop is not that, even when it reads the right state.
+precedes the write on the coordinator loop is not that, even when it reads the
+right state.
 
 ### Catalog mutations must bump the transient revision or stay invisible
 
@@ -246,9 +248,10 @@ shard to write to and panics, and only queue order provides this (DROP TABLE
 takes no write locks). Single-writer also makes in-process txns-shard
 conflicts impossible, so `InvalidUppers` from the worker always means another
 process wrote the shard, handled by retrying at a fresh oracle timestamp.
-Bootstrap's `register_table_collections` is the one exception, safe because
-nothing else runs during bootstrap. The catalog shard's analogous conflict
-protocol lives in the compare-and-append itself (`commit_transaction` and
+Bootstrap is the one exception (`register_table_collections` and its direct
+table appends), safe because nothing else runs during bootstrap. The catalog
+shard's analogous conflict protocol lives in the compare-and-append itself
+(`commit_transaction` and
 `advance_upper` in `src/catalog/src/durable/persist.rs`): empty progress is
 rebased over, foreign content surfaces as the graceful `CatalogOutOfSync`.
 Full protocol in the module docs of `src/adapter/src/coord/appends.rs`.

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -809,17 +809,17 @@ metrics:
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_group_commit_catalog_upper_seconds_bucket
-  help: The time it takes to advance the catalog shard upper during group commit.
+  help: The time it takes to advance the catalog shard upper for a txns-shard write (group commits and table register/forget).
   labels:
   - le
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_group_commit_catalog_upper_seconds_count
-  help: The time it takes to advance the catalog shard upper during group commit.
+  help: The time it takes to advance the catalog shard upper for a txns-shard write (group commits and table register/forget).
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_group_commit_catalog_upper_seconds_sum
-  help: The time it takes to advance the catalog shard upper during group commit.
+  help: The time it takes to advance the catalog shard upper for a txns-shard write (group commits and table register/forget).
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_handle_scheduling_decisions_seconds_bucket

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -702,6 +702,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "sql_server_cdc_cleanup_change_table",
     "sql_server_cdc_cleanup_change_table_max_deletes",
     "allow_user_sessions",
+    "group_commit_max_attempts",
     "with_0dt_deployment_ddl_check_interval",
     "enable_0dt_caught_up_check",
     "with_0dt_caught_up_check_allowed_lag",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1796,6 +1796,11 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_validate_part_bounds_on_write"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["group_commit_max_attempts"] = [
+            "1",
+            "100",
+            "1000",
+        ]
         self.flags_with_values["user_id_pool_batch_size"] = [
             "1",
             "5",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -284,6 +284,15 @@ pub const USER_ID_POOL_BATCH_SIZE: Config<u32> = Config::new(
     "Number of user IDs to pre-allocate in a batch for DDL operations.",
 );
 
+/// Maximum number of txns-shard write attempts before rebuilding `environmentd`.
+///
+/// The effective minimum is one attempt.
+pub const GROUP_COMMIT_MAX_ATTEMPTS: Config<usize> = Config::new(
+    "group_commit_max_attempts",
+    100,
+    "Maximum number of txns-shard write attempts before rebuilding environmentd. Values below 1 are treated as 1.",
+);
+
 /// OIDC client ID for the web console.
 pub const CONSOLE_OIDC_CLIENT_ID: Config<&'static str> = Config::new(
     "console_oidc_client_id",
@@ -457,6 +466,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&MCP_REQUEST_TIMEOUT)
         .add(&WEBHOOK_MAX_REQUEST_SIZE_BYTES)
         .add(&USER_ID_POOL_BATCH_SIZE)
+        .add(&GROUP_COMMIT_MAX_ATTEMPTS)
         .add(&CONSOLE_OIDC_CLIENT_ID)
         .add(&CONSOLE_OIDC_SCOPES)
         .add(&ARRANGEMENT_SIZE_HISTORY_COLLECTION_INTERVAL)

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -156,17 +156,14 @@ pub struct Catalog {
     shared_transient_revision: Arc<AtomicU64>,
 }
 
-/// A narrow handle to the durable catalog for advancing its upper from off the coordinator loop.
-///
-/// See [`Catalog::upper_handle`].
+/// A handle for advancing the durable catalog upper off the coordinator loop.
 #[derive(Debug, Clone)]
 pub struct CatalogUpperHandle {
     storage: Arc<tokio::sync::Mutex<Box<dyn mz_catalog::durable::DurableCatalogState>>>,
 }
 
 impl CatalogUpperHandle {
-    /// Advances the catalog upper to at least `new_upper`. See
-    /// [`Catalog::advance_upper`] for the semantics.
+    /// Advances the durable catalog upper to at least `new_upper`.
     pub async fn advance_upper(
         &self,
         new_upper: mz_repr::Timestamp,
@@ -1171,26 +1168,17 @@ impl Catalog {
         }
     }
 
-    /// Advances the catalog upper to at least `new_upper`, tolerating an upper that is already
-    /// past it.
+    /// Advances the catalog upper to at least `new_upper`.
     ///
-    /// A no-op when the catalog upper already reached `new_upper`: the group committer
-    /// allocates its write timestamp off the coordinator loop, so by the time it advances the
-    /// catalog upper to match,
-    /// an on-loop catalog transaction may already have advanced it past that timestamp. Content
-    /// committed by another writer in between surfaces as a `CatalogOutOfSync` error, on which we
-    /// must restart and rebuild from durable state.
+    /// Empty progress can overtake `new_upper`. A durable upper mismatch with content returns
+    /// `CatalogOutOfSync`. See [`mz_catalog::durable::DurableCatalogState::advance_upper`] for
+    /// fencing semantics.
     #[mz_ore::instrument(level = "debug")]
     pub async fn advance_upper(&self, new_upper: mz_repr::Timestamp) -> Result<(), AdapterError> {
         Ok(self.storage().await.advance_upper(new_upper).await?)
     }
 
-    /// Returns a narrow handle for advancing the catalog upper from off the coordinator loop.
-    ///
-    /// The handle shares the durable-storage mutex with catalog transactions, so advancement
-    /// stays serialized with DDL commits. It deliberately does not expose the in-memory
-    /// `CatalogState`: a clone held by a long-lived task would be a permanently stale snapshot,
-    /// inviting accidental use.
+    /// Returns a durable-upper handle that shares the catalog storage mutex.
     pub fn upper_handle(&self) -> CatalogUpperHandle {
         CatalogUpperHandle {
             storage: Arc::clone(&self.storage),

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -36,9 +36,8 @@ use mz_catalog::config::{BuiltinItemMigrationConfig, ClusterReplicaSizeMap, Conf
 #[cfg(test)]
 use mz_catalog::durable::CatalogError;
 use mz_catalog::durable::{
-    BootstrapArgs, DurableCatalogState, STORAGE_USAGE_ID_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY,
-    TestCatalogStateBuilder, USER_CLUSTER_ID_ALLOC_KEY, USER_ITEM_ALLOC_KEY,
-    USER_REPLICA_ID_ALLOC_KEY, test_bootstrap_args,
+    BootstrapArgs, DurableCatalogState, STORAGE_USAGE_ID_ALLOC_KEY, TestCatalogStateBuilder,
+    test_bootstrap_args,
 };
 use mz_catalog::expr_cache::{ExpressionCacheHandle, GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::error::{Error, ErrorKind};
@@ -622,20 +621,18 @@ impl Catalog {
         self.storage().await.current_upper().await
     }
 
+    /// Allocates and returns both a user [`CatalogItemId`] and [`GlobalId`], delegating to
+    /// [`DurableCatalogState::allocate_user_id`].
     pub async fn allocate_user_id(
         &self,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<(CatalogItemId, GlobalId), Error> {
-        use mz_ore::collections::CollectionExt;
-
-        let ids = self
+        Ok(self
             .storage()
             .await
-            .allocate_id(USER_ITEM_ALLOC_KEY, 1, commit_ts)
+            .allocate_user_id(commit_ts)
             .await
-            .maybe_terminate("allocating user ids")?;
-        let id = ids.into_element();
-        Ok((CatalogItemId::User(id), GlobalId::User(id)))
+            .maybe_terminate("allocating user ids")?)
     }
 
     /// Allocate `amount` many user IDs. See [`DurableCatalogState::allocate_user_ids`].
@@ -644,16 +641,12 @@ impl Catalog {
         amount: u64,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<Vec<(CatalogItemId, GlobalId)>, Error> {
-        let ids = self
+        Ok(self
             .storage()
             .await
-            .allocate_id(USER_ITEM_ALLOC_KEY, amount, commit_ts)
+            .allocate_user_ids(amount, commit_ts)
             .await
-            .maybe_terminate("allocating user ids")?;
-        Ok(ids
-            .iter()
-            .map(|id| (CatalogItemId::User(*id), GlobalId::User(*id)))
-            .collect())
+            .maybe_terminate("allocating user ids")?)
     }
 
     pub async fn allocate_user_id_for_test(&self) -> Result<(CatalogItemId, GlobalId), Error> {
@@ -720,20 +713,18 @@ impl Catalog {
             .err_into()
     }
 
+    /// Allocates and returns a user [`ClusterId`], delegating to
+    /// [`DurableCatalogState::allocate_user_cluster_id`].
     pub async fn allocate_user_cluster_id(
         &self,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<ClusterId, Error> {
-        use mz_ore::collections::CollectionExt;
-
-        let ids = self
+        Ok(self
             .storage()
             .await
-            .allocate_id(USER_CLUSTER_ID_ALLOC_KEY, 1, commit_ts)
+            .allocate_user_cluster_id(commit_ts)
             .await
-            .maybe_terminate("allocating user cluster ids")?;
-        let id = ids.into_element();
-        Ok(ClusterId::user(id).ok_or(SqlCatalogError::IdExhaustion)?)
+            .maybe_terminate("allocating user cluster ids")?)
     }
 
     /// Allocate `amount` many user replica IDs. See
@@ -743,13 +734,12 @@ impl Catalog {
         amount: u64,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<Vec<ReplicaId>, Error> {
-        let ids = self
+        Ok(self
             .storage()
             .await
-            .allocate_id(USER_REPLICA_ID_ALLOC_KEY, amount, commit_ts)
+            .allocate_user_replica_ids(amount, commit_ts)
             .await
-            .maybe_terminate("allocating user replica ids")?;
-        Ok(ids.into_iter().map(ReplicaId::User).collect())
+            .maybe_terminate("allocating user replica ids")?)
     }
 
     /// Allocate `amount` many system replica IDs. See
@@ -759,13 +749,12 @@ impl Catalog {
         amount: u64,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<Vec<ReplicaId>, Error> {
-        let ids = self
+        Ok(self
             .storage()
             .await
-            .allocate_id(SYSTEM_REPLICA_ID_ALLOC_KEY, amount, commit_ts)
+            .allocate_system_replica_ids(amount, commit_ts)
             .await
-            .maybe_terminate("allocating system replica ids")?;
-        Ok(ids.into_iter().map(ReplicaId::System).collect())
+            .maybe_terminate("allocating system replica ids")?)
     }
 
     /// Allocate `amount` many replica IDs for `cluster_id`, picking user or
@@ -1185,8 +1174,9 @@ impl Catalog {
     /// Advances the catalog upper to at least `new_upper`, tolerating an upper that is already
     /// past it.
     ///
-    /// A no-op when the catalog upper already reached `new_upper`: the group committer allocates
-    /// its write timestamp off the loop, so by the time it advances the catalog upper to match,
+    /// A no-op when the catalog upper already reached `new_upper`: the group committer
+    /// allocates its write timestamp off the coordinator loop, so by the time it advances the
+    /// catalog upper to match,
     /// an on-loop catalog transaction may already have advanced it past that timestamp. Content
     /// committed by another writer in between surfaces as a `CatalogOutOfSync` error, on which we
     /// must restart and rebuild from durable state.

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -36,8 +36,9 @@ use mz_catalog::config::{BuiltinItemMigrationConfig, ClusterReplicaSizeMap, Conf
 #[cfg(test)]
 use mz_catalog::durable::CatalogError;
 use mz_catalog::durable::{
-    BootstrapArgs, DurableCatalogState, STORAGE_USAGE_ID_ALLOC_KEY, TestCatalogStateBuilder,
-    test_bootstrap_args,
+    BootstrapArgs, DurableCatalogState, STORAGE_USAGE_ID_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY,
+    TestCatalogStateBuilder, USER_CLUSTER_ID_ALLOC_KEY, USER_ITEM_ALLOC_KEY,
+    USER_REPLICA_ID_ALLOC_KEY, test_bootstrap_args,
 };
 use mz_catalog::expr_cache::{ExpressionCacheHandle, GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::error::{Error, ErrorKind};
@@ -154,6 +155,25 @@ pub struct Catalog {
     /// session that has observed any evidence of a catalog change is
     /// guaranteed to see the corresponding bump.
     shared_transient_revision: Arc<AtomicU64>,
+}
+
+/// A narrow handle to the durable catalog for advancing its upper from off the coordinator loop.
+///
+/// See [`Catalog::upper_handle`].
+#[derive(Debug, Clone)]
+pub struct CatalogUpperHandle {
+    storage: Arc<tokio::sync::Mutex<Box<dyn mz_catalog::durable::DurableCatalogState>>>,
+}
+
+impl CatalogUpperHandle {
+    /// Advances the catalog upper to at least `new_upper`. See
+    /// [`Catalog::advance_upper`] for the semantics.
+    pub async fn advance_upper(
+        &self,
+        new_upper: mz_repr::Timestamp,
+    ) -> Result<(), mz_catalog::durable::CatalogError> {
+        self.storage.lock().await.advance_upper(new_upper).await
+    }
 }
 
 // Implement our own Clone because derive can't unless S is Clone, which it's
@@ -606,12 +626,16 @@ impl Catalog {
         &self,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<(CatalogItemId, GlobalId), Error> {
-        self.storage()
+        use mz_ore::collections::CollectionExt;
+
+        let ids = self
+            .storage()
             .await
-            .allocate_user_id(commit_ts)
+            .allocate_id(USER_ITEM_ALLOC_KEY, 1, commit_ts)
             .await
-            .maybe_terminate("allocating user ids")
-            .err_into()
+            .maybe_terminate("allocating user ids")?;
+        let id = ids.into_element();
+        Ok((CatalogItemId::User(id), GlobalId::User(id)))
     }
 
     /// Allocate `amount` many user IDs. See [`DurableCatalogState::allocate_user_ids`].
@@ -620,12 +644,16 @@ impl Catalog {
         amount: u64,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<Vec<(CatalogItemId, GlobalId)>, Error> {
-        self.storage()
+        let ids = self
+            .storage()
             .await
-            .allocate_user_ids(amount, commit_ts)
+            .allocate_id(USER_ITEM_ALLOC_KEY, amount, commit_ts)
             .await
-            .maybe_terminate("allocating user ids")
-            .err_into()
+            .maybe_terminate("allocating user ids")?;
+        Ok(ids
+            .iter()
+            .map(|id| (CatalogItemId::User(*id), GlobalId::User(*id)))
+            .collect())
     }
 
     pub async fn allocate_user_id_for_test(&self) -> Result<(CatalogItemId, GlobalId), Error> {
@@ -696,12 +724,16 @@ impl Catalog {
         &self,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<ClusterId, Error> {
-        self.storage()
+        use mz_ore::collections::CollectionExt;
+
+        let ids = self
+            .storage()
             .await
-            .allocate_user_cluster_id(commit_ts)
+            .allocate_id(USER_CLUSTER_ID_ALLOC_KEY, 1, commit_ts)
             .await
-            .maybe_terminate("allocating user cluster ids")
-            .err_into()
+            .maybe_terminate("allocating user cluster ids")?;
+        let id = ids.into_element();
+        Ok(ClusterId::user(id).ok_or(SqlCatalogError::IdExhaustion)?)
     }
 
     /// Allocate `amount` many user replica IDs. See
@@ -711,12 +743,13 @@ impl Catalog {
         amount: u64,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<Vec<ReplicaId>, Error> {
-        self.storage()
+        let ids = self
+            .storage()
             .await
-            .allocate_user_replica_ids(amount, commit_ts)
+            .allocate_id(USER_REPLICA_ID_ALLOC_KEY, amount, commit_ts)
             .await
-            .maybe_terminate("allocating user replica ids")
-            .err_into()
+            .maybe_terminate("allocating user replica ids")?;
+        Ok(ids.into_iter().map(ReplicaId::User).collect())
     }
 
     /// Allocate `amount` many system replica IDs. See
@@ -726,12 +759,13 @@ impl Catalog {
         amount: u64,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<Vec<ReplicaId>, Error> {
-        self.storage()
+        let ids = self
+            .storage()
             .await
-            .allocate_system_replica_ids(amount, commit_ts)
+            .allocate_id(SYSTEM_REPLICA_ID_ALLOC_KEY, amount, commit_ts)
             .await
-            .maybe_terminate("allocating system replica ids")
-            .err_into()
+            .maybe_terminate("allocating system replica ids")?;
+        Ok(ids.into_iter().map(ReplicaId::System).collect())
     }
 
     /// Allocate `amount` many replica IDs for `cluster_id`, picking user or
@@ -1148,9 +1182,29 @@ impl Catalog {
         }
     }
 
+    /// Advances the catalog upper to at least `new_upper`, tolerating an upper that is already
+    /// past it.
+    ///
+    /// A no-op when the catalog upper already reached `new_upper`: the group committer allocates
+    /// its write timestamp off the loop, so by the time it advances the catalog upper to match,
+    /// an on-loop catalog transaction may already have advanced it past that timestamp. Content
+    /// committed by another writer in between surfaces as a `CatalogOutOfSync` error, on which we
+    /// must restart and rebuild from durable state.
     #[mz_ore::instrument(level = "debug")]
     pub async fn advance_upper(&self, new_upper: mz_repr::Timestamp) -> Result<(), AdapterError> {
         Ok(self.storage().await.advance_upper(new_upper).await?)
+    }
+
+    /// Returns a narrow handle for advancing the catalog upper from off the coordinator loop.
+    ///
+    /// The handle shares the durable-storage mutex with catalog transactions, so advancement
+    /// stays serialized with DDL commits. It deliberately does not expose the in-memory
+    /// `CatalogState`: a clone held by a long-lived task would be a permanently stale snapshot,
+    /// inviting accidental use.
+    pub fn upper_handle(&self) -> CatalogUpperHandle {
+        CatalogUpperHandle {
+            storage: Arc::clone(&self.storage),
+        }
     }
 
     /// Return the ids of all log sources the given object depends on.

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -707,16 +707,11 @@ impl Catalog {
         let mut catalog_updates = vec![];
         let mut audit_events = vec![];
         let mut storage = self.storage().await;
-        // Open in-sync: content committed by another writer before this point means the ops were
-        // planned against stale catalog state, which surfaces as a graceful `CatalogOutOfSync`.
-        // The commit itself only detects writers that interleave after this open, so this check
-        // is load-bearing, see `transaction_in_sync`.
         let mut tx = storage
             .transaction_in_sync()
             .await
             .unwrap_or_terminate("starting catalog transaction");
-        // Empty progress (e.g. the group committer bumping the upper past our oracle timestamp)
-        // is safe to rebase over because it does not change catalog contents.
+        // Empty progress may have overtaken the timestamp chosen before opening the transaction.
         let commit_ts = std::cmp::max(oracle_write_ts, tx.upper());
 
         let new_state = Self::transact_inner(

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -708,7 +708,7 @@ impl Catalog {
         let mut audit_events = vec![];
         let mut storage = self.storage().await;
         let mut tx = storage
-            .transaction_in_sync()
+            .transaction()
             .await
             .unwrap_or_terminate("starting catalog transaction");
         // Empty progress may have overtaken the timestamp chosen before opening the transaction.

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -711,11 +711,19 @@ impl Catalog {
             .transaction()
             .await
             .unwrap_or_terminate("starting catalog transaction");
+        // Opening the transaction syncs the durable handle to its current upper. Empty progress
+        // is safe to cross because it does not change catalog contents. Real updates mean the
+        // adapter planned this transaction against stale catalog state, so we must restart and
+        // rebuild from durable state before applying catalog implications.
+        tx.ensure_not_out_of_sync()
+            .await
+            .unwrap_or_terminate("durable catalog changed before transaction");
+        let commit_ts = std::cmp::max(oracle_write_ts, tx.upper());
 
         let new_state = Self::transact_inner(
             TransactInnerMode::Commit,
             storage_collections,
-            oracle_write_ts,
+            commit_ts,
             session,
             ops,
             temporary_ids,
@@ -731,7 +739,7 @@ impl Catalog {
         // process if this fails, because we have to restart envd due to
         // indeterminate catalog state, which we only reconcile during catalog
         // init.
-        tx.commit(oracle_write_ts)
+        tx.commit(commit_ts)
             .await
             .unwrap_or_terminate("catalog storage transaction commit must succeed");
 

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -33,7 +33,7 @@ use mz_audit_log::{
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_catalog::builtin::BuiltinLog;
-use mz_catalog::durable::{NetworkPolicy, Snapshot, Transaction};
+use mz_catalog::durable::{DryRunTransaction, NetworkPolicy, Snapshot, Transaction};
 use mz_catalog::expr_cache::LocalExpressions;
 use mz_catalog::memory::error::{AmbiguousRename, Error, ErrorKind};
 use mz_catalog::memory::objects::{
@@ -798,10 +798,11 @@ impl Catalog {
         } else {
             // First statement: fresh transaction from durable storage, which
             // is in sync with the real catalog state.
-            storage
+            let tx = storage
                 .transaction()
                 .await
-                .unwrap_or_terminate("starting catalog transaction")
+                .unwrap_or_terminate("starting catalog transaction");
+            DryRunTransaction::new(tx)
         };
 
         // Process only the new ops against the accumulated state in dry-run mode.
@@ -815,7 +816,7 @@ impl Catalog {
             &mut builtin_table_updates,
             &mut catalog_updates,
             &mut audit_events,
-            &mut tx,
+            tx.transaction_mut(),
             base_state,
         )
         .await?;

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -707,17 +707,16 @@ impl Catalog {
         let mut catalog_updates = vec![];
         let mut audit_events = vec![];
         let mut storage = self.storage().await;
+        // Open in-sync: content committed by another writer before this point means the ops were
+        // planned against stale catalog state, which surfaces as a graceful `CatalogOutOfSync`.
+        // The commit itself only detects writers that interleave after this open, so this check
+        // is load-bearing, see `transaction_in_sync`.
         let mut tx = storage
-            .transaction()
+            .transaction_in_sync()
             .await
             .unwrap_or_terminate("starting catalog transaction");
-        // Opening the transaction syncs the durable handle to its current upper. Empty progress
-        // is safe to cross because it does not change catalog contents. Real updates mean the
-        // adapter planned this transaction against stale catalog state, so we must restart and
-        // rebuild from durable state before applying catalog implications.
-        tx.ensure_not_out_of_sync()
-            .await
-            .unwrap_or_terminate("durable catalog changed before transaction");
+        // Empty progress (e.g. the group committer bumping the upper past our oracle timestamp)
+        // is safe to rebase over because it does not change catalog contents.
         let commit_ts = std::cmp::max(oracle_write_ts, tx.upper());
 
         let new_state = Self::transact_inner(

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -354,23 +354,15 @@ pub enum Message {
     },
     /// Initiates a group commit.
     GroupCommitInitiate(Span, Option<GroupCommitPermit>),
-    /// Finalizes a group commit that the committer applied off the coordinator loop. The
-    /// committer does the oracle round trips, table append, oracle write application, and
-    /// catalog upper advancement, then hands back the cheap work that needs coordinator state:
-    /// record statement
-    /// execution timestamps, retire client responses, and downgrade local read holds.
+    /// Finalizes an applied group commit.
     ///
-    /// NOTE: Statement timestamps must be recorded before the responses are retired, because
-    /// retiring ends the statement execution and drops its logging record. That is why retiring
-    /// happens here on the coordinator loop rather than in the committer.
+    /// Statement timestamps precede response retirement because retirement ends statement logging.
     GroupCommitApplied {
-        /// Client responses to retire, once statement timestamps are recorded.
+        /// Responses to retire after recording statement timestamps.
         responses: Vec<crate::util::CompletedClientTransmitter>,
-        /// Statement executions whose execution timestamp is this commit's write timestamp.
+        /// Statement executions associated with this commit.
         statement_logging_ids: Vec<StatementLoggingId>,
-        /// This commit's write timestamp. Used for statement logging, per-session
-        /// read-your-writes, and for downgrading local read holds: the committer applied it to
-        /// the oracle, so the read ts is at least this.
+        /// The applied write timestamp.
         write_ts: Timestamp,
     },
     DeferredStatementReady,
@@ -1633,23 +1625,10 @@ impl Drop for ExecuteContextGuard {
     }
 }
 
-/// Bundle of state related to statement execution.
+/// Carries the session and statement state needed to retire an execution.
 ///
-/// This struct collects a bundle of state that needs to be threaded
-/// through various functions as part of statement execution.
-/// It is used to finalize execution, by calling `retire`. Finalizing execution
-/// involves sending the session back to the pgwire layer so that it
-/// may be used to process further commands. It also involves
-/// performing some work on the main coordinator thread
-/// (e.g., recording the time at which the statement finished
-/// executing). The state necessary to perform this work is bundled in
-/// the `ExecuteContextGuard` object.
-///
-/// Dropping one without calling [`Self::retire`] (or [`Self::into_parts`]) retires the client
-/// with an error instead. That backstop matters because contexts travel through queues and
-/// tasks (the group committer, internal messages): at process shutdown they get dropped
-/// wherever they are, and a raw drop would panic in `ClientTransmitter::drop`, and a panic
-/// inside a destructor aborts the process.
+/// Dropping an unretired context fails the client synchronously. Shutdown can drop contexts from
+/// task queues, where spawning response-barrier work is no longer safe.
 #[derive(Debug)]
 pub struct ExecuteContext {
     // `None` only after `retire`/`into_parts` consumed the context.
@@ -1674,13 +1653,8 @@ impl Drop for ExecuteContext {
         let Some(inner) = self.inner.take() else {
             return;
         };
-        // We were dropped without `retire`. That legitimately happens at process shutdown,
-        // when queues and tasks holding contexts get dropped with executions still in flight.
-        // Anywhere else it is a bug (a response silently never sent), which the warning below
-        // keeps visible. Retire the client with an error, fully synchronously: we bypass
-        // `retire` because it can spawn a task (response barriers), which must not happen in a
-        // destructor during runtime shutdown. The dropped `extra` guard best-effort-reports the
-        // retirement for statement logging.
+        // Destructors cannot spawn response-barrier tasks during runtime shutdown. Send the error
+        // synchronously and let the statement guard report retirement.
         tracing::warn!("execute context dropped without retirement, failing the client");
         let ExecuteContextInner { tx, session, .. } = *inner;
         tx.send(
@@ -2037,9 +2011,6 @@ pub struct Coordinator {
     /// waiting out its tick interval. Notified after catalog transactions that
     /// change durable cluster state.
     reconcile_now: Arc<Notify>,
-    /// Hands staged group commits and DDL table registration/forgetting to the
-    /// [`appends::GroupCommitter`] task, the single in-process writer to the txns shard, which
-    /// allocates timestamps and applies the writes off the coordinator loop.
     group_committer_tx: mpsc::UnboundedSender<appends::TableWriteCmd>,
 
     /// Channel for strict serializable reads ready to commit.
@@ -2885,7 +2856,7 @@ impl Coordinator {
                 let fut = self
                     .controller
                     .storage
-                    .append_table(min_timestamp, boot_ts.step_forward(), all_appends)
+                    .append_table_for_bootstrap(min_timestamp, boot_ts.step_forward(), all_appends)
                     .expect("cannot fail to append");
                 async {
                     fut.await
@@ -3071,7 +3042,7 @@ impl Coordinator {
         let table_fence_rx = self
             .controller
             .storage
-            .append_table(write_ts.clone(), advance_to, appends)
+            .append_table_for_bootstrap(write_ts.clone(), advance_to, appends)
             .expect("invalid updates");
 
         self.apply_local_write(write_ts).await;
@@ -3430,9 +3401,6 @@ impl Coordinator {
             })
             .collect();
 
-        // Collect every storage collection we create so we can register the tables among them in
-        // the txns shard after all layers are set up (below). `register_table_collections` selects
-        // the `DataSource::Table` collections, so handing it source-fed tables and the like is fine.
         let mut created_gids = Vec::new();
 
         while !pending.is_empty() {
@@ -3494,12 +3462,10 @@ impl Coordinator {
                 .unwrap_or_terminate("cannot fail to create collections");
         }
 
-        // Register the tables in the txns shard, making them available for writes. Bootstrap runs no
-        // group commits concurrently, so this cannot conflict with the off-loop committer. In
-        // read-only mode `register_table_collections` registers only migrated tables.
+        // Register txn-wal tables before the later system-table snapshot.
         self.controller
             .storage
-            .register_table_collections(register_ts, created_gids)
+            .register_table_collections_for_bootstrap(register_ts, created_gids)
             .await
             .unwrap_or_terminate("cannot fail to register tables");
 
@@ -4049,12 +4015,9 @@ impl Coordinator {
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                     // Receive a single command.
                     _ = self.advance_timelines_interval.tick() => {
-                        // Periodically bump table uppers and downgrade read holds. In read-only mode
-                        // we're not doing group commits, so we advance timelines directly. Otherwise
-                        // we trigger a keepalive group commit through the same notify+permit path as
-                        // user writes: the permit coalesces keepalives so they don't pile up behind a
-                        // slow oracle, and the committer advances timelines (via `GroupCommitApplied`)
-                        // when it's done.
+                        // Writable keepalives use the committer to advance tables and read holds.
+                        // Its permit coalesces ticks behind a slow oracle. Read-only mode advances
+                        // timelines directly.
                         if self.controller.read_only() {
                             messages.push(Message::AdvanceTimelines);
                         } else {
@@ -5169,12 +5132,7 @@ pub fn serve(
                     persist_client,
                 };
 
-                // Spawn the group committer, which applies txns-shard writes off the
-                // coordinator loop. It holds
-                // handles that stay valid for the process lifetime: the oracle is never replaced
-                // in-process, and the table write handle lives as long as the controller. Promotion
-                // out of read-only mode is a process restart, so a fresh committer is spawned then.
-                // We enter the runtime via `block_on` so the internal `task::spawn` has a reactor.
+                // Read-only promotion restarts the process and creates a fresh committer.
                 handle.block_on(async {
                     appends::spawn_group_committer(
                         group_committer_rx,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -354,14 +354,15 @@ pub enum Message {
     },
     /// Initiates a group commit.
     GroupCommitInitiate(Span, Option<GroupCommitPermit>),
-    /// Finalizes a group commit that the committer applied off the loop. The committer does the
-    /// oracle round trips, table append, oracle write application, and catalog upper advancement off
-    /// the loop, then hands back the cheap work that needs coordinator state: record statement
+    /// Finalizes a group commit that the committer applied off the coordinator loop. The
+    /// committer does the oracle round trips, table append, oracle write application, and
+    /// catalog upper advancement, then hands back the cheap work that needs coordinator state:
+    /// record statement
     /// execution timestamps, retire client responses, and downgrade local read holds.
     ///
     /// NOTE: Statement timestamps must be recorded before the responses are retired, because
     /// retiring ends the statement execution and drops its logging record. That is why retiring
-    /// happens here on the loop rather than in the committer.
+    /// happens here on the coordinator loop rather than in the committer.
     GroupCommitApplied {
         /// Client responses to retire, once statement timestamps are recorded.
         responses: Vec<crate::util::CompletedClientTransmitter>,
@@ -1643,21 +1644,51 @@ impl Drop for ExecuteContextGuard {
 /// (e.g., recording the time at which the statement finished
 /// executing). The state necessary to perform this work is bundled in
 /// the `ExecuteContextGuard` object.
+///
+/// Dropping one without calling [`Self::retire`] (or [`Self::into_parts`]) retires the client
+/// with an error instead. That backstop matters because contexts travel through queues and
+/// tasks (the group committer, internal messages): at process shutdown they get dropped
+/// wherever they are, and a raw drop would panic in `ClientTransmitter::drop`, and a panic
+/// inside a destructor aborts the process.
 #[derive(Debug)]
 pub struct ExecuteContext {
-    inner: Box<ExecuteContextInner>,
+    // `None` only after `retire`/`into_parts` consumed the context.
+    inner: Option<Box<ExecuteContextInner>>,
 }
 
 impl std::ops::Deref for ExecuteContext {
     type Target = ExecuteContextInner;
     fn deref(&self) -> &Self::Target {
-        &*self.inner
+        self.inner.as_ref().expect("only consumed by value")
     }
 }
 
 impl std::ops::DerefMut for ExecuteContext {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.inner
+        self.inner.as_mut().expect("only consumed by value")
+    }
+}
+
+impl Drop for ExecuteContext {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.take() else {
+            return;
+        };
+        // We were dropped without `retire`. That legitimately happens at process shutdown,
+        // when queues and tasks holding contexts get dropped with executions still in flight.
+        // Anywhere else it is a bug (a response silently never sent), which the warning below
+        // keeps visible. Retire the client with an error, fully synchronously: we bypass
+        // `retire` because it can spawn a task (response barriers), which must not happen in a
+        // destructor during runtime shutdown. The dropped `extra` guard best-effort-reports the
+        // retirement for statement logging.
+        tracing::warn!("execute context dropped without retirement, failing the client");
+        let ExecuteContextInner { tx, session, .. } = *inner;
+        tx.send(
+            Err(AdapterError::Internal(
+                "statement execution abandoned, outcome unknown (server shutting down)".into(),
+            )),
+            session,
+        );
     }
 }
 
@@ -1706,14 +1737,16 @@ impl ExecuteContext {
         response_barriers: Vec<BuiltinTableAppendNotify>,
     ) -> Self {
         Self {
-            inner: ExecuteContextInner {
-                tx,
-                session,
-                extra,
-                response_barriers,
-                internal_cmd_tx,
-            }
-            .into(),
+            inner: Some(
+                ExecuteContextInner {
+                    tx,
+                    session,
+                    extra,
+                    response_barriers,
+                    internal_cmd_tx,
+                }
+                .into(),
+            ),
         }
     }
 
@@ -1727,7 +1760,7 @@ impl ExecuteContext {
     /// eventual retirement. The returned response barriers must stay attached
     /// to the user-visible response path.
     pub fn into_parts(
-        self,
+        mut self,
     ) -> (
         ClientTransmitter<ExecuteResponse>,
         mpsc::UnboundedSender<Message>,
@@ -1741,20 +1774,20 @@ impl ExecuteContext {
             session,
             extra,
             response_barriers,
-        } = *self.inner;
+        } = *self.inner.take().expect("only consumed by value");
         (tx, internal_cmd_tx, session, extra, response_barriers)
     }
 
     /// Retire the execution, by sending a message to the coordinator.
     #[instrument(level = "debug")]
-    pub fn retire(self, result: Result<ExecuteResponse, AdapterError>) {
+    pub fn retire(mut self, result: Result<ExecuteResponse, AdapterError>) {
         let ExecuteContextInner {
             tx,
             internal_cmd_tx,
             session,
             extra,
             response_barriers,
-        } = *self.inner;
+        } = *self.inner.take().expect("only consumed by value");
         if response_barriers.is_empty() {
             retire_execution_context(tx, internal_cmd_tx, session, extra, result);
         } else {
@@ -2006,7 +2039,7 @@ pub struct Coordinator {
     reconcile_now: Arc<Notify>,
     /// Hands staged group commits and DDL table registration/forgetting to the
     /// [`appends::GroupCommitter`] task, the single in-process writer to the txns shard, which
-    /// allocates timestamps and applies the writes off the loop.
+    /// allocates timestamps and applies the writes off the coordinator loop.
     group_committer_tx: mpsc::UnboundedSender<appends::TableWriteCmd>,
 
     /// Channel for strict serializable reads ready to commit.
@@ -3126,8 +3159,8 @@ impl Coordinator {
 
         info!("coordinator init: sending builtin table updates");
         let builtin_updates_fut = self.builtin_table_update().execute(builtin_table_updates);
-        // Wait for the committer to apply the write off the loop, so the builtin tables are readable
-        // before we start serving. The committer allocates the timestamp and advances the oracle.
+        // Wait for the committer to apply the write, so the builtin tables are readable before
+        // we start serving. The committer allocates the timestamp and advances the oracle.
         builtin_updates_fut.await;
     }
 
@@ -5136,7 +5169,8 @@ pub fn serve(
                     persist_client,
                 };
 
-                // Spawn the group committer, which applies txns-shard writes off the loop. It holds
+                // Spawn the group committer, which applies txns-shard writes off the
+                // coordinator loop. It holds
                 // handles that stay valid for the process lifetime: the oracle is never replaced
                 // in-process, and the table write handle lives as long as the controller. Promotion
                 // out of read-only mode is a process restart, so a fresh committer is spawned then.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -354,6 +354,24 @@ pub enum Message {
     },
     /// Initiates a group commit.
     GroupCommitInitiate(Span, Option<GroupCommitPermit>),
+    /// Finalizes a group commit that the committer applied off the loop. The committer does the
+    /// oracle round trips, table append, oracle write application, and catalog upper advancement off
+    /// the loop, then hands back the cheap work that needs coordinator state: record statement
+    /// execution timestamps, retire client responses, and downgrade local read holds.
+    ///
+    /// NOTE: Statement timestamps must be recorded before the responses are retired, because
+    /// retiring ends the statement execution and drops its logging record. That is why retiring
+    /// happens here on the loop rather than in the committer.
+    GroupCommitApplied {
+        /// Client responses to retire, once statement timestamps are recorded.
+        responses: Vec<crate::util::CompletedClientTransmitter>,
+        /// Statement executions whose execution timestamp is this commit's write timestamp.
+        statement_logging_ids: Vec<StatementLoggingId>,
+        /// This commit's write timestamp. Used for statement logging, per-session
+        /// read-your-writes, and for downgrading local read holds: the committer applied it to
+        /// the oracle, so the read ts is at least this.
+        write_ts: Timestamp,
+    },
     DeferredStatementReady,
     AdvanceTimelines,
     ClusterEvent(ClusterEvent),
@@ -513,6 +531,7 @@ impl Message {
             Message::CreateConnectionValidationReady(_) => "create_connection_validation_ready",
             Message::TryDeferred { .. } => "try_deferred",
             Message::GroupCommitInitiate(..) => "group_commit_initiate",
+            Message::GroupCommitApplied { .. } => "group_commit_applied",
             Message::AdvanceTimelines => "advance_timelines",
             Message::ClusterEvent(_) => "cluster_event",
             Message::CancelPendingPeeks { .. } => "cancel_pending_peeks",
@@ -1985,6 +2004,10 @@ pub struct Coordinator {
     /// waiting out its tick interval. Notified after catalog transactions that
     /// change durable cluster state.
     reconcile_now: Arc<Notify>,
+    /// Hands staged group commits and DDL table registration/forgetting to the
+    /// [`appends::GroupCommitter`] task, the single in-process writer to the txns shard, which
+    /// allocates timestamps and applies the writes off the loop.
+    group_committer_tx: mpsc::UnboundedSender<appends::TableWriteCmd>,
 
     /// Channel for strict serializable reads ready to commit.
     strict_serializable_reads_tx: mpsc::UnboundedSender<(ConnectionId, PendingReadTxn)>,
@@ -3102,14 +3125,10 @@ impl Coordinator {
             .unwrap_or_terminate("cannot fail to append");
 
         info!("coordinator init: sending builtin table updates");
-        let (_builtin_updates_fut, write_ts) = self
-            .builtin_table_update()
-            .execute(builtin_table_updates)
-            .await;
-        info!(?write_ts, "our write ts");
-        if let Some(write_ts) = write_ts {
-            self.apply_local_write(write_ts).await;
-        }
+        let builtin_updates_fut = self.builtin_table_update().execute(builtin_table_updates);
+        // Wait for the committer to apply the write off the loop, so the builtin tables are readable
+        // before we start serving. The committer allocates the timestamp and advances the oracle.
+        builtin_updates_fut.await;
     }
 
     /// Initializes all storage collections required by catalog objects in the storage controller.
@@ -3378,6 +3397,11 @@ impl Coordinator {
             })
             .collect();
 
+        // Collect every storage collection we create so we can register the tables among them in
+        // the txns shard after all layers are set up (below). `register_table_collections` selects
+        // the `DataSource::Table` collections, so handing it source-fed tables and the like is fine.
+        let mut created_gids = Vec::new();
+
         while !pending.is_empty() {
             // Drain collections whose dependencies have all been registered already
             // (i.e., are not in `pending`).
@@ -3423,6 +3447,8 @@ impl Coordinator {
                 ready = mem::take(&mut pending).into_iter().collect();
             }
 
+            created_gids.extend(ready.iter().map(|(gid, _collection)| *gid));
+
             self.controller
                 .storage
                 .create_collections_for_bootstrap(
@@ -3434,6 +3460,15 @@ impl Coordinator {
                 .await
                 .unwrap_or_terminate("cannot fail to create collections");
         }
+
+        // Register the tables in the txns shard, making them available for writes. Bootstrap runs no
+        // group commits concurrently, so this cannot conflict with the off-loop committer. In
+        // read-only mode `register_table_collections` registers only migrated tables.
+        self.controller
+            .storage
+            .register_table_collections(register_ts, created_gids)
+            .await
+            .unwrap_or_terminate("cannot fail to register tables");
 
         if !self.controller.read_only() {
             self.apply_local_write(register_ts).await;
@@ -3981,17 +4016,16 @@ impl Coordinator {
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                     // Receive a single command.
                     _ = self.advance_timelines_interval.tick() => {
-                        let span = info_span!(parent: None, "coord::advance_timelines_interval");
-                        span.follows_from(Span::current());
-
-                        // Group commit sends an `AdvanceTimelines` message when
-                        // done, which is what downgrades read holds. In
-                        // read-only mode we send this message directly because
-                        // we're not doing group commits.
+                        // Periodically bump table uppers and downgrade read holds. In read-only mode
+                        // we're not doing group commits, so we advance timelines directly. Otherwise
+                        // we trigger a keepalive group commit through the same notify+permit path as
+                        // user writes: the permit coalesces keepalives so they don't pile up behind a
+                        // slow oracle, and the committer advances timelines (via `GroupCommitApplied`)
+                        // when it's done.
                         if self.controller.read_only() {
                             messages.push(Message::AdvanceTimelines);
                         } else {
-                            messages.push(Message::GroupCommitInitiate(span, None));
+                            self.group_commit_tx.notify();
                         }
                     },
                     // Re-check pending strict serializable reads. Deliberately
@@ -5047,12 +5081,14 @@ pub fn serve(
                 let catalog = Arc::new(catalog);
 
                 let caching_secrets_reader = CachingSecretsReader::new(secrets_controller.reader());
+                let (group_committer_tx, group_committer_rx) = mpsc::unbounded_channel();
                 let mut coord = Coordinator {
                     controller,
                     catalog,
                     internal_cmd_tx,
                     group_commit_tx,
                     reconcile_now: Arc::new(Notify::new()),
+                    group_committer_tx,
                     strict_serializable_reads_tx,
                     linearize_reads_notify: Arc::new(Notify::new()),
                     global_timelines: timestamp_oracles,
@@ -5099,6 +5135,24 @@ pub fn serve(
                     user_id_pool: IdPool::empty(),
                     persist_client,
                 };
+
+                // Spawn the group committer, which applies txns-shard writes off the loop. It holds
+                // handles that stay valid for the process lifetime: the oracle is never replaced
+                // in-process, and the table write handle lives as long as the controller. Promotion
+                // out of read-only mode is a process restart, so a fresh committer is spawned then.
+                // We enter the runtime via `block_on` so the internal `task::spawn` has a reactor.
+                handle.block_on(async {
+                    appends::spawn_group_committer(
+                        group_committer_rx,
+                        coord.get_local_timestamp_oracle(),
+                        coord.controller.storage.table_write_handle(),
+                        coord.catalog().upper_handle(),
+                        coord.internal_cmd_tx.clone(),
+                        coord.catalog().config().now.clone(),
+                        coord.metrics.clone(),
+                    );
+                });
+
                 let bootstrap = handle.block_on(async {
                     coord
                         .bootstrap(

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -5142,6 +5142,7 @@ pub fn serve(
                         coord.internal_cmd_tx.clone(),
                         coord.catalog().config().now.clone(),
                         coord.metrics.clone(),
+                        coord.catalog().system_config().dyncfgs(),
                     );
                 });
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2856,7 +2856,7 @@ impl Coordinator {
                 let fut = self
                     .controller
                     .storage
-                    .append_table_for_bootstrap(min_timestamp, boot_ts.step_forward(), all_appends)
+                    .append_table(min_timestamp, boot_ts.step_forward(), all_appends)
                     .expect("cannot fail to append");
                 async {
                     fut.await
@@ -3042,7 +3042,7 @@ impl Coordinator {
         let table_fence_rx = self
             .controller
             .storage
-            .append_table_for_bootstrap(write_ts.clone(), advance_to, appends)
+            .append_table(write_ts.clone(), advance_to, appends)
             .expect("invalid updates");
 
         self.apply_local_write(write_ts).await;
@@ -3465,7 +3465,7 @@ impl Coordinator {
         // Register txn-wal tables before the later system-table snapshot.
         self.controller
             .storage
-            .register_table_collections_for_bootstrap(register_ts, created_gids)
+            .register_table_collections(register_ts, created_gids)
             .await
             .unwrap_or_terminate("cannot fail to register tables");
 

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -42,7 +42,9 @@ use std::time::{Duration, Instant};
 use derivative::Derivative;
 use futures::future::{BoxFuture, FutureExt};
 use mz_adapter_types::connection::ConnectionId;
+use mz_adapter_types::dyncfgs::GROUP_COMMIT_MAX_ATTEMPTS;
 use mz_catalog::builtin::{BuiltinTable, MZ_SESSIONS};
+use mz_dyncfg::{ConfigSet, ConfigValHandle};
 use mz_expr::CollectionPlan;
 use mz_ore::assert_none;
 use mz_ore::halt;
@@ -265,6 +267,7 @@ pub(crate) struct GroupCommitter {
     internal_cmd_tx: mpsc::UnboundedSender<Message>,
     now: NowFn,
     metrics: Metrics,
+    max_attempts: ConfigValHandle<usize>,
 }
 
 impl GroupCommitter {
@@ -318,13 +321,15 @@ impl GroupCommitter {
         mut op: impl FnMut(Timestamp, Timestamp) -> oneshot::Receiver<Result<(), StorageError>>,
     ) -> Option<WriteTimestamp> {
         // Persistent conflicts indicate an unexpected writer. Halt instead of spinning forever.
-        const MAX_ATTEMPTS: usize = 100;
         let mut attempt = 0;
         let write_ts = loop {
-            attempt += 1;
-            if attempt > MAX_ATTEMPTS {
-                halt!("txns-shard write conflicted {MAX_ATTEMPTS} times, rebuilding");
+            let max_attempts = self.max_attempts.get().max(1);
+            if attempt >= max_attempts {
+                halt!(
+                    "txns-shard write reached attempt limit {max_attempts} after {attempt} conflicts, rebuilding"
+                );
             }
+            attempt += 1;
             let write_ts = self.oracle.write_ts().await;
 
             // A post-fence retry has an advance frontier above this handle's stale upper, so this
@@ -501,6 +506,7 @@ pub(crate) fn spawn_group_committer(
     internal_cmd_tx: mpsc::UnboundedSender<Message>,
     now: NowFn,
     metrics: Metrics,
+    dyncfgs: &ConfigSet,
 ) {
     let committer = GroupCommitter {
         rx,
@@ -510,6 +516,7 @@ pub(crate) fn spawn_group_committer(
         internal_cmd_tx,
         now,
         metrics,
+        max_attempts: GROUP_COMMIT_MAX_ATTEMPTS.handle(dyncfgs),
     };
     task::spawn(|| "group_committer", committer.run());
 }
@@ -1444,6 +1451,7 @@ mod tests {
                 internal_cmd_tx,
                 now: SYSTEM_TIME.clone(),
                 metrics: Metrics::register_into(&MetricsRegistry::new()),
+                max_attempts: ConfigValHandle::disconnected(2),
             };
 
             let write_ts = committer
@@ -1479,6 +1487,50 @@ mod tests {
                 "catalog upper {catalog_upper} must cover the write's advance_to {}",
                 write_ts.advance_to
             );
+
+            catalog.expire().await;
+        })
+        .await;
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn test_write_to_txns_zero_limit_allows_one_attempt() {
+        Catalog::with_debug(|catalog| async move {
+            let initial_upper = catalog.current_upper().await;
+            let oracle = Arc::new(MemTimestampOracle::starting_at(initial_upper));
+            let handle = Arc::new(ConflictingTableWriteHandle::new(0));
+            let oracle_dyn: Arc<dyn TimestampOracle<Timestamp> + Send + Sync> =
+                Arc::<MemTimestampOracle>::clone(&oracle);
+            let handle_dyn: Arc<dyn TableWriteHandle> =
+                Arc::<ConflictingTableWriteHandle>::clone(&handle);
+            let (_tx, rx) = mpsc::unbounded_channel();
+            let (internal_cmd_tx, _internal_cmd_rx) = mpsc::unbounded_channel();
+            let committer = GroupCommitter {
+                rx,
+                oracle: oracle_dyn,
+                table_write_handle: handle_dyn,
+                catalog_upper: catalog.upper_handle(),
+                internal_cmd_tx,
+                now: SYSTEM_TIME.clone(),
+                metrics: Metrics::register_into(&MetricsRegistry::new()),
+                max_attempts: ConfigValHandle::disconnected(0),
+            };
+
+            let write_ts = committer
+                .write_to_txns(None, |ts, advance_to| {
+                    handle.append(ts, advance_to, Vec::new())
+                })
+                .await
+                .expect("zero limit permits one successful attempt");
+
+            let attempts = handle
+                .write_timestamps
+                .lock()
+                .expect("lock poisoned")
+                .clone();
+            assert_eq!(attempts, vec![write_ts.timestamp]);
+            assert_eq!(oracle.apply_writes.load(Ordering::SeqCst), 1);
 
             catalog.expire().await;
         })

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -8,6 +8,36 @@
 // by the Apache License, Version 2.0.
 
 //! Logic and types for all appends executed by the [`Coordinator`].
+//!
+//! # The group committer
+//!
+//! All txns-shard writes (group-commit table appends, and table registration and forgetting for
+//! DDL) flow through one long-lived task, the [`GroupCommitter`], as [`TableWriteCmd`]s. The
+//! coordinator loop only does cheap, state-touching staging (draining pending writes, taking
+//! write locks, building append batches). The committer does everything that involves a
+//! timestamp, per command:
+//!
+//! 1. allocate a write timestamp from the oracle,
+//! 2. advance the catalog shard upper to the timestamp's `advance_to`, which keeps the catalog
+//!    readable at the read timestamp the oracle moves to in step 4 and, when the advance
+//!    actually writes, re-checks leadership before user data is written (see
+//!    materialize#28216; an advance that finds the upper already past the target short-circuits
+//!    without a durable check, so this is defense in depth, not a per-attempt guarantee),
+//! 3. issue the txns-shard write; an `InvalidUppers` conflict means another process advanced
+//!    the txns shard past our timestamp, so retry from step 1 at a fresh timestamp (a wasted
+//!    timestamp is harmless, `apply_write` is a high-water mark),
+//! 4. apply the write to the oracle, so no read ever observes a timestamp at which the write is
+//!    not yet durable.
+//!
+//! Processing one command at a time makes the committer the single in-process writer to the
+//! txns shard, and the queue order is load-bearing: an append staged before a table's forget
+//! reaches the table-write worker before it, and appends staged after a registration cannot
+//! overtake it. See the corresponding section in `doc/developer/guide-adapter.md` for why, and
+//! for the cross-process story.
+//!
+//! Finalization that needs coordinator state (statement-logging timestamps, retiring client
+//! responses, downgrading read holds) is handed back to the loop via
+//! [`Message::GroupCommitApplied`].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
@@ -180,12 +210,8 @@ impl PendingWriteTxn {
     }
 }
 
-/// A command for the [`GroupCommitter`], the single in-process writer to the txns shard.
-///
-/// All txns-shard writes flow through one queue and are applied one at a time, in queue order, at
-/// monotone oracle timestamps. That single-sender ordering is what makes concurrent DDL safe
-/// against in-flight appends: a staged append for a table is always applied before a later
-/// forget of that table, because the forget enters the queue behind it.
+/// A command for the [`GroupCommitter`]. See the module docs for the protocol and the ordering
+/// contract carried by the command queue.
 pub(crate) enum TableWriteCmd {
     /// A staged group commit, see [`GroupCommitRequest`].
     GroupCommit(GroupCommitRequest),
@@ -260,16 +286,8 @@ impl GroupCommitRequest {
     }
 }
 
-/// A single, long-lived task that owns all txns-shard writes: group commits (table appends) as
-/// well as table registration and forgetting for DDL, applied off the coordinator loop.
-///
-/// The coordinator loop stages each group commit (draining pending writes, acquiring write locks,
-/// and building the append batch, all cheap) and hands a [`TableWriteCmd`] here. This task does
-/// the timestamp-oracle round trips, the txns-shard write, and applies the write to the oracle.
-/// Processing one command at a time makes this task the serialization point for txns-shard
-/// writes: they reach the single table-write worker in queue order at monotone timestamps, so
-/// in-process conflicts cannot happen and an `InvalidUppers` conflict always means another
-/// process wrote the txns shard, which we handle by retrying at a fresh timestamp.
+/// A single, long-lived task that owns all txns-shard writes, applied off the coordinator loop.
+/// See the module docs for the protocol.
 ///
 /// It holds only shareable handles, captured once at startup. The oracle is never replaced
 /// in-process, and the table write handle stays valid for the controller's lifetime. The catalog
@@ -326,20 +344,8 @@ impl GroupCommitter {
         }
     }
 
-    /// Writes to the txns shard at a fresh oracle timestamp and applies the write to the oracle.
-    ///
-    /// Per attempt: allocate a write timestamp, advance the catalog upper to its `advance_to`
-    /// (keeping the catalog readable at the read timestamp the oracle moves to below, and, when
-    /// the advance actually writes, re-checking leadership before user data is written, see
-    /// materialize#28216; an advance that finds the upper already past `advance_to` short-circuits
-    /// without a durable check, so the leadership re-check is defense in depth, not a per-attempt
-    /// guarantee), then issue the op. An `InvalidUppers` conflict means another process advanced
-    /// the txns shard past our timestamp, so we retry at a fresh one. A wasted timestamp is
-    /// harmless: `apply_write` is a high-water mark, so the eventual, higher timestamp subsumes
-    /// it.
-    ///
-    /// Only after the op succeeds do we apply the write to the oracle, so no read observes a
-    /// timestamp at which the write (append, registration, forget) is not yet durable.
+    /// Writes to the txns shard at a fresh oracle timestamp and applies the write to the oracle,
+    /// implementing steps 1-4 of the protocol in the module docs.
     ///
     /// Returns `None` if the table write worker shut down, which only happens at process
     /// shutdown.
@@ -863,11 +869,8 @@ impl Coordinator {
     }
 
     /// Registers `tables` in the txns shard through the group committer, returning the timestamp
-    /// at which they became writable. The committer applies that timestamp to the oracle before
-    /// replying, so the tables are also readable once the oracle read ts passes it.
-    ///
-    /// Going through the committer orders the registration after all previously staged appends
-    /// and gives it the committer's conflict-retry protocol against concurrent processes.
+    /// at which they became writable (and readable, once the oracle read ts passes it). Going
+    /// through the committer orders the registration against staged appends, see the module docs.
     pub(crate) async fn register_tables_via_committer(
         &self,
         tables: Vec<TableRegistration>,
@@ -892,9 +895,9 @@ impl Coordinator {
     }
 
     /// Forgets `ids` in the txns shard through the group committer, returning the forget
-    /// timestamp. See [`Self::register_tables_via_committer`] for why this goes through the
-    /// committer: ordering after staged appends is what makes dropping a table with in-flight
-    /// writes safe.
+    /// timestamp. Going through the committer orders the forget after all previously staged
+    /// appends, which is what makes dropping a table with in-flight writes safe, see the module
+    /// docs.
     pub(crate) async fn forget_tables_via_committer(&self, ids: Vec<GlobalId>) -> Timestamp {
         let (tx, rx) = oneshot::channel();
         if self

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -18,12 +18,12 @@
 //! timestamp, per command:
 //!
 //! 1. allocate a write timestamp from the oracle,
-//! 2. advance the catalog shard upper to the timestamp's `advance_to`, which keeps the catalog
-//!    readable at the read timestamp the oracle moves to in step 4 and, when the advance
-//!    actually writes, re-checks leadership before user data is written (see
+//! 2. advance the catalog shard upper to the timestamp's [`WriteTimestamp::advance_to`], which
+//!    keeps the catalog readable at the read timestamp the oracle moves to in step 4 and, when
+//!    the advance actually writes, re-checks leadership before user data is written (see
 //!    materialize#28216; an advance that finds the upper already past the target short-circuits
 //!    without a durable check, so this is defense in depth, not a per-attempt guarantee),
-//! 3. issue the txns-shard write; an `InvalidUppers` conflict means another process advanced
+//! 3. issue the txns-shard write. An `InvalidUppers` conflict means another process advanced
 //!    the txns shard past our timestamp, so retry from step 1 at a fresh timestamp (a wasted
 //!    timestamp is harmless, `apply_write` is a high-water mark),
 //! 4. apply the write to the oracle, so no read ever observes a timestamp at which the write is
@@ -35,12 +35,33 @@
 //! overtake it. See the corresponding section in `doc/developer/guide-adapter.md` for why, and
 //! for the cross-process story.
 //!
+//! # Cross-generation safety
+//!
+//! A fenced-out process can keep this task alive for a moment, so a stale generation's txns
+//! write must never land above the new generation's system-table snapshot timestamp, where it
+//! would go unobserved. That holds because of three load-bearing invariants:
+//!
+//! - the shared timestamp oracle is strictly increasing across generations, so a write above
+//!   the snapshot timestamp requires a timestamp allocated after the fence,
+//! - every attempt advances the catalog upper before the txns-shard write, and a post-fence
+//!   timestamp forces a durable catalog check (the stale generation's cached upper is frozen
+//!   below the fence point, growing it requires a successful durable commit), which observes
+//!   the fence and halts before the txns write,
+//! - the new generation's bootstrap registers table collections in the txns shard, an
+//!   unconditional compare-and-append, before taking its system-table snapshot, so the txns
+//!   upper is a barrier: a stale generation's write can only land below the snapshot, where it
+//!   is observed (retracted for system tables, visible to reads for user tables).
+//!
+//! Reordering bootstrap or making the register's compare-and-append conditional would silently
+//! reopen this hole.
+//!
 //! Finalization that needs coordinator state (statement-logging timestamps, retiring client
-//! responses, downgrading read holds) is handed back to the loop via
+//! responses, downgrading read holds) is handed back to the coordinator loop via
 //! [`Message::GroupCommitApplied`].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
+use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
@@ -52,6 +73,7 @@ use mz_catalog::builtin::{BuiltinTable, MZ_SESSIONS};
 use mz_expr::CollectionPlan;
 use mz_ore::assert_none;
 use mz_ore::halt;
+use mz_ore::instrument;
 use mz_ore::now::NowFn;
 use mz_ore::task;
 use mz_repr::{CatalogItemId, GlobalId, Timestamp};
@@ -91,8 +113,8 @@ pub enum DeferredOp {
 impl DeferredOp {
     /// Certain operations, e.g. "blind writes"/`INSERT` statements, can be optimistically retried
     /// because we can share a write lock between multiple operations. In this case we wait to
-    /// acquire the locks until [`stage_group_commit`], where writes are groupped by collection and
-    /// comitted at a single timestamp.
+    /// acquire the locks until [`stage_group_commit`], where writes are grouped by collection and
+    /// committed at a single timestamp.
     ///
     /// Other operations, e.g. read-then-write plans/`UPDATE` statements, must uniquely hold their
     /// write locks and thus we should acquire the locks in [`try_deferred`] to prevent multiple
@@ -241,6 +263,12 @@ pub(crate) struct GroupCommitRequest {
     /// Client transmitters for user writes, retired once the commit is durable.
     responses: Vec<CompletedClientTransmitter>,
     /// Statement-logging ids for user writes, paired with the commit timestamp once we know it.
+    ///
+    /// Invariant: no execution-ended event may be emitted for these ids while they sit here. The
+    /// contexts that could end them are in `responses`, and the coordinator records the
+    /// timestamps before retiring those contexts when handling [`Message::GroupCommitApplied`].
+    /// A path that ends one of these executions early would turn the timestamp recording into a
+    /// write to an ended execution, see `set_statement_execution_timestamp`.
     statement_logging_ids: Vec<StatementLoggingId>,
     /// Notifiers for system-table writes (DDL, background heartbeats).
     notifies: Vec<oneshot::Sender<()>>,
@@ -293,6 +321,10 @@ impl GroupCommitRequest {
 /// in-process, and the table write handle stays valid for the controller's lifetime. The catalog
 /// upper handle shares the durable-storage mutex with catalog transactions, so upper advancement
 /// stays serialized with DDL commits.
+///
+/// No graceful shutdown: when the process shuts down, in-flight and queued responses are
+/// dropped, which retires the clients with a shutdown error, see the drop backstop on
+/// [`ExecuteContext`].
 pub(crate) struct GroupCommitter {
     rx: mpsc::UnboundedReceiver<TableWriteCmd>,
     oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
@@ -313,7 +345,10 @@ impl GroupCommitter {
                 match cmd {
                     TableWriteCmd::GroupCommit(request) => {
                         let span = request.span.clone();
-                        next = self.commit(request).instrument(span).await;
+                        match self.commit(request).instrument(span).await {
+                            ControlFlow::Continue(deferred) => next = deferred,
+                            ControlFlow::Break(()) => return,
+                        }
                     }
                     TableWriteCmd::Register { tables, result } => {
                         let Some(write_ts) = self
@@ -347,14 +382,26 @@ impl GroupCommitter {
     /// Writes to the txns shard at a fresh oracle timestamp and applies the write to the oracle,
     /// implementing steps 1-4 of the protocol in the module docs.
     ///
-    /// Returns `None` if the table write worker shut down, which only happens at process
-    /// shutdown.
+    /// Returns `None` when the table write worker is gone, which only happens at process
+    /// shutdown. The caller must wind the committer down then, see the `Err(_recv)` arm.
     async fn write_to_txns(
         &self,
         op_duration_metric: Option<&prometheus::Histogram>,
         mut op: impl FnMut(Timestamp, Timestamp) -> oneshot::Receiver<Result<(), StorageError>>,
     ) -> Option<WriteTimestamp> {
+        // In-process conflicts are impossible (single writer), and the only conflicting writer
+        // we understand today is another generation, whose fence stops us via `advance_upper`
+        // within a retry or two. A conflict that persists past this cap means a writer we don't
+        // understand, so we convert it into the halt-and-rebuild path instead of spinning
+        // forever. The cap is generous on purpose: halting is disruptive, and each retry warns,
+        // so a misbehaving writer is visible in the logs long before we give up.
+        const MAX_ATTEMPTS: usize = 100;
+        let mut attempt = 0;
         let write_ts = loop {
+            attempt += 1;
+            if attempt > MAX_ATTEMPTS {
+                halt!("txns-shard write conflicted {MAX_ATTEMPTS} times, rebuilding");
+            }
             let write_ts = self.oracle.write_ts().await;
 
             let catalog_upper_start = Instant::now();
@@ -377,19 +424,38 @@ impl GroupCommitter {
                 Ok(Err(StorageError::InvalidUppers(_))) => {
                     // Another process advanced the txns shard past us; retry at a fresh
                     // timestamp.
+                    warn!(
+                        write_ts = %write_ts.timestamp,
+                        attempt,
+                        "txns-shard write conflicted with another writer, retrying at a fresh timestamp"
+                    );
                     continue;
                 }
                 Ok(Err(other)) => {
-                    // Any other error is fatal, matching the previous on-loop behavior.
+                    // Only another writer's upper conflict is retryable, anything else is fatal.
                     Err::<(), _>(other).unwrap_or_terminate("cannot fail to write to txns shard");
                     unreachable!("unwrap_or_terminate does not return on Err");
                 }
                 Err(_recv) => {
-                    warn!("table write worker terminated with writes in indefinite state");
+                    // The worker replies to every command, so a dropped reply means its task
+                    // was cancelled, which only happens at process shutdown (a worker panic
+                    // aborts the process through the panic hook). The write is in an indefinite
+                    // state, but so is everything else at this point. Wind the committer down
+                    // instead of processing more writes during teardown: dropped responses
+                    // retire their clients via the `ExecuteContext` drop backstop, dropped
+                    // register/forget waiters halt, matching the storage controller's shutdown
+                    // posture on the bootstrap register path.
+                    warn!("table write worker gone (process shutting down), winding down");
                     return None;
                 }
             }
         };
+
+        // The committer bypasses `apply_local_write`, so run the runaway-timeline check here:
+        // a write timestamp far ahead of the wall clock is the signal that the timeline has run
+        // away (e.g. after a clock regression).
+        let now: Timestamp = (self.now)().into();
+        crate::coord::timeline::check_runaway_write_ts(&now, write_ts.timestamp);
 
         // Mark the write complete on the oracle so reads can advance to it.
         self.oracle.apply_write(write_ts.timestamp).await;
@@ -405,16 +471,20 @@ impl GroupCommitter {
     /// user-only batch. Merging stops at the first register or forget command, which is returned
     /// to the caller to process next, preserving queue order (an append staged after a register
     /// may target the newly registered table and must not commit before it).
-    async fn commit(&mut self, mut request: GroupCommitRequest) -> Option<TableWriteCmd> {
+    ///
+    /// `Break` means the table write worker is gone and the committer must wind down.
+    async fn commit(
+        &mut self,
+        mut request: GroupCommitRequest,
+    ) -> ControlFlow<(), Option<TableWriteCmd>> {
         let mut deferred_cmd = None;
         // Once the channel is closed, `recv` resolves immediately with `None`. Disable that
         // select branch then, so the throttle sleep still runs instead of busy-looping.
         let mut rx_closed = false;
 
-        // Throttle: keep the global write timeline from running ahead of the wall clock. We peek
-        // and sleep off the loop, so a slow oracle backend does not stall the coordinator. The
-        // internal system-write case bypasses this so tests with a mocked wall clock still make
-        // progress.
+        // Throttle: keep the global write timeline from running ahead of the wall clock. The
+        // peek and the sleep happen here in the committer task, so a slow oracle backend does
+        // not stall the coordinator loop.
         loop {
             while deferred_cmd.is_none() {
                 match self.rx.try_recv() {
@@ -424,27 +494,40 @@ impl GroupCommitter {
                 }
             }
 
+            // Check the bypasses before peeking the oracle, so bypassed batches (every DDL
+            // builtin-table commit, for one) skip that round trip. An internal system write
+            // bypasses the throttle so tests with a mocked wall clock still make progress. A
+            // deferred register or forget means a DDL statement is blocked on the coordinator
+            // loop behind this batch. DDL was never subject to the wall-clock throttle (its
+            // timestamp allocations advanced the timeline directly when they ran on the
+            // coordinator loop), so rather than stall the whole control plane until the clock
+            // catches up, we let the batch through.
+            if request.contains_internal_system_write || deferred_cmd.is_some() {
+                break;
+            }
             let ts = self.oracle.peek_write_ts().await;
             let now: Timestamp = (self.now)().into();
-            // A deferred register or forget means a DDL statement is blocked on the coordinator
-            // loop behind this batch. DDL was never subject to the wall-clock throttle (its
-            // timestamp allocations advanced the timeline directly when it ran on the loop), so
-            // rather than stall the whole control plane until the clock catches up, we let the
-            // batch through, the same way an internal system write does.
-            if ts <= now || request.contains_internal_system_write || deferred_cmd.is_some() {
+            if ts <= now {
                 break;
             }
             // Cap the wait at 1s so a wall clock that jumped far ahead and then back does not
-            // stall us for a long time.
+            // stall us for a long time. The deadline is fixed per peek: merge wakeups below
+            // re-check the bypasses but do not re-peek the oracle.
             let remaining_ms = std::cmp::min(ts.saturating_sub(now), Timestamp::from(1_000u64));
             let sleep = tokio::time::sleep(Duration::from_millis(remaining_ms.into()));
-            tokio::select! {
-                _ = sleep => {}
-                cmd = self.rx.recv(), if deferred_cmd.is_none() && !rx_closed => match cmd {
-                    Some(TableWriteCmd::GroupCommit(other)) => request.merge(other),
-                    Some(other) => deferred_cmd = Some(other),
-                    None => rx_closed = true,
-                },
+            tokio::pin!(sleep);
+            loop {
+                tokio::select! {
+                    _ = &mut sleep => break,
+                    cmd = self.rx.recv(), if deferred_cmd.is_none() && !rx_closed => match cmd {
+                        Some(TableWriteCmd::GroupCommit(other)) => request.merge(other),
+                        Some(other) => deferred_cmd = Some(other),
+                        None => rx_closed = true,
+                    },
+                }
+                if request.contains_internal_system_write || deferred_cmd.is_some() {
+                    break;
+                }
             }
         }
 
@@ -467,7 +550,9 @@ impl GroupCommitter {
             })
             .await
         else {
-            return deferred_cmd;
+            // Winding down at shutdown. Dropping the batch retires the clients with a shutdown
+            // error via the `ExecuteContext` drop backstop.
+            return ControlFlow::Break(());
         };
         let timestamp = write_ts.timestamp;
 
@@ -488,7 +573,7 @@ impl GroupCommitter {
         // IMPORTANT: Release the in-progress permits and write locks now, after the write is
         // applied at the oracle, so no other write goes through at a timestamp we have not yet
         // applied. Retiring the client responses does not need these locks, so we hand that back
-        // to the loop.
+        // to the coordinator loop.
         drop(permits);
         drop(write_locks);
 
@@ -498,23 +583,30 @@ impl GroupCommitter {
             let _ = notify.send(());
         }
 
-        // Hand the parts that need coordinator state back to the loop: recording statement
-        // execution timestamps, retiring client responses, and downgrading read holds. Retiring
-        // must happen on the loop after the timestamps are recorded, because it ends the statement
-        // execution.
+        // Hand the parts that need coordinator state back to the coordinator loop: recording
+        // statement execution timestamps, retiring client responses, and downgrading read holds.
+        // Retiring must happen there after the timestamps are recorded, because it ends the
+        // statement execution.
         //
         // NOTE: After `apply_write(timestamp)` the oracle read ts is at least `timestamp`, and
-        // reads at `timestamp` observe this commit, so the loop can downgrade the
+        // reads at `timestamp` observe this commit, so the coordinator can downgrade the
         // EpochMilliseconds read holds to `timestamp` without an oracle round trip.
-        if let Err(e) = self.internal_cmd_tx.send(Message::GroupCommitApplied {
-            responses,
-            statement_logging_ids,
-            write_ts: timestamp,
-        }) {
-            warn!("coordinator shut down before a group commit could be finalized: {e}");
+        if self
+            .internal_cmd_tx
+            .send(Message::GroupCommitApplied {
+                responses,
+                statement_logging_ids,
+                write_ts: timestamp,
+            })
+            .is_err()
+        {
+            // The coordinator loop is gone, which only happens at process shutdown. Dropping
+            // the responses retires the clients with a shutdown error, see the drop backstop on
+            // `ExecuteContext`.
+            warn!("coordinator shut down before a group commit could be finalized");
         }
 
-        deferred_cmd
+        ControlFlow::Continue(deferred_cmd)
     }
 }
 
@@ -646,7 +738,8 @@ impl Coordinator {
     }
 
     /// Stages all pending write transactions into a [`GroupCommitRequest`] and hands it to the
-    /// group committer, which allocates the write timestamp and applies the commit off the loop.
+    /// group committer, which allocates the write timestamp and applies the commit off the
+    /// coordinator loop.
     ///
     /// If the caller holds the write lock they can pass it in. Writes whose locks are held by
     /// another operation are deferred (only system writes and table advancement proceed). Writes
@@ -655,7 +748,8 @@ impl Coordinator {
     /// All included pending writes are combined into a single append committed at one timestamp,
     /// and all involved tables advance to a timestamp larger than the write's. This does no
     /// timestamp-oracle round trips itself: the committer does the throttle, allocation, and apply
-    /// off the loop.
+    /// off the coordinator loop.
+    #[instrument(name = "coord::stage_group_commit")]
     pub(crate) fn stage_group_commit(&mut self, permit: Option<GroupCommitPermit>) {
         let mut validated_writes = Vec::new();
         let mut deferred_writes = Vec::new();
@@ -797,8 +891,8 @@ impl Coordinator {
                             appends.entry(id).or_default().extend(table_data);
                         }
                     }
-                    // The commit timestamp is allocated off the loop, so we record it for statement
-                    // logging once the committer reports it back.
+                    // The commit timestamp is allocated by the committer, so we record it for
+                    // statement logging once the committer reports it back.
                     if let Some(id) = ctx.extra().contents() {
                         statement_logging_ids.push(id);
                     }
@@ -845,8 +939,8 @@ impl Coordinator {
             })
             .collect();
 
-        // Hand the staged commit to the committer, which allocates the timestamp and applies it off
-        // the loop.
+        // Hand the staged commit to the committer, which allocates the timestamp and applies it
+        // off the coordinator loop.
         //
         // NOTE: We always send, even with no appends, so the committer periodically bumps the upper
         // of all tables, which is required to keep them readable at the latest oracle read ts.
@@ -860,11 +954,17 @@ impl Coordinator {
             contains_internal_system_write,
             span: Span::current(),
         };
-        if let Err(e) = self
+        if self
             .group_committer_tx
             .send(TableWriteCmd::GroupCommit(request))
+            .is_err()
         {
-            warn!("group committer task gone, dropping group commit: {e}");
+            // The committer is gone, which only happens at process shutdown. Dropping the
+            // request retires the clients with a shutdown error, see the drop backstop on
+            // `ExecuteContext`. The notify senders are dropped too, which their
+            // waiters observe as completion. We cannot signal failure through them, and the
+            // process is shutting down regardless.
+            warn!("group committer task gone, dropping staged group commit");
         }
     }
 
@@ -1098,8 +1198,8 @@ impl<'a> BuiltinTableAppend<'a> {
     /// Submit a write to a system table and trigger a group commit.
     ///
     /// Returns a `Future` that completes once the write has been applied. Does not block the
-    /// coordinator on the timestamp oracle: the write timestamp is allocated by the group committer
-    /// off the loop.
+    /// coordinator on the timestamp oracle: the write timestamp is allocated by the group
+    /// committer off the coordinator loop.
     ///
     /// Note: When in read-only mode, this buffers the update and the returned future resolves
     /// immediately, without the update actually having been written.
@@ -1356,5 +1456,206 @@ pub(crate) fn waiting_on_startup_appends(
             Some((depends_on, wait_future.boxed()))
         }
         None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::now::SYSTEM_TIME;
+    use timely::progress::Antichain;
+
+    use super::*;
+    use crate::catalog::Catalog;
+
+    /// A minimal in-memory [`TimestampOracle`] for driving the committer in tests. Counts
+    /// `apply_write` calls so tests can assert how often the committer applies.
+    #[derive(Debug, Default)]
+    struct MemTimestampOracle {
+        read_write_ts: Mutex<(Timestamp, Timestamp)>,
+        apply_writes: AtomicUsize,
+    }
+
+    impl MemTimestampOracle {
+        fn starting_at(ts: Timestamp) -> Self {
+            Self {
+                read_write_ts: Mutex::new((ts, ts)),
+                apply_writes: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TimestampOracle<Timestamp> for MemTimestampOracle {
+        async fn write_ts(&self) -> WriteTimestamp {
+            let (read_ts, write_ts) = &mut *self.read_write_ts.lock().expect("lock poisoned");
+            let new_write_ts = std::cmp::max(*read_ts, *write_ts).step_forward();
+            *write_ts = new_write_ts;
+            WriteTimestamp {
+                timestamp: new_write_ts,
+                advance_to: new_write_ts.step_forward(),
+            }
+        }
+
+        async fn peek_write_ts(&self) -> Timestamp {
+            let (_, write_ts) = &*self.read_write_ts.lock().expect("lock poisoned");
+            *write_ts
+        }
+
+        async fn read_ts(&self) -> Timestamp {
+            let (read_ts, _) = &*self.read_write_ts.lock().expect("lock poisoned");
+            *read_ts
+        }
+
+        async fn apply_write(&self, lower_bound: Timestamp) {
+            self.apply_writes.fetch_add(1, Ordering::SeqCst);
+            let (read_ts, write_ts) = &mut *self.read_write_ts.lock().expect("lock poisoned");
+            *read_ts = std::cmp::max(*read_ts, lower_bound);
+            *write_ts = std::cmp::max(*read_ts, *write_ts);
+        }
+    }
+
+    /// A [`TableWriteHandle`] that reports an `InvalidUppers` conflict for the first
+    /// `conflicts` calls and succeeds afterwards, recording the write timestamp of every call.
+    #[derive(Debug)]
+    struct ConflictingTableWriteHandle {
+        conflicts: usize,
+        calls: AtomicUsize,
+        write_timestamps: Mutex<Vec<Timestamp>>,
+    }
+
+    impl ConflictingTableWriteHandle {
+        fn new(conflicts: usize) -> Self {
+            Self {
+                conflicts,
+                calls: AtomicUsize::new(0),
+                write_timestamps: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn respond(&self, write_ts: Timestamp) -> oneshot::Receiver<Result<(), StorageError>> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            self.write_timestamps
+                .lock()
+                .expect("lock poisoned")
+                .push(write_ts);
+            let (tx, rx) = oneshot::channel();
+            let result = if call < self.conflicts {
+                Err(StorageError::InvalidUppers(vec![
+                    mz_storage_types::controller::InvalidUpper {
+                        id: GlobalId::User(1),
+                        current_upper: Antichain::from_elem(write_ts.step_forward()),
+                    },
+                ]))
+            } else {
+                Ok(())
+            };
+            tx.send(result).expect("receiver still in scope");
+            rx
+        }
+    }
+
+    impl TableWriteHandle for ConflictingTableWriteHandle {
+        fn append(
+            &self,
+            write_ts: Timestamp,
+            _advance_to: Timestamp,
+            _commands: Vec<(GlobalId, Vec<TableData>)>,
+        ) -> oneshot::Receiver<Result<(), StorageError>> {
+            self.respond(write_ts)
+        }
+
+        fn register(
+            &self,
+            register_ts: Timestamp,
+            _tables: Vec<TableRegistration>,
+        ) -> oneshot::Receiver<Result<(), StorageError>> {
+            self.respond(register_ts)
+        }
+
+        fn forget(
+            &self,
+            forget_ts: Timestamp,
+            _ids: Vec<GlobalId>,
+        ) -> oneshot::Receiver<Result<(), StorageError>> {
+            self.respond(forget_ts)
+        }
+    }
+
+    /// Tests the committer's txns-shard conflict retry protocol: on `InvalidUppers` it retries
+    /// at a fresh, strictly larger oracle timestamp, durably advances the catalog upper, and
+    /// applies the write to the oracle exactly once, for the attempt that succeeds.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn test_write_to_txns_conflict_retry() {
+        Catalog::with_debug(|catalog| async move {
+            // Seed the oracle from the catalog upper, so the committer's `advance_upper` calls
+            // target timestamps past the freshly bootstrapped catalog and must take the durable
+            // compare-and-append path rather than the already-covered short-circuit.
+            let initial_upper = catalog.current_upper().await;
+            let oracle = Arc::new(MemTimestampOracle::starting_at(initial_upper));
+            let handle = Arc::new(ConflictingTableWriteHandle::new(1));
+            let oracle_dyn: Arc<dyn TimestampOracle<Timestamp> + Send + Sync> =
+                Arc::<MemTimestampOracle>::clone(&oracle);
+            let handle_dyn: Arc<dyn TableWriteHandle> =
+                Arc::<ConflictingTableWriteHandle>::clone(&handle);
+            let (_tx, rx) = mpsc::unbounded_channel();
+            let (internal_cmd_tx, _internal_cmd_rx) = mpsc::unbounded_channel();
+            let committer = GroupCommitter {
+                rx,
+                oracle: oracle_dyn,
+                table_write_handle: handle_dyn,
+                catalog_upper: catalog.upper_handle(),
+                internal_cmd_tx,
+                now: SYSTEM_TIME.clone(),
+                metrics: Metrics::register_into(&MetricsRegistry::new()),
+            };
+
+            let write_ts = committer
+                .write_to_txns(None, |ts, advance_to| {
+                    assert_eq!(advance_to, ts.step_forward());
+                    handle.append(ts, advance_to, Vec::new())
+                })
+                .await
+                .expect("worker stays alive in this test");
+
+            let attempts = handle
+                .write_timestamps
+                .lock()
+                .expect("lock poisoned")
+                .clone();
+            assert_eq!(attempts.len(), 2, "one conflict, one success");
+            assert!(
+                attempts[0] > initial_upper,
+                "attempts start past the initial catalog upper: {attempts:?} vs {initial_upper}"
+            );
+            assert!(
+                attempts[0] < attempts[1],
+                "retry must use a fresh, larger timestamp: {attempts:?}"
+            );
+            assert_eq!(write_ts.timestamp, attempts[1]);
+
+            // The write was applied to the oracle exactly once, and the successful timestamp is
+            // readable.
+            assert_eq!(oracle.apply_writes.load(Ordering::SeqCst), 1);
+            assert_eq!(oracle.read_ts().await, write_ts.timestamp);
+
+            // The catalog upper was durably advanced to (at least) the successful attempt's
+            // `advance_to`, which started beyond the bootstrap upper, so this fails if
+            // `write_to_txns` stops advancing the catalog upper.
+            let catalog_upper = catalog.current_upper().await;
+            assert!(
+                catalog_upper >= write_ts.advance_to,
+                "catalog upper {catalog_upper} must cover the write's advance_to {}",
+                write_ts.advance_to
+            );
+
+            catalog.expire().await;
+        })
+        .await;
     }
 }

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -37,23 +37,34 @@
 //!
 //! # Cross-generation safety
 //!
-//! A fenced-out process can keep this task alive for a moment, so a stale generation's txns
-//! write must never land above the new generation's system-table snapshot timestamp, where it
-//! would go unobserved. That holds because of three load-bearing invariants:
+//! The txns shard can have concurrent writers: another generation during a 0dt handover, or a
+//! fenced-out process whose committer stays alive for a moment. A stale generation's txns write
+//! must never land above the new generation's system-table snapshot timestamp, where it would go
+//! unobserved. Two mechanisms keep this safe, and neither is the catalog-upper advance of step 2.
 //!
-//! - the shared timestamp oracle is strictly increasing across generations, so a write above
-//!   the snapshot timestamp requires a timestamp allocated after the fence,
-//! - every attempt advances the catalog upper before the txns-shard write, and a post-fence
-//!   timestamp forces a durable catalog check (the stale generation's cached upper is frozen
-//!   below the fence point, growing it requires a successful durable commit), which observes
-//!   the fence and halts before the txns write,
-//! - the new generation's bootstrap registers table collections in the txns shard, an
-//!   unconditional compare-and-append, before taking its system-table snapshot, so the txns
-//!   upper is a barrier: a stale generation's write can only land below the snapshot, where it
-//!   is observed (retracted for system tables, visible to reads for user tables).
+//! Conflict-freedom comes from the shared oracle and the txns-shard compare-and-append. The
+//! oracle is strictly increasing across generations, so every write takes a unique, larger
+//! timestamp, and the compare-and-append linearizes concurrent writers: a loser sees
+//! `InvalidUppers` and retries from step 1 at a fresh timestamp. This orders writes but does not
+//! decide who may write, so on its own it does not stop a fresh write at a higher timestamp.
 //!
-//! Reordering bootstrap or making the register's compare-and-append conditional would silently
-//! reopen this hole.
+//! Authorization comes from fencing. A new generation fences the old one at the catalog shard,
+//! and the fenced generation halts: its coordinator exits the process on the next catalog
+//! operation that observes the fence, so it stops allocating timestamps. Any txns write it still
+//! has in flight was therefore allocated before the fence, below the new generation's snapshot
+//! timestamp, so it lands below the snapshot-and-reset and is observed there (retracted for
+//! system tables, visible to reads for user tables). A write above the snapshot would need a
+//! post-fence timestamp, which the halted generation does not allocate. This rests on the fenced
+//! generation winding down promptly and on the oracle being shared and strictly increasing across
+//! generations. A per-generation oracle, or a committer that kept running long past the fence,
+//! would reopen the hole.
+//!
+//! The catalog-upper advance is defense in depth on top of that contract, not a separate
+//! guarantee. Because it is a catalog write, a fenced committer that reaches its durable
+//! compare-and-append notices the fence there and halts before the txns write, one more place the
+//! outgoing generation stops. It is not a per-attempt check: the advance short-circuits when the
+//! upper is already past its target, and the coordinator's own catalog writes are the primary
+//! fence trigger.
 //!
 //! Finalization that needs coordinator state (statement-logging timestamps, retiring client
 //! responses, downgrading read holds) is handed back to the coordinator loop via

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -9,66 +9,28 @@
 
 //! Logic and types for all appends executed by the [`Coordinator`].
 //!
-//! # The group committer
+//! Runtime table appends, registrations, and forgets are serialized by the
+//! [`GroupCommitter`]. FIFO order is required so appends cannot overtake registration or
+//! forgetting.
 //!
-//! All txns-shard writes (group-commit table appends, and table registration and forgetting for
-//! DDL) flow through one long-lived task, the [`GroupCommitter`], as [`TableWriteCmd`]s. The
-//! coordinator loop only does cheap, state-touching staging (draining pending writes, taking
-//! write locks, building append batches). The committer does everything that involves a
-//! timestamp, per command:
+//! For each command, the committer:
 //!
-//! 1. allocate a write timestamp from the oracle,
-//! 2. advance the catalog shard upper to the timestamp's [`WriteTimestamp::advance_to`], which
-//!    keeps the catalog readable at the read timestamp the oracle moves to in step 4 and, when
-//!    the advance actually writes, re-checks leadership before user data is written (see
-//!    materialize#28216; an advance that finds the upper already past the target short-circuits
-//!    without a durable check, so this is defense in depth, not a per-attempt guarantee),
-//! 3. issue the txns-shard write. An `InvalidUppers` conflict means another process advanced
-//!    the txns shard past our timestamp, so retry from step 1 at a fresh timestamp (a wasted
-//!    timestamp is harmless, `apply_write` is a high-water mark),
-//! 4. apply the write to the oracle, so no read ever observes a timestamp at which the write is
-//!    not yet durable.
+//! 1. allocates a write timestamp from the shared oracle,
+//! 2. advances the catalog upper to [`WriteTimestamp::advance_to`],
+//! 3. writes the txns shard, retrying `InvalidUppers` from step 1, and
+//! 4. applies the successful write to the oracle.
 //!
-//! Processing one command at a time makes the committer the single in-process writer to the
-//! txns shard, and the queue order is load-bearing: an append staged before a table's forget
-//! reaches the table-write worker before it, and appends staged after a registration cannot
-//! overtake it. See the corresponding section in `doc/developer/guide-adapter.md` for why, and
-//! for the cross-process story.
+//! Step 2 keeps the catalog readable at the oracle read timestamp. It also enforces fencing for
+//! a post-fence retry: the fresh oracle timestamp's advance frontier is above the stale process's
+//! cached catalog upper, so the advance reaches Persist and observes the fence before another txns
+//! write.
 //!
-//! # Cross-generation safety
+//! During writable bootstrap, system-table snapshots cannot complete until a txns-shard write has
+//! advanced the table uppers. A stale write either linearizes before this barrier and is observed
+//! by the snapshot, or conflicts and follows the fenced retry path above. This relies on
+//! generations sharing the oracle.
 //!
-//! The txns shard can have concurrent writers: another generation during a 0dt handover, or a
-//! fenced-out process whose committer stays alive for a moment. A stale generation's txns write
-//! must never land above the new generation's system-table snapshot timestamp, where it would go
-//! unobserved. Two mechanisms keep this safe, and neither is the catalog-upper advance of step 2.
-//!
-//! Conflict-freedom comes from the shared oracle and the txns-shard compare-and-append. The
-//! oracle is strictly increasing across generations, so every write takes a unique, larger
-//! timestamp, and the compare-and-append linearizes concurrent writers: a loser sees
-//! `InvalidUppers` and retries from step 1 at a fresh timestamp. This orders writes but does not
-//! decide who may write, so on its own it does not stop a fresh write at a higher timestamp.
-//!
-//! Authorization comes from fencing. A new generation fences the old one at the catalog shard,
-//! and the fenced generation halts: its coordinator exits the process on the next catalog
-//! operation that observes the fence, so it stops allocating timestamps. Any txns write it still
-//! has in flight was therefore allocated before the fence, below the new generation's snapshot
-//! timestamp, so it lands below the snapshot-and-reset and is observed there (retracted for
-//! system tables, visible to reads for user tables). A write above the snapshot would need a
-//! post-fence timestamp, which the halted generation does not allocate. This rests on the fenced
-//! generation winding down promptly and on the oracle being shared and strictly increasing across
-//! generations. A per-generation oracle, or a committer that kept running long past the fence,
-//! would reopen the hole.
-//!
-//! The catalog-upper advance is defense in depth on top of that contract, not a separate
-//! guarantee. Because it is a catalog write, a fenced committer that reaches its durable
-//! compare-and-append notices the fence there and halts before the txns write, one more place the
-//! outgoing generation stops. It is not a per-attempt check: the advance short-circuits when the
-//! upper is already past its target, and the coordinator's own catalog writes are the primary
-//! fence trigger.
-//!
-//! Finalization that needs coordinator state (statement-logging timestamps, retiring client
-//! responses, downgrading read holds) is handed back to the coordinator loop via
-//! [`Message::GroupCommitApplied`].
+//! Work that requires coordinator state is returned via [`Message::GroupCommitApplied`].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
@@ -243,63 +205,33 @@ impl PendingWriteTxn {
     }
 }
 
-/// A command for the [`GroupCommitter`]. See the module docs for the protocol and the ordering
-/// contract carried by the command queue.
 pub(crate) enum TableWriteCmd {
-    /// A staged group commit, see [`GroupCommitRequest`].
     GroupCommit(GroupCommitRequest),
-    /// Register tables in the txns shard, making them available for writes. Replies with the
-    /// registration timestamp, which is also the timestamp at which the tables become readable
-    /// (the committer applies it to the oracle before replying).
     Register {
         tables: Vec<TableRegistration>,
         result: oneshot::Sender<Timestamp>,
     },
-    /// Forget tables in the txns shard. Replies with the forget timestamp.
     Forget {
         ids: Vec<GlobalId>,
         result: oneshot::Sender<Timestamp>,
     },
 }
 
-/// A batch of writes staged on the coordinator loop, to be committed by the [`GroupCommitter`].
-///
-/// The loop does the cheap, state-touching work (draining pending writes, acquiring write locks,
-/// building the append batch) and hands the rest to the committer. Timestamp allocation, the table
-/// append, advancing the catalog upper, and applying the write to the oracle all happen off the
-/// loop.
+/// A group commit staged on the coordinator loop for the [`GroupCommitter`].
 pub(crate) struct GroupCommitRequest {
-    /// Table appends, resolved to their latest [`GlobalId`] and consolidated. Empty for a keepalive.
+    /// Appends resolved to their latest [`GlobalId`]. Empty for a keepalive.
     appends: Vec<(GlobalId, Vec<TableData>)>,
-    /// Client transmitters for user writes, retired once the commit is durable.
     responses: Vec<CompletedClientTransmitter>,
-    /// Statement-logging ids for user writes, paired with the commit timestamp once we know it.
-    ///
-    /// Invariant: no execution-ended event may be emitted for these ids while they sit here. The
-    /// contexts that could end them are in `responses`, and the coordinator records the
-    /// timestamps before retiring those contexts when handling [`Message::GroupCommitApplied`].
-    /// A path that ends one of these executions early would turn the timestamp recording into a
-    /// write to an ended execution, see `set_statement_execution_timestamp`.
     statement_logging_ids: Vec<StatementLoggingId>,
-    /// Notifiers for system-table writes (DDL, background heartbeats).
     notifies: Vec<oneshot::Sender<()>>,
-    /// Write locks held for the duration of the commit.
     write_locks: GroupCommitWriteLocks,
-    /// In-progress permits, released once the commit is applied. Merging batches can accumulate
-    /// more than one.
+    /// In-progress permits held until the commit is applied.
     permits: Vec<GroupCommitPermit>,
-    /// Whether the batch has an internal system write (e.g. `mz_sessions`), which bypasses the
-    /// throttle so that tests with a mocked wall clock can still make progress.
     contains_internal_system_write: bool,
     span: Span,
 }
 
 impl GroupCommitRequest {
-    /// Absorbs another staged commit into this one, so both apply at a single timestamp.
-    ///
-    /// Lock sets of separately staged commits are disjoint (staging defers writes whose locks are
-    /// already held), so extending the lock map cannot double-lock. The other request's span is
-    /// dropped, which loses its trace linkage. Not great, but merged batches are the exception.
     fn merge(&mut self, other: GroupCommitRequest) {
         let GroupCommitRequest {
             appends,
@@ -311,31 +243,20 @@ impl GroupCommitRequest {
             contains_internal_system_write,
             span: _,
         } = other;
-        // The worker applies every (id, updates) entry, so duplicate ids across the merged
-        // batches are fine.
         self.appends.extend(appends);
         self.responses.extend(responses);
         self.statement_logging_ids.extend(statement_logging_ids);
         self.notifies.extend(notifies);
         self.write_locks.extend(write_locks);
-        // Hold all merged permits until the combined batch is applied, so the permit keeps
-        // bounding in-flight batches as documented.
         self.permits.extend(permits);
         self.contains_internal_system_write |= contains_internal_system_write;
     }
 }
 
-/// A single, long-lived task that owns all txns-shard writes, applied off the coordinator loop.
-/// See the module docs for the protocol.
+/// Serializes runtime txns-shard writes off the coordinator loop.
 ///
-/// It holds only shareable handles, captured once at startup. The oracle is never replaced
-/// in-process, and the table write handle stays valid for the controller's lifetime. The catalog
-/// upper handle shares the durable-storage mutex with catalog transactions, so upper advancement
-/// stays serialized with DDL commits.
-///
-/// No graceful shutdown: when the process shuts down, in-flight and queued responses are
-/// dropped, which retires the clients with a shutdown error, see the drop backstop on
-/// [`ExecuteContext`].
+/// Dropped group-commit requests retire their clients through [`ExecuteContext`]. Dropped
+/// registration or forget replies cause their coordinator waiters to halt.
 pub(crate) struct GroupCommitter {
     rx: mpsc::UnboundedReceiver<TableWriteCmd>,
     oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
@@ -370,7 +291,6 @@ impl GroupCommitter {
                         else {
                             return;
                         };
-                        // We don't care if the waiter has gone away.
                         let _ = result.send(write_ts.timestamp);
                     }
                     TableWriteCmd::Forget { ids, result } => {
@@ -382,7 +302,6 @@ impl GroupCommitter {
                         else {
                             return;
                         };
-                        // We don't care if the waiter has gone away.
                         let _ = result.send(write_ts.timestamp);
                     }
                 }
@@ -390,22 +309,15 @@ impl GroupCommitter {
         }
     }
 
-    /// Writes to the txns shard at a fresh oracle timestamp and applies the write to the oracle,
-    /// implementing steps 1-4 of the protocol in the module docs.
+    /// Writes at a fresh oracle timestamp and applies a successful write to the oracle.
     ///
-    /// Returns `None` when the table write worker is gone, which only happens at process
-    /// shutdown. The caller must wind the committer down then, see the `Err(_recv)` arm.
+    /// Returns `None` when the table write worker shuts down.
     async fn write_to_txns(
         &self,
         op_duration_metric: Option<&prometheus::Histogram>,
         mut op: impl FnMut(Timestamp, Timestamp) -> oneshot::Receiver<Result<(), StorageError>>,
     ) -> Option<WriteTimestamp> {
-        // In-process conflicts are impossible (single writer), and the only conflicting writer
-        // we understand today is another generation, whose fence stops us via `advance_upper`
-        // within a retry or two. A conflict that persists past this cap means a writer we don't
-        // understand, so we convert it into the halt-and-rebuild path instead of spinning
-        // forever. The cap is generous on purpose: halting is disruptive, and each retry warns,
-        // so a misbehaving writer is visible in the logs long before we give up.
+        // Persistent conflicts indicate an unexpected writer. Halt instead of spinning forever.
         const MAX_ATTEMPTS: usize = 100;
         let mut attempt = 0;
         let write_ts = loop {
@@ -415,6 +327,8 @@ impl GroupCommitter {
             }
             let write_ts = self.oracle.write_ts().await;
 
+            // A post-fence retry has an advance frontier above this handle's stale upper, so this
+            // reaches Persist and observes the fence.
             let catalog_upper_start = Instant::now();
             self.catalog_upper
                 .advance_upper(write_ts.advance_to)
@@ -433,8 +347,6 @@ impl GroupCommitter {
             match op_res {
                 Ok(Ok(())) => break write_ts,
                 Ok(Err(StorageError::InvalidUppers(_))) => {
-                    // Another process advanced the txns shard past us; retry at a fresh
-                    // timestamp.
                     warn!(
                         write_ts = %write_ts.timestamp,
                         attempt,
@@ -443,47 +355,29 @@ impl GroupCommitter {
                     continue;
                 }
                 Ok(Err(other)) => {
-                    // Only another writer's upper conflict is retryable, anything else is fatal.
                     Err::<(), _>(other).unwrap_or_terminate("cannot fail to write to txns shard");
                     unreachable!("unwrap_or_terminate does not return on Err");
                 }
                 Err(_recv) => {
-                    // The worker replies to every command, so a dropped reply means its task
-                    // was cancelled, which only happens at process shutdown (a worker panic
-                    // aborts the process through the panic hook). The write is in an indefinite
-                    // state, but so is everything else at this point. Wind the committer down
-                    // instead of processing more writes during teardown: dropped responses
-                    // retire their clients via the `ExecuteContext` drop backstop, dropped
-                    // register/forget waiters halt, matching the storage controller's shutdown
-                    // posture on the bootstrap register path.
+                    // The outcome is indeterminate. Stop before processing more writes.
                     warn!("table write worker gone (process shutting down), winding down");
                     return None;
                 }
             }
         };
 
-        // The committer bypasses `apply_local_write`, so run the runaway-timeline check here:
-        // a write timestamp far ahead of the wall clock is the signal that the timeline has run
-        // away (e.g. after a clock regression).
         let now: Timestamp = (self.now)().into();
         crate::coord::timeline::check_runaway_write_ts(&now, write_ts.timestamp);
 
-        // Mark the write complete on the oracle so reads can advance to it.
         self.oracle.apply_write(write_ts.timestamp).await;
 
         Some(write_ts)
     }
 
-    /// Applies one staged group commit: allocate a timestamp, append, and apply the write.
+    /// Applies a staged group commit.
     ///
-    /// While waiting in the wall-clock throttle, later queued group commits are merged into this
-    /// one. That bounds queue growth under a slow oracle, and it lets an arriving internal system
-    /// write flip the throttle bypass, so system writes are not stuck behind a throttled
-    /// user-only batch. Merging stops at the first register or forget command, which is returned
-    /// to the caller to process next, preserving queue order (an append staged after a register
-    /// may target the newly registered table and must not commit before it).
-    ///
-    /// `Break` means the table write worker is gone and the committer must wind down.
+    /// Group commits queued during throttling are merged until a registration or forget command
+    /// preserves the queue boundary. `Break` means the table worker shut down.
     async fn commit(
         &mut self,
         mut request: GroupCommitRequest,
@@ -505,14 +399,8 @@ impl GroupCommitter {
                 }
             }
 
-            // Check the bypasses before peeking the oracle, so bypassed batches (every DDL
-            // builtin-table commit, for one) skip that round trip. An internal system write
-            // bypasses the throttle so tests with a mocked wall clock still make progress. A
-            // deferred register or forget means a DDL statement is blocked on the coordinator
-            // loop behind this batch. DDL was never subject to the wall-clock throttle (its
-            // timestamp allocations advanced the timeline directly when they ran on the
-            // coordinator loop), so rather than stall the whole control plane until the clock
-            // catches up, we let the batch through.
+            // Internal writes bypass the throttle for mocked clocks. A queued DDL registration or
+            // forget bypasses it because DDL was not previously throttled and blocks the loop.
             if request.contains_internal_system_write || deferred_cmd.is_some() {
                 break;
             }
@@ -521,9 +409,8 @@ impl GroupCommitter {
             if ts <= now {
                 break;
             }
-            // Cap the wait at 1s so a wall clock that jumped far ahead and then back does not
-            // stall us for a long time. The deadline is fixed per peek: merge wakeups below
-            // re-check the bypasses but do not re-peek the oracle.
+            // A fixed one-second cap bounds clock-regression stalls. Queue wakeups do not extend
+            // this deadline.
             let remaining_ms = std::cmp::min(ts.saturating_sub(now), Timestamp::from(1_000u64));
             let sleep = tokio::time::sleep(Duration::from_millis(remaining_ms.into()));
             tokio::pin!(sleep);
@@ -561,13 +448,11 @@ impl GroupCommitter {
             })
             .await
         else {
-            // Winding down at shutdown. Dropping the batch retires the clients with a shutdown
-            // error via the `ExecuteContext` drop backstop.
+            // Dropping the batch retires its clients through `ExecuteContext`.
             return ControlFlow::Break(());
         };
         let timestamp = write_ts.timestamp;
 
-        // Log non-empty user appends.
         let modified_tables: Vec<_> = appends
             .iter()
             .filter_map(|(id, updates)| {
@@ -581,27 +466,17 @@ impl GroupCommitter {
             );
         }
 
-        // IMPORTANT: Release the in-progress permits and write locks now, after the write is
-        // applied at the oracle, so no other write goes through at a timestamp we have not yet
-        // applied. Retiring the client responses does not need these locks, so we hand that back
-        // to the coordinator loop.
+        // Hold permits and locks until `apply_write` completes. Otherwise another write could
+        // proceed while this timestamp is not yet readable.
         drop(permits);
         drop(write_locks);
 
-        // Notify system-table write waiters (DDL, background heartbeats).
         for notify in notifies {
-            // We don't care if the listeners have gone away.
             let _ = notify.send(());
         }
 
-        // Hand the parts that need coordinator state back to the coordinator loop: recording
-        // statement execution timestamps, retiring client responses, and downgrading read holds.
-        // Retiring must happen there after the timestamps are recorded, because it ends the
-        // statement execution.
-        //
-        // NOTE: After `apply_write(timestamp)` the oracle read ts is at least `timestamp`, and
-        // reads at `timestamp` observe this commit, so the coordinator can downgrade the
-        // EpochMilliseconds read holds to `timestamp` without an oracle round trip.
+        // The coordinator records timestamps before retiring responses. The applied write
+        // timestamp is also a valid frontier for local read holds.
         if self
             .internal_cmd_tx
             .send(Message::GroupCommitApplied {
@@ -611,9 +486,6 @@ impl GroupCommitter {
             })
             .is_err()
         {
-            // The coordinator loop is gone, which only happens at process shutdown. Dropping
-            // the responses retires the clients with a shutdown error, see the drop backstop on
-            // `ExecuteContext`.
             warn!("coordinator shut down before a group commit could be finalized");
         }
 
@@ -621,9 +493,6 @@ impl GroupCommitter {
     }
 }
 
-/// Spawns the [`GroupCommitter`] task, consuming `rx` for staged commits.
-///
-/// Called once at coordinator startup with handles that stay valid for the process lifetime.
 pub(crate) fn spawn_group_committer(
     rx: mpsc::UnboundedReceiver<TableWriteCmd>,
     oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
@@ -748,18 +617,9 @@ impl Coordinator {
         }
     }
 
-    /// Stages all pending write transactions into a [`GroupCommitRequest`] and hands it to the
-    /// group committer, which allocates the write timestamp and applies the commit off the
-    /// coordinator loop.
+    /// Stages pending writes for the group committer.
     ///
-    /// If the caller holds the write lock they can pass it in. Writes whose locks are held by
-    /// another operation are deferred (only system writes and table advancement proceed). Writes
-    /// whose locks are free are acquired here and included.
-    ///
-    /// All included pending writes are combined into a single append committed at one timestamp,
-    /// and all involved tables advance to a timestamp larger than the write's. This does no
-    /// timestamp-oracle round trips itself: the committer does the throttle, allocation, and apply
-    /// off the coordinator loop.
+    /// Writes blocked on locks are deferred. Included writes share one timestamp.
     #[instrument(name = "coord::stage_group_commit")]
     pub(crate) fn stage_group_commit(&mut self, permit: Option<GroupCommitPermit>) {
         let mut validated_writes = Vec::new();
@@ -902,8 +762,6 @@ impl Coordinator {
                             appends.entry(id).or_default().extend(table_data);
                         }
                     }
-                    // The commit timestamp is allocated by the committer, so we record it for
-                    // statement logging once the committer reports it back.
                     if let Some(id) = ctx.extra().contents() {
                         statement_logging_ids.push(id);
                     }
@@ -950,11 +808,7 @@ impl Coordinator {
             })
             .collect();
 
-        // Hand the staged commit to the committer, which allocates the timestamp and applies it
-        // off the coordinator loop.
-        //
-        // NOTE: We always send, even with no appends, so the committer periodically bumps the upper
-        // of all tables, which is required to keep them readable at the latest oracle read ts.
+        // Always enqueue keepalives so registered tables remain readable at the oracle read ts.
         let request = GroupCommitRequest {
             appends,
             responses,
@@ -970,18 +824,12 @@ impl Coordinator {
             .send(TableWriteCmd::GroupCommit(request))
             .is_err()
         {
-            // The committer is gone, which only happens at process shutdown. Dropping the
-            // request retires the clients with a shutdown error, see the drop backstop on
-            // `ExecuteContext`. The notify senders are dropped too, which their
-            // waiters observe as completion. We cannot signal failure through them, and the
-            // process is shutting down regardless.
+            // Dropping the request retires its clients and notifies its waiters.
             warn!("group committer task gone, dropping staged group commit");
         }
     }
 
-    /// Registers `tables` in the txns shard through the group committer, returning the timestamp
-    /// at which they became writable (and readable, once the oracle read ts passes it). Going
-    /// through the committer orders the registration against staged appends, see the module docs.
+    /// Registers `tables` in FIFO order and returns the applied timestamp.
     pub(crate) async fn register_tables_via_committer(
         &self,
         tables: Vec<TableRegistration>,
@@ -992,23 +840,15 @@ impl Coordinator {
             .send(TableWriteCmd::Register { tables, result: tx })
             .is_err()
         {
-            // The command never entered the queue, so the txns shard was not touched, but the
-            // committer only disappears at process shutdown and we cannot make progress.
             halt!("group committer terminated before a table registration could be submitted");
         }
         match rx.await {
             Ok(ts) => ts,
-            // The committer only stops replying when the table write worker shut down, i.e. at
-            // process shutdown. The registration is in an indeterminate state, so we cannot
-            // continue.
             Err(_) => halt!("group committer terminated with a table registration outstanding"),
         }
     }
 
-    /// Forgets `ids` in the txns shard through the group committer, returning the forget
-    /// timestamp. Going through the committer orders the forget after all previously staged
-    /// appends, which is what makes dropping a table with in-flight writes safe, see the module
-    /// docs.
+    /// Forgets `ids` in FIFO order and returns the applied timestamp.
     pub(crate) async fn forget_tables_via_committer(&self, ids: Vec<GlobalId>) -> Timestamp {
         let (tx, rx) = oneshot::channel();
         if self
@@ -1016,12 +856,10 @@ impl Coordinator {
             .send(TableWriteCmd::Forget { ids, result: tx })
             .is_err()
         {
-            // See `register_tables_via_committer`.
             halt!("group committer terminated before a table forget could be submitted");
         }
         match rx.await {
             Ok(ts) => ts,
-            // See `register_tables_via_committer` for why halting is the only option.
             Err(_) => halt!("group committer terminated with a table forget outstanding"),
         }
     }
@@ -1206,14 +1044,9 @@ impl<'a> BuiltinTableAppend<'a> {
         Box::pin(rx.map(|_| ()))
     }
 
-    /// Submit a write to a system table and trigger a group commit.
+    /// Submits a system-table write immediately and returns its completion future.
     ///
-    /// Returns a `Future` that completes once the write has been applied. Does not block the
-    /// coordinator on the timestamp oracle: the write timestamp is allocated by the group
-    /// committer off the coordinator loop.
-    ///
-    /// Note: When in read-only mode, this buffers the update and the returned future resolves
-    /// immediately, without the update actually having been written.
+    /// In read-only mode, buffers the update and returns a ready future.
     pub fn execute(self, mut updates: Vec<BuiltinTableUpdate>) -> BuiltinTableAppendNotify {
         if self.coord.controller.read_only() {
             self.coord
@@ -1227,19 +1060,15 @@ impl<'a> BuiltinTableAppend<'a> {
 
         let (tx, rx) = oneshot::channel();
 
-        // Most DDL queries write to system tables. Unlike user-table writes, system table writes
-        // explicitly trigger a group commit rather than waiting for the next one. If DDL runs faster
-        // than one query per millisecond the global timeline can advance past the system clock,
-        // which can make future queries block but does not affect correctness. That rate of DDL is
-        // unlikely, so we let DDL trigger a commit directly.
+        // DDL system writes bypass the periodic wait. Extremely fast DDL can advance the global
+        // timeline ahead of the wall clock, delaying later queries without affecting correctness.
         self.coord.pending_writes.push(PendingWriteTxn::System {
             updates,
             source: BuiltinTableUpdateSource::Internal(tx),
         });
         self.coord.stage_group_commit(None);
 
-        // Avoid excessive group commits by resetting the periodic table advancement timer. The
-        // commit staged above already advances all tables.
+        // The staged commit already advances every table.
         self.coord.advance_timelines_interval.reset();
 
         Box::pin(rx.map(|_| ()))
@@ -1483,8 +1312,6 @@ mod tests {
     use super::*;
     use crate::catalog::Catalog;
 
-    /// A minimal in-memory [`TimestampOracle`] for driving the committer in tests. Counts
-    /// `apply_write` calls so tests can assert how often the committer applies.
     #[derive(Debug, Default)]
     struct MemTimestampOracle {
         read_write_ts: Mutex<(Timestamp, Timestamp)>,
@@ -1530,8 +1357,6 @@ mod tests {
         }
     }
 
-    /// A [`TableWriteHandle`] that reports an `InvalidUppers` conflict for the first
-    /// `conflicts` calls and succeeds afterwards, recording the write timestamp of every call.
     #[derive(Debug)]
     struct ConflictingTableWriteHandle {
         conflicts: usize,
@@ -1597,16 +1422,11 @@ mod tests {
         }
     }
 
-    /// Tests the committer's txns-shard conflict retry protocol: on `InvalidUppers` it retries
-    /// at a fresh, strictly larger oracle timestamp, durably advances the catalog upper, and
-    /// applies the write to the oracle exactly once, for the attempt that succeeds.
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
     async fn test_write_to_txns_conflict_retry() {
         Catalog::with_debug(|catalog| async move {
-            // Seed the oracle from the catalog upper, so the committer's `advance_upper` calls
-            // target timestamps past the freshly bootstrapped catalog and must take the durable
-            // compare-and-append path rather than the already-covered short-circuit.
+            // Start beyond the catalog upper to exercise the durable advance path.
             let initial_upper = catalog.current_upper().await;
             let oracle = Arc::new(MemTimestampOracle::starting_at(initial_upper));
             let handle = Arc::new(ConflictingTableWriteHandle::new(1));
@@ -1650,14 +1470,9 @@ mod tests {
             );
             assert_eq!(write_ts.timestamp, attempts[1]);
 
-            // The write was applied to the oracle exactly once, and the successful timestamp is
-            // readable.
             assert_eq!(oracle.apply_writes.load(Ordering::SeqCst), 1);
             assert_eq!(oracle.read_ts().await, write_ts.timestamp);
 
-            // The catalog upper was durably advanced to (at least) the successful attempt's
-            // `advance_to`, which started beyond the bootstrap upper, so this fails if
-            // `write_to_txns` stops advancing the catalog upper.
             let catalog_upper = catalog.current_upper().await;
             assert!(
                 catalog_upper >= write_ts.advance_to,

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -20,23 +20,27 @@ use futures::future::{BoxFuture, FutureExt};
 use mz_adapter_types::connection::ConnectionId;
 use mz_catalog::builtin::{BuiltinTable, MZ_SESSIONS};
 use mz_expr::CollectionPlan;
-use mz_ore::metrics::MetricsFutureExt;
+use mz_ore::assert_none;
+use mz_ore::halt;
+use mz_ore::now::NowFn;
 use mz_ore::task;
-use mz_ore::tracing::OpenTelemetryContext;
-use mz_ore::{assert_none, instrument};
-use mz_repr::{CatalogItemId, Timestamp};
+use mz_repr::{CatalogItemId, GlobalId, Timestamp};
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{ExplainPlanPlan, ExplainTimestampPlan, Explainee, ExplaineeStatement, Plan};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_client::client::TableData;
-use mz_timestamp_oracle::WriteTimestamp;
+use mz_storage_client::controller::{TableRegistration, TableWriteHandle};
+use mz_storage_types::controller::StorageError;
+use mz_timestamp_oracle::{TimestampOracle, WriteTimestamp};
 use smallvec::SmallVec;
-use tokio::sync::{Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore, oneshot};
-use tracing::{Instrument, Span, debug_span, info, warn};
+use tokio::sync::{Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
+use tracing::{Instrument, Span, info, warn};
 
-use crate::catalog::{BuiltinTableUpdate, Catalog};
+use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogUpperHandle};
 use crate::coord::{Coordinator, Message, PendingTxn, PlanValidity};
+use crate::metrics::Metrics;
 use crate::session::{GroupCommitWriteLocks, Session, WriteLocks};
+use crate::statement_logging::StatementLoggingId;
 use crate::util::{CompletedClientTransmitter, ResultExt};
 use crate::{AdapterError, ExecuteContext};
 
@@ -57,7 +61,7 @@ pub enum DeferredOp {
 impl DeferredOp {
     /// Certain operations, e.g. "blind writes"/`INSERT` statements, can be optimistically retried
     /// because we can share a write lock between multiple operations. In this case we wait to
-    /// acquire the locks until [`group_commit`], where writes are groupped by collection and
+    /// acquire the locks until [`stage_group_commit`], where writes are groupped by collection and
     /// comitted at a single timestamp.
     ///
     /// Other operations, e.g. read-then-write plans/`UPDATE` statements, must uniquely hold their
@@ -65,7 +69,7 @@ impl DeferredOp {
     /// queued plans attempting to get retried at the same time, when we know only one can proceed.
     ///
     /// [`try_deferred`]: crate::coord::Coordinator::try_deferred
-    /// [`group_commit`]: crate::coord::Coordinator::group_commit
+    /// [`stage_group_commit`]: crate::coord::Coordinator::stage_group_commit
     pub(crate) fn can_be_optimistically_retried(&self) -> bool {
         match self {
             DeferredOp::Plan(_) => false,
@@ -176,6 +180,362 @@ impl PendingWriteTxn {
     }
 }
 
+/// A command for the [`GroupCommitter`], the single in-process writer to the txns shard.
+///
+/// All txns-shard writes flow through one queue and are applied one at a time, in queue order, at
+/// monotone oracle timestamps. That single-sender ordering is what makes concurrent DDL safe
+/// against in-flight appends: a staged append for a table is always applied before a later
+/// forget of that table, because the forget enters the queue behind it.
+pub(crate) enum TableWriteCmd {
+    /// A staged group commit, see [`GroupCommitRequest`].
+    GroupCommit(GroupCommitRequest),
+    /// Register tables in the txns shard, making them available for writes. Replies with the
+    /// registration timestamp, which is also the timestamp at which the tables become readable
+    /// (the committer applies it to the oracle before replying).
+    Register {
+        tables: Vec<TableRegistration>,
+        result: oneshot::Sender<Timestamp>,
+    },
+    /// Forget tables in the txns shard. Replies with the forget timestamp.
+    Forget {
+        ids: Vec<GlobalId>,
+        result: oneshot::Sender<Timestamp>,
+    },
+}
+
+/// A batch of writes staged on the coordinator loop, to be committed by the [`GroupCommitter`].
+///
+/// The loop does the cheap, state-touching work (draining pending writes, acquiring write locks,
+/// building the append batch) and hands the rest to the committer. Timestamp allocation, the table
+/// append, advancing the catalog upper, and applying the write to the oracle all happen off the
+/// loop.
+pub(crate) struct GroupCommitRequest {
+    /// Table appends, resolved to their latest [`GlobalId`] and consolidated. Empty for a keepalive.
+    appends: Vec<(GlobalId, Vec<TableData>)>,
+    /// Client transmitters for user writes, retired once the commit is durable.
+    responses: Vec<CompletedClientTransmitter>,
+    /// Statement-logging ids for user writes, paired with the commit timestamp once we know it.
+    statement_logging_ids: Vec<StatementLoggingId>,
+    /// Notifiers for system-table writes (DDL, background heartbeats).
+    notifies: Vec<oneshot::Sender<()>>,
+    /// Write locks held for the duration of the commit.
+    write_locks: GroupCommitWriteLocks,
+    /// In-progress permits, released once the commit is applied. Merging batches can accumulate
+    /// more than one.
+    permits: Vec<GroupCommitPermit>,
+    /// Whether the batch has an internal system write (e.g. `mz_sessions`), which bypasses the
+    /// throttle so that tests with a mocked wall clock can still make progress.
+    contains_internal_system_write: bool,
+    span: Span,
+}
+
+impl GroupCommitRequest {
+    /// Absorbs another staged commit into this one, so both apply at a single timestamp.
+    ///
+    /// Lock sets of separately staged commits are disjoint (staging defers writes whose locks are
+    /// already held), so extending the lock map cannot double-lock. The other request's span is
+    /// dropped, which loses its trace linkage. Not great, but merged batches are the exception.
+    fn merge(&mut self, other: GroupCommitRequest) {
+        let GroupCommitRequest {
+            appends,
+            responses,
+            statement_logging_ids,
+            notifies,
+            write_locks,
+            permits,
+            contains_internal_system_write,
+            span: _,
+        } = other;
+        // The worker applies every (id, updates) entry, so duplicate ids across the merged
+        // batches are fine.
+        self.appends.extend(appends);
+        self.responses.extend(responses);
+        self.statement_logging_ids.extend(statement_logging_ids);
+        self.notifies.extend(notifies);
+        self.write_locks.extend(write_locks);
+        // Hold all merged permits until the combined batch is applied, so the permit keeps
+        // bounding in-flight batches as documented.
+        self.permits.extend(permits);
+        self.contains_internal_system_write |= contains_internal_system_write;
+    }
+}
+
+/// A single, long-lived task that owns all txns-shard writes: group commits (table appends) as
+/// well as table registration and forgetting for DDL, applied off the coordinator loop.
+///
+/// The coordinator loop stages each group commit (draining pending writes, acquiring write locks,
+/// and building the append batch, all cheap) and hands a [`TableWriteCmd`] here. This task does
+/// the timestamp-oracle round trips, the txns-shard write, and applies the write to the oracle.
+/// Processing one command at a time makes this task the serialization point for txns-shard
+/// writes: they reach the single table-write worker in queue order at monotone timestamps, so
+/// in-process conflicts cannot happen and an `InvalidUppers` conflict always means another
+/// process wrote the txns shard, which we handle by retrying at a fresh timestamp.
+///
+/// It holds only shareable handles, captured once at startup. The oracle is never replaced
+/// in-process, and the table write handle stays valid for the controller's lifetime. The catalog
+/// upper handle shares the durable-storage mutex with catalog transactions, so upper advancement
+/// stays serialized with DDL commits.
+pub(crate) struct GroupCommitter {
+    rx: mpsc::UnboundedReceiver<TableWriteCmd>,
+    oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
+    table_write_handle: Arc<dyn TableWriteHandle>,
+    catalog_upper: CatalogUpperHandle,
+    internal_cmd_tx: mpsc::UnboundedSender<Message>,
+    now: NowFn,
+    metrics: Metrics,
+}
+
+impl GroupCommitter {
+    async fn run(mut self) {
+        while let Some(cmd) = self.rx.recv().await {
+            // `commit` may pull a non-mergeable command off the queue while it waits in the
+            // throttle. Process it before receiving anew, to preserve queue order.
+            let mut next = Some(cmd);
+            while let Some(cmd) = next.take() {
+                match cmd {
+                    TableWriteCmd::GroupCommit(request) => {
+                        let span = request.span.clone();
+                        next = self.commit(request).instrument(span).await;
+                    }
+                    TableWriteCmd::Register { tables, result } => {
+                        let Some(write_ts) = self
+                            .write_to_txns(None, |ts, _advance_to| {
+                                self.table_write_handle.register(ts, tables.clone())
+                            })
+                            .await
+                        else {
+                            return;
+                        };
+                        // We don't care if the waiter has gone away.
+                        let _ = result.send(write_ts.timestamp);
+                    }
+                    TableWriteCmd::Forget { ids, result } => {
+                        let Some(write_ts) = self
+                            .write_to_txns(None, |ts, _advance_to| {
+                                self.table_write_handle.forget(ts, ids.clone())
+                            })
+                            .await
+                        else {
+                            return;
+                        };
+                        // We don't care if the waiter has gone away.
+                        let _ = result.send(write_ts.timestamp);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Writes to the txns shard at a fresh oracle timestamp and applies the write to the oracle.
+    ///
+    /// Per attempt: allocate a write timestamp, advance the catalog upper to its `advance_to`
+    /// (keeping the catalog readable at the read timestamp the oracle moves to below, and, when
+    /// the advance actually writes, re-checking leadership before user data is written, see
+    /// materialize#28216; an advance that finds the upper already past `advance_to` short-circuits
+    /// without a durable check, so the leadership re-check is defense in depth, not a per-attempt
+    /// guarantee), then issue the op. An `InvalidUppers` conflict means another process advanced
+    /// the txns shard past our timestamp, so we retry at a fresh one. A wasted timestamp is
+    /// harmless: `apply_write` is a high-water mark, so the eventual, higher timestamp subsumes
+    /// it.
+    ///
+    /// Only after the op succeeds do we apply the write to the oracle, so no read observes a
+    /// timestamp at which the write (append, registration, forget) is not yet durable.
+    ///
+    /// Returns `None` if the table write worker shut down, which only happens at process
+    /// shutdown.
+    async fn write_to_txns(
+        &self,
+        op_duration_metric: Option<&prometheus::Histogram>,
+        mut op: impl FnMut(Timestamp, Timestamp) -> oneshot::Receiver<Result<(), StorageError>>,
+    ) -> Option<WriteTimestamp> {
+        let write_ts = loop {
+            let write_ts = self.oracle.write_ts().await;
+
+            let catalog_upper_start = Instant::now();
+            self.catalog_upper
+                .advance_upper(write_ts.advance_to)
+                .await
+                .unwrap_or_terminate("unable to advance catalog upper");
+            self.metrics
+                .group_commit_catalog_upper_seconds
+                .observe(catalog_upper_start.elapsed().as_secs_f64());
+
+            let op_start = Instant::now();
+            let op_res = op(write_ts.timestamp, write_ts.advance_to).await;
+            if let Some(metric) = op_duration_metric {
+                metric.observe(op_start.elapsed().as_secs_f64());
+            }
+
+            match op_res {
+                Ok(Ok(())) => break write_ts,
+                Ok(Err(StorageError::InvalidUppers(_))) => {
+                    // Another process advanced the txns shard past us; retry at a fresh
+                    // timestamp.
+                    continue;
+                }
+                Ok(Err(other)) => {
+                    // Any other error is fatal, matching the previous on-loop behavior.
+                    Err::<(), _>(other).unwrap_or_terminate("cannot fail to write to txns shard");
+                    unreachable!("unwrap_or_terminate does not return on Err");
+                }
+                Err(_recv) => {
+                    warn!("table write worker terminated with writes in indefinite state");
+                    return None;
+                }
+            }
+        };
+
+        // Mark the write complete on the oracle so reads can advance to it.
+        self.oracle.apply_write(write_ts.timestamp).await;
+
+        Some(write_ts)
+    }
+
+    /// Applies one staged group commit: allocate a timestamp, append, and apply the write.
+    ///
+    /// While waiting in the wall-clock throttle, later queued group commits are merged into this
+    /// one. That bounds queue growth under a slow oracle, and it lets an arriving internal system
+    /// write flip the throttle bypass, so system writes are not stuck behind a throttled
+    /// user-only batch. Merging stops at the first register or forget command, which is returned
+    /// to the caller to process next, preserving queue order (an append staged after a register
+    /// may target the newly registered table and must not commit before it).
+    async fn commit(&mut self, mut request: GroupCommitRequest) -> Option<TableWriteCmd> {
+        let mut deferred_cmd = None;
+        // Once the channel is closed, `recv` resolves immediately with `None`. Disable that
+        // select branch then, so the throttle sleep still runs instead of busy-looping.
+        let mut rx_closed = false;
+
+        // Throttle: keep the global write timeline from running ahead of the wall clock. We peek
+        // and sleep off the loop, so a slow oracle backend does not stall the coordinator. The
+        // internal system-write case bypasses this so tests with a mocked wall clock still make
+        // progress.
+        loop {
+            while deferred_cmd.is_none() {
+                match self.rx.try_recv() {
+                    Ok(TableWriteCmd::GroupCommit(other)) => request.merge(other),
+                    Ok(other) => deferred_cmd = Some(other),
+                    Err(_) => break,
+                }
+            }
+
+            let ts = self.oracle.peek_write_ts().await;
+            let now: Timestamp = (self.now)().into();
+            // A deferred register or forget means a DDL statement is blocked on the coordinator
+            // loop behind this batch. DDL was never subject to the wall-clock throttle (its
+            // timestamp allocations advanced the timeline directly when it ran on the loop), so
+            // rather than stall the whole control plane until the clock catches up, we let the
+            // batch through, the same way an internal system write does.
+            if ts <= now || request.contains_internal_system_write || deferred_cmd.is_some() {
+                break;
+            }
+            // Cap the wait at 1s so a wall clock that jumped far ahead and then back does not
+            // stall us for a long time.
+            let remaining_ms = std::cmp::min(ts.saturating_sub(now), Timestamp::from(1_000u64));
+            let sleep = tokio::time::sleep(Duration::from_millis(remaining_ms.into()));
+            tokio::select! {
+                _ = sleep => {}
+                cmd = self.rx.recv(), if deferred_cmd.is_none() && !rx_closed => match cmd {
+                    Some(TableWriteCmd::GroupCommit(other)) => request.merge(other),
+                    Some(other) => deferred_cmd = Some(other),
+                    None => rx_closed = true,
+                },
+            }
+        }
+
+        let GroupCommitRequest {
+            appends,
+            responses,
+            statement_logging_ids,
+            notifies,
+            write_locks,
+            permits,
+            contains_internal_system_write: _,
+            span: _,
+        } = request;
+
+        let append_metric = self.metrics.append_table_duration_seconds.clone();
+        let Some(write_ts) = self
+            .write_to_txns(Some(&append_metric), |ts, advance_to| {
+                self.table_write_handle
+                    .append(ts, advance_to, appends.clone())
+            })
+            .await
+        else {
+            return deferred_cmd;
+        };
+        let timestamp = write_ts.timestamp;
+
+        // Log non-empty user appends.
+        let modified_tables: Vec<_> = appends
+            .iter()
+            .filter_map(|(id, updates)| {
+                (id.is_user() && !updates.iter().all(|u| u.is_empty())).then_some(id)
+            })
+            .collect();
+        if !modified_tables.is_empty() {
+            info!(
+                "Appending to tables, {modified_tables:?}, at {timestamp}, advancing to {}",
+                write_ts.advance_to
+            );
+        }
+
+        // IMPORTANT: Release the in-progress permits and write locks now, after the write is
+        // applied at the oracle, so no other write goes through at a timestamp we have not yet
+        // applied. Retiring the client responses does not need these locks, so we hand that back
+        // to the loop.
+        drop(permits);
+        drop(write_locks);
+
+        // Notify system-table write waiters (DDL, background heartbeats).
+        for notify in notifies {
+            // We don't care if the listeners have gone away.
+            let _ = notify.send(());
+        }
+
+        // Hand the parts that need coordinator state back to the loop: recording statement
+        // execution timestamps, retiring client responses, and downgrading read holds. Retiring
+        // must happen on the loop after the timestamps are recorded, because it ends the statement
+        // execution.
+        //
+        // NOTE: After `apply_write(timestamp)` the oracle read ts is at least `timestamp`, and
+        // reads at `timestamp` observe this commit, so the loop can downgrade the
+        // EpochMilliseconds read holds to `timestamp` without an oracle round trip.
+        if let Err(e) = self.internal_cmd_tx.send(Message::GroupCommitApplied {
+            responses,
+            statement_logging_ids,
+            write_ts: timestamp,
+        }) {
+            warn!("coordinator shut down before a group commit could be finalized: {e}");
+        }
+
+        deferred_cmd
+    }
+}
+
+/// Spawns the [`GroupCommitter`] task, consuming `rx` for staged commits.
+///
+/// Called once at coordinator startup with handles that stay valid for the process lifetime.
+pub(crate) fn spawn_group_committer(
+    rx: mpsc::UnboundedReceiver<TableWriteCmd>,
+    oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
+    table_write_handle: Arc<dyn TableWriteHandle>,
+    catalog_upper: CatalogUpperHandle,
+    internal_cmd_tx: mpsc::UnboundedSender<Message>,
+    now: NowFn,
+    metrics: Metrics,
+) {
+    let committer = GroupCommitter {
+        rx,
+        oracle,
+        table_write_handle,
+        catalog_upper,
+        internal_cmd_tx,
+        now,
+        metrics,
+    };
+    task::spawn(|| "group_committer", committer.run());
+}
+
 impl Coordinator {
     /// Send a message to the Coordinate to start a group commit.
     pub(crate) fn trigger_group_commit(&mut self) {
@@ -279,67 +639,18 @@ impl Coordinator {
         }
     }
 
-    /// Attempts to commit all pending write transactions in a group commit. If the timestamp
-    /// chosen for the writes is not ahead of `now()`, then we can execute and commit the writes
-    /// immediately. Otherwise we must wait for `now()` to advance past the timestamp chosen for the
-    /// writes.
-    #[instrument(level = "debug")]
-    pub(crate) async fn try_group_commit(&mut self, permit: Option<GroupCommitPermit>) {
-        let timestamp = self.peek_local_write_ts().await;
-        let now = Timestamp::from((self.catalog().config().now)());
-
-        // HACK: This is a special case to allow writes to the mz_sessions table to proceed even
-        // if the timestamp oracle is ahead of the current walltime. We do this because there are
-        // some tests that mock the walltime, so it doesn't automatically advance, and updating
-        // those tests to advance the walltime while creating a connection is too much.
-        //
-        // TODO(parkmycar): Get rid of the check below when refactoring group commits.
-        let contains_internal_system_write = self
-            .pending_writes
-            .iter()
-            .any(|write| write.is_internal_system());
-
-        if timestamp > now && !contains_internal_system_write {
-            // Cap retry time to 1s. In cases where the system clock has retreated by
-            // some large amount of time, this prevents against then waiting for that
-            // large amount of time in case the system clock then advances back to near
-            // what it was.
-            let remaining_ms = std::cmp::min(timestamp.saturating_sub(now), 1_000.into());
-            let internal_cmd_tx = self.internal_cmd_tx.clone();
-            task::spawn(
-                || "group_commit_initiate",
-                async move {
-                    tokio::time::sleep(Duration::from_millis(remaining_ms.into())).await;
-                    // It is not an error for this task to be running after `internal_cmd_rx` is dropped.
-                    let result =
-                        internal_cmd_tx.send(Message::GroupCommitInitiate(Span::current(), permit));
-                    if let Err(e) = result {
-                        warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-                    }
-                }
-                .instrument(Span::current()),
-            );
-        } else {
-            self.group_commit(permit).await;
-        }
-    }
-
-    /// Tries to commit all pending writes transactions at the same timestamp.
+    /// Stages all pending write transactions into a [`GroupCommitRequest`] and hands it to the
+    /// group committer, which allocates the write timestamp and applies the commit off the loop.
     ///
-    /// If the caller of this function has the `write_lock` acquired, then they can optionally pass
-    /// it in to this method. If the caller does not have the `write_lock` acquired and the
-    /// `write_lock` is currently locked by another operation, then only writes to system tables
-    /// and table advancements will be applied. If the caller does not have the `write_lock`
-    /// acquired and the `write_lock` is not currently locked by another operation, then group
-    /// commit will acquire it and all writes will be applied.
+    /// If the caller holds the write lock they can pass it in. Writes whose locks are held by
+    /// another operation are deferred (only system writes and table advancement proceed). Writes
+    /// whose locks are free are acquired here and included.
     ///
-    /// All applicable pending writes will be combined into a single Append command and sent to
-    /// STORAGE as a single batch. All applicable writes will happen at the same timestamp and all
-    /// involved tables will be advanced to some timestamp larger than the timestamp of the write.
-    ///
-    /// Returns the timestamp of the write.
-    #[instrument(name = "coord::group_commit")]
-    pub(crate) async fn group_commit(&mut self, permit: Option<GroupCommitPermit>) -> Timestamp {
+    /// All included pending writes are combined into a single append committed at one timestamp,
+    /// and all involved tables advance to a timestamp larger than the write's. This does no
+    /// timestamp-oracle round trips itself: the committer does the throttle, allocation, and apply
+    /// off the loop.
+    pub(crate) fn stage_group_commit(&mut self, permit: Option<GroupCommitPermit>) {
         let mut validated_writes = Vec::new();
         let mut deferred_writes = Vec::new();
         let mut group_write_locks = GroupCommitWriteLocks::default();
@@ -447,32 +758,13 @@ impl Coordinator {
             self.defer_op(acquire_future, DeferredOp::Write(write));
         }
 
-        // The value returned here still might be ahead of `now()` if `now()` has gone backwards at
-        // any point during this method or if this was triggered from DDL. We will still commit the
-        // write without waiting for `now()` to advance. This is ok because the next batch of writes
-        // will trigger the wait loop in `try_group_commit()` if `now()` hasn't advanced past the
-        // global timeline, preventing an unbounded advancing of the global timeline ahead of
-        // `now()`. Additionally DDL is infrequent enough and takes long enough that we don't think
-        // it's practical for continuous DDL to advance the global timestamp in an unbounded manner.
-        let WriteTimestamp {
-            timestamp,
-            advance_to,
-        } = self.get_local_write_ts().await;
-
-        // Advance the catalog shard's upper to keep it in sync with the oracle
-        // timestamp. This ensures that reads of mz_catalog_raw at the oracle's
-        // read_ts do not block waiting for the catalog shard's upper to advance.
-        let catalog_upper_start = Instant::now();
-        self.catalog
-            .advance_upper(advance_to)
-            .await
-            .unwrap_or_terminate("unable to advance catalog upper");
-        self.metrics
-            .group_commit_catalog_upper_seconds
-            .observe(catalog_upper_start.elapsed().as_secs_f64());
+        let contains_internal_system_write = validated_writes
+            .iter()
+            .any(|write| write.is_internal_system());
 
         let mut appends: BTreeMap<CatalogItemId, SmallVec<[TableData; 1]>> = BTreeMap::new();
         let mut responses = Vec::with_capacity(validated_writes.len());
+        let mut statement_logging_ids = Vec::new();
         let mut notifies = Vec::new();
 
         for validated_write_txn in validated_writes {
@@ -499,8 +791,10 @@ impl Coordinator {
                             appends.entry(id).or_default().extend(table_data);
                         }
                     }
+                    // The commit timestamp is allocated off the loop, so we record it for statement
+                    // logging once the committer reports it back.
                     if let Some(id) = ctx.extra().contents() {
-                        self.set_statement_execution_timestamp(id, timestamp);
+                        statement_logging_ids.push(id);
                     }
 
                     responses.push(CompletedClientTransmitter::new(ctx, response, action));
@@ -545,91 +839,77 @@ impl Coordinator {
             })
             .collect();
 
-        // Log non-empty user appends.
-        let modified_tables: Vec<_> = appends
-            .iter()
-            .filter_map(|(id, updates)| {
-                if id.is_user() && !updates.iter().all(|u| u.is_empty()) {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if !modified_tables.is_empty() {
-            info!(
-                "Appending to tables, {modified_tables:?}, at {timestamp}, advancing to {advance_to}"
-            );
+        // Hand the staged commit to the committer, which allocates the timestamp and applies it off
+        // the loop.
+        //
+        // NOTE: We always send, even with no appends, so the committer periodically bumps the upper
+        // of all tables, which is required to keep them readable at the latest oracle read ts.
+        let request = GroupCommitRequest {
+            appends,
+            responses,
+            statement_logging_ids,
+            notifies,
+            write_locks: group_write_locks,
+            permits: permit.into_iter().collect(),
+            contains_internal_system_write,
+            span: Span::current(),
+        };
+        if let Err(e) = self
+            .group_committer_tx
+            .send(TableWriteCmd::GroupCommit(request))
+        {
+            warn!("group committer task gone, dropping group commit: {e}");
         }
+    }
 
-        // Instrument our table writes since they can block the coordinator.
-        let histogram = self.metrics.append_table_duration_seconds.clone();
+    /// Registers `tables` in the txns shard through the group committer, returning the timestamp
+    /// at which they became writable. The committer applies that timestamp to the oracle before
+    /// replying, so the tables are also readable once the oracle read ts passes it.
+    ///
+    /// Going through the committer orders the registration after all previously staged appends
+    /// and gives it the committer's conflict-retry protocol against concurrent processes.
+    pub(crate) async fn register_tables_via_committer(
+        &self,
+        tables: Vec<TableRegistration>,
+    ) -> Timestamp {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .group_committer_tx
+            .send(TableWriteCmd::Register { tables, result: tx })
+            .is_err()
+        {
+            // The command never entered the queue, so the txns shard was not touched, but the
+            // committer only disappears at process shutdown and we cannot make progress.
+            halt!("group committer terminated before a table registration could be submitted");
+        }
+        match rx.await {
+            Ok(ts) => ts,
+            // The committer only stops replying when the table write worker shut down, i.e. at
+            // process shutdown. The registration is in an indeterminate state, so we cannot
+            // continue.
+            Err(_) => halt!("group committer terminated with a table registration outstanding"),
+        }
+    }
 
-        // NOTE: It is important that we append, even when there are no actual
-        // appends. This makes sure we periodically bump the upper of all
-        // tables, which is required to make them readable at the latest oracle
-        // read ts.
-
-        let append_fut = self
-            .controller
-            .storage
-            .append_table(timestamp, advance_to, appends)
-            .expect("invalid updates")
-            .wall_time()
-            .observe(histogram);
-
-        // Spawn a task to do the table writes.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-        let apply_write_fut = self.apply_local_write(timestamp);
-
-        let span = debug_span!(parent: None, "group_commit_apply");
-        OpenTelemetryContext::obtain().attach_as_parent_to(&span);
-        task::spawn(
-            || "group_commit_apply",
-            async move {
-                // Wait for the writes to complete.
-                match append_fut
-                    .instrument(debug_span!("group_commit_apply::append_fut"))
-                    .await
-                {
-                    Ok(append_result) => {
-                        append_result.unwrap_or_terminate("cannot fail to apply appends")
-                    }
-                    Err(_) => warn!("Writer terminated with writes in indefinite state"),
-                };
-
-                // Apply the write by marking the timestamp as complete on the timeline.
-                apply_write_fut
-                    .instrument(debug_span!("group_commit_apply::append_write_fut"))
-                    .await;
-
-                // Notify the external clients of the result.
-                for response in responses {
-                    let (mut ctx, result) = response.finalize();
-                    ctx.session_mut().apply_write(timestamp);
-                    ctx.retire(result);
-                }
-
-                // IMPORTANT: Make sure we hold the permit and write locks
-                // until here, to prevent other writes from going through while
-                // we haven't yet applied the write at the timestamp oracle.
-                drop(permit);
-                drop(group_write_locks);
-
-                // Advance other timelines.
-                if let Err(e) = internal_cmd_tx.send(Message::AdvanceTimelines) {
-                    warn!("Server closed with non-advanced timelines, {e}");
-                }
-
-                for notify in notifies {
-                    // We don't care if the listeners have gone away.
-                    let _ = notify.send(());
-                }
-            }
-            .instrument(span),
-        );
-
-        timestamp
+    /// Forgets `ids` in the txns shard through the group committer, returning the forget
+    /// timestamp. See [`Self::register_tables_via_committer`] for why this goes through the
+    /// committer: ordering after staged appends is what makes dropping a table with in-flight
+    /// writes safe.
+    pub(crate) async fn forget_tables_via_committer(&self, ids: Vec<GlobalId>) -> Timestamp {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .group_committer_tx
+            .send(TableWriteCmd::Forget { ids, result: tx })
+            .is_err()
+        {
+            // See `register_tables_via_committer`.
+            halt!("group committer terminated before a table forget could be submitted");
+        }
+        match rx.await {
+            Ok(ts) => ts,
+            // See `register_tables_via_committer` for why halting is the only option.
+            Err(_) => halt!("group committer terminated with a table forget outstanding"),
+        }
     }
 
     /// Submit a write to be executed during the next group commit and trigger a group commit.
@@ -812,19 +1092,15 @@ impl<'a> BuiltinTableAppend<'a> {
         Box::pin(rx.map(|_| ()))
     }
 
-    /// Submit a write to a system table.
+    /// Submit a write to a system table and trigger a group commit.
     ///
-    /// This method will block the Coordinator on acquiring a write timestamp from the timestamp
-    /// oracle, and then returns a `Future` that will complete once the write has been applied and
-    /// the write timestamp.
+    /// Returns a `Future` that completes once the write has been applied. Does not block the
+    /// coordinator on the timestamp oracle: the write timestamp is allocated by the group committer
+    /// off the loop.
     ///
-    /// Note: When in read-only mode, this will buffer the update, the
-    /// returned future will resolve immediately, without the update actually
-    /// having been written, and no timestamp is returned.
-    pub async fn execute(
-        self,
-        mut updates: Vec<BuiltinTableUpdate>,
-    ) -> (BuiltinTableAppendNotify, Option<Timestamp>) {
+    /// Note: When in read-only mode, this buffers the update and the returned future resolves
+    /// immediately, without the update actually having been written.
+    pub fn execute(self, mut updates: Vec<BuiltinTableUpdate>) -> BuiltinTableAppendNotify {
         if self.coord.controller.read_only() {
             self.coord
                 .buffered_builtin_table_updates
@@ -832,28 +1108,27 @@ impl<'a> BuiltinTableAppend<'a> {
                 .expect("in read-only mode")
                 .append(&mut updates);
 
-            return (Box::pin(futures::future::ready(())), None);
+            return Box::pin(futures::future::ready(()));
         }
 
         let (tx, rx) = oneshot::channel();
 
-        // Most DDL queries cause writes to system tables. Unlike writes to user tables, system
-        // table writes do not wait for a group commit, they explicitly trigger one. There is a
-        // possibility that if a user is executing DDL at a rate faster than 1 query per
-        // millisecond, then the global timeline will unboundedly advance past the system clock.
-        // This can cause future queries to block, but will not affect correctness. Since this
-        // rate of DDL is unlikely, we allow DDL to explicitly trigger group commit.
+        // Most DDL queries write to system tables. Unlike user-table writes, system table writes
+        // explicitly trigger a group commit rather than waiting for the next one. If DDL runs faster
+        // than one query per millisecond the global timeline can advance past the system clock,
+        // which can make future queries block but does not affect correctness. That rate of DDL is
+        // unlikely, so we let DDL trigger a commit directly.
         self.coord.pending_writes.push(PendingWriteTxn::System {
             updates,
             source: BuiltinTableUpdateSource::Internal(tx),
         });
-        let write_ts = self.coord.group_commit(None).await;
+        self.coord.stage_group_commit(None);
 
         // Avoid excessive group commits by resetting the periodic table advancement timer. The
-        // group commit triggered by above will already advance all tables.
+        // commit staged above already advances all tables.
         self.coord.advance_timelines_interval.reset();
 
-        (Box::pin(rx.map(|_| ())), Some(write_ts))
+        Box::pin(rx.map(|_| ()))
     }
 }
 

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -25,10 +25,10 @@
 //! cached catalog upper, so the advance reaches Persist and observes the fence before another txns
 //! write.
 //!
-//! During writable bootstrap, system-table snapshots cannot complete until a txns-shard write has
-//! advanced the table uppers. A stale write either linearizes before this barrier and is observed
-//! by the snapshot, or conflicts and follows the fenced retry path above. This relies on
-//! generations sharing the oracle.
+//! On `environmentd` bootstrap in read/write mode, system-table snapshots cannot complete until a
+//! txns-shard write has advanced the table uppers. A stale write either linearizes before this
+//! barrier and is observed by the snapshot, or conflicts and follows the fenced retry path above.
+//! This relies on generations sharing the oracle.
 //!
 //! Work that requires coordinator state is returned via [`Message::GroupCommitApplied`].
 

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -946,8 +946,8 @@ impl Coordinator {
             // logging around to indicate when an actual dependency error might
             // occur.
             if !tables_to_drop.is_empty() {
-                let ts = self.get_local_write_ts().await;
-                self.drop_tables(tables_to_drop.into_iter().collect_vec(), ts.timestamp);
+                self.drop_tables(tables_to_drop.into_iter().collect_vec())
+                    .await;
             }
 
             if !sources_to_drop.is_empty() {
@@ -1099,41 +1099,59 @@ impl Coordinator {
         table_collections_to_create: BTreeMap<GlobalId, CollectionDescription>,
         execution_timestamps_to_set: BTreeSet<StatementLoggingId>,
     ) -> Result<(), AdapterError> {
-        // If we have tables, determine the initial validity for the table.
+        // Source-fed tables and webhooks flow through here too (they are table catalog items), but
+        // `table_registrations` below filters to the real (`DataSource::Table`) tables that need
+        // txns-shard registration, so we can hand it all of them.
+        let table_ids: Vec<GlobalId> = table_collections_to_create.keys().copied().collect();
+        let collections = table_collections_to_create.into_iter().collect_vec();
+
+        // Allocate a write timestamp and make the catalog readable at the read ts we bump to below
+        // (this also serves as the leader/fencing check, see materialize#28216). The tables' initial
+        // read frontier (since) is set to this timestamp in `create_collections`.
         let write_ts = self.get_local_write_ts().await;
         let register_ts = write_ts.timestamp;
-
-        // After acquiring `register_ts` but before using it, we need to
-        // be sure we're still the leader. Otherwise a new generation
-        // may also be trying to use `register_ts` for a different
-        // purpose. See materialize#28216.
-        //
-        // We also should advance the upper of the catalog shard, to ensure it
-        // is readable at the oracle read ts after we bump it to the
-        // `register_ts` below. Both of these needs are served by calling
-        // `advance_upper`.
         self.catalog
             .advance_upper(write_ts.advance_to)
             .await
             .unwrap_or_terminate("unable to advance catalog upper");
 
-        for id in execution_timestamps_to_set {
-            self.set_statement_execution_timestamp(id, register_ts);
+        {
+            let storage_metadata = self.catalog.state().storage_metadata();
+            self.controller
+                .storage
+                .create_collections(storage_metadata, Some(register_ts), collections)
+                .await
+                .unwrap_or_terminate("cannot fail to create collections");
         }
 
-        let storage_metadata = self.catalog.state().storage_metadata();
-
-        self.controller
+        // Register the tables in the txns shard through the group committer, making them
+        // available for writes. The committer is the single in-process txns-shard writer, so the
+        // registration is ordered after all staged appends and needs no local conflict handling.
+        // It allocates its own, possibly later timestamp and applies it to the oracle, so reads
+        // never observe a partially registered table: the read ts only passes the registration
+        // timestamp after the registration is durable.
+        //
+        // NOTE: The table since (set to `register_ts` in `create_collections` above) may end up
+        // below the final registration timestamp. That is the safe direction: txns registration
+        // does not constrain the data shard since, and reads only happen at or beyond the final
+        // timestamp.
+        let registrations = self
+            .controller
             .storage
-            .create_collections(
-                storage_metadata,
-                Some(register_ts),
-                table_collections_to_create.into_iter().collect_vec(),
-            )
-            .await
-            .unwrap_or_terminate("cannot fail to create collections");
+            .table_registrations(table_ids)
+            .unwrap_or_terminate("cannot fail to look up table registrations");
+        let table_ts = if registrations.is_empty() {
+            // Nothing to register (e.g. only source-fed tables). Bump the oracle read ts
+            // ourselves so the collections become readable at `register_ts`.
+            self.apply_local_write(register_ts).await;
+            register_ts
+        } else {
+            self.register_tables_via_committer(registrations).await
+        };
 
-        self.apply_local_write(register_ts).await;
+        for id in execution_timestamps_to_set {
+            self.set_statement_execution_timestamp(id, table_ts);
+        }
 
         Ok(())
     }
@@ -1361,28 +1379,29 @@ impl Coordinator {
             .desc
             .at_version(RelationVersionSelector::Specific(new_version));
 
+        // Make the catalog readable at the read ts the registration below bumps to, and re-check
+        // leadership (see materialize#28216) before mutating controller state.
         let write_ts = self.get_local_write_ts().await;
-        let register_ts = write_ts.timestamp;
-
-        // Ensure the catalog will be immediately readable at the read ts we're
-        // about to bump.
         self.catalog
             .advance_upper(write_ts.advance_to)
             .await
             .unwrap_or_terminate("unable to advance catalog upper");
 
-        // Alter the table description, creating a "new" collection.
         self.controller
             .storage
-            .alter_table_desc(
-                existing_gid,
-                new_gid,
-                new_desc,
-                expected_version,
-                register_ts,
-            )
+            .alter_table_desc(existing_gid, new_gid, new_desc, expected_version)
             .await
-            .expect("failed to alter desc of table");
+            .unwrap_or_terminate("failed to alter desc of table");
+
+        // Register the evolved collection in the txns shard through the group committer, making
+        // it available for writes. As with CREATE TABLE, the committer orders the registration
+        // after all staged appends and handles conflicts with concurrent processes.
+        let registrations = self
+            .controller
+            .storage
+            .table_registrations(vec![new_gid])
+            .unwrap_or_terminate("cannot fail to look up table registrations");
+        self.register_tables_via_committer(registrations).await;
 
         // Initialize the ReadPolicy which ensures we have the correct read holds.
         let compaction_window = new_table
@@ -1396,8 +1415,6 @@ impl Coordinator {
             compaction_window,
         )
         .await;
-
-        self.apply_local_write(register_ts).await;
 
         // Alter is complete! We can drop our read hold.
         drop(existing_table_read_hold);

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -1099,15 +1099,11 @@ impl Coordinator {
         table_collections_to_create: BTreeMap<GlobalId, CollectionDescription>,
         execution_timestamps_to_set: BTreeSet<StatementLoggingId>,
     ) -> Result<(), AdapterError> {
-        // Source-fed tables and webhooks flow through here too (they are table catalog items), but
-        // `table_registrations` below filters to the real (`DataSource::Table`) tables that need
-        // txns-shard registration, so we can hand it all of them.
+        // Storage filters table catalog items that are not managed by txn-wal.
         let table_ids: Vec<GlobalId> = table_collections_to_create.keys().copied().collect();
         let collections = table_collections_to_create.into_iter().collect_vec();
 
-        // Allocate a write timestamp and make the catalog readable at the read ts we bump to below
-        // (this also serves as the leader/fencing check, see materialize#28216). The tables' initial
-        // read frontier (since) is set to this timestamp in `create_collections`.
+        // Confirm leadership after allocating the collections' initial timestamp.
         let write_ts = self.get_local_write_ts().await;
         let register_ts = write_ts.timestamp;
         self.catalog
@@ -1124,25 +1120,15 @@ impl Coordinator {
                 .unwrap_or_terminate("cannot fail to create collections");
         }
 
-        // Register the tables in the txns shard through the group committer, making them
-        // available for writes. The committer is the single in-process txns-shard writer, so the
-        // registration is ordered after all staged appends and needs no local conflict handling.
-        // It allocates its own, possibly later timestamp and applies it to the oracle, so reads
-        // never observe a partially registered table: the read ts only passes the registration
-        // timestamp after the registration is durable.
-        //
-        // NOTE: The table since (set to `register_ts` in `create_collections` above) may end up
-        // below the final registration timestamp. That is the safe direction: txns registration
-        // does not constrain the data shard since, and reads only happen at or beyond the final
-        // timestamp.
+        // Registration can choose a later timestamp than the collections' initial since. Reads
+        // remain above the applied registration timestamp.
         let registrations = self
             .controller
             .storage
             .table_registrations(table_ids)
             .unwrap_or_terminate("cannot fail to look up table registrations");
         let table_ts = if registrations.is_empty() {
-            // Nothing to register (e.g. only source-fed tables). Bump the oracle read ts
-            // ourselves so the collections become readable at `register_ts`.
+            // Without txn-wal registration, this timestamp still makes the collections readable.
             self.apply_local_write(register_ts).await;
             register_ts
         } else {
@@ -1379,8 +1365,7 @@ impl Coordinator {
             .desc
             .at_version(RelationVersionSelector::Specific(new_version));
 
-        // Make the catalog readable at the read ts the registration below bumps to, and re-check
-        // leadership (see materialize#28216) before mutating controller state.
+        // Confirm leadership before mutating controller state.
         let write_ts = self.get_local_write_ts().await;
         self.catalog
             .advance_upper(write_ts.advance_to)
@@ -1393,9 +1378,7 @@ impl Coordinator {
             .await
             .unwrap_or_terminate("failed to alter desc of table");
 
-        // Register the evolved collection in the txns shard through the group committer, making
-        // it available for writes. As with CREATE TABLE, the committer orders the registration
-        // after all staged appends and handles conflicts with concurrent processes.
+        // FIFO registration follows all staged writes to the old collection.
         let registrations = self
             .controller
             .storage

--- a/src/adapter/src/coord/cluster_controller.rs
+++ b/src/adapter/src/coord/cluster_controller.rs
@@ -553,11 +553,11 @@ impl Coordinator {
                 continue;
             };
             let id_ts = self.get_catalog_write_ts().await;
-            match self
+            let result = self
                 .catalog()
                 .allocate_replica_ids(*cluster_id, 1, id_ts)
-                .await
-            {
+                .await;
+            match result {
                 Ok(ids) => {
                     replica_ids.push(ids.into_iter().next().expect("allocated one replica id"))
                 }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -642,7 +642,7 @@ impl Coordinator {
         let storage_metadata = self.catalog.state().storage_metadata();
         self.controller
             .storage
-            .schedule_drop_tables_after_txns_forget(storage_metadata, table_gids)
+            .drop_tables(storage_metadata, table_gids)
             .unwrap_or_terminate("cannot fail to drop tables");
     }
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -633,14 +633,11 @@ impl Coordinator {
         // committer is the single in-process txns-shard writer, so the forget is ordered after
         // all staged appends (a staged INSERT into a table being dropped still lands before the
         // forget), and conflicts with concurrent processes are retried there.
-        let forget_ids: Vec<_> = self
+        let forget_ids = self
             .controller
             .storage
-            .table_registrations(table_gids.clone())
-            .unwrap_or_terminate("cannot fail to look up table registrations")
-            .into_iter()
-            .map(|registration| registration.id)
-            .collect();
+            .txns_table_ids(table_gids.clone())
+            .unwrap_or_terminate("cannot fail to look up txns-registered tables");
         if !forget_ids.is_empty() {
             self.forget_tables_via_committer(forget_ids).await;
         }
@@ -746,8 +743,8 @@ impl Coordinator {
         // Retire off the coordinator loop. We wait for each `mz_subscriptions` retraction
         // before telling the subscribing client that the sink is gone. The returned notify
         // lets statements that caused the retirement also wait before sending their response.
-        // The wait must not happen on the loop, since that would block every other session
-        // on the group-commit oracle round trip.
+        // The wait must not happen on the coordinator loop, since that would block every
+        // other session on the group-commit oracle round trip.
         let (done_tx, done_rx) = tokio::sync::oneshot::channel();
         task::spawn(|| "retire_compute_sinks", async move {
             for (sink, write_notify, reason) in to_retire {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -467,7 +467,7 @@ impl Coordinator {
         // always going up, and believe we will always be close to the system
         // clock because it is well configured (chrony) and so may only rarely
         // regress or pause for 10s.
-        let oracle_write_ts = self.get_local_write_ts().await.timestamp;
+        let oracle_write_ts = self.get_catalog_write_ts().await;
 
         let Coordinator {
             catalog,
@@ -517,10 +517,7 @@ impl Coordinator {
 
         // Append our builtin table updates, then return the notify so we can run other tasks in
         // parallel.
-        let (builtin_update_notify, _) = self
-            .builtin_table_update()
-            .execute(builtin_table_updates)
-            .await;
+        let builtin_update_notify = self.builtin_table_update().execute(builtin_table_updates);
 
         // No error returns are allowed after this point. Enforce this at compile time
         // by using this odd structure so we don't accidentally add a stray `?`.
@@ -625,16 +622,35 @@ impl Coordinator {
     }
 
     /// A convenience method for dropping tables.
-    pub(crate) fn drop_tables(&mut self, tables: Vec<(CatalogItemId, GlobalId)>, ts: Timestamp) {
+    pub(crate) async fn drop_tables(&mut self, tables: Vec<(CatalogItemId, GlobalId)>) {
         for (item_id, _gid) in &tables {
             self.active_webhooks.remove(item_id);
         }
 
+        let table_gids: Vec<_> = tables.into_iter().map(|(_id, gid)| gid).collect();
+
+        // Forget the txns-shard-registered tables among them through the group committer. The
+        // committer is the single in-process txns-shard writer, so the forget is ordered after
+        // all staged appends (a staged INSERT into a table being dropped still lands before the
+        // forget), and conflicts with concurrent processes are retried there.
+        let forget_ids: Vec<_> = self
+            .controller
+            .storage
+            .table_registrations(table_gids.clone())
+            .unwrap_or_terminate("cannot fail to look up table registrations")
+            .into_iter()
+            .map(|registration| registration.id)
+            .collect();
+        if !forget_ids.is_empty() {
+            self.forget_tables_via_committer(forget_ids).await;
+        }
+
+        // With the forget durable, clean up the controller side: schedule shard finalization and
+        // drop the collections.
         let storage_metadata = self.catalog.state().storage_metadata();
-        let table_gids = tables.into_iter().map(|(_id, gid)| gid).collect();
         self.controller
             .storage
-            .drop_tables(storage_metadata, table_gids, ts)
+            .drop_tables(storage_metadata, table_gids)
             .unwrap_or_terminate("cannot fail to drop tables");
     }
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -629,10 +629,7 @@ impl Coordinator {
 
         let table_gids: Vec<_> = tables.into_iter().map(|(_id, gid)| gid).collect();
 
-        // Forget the txns-shard-registered tables among them through the group committer. The
-        // committer is the single in-process txns-shard writer, so the forget is ordered after
-        // all staged appends (a staged INSERT into a table being dropped still lands before the
-        // forget), and conflicts with concurrent processes are retried there.
+        // FIFO ordering places the forget after every staged append.
         let forget_ids = self
             .controller
             .storage
@@ -642,12 +639,10 @@ impl Coordinator {
             self.forget_tables_via_committer(forget_ids).await;
         }
 
-        // With the forget durable, clean up the controller side: schedule shard finalization and
-        // drop the collections.
         let storage_metadata = self.catalog.state().storage_metadata();
         self.controller
             .storage
-            .drop_tables(storage_metadata, table_gids)
+            .schedule_drop_tables_after_txns_forget(storage_metadata, table_gids)
             .unwrap_or_terminate("cannot fail to drop tables");
     }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -127,11 +127,17 @@ impl Coordinator {
                     ctx.retire(result);
                 }
                 // The committer applied `write_ts` to the oracle, so the read ts is at least
-                // that and we can downgrade read holds without an oracle round trip.
-                self.advance_timelines(Some(write_ts)).boxed_local().await;
+                // that and we can downgrade the local read holds without an oracle round trip.
+                self.downgrade_local_read_holds(write_ts);
+                self.advance_custom_timelines().boxed_local().await;
             }
             Message::AdvanceTimelines => {
-                self.advance_timelines(None).boxed_local().await;
+                // Only sent by the periodic tick in read-only mode, where group commits (which
+                // otherwise drive the local timeline) don't run. Fetch the oracle's read ts here,
+                // it is the freshest timestamp the read holds may downgrade to.
+                let read_ts = self.get_local_read_ts().await;
+                self.downgrade_local_read_holds(read_ts);
+                self.advance_custom_timelines().boxed_local().await;
             }
             Message::ClusterEvent(event) => self.message_cluster_event(event).boxed_local().await,
             Message::CancelPendingPeeks { conn_id } => {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -109,13 +109,29 @@ impl Coordinator {
             Message::GroupCommitInitiate(span, permit) => {
                 // Add an OpenTelemetry link to our current span.
                 tracing::Span::current().add_link(span.context().span().span_context().clone());
-                self.try_group_commit(permit)
-                    .instrument(span)
-                    .boxed_local()
-                    .await
+                span.in_scope(|| self.stage_group_commit(permit));
+            }
+            Message::GroupCommitApplied {
+                responses,
+                statement_logging_ids,
+                write_ts,
+            } => {
+                // Record statement timestamps before retiring, since retiring ends the statement
+                // execution and drops its logging record.
+                for id in statement_logging_ids {
+                    self.set_statement_execution_timestamp(id, write_ts);
+                }
+                for response in responses {
+                    let (mut ctx, result) = response.finalize();
+                    ctx.session_mut().apply_write(write_ts);
+                    ctx.retire(result);
+                }
+                // The committer applied `write_ts` to the oracle, so the read ts is at least
+                // that and we can downgrade read holds without an oracle round trip.
+                self.advance_timelines(Some(write_ts)).boxed_local().await;
             }
             Message::AdvanceTimelines => {
-                self.advance_timelines().boxed_local().await;
+                self.advance_timelines(None).boxed_local().await;
             }
             Message::ClusterEvent(event) => self.message_cluster_event(event).boxed_local().await,
             Message::CancelPendingPeeks { conn_id } => {
@@ -290,7 +306,7 @@ impl Coordinator {
         //
         // `storage_usage_fetch` skips this path in read-only mode, so we can
         // unconditionally bump the oracle write ts here.
-        let write_ts = self.get_local_write_ts().await.timestamp;
+        let write_ts = self.get_catalog_write_ts().await;
         let collection_timestamp: EpochMillis = write_ts.into();
 
         // All rows in this collection cycle share `batch_id` so consumers can
@@ -320,7 +336,7 @@ impl Coordinator {
             })
             .collect();
 
-        let (table_updates, _) = self.builtin_table_update().execute(updates).await;
+        let table_updates = self.builtin_table_update().execute(updates);
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let task_span = info_span!(parent: None, "coord::storage_usage_update::table_updates");
@@ -336,7 +352,7 @@ impl Coordinator {
 
     #[mz_ore::instrument(level = "debug")]
     async fn storage_usage_prune(&mut self, expired: Vec<BuiltinTableUpdate>) {
-        let (fut, _) = self.builtin_table_update().execute(expired).await;
+        let fut = self.builtin_table_update().execute(expired);
         task::spawn(|| "storage_usage_pruning_apply", async move {
             fut.await;
         });
@@ -637,7 +653,7 @@ impl Coordinator {
         // in https://github.com/MaterializeInc/materialize/pull/35436 lands,
         // append directly on `mz_catalog_server` instead of going through
         // the environmentd builtin-table-update path.
-        let (fut, _) = self.builtin_table_update().execute(updates).await;
+        let fut = self.builtin_table_update().execute(updates);
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let task_span = info_span!(parent: None, "coord::arrangement_sizes_write::table_updates");
         OpenTelemetryContext::obtain().attach_as_parent_to(&task_span);
@@ -655,7 +671,7 @@ impl Coordinator {
 
     #[mz_ore::instrument(level = "debug")]
     async fn arrangement_sizes_prune(&mut self, expired: Vec<BuiltinTableUpdate>) {
-        let (fut, _) = self.builtin_table_update().execute(expired).await;
+        let fut = self.builtin_table_update().execute(expired);
         task::spawn(|| "arrangement_sizes_pruning_apply", async move {
             fut.await;
         });

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4953,7 +4953,7 @@ impl Coordinator {
     ///   `set_dataflow_metainfo`,
     /// - and returns a future that resolves once the builtin-table append
     ///   has been observed, or `None` if nothing was appended.
-    async fn persist_dataflow_metainfo(
+    fn persist_dataflow_metainfo(
         &mut self,
         df_meta: DataflowMetainfo<Arc<OptimizerNotice>>,
         export_id: GlobalId,
@@ -4973,12 +4973,7 @@ impl Coordinator {
             // Save the metainfo.
             self.catalog_mut().set_dataflow_metainfo(export_id, df_meta);
 
-            Some(
-                self.builtin_table_update()
-                    .execute(builtin_table_updates)
-                    .await
-                    .0,
-            )
+            Some(self.builtin_table_update().execute(builtin_table_updates))
         } else {
             // Save the metainfo.
             self.catalog_mut().set_dataflow_metainfo(export_id, df_meta);

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -1915,10 +1915,11 @@ impl Coordinator {
         // round-trip just to allocate nothing.
         let mut new_replica_ids = if needed_replica_ids > 0 {
             let id_ts = self.get_catalog_write_ts().await;
-            self.catalog()
+            let ids = self
+                .catalog()
                 .allocate_replica_ids(cluster_id, u64::from(needed_replica_ids), id_ts)
-                .await?
-                .into_iter()
+                .await?;
+            ids.into_iter()
         } else {
             Vec::<ReplicaId>::new().into_iter()
         };

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -547,7 +547,7 @@ impl Coordinator {
                         .set_physical_plan(global_id, df_desc.clone());
 
                     let notice_builtin_updates_fut =
-                        coord.persist_dataflow_metainfo(df_meta, global_id).await;
+                        coord.persist_dataflow_metainfo(df_meta, global_id);
 
                     // We're putting in place read holds, such that ship_dataflow,
                     // below, which calls update_read_capabilities, can successfully

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -766,7 +766,7 @@ impl Coordinator {
                         .set_physical_plan(global_id, df_desc.clone());
 
                     let notice_builtin_updates_fut =
-                        coord.persist_dataflow_metainfo(df_meta, global_id).await;
+                        coord.persist_dataflow_metainfo(df_meta, global_id);
 
                     df_desc.set_as_of(dataflow_as_of.clone());
                     df_desc.set_initial_as_of(initial_as_of);

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -324,7 +324,8 @@ impl Coordinator {
     /// `mz_subscriptions` retraction is durable. The retraction is deferred to a group
     /// commit rather than committed inline, which would block the coordinator loop on a
     /// timestamp-oracle round trip. Callers that expose completion of the retirement
-    /// should wait on the notify off the loop before responding. The notify is already
+    /// should wait on the notify off the coordinator loop before responding. The notify is
+    /// already
     /// resolved for sinks that write no introspection row (internal subscribes and COPY TO).
     ///
     /// This is a low-level method. The caller is responsible for dropping the
@@ -358,7 +359,8 @@ impl Coordinator {
                         // Defer the retraction to a group commit, for the same reason we
                         // defer the insert (see `add_active_compute_sink`): committing inline
                         // would block the coordinator loop. Callers that expose the
-                        // retirement wait on the notify off the loop before responding.
+                        // retirement wait on the notify off the coordinator loop
+                        // before responding.
                         self.builtin_table_update().defer(vec![update])
                     } else {
                         Box::pin(std::future::ready(()))

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -572,12 +572,27 @@ impl Coordinator {
         });
     }
 
-    /// Set the `execution_timestamp` for a statement, once it's known
+    /// Set the `execution_timestamp` for a statement, once it's known.
+    ///
+    /// Unlike the other record mutations, this tolerates the execution having already ended.
+    /// Group commit records the timestamp asynchronously, after the write is durable, and the
+    /// end sink deliberately tolerates duplicate ends (see `end_statement_execution`). If a
+    /// duplicate end ever ends one of these executions early, this update is a lost update on a
+    /// record whose ended row was already emitted, not corruption, so we warn instead of
+    /// panicking.
     pub(crate) fn set_statement_execution_timestamp(
         &mut self,
         id: StatementLoggingId,
         timestamp: Timestamp,
     ) {
+        let StatementLoggingId(uuid) = id;
+        if !self.statement_logging.executions_begun.contains_key(&uuid) {
+            tracing::warn!(
+                statement_uuid = %uuid,
+                "execution already ended, skipping execution timestamp update",
+            );
+            return;
+        }
         self.mutate_record(id, |record| {
             record.execution_timestamp = Some(u64::from(timestamp));
         });

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -572,14 +572,10 @@ impl Coordinator {
         });
     }
 
-    /// Set the `execution_timestamp` for a statement, once it's known.
+    /// Sets the execution timestamp if the statement is still active.
     ///
-    /// Unlike the other record mutations, this tolerates the execution having already ended.
-    /// Group commit records the timestamp asynchronously, after the write is durable, and the
-    /// end sink deliberately tolerates duplicate ends (see `end_statement_execution`). If a
-    /// duplicate end ever ends one of these executions early, this update is a lost update on a
-    /// record whose ended row was already emitted, not corruption, so we warn instead of
-    /// panicking.
+    /// A duplicate end can race the asynchronous group-commit update, so an ended statement is
+    /// skipped rather than treated as corruption.
     pub(crate) fn set_statement_execution_timestamp(
         &mut self,
         id: StatementLoggingId,

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -143,15 +143,7 @@ impl Coordinator {
         timestamp: Timestamp,
     ) -> impl Future<Output = ()> + Send + 'static {
         let now = self.now().into();
-
-        let upper_bound = upper_bound(&now);
-        if timestamp > upper_bound {
-            error!(
-                %now,
-                "Setting local read timestamp to {timestamp}, which is more than \
-                the desired upper bound {upper_bound}."
-            );
-        }
+        check_runaway_write_ts(&now, timestamp);
 
         let oracle = self.get_local_timestamp_oracle();
 
@@ -279,14 +271,38 @@ impl Coordinator {
         became_empty
     }
 
-    #[instrument(level = "debug")]
-    /// Downgrades read holds on all timelines to the current read ts.
+    /// Downgrades the [`EpochMilliseconds`](Timeline::EpochMilliseconds) timeline's read holds
+    /// to `read_ts`.
     ///
-    /// For the [`EpochMilliseconds`](Timeline::EpochMilliseconds) timeline, the group committer
-    /// applies writes off the loop and passes the resulting `local_read_ts` in, so we downgrade to
-    /// it without a round trip. When it is `None` (read-only mode, driven by the periodic tick) we
-    /// read the ts from the oracle here. Other timelines are advanced from their objects' uppers.
-    pub(crate) async fn advance_timelines(&mut self, local_read_ts: Option<Timestamp>) {
+    /// `read_ts` must not exceed the local oracle's read frontier, i.e. it must come from the
+    /// oracle's `read_ts()` or from a write that was already applied with `apply_write`.
+    /// Downgrading past the oracle's read frontier could let compaction pass timestamps the
+    /// oracle can still serve reads at.
+    pub(crate) fn downgrade_local_read_holds(&mut self, read_ts: Timestamp) {
+        let TimelineState { read_holds, .. } = self
+            .global_timelines
+            .get_mut(&Timeline::EpochMilliseconds)
+            .expect("no realtime timeline");
+        read_holds.downgrade(read_ts);
+    }
+
+    /// Advances all timelines other than [`EpochMilliseconds`](Timeline::EpochMilliseconds) to
+    /// their objects' uppers and downgrades their read holds accordingly.
+    ///
+    /// The `EpochMilliseconds` oracle is advanced by group commits, so it is not touched here.
+    /// Its read holds are downgraded separately via [`Self::downgrade_local_read_holds`].
+    #[instrument(level = "debug")]
+    pub(crate) async fn advance_custom_timelines(&mut self) {
+        // Common case: only the EpochMilliseconds timeline exists, nothing to do.
+        if !self
+            .global_timelines
+            .keys()
+            .any(|timeline| *timeline != Timeline::EpochMilliseconds)
+        {
+            return;
+        }
+
+        // Take the map so we can call `&self` methods while mutating the timeline states.
         let global_timelines = std::mem::take(&mut self.global_timelines);
         for (
             timeline,
@@ -296,37 +312,34 @@ impl Coordinator {
             },
         ) in global_timelines
         {
-            let read_ts = if timeline == Timeline::EpochMilliseconds {
-                // The EpochMilliseconds timeline is advanced by group commits, not here.
-                match local_read_ts {
-                    Some(read_ts) => read_ts,
-                    None => oracle.read_ts().await,
-                }
-            } else {
-                if !self.read_only_controllers {
-                    // For non realtime sources, we define now as the largest timestamp, not in
-                    // advance of any object's upper. This is the largest timestamp that is closed
-                    // to writes.
-                    let id_bundle = self.catalog().ids_in_timeline(&timeline);
+            if timeline == Timeline::EpochMilliseconds {
+                self.global_timelines
+                    .insert(timeline, TimelineState { oracle, read_holds });
+                continue;
+            }
+            if !self.read_only_controllers {
+                // For non realtime sources, we define now as the largest timestamp, not in
+                // advance of any object's upper. This is the largest timestamp that is closed
+                // to writes.
+                let id_bundle = self.catalog().ids_in_timeline(&timeline);
 
-                    // Advance the timeline if-and-only-if there are objects in it.
-                    // Otherwise we'd advance to the empty frontier, meaning we
-                    // close it off for ever.
-                    if !id_bundle.is_empty() {
-                        let least_valid_write = self.least_valid_write(&id_bundle);
-                        let now = Self::largest_not_in_advance_of_upper(&least_valid_write);
-                        oracle.apply_write(now).await;
-                        debug!(
-                            least_valid_write = ?least_valid_write,
-                            oracle_read_ts = ?oracle.read_ts().await,
-                            "advanced {:?} to {}",
-                            timeline,
-                            now,
-                        );
-                    }
+                // Advance the timeline if-and-only-if there are objects in it.
+                // Otherwise we'd advance to the empty frontier, meaning we
+                // close it off for ever.
+                if !id_bundle.is_empty() {
+                    let least_valid_write = self.least_valid_write(&id_bundle);
+                    let now = Self::largest_not_in_advance_of_upper(&least_valid_write);
+                    oracle.apply_write(now).await;
+                    debug!(
+                        least_valid_write = ?least_valid_write,
+                        oracle_read_ts = ?oracle.read_ts().await,
+                        "advanced {:?} to {}",
+                        timeline,
+                        now,
+                    );
                 }
-                oracle.read_ts().await
-            };
+            }
+            let read_ts = oracle.read_ts().await;
             read_holds.downgrade(read_ts);
             self.global_timelines
                 .insert(timeline, TimelineState { oracle, read_holds });
@@ -341,6 +354,20 @@ fn upper_bound(now: &mz_repr::Timestamp) -> mz_repr::Timestamp {
     const TIMESTAMP_INTERVAL_UPPER_BOUND: u64 = 2;
 
     now.saturating_add(TIMESTAMP_INTERVAL_MS * TIMESTAMP_INTERVAL_UPPER_BOUND)
+}
+
+/// Logs an error when `timestamp` is further ahead of `now` than a local write timestamp
+/// should ever be, the signal that the `EpochMilliseconds` timeline has run away (e.g. after a
+/// wall-clock regression).
+pub(crate) fn check_runaway_write_ts(now: &mz_repr::Timestamp, timestamp: mz_repr::Timestamp) {
+    let upper_bound = upper_bound(now);
+    if timestamp > upper_bound {
+        error!(
+            %now,
+            "Setting local read timestamp to {timestamp}, which is more than \
+            the desired upper bound {upper_bound}."
+        );
+    }
 }
 
 /// Return the set of ids in a timedomain and verify timeline correctness.

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -280,7 +280,13 @@ impl Coordinator {
     }
 
     #[instrument(level = "debug")]
-    pub(crate) async fn advance_timelines(&mut self) {
+    /// Downgrades read holds on all timelines to the current read ts.
+    ///
+    /// For the [`EpochMilliseconds`](Timeline::EpochMilliseconds) timeline, the group committer
+    /// applies writes off the loop and passes the resulting `local_read_ts` in, so we downgrade to
+    /// it without a round trip. When it is `None` (read-only mode, driven by the periodic tick) we
+    /// read the ts from the oracle here. Other timelines are advanced from their objects' uppers.
+    pub(crate) async fn advance_timelines(&mut self, local_read_ts: Option<Timestamp>) {
         let global_timelines = std::mem::take(&mut self.global_timelines);
         for (
             timeline,
@@ -290,31 +296,37 @@ impl Coordinator {
             },
         ) in global_timelines
         {
-            // Timeline::EpochMilliseconds is advanced in group commits and doesn't need to be
-            // manually advanced here.
-            if timeline != Timeline::EpochMilliseconds && !self.read_only_controllers {
-                // For non realtime sources, we define now as the largest timestamp, not in
-                // advance of any object's upper. This is the largest timestamp that is closed
-                // to writes.
-                let id_bundle = self.catalog().ids_in_timeline(&timeline);
-
-                // Advance the timeline if-and-only-if there are objects in it.
-                // Otherwise we'd advance to the empty frontier, meaning we
-                // close it off for ever.
-                if !id_bundle.is_empty() {
-                    let least_valid_write = self.least_valid_write(&id_bundle);
-                    let now = Self::largest_not_in_advance_of_upper(&least_valid_write);
-                    oracle.apply_write(now).await;
-                    debug!(
-                        least_valid_write = ?least_valid_write,
-                        oracle_read_ts = ?oracle.read_ts().await,
-                        "advanced {:?} to {}",
-                        timeline,
-                        now,
-                    );
+            let read_ts = if timeline == Timeline::EpochMilliseconds {
+                // The EpochMilliseconds timeline is advanced by group commits, not here.
+                match local_read_ts {
+                    Some(read_ts) => read_ts,
+                    None => oracle.read_ts().await,
                 }
+            } else {
+                if !self.read_only_controllers {
+                    // For non realtime sources, we define now as the largest timestamp, not in
+                    // advance of any object's upper. This is the largest timestamp that is closed
+                    // to writes.
+                    let id_bundle = self.catalog().ids_in_timeline(&timeline);
+
+                    // Advance the timeline if-and-only-if there are objects in it.
+                    // Otherwise we'd advance to the empty frontier, meaning we
+                    // close it off for ever.
+                    if !id_bundle.is_empty() {
+                        let least_valid_write = self.least_valid_write(&id_bundle);
+                        let now = Self::largest_not_in_advance_of_upper(&least_valid_write);
+                        oracle.apply_write(now).await;
+                        debug!(
+                            least_valid_write = ?least_valid_write,
+                            oracle_read_ts = ?oracle.read_ts().await,
+                            "advanced {:?} to {}",
+                            timeline,
+                            now,
+                        );
+                    }
+                }
+                oracle.read_ts().await
             };
-            let read_ts = oracle.read_ts().await;
             read_holds.downgrade(read_ts);
             self.global_timelines
                 .insert(timeline, TimelineState { oracle, read_holds });

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -364,7 +364,7 @@ pub(crate) fn check_runaway_write_ts(now: &mz_repr::Timestamp, timestamp: mz_rep
     if timestamp > upper_bound {
         error!(
             %now,
-            "Setting local read timestamp to {timestamp}, which is more than \
+            "Setting local write timestamp to {timestamp}, which is more than \
             the desired upper bound {upper_bound}."
         );
     }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -286,7 +286,7 @@ impl Metrics {
             )),
             group_commit_catalog_upper_seconds: registry.register(metric!(
                 name: "mz_group_commit_catalog_upper_seconds",
-                help: "The time it takes to advance the catalog shard upper during group commit.",
+                help: "The time it takes to advance the catalog shard upper for a txns-shard write (group commits and table register/forget).",
                 buckets: histogram_seconds_buckets(0.001, 32.0),
             )),
         }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1832,11 +1832,12 @@ impl GroupCommitWriteLocks {
         self.locks.extend(existing);
     }
 
-    /// Absorbs the locks of another group-commit lock collection.
-    ///
-    /// Lock sets of separately staged group commits are disjoint (staging defers writes whose
-    /// locks are already held elsewhere), so this cannot end up holding a lock twice.
+    /// Absorbs a disjoint group-commit lock collection.
     pub fn extend(&mut self, mut other: GroupCommitWriteLocks) {
+        assert!(
+            self.locks.keys().all(|id| !other.locks.contains_key(id)),
+            "separately staged group commits must have disjoint lock sets"
+        );
         self.locks.extend(std::mem::take(&mut other.locks));
     }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1769,7 +1769,7 @@ impl WriteLocksBuilder {
     }
 }
 
-/// Collection of [`WriteLocks`] gathered during [`group_commit`].
+/// Collection of [`WriteLocks`] gathered during [`stage_group_commit`].
 ///
 /// Note: This struct should __never__ be used outside of group commit because it attempts to merge
 /// together several collections of [`WriteLocks`] which if not done carefully can cause deadlocks
@@ -1816,7 +1816,7 @@ impl WriteLocksBuilder {
 /// For total order to exist, Ta < Tb < Tc < Ta, which is impossible.
 /// ```
 ///
-/// [`group_commit`]: super::coord::Coordinator::group_commit
+/// [`stage_group_commit`]: super::coord::Coordinator::stage_group_commit
 #[derive(Debug, Default)]
 pub(crate) struct GroupCommitWriteLocks {
     locks: BTreeMap<CatalogItemId, tokio::sync::OwnedMutexGuard<()>>,
@@ -1830,6 +1830,14 @@ impl GroupCommitWriteLocks {
         // See: <https://github.com/rust-lang/rust/issues/81074>
         let existing = std::mem::take(&mut locks.locks);
         self.locks.extend(existing);
+    }
+
+    /// Absorbs the locks of another group-commit lock collection.
+    ///
+    /// Lock sets of separately staged group commits are disjoint (staging defers writes whose
+    /// locks are already held elsewhere), so this cannot end up holding a lock twice.
+    pub fn extend(&mut self, mut other: GroupCommitWriteLocks) {
+        self.locks.extend(std::mem::take(&mut other.locks));
     }
 
     /// Returns the collections we're missing locks for, if any.

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -314,6 +314,7 @@ impl ShouldTerminateGracefully for DurableCatalogError {
     fn should_terminate_gracefully(&self) -> bool {
         match self {
             DurableCatalogError::Fence(err) => err.should_terminate_gracefully(),
+            DurableCatalogError::CatalogOutOfSync { .. } => true,
             DurableCatalogError::IncompatibleDataVersion { .. }
             | DurableCatalogError::IncompatiblePersistVersion { .. }
             | DurableCatalogError::Proto(_)

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -149,13 +149,9 @@ impl Transmittable for () {
     }
 }
 
-/// `ClientTransmitter` with a response to send.
-/// A client transmitter for a write whose commit outcome is pending, together with everything
-/// needed to finalize the response once the outcome is known.
+/// A pending write result and the context needed to deliver it.
 ///
-/// Dropping one without calling [`Self::finalize`] retires the client with an error, via the
-/// drop backstop on the inner [`ExecuteContext`]. These travel through the group committer task
-/// and its queue, which get dropped at process shutdown.
+/// Dropping it uses the [`ExecuteContext`] retirement backstop.
 #[derive(Debug)]
 pub struct CompletedClientTransmitter {
     ctx: ExecuteContext,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -325,6 +325,7 @@ impl ShouldTerminateGracefully for DurableCatalogError {
             | DurableCatalogError::Proto(_)
             | DurableCatalogError::Uninitialized
             | DurableCatalogError::NotWritable(_)
+            | DurableCatalogError::DryRunTransaction
             | DurableCatalogError::DuplicateKey
             | DurableCatalogError::UniquenessViolation
             | DurableCatalogError::Storage(_)

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -96,15 +96,18 @@ impl<T: Transmittable + std::fmt::Debug> ClientTransmitter<T> {
                 otel_ctx: OpenTelemetryContext::obtain(),
             })
         {
-            self.internal_cmd_tx
-                .send(Message::Command(
-                    OpenTelemetryContext::obtain(),
-                    Command::Terminate {
-                        conn_id: res.session.conn_id().clone(),
-                        tx: None,
-                    },
-                ))
-                .expect("coordinator unexpectedly gone");
+            // If the coordinator is gone too, the process is shutting down and there is no
+            // session state left to clean up, so a failed send is fine.
+            let send_res = self.internal_cmd_tx.send(Message::Command(
+                OpenTelemetryContext::obtain(),
+                Command::Terminate {
+                    conn_id: res.session.conn_id().clone(),
+                    tx: None,
+                },
+            ));
+            if send_res.is_err() {
+                tracing::warn!("coordinator gone, could not clean up session");
+            }
         }
     }
 
@@ -147,6 +150,12 @@ impl Transmittable for () {
 }
 
 /// `ClientTransmitter` with a response to send.
+/// A client transmitter for a write whose commit outcome is pending, together with everything
+/// needed to finalize the response once the outcome is known.
+///
+/// Dropping one without calling [`Self::finalize`] retires the client with an error, via the
+/// drop backstop on the inner [`ExecuteContext`]. These travel through the group committer task
+/// and its queue, which get dropped at process shutdown.
 #[derive(Debug)]
 pub struct CompletedClientTransmitter {
     ctx: ExecuteContext,

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -12,7 +12,7 @@
 use std::fmt::Debug;
 use std::num::NonZeroI64;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use mz_audit_log::VersionedEvent;
@@ -308,7 +308,9 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     /// Marks the bootstrap process as complete.
     async fn mark_bootstrap_complete(&mut self);
 
-    /// Creates a new durable catalog state transaction.
+    /// Creates a transaction only if no durable catalog content is pending.
+    ///
+    /// Empty upper progress is accepted.
     async fn transaction(&mut self) -> Result<Transaction, CatalogError>;
 
     /// Creates a new transaction initialized from the given [`Snapshot`]
@@ -320,15 +322,6 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         &mut self,
         snapshot: Snapshot,
     ) -> Result<Transaction, CatalogError>;
-
-    /// Opens a transaction only if no durable catalog content is pending.
-    ///
-    /// Empty upper progress is accepted. Callers with derived in-memory state must use this method.
-    async fn transaction_in_sync(&mut self) -> Result<Transaction, CatalogError> {
-        let mut txn = self.transaction().await?;
-        txn.ensure_not_out_of_sync().await?;
-        Ok(txn)
-    }
 
     /// Commits a durable catalog state transaction. The transaction will be committed at
     /// `commit_ts`.
@@ -354,25 +347,12 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     ///
     /// Allocation rebases over empty upper progress. Fresh IDs do not require a catalog
     /// staleness check.
-    #[mz_ore::instrument(level = "debug")]
     async fn allocate_id(
         &mut self,
         id_type: &str,
         amount: u64,
         commit_ts: Timestamp,
-    ) -> Result<Vec<u64>, CatalogError> {
-        let start = Instant::now();
-        if amount == 0 {
-            return Ok(Vec::new());
-        }
-        let mut txn = self.transaction().await?;
-        let ids = txn.get_and_increment_id_by(id_type.to_string(), amount)?;
-        txn.commit_internal(commit_ts).await?;
-        self.metrics()
-            .allocate_id_seconds
-            .observe(start.elapsed().as_secs_f64());
-        Ok(ids)
-    }
+    ) -> Result<Vec<u64>, CatalogError>;
 
     /// Allocates and returns `amount` many user [`CatalogItemId`] and [`GlobalId`].
     ///

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -321,15 +321,9 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         snapshot: Snapshot,
     ) -> Result<Transaction, CatalogError>;
 
-    /// Opens a [`Transaction`] after verifying that this handle has applied all durable catalog
-    /// content, erroring with [`DurableCatalogError::CatalogOutOfSync`] otherwise.
+    /// Opens a transaction only if no durable catalog content is pending.
     ///
-    /// Opening syncs the handle to the current upper, so any content updates observed there mean
-    /// that whatever state the caller planned against is stale. Callers that maintain derived
-    /// in-memory state (the adapter) must open through this method, so staleness surfaces as an
-    /// error they can react to (today by restarting and rebuilding from durable state) instead of
-    /// being absorbed silently. Pure empty progress (upper movement without content, e.g. from
-    /// the group committer) is not an error.
+    /// Empty upper progress is accepted. Callers with derived in-memory state must use this method.
     async fn transaction_in_sync(&mut self) -> Result<Transaction, CatalogError> {
         let mut txn = self.transaction().await?;
         txn.ensure_not_out_of_sync().await?;
@@ -349,29 +343,17 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         commit_ts: Timestamp,
     ) -> Result<Timestamp, CatalogError>;
 
-    /// Advances the upper of the catalog shard to at least `new_upper`, doing nothing if the
-    /// upper is already at or past it.
+    /// Advances the catalog upper to at least `new_upper`.
     ///
-    /// This implicitly confirms leadership, as attempting to advance the catalog frontier will
-    /// fail if the writer has been fenced out.
-    ///
-    /// Callers may pass a timestamp that has been superseded since it was chosen (e.g. the group
-    /// committer's, allocated off the coordinator loop and possibly overtaken by a catalog
-    /// transaction). If another writer moved the upper with content updates in between, this
-    /// returns [`DurableCatalogError::CatalogOutOfSync`], and the caller must rebuild from
-    /// durable state.
+    /// A durable attempt observes fencing and reports concurrent non-fencing content as
+    /// [`DurableCatalogError::CatalogOutOfSync`]. A no-op only validates a fence already observed
+    /// by this handle.
     async fn advance_upper(&mut self, new_upper: Timestamp) -> Result<(), CatalogError>;
 
     /// Allocates and returns `amount` IDs of `id_type`.
     ///
-    /// Tolerates the catalog upper having moved since the caller chose `commit_ts` (the commit
-    /// rebases past empty progress, and content committed by another writer surfaces as
-    /// [`DurableCatalogError::CatalogOutOfSync`] from the commit itself). Allocation needs no
-    /// staleness check of its own: an allocated ID is fresh and unique regardless of whether the
-    /// caller's in-memory state is current, and staleness is detected by the next catalog
-    /// transaction that plans against it.
-    ///
-    /// See [`Self::commit_transaction`] for details on `commit_ts`.
+    /// Allocation rebases over empty upper progress. Fresh IDs do not require a catalog
+    /// staleness check.
     #[mz_ore::instrument(level = "debug")]
     async fn allocate_id(
         &mut self,

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -274,6 +274,23 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send + Sync {
         target_upper: Timestamp,
     ) -> Result<Vec<memory::objects::StateUpdate>, CatalogError>;
 
+    /// Returns an error if syncing to `target_upper` observes unapplied catalog updates.
+    async fn ensure_not_out_of_sync(
+        &mut self,
+        target_upper: Timestamp,
+    ) -> Result<(), CatalogError> {
+        let updates = self.sync_updates(target_upper).await?;
+        if updates.is_empty() {
+            Ok(())
+        } else {
+            Err(DurableCatalogError::CatalogOutOfSync {
+                update_count: updates.len(),
+                upper: target_upper,
+            }
+            .into())
+        }
+    }
+
     /// Fetch the current upper of the catalog state.
     async fn current_upper(&mut self) -> Timestamp;
 }
@@ -317,13 +334,27 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         commit_ts: Timestamp,
     ) -> Result<Timestamp, CatalogError>;
 
-    /// Advances the upper of the catalog shard to `new_upper`.
+    /// Advances the upper of the catalog shard to at least `new_upper`, doing nothing if the
+    /// upper is already at or past it.
     ///
     /// This implicitly confirms leadership, as attempting to advance the catalog frontier will
     /// fail if the writer has been fenced out.
+    ///
+    /// Callers may pass a timestamp that has been superseded since it was chosen (e.g. the group
+    /// committer's, allocated off the coordinator loop and possibly overtaken by a catalog
+    /// transaction). If another writer moved the upper with content updates in between, this
+    /// returns [`DurableCatalogError::CatalogOutOfSync`], and the caller must rebuild from
+    /// durable state.
     async fn advance_upper(&mut self, new_upper: Timestamp) -> Result<(), CatalogError>;
 
     /// Allocates and returns `amount` IDs of `id_type`.
+    ///
+    /// Tolerates the catalog upper having moved since the caller chose `commit_ts` (the commit
+    /// rebases past empty progress, and content committed by another writer surfaces as
+    /// [`DurableCatalogError::CatalogOutOfSync`] from the commit itself). Allocation needs no
+    /// staleness check of its own: an allocated ID is fresh and unique regardless of whether the
+    /// caller's in-memory state is current, and staleness is detected by the next catalog
+    /// transaction that plans against it.
     ///
     /// See [`Self::commit_transaction`] for details on `commit_ts`.
     #[mz_ore::instrument(level = "debug")]

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -41,8 +41,8 @@ pub use crate::durable::objects::{
 };
 pub use crate::durable::persist::shard_id;
 use crate::durable::persist::{Timestamp, UnopenedPersistCatalogState};
-pub use crate::durable::transaction::Transaction;
 use crate::durable::transaction::TransactionBatch;
+pub use crate::durable::transaction::{DryRunTransaction, Transaction};
 pub use crate::durable::upgrade::CATALOG_VERSION;
 use crate::memory;
 
@@ -274,22 +274,11 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send + Sync {
         target_upper: Timestamp,
     ) -> Result<Vec<memory::objects::StateUpdate>, CatalogError>;
 
-    /// Returns an error if syncing to `target_upper` observes unapplied catalog updates.
-    async fn ensure_not_out_of_sync(
-        &mut self,
-        target_upper: Timestamp,
-    ) -> Result<(), CatalogError> {
-        let updates = self.sync_updates(target_upper).await?;
-        if updates.is_empty() {
-            Ok(())
-        } else {
-            Err(DurableCatalogError::CatalogOutOfSync {
-                update_count: updates.len(),
-                upper: target_upper,
-            }
-            .into())
-        }
-    }
+    /// Checks for unapplied catalog content before `target_upper` without consuming it.
+    ///
+    /// Returns an error if this instance has been fenced out.
+    async fn ensure_not_out_of_sync(&mut self, target_upper: Timestamp)
+    -> Result<(), CatalogError>;
 
     /// Fetch the current upper of the catalog state.
     async fn current_upper(&mut self) -> Timestamp;
@@ -313,15 +302,13 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     /// Empty upper progress is accepted.
     async fn transaction(&mut self) -> Result<Transaction, CatalogError>;
 
-    /// Creates a new transaction initialized from the given [`Snapshot`]
-    /// instead of reading from durable storage. Used for incremental DDL
-    /// dry runs where the transaction state from a previous dry run has been
-    /// saved and needs to be restored so it stays in sync with the accumulated
-    /// `CatalogState`.
+    /// Creates a non-committable dry-run transaction from the given [`Snapshot`].
+    ///
+    /// The snapshot may include changes accumulated by earlier incremental dry runs.
     fn transaction_from_snapshot(
         &mut self,
         snapshot: Snapshot,
-    ) -> Result<Transaction, CatalogError>;
+    ) -> Result<DryRunTransaction, CatalogError>;
 
     /// Commits a durable catalog state transaction. The transaction will be committed at
     /// `commit_ts`.

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -321,6 +321,21 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         snapshot: Snapshot,
     ) -> Result<Transaction, CatalogError>;
 
+    /// Opens a [`Transaction`] after verifying that this handle has applied all durable catalog
+    /// content, erroring with [`DurableCatalogError::CatalogOutOfSync`] otherwise.
+    ///
+    /// Opening syncs the handle to the current upper, so any content updates observed there mean
+    /// that whatever state the caller planned against is stale. Callers that maintain derived
+    /// in-memory state (the adapter) must open through this method, so staleness surfaces as an
+    /// error they can react to (today by restarting and rebuilding from durable state) instead of
+    /// being absorbed silently. Pure empty progress (upper movement without content, e.g. from
+    /// the group committer) is not an error.
+    async fn transaction_in_sync(&mut self) -> Result<Transaction, CatalogError> {
+        let mut txn = self.transaction().await?;
+        txn.ensure_not_out_of_sync().await?;
+        Ok(txn)
+    }
+
     /// Commits a durable catalog state transaction. The transaction will be committed at
     /// `commit_ts`.
     ///

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -80,6 +80,16 @@ pub enum DurableCatalogError {
     /// A programming error occurred during a [`mz_storage_client::controller::StorageTxn`].
     #[error(transparent)]
     Storage(StorageError),
+    /// The durable catalog contains updates that this process has not applied.
+    ///
+    /// NOTE: `update_count` counts raw durable updates when produced by the write-conflict
+    /// classification (commit and advance paths) but memory updates when produced by
+    /// `ensure_not_out_of_sync`. It is diagnostic only, do not compare across producers.
+    #[error("durable catalog advanced to {upper} with {update_count} unapplied updates")]
+    CatalogOutOfSync {
+        update_count: usize,
+        upper: Timestamp,
+    },
     /// An internal programming error.
     #[error("Internal catalog error: {0}")]
     Internal(String),

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -68,6 +68,9 @@ pub enum DurableCatalogError {
     /// Catalog is not in a writable state.
     #[error("{0}")]
     NotWritable(String),
+    /// A dry-run transaction reached a commit path.
+    #[error("cannot commit a dry-run catalog transaction")]
+    DryRunTransaction,
     /// Unable to serialize/deserialize Protobuf message.
     #[error("proto: {0}")]
     Proto(TryFromProtoError),

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -157,6 +157,7 @@ impl StateUpdate {
             txn_wal_shard,
             audit_log_updates,
             upper: _,
+            ..
         } = txn_batch;
         let databases = from_batch(databases, StateUpdateKind::Database);
         let schemas = from_batch(schemas, StateUpdateKind::Schema);

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -371,12 +371,10 @@ pub(crate) struct PersistHandle<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> {
     /// [`Self::maybe_consolidate`] to decide when to consolidate. Initialized
     /// lazily on the first call.
     size_at_last_consolidation: Option<usize>,
-    /// Counts every raw update applied to this handle, across all kinds. Used to distinguish
-    /// empty progress (upper movement with zero updates) from content written by another catalog:
-    /// capture the count before a compare-and-append, and if it is unchanged after the
-    /// conflict-triggered sync, the interval was pure empty progress and it is safe to rebase.
-    /// Memory-update emptiness is not a substitute, because some kinds (e.g. ID allocators) do
-    /// not surface as memory updates but still invalidate a rebase.
+    /// Counts raw updates applied to this handle.
+    ///
+    /// This distinguishes empty upper progress from content. Memory updates are insufficient
+    /// because kinds such as ID allocators do not produce them.
     updates_applied: u64,
 }
 
@@ -411,11 +409,7 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
             )
         });
         let next_upper = commit_ts.step_forward();
-        // NOTE: An `UpperMismatch` here is a legitimate outcome, not a programming error:
-        // another writer (a fencer, or a concurrent catalog advancing the upper) got in between
-        // our snapshot of the upper and this write. Callers classify the conflict and either
-        // rebase over empty progress or surface it, see `commit_transaction` and
-        // `advance_upper`.
+        // Upper mismatches are classified by the commit and advance callers.
         self.compare_and_append_inner(updates, next_upper).await?;
 
         self.sync(next_upper).await?;
@@ -479,14 +473,10 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
         Ok(())
     }
 
-    /// Classifies an [`UpperMismatch`] from a compare-and-append attempt: pure empty progress
-    /// (safe to rebase over and retry) returns `Ok(())`, foreign content returns the graceful
-    /// [`DurableCatalogError::CatalogOutOfSync`].
+    /// Accepts an upper mismatch caused only by empty progress.
     ///
-    /// `updates_applied_before` must be captured from `self.updates_applied` before the attempt.
-    /// The compare-and-append syncs the handle to the current upper on mismatch, so any raw
-    /// update applied since means another writer committed content this handle's owner has not
-    /// planned against.
+    /// `updates_applied_before` must be captured before the compare-and-append, which synchronizes
+    /// this handle on mismatch.
     fn classify_upper_mismatch(
         &self,
         updates_applied_before: u64,
@@ -1840,11 +1830,8 @@ impl DurableCatalogState for PersistCatalogState {
                 return Ok(catalog.upper);
             }
 
-            // The handle must not have synced past the upper the transaction was built on. All
-            // in-process users run transactions on one handle behind a mutex held from open to
-            // commit, so a mismatch here is a local programming error, not external interference
-            // (a concurrent writer does not move our cached upper, it makes the
-            // compare-and-append below fail, which is handled gracefully).
+            // The handle is mutex-protected from transaction creation through commit, so only a
+            // local programming error can change its cached upper here.
             assert_eq!(
                 catalog.upper, txn_batch.upper,
                 "the handle was mutated mid-transaction"
@@ -1853,10 +1840,7 @@ impl DurableCatalogState for PersistCatalogState {
             let updates: Vec<_> = StateUpdate::from_txn_batch(txn_batch).collect();
             debug!("committing updates: {updates:?}");
 
-            // Rebase over empty progress: the group committer (and in the future other
-            // processes) advances the upper without content, which must not invalidate this
-            // transaction. Real content committed by another writer does invalidate it, and
-            // surfaces as `CatalogOutOfSync` below.
+            // Empty upper progress does not invalidate the transaction.
             let mut commit_ts = max(commit_ts, catalog.upper);
 
             let next_upper = match catalog.mode {
@@ -1866,11 +1850,8 @@ impl DurableCatalogState for PersistCatalogState {
                         Ok(next_upper) => break next_upper,
                         Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
                         Err(CompareAndAppendError::UpperMismatch { actual_upper, .. }) => {
-                            // Another writer got in between our snapshot of the upper and the
-                            // compare-and-append, which synced us to the current upper. Empty
-                            // progress means we can rebase the commit timestamp and retry,
-                            // foreign content means the transaction was planned against stale
-                            // state.
+                            // The mismatch synchronized the handle. Retry only if it applied no
+                            // content.
                             catalog
                                 .classify_upper_mismatch(updates_applied_before, actual_upper)?;
                             commit_ts = max(commit_ts, catalog.upper);
@@ -1904,14 +1885,8 @@ impl DurableCatalogState for PersistCatalogState {
     async fn advance_upper(&mut self, new_upper: Timestamp) -> Result<(), CatalogError> {
         loop {
             if self.upper >= new_upper {
-                // Someone (an on-loop catalog transaction, or another process) already advanced
-                // the upper to or past `new_upper`. Advancing is "to at least", so nothing to
-                // write. We still validate the fence: a sync since the last durable check may have
-                // observed a new generation's fence token (and bumped the cached upper past our
-                // target at the same time). This is a cheap defense-in-depth check on the
-                // short-circuit path, not a guarantee callers depend on (see the cross-generation
-                // section in `src/adapter/src/coord/appends.rs` for what the safety actually rests
-                // on).
+                // This does not consult Persist. It only revalidates a fence already cached by
+                // this handle, since a sync can advance `upper` while recording the fence.
                 self.fenceable_token.validate()?;
                 return Ok(());
             }
@@ -1939,10 +1914,7 @@ impl DurableCatalogState for PersistCatalogState {
                 }
                 Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
                 Err(CompareAndAppendError::UpperMismatch { actual_upper, .. }) => {
-                    // Another writer advanced the shard between our snapshot of the upper and
-                    // the compare-and-append, which synced us to the current upper. Empty
-                    // progress means we simply re-evaluate against the new upper, foreign
-                    // content means the caller must rebuild from durable state.
+                    // The mismatch synchronized the handle. Retry only if it applied no content.
                     self.classify_upper_mismatch(updates_applied_before, actual_upper)?;
                 }
             }

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1906,10 +1906,12 @@ impl DurableCatalogState for PersistCatalogState {
             if self.upper >= new_upper {
                 // Someone (an on-loop catalog transaction, or another process) already advanced
                 // the upper to or past `new_upper`. Advancing is "to at least", so nothing to
-                // write. The short-circuit must not mask a fence though: a sync since the last
-                // durable check may have observed a new generation's fence token (and bumped the
-                // cached upper past our target at the same time), and callers rely on the
-                // advance to re-check leadership before user data is written.
+                // write. We still validate the fence: a sync since the last durable check may have
+                // observed a new generation's fence token (and bumped the cached upper past our
+                // target at the same time). This is a cheap defense-in-depth check on the
+                // short-circuit path, not a guarantee callers depend on (see the cross-generation
+                // section in `src/adapter/src/coord/appends.rs` for what the safety actually rests
+                // on).
                 self.fenceable_token.validate()?;
                 return Ok(());
             }

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -479,6 +479,29 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
         Ok(())
     }
 
+    /// Classifies an [`UpperMismatch`] from a compare-and-append attempt: pure empty progress
+    /// (safe to rebase over and retry) returns `Ok(())`, foreign content returns the graceful
+    /// [`DurableCatalogError::CatalogOutOfSync`].
+    ///
+    /// `updates_applied_before` must be captured from `self.updates_applied` before the attempt.
+    /// The compare-and-append syncs the handle to the current upper on mismatch, so any raw
+    /// update applied since means another writer committed content this handle's owner has not
+    /// planned against.
+    fn classify_upper_mismatch(
+        &self,
+        updates_applied_before: u64,
+        actual_upper: Timestamp,
+    ) -> Result<(), DurableCatalogError> {
+        if self.updates_applied != updates_applied_before {
+            Err(DurableCatalogError::CatalogOutOfSync {
+                update_count: usize::cast_from(self.updates_applied - updates_applied_before),
+                upper: actual_upper,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
     /// Generates an iterator of [`StateUpdate`] that contain all unconsolidated updates to the
     /// catalog state up to, and including, `as_of`.
     #[mz_ore::instrument]
@@ -1844,19 +1867,12 @@ impl DurableCatalogState for PersistCatalogState {
                         Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
                         Err(CompareAndAppendError::UpperMismatch { actual_upper, .. }) => {
                             // Another writer got in between our snapshot of the upper and the
-                            // compare-and-append. `compare_and_append_inner` synced us to the
-                            // current upper. Zero applied updates means pure empty progress, so
-                            // we rebase the commit timestamp and retry. Anything else means the
-                            // transaction was planned against stale state.
-                            if catalog.updates_applied != updates_applied_before {
-                                return Err(DurableCatalogError::CatalogOutOfSync {
-                                    update_count: usize::cast_from(
-                                        catalog.updates_applied - updates_applied_before,
-                                    ),
-                                    upper: actual_upper,
-                                }
-                                .into());
-                            }
+                            // compare-and-append, which synced us to the current upper. Empty
+                            // progress means we can rebase the commit timestamp and retry,
+                            // foreign content means the transaction was planned against stale
+                            // state.
+                            catalog
+                                .classify_upper_mismatch(updates_applied_before, actual_upper)?;
                             commit_ts = max(commit_ts, catalog.upper);
                         }
                     }
@@ -1889,7 +1905,12 @@ impl DurableCatalogState for PersistCatalogState {
         loop {
             if self.upper >= new_upper {
                 // Someone (an on-loop catalog transaction, or another process) already advanced
-                // the upper to or past `new_upper`. Advancing is "to at least", so nothing to do.
+                // the upper to or past `new_upper`. Advancing is "to at least", so nothing to
+                // write. The short-circuit must not mask a fence though: a sync since the last
+                // durable check may have observed a new generation's fence token (and bumped the
+                // cached upper past our target at the same time), and callers rely on the
+                // advance to re-check leadership before user data is written.
+                self.fenceable_token.validate()?;
                 return Ok(());
             }
 
@@ -1916,22 +1937,11 @@ impl DurableCatalogState for PersistCatalogState {
                 }
                 Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
                 Err(CompareAndAppendError::UpperMismatch { actual_upper, .. }) => {
-                    // Another writer advanced the shard between our snapshot of the upper and the
-                    // compare-and-append. `compare_and_append_inner` already synced us to the
-                    // current upper. If that sync applied any updates, the other writer committed
-                    // content we have not planned against, and the caller must rebuild from
-                    // durable state. If it applied none, the interval was pure empty progress
-                    // (e.g. another upper bump) and we can simply re-evaluate against the new
-                    // upper.
-                    if self.updates_applied != updates_applied_before {
-                        return Err(DurableCatalogError::CatalogOutOfSync {
-                            update_count: usize::cast_from(
-                                self.updates_applied - updates_applied_before,
-                            ),
-                            upper: actual_upper,
-                        }
-                        .into());
-                    }
+                    // Another writer advanced the shard between our snapshot of the upper and
+                    // the compare-and-append, which synced us to the current upper. Empty
+                    // progress means we simply re-evaluate against the new upper, foreign
+                    // content means the caller must rebuild from durable state.
+                    self.classify_upper_mismatch(updates_applied_before, actual_upper)?;
                 }
             }
         }

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1310,7 +1310,7 @@ impl UnopenedPersistCatalogState {
 
         let catalog_content_version = catalog.catalog_content_version.to_string();
         let txn = if is_initialized {
-            let mut txn = catalog.transaction().await?;
+            let mut txn = catalog.transaction_unchecked().await?;
 
             // Ad-hoc migration: Initialize the `migration_version` expected by adapter to be
             // present in existing catalogs.
@@ -1337,7 +1337,7 @@ impl UnopenedPersistCatalogState {
                 catalog.snapshot
             );
 
-            let mut txn = catalog.transaction().await?;
+            let mut txn = catalog.transaction_unchecked().await?;
             initialize::initialize(
                 &mut txn,
                 bootstrap_args,
@@ -1647,6 +1647,16 @@ impl ApplyUpdate<StateUpdateKind> for CatalogStateInner {
 /// so that it can expire its leases. If/when rust gets AsyncDrop, this will be done automatically.
 type PersistCatalogState = PersistHandle<StateUpdateKind, CatalogStateInner>;
 
+impl PersistHandle<StateUpdateKind, CatalogStateInner> {
+    /// Creates a transaction without validating pending catalog updates.
+    async fn transaction_unchecked(&mut self) -> Result<Transaction<'_>, CatalogError> {
+        self.metrics.transactions_started.inc();
+        let snapshot = self.snapshot().await?;
+        let commit_ts = self.upper;
+        Transaction::new(self, snapshot, commit_ts)
+    }
+}
+
 #[async_trait]
 impl ReadOnlyDurableCatalogState for PersistCatalogState {
     fn epoch(&self) -> Epoch {
@@ -1785,10 +1795,9 @@ impl DurableCatalogState for PersistCatalogState {
 
     #[mz_ore::instrument(level = "debug")]
     async fn transaction(&mut self) -> Result<Transaction, CatalogError> {
-        self.metrics.transactions_started.inc();
-        let snapshot = self.snapshot().await?;
-        let commit_ts = self.upper.clone();
-        Transaction::new(self, snapshot, commit_ts)
+        let mut txn = self.transaction_unchecked().await?;
+        txn.ensure_not_out_of_sync().await?;
+        Ok(txn)
     }
 
     fn transaction_from_snapshot(
@@ -1797,6 +1806,26 @@ impl DurableCatalogState for PersistCatalogState {
     ) -> Result<Transaction, CatalogError> {
         let commit_ts = self.upper.clone();
         Transaction::new(self, snapshot, commit_ts)
+    }
+
+    #[mz_ore::instrument(level = "debug")]
+    async fn allocate_id(
+        &mut self,
+        id_type: &str,
+        amount: u64,
+        commit_ts: Timestamp,
+    ) -> Result<Vec<u64>, CatalogError> {
+        let start = Instant::now();
+        if amount == 0 {
+            return Ok(Vec::new());
+        }
+        let mut txn = self.transaction_unchecked().await?;
+        let ids = txn.get_and_increment_id_by(id_type.to_string(), amount)?;
+        txn.commit_internal(commit_ts).await?;
+        self.metrics
+            .allocate_id_seconds
+            .observe(start.elapsed().as_secs_f64());
+        Ok(ids)
     }
 
     #[mz_ore::instrument(level = "debug")]

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -62,9 +62,9 @@ use crate::durable::objects::{AuditLogKey, FenceToken, Snapshot};
 use crate::durable::transaction::TransactionBatch;
 use crate::durable::upgrade::upgrade;
 use crate::durable::{
-    BootstrapArgs, CATALOG_CONTENT_VERSION_KEY, CatalogError, DurableCatalogError,
-    DurableCatalogState, Epoch, OpenableDurableCatalogState, ReadOnlyDurableCatalogState,
-    Transaction, initialize, persist_desc,
+    BootstrapArgs, CATALOG_CONTENT_VERSION_KEY, CatalogError, DryRunTransaction,
+    DurableCatalogError, DurableCatalogState, Epoch, OpenableDurableCatalogState,
+    ReadOnlyDurableCatalogState, Transaction, initialize, persist_desc,
 };
 use crate::memory;
 
@@ -1349,7 +1349,7 @@ impl UnopenedPersistCatalogState {
         };
 
         if read_only {
-            let (txn_batch, _) = txn.into_parts();
+            let (txn_batch, _) = txn.into_parts()?;
             // The upper here doesn't matter because we are only applying the updates in memory.
             let updates = StateUpdate::from_txn_batch_ts(txn_batch, catalog.upper);
             catalog.apply_updates_and_consolidate(updates)?;
@@ -1767,6 +1767,29 @@ impl ReadOnlyDurableCatalogState for PersistCatalogState {
         Ok(updates)
     }
 
+    #[mz_ore::instrument(level = "debug")]
+    async fn ensure_not_out_of_sync(
+        &mut self,
+        target_upper: Timestamp,
+    ) -> Result<(), CatalogError> {
+        self.sync(target_upper).await?;
+        let update_count = self
+            .update_applier
+            .updates
+            .iter()
+            .take_while(|update| update.ts < target_upper)
+            .count();
+        if update_count == 0 {
+            Ok(())
+        } else {
+            Err(DurableCatalogError::CatalogOutOfSync {
+                update_count,
+                upper: target_upper,
+            }
+            .into())
+        }
+    }
+
     async fn current_upper(&mut self) -> Timestamp {
         self.current_upper().await
     }
@@ -1803,9 +1826,9 @@ impl DurableCatalogState for PersistCatalogState {
     fn transaction_from_snapshot(
         &mut self,
         snapshot: Snapshot,
-    ) -> Result<Transaction, CatalogError> {
-        let commit_ts = self.upper.clone();
-        Transaction::new(self, snapshot, commit_ts)
+    ) -> Result<DryRunTransaction, CatalogError> {
+        let commit_ts = self.upper;
+        Transaction::new(self, snapshot, commit_ts).map(DryRunTransaction::new)
     }
 
     #[mz_ore::instrument(level = "debug")]

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -22,6 +22,7 @@ use differential_dataflow::lattice::Lattice;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use mz_audit_log::VersionedEvent;
+use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::EpochMillis;
 use mz_ore::{
@@ -278,8 +279,10 @@ impl FenceableToken {
 pub(crate) enum CompareAndAppendError {
     #[error(transparent)]
     Fence(#[from] FenceError),
-    /// Catalog encountered an upper mismatch when trying to write to the catalog. This should only
-    /// happen while trying to fence out other catalogs.
+    /// Catalog encountered an upper mismatch when trying to write to the catalog: another
+    /// writer moved the upper between our snapshot of it and the write. Handled by the conflict
+    /// classification in the commit and advance paths (rebase over empty progress, surface
+    /// content conflicts as out-of-sync).
     #[error(
         "expected catalog upper {expected_upper:?} did not match actual catalog upper {actual_upper:?}"
     )]
@@ -368,6 +371,13 @@ pub(crate) struct PersistHandle<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> {
     /// [`Self::maybe_consolidate`] to decide when to consolidate. Initialized
     /// lazily on the first call.
     size_at_last_consolidation: Option<usize>,
+    /// Counts every raw update applied to this handle, across all kinds. Used to distinguish
+    /// empty progress (upper movement with zero updates) from content written by another catalog:
+    /// capture the count before a compare-and-append, and if it is unchanged after the
+    /// conflict-triggered sync, the interval was pure empty progress and it is safe to rebase.
+    /// Memory-update emptiness is not a substitute, because some kinds (e.g. ID allocators) do
+    /// not surface as memory updates but still invalidate a rebase.
+    updates_applied: u64,
 }
 
 impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
@@ -392,28 +402,6 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
         updates: Vec<(S, Diff)>,
         commit_ts: Timestamp,
     ) -> Result<Timestamp, CompareAndAppendError> {
-        // The fencing check is expensive, so run it only with soft assertions enabled.
-        let contains_fence = if mz_ore::assert::soft_assertions_enabled() {
-            let parsed_updates: Vec<_> = updates
-                .clone()
-                .into_iter()
-                .filter_map(|(update, diff)| {
-                    let update: StateUpdateKindJson = update.into();
-                    let update = TryIntoStateUpdateKind::try_into(update).ok()?;
-                    Some((update, diff))
-                })
-                .collect();
-            let contains_retraction = parsed_updates.iter().any(|(update, diff)| {
-                matches!(update, StateUpdateKind::FenceToken(..)) && *diff == Diff::MINUS_ONE
-            });
-            let contains_addition = parsed_updates.iter().any(|(update, diff)| {
-                matches!(update, StateUpdateKind::FenceToken(..)) && *diff == Diff::ONE
-            });
-            Some(contains_retraction && contains_addition)
-        } else {
-            None
-        };
-
         let updates = updates.into_iter().map(|(kind, diff)| {
             let kind: StateUpdateKindJson = kind.into();
             (
@@ -423,20 +411,12 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
             )
         });
         let next_upper = commit_ts.step_forward();
-        self.compare_and_append_inner(updates, next_upper)
-            .await
-            .inspect_err(|e| {
-                // A compare-and-append failure means someone else must have written to the
-                // catalog. We expect to have been fenced out, since writing to the catalog without
-                // fencing other catalogs should be impossible. The one exception is if we are
-                // trying to fence other catalogs with this write.
-                if let Some(contains_fence) = contains_fence {
-                    soft_assert_or_log!(
-                        matches!(e, CompareAndAppendError::Fence(_)) || contains_fence,
-                        "encountered an upper mismatch on a non-fencing write"
-                    );
-                }
-            })?;
+        // NOTE: An `UpperMismatch` here is a legitimate outcome, not a programming error:
+        // another writer (a fencer, or a concurrent catalog advancing the upper) got in between
+        // our snapshot of the upper and this write. Callers classify the conflict and either
+        // rebase over empty progress or surface it, see `commit_transaction` and
+        // `advance_upper`.
+        self.compare_and_append_inner(updates, next_upper).await?;
 
         self.sync(next_upper).await?;
         Ok(next_upper)
@@ -655,6 +635,7 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
             if diff != Diff::ONE && diff != Diff::MINUS_ONE {
                 panic!("invalid update in consolidated trace: ({kind:?}, {ts:?}, {diff:?})");
             }
+            self.updates_applied += 1;
 
             match self.update_applier.apply_update(
                 StateUpdate { kind, ts, diff },
@@ -1097,6 +1078,7 @@ impl UnopenedPersistCatalogState {
             bootstrap_complete: false,
             metrics,
             size_at_last_consolidation: None,
+            updates_applied: 0,
         };
         // If the snapshot is not consolidated, and we see multiple epoch values while applying the
         // updates, then we might accidentally fence ourselves out.
@@ -1297,6 +1279,7 @@ impl UnopenedPersistCatalogState {
             bootstrap_complete: false,
             metrics: self.metrics,
             size_at_last_consolidation: None,
+            updates_applied: 0,
         };
         catalog.metrics.collection_entries.reset();
         // Normally, `collection_entries` is updated in `apply_updates`. The audit log updates skip
@@ -1834,30 +1817,50 @@ impl DurableCatalogState for PersistCatalogState {
                 return Ok(catalog.upper);
             }
 
-            // If the current upper does not match the transaction's commit timestamp, then the
-            // catalog must have changed since the transaction was started, making the transaction
-            // invalid. When/if we want a multi-writer catalog, this will likely have to change
-            // from an assert to a retry.
+            // The handle must not have synced past the upper the transaction was built on. All
+            // in-process users run transactions on one handle behind a mutex held from open to
+            // commit, so a mismatch here is a local programming error, not external interference
+            // (a concurrent writer does not move our cached upper, it makes the
+            // compare-and-append below fail, which is handled gracefully).
             assert_eq!(
                 catalog.upper, txn_batch.upper,
-                "only one transaction at a time is supported"
+                "the handle was mutated mid-transaction"
             );
 
-            assert!(
-                commit_ts >= catalog.upper,
-                "expected commit ts, {}, to be greater than or equal to upper, {}",
-                commit_ts,
-                catalog.upper
-            );
-
-            let updates = StateUpdate::from_txn_batch(txn_batch).collect();
+            let updates: Vec<_> = StateUpdate::from_txn_batch(txn_batch).collect();
             debug!("committing updates: {updates:?}");
 
+            // Rebase over empty progress: the group committer (and in the future other
+            // processes) advances the upper without content, which must not invalidate this
+            // transaction. Real content committed by another writer does invalidate it, and
+            // surfaces as `CatalogOutOfSync` below.
+            let mut commit_ts = max(commit_ts, catalog.upper);
+
             let next_upper = match catalog.mode {
-                Mode::Writable => catalog
-                    .compare_and_append(updates, commit_ts)
-                    .await
-                    .map_err(|e| e.unwrap_fence_error())?,
+                Mode::Writable => loop {
+                    let updates_applied_before = catalog.updates_applied;
+                    match catalog.compare_and_append(updates.clone(), commit_ts).await {
+                        Ok(next_upper) => break next_upper,
+                        Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
+                        Err(CompareAndAppendError::UpperMismatch { actual_upper, .. }) => {
+                            // Another writer got in between our snapshot of the upper and the
+                            // compare-and-append. `compare_and_append_inner` synced us to the
+                            // current upper. Zero applied updates means pure empty progress, so
+                            // we rebase the commit timestamp and retry. Anything else means the
+                            // transaction was planned against stale state.
+                            if catalog.updates_applied != updates_applied_before {
+                                return Err(DurableCatalogError::CatalogOutOfSync {
+                                    update_count: usize::cast_from(
+                                        catalog.updates_applied - updates_applied_before,
+                                    ),
+                                    upper: actual_upper,
+                                }
+                                .into());
+                            }
+                            commit_ts = max(commit_ts, catalog.upper);
+                        }
+                    }
+                },
                 Mode::Savepoint => {
                     let updates = updates.into_iter().map(|(kind, diff)| StateUpdate {
                         kind,
@@ -1883,39 +1886,55 @@ impl DurableCatalogState for PersistCatalogState {
 
     #[mz_ore::instrument(level = "debug")]
     async fn advance_upper(&mut self, new_upper: Timestamp) -> Result<(), CatalogError> {
-        if self.upper >= new_upper {
-            // We don't expect a no-op advancement, but if we are wrong we'd crash the process.
-            // Seems safer to only soft-assert and return gracefully in production. If we get here
-            // that means we tried to make the catalog shard readable at a time it was already
-            // readable, which likely means we are violating linearizability. That's not great, but
-            // crashing (or even crash-looping) is worse.
-            //
-            // TODO: Consider removing this once we have built some confidence.
-            soft_panic_or_log!(
-                "new_upper ({new_upper}) not greater than current upper ({})",
-                self.upper
-            );
-            return Ok(());
-        }
+        loop {
+            if self.upper >= new_upper {
+                // Someone (an on-loop catalog transaction, or another process) already advanced
+                // the upper to or past `new_upper`. Advancing is "to at least", so nothing to do.
+                return Ok(());
+            }
 
-        match self.mode {
-            Mode::Writable => self
-                .compare_and_append_inner([], new_upper)
-                .await
-                .map_err(|e| e.unwrap_fence_error())?,
-            Mode::Savepoint => (),
-            Mode::Readonly => {
-                return Err(DurableCatalogError::NotWritable(
-                    "cannot advance upper of a read-only catalog".into(),
-                )
-                .into());
+            match self.mode {
+                Mode::Writable => {}
+                Mode::Savepoint => {
+                    self.upper = new_upper;
+                    return Ok(());
+                }
+                Mode::Readonly => {
+                    return Err(DurableCatalogError::NotWritable(
+                        "cannot advance upper of a read-only catalog".into(),
+                    )
+                    .into());
+                }
+            }
+
+            let updates_applied_before = self.updates_applied;
+            match self.compare_and_append_inner([], new_upper).await {
+                Ok(()) => {
+                    self.upper = new_upper;
+                    // No sync needed since no data was written.
+                    return Ok(());
+                }
+                Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
+                Err(CompareAndAppendError::UpperMismatch { actual_upper, .. }) => {
+                    // Another writer advanced the shard between our snapshot of the upper and the
+                    // compare-and-append. `compare_and_append_inner` already synced us to the
+                    // current upper. If that sync applied any updates, the other writer committed
+                    // content we have not planned against, and the caller must rebuild from
+                    // durable state. If it applied none, the interval was pure empty progress
+                    // (e.g. another upper bump) and we can simply re-evaluate against the new
+                    // upper.
+                    if self.updates_applied != updates_applied_before {
+                        return Err(DurableCatalogError::CatalogOutOfSync {
+                            update_count: usize::cast_from(
+                                self.updates_applied - updates_applied_before,
+                            ),
+                            upper: actual_upper,
+                        }
+                        .into());
+                    }
+                }
             }
         }
-
-        self.upper = new_upper;
-        // No sync needed since no data was written.
-
-        Ok(())
     }
 
     fn shard_id(&self) -> ShardId {

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -74,6 +74,9 @@ use crate::memory::objects::{StateDiff, StateUpdate, StateUpdateKind};
 
 type Timestamp = u64;
 
+#[derive(Debug, PartialEq)]
+struct CommitCapability;
+
 /// A [`Transaction`] batches multiple catalog operations together and commits them atomically.
 /// An operation also logically groups multiple catalog updates together.
 #[derive(Derivative)]
@@ -116,6 +119,34 @@ pub struct Transaction<'a> {
     upper: mz_repr::Timestamp,
     /// The ID of the current operation of this transaction.
     op_id: Timestamp,
+    // `DryRunTransaction` removes this token. Commit entry points check it.
+    // Decomposition transfers it to `TransactionBatch` before exposing the
+    // durable handle.
+    commit_capability: Option<CommitCapability>,
+}
+
+/// A catalog transaction that can be evaluated but cannot be committed.
+#[derive(Debug)]
+pub struct DryRunTransaction<'a> {
+    transaction: Transaction<'a>,
+}
+
+impl<'a> DryRunTransaction<'a> {
+    /// Permanently revokes commit permission and returns a dry-run transaction.
+    pub fn new(mut transaction: Transaction<'a>) -> Self {
+        transaction.commit_capability = None;
+        Self { transaction }
+    }
+
+    /// Returns a mutable view for evaluating catalog operations.
+    pub fn transaction_mut(&mut self) -> &mut Transaction<'a> {
+        &mut self.transaction
+    }
+
+    /// Exports the current dry-run state as a [`Snapshot`].
+    pub fn current_snapshot(&self) -> Snapshot {
+        self.transaction.current_snapshot()
+    }
 }
 
 impl<'a> Transaction<'a> {
@@ -230,6 +261,7 @@ impl<'a> Transaction<'a> {
             audit_log_updates: Vec::new(),
             upper,
             op_id: 0,
+            commit_capability: Some(CommitCapability),
         })
     }
 
@@ -2443,6 +2475,7 @@ impl<'a> Transaction<'a> {
             txn_wal_shard: _,
             upper,
             op_id: _,
+            commit_capability: _,
         } = &self;
 
         let updates = std::iter::empty()
@@ -2572,6 +2605,13 @@ impl<'a> Transaction<'a> {
         self.upper
     }
 
+    fn ensure_committable(&self) -> Result<(), CatalogError> {
+        match self.commit_capability {
+            Some(_) => Ok(()),
+            None => Err(DurableCatalogError::DryRunTransaction.into()),
+        }
+    }
+
     /// Verifies that this process has not missed catalog content updates.
     pub(super) async fn ensure_not_out_of_sync(&mut self) -> Result<(), CatalogError> {
         self.durable_catalog
@@ -2579,7 +2619,12 @@ impl<'a> Transaction<'a> {
             .await
     }
 
-    pub(crate) fn into_parts(self) -> (TransactionBatch, &'a mut dyn DurableCatalogState) {
+    pub(crate) fn into_parts(
+        self,
+    ) -> Result<(TransactionBatch, &'a mut dyn DurableCatalogState), CatalogError> {
+        let commit_capability = self
+            .commit_capability
+            .ok_or(DurableCatalogError::DryRunTransaction)?;
         let audit_log_updates = self
             .audit_log_updates
             .into_iter()
@@ -2612,14 +2657,19 @@ impl<'a> Transaction<'a> {
             txn_wal_shard: self.txn_wal_shard.pending(),
             audit_log_updates,
             upper: self.upper,
+            _commit_capability: commit_capability,
         };
-        (txn_batch, self.durable_catalog)
+        Ok((txn_batch, self.durable_catalog))
     }
 
-    /// Commits the storage transaction to durable storage. Any error returned outside read-only
-    /// mode indicates the catalog may be in an indeterminate state and needs to be fully re-read
-    /// before proceeding. In general, this must be fatal to the calling process. We do not
-    /// panic/halt inside this function itself so that errors can bubble up during initialization.
+    /// Commits the storage transaction to durable storage.
+    ///
+    /// [`DurableCatalogError::DryRunTransaction`] is a pre-effect
+    /// programming error that leaves durable state unchanged. Any other error
+    /// outside read-only mode indicates the catalog may be in an indeterminate
+    /// state and needs to be fully re-read before proceeding. In general, such
+    /// errors must be fatal to the calling process. We do not panic/halt here so
+    /// initialization can report them.
     ///
     /// The transaction is committed at `commit_ts`.
     ///
@@ -2632,7 +2682,8 @@ impl<'a> Transaction<'a> {
         self,
         commit_ts: mz_repr::Timestamp,
     ) -> Result<(&'a mut dyn DurableCatalogState, mz_repr::Timestamp), CatalogError> {
-        let (mut txn_batch, durable_catalog) = self.into_parts();
+        self.ensure_committable()?;
+        let (mut txn_batch, durable_catalog) = self.into_parts()?;
         let TransactionBatch {
             databases,
             schemas,
@@ -2659,6 +2710,7 @@ impl<'a> Transaction<'a> {
             txn_wal_shard,
             audit_log_updates,
             upper: _,
+            _commit_capability: _,
         } = &mut txn_batch;
         // Consolidate in memory because it will likely be faster than consolidating after the
         // transaction has been made durable.
@@ -2693,10 +2745,14 @@ impl<'a> Transaction<'a> {
         Ok((durable_catalog, upper))
     }
 
-    /// Commits the storage transaction to durable storage. Any error returned outside read-only
-    /// mode indicates the catalog may be in an indeterminate state and needs to be fully re-read
-    /// before proceeding. In general, this must be fatal to the calling process. We do not
-    /// panic/halt inside this function itself so that errors can bubble up during initialization.
+    /// Commits the storage transaction to durable storage.
+    ///
+    /// [`DurableCatalogError::DryRunTransaction`] is a pre-effect
+    /// programming error that leaves durable state unchanged. Any other error
+    /// outside read-only mode indicates the catalog may be in an indeterminate
+    /// state and needs to be fully re-read before proceeding. In general, such
+    /// errors must be fatal to the calling process. We do not panic/halt here so
+    /// initialization can report them.
     ///
     /// In read-only mode, this will return an error for non-empty transactions indicating that the
     /// catalog is not writeable.
@@ -2711,6 +2767,7 @@ impl<'a> Transaction<'a> {
     /// about the caller in this method, in practice it results in duplicate work on every commit.
     #[mz_ore::instrument(level = "debug")]
     pub async fn commit(self, commit_ts: mz_repr::Timestamp) -> Result<(), CatalogError> {
+        self.ensure_committable()?;
         let op_updates = self.get_op_updates();
         assert!(
             op_updates.is_empty(),
@@ -2725,8 +2782,9 @@ impl<'a> Transaction<'a> {
         // Read-only catalogs can only commit empty transactions, so they don't need to consume all
         // updates before committing.
         //
-        // NOTE: The commit may have rebased over empty progress to a timestamp past `commit_ts`,
-        // so we check against the upper the commit reported rather than `commit_ts` exactly.
+        // The off-loop group committer can advance the catalog upper without content while this
+        // transaction is open. The commit then rebases above `commit_ts`. Its returned `upper` is
+        // the exclusive upper of the successful write.
         soft_assert_no_log!(
             durable_storage.is_read_only()
                 || updates
@@ -2849,7 +2907,7 @@ impl StorageTxn for Transaction<'_> {
 }
 
 /// Describes a set of changes to apply as the result of a catalog transaction.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct TransactionBatch {
     pub(crate) databases: Vec<(proto::DatabaseKey, proto::DatabaseValue, Diff)>,
     pub(crate) schemas: Vec<(proto::SchemaKey, proto::SchemaValue, Diff)>,
@@ -2909,6 +2967,9 @@ pub struct TransactionBatch {
     pub(crate) audit_log_updates: Vec<(proto::AuditLogKey, (), Diff)>,
     /// The upper of the catalog when the transaction started.
     pub(crate) upper: mz_repr::Timestamp,
+    // A private, non-cloneable capability keeps batches constructible only by
+    // transaction decomposition.
+    _commit_capability: CommitCapability,
 }
 
 impl TransactionBatch {
@@ -2939,6 +3000,7 @@ impl TransactionBatch {
             txn_wal_shard,
             audit_log_updates,
             upper: _,
+            _commit_capability: _,
         } = self;
         databases.is_empty()
             && schemas.is_empty()
@@ -4348,6 +4410,116 @@ mod tests {
         assert_eq!(db_name, db.name);
         assert_eq!(db_owner, db.owner_id);
         assert_eq!(db_privileges, db.privileges);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn test_dry_run_transaction_rejects_internal_commit() {
+        const VERSION: Version = Version::new(26, 0, 0);
+        let mut persist_cache = PersistClientCache::new_no_metrics();
+        persist_cache.cfg.build_version = VERSION;
+        let persist_client = persist_cache
+            .open(PersistLocation::new_in_mem())
+            .await
+            .unwrap();
+        let mut state = TestCatalogStateBuilder::new(persist_client)
+            .with_default_deploy_generation()
+            .with_version(VERSION)
+            .unwrap_build()
+            .await
+            .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+            .await
+            .unwrap();
+        let _ = state.sync_to_current_updates().await.unwrap();
+
+        let initial_id = state.get_next_id(USER_ITEM_ALLOC_KEY).await.unwrap();
+        let initial_upper = state.current_upper().await;
+        let snapshot = state.snapshot().await.unwrap();
+        let mut dry_run = state.transaction_from_snapshot(snapshot).unwrap();
+        let ids = dry_run
+            .transaction_mut()
+            .get_and_increment_id_by(USER_ITEM_ALLOC_KEY.to_string(), 1)
+            .unwrap();
+        assert_eq!(ids, vec![initial_id]);
+
+        let transaction = dry_run.transaction;
+        let err = transaction
+            .commit_internal(initial_upper)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            CatalogError::Durable(DurableCatalogError::DryRunTransaction)
+        ));
+        assert_eq!(state.current_upper().await, initial_upper);
+        assert_eq!(
+            state.get_next_id(USER_ITEM_ALLOC_KEY).await.unwrap(),
+            initial_id
+        );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn test_dry_run_transaction_rejects_into_parts_escape() {
+        const VERSION: Version = Version::new(26, 0, 0);
+        let mut persist_cache = PersistClientCache::new_no_metrics();
+        persist_cache.cfg.build_version = VERSION;
+        let persist_client = persist_cache
+            .open(PersistLocation::new_in_mem())
+            .await
+            .unwrap();
+        let mut dry_run_state = TestCatalogStateBuilder::new(persist_client.clone())
+            .with_default_deploy_generation()
+            .with_version(VERSION)
+            .unwrap_build()
+            .await
+            .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+            .await
+            .unwrap();
+        let mut replacement_state = TestCatalogStateBuilder::new(persist_client)
+            .with_default_deploy_generation()
+            .with_version(VERSION)
+            .unwrap_build()
+            .await
+            .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+            .await
+            .unwrap();
+        let _ = dry_run_state.sync_to_current_updates().await.unwrap();
+        let _ = replacement_state.sync_to_current_updates().await.unwrap();
+
+        let initial_id = dry_run_state
+            .get_next_id(USER_ITEM_ALLOC_KEY)
+            .await
+            .unwrap();
+        let initial_upper = dry_run_state.current_upper().await;
+        let snapshot = dry_run_state.snapshot().await.unwrap();
+        let mut dry_run = dry_run_state.transaction_from_snapshot(snapshot).unwrap();
+        let ids = dry_run
+            .transaction_mut()
+            .get_and_increment_id_by(USER_ITEM_ALLOC_KEY.to_string(), 1)
+            .unwrap();
+        assert_eq!(ids, vec![initial_id]);
+
+        let replacement = replacement_state.transaction().await.unwrap();
+        let escaped = std::mem::replace(dry_run.transaction_mut(), replacement);
+        drop(dry_run);
+
+        let err = match escaped.into_parts() {
+            Ok(_) => panic!("dry-run transaction decomposed into committable parts"),
+            Err(err) => err,
+        };
+        assert!(matches!(
+            err,
+            CatalogError::Durable(DurableCatalogError::DryRunTransaction)
+        ));
+        assert_eq!(dry_run_state.current_upper().await, initial_upper);
+        assert_eq!(
+            dry_run_state
+                .get_next_id(USER_ITEM_ALLOC_KEY)
+                .await
+                .unwrap(),
+            initial_id
+        );
     }
 
     /// Regression test for DB-147: inserting a replica with an explicit id must not consume the

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -119,7 +119,7 @@ pub struct Transaction<'a> {
 }
 
 impl<'a> Transaction<'a> {
-    pub fn new(
+    pub(super) fn new(
         durable_catalog: &'a mut dyn DurableCatalogState,
         Snapshot {
             databases,
@@ -2573,7 +2573,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Verifies that this process has not missed catalog content updates.
-    pub async fn ensure_not_out_of_sync(&mut self) -> Result<(), CatalogError> {
+    pub(super) async fn ensure_not_out_of_sync(&mut self) -> Result<(), CatalogError> {
         self.durable_catalog
             .ensure_not_out_of_sync(self.upper)
             .await
@@ -4400,12 +4400,16 @@ mod tests {
             .into_element();
         assert!(a.is_user());
 
+        let initial_updates = state.sync_to_current_updates().await.unwrap();
+        assert!(!initial_updates.is_empty());
+
         // Step 2: insert a replica with that explicit id and commit.
         let mut txn = state.transaction().await.unwrap();
         txn.insert_cluster_replica_with_id(cluster_id, a, "explicit", config, owner_id)
             .unwrap();
         let commit_ts = txn.upper();
         txn.commit_internal(commit_ts).await.unwrap();
+        let _ = state.sync_to_current_updates().await.unwrap();
 
         // Step 3: allocate one more user replica id.
         let commit_ts = state.current_upper().await;

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -2572,6 +2572,13 @@ impl<'a> Transaction<'a> {
         self.upper
     }
 
+    /// Verifies that this process has not missed catalog content updates.
+    pub async fn ensure_not_out_of_sync(&mut self) -> Result<(), CatalogError> {
+        self.durable_catalog
+            .ensure_not_out_of_sync(self.upper)
+            .await
+    }
+
     pub(crate) fn into_parts(self) -> (TransactionBatch, &'a mut dyn DurableCatalogState) {
         let audit_log_updates = self
             .audit_log_updates
@@ -2717,9 +2724,15 @@ impl<'a> Transaction<'a> {
         // transaction, otherwise the commit was performed with an out of date state.
         // Read-only catalogs can only commit empty transactions, so they don't need to consume all
         // updates before committing.
+        //
+        // NOTE: The commit may have rebased over empty progress to a timestamp past `commit_ts`,
+        // so we check against the upper the commit reported rather than `commit_ts` exactly.
         soft_assert_no_log!(
-            durable_storage.is_read_only() || updates.iter().all(|update| update.ts == commit_ts),
-            "unconsumed updates existed before transaction commit: commit_ts={commit_ts:?}, updates:{updates:?}"
+            durable_storage.is_read_only()
+                || updates
+                    .iter()
+                    .all(|update| update.ts >= commit_ts && update.ts < upper),
+            "unconsumed updates existed before transaction commit: commit_ts={commit_ts:?}, upper={upper:?}, updates:{updates:?}"
         );
         Ok(())
     }

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -369,6 +369,7 @@ async fn test_debug_edit_fencing(state_builder: TestCatalogStateBuilder) {
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
         .unwrap();
+    let _ = state.sync_to_current_updates().await.unwrap();
 
     let mut debug_state = state_builder
         .clone()

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -137,8 +137,6 @@ async fn test_persist_advance_upper_at_least_semantics() {
 
     let upper = state.current_upper().await;
 
-    // Advancing to the current upper or behind it is a no-op, not an error: the group committer
-    // advances with timestamps that on-loop catalog transactions may have overtaken.
     assert_ok!(state.advance_upper(upper).await);
     assert_ok!(
         state
@@ -147,7 +145,6 @@ async fn test_persist_advance_upper_at_least_semantics() {
     );
     assert_eq!(state.current_upper().await, upper);
 
-    // Advancing past the upper moves it.
     let target = upper.step_forward().step_forward();
     assert_ok!(state.advance_upper(target).await);
     assert_eq!(state.current_upper().await, target);
@@ -170,9 +167,6 @@ async fn test_persist_commit_rebases_over_empty_progress() {
         .await
         .unwrap();
 
-    // Choose a commit timestamp, then advance the upper past it with empty progress, the way the
-    // group committer overtakes an on-loop timestamp allocation. The commit must rebase past the
-    // moved upper instead of failing.
     let commit_ts = state.current_upper().await;
     let overtaken = commit_ts.step_forward().step_forward();
     assert_ok!(state.advance_upper(overtaken).await);
@@ -181,7 +175,6 @@ async fn test_persist_commit_rebases_over_empty_progress() {
     let ids = state.allocate_id(id_type, 1, commit_ts).await.unwrap();
     assert_eq!(ids, vec![start_id]);
 
-    // The allocation must be readable at the new upper, which is past the overtaken timestamp.
     assert!(state.current_upper().await > overtaken);
     let next_id = state.get_next_id(id_type).await.unwrap();
     assert_eq!(next_id, start_id + 1);
@@ -207,14 +200,10 @@ async fn test_persist_conflicts_with_empty_progress_rebase() {
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
         .unwrap();
-    // Drain the queued bootstrap updates, as the adapter does after opening, so the commit-time
-    // drain below only sees this test's own updates.
+    // Exclude bootstrap updates from conflict classification below.
     let _ = state.sync_to_current_updates().await.unwrap();
 
-    // A raw write handle on the catalog shard, simulating a concurrent writer that advances the
-    // upper with empty progress behind the catalog handle's back. Unlike a second catalog open,
-    // this does not fence, so it exercises the `UpperMismatch` classification rather than the
-    // fence path.
+    // A raw handle advances the upper without fencing, exercising upper-mismatch classification.
     let mut raw_write = persist_client
         .open_writer::<SourceData, (), mz_repr::Timestamp, i64>(
             state.shard_id(),
@@ -229,8 +218,6 @@ async fn test_persist_conflicts_with_empty_progress_rebase() {
         .expect("invalid usage");
     let empty: Vec<((SourceData, ()), mz_repr::Timestamp, i64)> = Vec::new();
 
-    // Case 1: `advance_upper` hits the conflict, classifies the interval as empty progress
-    // (zero updates applied by the sync), and retries to success.
     let upper = state.current_upper().await;
     let bumped = upper.step_forward().step_forward();
     raw_write
@@ -246,8 +233,6 @@ async fn test_persist_conflicts_with_empty_progress_rebase() {
     assert_ok!(state.advance_upper(target).await);
     assert_eq!(state.current_upper().await, target);
 
-    // Case 2: a transaction commit whose compare-and-append conflicts with empty progress
-    // injected mid-transaction rebases and retries instead of failing.
     let id_type = USER_ITEM_ALLOC_KEY;
     let start_id = state.get_next_id(id_type).await.unwrap();
     let mut txn = state.transaction().await.unwrap();

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -124,6 +124,155 @@ async fn test_allocate_id(state_builder: TestCatalogStateBuilder) {
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_persist_advance_upper_at_least_semantics() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let state_builder = TestCatalogStateBuilder::new(persist_client);
+    let state_builder = state_builder.with_default_deploy_generation();
+    let mut state = state_builder
+        .unwrap_build()
+        .await
+        .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+        .await
+        .unwrap();
+
+    let upper = state.current_upper().await;
+
+    // Advancing to the current upper or behind it is a no-op, not an error: the group committer
+    // advances with timestamps that on-loop catalog transactions may have overtaken.
+    assert_ok!(state.advance_upper(upper).await);
+    assert_ok!(
+        state
+            .advance_upper(upper.step_back().unwrap_or_default())
+            .await
+    );
+    assert_eq!(state.current_upper().await, upper);
+
+    // Advancing past the upper moves it.
+    let target = upper.step_forward().step_forward();
+    assert_ok!(state.advance_upper(target).await);
+    assert_eq!(state.current_upper().await, target);
+
+    Box::new(state).expire().await;
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_persist_commit_rebases_over_empty_progress() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let state_builder = TestCatalogStateBuilder::new(persist_client);
+    let state_builder = state_builder.with_default_deploy_generation();
+
+    let id_type = USER_ITEM_ALLOC_KEY;
+    let mut state = state_builder
+        .unwrap_build()
+        .await
+        .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+        .await
+        .unwrap();
+
+    // Choose a commit timestamp, then advance the upper past it with empty progress, the way the
+    // group committer overtakes an on-loop timestamp allocation. The commit must rebase past the
+    // moved upper instead of failing.
+    let commit_ts = state.current_upper().await;
+    let overtaken = commit_ts.step_forward().step_forward();
+    assert_ok!(state.advance_upper(overtaken).await);
+
+    let start_id = state.get_next_id(id_type).await.unwrap();
+    let ids = state.allocate_id(id_type, 1, commit_ts).await.unwrap();
+    assert_eq!(ids, vec![start_id]);
+
+    // The allocation must be readable at the new upper, which is past the overtaken timestamp.
+    assert!(state.current_upper().await > overtaken);
+    let next_id = state.get_next_id(id_type).await.unwrap();
+    assert_eq!(next_id, start_id + 1);
+
+    Box::new(state).expire().await;
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_persist_conflicts_with_empty_progress_rebase() {
+    use mz_catalog::durable::persist_desc;
+    use mz_persist_client::Diagnostics;
+    use mz_persist_types::codec_impls::UnitSchema;
+    use mz_storage_types::sources::SourceData;
+    use timely::progress::Antichain;
+
+    let persist_client = PersistClient::new_for_tests().await;
+    let state_builder =
+        TestCatalogStateBuilder::new(persist_client.clone()).with_default_deploy_generation();
+    let mut state = state_builder
+        .unwrap_build()
+        .await
+        .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+        .await
+        .unwrap();
+    // Drain the queued bootstrap updates, as the adapter does after opening, so the commit-time
+    // drain below only sees this test's own updates.
+    let _ = state.sync_to_current_updates().await.unwrap();
+
+    // A raw write handle on the catalog shard, simulating a concurrent writer that advances the
+    // upper with empty progress behind the catalog handle's back. Unlike a second catalog open,
+    // this does not fence, so it exercises the `UpperMismatch` classification rather than the
+    // fence path.
+    let mut raw_write = persist_client
+        .open_writer::<SourceData, (), mz_repr::Timestamp, i64>(
+            state.shard_id(),
+            Arc::new(persist_desc()),
+            Arc::new(UnitSchema::default()),
+            Diagnostics {
+                shard_name: "catalog".to_string(),
+                handle_purpose: "test concurrent empty progress".to_string(),
+            },
+        )
+        .await
+        .expect("invalid usage");
+    let empty: Vec<((SourceData, ()), mz_repr::Timestamp, i64)> = Vec::new();
+
+    // Case 1: `advance_upper` hits the conflict, classifies the interval as empty progress
+    // (zero updates applied by the sync), and retries to success.
+    let upper = state.current_upper().await;
+    let bumped = upper.step_forward().step_forward();
+    raw_write
+        .compare_and_append(
+            empty.clone(),
+            Antichain::from_elem(upper),
+            Antichain::from_elem(bumped),
+        )
+        .await
+        .expect("invalid usage")
+        .expect("no conflict");
+    let target = bumped.step_forward();
+    assert_ok!(state.advance_upper(target).await);
+    assert_eq!(state.current_upper().await, target);
+
+    // Case 2: a transaction commit whose compare-and-append conflicts with empty progress
+    // injected mid-transaction rebases and retries instead of failing.
+    let id_type = USER_ITEM_ALLOC_KEY;
+    let start_id = state.get_next_id(id_type).await.unwrap();
+    let mut txn = state.transaction().await.unwrap();
+    let commit_ts = txn.upper();
+    let ids = txn.get_and_increment_id_by(id_type.to_string(), 1).unwrap();
+    assert_eq!(ids, vec![start_id]);
+    let _updates = txn.get_and_commit_op_updates();
+    raw_write
+        .compare_and_append(
+            empty,
+            Antichain::from_elem(target),
+            Antichain::from_elem(target.step_forward()),
+        )
+        .await
+        .expect("invalid usage")
+        .expect("no conflict");
+    assert_ok!(txn.commit(commit_ts).await);
+    let next_id = state.get_next_id(id_type).await.unwrap();
+    assert_eq!(next_id, start_id + 1);
+
+    Box::new(state).expire().await;
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_persist_audit_logs() {
     let persist_client = PersistClient::new_for_tests().await;
     let state_builder = TestCatalogStateBuilder::new(persist_client);

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -135,15 +135,86 @@ async fn test_persist_transaction_rejects_pending_catalog_content() {
         .await
         .unwrap();
 
-    let err = state.transaction().await.unwrap_err();
-    match err {
-        CatalogError::Durable(DurableCatalogError::CatalogOutOfSync { update_count, .. }) => {
-            assert!(update_count > 0)
+    let mut update_counts = Vec::new();
+    for _ in 0..2 {
+        let err = state.transaction().await.unwrap_err();
+        match err {
+            CatalogError::Durable(DurableCatalogError::CatalogOutOfSync {
+                update_count, ..
+            }) => {
+                assert!(update_count > 0);
+                update_counts.push(update_count);
+            }
+            err => panic!("unexpected error: {err:?}"),
         }
-        err => panic!("unexpected error: {err:?}"),
     }
+    assert_eq!(update_counts[0], update_counts[1]);
+
+    let updates = state.sync_to_current_updates().await.unwrap();
+    assert_eq!(updates.len(), update_counts[0]);
+
+    let txn = state.transaction().await.unwrap();
+    drop(txn);
 
     Box::new(state).expire().await;
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_dry_run_transaction_rejects_mem_replace_escape() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let mut dry_run_state = TestCatalogStateBuilder::new(persist_client.clone())
+        .with_default_deploy_generation()
+        .unwrap_build()
+        .await
+        .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+        .await
+        .unwrap();
+    let mut replacement_state = TestCatalogStateBuilder::new(persist_client)
+        .with_default_deploy_generation()
+        .unwrap_build()
+        .await
+        .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+        .await
+        .unwrap();
+    let _ = dry_run_state.sync_to_current_updates().await.unwrap();
+    let _ = replacement_state.sync_to_current_updates().await.unwrap();
+
+    let initial_id = dry_run_state
+        .get_next_id(USER_ITEM_ALLOC_KEY)
+        .await
+        .unwrap();
+    let initial_upper = dry_run_state.current_upper().await;
+    let snapshot = dry_run_state.snapshot().await.unwrap();
+    let mut dry_run = dry_run_state.transaction_from_snapshot(snapshot).unwrap();
+    let ids = dry_run
+        .transaction_mut()
+        .get_and_increment_id_by(USER_ITEM_ALLOC_KEY.to_string(), 1)
+        .unwrap();
+    assert_eq!(ids, vec![initial_id]);
+    let _ = dry_run.transaction_mut().get_and_commit_op_updates();
+
+    let replacement = replacement_state.transaction().await.unwrap();
+    let escaped = std::mem::replace(dry_run.transaction_mut(), replacement);
+    drop(dry_run);
+
+    let commit_ts = escaped.upper();
+    let err = escaped.commit(commit_ts).await.unwrap_err();
+    assert!(matches!(
+        err,
+        CatalogError::Durable(DurableCatalogError::DryRunTransaction)
+    ));
+    assert_eq!(dry_run_state.current_upper().await, initial_upper);
+    assert_eq!(
+        dry_run_state
+            .get_next_id(USER_ITEM_ALLOC_KEY)
+            .await
+            .unwrap(),
+        initial_id
+    );
+
+    Box::new(dry_run_state).expire().await;
+    Box::new(replacement_state).expire().await;
 }
 
 #[mz_ore::test(tokio::test)]

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -102,6 +102,7 @@ async fn test_allocate_id(state_builder: TestCatalogStateBuilder) {
 
     let start_id = state.get_next_id(id_type).await.unwrap();
     let commit_ts = state.current_upper().await;
+    // Allocation does not require the initial update queue to be drained.
     let ids = state.allocate_id(id_type, 3, commit_ts).await.unwrap();
     assert_eq!(ids, (start_id..(start_id + 3)).collect::<Vec<_>>());
 
@@ -119,6 +120,29 @@ async fn test_allocate_id(state_builder: TestCatalogStateBuilder) {
         name: id_type.to_string(),
         next_id: start_id + 3,
     }));
+    Box::new(state).expire().await;
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_persist_transaction_rejects_pending_catalog_content() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let mut state = TestCatalogStateBuilder::new(persist_client)
+        .with_default_deploy_generation()
+        .unwrap_build()
+        .await
+        .open(SYSTEM_TIME().into(), &test_bootstrap_args())
+        .await
+        .unwrap();
+
+    let err = state.transaction().await.unwrap_err();
+    match err {
+        CatalogError::Durable(DurableCatalogError::CatalogOutOfSync { update_count, .. }) => {
+            assert!(update_count > 0)
+        }
+        err => panic!("unexpected error: {err:?}"),
+    }
+
     Box::new(state).expire().await;
 }
 
@@ -229,6 +253,11 @@ async fn test_persist_conflicts_with_empty_progress_rebase() {
         .await
         .expect("invalid usage")
         .expect("no conflict");
+
+    let txn = state.transaction().await.unwrap();
+    assert_eq!(txn.upper(), bumped);
+    drop(txn);
+
     let target = bumped.step_forward();
     assert_ok!(state.advance_upper(target).await);
     assert_eq!(state.current_upper().await, target);
@@ -580,6 +609,8 @@ async fn test_non_writer_commits(state_builder: TestCatalogStateBuilder) {
 
     // Read-only catalog can successfully commit empty transaction.
     {
+        let updates = reader_state.sync_to_current_updates().await.unwrap();
+        assert!(!updates.is_empty());
         let txn = reader_state.transaction().await.unwrap();
         let commit_ts = txn.upper();
         txn.commit(commit_ts).await.unwrap();

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -257,6 +257,11 @@ async fn check_ddl_changes(
         .await
         .unwrap_or_terminate("can open in savepoint mode");
 
+    // This savepoint reader has no derived state to consume the initial updates.
+    let _ = catalog
+        .sync_to_current_updates()
+        .await
+        .unwrap_or_terminate("unexpected error while draining initial catalog updates");
     let tx = catalog
         .transaction()
         .await
@@ -344,6 +349,11 @@ async fn get_next_ids(
         .await
         .unwrap_or_terminate("can open in savepoint mode");
 
+    // This savepoint reader has no derived state to consume the initial updates.
+    let _ = catalog
+        .sync_to_current_updates()
+        .await
+        .unwrap_or_terminate("unexpected error while draining initial catalog updates");
     let tx = catalog
         .transaction()
         .await

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -257,7 +257,8 @@ async fn check_ddl_changes(
         .await
         .unwrap_or_terminate("can open in savepoint mode");
 
-    // This savepoint reader has no derived state to consume the initial updates.
+    // `transaction` rejects unapplied catalog content. This reader has no derived catalog to
+    // update, so discard the initial update stream before opening the transaction.
     let _ = catalog
         .sync_to_current_updates()
         .await
@@ -349,7 +350,8 @@ async fn get_next_ids(
         .await
         .unwrap_or_terminate("can open in savepoint mode");
 
-    // This savepoint reader has no derived state to consume the initial updates.
+    // `transaction` rejects unapplied catalog content. This reader has no derived catalog to
+    // update, so discard the initial update stream before opening the transaction.
     let _ = catalog
         .sync_to_current_updates()
         .await

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -7250,3 +7250,49 @@ fn test_inject_audit_events_malformed() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
+
+// Regression test for a shutdown abort: dropping the server while user INSERTs are in flight
+// used to drop un-retired `CompletedClientTransmitter`s, queued in `GroupCommitApplied`
+// messages that the coordinator loop never received. Dropping one panics in
+// `ClientTransmitter::drop`, and a panic in a destructor aborts the process, so this test's
+// only assertion is surviving the rounds.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+fn test_shutdown_with_inflight_writes() {
+    for round in 0..3 {
+        let server = test_util::TestHarness::default().start_blocking();
+        {
+            let mut client = server.connect(postgres::NoTls).unwrap();
+            client.batch_execute("CREATE TABLE t (a int)").unwrap();
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let pg_config = server.pg_config();
+            let stop = Arc::clone(&stop);
+            handles.push(thread::spawn(move || {
+                let Ok(mut client) = pg_config.connect(postgres::NoTls) else {
+                    return;
+                };
+                while !stop.load(Ordering::Relaxed) {
+                    // Errors are expected once the server goes away.
+                    if client.batch_execute("INSERT INTO t VALUES (1)").is_err() {
+                        return;
+                    }
+                }
+            }));
+        }
+
+        // Let the insert threads get going, then shut the server down under write load.
+        thread::sleep(Duration::from_millis(500));
+        drop(server);
+
+        stop.store(true, Ordering::Relaxed);
+        for handle in handles {
+            let _ = handle.join();
+        }
+        tracing::info!("round {round} survived");
+    }
+}

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -7251,11 +7251,7 @@ fn test_inject_audit_events_malformed() {
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
 
-// Regression test for a shutdown abort: dropping the server while user INSERTs are in flight
-// used to drop un-retired `CompletedClientTransmitter`s, queued in `GroupCommitApplied`
-// messages that the coordinator loop never received. Dropping one panics in
-// `ClientTransmitter::drop`, and a panic in a destructor aborts the process, so this test's
-// only assertion is surviving the rounds.
+// Dropping queued write responses during shutdown must not panic in a destructor.
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // too slow
 #[allow(clippy::disallowed_methods)]
@@ -7277,7 +7273,6 @@ fn test_shutdown_with_inflight_writes() {
                     return;
                 };
                 while !stop.load(Ordering::Relaxed) {
-                    // Errors are expected once the server goes away.
                     if client.batch_execute("INSERT INTO t VALUES (1)").is_err() {
                         return;
                     }
@@ -7285,7 +7280,6 @@ fn test_shutdown_with_inflight_writes() {
             }));
         }
 
-        // Let the insert threads get going, then shut the server down under write load.
         thread::sleep(Duration::from_millis(500));
         drop(server);
 

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -713,6 +713,33 @@ impl PersistClient {
         Ok(machine.latest_schema())
     }
 
+    /// Fetches and returns a recent shard-global `upper`, without requiring a
+    /// [`WriteHandle`].
+    ///
+    /// Importantly, this operation is linearized with write operations, giving
+    /// the same guarantee as [`WriteHandle::fetch_recent_upper`]. It requires
+    /// fetching the latest state from consensus and is therefore a potentially
+    /// expensive operation.
+    ///
+    /// If `shard_id` has never been used before, initializes the shard and
+    /// returns an upper of `Antichain::from_elem(T::minimum())`.
+    pub async fn recent_upper<K, V, T, D>(
+        &self,
+        shard_id: ShardId,
+        diagnostics: Diagnostics,
+    ) -> Result<Antichain<T>, InvalidUsage<T>>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64 + Sync,
+        D: Monoid + Codec64 + Send + Sync,
+    {
+        let machine = self
+            .make_machine::<K, V, T, D>(shard_id, diagnostics)
+            .await?;
+        Ok(machine.applier.fetch_upper(|upper| upper.clone()).await)
+    }
+
     /// Registers a schema for the given shard.
     ///
     /// Returns the new schema ID if the registration succeeds, and `None`

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -303,11 +303,7 @@ impl StorageWriteOp {
     }
 }
 
-/// Metadata needed to register a table in the txns shard: the collection's data shard and its
-/// schema. Produced by [`StorageController::table_registrations`] and consumed by the table-write
-/// worker, which opens the persist write handles itself (handles are consumed by registration, so
-/// retries need fresh ones, and keeping the opening in the worker keeps that detail out of
-/// callers).
+/// Metadata required to register a table with the txns shard.
 #[derive(Debug, Clone)]
 pub struct TableRegistration {
     pub id: GlobalId,
@@ -315,34 +311,13 @@ pub struct TableRegistration {
     pub relation_desc: RelationDesc,
 }
 
-/// A cloneable, `Send + Sync` handle for writing to the txns shard from off the
-/// main storage-controller loop: table appends, table registration, and table
-/// forgetting.
+/// Queues txns-shard operations on the storage table worker.
 ///
-/// Commands issued through this handle go through the same single serializing
-/// worker as [`StorageController::append_table`], so they are applied in the
-/// order the methods are called, not the order the returned futures are polled.
-/// That ordering guarantee is load-bearing: an append containing writes for a
-/// table must reach the worker before the forget for that table, otherwise the
-/// worker has no registered shard to write to. The group committer is the only
-/// runtime caller, which makes it the single in-process serialization point for
-/// txns-shard writes.
-///
-/// A [`StorageError::InvalidUppers`] result means the timestamp was below the
-/// current txns-shard upper (another process wrote concurrently). The worker
-/// rolls its bookkeeping back in that case, and the caller must re-issue the
-/// command at a higher timestamp.
-///
-/// The handle stays valid for the lifetime of the controller (and thus the
-/// process). It does not track catalog rebuilds because the underlying worker
-/// is independent of them.
+/// The adapter's group committer is the sole runtime caller, preserving FIFO order across appends,
+/// registrations, and forgets. On [`StorageError::InvalidUppers`], the writable implementation
+/// restores its bookkeeping and the caller must retry at a fresh timestamp.
 pub trait TableWriteHandle: Debug + Send + Sync {
-    /// Appends `commands` at `write_ts`, advancing the upper of all registered
-    /// tables to `advance_to`.
-    ///
-    /// The returned receiver resolves once the append is durable, or with an
-    /// error if the write could not be applied. A dropped sender (receiver
-    /// error) means the worker has shut down.
+    /// Appends `commands` at `write_ts` and advances all registered tables to `advance_to`.
     fn append(
         &self,
         write_ts: Timestamp,
@@ -350,19 +325,14 @@ pub trait TableWriteHandle: Debug + Send + Sync {
         commands: Vec<(GlobalId, Vec<TableData>)>,
     ) -> oneshot::Receiver<Result<(), StorageError>>;
 
-    /// Registers `tables` in the txns shard at `register_ts`, making them
-    /// available for writes. Registering an empty set still advances the txns
-    /// shard to `register_ts`.
+    /// Registers `tables` at `register_ts`.
     fn register(
         &self,
         register_ts: Timestamp,
         tables: Vec<TableRegistration>,
     ) -> oneshot::Receiver<Result<(), StorageError>>;
 
-    /// Forgets `ids` in the txns shard at `forget_ts`. The tables' shards are
-    /// no longer written through the txns system afterwards. Ids that were
-    /// never registered are ignored, and if none remain the txns shard is not
-    /// touched at all.
+    /// Forgets registered `ids` at `forget_ts`, ignoring unknown IDs.
     fn forget(
         &self,
         forget_ts: Timestamp,
@@ -524,10 +494,9 @@ pub trait StorageController: Debug {
     /// must provide a Some if any of the collections is a table. A None may be given if none of the
     /// collections are a table (i.e. all materialized views, sources, etc).
     ///
-    /// This sets up storage but does not register tables in the txns shard. The caller registers
-    /// them (making them available for writes) through the group committer's
-    /// [`TableWriteHandle::register`] at runtime, or via [`Self::register_table_collections`] at
-    /// bootstrap.
+    /// This sets up storage but does not register tables in the txns shard. Runtime registration
+    /// must go through the adapter's group committer. Bootstrap uses
+    /// [`Self::register_table_collections_for_bootstrap`].
     async fn create_collections(
         &mut self,
         storage_metadata: &StorageMetadata,
@@ -585,11 +554,9 @@ pub trait StorageController: Debug {
         source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
     ) -> Result<(), StorageError>;
 
-    /// Evolves the [`RelationDesc`] of a table, creating the new collection.
+    /// Evolves a table's schema without registering the new collection in the txns shard.
     ///
-    /// This sets up the new collection but does not register it in the txns shard. The caller
-    /// registers it (making it available for writes) through the group committer's
-    /// [`TableWriteHandle::register`].
+    /// Runtime registration must go through the adapter's group committer.
     async fn alter_table_desc(
         &mut self,
         existing_collection: GlobalId,
@@ -598,44 +565,25 @@ pub trait StorageController: Debug {
         expected_version: RelationVersion,
     ) -> Result<(), StorageError>;
 
-    /// Registers tables in the txns shard, making them available for writes at `register_ts`.
+    /// Registers the `DataSource::Table` collections among `ids` during bootstrap.
     ///
-    /// This is a bootstrap-only convenience: bootstrap registers many tables at a caller-chosen
-    /// timestamp, and no group commits run concurrently, so the registration cannot conflict.
-    /// Runtime DDL must instead register through the group committer's [`TableWriteHandle`], the
-    /// single in-process serialization point for txns-shard writes, using
-    /// [`Self::table_registrations`] to obtain the registration metadata.
-    ///
-    /// Only `DataSource::Table` collections among `ids` are registered. Source-fed tables
-    /// (`IngestionExport`) and webhooks are created as table catalog items too but are written by
-    /// the storage layer, so they are ignored here. Callers may therefore pass all the collections
-    /// they created without pre-filtering. In read-only mode only migrated tables are registered,
-    /// since the read-write environment owns the rest.
-    async fn register_table_collections(
+    /// Runtime registration must go through the adapter's group committer. In read-only mode, only
+    /// migrated tables are registered.
+    async fn register_table_collections_for_bootstrap(
         &mut self,
         register_ts: Timestamp,
         ids: Vec<GlobalId>,
     ) -> Result<(), StorageError>;
 
-    /// Returns the txns-shard registration metadata for the `DataSource::Table` collections among
-    /// `ids`, which must already be set up via [`Self::create_collections`] or
-    /// [`Self::alter_table_desc`].
+    /// Returns registration metadata for the `DataSource::Table` collections among `ids`.
     ///
-    /// Non-table collections among `ids` (source-fed tables, webhooks) are silently skipped, the
-    /// data source is authoritative here, so callers can pass all the table catalog items they
-    /// have without pre-filtering. The result feeds [`TableWriteHandle::register`] and
-    /// [`TableWriteHandle::forget`].
+    /// Other data sources are ignored.
     fn table_registrations(
         &self,
         ids: Vec<GlobalId>,
     ) -> Result<Vec<TableRegistration>, StorageError>;
 
-    /// Returns the subset of `ids` that are `DataSource::Table` collections, i.e. the ones
-    /// written via the txns table-write path and registered in the txns shard.
-    ///
-    /// Like [`Self::table_registrations`], non-table collections among `ids` are silently
-    /// skipped, so callers can pass all the table catalog items they have without pre-filtering.
-    /// Use this to decide which collections need a txns-shard forget on drop.
+    /// Returns the `DataSource::Table` IDs among `ids`.
     fn txns_table_ids(&self, ids: Vec<GlobalId>) -> Result<Vec<GlobalId>, StorageError>;
 
     /// Acquire an immutable reference to the export state, should it exist.
@@ -670,13 +618,11 @@ pub trait StorageController: Debug {
         exports: BTreeMap<GlobalId, StorageSinkConnection>,
     ) -> Result<(), StorageError>;
 
-    /// Drops the read capability for the tables and allows their resources to be reclaimed.
+    /// Schedules controller cleanup for tables.
     ///
-    /// The txns-shard forget for the `DataSource::Table` collections among `identifiers` must
-    /// already have happened through the group committer's [`TableWriteHandle::forget`] before
-    /// this is called. This method only performs the controller-side cleanup: scheduling shard
-    /// finalization and dropping the collections.
-    fn drop_tables(
+    /// The txn-wal tables among `identifiers` must first be forgotten through the adapter's group
+    /// committer.
+    fn schedule_drop_tables_after_txns_forget(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
@@ -728,26 +674,18 @@ pub trait StorageController: Debug {
         identifiers: Vec<GlobalId>,
     ) -> Result<(), StorageError>;
 
-    /// Append `updates` into the local input named `id` and advance its upper to `upper`.
+    /// Appends to tables during bootstrap.
     ///
-    /// The method returns a oneshot that can be awaited to indicate completion of the write.
-    /// The method may return an error, indicating an immediately visible error, and also the
-    /// oneshot may return an error if one is encountered during the write.
-    ///
-    /// All updates in `commands` are applied atomically.
-    // TODO(petrosagg): switch upper to `Antichain<Timestamp>`
-    fn append_table(
+    /// Runtime writes must go through the adapter's group committer. The returned receiver resolves
+    /// when the atomic write completes.
+    fn append_table_for_bootstrap(
         &mut self,
         write_ts: Timestamp,
         advance_to: Timestamp,
         commands: Vec<(GlobalId, Vec<TableData>)>,
     ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError>;
 
-    /// Returns a cloneable handle for txns-shard writes (appends, registers, forgets) off the
-    /// main loop.
-    ///
-    /// See [`TableWriteHandle`]. The returned handle stays valid for the lifetime
-    /// of the controller.
+    /// Returns the process-lifetime storage mechanism used by the adapter's group committer.
     fn table_write_handle(&self) -> Arc<dyn TableWriteHandle>;
 
     /// Returns a [`MonotonicAppender`] which is a channel that can be used to monotonically

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -303,6 +303,73 @@ impl StorageWriteOp {
     }
 }
 
+/// Metadata needed to register a table in the txns shard: the collection's data shard and its
+/// schema. Produced by [`StorageController::table_registrations`] and consumed by the table-write
+/// worker, which opens the persist write handles itself (handles are consumed by registration, so
+/// retries need fresh ones, and keeping the opening in the worker keeps that detail out of
+/// callers).
+#[derive(Debug, Clone)]
+pub struct TableRegistration {
+    pub id: GlobalId,
+    pub data_shard: ShardId,
+    pub relation_desc: RelationDesc,
+}
+
+/// A cloneable, `Send + Sync` handle for writing to the txns shard from off the
+/// main storage-controller loop: table appends, table registration, and table
+/// forgetting.
+///
+/// Commands issued through this handle go through the same single serializing
+/// worker as [`StorageController::append_table`], so they are applied in the
+/// order the methods are called, not the order the returned futures are polled.
+/// That ordering guarantee is load-bearing: an append containing writes for a
+/// table must reach the worker before the forget for that table, otherwise the
+/// worker has no registered shard to write to. The group committer is the only
+/// runtime caller, which makes it the single in-process serialization point for
+/// txns-shard writes.
+///
+/// A [`StorageError::InvalidUppers`] result means the timestamp was below the
+/// current txns-shard upper (another process wrote concurrently). The worker
+/// rolls its bookkeeping back in that case, and the caller must re-issue the
+/// command at a higher timestamp.
+///
+/// The handle stays valid for the lifetime of the controller (and thus the
+/// process). It does not track catalog rebuilds because the underlying worker
+/// is independent of them.
+pub trait TableWriteHandle: Debug + Send + Sync {
+    /// Appends `commands` at `write_ts`, advancing the upper of all registered
+    /// tables to `advance_to`.
+    ///
+    /// The returned receiver resolves once the append is durable, or with an
+    /// error if the write could not be applied. A dropped sender (receiver
+    /// error) means the worker has shut down.
+    fn append(
+        &self,
+        write_ts: Timestamp,
+        advance_to: Timestamp,
+        commands: Vec<(GlobalId, Vec<TableData>)>,
+    ) -> oneshot::Receiver<Result<(), StorageError>>;
+
+    /// Registers `tables` in the txns shard at `register_ts`, making them
+    /// available for writes. Registering an empty set still advances the txns
+    /// shard to `register_ts`.
+    fn register(
+        &self,
+        register_ts: Timestamp,
+        tables: Vec<TableRegistration>,
+    ) -> oneshot::Receiver<Result<(), StorageError>>;
+
+    /// Forgets `ids` in the txns shard at `forget_ts`. The tables' shards are
+    /// no longer written through the txns system afterwards. Ids that were
+    /// never registered are ignored, and if none remain the txns shard is not
+    /// touched at all.
+    fn forget(
+        &self,
+        forget_ts: Timestamp,
+        ids: Vec<GlobalId>,
+    ) -> oneshot::Receiver<Result<(), StorageError>>;
+}
+
 #[async_trait(?Send)]
 pub trait StorageController: Debug {
     /// Marks the end of any initialization commands.
@@ -452,10 +519,15 @@ pub trait StorageController: Debug {
     /// collections and leave the controller in an inconsistent state. It is almost
     /// always wrong to do anything but abort the process on `Err`.
     ///
-    /// The `register_ts` is used as the initial timestamp that tables are available for reads. (We
+    /// The `register_ts` is the initial timestamp at which tables become available for reads. (We
     /// might later give non-tables the same treatment, but hold off on that initially.) Callers
     /// must provide a Some if any of the collections is a table. A None may be given if none of the
     /// collections are a table (i.e. all materialized views, sources, etc).
+    ///
+    /// This sets up storage but does not register tables in the txns shard. The caller registers
+    /// them (making them available for writes) through the group committer's
+    /// [`TableWriteHandle::register`] at runtime, or via [`Self::register_table_collections`] at
+    /// bootstrap.
     async fn create_collections(
         &mut self,
         storage_metadata: &StorageMetadata,
@@ -513,14 +585,50 @@ pub trait StorageController: Debug {
         source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
     ) -> Result<(), StorageError>;
 
+    /// Evolves the [`RelationDesc`] of a table, creating the new collection.
+    ///
+    /// This sets up the new collection but does not register it in the txns shard. The caller
+    /// registers it (making it available for writes) through the group committer's
+    /// [`TableWriteHandle::register`].
     async fn alter_table_desc(
         &mut self,
         existing_collection: GlobalId,
         new_collection: GlobalId,
         new_desc: RelationDesc,
         expected_version: RelationVersion,
-        register_ts: Timestamp,
     ) -> Result<(), StorageError>;
+
+    /// Registers tables in the txns shard, making them available for writes at `register_ts`.
+    ///
+    /// This is a bootstrap-only convenience: bootstrap registers many tables at a caller-chosen
+    /// timestamp, and no group commits run concurrently, so the registration cannot conflict.
+    /// Runtime DDL must instead register through the group committer's [`TableWriteHandle`], the
+    /// single in-process serialization point for txns-shard writes, using
+    /// [`Self::table_registrations`] to obtain the registration metadata.
+    ///
+    /// Only `DataSource::Table` collections among `ids` are registered. Source-fed tables
+    /// (`IngestionExport`) and webhooks are created as table catalog items too but are written by
+    /// the storage layer, so they are ignored here. Callers may therefore pass all the collections
+    /// they created without pre-filtering. In read-only mode only migrated tables are registered,
+    /// since the read-write environment owns the rest.
+    async fn register_table_collections(
+        &mut self,
+        register_ts: Timestamp,
+        ids: Vec<GlobalId>,
+    ) -> Result<(), StorageError>;
+
+    /// Returns the txns-shard registration metadata for the `DataSource::Table` collections among
+    /// `ids`, which must already be set up via [`Self::create_collections`] or
+    /// [`Self::alter_table_desc`].
+    ///
+    /// Non-table collections among `ids` (source-fed tables, webhooks) are silently skipped, the
+    /// data source is authoritative here, so callers can pass all the table catalog items they
+    /// have without pre-filtering. The result feeds [`TableWriteHandle::register`] and
+    /// [`TableWriteHandle::forget`].
+    fn table_registrations(
+        &self,
+        ids: Vec<GlobalId>,
+    ) -> Result<Vec<TableRegistration>, StorageError>;
 
     /// Acquire an immutable reference to the export state, should it exist.
     fn export(&self, id: GlobalId) -> Result<&ExportState, StorageError>;
@@ -555,11 +663,15 @@ pub trait StorageController: Debug {
     ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the tables and allows their resources to be reclaimed.
+    ///
+    /// The txns-shard forget for the `DataSource::Table` collections among `identifiers` must
+    /// already have happened through the group committer's [`TableWriteHandle::forget`] before
+    /// this is called. This method only performs the controller-side cleanup: scheduling shard
+    /// finalization and dropping the collections.
     fn drop_tables(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-        ts: Timestamp,
     ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
@@ -622,6 +734,13 @@ pub trait StorageController: Debug {
         advance_to: Timestamp,
         commands: Vec<(GlobalId, Vec<TableData>)>,
     ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError>;
+
+    /// Returns a cloneable handle for txns-shard writes (appends, registers, forgets) off the
+    /// main loop.
+    ///
+    /// See [`TableWriteHandle`]. The returned handle stays valid for the lifetime
+    /// of the controller.
+    fn table_write_handle(&self) -> Arc<dyn TableWriteHandle>;
 
     /// Returns a [`MonotonicAppender`] which is a channel that can be used to monotonically
     /// append to the specified [`GlobalId`].

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -630,6 +630,14 @@ pub trait StorageController: Debug {
         ids: Vec<GlobalId>,
     ) -> Result<Vec<TableRegistration>, StorageError>;
 
+    /// Returns the subset of `ids` that are `DataSource::Table` collections, i.e. the ones
+    /// written via the txns table-write path and registered in the txns shard.
+    ///
+    /// Like [`Self::table_registrations`], non-table collections among `ids` are silently
+    /// skipped, so callers can pass all the table catalog items they have without pre-filtering.
+    /// Use this to decide which collections need a txns-shard forget on drop.
+    fn txns_table_ids(&self, ids: Vec<GlobalId>) -> Result<Vec<GlobalId>, StorageError>;
+
     /// Acquire an immutable reference to the export state, should it exist.
     fn export(&self, id: GlobalId) -> Result<&ExportState, StorageError>;
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -496,7 +496,7 @@ pub trait StorageController: Debug {
     ///
     /// This sets up storage but does not register tables in the txns shard. Runtime registration
     /// must go through the adapter's group committer. Bootstrap uses
-    /// [`Self::register_table_collections_for_bootstrap`].
+    /// [`Self::register_table_collections`].
     async fn create_collections(
         &mut self,
         storage_metadata: &StorageMetadata,
@@ -569,7 +569,7 @@ pub trait StorageController: Debug {
     ///
     /// Runtime registration must go through the adapter's group committer. In read-only mode, only
     /// migrated tables are registered.
-    async fn register_table_collections_for_bootstrap(
+    async fn register_table_collections(
         &mut self,
         register_ts: Timestamp,
         ids: Vec<GlobalId>,
@@ -622,7 +622,7 @@ pub trait StorageController: Debug {
     ///
     /// The txn-wal tables among `identifiers` must first be forgotten through the adapter's group
     /// committer.
-    fn schedule_drop_tables_after_txns_forget(
+    fn drop_tables(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
@@ -678,7 +678,7 @@ pub trait StorageController: Debug {
     ///
     /// Runtime writes must go through the adapter's group committer. The returned receiver resolves
     /// when the atomic write completes.
-    fn append_table_for_bootstrap(
+    fn append_table(
         &mut self,
         write_ts: Timestamp,
         advance_to: Timestamp,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -242,6 +242,33 @@ pub struct Controller {
 ///
 /// With better parallelism during startup this would likely be unnecessary, but empirically we see
 /// some nice speedups with this relatively simple function.
+/// What `create_collections_for_bootstrap` opens per collection: a write handle for collections
+/// the controller writes directly, or just a recent, linearized upper for txns-managed tables,
+/// whose writes go through the table-write worker (which opens its own handles per
+/// registration).
+enum WriteHandleOrUpper {
+    Handle(WriteHandle<SourceData, (), Timestamp, StorageDiff>),
+    Upper(Antichain<Timestamp>),
+}
+
+impl WriteHandleOrUpper {
+    fn upper(&self) -> Antichain<Timestamp> {
+        match self {
+            Self::Handle(handle) => handle.upper().clone(),
+            Self::Upper(upper) => upper.clone(),
+        }
+    }
+
+    /// Returns the write handle, panicking for the `Upper` variant. Only call for data sources
+    /// that are never tables.
+    fn expect_handle(self, context: &str) -> WriteHandle<SourceData, (), Timestamp, StorageDiff> {
+        match self {
+            Self::Handle(handle) => handle,
+            Self::Upper(_) => panic!("write handle required: {context}"),
+        }
+    }
+}
+
 fn warm_persist_state_in_background(
     client: PersistClient,
     shard_ids: impl Iterator<Item = ShardId> + Send + 'static,
@@ -840,14 +867,34 @@ impl StorageController for Controller {
                     // but for now, it's helpful to have this mapping written down somewhere
                     debug!("mapping GlobalId={} to shard ({})", id, metadata.data_shard);
 
-                    let write = this
-                        .open_data_handles(
-                            &id,
-                            metadata.data_shard,
-                            metadata.relation_desc.clone(),
-                            persist_client,
-                        )
-                        .await;
+                    // Tables are written through the txns table-write worker, which opens its
+                    // own write handles per registration, so opening one here would be pure
+                    // overhead (an extra persist open per table on the startup path). The
+                    // controller only needs a recent upper for them.
+                    let write = if matches!(description.data_source, DataSource::Table) {
+                        let diagnostics = Diagnostics {
+                            shard_name: id.to_string(),
+                            handle_purpose: format!("controller data for {}", id),
+                        };
+                        let upper = persist_client
+                            .recent_upper::<SourceData, (), Timestamp, StorageDiff>(
+                                metadata.data_shard,
+                                diagnostics,
+                            )
+                            .await
+                            .expect("invalid persist usage");
+                        WriteHandleOrUpper::Upper(upper)
+                    } else {
+                        let write = this
+                            .open_data_handles(
+                                &id,
+                                metadata.data_shard,
+                                metadata.relation_desc.clone(),
+                                persist_client,
+                            )
+                            .await;
+                        WriteHandleOrUpper::Handle(write)
+                    };
 
                     Ok::<_, StorageError>((id, description, write, metadata))
                 }
@@ -973,7 +1020,7 @@ impl StorageController for Controller {
                     mz_ore::soft_assert_or_log!(
                         write_frontier.elements() == &[Timestamp::MIN]
                             || write_frontier.is_empty()
-                            || PartialOrder::less_than(&dependency_since, write_frontier),
+                            || PartialOrder::less_than(&dependency_since, &write_frontier),
                         "dependency since has advanced past dependent ({id}) upper \n
                             dependent ({id}): upper {:?} \n
                             dependency since {:?} \n
@@ -1002,7 +1049,7 @@ impl StorageController for Controller {
                     self.register_introspection_collection(
                         id,
                         *typ,
-                        write,
+                        write.expect_handle("introspection collections are not tables"),
                         persist_client.clone(),
                     )?;
                 }
@@ -1019,8 +1066,12 @@ impl StorageController for Controller {
                     // NOTE: Maybe this shouldn't be in the collection manager,
                     // and collection manager should only be responsible for
                     // built-in introspection collections?
-                    self.collection_manager
-                        .register_append_only_collection(id, write, false, None);
+                    self.collection_manager.register_append_only_collection(
+                        id,
+                        write.expect_handle("webhook collections are not tables"),
+                        false,
+                        None,
+                    );
                 }
                 DataSource::IngestionExport {
                     ingestion_id,
@@ -1437,6 +1488,11 @@ impl StorageController for Controller {
         if self.read_only {
             tables.retain(|table| self.migrated_storage_collections.contains(&table.id));
         }
+        // NOTE: Skipping the register when no tables remain also skips the txns-shard
+        // compare-and-append that acts as a cross-generation write barrier (see the module docs
+        // of the adapter's coord/appends.rs). That is safe only because a writable bootstrap
+        // always registers at least the builtin system tables, so its register set is never
+        // empty.
         if tables.is_empty() {
             return Ok(());
         }
@@ -1472,6 +1528,17 @@ impl StorageController for Controller {
                     data_shard: metadata.data_shard,
                     relation_desc: metadata.relation_desc.clone(),
                 });
+            }
+        }
+        Ok(tables)
+    }
+
+    fn txns_table_ids(&self, ids: Vec<GlobalId>) -> Result<Vec<GlobalId>, StorageError> {
+        let mut tables = Vec::with_capacity(ids.len());
+        for id in ids {
+            let collection = self.collection(id)?;
+            if matches!(collection.data_source, DataSource::Table) {
+                tables.push(id);
             }
         }
         Ok(tables)
@@ -3090,13 +3157,10 @@ where
         Ok(())
     }
 
-    /// Opens a write and critical since handles for the given `shard`.
+    /// Opens a write handle for the given `shard` and fetches a recent upper for it.
     ///
-    /// `since` is an optional `since` that the read handle will be forwarded to if it is less than
-    /// its current since.
-    ///
-    /// This will `halt!` the process if we cannot successfully acquire a critical handle with our
-    /// current epoch.
+    /// Used for collections the controller itself writes to. Tables are not opened through this,
+    /// see `create_collections_for_bootstrap`.
     async fn open_data_handles(
         &self,
         id: &GlobalId,
@@ -3119,12 +3183,9 @@ where
             .await
             .expect("invalid persist usage");
 
-        // N.B.
-        // Fetch the most recent upper for the write handle. Otherwise, this may be behind
-        // the since of the since handle. Its vital this happens AFTER we create
-        // the since handle as it needs to be linearized with that operation. It may be true
-        // that creating the write handle after the since handle already ensures this, but we
-        // do this out of an abundance of caution.
+        // Fetch the most recent upper for the write handle, so callers reading the cached
+        // upper (e.g. for collection-state init) see a linearized, recent value rather than
+        // whatever the handle was opened with.
         //
         // Note that this returns the upper, but also sets it on the handle to be fetched later.
         write.fetch_recent_upper().await;

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1468,7 +1468,7 @@ impl StorageController for Controller {
         Ok(())
     }
 
-    async fn register_table_collections_for_bootstrap(
+    async fn register_table_collections(
         &mut self,
         register_ts: Timestamp,
         ids: Vec<GlobalId>,
@@ -1806,7 +1806,7 @@ impl StorageController for Controller {
         Ok(())
     }
 
-    fn schedule_drop_tables_after_txns_forget(
+    fn drop_tables(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
@@ -2132,7 +2132,7 @@ impl StorageController for Controller {
     }
 
     #[instrument(level = "debug")]
-    fn append_table_for_bootstrap(
+    fn append_table(
         &mut self,
         write_ts: Timestamp,
         advance_to: Timestamp,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -58,7 +58,8 @@ use mz_storage_client::client::{
 use mz_storage_client::controller::{
     BoxFuture, CollectionDescription, DataSource, ExportDescription, ExportState,
     IntrospectionType, MonotonicAppender, PersistEpoch, Response, StorageController,
-    StorageMetadata, StorageTxn, StorageWriteOp, WallclockLag, WallclockLagHistogramPeriod,
+    StorageMetadata, StorageTxn, StorageWriteOp, TableRegistration, WallclockLag,
+    WallclockLagHistogramPeriod,
 };
 use mz_storage_client::healthcheck::{
     MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC, MZ_SINK_STATUS_HISTORY_DESC,
@@ -876,7 +877,6 @@ impl StorageController for Controller {
         // `DataSource::IngestionExport` is added as a new collection, but is
         // not executed directly.
         let mut new_collections = BTreeSet::new();
-        let mut table_registers = Vec::with_capacity(to_register.len());
 
         // Reorder in dependency order.
         to_register.sort_by_key(|(id, ..)| *id);
@@ -1079,9 +1079,9 @@ impl StorageController for Controller {
                 DataSource::Table => {
                     debug!(
                         ?data_source, meta = ?metadata,
-                        "registering {id} with persist table worker",
+                        "not registering {id} with the txns shard here; the caller does that \
+                         through the group committer",
                     );
-                    table_registers.push((id, write));
                 }
                 DataSource::Progress | DataSource::Other => {
                     debug!(
@@ -1155,36 +1155,6 @@ impl StorageController for Controller {
             // here.
         }
 
-        // Register the tables all in one batch.
-        if !table_registers.is_empty() {
-            let register_ts = register_ts
-                .expect("caller should have provided a register_ts when creating a table");
-
-            if self.read_only {
-                // In read-only mode, we use a special read-only table worker
-                // that allows writing to migrated tables and will continually
-                // bump their shard upper so that it tracks the txn shard upper.
-                // We do this, so that they remain readable at a recent
-                // timestamp, which in turn allows dataflows that depend on them
-                // to (re-)hydrate.
-                //
-                // We only want to register migrated tables, though, and leave
-                // existing tables out/never write to them in read-only mode.
-                table_registers
-                    .retain(|(id, _write_handle)| migrated_storage_collections.contains(id));
-
-                self.persist_table_worker
-                    .register(register_ts, table_registers)
-                    .await
-                    .expect("table worker unexpectedly shut down");
-            } else {
-                self.persist_table_worker
-                    .register(register_ts, table_registers)
-                    .await
-                    .expect("table worker unexpectedly shut down");
-            }
-        }
-
         self.append_shard_mappings(new_collections.into_iter(), Diff::ONE);
 
         // TODO(guswynn): perform the io in this final section concurrently.
@@ -1214,6 +1184,9 @@ impl StorageController for Controller {
             };
         }
 
+        // We do not register tables in the txns shard here. The caller does that as a separate
+        // step through the group committer (or `register_table_collections` at bootstrap), which
+        // owns timestamp selection and conflict handling for txns-shard writes.
         Ok(())
     }
 
@@ -1394,7 +1367,6 @@ impl StorageController for Controller {
         new_collection: GlobalId,
         new_desc: RelationDesc,
         expected_version: RelationVersion,
-        register_ts: Timestamp,
     ) -> Result<(), StorageError> {
         let data_shard = {
             let Controller {
@@ -1423,20 +1395,6 @@ impl StorageController for Controller {
             existing.collection_metadata.data_shard.clone()
         };
 
-        let persist_client = self
-            .persist
-            .open(self.persist_location.clone())
-            .await
-            .expect("invalid persist location");
-        let write_handle = self
-            .open_data_handles(
-                &existing_collection,
-                data_shard,
-                new_desc.clone(),
-                &persist_client,
-            )
-            .await;
-
         let collection_meta = CollectionMetadata {
             persist_location: self.persist_location.clone(),
             data_shard,
@@ -1457,14 +1415,66 @@ impl StorageController for Controller {
         // in-memory data structures.
         self.collections.insert(new_collection, collection_state);
 
-        self.persist_table_worker
-            .register(register_ts, vec![(new_collection, write_handle)])
-            .await
-            .expect("table worker unexpectedly shut down");
-
         self.append_shard_mappings([new_collection].into_iter(), Diff::ONE);
 
+        // We do not register the evolved collection in the txns shard here. The caller does that
+        // through the group committer, which owns timestamp selection and conflict handling for
+        // txns-shard writes.
         Ok(())
+    }
+
+    async fn register_table_collections(
+        &mut self,
+        register_ts: Timestamp,
+        ids: Vec<GlobalId>,
+    ) -> Result<(), StorageError> {
+        let mut tables = self.table_registrations(ids)?;
+
+        // In read-only mode only migrated tables are registered; the read-write environment owns
+        // the rest and we must not re-register them. The read-only table worker keeps a migrated
+        // table's shard upper tracking the txns upper so it stays readable at a recent timestamp,
+        // which lets dependent dataflows (re-)hydrate.
+        if self.read_only {
+            tables.retain(|table| self.migrated_storage_collections.contains(&table.id));
+        }
+        if tables.is_empty() {
+            return Ok(());
+        }
+
+        match self
+            .persist_table_worker
+            .register(register_ts, tables)
+            .await
+        {
+            Ok(res) => res,
+            // The worker is gone; treat as shutting down.
+            Err(_recv) => Err(StorageError::ShuttingDown("persist_table_worker")),
+        }
+    }
+
+    fn table_registrations(
+        &self,
+        ids: Vec<GlobalId>,
+    ) -> Result<Vec<TableRegistration>, StorageError> {
+        // Only `DataSource::Table` collections are written via the txns table-write path and thus
+        // registered in the txns shard. Source-fed tables (`IngestionExport`) and webhooks are
+        // also created as table catalog items, but they are written by the storage layer, so we
+        // ignore them here. Keeping this decision in the storage controller, where the data
+        // source is authoritative, means callers can pass all the collections they created
+        // without having to know which ones belong in the txns shard.
+        let mut tables = Vec::with_capacity(ids.len());
+        for id in ids {
+            let collection = self.collection(id)?;
+            if matches!(collection.data_source, DataSource::Table) {
+                let metadata = &collection.collection_metadata;
+                tables.push(TableRegistration {
+                    id,
+                    data_shard: metadata.data_shard,
+                    relation_desc: metadata.relation_desc.clone(),
+                });
+            }
+        }
+        Ok(tables)
     }
 
     fn export(&self, id: GlobalId) -> Result<&ExportState, StorageError> {
@@ -1767,7 +1777,6 @@ impl StorageController for Controller {
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-        ts: Timestamp,
     ) -> Result<(), StorageError> {
         // Collect tables by their data_source
         let (table_write_ids, data_source_ids): (Vec<_>, Vec<_>) = identifiers
@@ -1778,18 +1787,14 @@ impl StorageController for Controller {
                 _ => panic!("identifier is not a table: {}", id),
             });
 
-        // Drop table write tables
+        // Schedule cleanup of the table-write tables. The txns-shard forget has already happened
+        // through the group committer (see the trait docs), so all that is left is finalizing the
+        // shards and dropping the collections.
         if table_write_ids.len() > 0 {
-            let drop_notif = self
-                .persist_table_worker
-                .drop_handles(table_write_ids.clone(), ts);
             let tx = self.pending_table_handle_drops_tx.clone();
-            mz_ore::task::spawn(|| "table-cleanup".to_string(), async move {
-                drop_notif.await;
-                for identifier in table_write_ids {
-                    let _ = tx.send(identifier);
-                }
-            });
+            for identifier in table_write_ids {
+                let _ = tx.send(identifier);
+            }
         }
 
         // Drop source-fed tables
@@ -2128,6 +2133,12 @@ impl StorageController for Controller {
         Ok(self
             .persist_table_worker
             .append(write_ts, advance_to, commands))
+    }
+
+    fn table_write_handle(&self) -> Arc<dyn mz_storage_client::controller::TableWriteHandle> {
+        Arc::new(persist_handles::TableWriteWorkerHandle(
+            self.persist_table_worker.clone(),
+        ))
     }
 
     fn monotonic_appender(&self, id: GlobalId) -> Result<MonotonicAppender, StorageError> {
@@ -2771,7 +2782,10 @@ where
                 )
                 .await
                 .expect("txns schema shouldn't change");
-            persist_handles::PersistTableWriteWorker::new_read_only_mode(txns_write)
+            persist_handles::PersistTableWriteWorker::new_read_only_mode(
+                txns_write,
+                txns_client.clone(),
+            )
         } else {
             let mut txns = TxnsHandle::open(
                 Timestamp::MIN,
@@ -2783,7 +2797,7 @@ where
             )
             .await;
             txns.upgrade_version().await;
-            persist_handles::PersistTableWriteWorker::new_txns(txns)
+            persist_handles::PersistTableWriteWorker::new_txns(txns, txns_client.clone())
         };
         let txns_read = TxnsRead::start::<TxnsCodecRow>(txns_client.clone(), txns_id).await;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1235,9 +1235,6 @@ impl StorageController for Controller {
             };
         }
 
-        // We do not register tables in the txns shard here. The caller does that as a separate
-        // step through the group committer (or `register_table_collections` at bootstrap), which
-        // owns timestamp selection and conflict handling for txns-shard writes.
         Ok(())
     }
 
@@ -1468,31 +1465,20 @@ impl StorageController for Controller {
 
         self.append_shard_mappings([new_collection].into_iter(), Diff::ONE);
 
-        // We do not register the evolved collection in the txns shard here. The caller does that
-        // through the group committer, which owns timestamp selection and conflict handling for
-        // txns-shard writes.
         Ok(())
     }
 
-    async fn register_table_collections(
+    async fn register_table_collections_for_bootstrap(
         &mut self,
         register_ts: Timestamp,
         ids: Vec<GlobalId>,
     ) -> Result<(), StorageError> {
         let mut tables = self.table_registrations(ids)?;
 
-        // In read-only mode only migrated tables are registered; the read-write environment owns
-        // the rest and we must not re-register them. The read-only table worker keeps a migrated
-        // table's shard upper tracking the txns upper so it stays readable at a recent timestamp,
-        // which lets dependent dataflows (re-)hydrate.
+        // A read-only deployment only writes its migrated builtin tables.
         if self.read_only {
             tables.retain(|table| self.migrated_storage_collections.contains(&table.id));
         }
-        // NOTE: Skipping the register when no tables remain also skips the txns-shard
-        // compare-and-append that acts as a cross-generation write barrier (see the module docs
-        // of the adapter's coord/appends.rs). That is safe only because a writable bootstrap
-        // always registers at least the builtin system tables, so its register set is never
-        // empty.
         if tables.is_empty() {
             return Ok(());
         }
@@ -1503,7 +1489,6 @@ impl StorageController for Controller {
             .await
         {
             Ok(res) => res,
-            // The worker is gone; treat as shutting down.
             Err(_recv) => Err(StorageError::ShuttingDown("persist_table_worker")),
         }
     }
@@ -1512,12 +1497,7 @@ impl StorageController for Controller {
         &self,
         ids: Vec<GlobalId>,
     ) -> Result<Vec<TableRegistration>, StorageError> {
-        // Only `DataSource::Table` collections are written via the txns table-write path and thus
-        // registered in the txns shard. Source-fed tables (`IngestionExport`) and webhooks are
-        // also created as table catalog items, but they are written by the storage layer, so we
-        // ignore them here. Keeping this decision in the storage controller, where the data
-        // source is authoritative, means callers can pass all the collections they created
-        // without having to know which ones belong in the txns shard.
+        // The storage data source decides which table catalog items use txn-wal.
         let mut tables = Vec::with_capacity(ids.len());
         for id in ids {
             let collection = self.collection(id)?;
@@ -1826,26 +1806,11 @@ impl StorageController for Controller {
         Ok(())
     }
 
-    // Dropping a table takes roughly the following flow:
-    //
-    // First determine if this is a TableWrites table or a source-fed table (an IngestionExport):
-    //
-    // If this is a TableWrites table:
-    //   1. We remove the table from the persist table write worker.
-    //   2. The table removal is awaited in an async task.
-    //   3. A message is sent to the storage controller that the table has been removed from the
-    //      table write worker.
-    //   4. The controller drains all table drop messages during `process`.
-    //   5. `process` calls `drop_sources` with the dropped tables.
-    //
-    // If this is an IngestionExport table:
-    //   1. We validate the ids and then call drop_sources_unvalidated to proceed dropping.
-    fn drop_tables(
+    fn schedule_drop_tables_after_txns_forget(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
     ) -> Result<(), StorageError> {
-        // Collect tables by their data_source
         let (table_write_ids, data_source_ids): (Vec<_>, Vec<_>) = identifiers
             .into_iter()
             .partition(|id| match self.collections[id].data_source {
@@ -1854,9 +1819,6 @@ impl StorageController for Controller {
                 _ => panic!("identifier is not a table: {}", id),
             });
 
-        // Schedule cleanup of the table-write tables. The txns-shard forget has already happened
-        // through the group committer (see the trait docs), so all that is left is finalizing the
-        // shards and dropping the collections.
         if table_write_ids.len() > 0 {
             let tx = self.pending_table_handle_drops_tx.clone();
             for identifier in table_write_ids {
@@ -1864,7 +1826,6 @@ impl StorageController for Controller {
             }
         }
 
-        // Drop source-fed tables
         if data_source_ids.len() > 0 {
             self.validate_collection_ids(data_source_ids.iter().cloned())?;
             self.drop_sources_unvalidated(storage_metadata, data_source_ids)?;
@@ -2171,7 +2132,7 @@ impl StorageController for Controller {
     }
 
     #[instrument(level = "debug")]
-    fn append_table(
+    fn append_table_for_bootstrap(
         &mut self,
         write_ts: Timestamp,
         advance_to: Timestamp,
@@ -3157,10 +3118,7 @@ where
         Ok(())
     }
 
-    /// Opens a write handle for the given `shard` and fetches a recent upper for it.
-    ///
-    /// Used for collections the controller itself writes to. Tables are not opened through this,
-    /// see `create_collections_for_bootstrap`.
+    /// Opens a write handle and synchronizes its cached upper.
     async fn open_data_handles(
         &self,
         id: &GlobalId,
@@ -3183,11 +3141,7 @@ where
             .await
             .expect("invalid persist usage");
 
-        // Fetch the most recent upper for the write handle, so callers reading the cached
-        // upper (e.g. for collection-state init) see a linearized, recent value rather than
-        // whatever the handle was opened with.
-        //
-        // Note that this returns the upper, but also sets it on the handle to be fetched later.
+        // Synchronize the cached upper before it initializes collection state.
         write.fetch_recent_upper().await;
 
         write

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -15,15 +15,16 @@ use std::fmt::Debug;
 use std::fmt::Write;
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
+use futures::StreamExt;
 use futures::stream::FuturesUnordered;
-use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_persist_client::ShardId;
 use mz_persist_client::write::WriteHandle;
+use mz_persist_client::{Diagnostics, PersistClient, ShardId};
+use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::client::{TableData, Update};
+use mz_storage_client::controller::TableRegistration;
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::{InvalidUpper, TxnsCodecRow};
 use mz_storage_types::sources::SourceData;
@@ -47,32 +48,15 @@ pub struct PersistTableWriteWorker {
 enum PersistTableWriteCmd {
     Register(
         Timestamp,
-        Vec<(
-            GlobalId,
-            WriteHandle<SourceData, (), Timestamp, StorageDiff>,
-        )>,
-        tokio::sync::oneshot::Sender<()>,
+        Vec<TableRegistration>,
+        tokio::sync::oneshot::Sender<Result<(), StorageError>>,
     ),
-    Update {
-        /// Existing collection for the table.
-        existing_collection: GlobalId,
-        /// New collection we'll emit writes to.
-        new_collection: GlobalId,
-        /// Timestamp to forget the original handle at.
-        forget_ts: Timestamp,
-        /// Timestamp to register the new handle at.
-        register_ts: Timestamp,
-        /// New write handle to register.
-        handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
-        /// Notifies us when the handle has been updated.
-        tx: oneshot::Sender<()>,
-    },
     DropHandles {
         forget_ts: Timestamp,
         /// Tables that we want to drop our handle for.
         ids: Vec<GlobalId>,
         /// Notifies us when all resources have been cleaned up.
-        tx: oneshot::Sender<()>,
+        tx: oneshot::Sender<Result<(), StorageError>>,
     },
     Append {
         write_ts: Timestamp,
@@ -87,12 +71,46 @@ impl PersistTableWriteCmd {
     fn name(&self) -> &'static str {
         match self {
             PersistTableWriteCmd::Register(_, _, _) => "PersistTableWriteCmd::Register",
-            PersistTableWriteCmd::Update { .. } => "PersistTableWriteCmd::Update",
             PersistTableWriteCmd::DropHandles { .. } => "PersistTableWriteCmd::DropHandle",
             PersistTableWriteCmd::Append { .. } => "PersistTableWriteCmd::Append",
             PersistTableWriteCmd::Shutdown => "PersistTableWriteCmd::Shutdown",
         }
     }
+}
+
+/// Opens write handles for `tables`, concurrently since bootstrap registers many tables at once.
+///
+/// Registration consumes write handles (also on conflict), so the workers open fresh ones per
+/// register command rather than having callers thread handles through.
+async fn open_table_write_handles(
+    persist_client: &PersistClient,
+    tables: Vec<TableRegistration>,
+) -> Vec<(
+    GlobalId,
+    WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+)> {
+    futures::stream::iter(tables)
+        .map(|table| async move {
+            let mut write = persist_client
+                .open_writer(
+                    table.data_shard,
+                    Arc::new(table.relation_desc),
+                    Arc::new(UnitSchema),
+                    Diagnostics {
+                        shard_name: table.id.to_string(),
+                        handle_purpose: format!("table write worker data for {}", table.id),
+                    },
+                )
+                .await
+                .expect("invalid persist usage");
+            // Fetch the most recent upper: a freshly opened handle may otherwise report an upper
+            // behind the shard's since.
+            write.fetch_recent_upper().await;
+            (table.id, write)
+        })
+        .buffer_unordered(50)
+        .collect()
+        .await
 }
 
 async fn append_work(
@@ -164,12 +182,13 @@ impl PersistTableWriteWorker {
     /// upper of the txns shard.
     pub(crate) fn new_read_only_mode(
         txns_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        persist_client: PersistClient,
     ) -> Self {
         let (tx, rx) =
             tokio::sync::mpsc::unbounded_channel::<(tracing::Span, PersistTableWriteCmd)>();
         mz_ore::task::spawn(
             || "PersistTableWriteWorker",
-            read_only_table_worker::read_only_mode_table_worker(rx, txns_handle),
+            read_only_table_worker::read_only_mode_table_worker(rx, txns_handle, persist_client),
         );
         Self {
             inner: Arc::new(PersistTableWriteWorkerInner::new(tx)),
@@ -178,12 +197,14 @@ impl PersistTableWriteWorker {
 
     pub(crate) fn new_txns(
         txns: TxnsHandle<SourceData, (), Timestamp, StorageDiff, TxnsCodecRow>,
+        persist_client: PersistClient,
     ) -> Self {
         let (tx, rx) =
             tokio::sync::mpsc::unbounded_channel::<(tracing::Span, PersistTableWriteCmd)>();
         mz_ore::task::spawn(|| "PersistTableWriteWorker", async move {
             let mut worker = TxnsTableWorker {
                 txns,
+                persist_client,
                 write_handles: BTreeMap::new(),
                 tidy: Tidy::default(),
             };
@@ -197,44 +218,13 @@ impl PersistTableWriteWorker {
     pub(crate) fn register(
         &self,
         register_ts: Timestamp,
-        ids_handles: Vec<(
-            GlobalId,
-            WriteHandle<SourceData, (), Timestamp, StorageDiff>,
-        )>,
-    ) -> tokio::sync::oneshot::Receiver<()> {
+        tables: Vec<TableRegistration>,
+    ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
         // We expect this to be awaited, so keep the span connected.
         let span = info_span!("PersistTableWriteCmd::Register");
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let cmd = PersistTableWriteCmd::Register(register_ts, ids_handles, tx);
+        let cmd = PersistTableWriteCmd::Register(register_ts, tables, tx);
         self.inner.send_with_span(span, cmd);
-        rx
-    }
-
-    /// Update the existing write handle associated with `id` to `write_handle`.
-    ///
-    /// Note that this should only be called when updating a write handle; to
-    /// initially associate an `id` to a write handle, use [`Self::register`].
-    ///
-    /// # Panics
-    /// - If `id` is not currently associated with any write handle.
-    #[allow(dead_code)]
-    pub(crate) fn update(
-        &self,
-        existing_collection: GlobalId,
-        new_collection: GlobalId,
-        forget_ts: Timestamp,
-        register_ts: Timestamp,
-        handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
-    ) -> oneshot::Receiver<()> {
-        let (tx, rx) = oneshot::channel();
-        self.send(PersistTableWriteCmd::Update {
-            existing_collection,
-            new_collection,
-            forget_ts,
-            register_ts,
-            handle,
-            tx,
-        });
         rx
     }
 
@@ -258,27 +248,51 @@ impl PersistTableWriteWorker {
         rx
     }
 
-    /// Drops the handles associated with `ids` from this worker.
-    ///
-    /// Note that this does not perform any other cleanup, such as finalizing
-    /// the handle's shard.
-    pub(crate) fn drop_handles(
-        &self,
-        ids: Vec<GlobalId>,
-        forget_ts: Timestamp,
-    ) -> BoxFuture<'static, ()> {
-        let (tx, rx) = oneshot::channel();
-        self.send(PersistTableWriteCmd::DropHandles { forget_ts, ids, tx });
-        Box::pin(rx.map(|_| ()))
-    }
-
     fn send(&self, cmd: PersistTableWriteCmd) {
         self.inner.send(cmd);
     }
 }
 
+/// A cloneable [`TableWriteHandle`](mz_storage_client::controller::TableWriteHandle)
+/// backed by the [`PersistTableWriteWorker`].
+///
+/// A newtype so the trait methods do not clash with the inherent ones.
+#[derive(Debug, Clone)]
+pub(crate) struct TableWriteWorkerHandle(pub(crate) PersistTableWriteWorker);
+
+impl mz_storage_client::controller::TableWriteHandle for TableWriteWorkerHandle {
+    fn append(
+        &self,
+        write_ts: Timestamp,
+        advance_to: Timestamp,
+        commands: Vec<(GlobalId, Vec<TableData>)>,
+    ) -> oneshot::Receiver<Result<(), StorageError>> {
+        self.0.append(write_ts, advance_to, commands)
+    }
+
+    fn register(
+        &self,
+        register_ts: Timestamp,
+        tables: Vec<TableRegistration>,
+    ) -> oneshot::Receiver<Result<(), StorageError>> {
+        self.0.register(register_ts, tables)
+    }
+
+    fn forget(
+        &self,
+        forget_ts: Timestamp,
+        ids: Vec<GlobalId>,
+    ) -> oneshot::Receiver<Result<(), StorageError>> {
+        let (tx, rx) = oneshot::channel();
+        self.0
+            .send(PersistTableWriteCmd::DropHandles { forget_ts, ids, tx });
+        rx
+    }
+}
+
 struct TxnsTableWorker {
     txns: TxnsHandle<SourceData, (), Timestamp, StorageDiff, TxnsCodecRow>,
+    persist_client: PersistClient,
     write_handles: BTreeMap<GlobalId, ShardId>,
     tidy: Tidy,
 }
@@ -290,36 +304,15 @@ impl TxnsTableWorker {
     ) {
         while let Some((span, command)) = rx.recv().await {
             match command {
-                PersistTableWriteCmd::Register(register_ts, ids_handles, tx) => {
-                    self.register(register_ts, ids_handles)
-                        .instrument(span)
-                        .await;
+                PersistTableWriteCmd::Register(register_ts, tables, tx) => {
+                    let res = self.register(register_ts, tables).instrument(span).await;
                     // We don't care if our waiter has gone away.
-                    let _ = tx.send(());
-                }
-                PersistTableWriteCmd::Update {
-                    existing_collection,
-                    new_collection,
-                    forget_ts,
-                    register_ts,
-                    handle,
-                    tx,
-                } => {
-                    async {
-                        self.drop_handles(vec![existing_collection], forget_ts)
-                            .await;
-                        self.register(register_ts, vec![(new_collection, handle)])
-                            .await;
-                    }
-                    .instrument(span)
-                    .await;
-                    // We don't care if our waiter has gone away.
-                    let _ = tx.send(());
+                    let _ = tx.send(res);
                 }
                 PersistTableWriteCmd::DropHandles { forget_ts, ids, tx } => {
-                    self.drop_handles(ids, forget_ts).instrument(span).await;
+                    let res = self.drop_handles(ids, forget_ts).instrument(span).await;
                     // We don't care if our waiter has gone away.
-                    let _ = tx.send(());
+                    let _ = tx.send(res);
                 }
                 PersistTableWriteCmd::Append {
                     write_ts,
@@ -344,11 +337,9 @@ impl TxnsTableWorker {
     async fn register(
         &mut self,
         register_ts: Timestamp,
-        mut ids_handles: Vec<(
-            GlobalId,
-            WriteHandle<SourceData, (), Timestamp, StorageDiff>,
-        )>,
-    ) {
+        tables: Vec<TableRegistration>,
+    ) -> Result<(), StorageError> {
+        let mut ids_handles = open_table_write_handles(&self.persist_client, tables).await;
         // As tables evolve (e.g. columns are added) we treat the older versions as
         // "views" on the later versions. While it's not required, it's easier to reason
         // about table registration if we do it in GlobalId order.
@@ -373,38 +364,79 @@ impl TxnsTableWorker {
         match res {
             Ok(tidy) => {
                 self.tidy.merge(tidy);
+                Ok(())
             }
             Err(current) => {
-                panic!(
-                    "cannot register {:?} at {:?} because txns is at {:?}",
-                    new_ids, register_ts, current
+                // The register timestamp was behind the txns upper, most likely because the
+                // off-loop group committer advanced it between our timestamp allocation and this
+                // call. Roll back the bookkeeping we just did so the caller can retry at a fresh
+                // timestamp, and report the conflict as an `InvalidUppers`.
+                debug!(
+                    "register at {:?} conflicted with txns upper {:?}, rolling back {:?}",
+                    register_ts, current, new_ids
                 );
+                for id in &new_ids {
+                    self.write_handles.remove(id);
+                }
+                Err(StorageError::InvalidUppers(
+                    new_ids
+                        .into_iter()
+                        .map(|id| InvalidUpper {
+                            id,
+                            current_upper: Antichain::from_elem(current),
+                        })
+                        .collect(),
+                ))
             }
         }
     }
 
-    async fn drop_handles(&mut self, ids: Vec<GlobalId>, forget_ts: Timestamp) {
+    async fn drop_handles(
+        &mut self,
+        ids: Vec<GlobalId>,
+        forget_ts: Timestamp,
+    ) -> Result<(), StorageError> {
         tracing::info!(?ids, "drop tables");
-        let data_ids = ids
+        let removed = ids
             .iter()
             // n.b. this should only remove the handle from the persist
             // worker and not take any additional action such as closing
             // the shard it's connected to because dataflows might still
             // be using it.
-            .filter_map(|id| self.write_handles.remove(id))
+            .filter_map(|id| self.write_handles.remove(id).map(|shard| (*id, shard)))
+            .collect::<Vec<_>>();
+        let data_ids = removed
+            .iter()
+            .map(|(_, shard)| *shard)
             .collect::<BTreeSet<_>>();
         if !data_ids.is_empty() {
             match self.txns.forget(forget_ts, data_ids.clone()).await {
                 Ok(tidy) => {
                     self.tidy.merge(tidy);
+                    Ok(())
                 }
                 Err(current) => {
-                    panic!(
-                        "cannot forget {:?} at {:?} because txns is at {:?}",
-                        ids, forget_ts, current
+                    // The forget timestamp was behind the txns upper (see `register`). Restore the
+                    // bookkeeping so the caller can retry at a fresh timestamp.
+                    debug!(
+                        "forget at {:?} conflicted with txns upper {:?}, restoring {:?}",
+                        forget_ts, current, ids
                     );
+                    for (id, shard) in removed {
+                        self.write_handles.insert(id, shard);
+                    }
+                    Err(StorageError::InvalidUppers(
+                        ids.into_iter()
+                            .map(|id| InvalidUpper {
+                                id,
+                                current_upper: Antichain::from_elem(current),
+                            })
+                            .collect(),
+                    ))
                 }
             }
+        } else {
+            Ok(())
         }
     }
 

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -78,10 +78,9 @@ impl PersistTableWriteCmd {
     }
 }
 
-/// Opens write handles for `tables`, concurrently since bootstrap registers many tables at once.
+/// Opens fresh table write handles concurrently.
 ///
-/// Registration consumes write handles (also on conflict), so the workers open fresh ones per
-/// register command rather than having callers thread handles through.
+/// Registration consumes handles even on conflict, so retries cannot reuse them.
 async fn open_table_write_handles(
     persist_client: &PersistClient,
     tables: Vec<TableRegistration>,
@@ -253,10 +252,8 @@ impl PersistTableWriteWorker {
     }
 }
 
-/// A cloneable [`TableWriteHandle`](mz_storage_client::controller::TableWriteHandle)
-/// backed by the [`PersistTableWriteWorker`].
-///
-/// A newtype so the trait methods do not clash with the inherent ones.
+/// A [`TableWriteHandle`](mz_storage_client::controller::TableWriteHandle) backed by the table
+/// worker.
 #[derive(Debug, Clone)]
 pub(crate) struct TableWriteWorkerHandle(pub(crate) PersistTableWriteWorker);
 
@@ -367,10 +364,8 @@ impl TxnsTableWorker {
                 Ok(())
             }
             Err(current) => {
-                // The register timestamp was behind the txns upper, most likely because the
-                // off-loop group committer advanced it between our timestamp allocation and this
-                // call. Roll back the bookkeeping we just did so the caller can retry at a fresh
-                // timestamp, and report the conflict as an `InvalidUppers`.
+                // Registration consumed the handles. Roll back the IDs so a fresh retry can
+                // register them.
                 debug!(
                     "register at {:?} conflicted with txns upper {:?}, rolling back {:?}",
                     register_ts, current, new_ids
@@ -416,8 +411,7 @@ impl TxnsTableWorker {
                     Ok(())
                 }
                 Err(current) => {
-                    // The forget timestamp was behind the txns upper (see `register`). Restore the
-                    // bookkeeping so the caller can retry at a fresh timestamp.
+                    // Restore local bookkeeping before the caller retries.
                     debug!(
                         "forget at {:?} conflicted with txns upper {:?}, restoring {:?}",
                         forget_ts, current, ids

--- a/src/storage-controller/src/persist_handles/read_only_table_worker.rs
+++ b/src/storage-controller/src/persist_handles/read_only_table_worker.rs
@@ -49,6 +49,7 @@ use crate::persist_handles::{PersistTableWriteCmd, append_work};
 pub(crate) async fn read_only_mode_table_worker(
     mut rx: tokio::sync::mpsc::UnboundedReceiver<(Span, PersistTableWriteCmd)>,
     txns_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+    persist_client: mz_persist_client::PersistClient,
 ) {
     let mut write_handles =
         BTreeMap::<GlobalId, WriteHandle<SourceData, (), Timestamp, StorageDiff>>::new();
@@ -93,7 +94,7 @@ pub(crate) async fn read_only_mode_table_worker(
                     commands.push_back(cmd);
                 }
 
-                let result = handle_commands(&mut write_handles, commands).await;
+                let result = handle_commands(&mut write_handles, commands, &persist_client).await;
 
                 match result {
                     ControlFlow::Continue(_) => {
@@ -115,6 +116,7 @@ pub(crate) async fn read_only_mode_table_worker(
 async fn handle_commands(
     write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), Timestamp, StorageDiff>>,
     mut commands: VecDeque<(Span, PersistTableWriteCmd)>,
+    persist_client: &mz_persist_client::PersistClient,
 ) -> ControlFlow<String> {
     let mut shutdown = false;
 
@@ -124,7 +126,9 @@ async fn handle_commands(
 
     while let Some((span, command)) = commands.pop_front() {
         match command {
-            PersistTableWriteCmd::Register(_register_ts, ids_handles, tx) => {
+            PersistTableWriteCmd::Register(_register_ts, tables, tx) => {
+                let ids_handles =
+                    crate::persist_handles::open_table_write_handles(persist_client, tables).await;
                 for (id, write_handle) in ids_handles {
                     // As of today, we can only migrate builtin (system) tables.
                     assert!(id.is_system(), "trying to register non-system id {id}");
@@ -135,22 +139,7 @@ async fn handle_commands(
                     }
                 }
                 // We don't care if our waiter has gone away.
-                let _ = tx.send(());
-            }
-            PersistTableWriteCmd::Update {
-                existing_collection,
-                new_collection,
-                handle,
-                forget_ts: _,
-                register_ts: _,
-                tx,
-            } => {
-                write_handles.remove(&existing_collection);
-                write_handles.insert(new_collection, handle).expect(
-                    "PersistTableWriteCmd::Update only valid for updating extant write handles",
-                );
-                // We don't care if our waiter has gone away.
-                let _ = tx.send(());
+                let _ = tx.send(Ok(()));
             }
             PersistTableWriteCmd::DropHandles {
                 forget_ts: _,
@@ -167,7 +156,7 @@ async fn handle_commands(
                     write_handles.remove(&id);
                 }
                 // We don't care if our waiter has gone away.
-                let _ = tx.send(());
+                let _ = tx.send(Ok(()));
             }
             PersistTableWriteCmd::Append {
                 write_ts,


### PR DESCRIPTION
## Motivation

The group commit path did its timestamp-oracle round trips inline on the coordinator loop: `peek_write_ts` and `write_ts` when allocating the write timestamp, and `read_ts` when downgrading read holds afterwards. The keepalive commit fires every `default_timestamp_interval` (1s) regardless of load, so under a slow oracle backend the loop spent most of its time blocked on these round trips and stalled every other session, including pure reads that never touch the oracle.

Under an injected 500ms oracle latency with 8 concurrent INSERT workers, a victim `SELECT 1` goes from multiple seconds to p50 6ms / p95 9ms with this change.

Fixes SQL-447

## The design

**A single group committer task owns all txns-shard writes.** The loop only does the cheap, state-touching work: `stage_group_commit` drains pending writes, validates and acquires write locks, builds the append batch, and hands a command to the committer. The committer owns the write protocol, per attempt: allocate the write timestamp, advance the catalog shard upper (keeping the catalog readable at the read timestamp the oracle moves to, and re-checking leadership before user data is written, see #28216), issue the txns-shard write, and apply the write to the oracle only after success. Finalization that needs coordinator state (statement-logging timestamps, retiring client responses, downgrading read holds) goes back to the loop via `Message::GroupCommitApplied`.

**DDL's table registration and forgetting flow through the same queue** as commands, which makes the committer the single in-process writer to the txns shard. That single-sender ordering is load-bearing: a staged INSERT for a table always reaches the table-write worker before a later DROP TABLE's forget (DROP takes no write locks, so nothing else orders the two), and in-process timestamp conflicts on the txns shard are impossible by construction. An `InvalidUppers` conflict from the worker therefore means exactly one thing: another process wrote the txns shard. The committer retries at a fresh oracle timestamp, which is the posture we want for future concurrent `environmentd` instances. The worker returns the conflict instead of panicking, rolls back its bookkeeping so retries are clean, and opens its own table write handles from registration metadata (registration consumes handles, so retries need fresh ones). DROP TABLE's txns forget moves off the loop in the process. The bootstrap-only `register_table_collections` remains the one direct registration path, safe because nothing else runs during bootstrap.

**The catalog shard gets a matching write-conflict protocol, enforced by the compare-and-append itself** rather than by checks before it (per the guidance in `doc/developer/guide-adapter.md`). The strict/tolerant `advance_upper` duality collapses into one to-at-least primitive, and both it and `commit_transaction` classify an upper mismatch by counting raw updates applied by the conflict sync: zero means pure empty progress (e.g. the committer bumping the upper with a timestamp that an on-loop catalog transaction overtook), which is rebased over and retried, while content from another writer surfaces as the graceful `CatalogOutOfSync` error instead of the previous panic paths. ID allocation and DDL transactions tolerate overtaken commit timestamps the same way. Raw updates rather than memory updates matter because some kinds (ID allocators) never surface as memory updates but still invalidate a rebase.

**Throttle behavior.** While waiting in the wall-clock throttle the committer merges later queued group commits into the current batch, which bounds queue growth under a slow oracle and lets an arriving internal system write flip the throttle bypass. A queued register or forget also lifts the throttle, since a DDL statement is blocked on the loop behind it and DDL was never throttled when it ran on the loop. Merging stops at such commands to preserve queue order.

## Testing

- New tests in `src/catalog/tests/read-write.rs` cover the to-at-least advance semantics, the commit rebase over an overtaken timestamp, and the compare-and-append conflict classification against a concurrent empty-progress writer (injected through a raw persist handle on the catalog shard).
- A deterministic unit test in `appends.rs` drives the committer's `write_to_txns` through an injected txns-shard conflict against a real debug catalog: retry at a fresh, strictly larger oracle timestamp, durable catalog upper advancement, and exactly one oracle write application, for the successful attempt. (In-process txns conflicts are impossible by construction, so the conflict is injected through a mock table write handle.)
- A regression test drops the server with INSERTs in flight, which used to abort the process via un-retired client responses in queues (a destructor panic). Shutdown posture: no graceful completion of in-flight responses, a drop backstop on `ExecuteContext` retires stranded clients with an error.
- Manual validation: injected 500ms oracle latency with concurrent inserters and DDL (latency numbers above), and a fast-oracle stress with three inserters and three concurrent CREATE/DROP TABLE loops, with read-your-writes and cross-session reads intact and no panics. That stress exercised the catalog shard's empty-progress rebase (DDL commits racing the committer's upper advancement), not txns-shard conflicts, which are covered by the deterministic test above.
- The single-writer invariant and the catalog conflict protocol are recorded in `doc/developer/guide-adapter.md`.

## Tips for reviewer

The interesting files are `src/adapter/src/coord/appends.rs` (the committer task and its protocol), `src/catalog/src/durable/persist.rs` (`advance_upper` and `commit_transaction`), and `src/storage-controller/src/persist_handles.rs` (worker-side handle opening and conflict rollback).

## Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
