### PR TITLE
mz-deploy: stop rotating SSH tunnel keys on every apply (DEX-53)

### DIFF
--- a/src/mz-deploy/src/cli/commands/apply_connections.rs
+++ b/src/mz-deploy/src/cli/commands/apply_connections.rs
@@ -323,10 +323,53 @@ fn diff_connection_options(
 /// Reconciling them would emit an `ALTER CONNECTION` that rotates the keypair on
 /// every apply, so they are excluded from the diff entirely.
 fn is_server_managed(name: ConnectionOptionName) -> bool {
-    matches!(
-        name,
-        ConnectionOptionName::PublicKey1 | ConnectionOptionName::PublicKey2
-    )
+    use ConnectionOptionName::*;
+    match name {
+        // Server-generated for SSH connections and overwritten by the planner on
+        // every `plan_create_connection`, never taken from the user.
+        PublicKey1 | PublicKey2 => true,
+        // Everything else is user-authored. Enumerated explicitly (no `_`) so a
+        // new ConnectionOptionName variant fails to compile here until it is
+        // classified. Defaulting a future server-generated option to
+        // user-authored would silently reintroduce the rotate-on-every-apply bug.
+        AccessKeyId
+        | AssumeRoleArn
+        | AssumeRoleSessionName
+        | AvailabilityZones
+        | AwsConnection
+        | AwsPrivatelink
+        | Broker
+        | Brokers
+        | Credential
+        | Database
+        | Endpoint
+        | GcpConnection
+        | Host
+        | Password
+        | Port
+        | ProgressTopic
+        | ProgressTopicReplicationFactor
+        | Region
+        | Registry
+        | SaslMechanisms
+        | SaslPassword
+        | SaslUsername
+        | Scope
+        | SecretAccessKey
+        | SecurityProtocol
+        | ServiceAccountKey
+        | ServiceName
+        | SshTunnel
+        | SslCertificate
+        | SslCertificateAuthority
+        | SslKey
+        | SslMode
+        | SessionToken
+        | CatalogType
+        | Url
+        | User
+        | Warehouse => false,
+    }
 }
 
 #[cfg(test)]

--- a/src/mz-deploy/src/cli/commands/apply_connections.rs
+++ b/src/mz-deploy/src/cli/commands/apply_connections.rs
@@ -289,6 +289,9 @@ fn diff_connection_options(
 
     // Options in project but not in live, or with different values → SET
     for (name, project_opt) in &project_map {
+        if is_server_managed(*name) {
+            continue;
+        }
         match live_map.get(name) {
             None => to_set.push((*project_opt).clone()),
             Some(live_opt) => {
@@ -301,12 +304,29 @@ fn diff_connection_options(
 
     // Options in live but not in project → DROP
     for name in live_map.keys() {
+        if is_server_managed(*name) {
+            continue;
+        }
         if !project_map.contains_key(name) {
             to_drop.push(*name);
         }
     }
 
     (to_set, to_drop)
+}
+
+/// Whether a connection option is generated and owned by the server rather than
+/// written by the user.
+///
+/// An SSH tunnel connection's `PUBLIC KEY 1`/`PUBLIC KEY 2` are produced by the
+/// server and shown by `SHOW CREATE`, but cannot appear in project SQL.
+/// Reconciling them would emit an `ALTER CONNECTION` that rotates the keypair on
+/// every apply, so they are excluded from the diff entirely.
+fn is_server_managed(name: ConnectionOptionName) -> bool {
+    matches!(
+        name,
+        ConnectionOptionName::PublicKey1 | ConnectionOptionName::PublicKey2
+    )
 }
 
 #[cfg(test)]
@@ -374,6 +394,28 @@ mod tests {
         assert!(to_set.is_empty());
         assert_eq!(to_drop.len(), 1);
         assert_eq!(to_drop[0], ConnectionOptionName::Database);
+    }
+
+    #[mz_ore::test]
+    fn test_diff_ignores_server_managed_public_keys() {
+        // SHOW CREATE on an SSH tunnel connection reports server-generated
+        // public keys the user never wrote. Reconciling them would rotate the
+        // keypair, so the diff must ignore them.
+        let project = vec![make_option(
+            ConnectionOptionName::Host,
+            "bastion.example.com",
+        )];
+        let live = vec![
+            make_option(ConnectionOptionName::Host, "bastion.example.com"),
+            make_option(ConnectionOptionName::PublicKey1, "ssh-ed25519 AAAA1"),
+            make_option(ConnectionOptionName::PublicKey2, "ssh-ed25519 AAAA2"),
+        ];
+        let (to_set, to_drop) = diff_connection_options(&project, &live);
+        assert!(to_set.is_empty(), "no options should be set");
+        assert!(
+            to_drop.is_empty(),
+            "server-managed public keys must not be dropped, got: {to_drop:?}"
+        );
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
The connection-options diff is purely structural, so the server-generated
`PUBLIC KEY 1`/`PUBLIC KEY 2` that `SHOW CREATE` reports for an SSH tunnel
connection (and that a user cannot write in project SQL) always looked
like drift. Every re-apply emitted `ALTER CONNECTION ... DROP (PUBLIC KEY
1/2)`, which rotates the keypair and breaks bastions authorized against
the old keys. Exclude these server-managed options from both sides of the
diff so apply is idempotent.

Ticket: [DEX-53](https://linear.app/materializeinc/issue/DEX-53)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAcnVpSQi8ZgF5LekQRwvw