### PR TITLE
mz-deploy: identifier-overflow panics and reference validation (DEX-52, DEX-63, DEX-59, DEX-51, DEX-47, DEX-62)

### DIFF
--- a/src/mz-deploy/src/cli/executor.rs
+++ b/src/mz-deploy/src/cli/executor.rs
@@ -571,7 +571,8 @@ impl<'a> DeploymentExecutor<'a> {
                                 std::slice::from_mut(&mut rewritten),
                                 schema,
                                 suffix,
-                            );
+                            )
+                            .map_err(project::error::ProjectError::from)?;
                             verbose!("Applying schema setup for: {}.{}", database, staging_schema);
                             self.execute_sql(&rewritten).await?;
                         } else {

--- a/src/mz-deploy/src/project.rs
+++ b/src/mz-deploy/src/project.rs
@@ -375,6 +375,51 @@ mod plan_tests {
             derived.dependencies,
         );
     }
+
+    /// A supporting statement on an unqualified object must still be rejected
+    /// when it targets a different schema than the file's object.
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn plan_sync_rejects_wrong_schema_grant_on_unqualified_object() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("project.toml"), "").unwrap();
+        let dir = root.path().join("models/app/ingest");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("users.sql"),
+            "CREATE TABLE users (id INT);\n\
+             GRANT SELECT ON TABLE other_schema.users TO some_role;\n",
+        )
+        .unwrap();
+
+        let fs = crate::fs::FileSystem::new();
+        let result = plan_sync(&fs, root.path(), None, None, &Default::default());
+        assert!(
+            result.is_err(),
+            "grant targeting a different schema than the file's object must be rejected",
+        );
+    }
+
+    /// The same-schema control still validates: an unqualified object with a
+    /// grant on its own (unqualified) name compiles cleanly.
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn plan_sync_accepts_same_schema_grant_on_unqualified_object() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("project.toml"), "").unwrap();
+        let dir = root.path().join("models/app/ingest");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("users.sql"),
+            "CREATE TABLE users (id INT);\n\
+             GRANT SELECT ON TABLE users TO some_role;\n",
+        )
+        .unwrap();
+
+        let fs = crate::fs::FileSystem::new();
+        plan_sync(&fs, root.path(), None, None, &Default::default())
+            .expect("grant on the file's own object should validate");
+    }
 }
 
 /// Compile a project root into a planned deployment representation.

--- a/src/mz-deploy/src/project.rs
+++ b/src/mz-deploy/src/project.rs
@@ -327,6 +327,54 @@ mod plan_tests {
             "over-qualified column reference must be a validation error, not a panic",
         );
     }
+
+    /// A cross-database reference to a database whose name is not bare (needs
+    /// SQL quoting, e.g. `café`) still gets its profile suffix. The name-map
+    /// lookup must key off the raw identifier, not its quoted `Display` form.
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn plan_sync_profile_suffix_suffixes_non_bare_database_name() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("project.toml"), "").unwrap();
+
+        let a_dir = root.path().join("models/café/public");
+        std::fs::create_dir_all(&a_dir).unwrap();
+        std::fs::write(
+            a_dir.join("base.sql"),
+            "CREATE TABLE \"café\".public.base (id INT);\n",
+        )
+        .unwrap();
+
+        let b_dir = root.path().join("models/app/public");
+        std::fs::create_dir_all(&b_dir).unwrap();
+        std::fs::write(
+            b_dir.join("derived.sql"),
+            "CREATE VIEW app.public.derived AS SELECT id FROM \"café\".public.base;\n",
+        )
+        .unwrap();
+
+        let fs = crate::fs::FileSystem::new();
+        let project = plan_sync(&fs, root.path(), None, Some("_dev"), &Default::default())
+            .expect("non-bare cross-database reference should compile under a profile suffix");
+
+        let derived = project
+            .find_object(&ir::object_id::ObjectId::new(
+                "app_dev".to_string(),
+                "public".to_string(),
+                "derived".to_string(),
+            ))
+            .expect("derived view should appear under the suffixed database");
+
+        assert!(
+            derived.dependencies.contains(&ir::object_id::ObjectId::new(
+                "café_dev".to_string(),
+                "public".to_string(),
+                "base".to_string(),
+            )),
+            "non-bare database reference should be suffixed; got {:?}",
+            derived.dependencies,
+        );
+    }
 }
 
 /// Compile a project root into a planned deployment representation.

--- a/src/mz-deploy/src/project.rs
+++ b/src/mz-deploy/src/project.rs
@@ -270,6 +270,39 @@ mod plan_tests {
             "statement's own name should be suffixed; got: {serialized}",
         );
     }
+
+    /// A cluster name that overflows the identifier length limit once the
+    /// profile suffix is appended surfaces as a compile error, not a panic.
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn plan_sync_cluster_name_too_long_after_suffix_errors() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("project.toml"), "").unwrap();
+        let schema_dir = root.path().join("models/mydb/public");
+        std::fs::create_dir_all(&schema_dir).unwrap();
+        let long_cluster = "c".repeat(250);
+        std::fs::write(
+            schema_dir.join("v.sql"),
+            format!(
+                "CREATE MATERIALIZED VIEW mydb.public.v IN CLUSTER {long_cluster} AS SELECT 1 AS x;\n"
+            ),
+        )
+        .unwrap();
+
+        let fs = crate::fs::FileSystem::new();
+        let err = plan_sync(
+            &fs,
+            root.path(),
+            None,
+            Some("__staging"),
+            &Default::default(),
+        )
+        .expect_err("over-length suffixed cluster name must error, not panic");
+        assert!(
+            err.to_string().contains("too long"),
+            "error should explain the length overflow; got: {err}",
+        );
+    }
 }
 
 /// Compile a project root into a planned deployment representation.

--- a/src/mz-deploy/src/project.rs
+++ b/src/mz-deploy/src/project.rs
@@ -303,6 +303,30 @@ mod plan_tests {
             "error should explain the length overflow; got: {err}",
         );
     }
+
+    /// A supporting statement that references an object with too many
+    /// qualification levels is reported as a validation error, not a panic.
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn plan_sync_overqualified_reference_errors() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("project.toml"), "").unwrap();
+        let schema_dir = root.path().join("models/mydb/public");
+        std::fs::create_dir_all(&schema_dir).unwrap();
+        std::fs::write(
+            schema_dir.join("t.sql"),
+            "CREATE TABLE mydb.public.t (id INT);\n\
+             COMMENT ON COLUMN mydb.public.t.extra.id IS 'bad';\n",
+        )
+        .unwrap();
+
+        let fs = crate::fs::FileSystem::new();
+        let result = plan_sync(&fs, root.path(), None, None, &Default::default());
+        assert!(
+            result.is_err(),
+            "over-qualified column reference must be a validation error, not a panic",
+        );
+    }
 }
 
 /// Compile a project root into a planned deployment representation.

--- a/src/mz-deploy/src/project/ast.rs
+++ b/src/mz-deploy/src/project/ast.rs
@@ -34,25 +34,38 @@ pub struct DatabaseIdent {
     pub object: Ident,
 }
 
-impl From<UnresolvedItemName> for DatabaseIdent {
-    fn from(value: UnresolvedItemName) -> Self {
+impl TryFrom<UnresolvedItemName> for DatabaseIdent {
+    /// A human-readable reason the name could not be interpreted as an object
+    /// identifier.
+    type Error = String;
+
+    /// Interpret an `UnresolvedItemName` as an object identifier.
+    ///
+    /// Object references carry at most three qualification levels
+    /// (`database.schema.object`). The SQL parser accepts arbitrarily deep
+    /// dotted names, so a reference with zero or four-plus parts is rejected
+    /// here rather than panicking.
+    fn try_from(value: UnresolvedItemName) -> Result<Self, Self::Error> {
         match value.0.as_slice() {
-            [object] => Self {
+            [object] => Ok(Self {
                 database: None,
                 schema: None,
                 object: object.clone(),
-            },
-            [schema, object] => Self {
+            }),
+            [schema, object] => Ok(Self {
                 database: None,
                 schema: Some(schema.clone()),
                 object: object.clone(),
-            },
-            [database, schema, object] => Self {
+            }),
+            [database, schema, object] => Ok(Self {
                 database: Some(database.clone()),
                 schema: Some(schema.clone()),
                 object: object.clone(),
-            },
-            _ => unreachable!(),
+            }),
+            _ => Err(format!(
+                "'{}' has too many qualification levels; expected at most database.schema.object",
+                value
+            )),
         }
     }
 }
@@ -191,22 +204,28 @@ impl Statement {
     /// Extracts the database identifier from the statement.
     ///
     /// Returns the object name (potentially qualified with schema/database)
-    /// declared in the CREATE statement.
+    /// declared in the CREATE statement. A name with more than three
+    /// qualification levels yields an object that matches nothing, so name
+    /// validation reports it rather than this method panicking.
     pub fn ident(&self) -> DatabaseIdent {
-        match self {
+        let name = match self {
             Statement::CreateSink(s) => s
                 .name
                 .clone()
-                .expect("CREATE SINK statement should have a name")
-                .into(),
-            Statement::CreateView(v) => v.definition.name.clone().into(),
-            Statement::CreateMaterializedView(m) => m.name.clone().into(),
-            Statement::CreateTable(t) => t.name.clone().into(),
-            Statement::CreateTableFromSource(t) => t.name.clone().into(),
-            Statement::CreateSource(s) => s.name.clone().into(),
-            Statement::CreateSecret(s) => s.name.clone().into(),
-            Statement::CreateConnection(c) => c.name.clone().into(),
-        }
+                .expect("CREATE SINK statement should have a name"),
+            Statement::CreateView(v) => v.definition.name.clone(),
+            Statement::CreateMaterializedView(m) => m.name.clone(),
+            Statement::CreateTable(t) => t.name.clone(),
+            Statement::CreateTableFromSource(t) => t.name.clone(),
+            Statement::CreateSource(s) => s.name.clone(),
+            Statement::CreateSecret(s) => s.name.clone(),
+            Statement::CreateConnection(c) => c.name.clone(),
+        };
+        DatabaseIdent::try_from(name.clone()).unwrap_or_else(|_| DatabaseIdent {
+            database: None,
+            schema: None,
+            object: Ident::new_unchecked(name.to_string()),
+        })
     }
 }
 
@@ -323,5 +342,21 @@ mod tests {
         };
 
         assert!(!ident4.matches(&ident2));
+    }
+
+    #[mz_ore::test]
+    fn test_database_ident_try_from_arity() {
+        let name = |parts: &[&str]| {
+            UnresolvedItemName(parts.iter().map(|p| Ident::new_unchecked(*p)).collect())
+        };
+
+        assert!(DatabaseIdent::try_from(name(&["obj"])).is_ok());
+        assert!(DatabaseIdent::try_from(name(&["schema", "obj"])).is_ok());
+        assert!(DatabaseIdent::try_from(name(&["db", "schema", "obj"])).is_ok());
+
+        // Four qualification levels is not a valid object reference. It must
+        // error rather than panic.
+        assert!(DatabaseIdent::try_from(name(&["a", "b", "c", "d"])).is_err());
+        assert!(DatabaseIdent::try_from(name(&[])).is_err());
     }
 }

--- a/src/mz-deploy/src/project/compiler.rs
+++ b/src/mz-deploy/src/project/compiler.rs
@@ -96,7 +96,7 @@ use cache::build_artifact::{CompiledObjectArtifact, CompiledObjectArtifactData, 
 use cache_io::hex_digest;
 use mz_sql_parser::ast::{
     CommentStatement, CreateIndexStatement, ExecuteUnitTestStatement, GrantPrivilegesStatement,
-    Raw, Statement,
+    Ident, Raw, Statement,
 };
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
@@ -431,7 +431,7 @@ fn compile_sync_with_stats<P: AsRef<Path>>(
         compiled_project.rewrite_database_references(&discovery.db_name_map);
     }
     if let Some(ps) = profile_suffix {
-        let cluster_name_map = build_cluster_name_map(&compiled_project, ps);
+        let cluster_name_map = build_cluster_name_map(&compiled_project, ps)?;
         if !cluster_name_map.is_empty() {
             compiled_project.rewrite_cluster_references(&cluster_name_map);
         }
@@ -455,10 +455,14 @@ fn compile_sync_with_stats<P: AsRef<Path>>(
 
 /// Build a map from original cluster name to the suffixed cluster name for all
 /// clusters referenced by the compiled project.
+///
+/// Returns [`LoadError::SuffixedIdentifierTooLong`] if any suffixed name
+/// exceeds the identifier length limit, so the overflow surfaces as a normal
+/// compile error rather than a panic in the rewrite pass.
 fn build_cluster_name_map(
     project: &compiled::Project,
     cluster_suffix: &str,
-) -> BTreeMap<String, String> {
+) -> Result<BTreeMap<String, Ident>, LoadError> {
     let mut names = BTreeSet::new();
     for db in &project.databases {
         for schema in &db.schemas {
@@ -471,7 +475,12 @@ fn build_cluster_name_map(
         .into_iter()
         .map(|name| {
             let suffixed = format!("{}{}", name, cluster_suffix);
-            (name, suffixed)
+            let ident =
+                Ident::new(&suffixed).map_err(|_| LoadError::SuffixedIdentifierTooLong {
+                    name: suffixed,
+                    limit: Ident::MAX_LENGTH,
+                })?;
+            Ok((name, ident))
         })
         .collect()
 }

--- a/src/mz-deploy/src/project/compiler.rs
+++ b/src/mz-deploy/src/project/compiler.rs
@@ -701,7 +701,7 @@ fn parse_mod_statements(
             &mut statements,
             original_db_name,
             suffix,
-        );
+        )?;
     }
     Ok(Some(statements))
 }

--- a/src/mz-deploy/src/project/compiler/object_validation.rs
+++ b/src/mz-deploy/src/project/compiler/object_validation.rs
@@ -55,7 +55,7 @@ use references::{
 };
 use schema_constraints::validate_no_storage_and_computation_in_schema;
 
-use super::super::ast::Statement;
+use super::super::ast::{DatabaseIdent, Statement};
 use crate::project::SchemaQualifier;
 use crate::project::error::{ValidationError, ValidationErrorKind, ValidationErrors};
 use crate::project::ir::compiled::{Database, DatabaseObject, FullyQualifiedName, Project, Schema};
@@ -364,8 +364,15 @@ fn validate_single_variant(
         }
     };
 
-    // Get identifier from original statement before normalization
-    let main_ident = stmt.ident();
+    // Fully qualify the object's own identifier from the file's FQN. Supporting
+    // statements are normalized to fully qualified names below, so an
+    // unqualified main name (the idiomatic style) must still carry its database
+    // and schema for reference matching to detect a wrong-schema target.
+    let main_ident = DatabaseIdent {
+        database: Some(Ident::new_unchecked(fqn.database())),
+        schema: Some(Ident::new_unchecked(fqn.schema())),
+        object: Ident::new_unchecked(fqn.object()),
+    };
 
     // Validate the original statement identifier against FQN
     validate_ident(&stmt, &fqn, main_offset, &mut errors);

--- a/src/mz-deploy/src/project/compiler/object_validation/references.rs
+++ b/src/mz-deploy/src/project/compiler/object_validation/references.rs
@@ -17,6 +17,33 @@ use crate::project::error::{ValidationError, ValidationErrorKind};
 use crate::project::ir::compiled::FullyQualifiedName;
 use mz_sql_parser::ast::*;
 
+/// Interpret a referenced object name as a [`DatabaseIdent`], recording an
+/// `InvalidIdentifier` error and returning `None` if it has too many
+/// qualification levels to be a valid object reference.
+fn reference_ident(
+    name: &UnresolvedItemName,
+    fqn: &FullyQualifiedName,
+    sql: &str,
+    offset: usize,
+    errors: &mut Vec<ValidationError>,
+) -> Option<DatabaseIdent> {
+    match DatabaseIdent::try_from(name.clone()) {
+        Ok(ident) => Some(ident),
+        Err(reason) => {
+            errors.push(ValidationError::with_file_sql_and_offset(
+                ValidationErrorKind::InvalidIdentifier {
+                    name: name.to_string(),
+                    reason,
+                },
+                fqn.path.clone(),
+                sql.to_string(),
+                offset,
+            ));
+            None
+        }
+    }
+}
+
 /// Validates that all CREATE INDEX statements reference the main object.
 ///
 /// Ensures that every index defined in the file is created on the object
@@ -44,9 +71,12 @@ pub(super) fn validate_index_references(
     errors: &mut Vec<ValidationError>,
 ) {
     for (i, index) in indexes.iter().enumerate() {
-        let on: DatabaseIdent = index.on_name.name().clone().into();
+        let index_sql = format!("{};", index);
+        let Some(on) = reference_ident(index.on_name.name(), fqn, &index_sql, offsets[i], errors)
+        else {
+            continue;
+        };
         if !on.matches(main_ident) {
-            let index_sql = format!("{};", index);
             errors.push(ValidationError::with_file_sql_and_offset(
                 ValidationErrorKind::IndexReferenceMismatch {
                     referenced: on.object.to_string(),
@@ -124,7 +154,11 @@ pub(super) fn validate_grant_references(
                     for obj in names {
                         match obj {
                             UnresolvedObjectName::Item(item_name) => {
-                                let grant_target: DatabaseIdent = item_name.clone().into();
+                                let Some(grant_target) =
+                                    reference_ident(item_name, fqn, &grant_sql, offset, errors)
+                                else {
+                                    continue;
+                                };
                                 if !grant_target.matches(main_ident) {
                                     errors.push(ValidationError::with_file_sql_and_offset(
                                         ValidationErrorKind::GrantReferenceMismatch {
@@ -239,7 +273,11 @@ fn validate_comment_target(
     offset: usize,
     errors: &mut Vec<ValidationError>,
 ) {
-    let comment_target: DatabaseIdent = comment_name.name().clone().into();
+    let Some(comment_target) =
+        reference_ident(comment_name.name(), fqn, comment_sql, offset, errors)
+    else {
+        return;
+    };
 
     // Check that the comment references the main object
     if !comment_target.matches(main_ident) {
@@ -327,7 +365,11 @@ pub(super) fn validate_comment_references(
 
         // Handle column comments specially (they reference the parent table)
         if let CommentObjectType::Column { name } = &comment.object {
-            let column_parent: DatabaseIdent = name.relation.name().clone().into();
+            let Some(column_parent) =
+                reference_ident(name.relation.name(), fqn, &comment_sql, offset, errors)
+            else {
+                continue;
+            };
             if !column_parent.matches(main_ident) {
                 errors.push(ValidationError::with_file_sql_and_offset(
                     ValidationErrorKind::ColumnCommentReferenceMismatch {

--- a/src/mz-deploy/src/project/error/load.rs
+++ b/src/mz-deploy/src/project/error/load.rs
@@ -117,4 +117,15 @@ pub enum LoadError {
         path1: PathBuf,
         path2: PathBuf,
     },
+
+    /// A profile suffix pushed an identifier past the maximum length.
+    #[error(
+        "identifier '{name}' is too long after applying the profile suffix (limit is {limit} bytes)"
+    )]
+    SuffixedIdentifierTooLong {
+        /// The over-length identifier, suffix included.
+        name: String,
+        /// The maximum allowed identifier length in bytes.
+        limit: usize,
+    },
 }

--- a/src/mz-deploy/src/project/ir/compiled.rs
+++ b/src/mz-deploy/src/project/ir/compiled.rs
@@ -473,7 +473,7 @@ impl DatabaseObject {
     /// For any `RawClusterName::Unresolved(ident)` where the ident matches a key
     /// in the map, replace it with the suffixed name. This applies to `IN CLUSTER`
     /// clauses in the main statement and in index definitions.
-    pub fn rewrite_cluster_references(&mut self, cluster_map: &BTreeMap<String, String>) {
+    pub fn rewrite_cluster_references(&mut self, cluster_map: &BTreeMap<String, Ident>) {
         // Rewrite IN CLUSTER on the main statement
         match &mut self.stmt {
             Statement::CreateMaterializedView(s) => {
@@ -620,7 +620,7 @@ impl Project {
     ///
     /// Walks all objects in all databases/schemas and replaces cluster names in
     /// `IN CLUSTER` clauses when the cluster name is a key in the map.
-    pub fn rewrite_cluster_references(&mut self, cluster_map: &BTreeMap<String, String>) {
+    pub fn rewrite_cluster_references(&mut self, cluster_map: &BTreeMap<String, Ident>) {
         for db in &mut self.databases {
             for schema in &mut db.schemas {
                 for obj in &mut schema.objects {
@@ -649,12 +649,12 @@ impl Project {
 /// Rewrite an optional `RawClusterName::Unresolved` ident if it matches a key in the map.
 fn rewrite_in_cluster(
     in_cluster: &mut Option<RawClusterName>,
-    cluster_map: &BTreeMap<String, String>,
+    cluster_map: &BTreeMap<String, Ident>,
 ) {
     if let Some(RawClusterName::Unresolved(ident)) = in_cluster {
         let name = ident.to_string();
         if let Some(suffixed) = cluster_map.get(&name) {
-            *ident = Ident::new(suffixed).expect("valid cluster identifier");
+            *ident = suffixed.clone();
         }
     }
 }

--- a/src/mz-deploy/src/project/resolve/normalize/mod_rewriter.rs
+++ b/src/mz-deploy/src/project/resolve/normalize/mod_rewriter.rs
@@ -43,23 +43,43 @@ use mz_sql_parser::ast::{
     Ident, Raw, Statement, UnresolvedDatabaseName, UnresolvedObjectName, UnresolvedSchemaName,
 };
 
+use crate::project::error::LoadError;
+
+/// Build an [`Ident`] from `name + suffix`, mapping an over-length result to a
+/// [`LoadError`] so the overflow reports as a compile error rather than a panic.
+fn suffixed_ident(name: &str, suffix: &str) -> Result<Ident, LoadError> {
+    let suffixed = format!("{}{}", name, suffix);
+    Ident::new(&suffixed).map_err(|_| LoadError::SuffixedIdentifierTooLong {
+        name: suffixed,
+        limit: Ident::MAX_LENGTH,
+    })
+}
+
 /// Append `suffix` to the database name if it matches `database_name`.
-fn rewrite_database_name(node: &mut UnresolvedDatabaseName, database_name: &str, suffix: &str) {
+fn rewrite_database_name(
+    node: &mut UnresolvedDatabaseName,
+    database_name: &str,
+    suffix: &str,
+) -> Result<(), LoadError> {
     if node.0.as_str() == database_name {
-        node.0 =
-            Ident::new(format!("{}{}", database_name, suffix)).expect("valid database identifier");
+        node.0 = suffixed_ident(database_name, suffix)?;
     }
+    Ok(())
 }
 
 /// Append `suffix` to the schema part (last ident) if it matches `schema_name`.
-fn rewrite_schema_name(node: &mut UnresolvedSchemaName, schema_name: &str, suffix: &str) {
+fn rewrite_schema_name(
+    node: &mut UnresolvedSchemaName,
+    schema_name: &str,
+    suffix: &str,
+) -> Result<(), LoadError> {
     if let Some(last) = node.0.last() {
         if last.as_str() == schema_name {
             let idx = node.0.len() - 1;
-            node.0[idx] =
-                Ident::new(format!("{}{}", schema_name, suffix)).expect("valid schema identifier");
+            node.0[idx] = suffixed_ident(schema_name, suffix)?;
         }
     }
+    Ok(())
 }
 
 /// Visitor that rewrites database name identifiers by appending a suffix.
@@ -70,21 +90,32 @@ fn rewrite_schema_name(node: &mut UnresolvedSchemaName, schema_name: &str, suffi
 struct DatabaseNameRewriter<'a> {
     database_name: &'a str,
     suffix: &'a str,
+    error: Option<LoadError>,
+}
+
+impl<'a> DatabaseNameRewriter<'a> {
+    fn rewrite(&mut self, node: &mut UnresolvedDatabaseName) {
+        if self.error.is_none() {
+            if let Err(e) = rewrite_database_name(node, self.database_name, self.suffix) {
+                self.error = Some(e);
+            }
+        }
+    }
 }
 
 impl<'a> VisitMut<'_, Raw> for DatabaseNameRewriter<'a> {
     fn visit_database_name_mut(&mut self, node: &mut UnresolvedDatabaseName) {
-        rewrite_database_name(node, self.database_name, self.suffix);
+        self.rewrite(node);
     }
 
     fn visit_object_name_mut(&mut self, node: &mut UnresolvedObjectName) {
         if let UnresolvedObjectName::Database(db_name) = node {
-            rewrite_database_name(db_name, self.database_name, self.suffix);
+            self.rewrite(db_name);
         }
     }
 
     fn visit_unresolved_database_name_mut(&mut self, node: &mut UnresolvedDatabaseName) {
-        rewrite_database_name(node, self.database_name, self.suffix);
+        self.rewrite(node);
     }
 }
 
@@ -96,21 +127,32 @@ impl<'a> VisitMut<'_, Raw> for DatabaseNameRewriter<'a> {
 struct SchemaNameRewriter<'a> {
     schema_name: &'a str,
     suffix: &'a str,
+    error: Option<LoadError>,
+}
+
+impl<'a> SchemaNameRewriter<'a> {
+    fn rewrite(&mut self, node: &mut UnresolvedSchemaName) {
+        if self.error.is_none() {
+            if let Err(e) = rewrite_schema_name(node, self.schema_name, self.suffix) {
+                self.error = Some(e);
+            }
+        }
+    }
 }
 
 impl<'a> VisitMut<'_, Raw> for SchemaNameRewriter<'a> {
     fn visit_object_name_mut(&mut self, node: &mut UnresolvedObjectName) {
         if let UnresolvedObjectName::Schema(schema_name) = node {
-            rewrite_schema_name(schema_name, self.schema_name, self.suffix);
+            self.rewrite(schema_name);
         }
     }
 
     fn visit_schema_name_mut(&mut self, node: &mut UnresolvedSchemaName) {
-        rewrite_schema_name(node, self.schema_name, self.suffix);
+        self.rewrite(node);
     }
 
     fn visit_unresolved_schema_name_mut(&mut self, node: &mut UnresolvedSchemaName) {
-        rewrite_schema_name(node, self.schema_name, self.suffix);
+        self.rewrite(node);
     }
 }
 
@@ -129,14 +171,19 @@ pub(crate) fn rewrite_database_names(
     statements: &mut [Statement<Raw>],
     database_name: &str,
     suffix: &str,
-) {
+) -> Result<(), LoadError> {
     let mut rewriter = DatabaseNameRewriter {
         database_name,
         suffix,
+        error: None,
     };
     for stmt in statements {
         visit_mut::visit_statement_mut(&mut rewriter, stmt);
+        if let Some(e) = rewriter.error.take() {
+            return Err(e);
+        }
     }
+    Ok(())
 }
 
 /// Rewrite schema names in parsed mod statements by appending a suffix.
@@ -154,14 +201,19 @@ pub(crate) fn rewrite_schema_names(
     statements: &mut [Statement<Raw>],
     schema_name: &str,
     suffix: &str,
-) {
+) -> Result<(), LoadError> {
     let mut rewriter = SchemaNameRewriter {
         schema_name,
         suffix,
+        error: None,
     };
     for stmt in statements {
         visit_mut::visit_statement_mut(&mut rewriter, stmt);
+        if let Some(e) = rewriter.error.take() {
+            return Err(e);
+        }
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -177,13 +229,13 @@ mod tests {
 
     fn rewrite_db(sql: &str, db_name: &str, suffix: &str) -> String {
         let mut stmts = vec![parse_one(sql)];
-        rewrite_database_names(&mut stmts, db_name, suffix);
+        rewrite_database_names(&mut stmts, db_name, suffix).expect("valid suffixed name");
         format!("{}", stmts[0])
     }
 
     fn rewrite_schema(sql: &str, schema_name: &str, suffix: &str) -> String {
         let mut stmts = vec![parse_one(sql)];
-        rewrite_schema_names(&mut stmts, schema_name, suffix);
+        rewrite_schema_names(&mut stmts, schema_name, suffix).expect("valid suffixed name");
         format!("{}", stmts[0])
     }
 
@@ -291,5 +343,25 @@ mod tests {
             !result.contains("_staging"),
             "non-matching schema should be untouched: {result}"
         );
+    }
+
+    #[mz_ore::test]
+    fn test_database_suffix_overflow_errors() {
+        let long_db = "a".repeat(250);
+        let mut stmts = vec![parse_one(&format!("COMMENT ON DATABASE {long_db} IS 'x'"))];
+        let err = rewrite_database_names(&mut stmts, &long_db, "_staging")
+            .expect_err("over-length suffixed database name must error, not panic");
+        assert!(err.to_string().contains("too long"), "got: {err}");
+    }
+
+    #[mz_ore::test]
+    fn test_schema_suffix_overflow_errors() {
+        let long_schema = "a".repeat(250);
+        let mut stmts = vec![parse_one(&format!(
+            "COMMENT ON SCHEMA app.{long_schema} IS 'x'"
+        ))];
+        let err = rewrite_schema_names(&mut stmts, &long_schema, "_staging")
+            .expect_err("over-length suffixed schema name must error, not panic");
+        assert!(err.to_string().contains("too long"), "got: {err}");
     }
 }

--- a/src/mz-deploy/src/project/resolve/normalize/transformers.rs
+++ b/src/mz-deploy/src/project/resolve/normalize/transformers.rs
@@ -106,8 +106,8 @@ impl<'a> NameTransformer for FullyQualifyingTransformer<'a> {
             3 => {
                 // Already fully qualified — optionally rewrite database name
                 if let Some(map) = &self.database_name_map {
-                    let db_str = name.0[0].to_string();
-                    if let Some(new_db) = map.get(&db_str) {
+                    let db_str = name.0[0].as_str();
+                    if let Some(new_db) = map.get(db_str) {
                         let database = Ident::new(new_db).expect("valid identifier");
                         return UnresolvedItemName(vec![
                             database,


### PR DESCRIPTION
Supporting statements (GRANT, COMMENT, CREATE INDEX) are normalized to
fully qualified names, but the object they were checked against came from
the un-normalized CREATE statement. For an unqualified object (the
idiomatic style) that identifier carried no database or schema, so the
schema comparison short-circuited and a supporting statement pointing at
a different schema was silently accepted. Build the object identifier
from the file's fully qualified name so the schema is always present.

Ticket: [DEX-47](https://linear.app/materializeinc/issue/DEX-47), [DEX-62](https://linear.app/materializeinc/issue/DEX-62)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

The cross-database reference rewrite looked up the database name map with
`Ident::to_string()`, which renders a non-bare identifier in its quoted
SQL form (`café` -> `"café"`). The map is keyed by the raw directory
name, so any database whose name needs quoting missed the lookup and kept
its unsuffixed name under a profile. Key the lookup off the raw
identifier via `as_str()`.

Ticket: [DEX-51](https://linear.app/materializeinc/issue/DEX-51)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Converting an `UnresolvedItemName` to a `DatabaseIdent` matched only one,
two, or three qualification levels and treated anything else as
`unreachable!()`. The SQL parser places no cap on dotted names, so a
supporting statement referencing a four-part name (e.g.
`COMMENT ON COLUMN a.b.c.d.id`) panicked during reference validation.

Make the conversion fallible. The four reference validators
(index, grant, comment target, column comment) now report an
`InvalidIdentifier` validation error for an unusable reference name. The
object's own-name extraction falls back to a non-matching identifier so
name validation reports it rather than panicking.

Ticket: [DEX-59](https://linear.app/materializeinc/issue/DEX-59)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Rewriting database and schema names in mod statements appended the
profile/staging suffix and built the result with
`Ident::new(...).expect(...)`. A name already near the identifier length
limit overflowed it once suffixed, so compiling or applying such a
project panicked. Record the over-length condition as a `LoadError`
through the rewrite visitors and propagate it, so it surfaces as a
normal error.

Ticket: [DEX-63](https://linear.app/materializeinc/issue/DEX-63)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Applying a profile suffix to a cluster name that is already near the
identifier length limit produced a name longer than the limit. The
cluster rewrite passed that name to `Ident::new(...).expect(...)`, so
compiling such a project under a suffixing profile panicked. Validate
suffixed cluster names once, where the name map is built, and surface an
over-length name as a `LoadError` so it reports as a normal compile
error. The rewrite now consumes pre-validated `Ident`s.

Ticket: [DEX-52](https://linear.app/materializeinc/issue/DEX-52)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAcnVpSQi8ZgF5LekQRwvw