### PR TITLE
edu-54: update procedure for TF upgrades

### DIFF
--- a/doc/user/content/self-managed-deployments/upgrading/upgrade-on-aws.md
+++ b/doc/user/content/self-managed-deployments/upgrading/upgrade-on-aws.md
@@ -34,7 +34,6 @@ name="downgrade-restriction" >}}
 - [Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform)
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 - [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html)
-- [Helm 3.2.0+](https://helm.sh/docs/intro/install/)
 
 ## Upgrade process
 
@@ -44,83 +43,95 @@ The following procedure performs a rolling upgrade, where both the old and new M
 
 {{</ important >}}
 
-### Step 1: Set up
+### Step 1: Update TF module source version
 
-1. Open a Terminal window.
-
-1. Configure AWS CLI with your AWS credentials. For details, see the [AWS
-   documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
-
-1. Go to the Terraform directory for your Materialize deployment. For example,
-   if you deployed from the `aws/examples/simple` directory:
-
-   ```bash
-   cd materialize-terraform-self-managed/aws/examples/simple
-   ```
-
-1. Ensure your AWS CLI is configured with the appropriate profile, substitute
-   `<your-aws-profile>` with the profile to use:
-
-   ```bash
-   # Set your AWS profile for the session
-   export AWS_PROFILE=<your-aws-profile>
-   ```
-
-1. Configure `kubectl` to connect to your EKS cluster, replacing:
-
-   - `<your-eks-cluster-name>` with the your cluster name; i.e., the
-     `eks_cluster_name` in the Terraform output. For the
-     sample example, your cluster name has the form `{prefix_name}-eks`; e.g.,
-     `simple-demo-eks`.
-
-   - `<your-region>` with the region of your cluster. Your region can be
-     found in your `terraform.tfvars` file; e.g., `us-east-1`.
-
-   ```bash
-   # aws eks update-kubeconfig --name <your-eks-cluster-name> --region <your-region>
-   aws eks update-kubeconfig --name $(terraform output -raw eks_cluster_name) --region <your-region>
-   ```
-
-   To verify that you have configured correctly, run the following command:
-
-   ```bash
-   kubectl get nodes
-   ```
-
-   For help with `kubectl` commands, see [kubectl Quick reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
-
-### Step 2: Update the Helm Chart
+Update each module's `source` to point to the desired release tag, substituting
+`<RELEASE_TAG>` in the code block below with your tag version:
 
 {{< important >}}
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+The following code block is not comprehensive. Only the core modules and their
+dependency chain are shown below.
 
-{{</ important >}}
+If your configuration includes additional modules (networking, storage,
+database, node pools, etc.) provided by Materialize, **update those to the same
+release tag as well**.
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-update-helm-chart" %}}
+{{< /important >}}
 
-### Step 3: Upgrade the Materialize Operator
+```hcl
+module "eks" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//aws/modules/eks?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
+}
 
-{{< important >}}
+module "cert_manager" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//kubernetes/modules/cert-manager?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.eks]
+}
 
-{{</ important >}}
+module "operator" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//aws/modules/operator?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-materialize-operator" %}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.cert_manager]
+}
 
-### Step 4: Upgrading Materialize Instances
+module "materialize_instance" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//kubernetes/modules/materialize-instance?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{< important >}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.operator]
+}
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+# Update the source of any additional Materialize-provided modules to the same release tag
+```
 
-{{</ important >}}
+### Step 2: Request rollout
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-materialize-instance" %}}
+{{% include-from-yaml data="self_managed/upgrades" name="upgrade-request_rollout" %}}
+
+### Step 3: Apply the updated TF
+
+1. Initialize the Terraform directory to download the required providers
+    and modules:
+
+    ```bash
+    terraform init
+    ```
+
+1. Review the execution plan before applying. In particular, check for any
+   resources Terraform plans to destroy and recreate (shown as `-/+` in the
+   plan), especially stateful resources such as your cluster, storage, and
+   database:
+
+    ```bash
+    terraform plan
+    ```
+
+1. After reviewing the plan, apply the Terraform configuration.
+
+    ```bash
+    terraform apply
+    ```
+
+### Step 4: Verify the upgrade
+
+Configure `kubectl` to connect to your EKS cluster, replacing `<your-region>`
+with the region of your cluster (found in your `terraform.tfvars`; e.g.,
+`us-east-1`):
+
+```bash
+# aws eks update-kubeconfig --name <your-eks-cluster-name> --region <your-region>
+aws eks update-kubeconfig --name $(terraform output -raw eks_cluster_name) --region <your-region>
+```
+
+{{% include-from-yaml data="self_managed/upgrades" name="upgrade-verify-status" %}}
 
 ## See also
 

--- a/doc/user/content/self-managed-deployments/upgrading/upgrade-on-azure.md
+++ b/doc/user/content/self-managed-deployments/upgrading/upgrade-on-azure.md
@@ -34,7 +34,6 @@ name="downgrade-restriction" >}}
 - [Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform)
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
-- [Helm 3.2.0+](https://helm.sh/docs/intro/install/)
 
 ## Upgrade process
 
@@ -44,75 +43,93 @@ The following procedure performs a rolling upgrade, where both the old and new M
 
 {{</ important >}}
 
-### Step 1: Set up
+### Step 1: Update TF module source version
 
-1. Open a Terminal window.
-
-1. Configure Azure CLI with your Azure credentials. For details, see the [Azure
-   documentation](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli).
-
-1. Go to the Terraform directory for your Materialize deployment. For example,
-   if you deployed from the `azure/examples/simple` directory:
-
-   ```bash
-   cd materialize-terraform-self-managed/azure/examples/simple
-   ```
-
-1. Configure `kubectl` to connect to your AKS cluster, replacing:
-
-   - `<your-resource-group-name>` with your resource group name; i.e., the
-     `resource_group_name` in the Terraform output or in the
-     `terraform.tfvars` file.
-
-   - `<your-aks-cluster-name>` with your cluster name; i.e., the
-     `aks_cluster_name` in the Terraform output. For the sample example,
-     your cluster name has the form `{prefix_name}-aks`; e.g., simple-demo-aks`.
-
-   ```bash
-   # az aks get-credentials --resource-group <your-resource-group-name> --name <your-aks-cluster-name>
-   az aks get-credentials --resource-group $(terraform output -raw resource_group_name) --name $(terraform output -raw aks_cluster_name)
-   ```
-
-   To verify that you have configured correctly, run the following command:
-
-   ```bash
-   kubectl get nodes
-   ```
-
-   For help with `kubectl` commands, see [kubectl Quick reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
-
-### Step 2: Update the Helm Chart
+Update each module's `source` to point to the desired release tag, substituting
+`<RELEASE_TAG>` in the code block below with your tag version:
 
 {{< important >}}
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+The following code block is not comprehensive. Only the core modules and their
+dependency chain are shown below.
 
-{{</ important >}}
+If your configuration includes additional modules (networking, storage,
+database, node pools, etc.) provided by Materialize, **update those to the same
+release tag as well**.
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-update-helm-chart" %}}
+{{< /important >}}
 
-### Step 3: Upgrade the Materialize Operator
+```hcl
+module "aks" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//azure/modules/aks?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
+}
 
-{{< important >}}
+module "cert_manager" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//kubernetes/modules/cert-manager?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.aks]
+}
 
-{{</ important >}}
+module "operator" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//azure/modules/operator?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-materialize-operator" %}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.cert_manager]
+}
 
-### Step 4: Upgrading Materialize Instances
+module "materialize_instance" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//kubernetes/modules/materialize-instance?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{< important >}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.operator]
+}
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+# Update the source of any additional Materialize-provided modules to the same release tag
+```
 
-{{</ important >}}
+### Step 2: Request rollout
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-materialize-instance" %}}
+{{% include-from-yaml data="self_managed/upgrades" name="upgrade-request_rollout" %}}
+
+### Step 3: Apply the updated TF
+
+1. Initialize the Terraform directory to download the required providers
+    and modules:
+
+    ```bash
+    terraform init
+    ```
+
+1. Review the execution plan before applying. In particular, check for any
+   resources Terraform plans to destroy and recreate (shown as `-/+` in the
+   plan), especially stateful resources such as your cluster, storage, and
+   database:
+
+    ```bash
+    terraform plan
+    ```
+
+1. After reviewing the plan, apply the Terraform configuration.
+
+    ```bash
+    terraform apply
+    ```
+
+### Step 4: Verify the upgrade
+
+Configure `kubectl` to connect to your AKS cluster:
+
+```bash
+# az aks get-credentials --resource-group <your-resource-group-name> --name <your-aks-cluster-name>
+az aks get-credentials --resource-group $(terraform output -raw resource_group_name) --name $(terraform output -raw aks_cluster_name)
+```
+
+{{% include-from-yaml data="self_managed/upgrades" name="upgrade-verify-status" %}}
 
 ## See also
 

--- a/doc/user/content/self-managed-deployments/upgrading/upgrade-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/upgrading/upgrade-on-gcp.md
@@ -34,7 +34,6 @@ name="downgrade-restriction" >}}
 - [Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform)
 - [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
-- [Helm 3.2.0+](https://helm.sh/docs/intro/install/)
 
 ## Upgrade process
 
@@ -44,79 +43,96 @@ The following procedure performs a rolling upgrade, where both the old and new M
 
 {{</ important >}}
 
-### Step 1: Set up
+### Step 1: Update TF module source version
 
-1. Open a Terminal window.
-
-1. Configure Google Cloud CLI with your GCP credentials. For details, see the [Google Cloud
-   documentation](https://cloud.google.com/sdk/docs/initializing).
-
-1. Go to the Terraform directory for your Materialize deployment. For example,
-   if you deployed from the `gcp/examples/simple` directory:
-
-   ```bash
-   cd materialize-terraform-self-managed/gcp/examples/simple
-   ```
-
-1. Configure `kubectl` to connect to your GKE cluster, replacing:
-
-   - `<your-gke-cluster-name>` with your cluster name; i.e., the
-     `gke_cluster_name` in the Terraform output. For the sample example, your
-     cluster name has the form `<name_prefix>-gke`; e.g., `simple-demo-gke`
-
-   - `<your-region>` with your cluster location; i.e., the
-     `gke_cluster_location` in the Terraform output. Your
-     region can also be found in your `terraform.tfvars` file.
-
-   - `<your-project-id>` with your GCP project ID.
-
-   ```bash
-   # gcloud container clusters get-credentials <your-gke-cluster-name> --region <your-region> --project <your-project-id>
-   gcloud container clusters get-credentials $(terraform output -raw gke_cluster_name) \
-    --region $(terraform output -raw gke_cluster_location) \
-    --project <your-project-id>
-   ```
-
-   To verify that you have configured correctly, run the following command:
-
-   ```bash
-   kubectl get nodes
-   ```
-
-   For help with `kubectl` commands, see [kubectl Quick reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
-
-### Step 2: Update the Helm Chart
+Update each module's `source` to point to the desired release tag, substituting
+`<RELEASE_TAG>` in the code block below with your tag version:
 
 {{< important >}}
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+The following code block is not comprehensive. Only the core modules and their
+dependency chain are shown below.
 
-{{</ important >}}
+If your configuration includes additional modules (networking, storage,
+database, node pools, etc.) provided by Materialize, **update those to the same
+release tag as well**.
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-update-helm-chart" %}}
+{{< /important >}}
 
-### Step 3: Upgrade the Materialize Operator
+```hcl
+module "gke" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//gcp/modules/gke?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
+}
 
-{{< important >}}
+module "cert_manager" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//kubernetes/modules/cert-manager?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.gke]
+}
 
-{{</ important >}}
+module "operator" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//gcp/modules/operator?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-materialize-operator" %}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.cert_manager]
+}
 
-### Step 4: Upgrading Materialize Instances
+module "materialize_instance" {
+  source = "github.com/MaterializeInc/materialize-terraform-self-managed//kubernetes/modules/materialize-instance?ref=<RELEASE_TAG>"
+  # ... your existing configuration ...
 
-{{< important >}}
+  # Your configuration may have additional dependencies here.
+  depends_on = [module.operator]
+}
 
-{{% include-from-yaml data="self_managed/upgrades" name="upgrade-order-rule" %}}
+# Update the source of any additional Materialize-provided modules to the same release tag
+```
 
-{{</ important >}}
+### Step 2: Request rollout
 
-{{% include-from-yaml data="self_managed/upgrades"
-name="upgrade-materialize-instance" %}}
+{{% include-from-yaml data="self_managed/upgrades" name="upgrade-request_rollout" %}}
+
+### Step 3: Apply the updated TF
+
+1. Initialize the Terraform directory to download the required providers
+    and modules:
+
+    ```bash
+    terraform init
+    ```
+
+1. Review the execution plan before applying. In particular, check for any
+   resources Terraform plans to destroy and recreate (shown as `-/+` in the
+   plan), especially stateful resources such as your cluster, storage, and
+   database:
+
+    ```bash
+    terraform plan
+    ```
+
+1. After reviewing the plan, apply the Terraform configuration.
+
+    ```bash
+    terraform apply
+    ```
+
+### Step 4: Verify the upgrade
+
+Configure `kubectl` to connect to your GKE cluster, replacing `<your-project-id>`
+with your GCP project ID:
+
+```bash
+# gcloud container clusters get-credentials <your-gke-cluster-name> --region <your-region> --project <your-project-id>
+gcloud container clusters get-credentials $(terraform output -raw gke_cluster_name) \
+ --region $(terraform output -raw gke_cluster_location) \
+ --project <your-project-id>
+```
+
+{{% include-from-yaml data="self_managed/upgrades" name="upgrade-verify-status" %}}
 
 ## See also
 

--- a/doc/user/data/self_managed/installation.yml
+++ b/doc/user/data/self_managed/installation.yml
@@ -74,7 +74,7 @@
     ```bash
     kubectl -n materialize get all
     ```
-    {{< /tabs >}}
+    {{< /tab >}}
     {{< tab "Materialize instance" >}}
     To check the status of the Materialize instance, which runs in the `materialize-environment` namespace:
     ```bash

--- a/doc/user/data/self_managed/upgrades.yml
+++ b/doc/user/data/self_managed/upgrades.yml
@@ -152,6 +152,37 @@
        The **APP VERSION** will be the value that you will use for upgrading
        Materialize instances.
 
+- name: upgrade-verify-status
+  content: |
+    {{< note >}}
+    `terraform apply` returns once the Materialize custom resource is updated.
+    The Operator then rolls out the new generation asynchronously, so the new
+    `environmentd` pods may take a few minutes to become ready.
+    {{< /note >}}
+
+    1. Check the status of the `materialize` namespace:
+
+       ```bash
+       kubectl -n materialize get all
+       ```
+
+    1. Check the status of the `materialize-environment` namespace:
+
+       ```bash
+       kubectl -n materialize-environment get all
+       ```
+
+    1. Once a new `environmentd` is up (may take a few minutes), confirm the
+       running `environmentd` version matches the version you upgraded to. Check
+       the `Image` field in the pod description.
+
+       ```bash
+       kubectl -n materialize-environment describe pod -l app=environmentd
+       ```
+
+    If you run into an error during the upgrade, refer to the
+    [Troubleshooting](/self-managed-deployments/troubleshooting/).
+
 - name: upgrade-materialize-instance
   content: |
 
@@ -203,3 +234,15 @@
        ```bash
        kubectl -n materialize-environment describe pod -l app=environmentd
        ```
+
+- name: upgrade-request_rollout
+  content: |
+    Update your `terraform.tfvars` file to set the `request_rollout` variable to
+    a new UUID value, substituting the example value in the code block below with
+    a UUID you generate (for example, with `uuidgen`):
+
+    ```hcl
+    # ...
+    # ...
+    request_rollout = "DBB4FCEC-1837-44F6-9CF2-3894678DD8D5"
+    ```


### PR DESCRIPTION
Per [slack discussion](https://materializeinc.slack.com/archives/C07PN7KSB0T/p1782818386126619?thread_ts=1782746091.862029&cid=C07PN7KSB0T)
Heads up: I think (?) for this PR can go out, we will need a TF change (possibly 2):
- On AWS, I was able to use the procedure to go from TF v3.0.12 to v3.1.0
- But, on Google, I received the following:
```
│ Warning: Value for undeclared variable
│ 
│ The root module does not declare a variable named "request_rollout" but a value was found in file "terraform.tfvars". If you meant to use this value,
│ add a "variable" block to the configuration.
│ 
│ To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in your organization. To
│ reduce the verbosity of these warnings, use the -compact-warnings option.
╵
```
(This is what I meant in the meeting if people are only updating the  module source version .. .could the variable files, etc. be otherwise out of whack with the new source version?  I'm good with adding a blurb to our docs w.r.t. this if you can suggest something).