### PR TITLE
mz-deploy: fix LSP panic on position past end of document (DEX-55)

### DIFF
--- a/src/mz-deploy/src/lsp/diagnostics.rs
+++ b/src/mz-deploy/src/lsp/diagnostics.rs
@@ -341,11 +341,13 @@ pub(crate) fn offset_to_position(offset: usize, rope: &Rope) -> Option<Position>
 }
 
 /// Convert an LSP [`Position`] into a byte offset using a [`Rope`].
+///
+/// Returns `None` if the position lies past the end of the document.
 pub(crate) fn position_to_offset(position: Position, rope: &Rope) -> Option<usize> {
     let line = usize::try_from(position.line).ok()?;
     let target_col = usize::try_from(position.character).ok()?;
     let line_start_char = rope.try_line_to_char(line).ok()?;
-    let line_text = rope.line(line);
+    let line_text = rope.get_line(line)?;
 
     let mut utf16_col = 0usize;
     let mut char_delta = 0usize;
@@ -432,6 +434,14 @@ mod tests {
             position_to_offset(Position::new(0, 12), &rope),
             Some(text.len())
         );
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `llvm.aarch64.neon.uaddlv.i32.v16i8` on OS `linux`
+    fn position_to_offset_at_line_past_end_returns_none() {
+        let rope = Rope::from_str("a\nb");
+        let past_end = u32::try_from(rope.len_lines()).unwrap();
+        assert_eq!(position_to_offset(Position::new(past_end, 0), &rope), None);
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
`position_to_offset` guarded the line index with the fallible
`try_line_to_char`, which succeeds for a line index equal to the rope's
line count, then fetched the line with the infallible `rope.line`, which
panics there. A language client can request a one-past-the-end line
during a transient document-sync desync, crashing the LSP worker. Fetch
the line fallibly with `get_line` so the position resolves to `None`.

Ticket: DEX-55

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAcnVpSQi8ZgF5LekQRwvw