### PR TITLE
mz-deploy: run the roles phase before clusters in apply-all (DEX-49)

### DIFF
--- a/src/mz-deploy/src/cli/commands/apply_all.rs
+++ b/src/mz-deploy/src/cli/commands/apply_all.rs
@@ -9,7 +9,7 @@
 
 //! Apply-all orchestrator — runs all infrastructure apply steps in dependency order.
 //!
-//! Dependency order: clusters → roles → network policies → secrets → connections → sources → tables.
+//! Dependency order: roles → clusters → network policies → secrets → connections → sources → tables.
 //!
 //! **Key Insight:** The ordering ensures referential integrity — clusters must
 //! exist before MVs can reference them, connections must exist before sources
@@ -28,7 +28,7 @@ use crate::config::Settings;
 /// Run all infrastructure apply steps in dependency order.
 ///
 /// Plans all phases first with a shared client, then executes if not dry-run.
-/// Applies: clusters → roles → network policies → secrets (unless skipped) → connections → sources → tables.
+/// Applies: roles → clusters → network policies → secrets (unless skipped) → connections → sources → tables.
 pub async fn run(
     settings: &Settings,
     skip_secrets: bool,
@@ -40,8 +40,8 @@ pub async fn run(
     let executor = DeploymentExecutor::new_dry_run(&client);
 
     // Infrastructure phases (no schemas needed)
-    plan.add_phase(super::clusters::plan(settings, &client, &executor).await?);
     plan.add_phase(super::roles::plan(settings, &client, &executor).await?);
+    plan.add_phase(super::clusters::plan(settings, &client, &executor).await?);
     plan.add_phase(super::apply_network_policies::plan(settings, &client, &executor).await?);
 
     // Database object phases (schemas deduplicated via plan)

--- a/test/mz-deploy/mzcompose.py
+++ b/test/mz-deploy/mzcompose.py
@@ -2501,3 +2501,31 @@ def workflow_autoscaling(c: Composition, parser: WorkflowArgumentParser) -> None
         result = run_mz_deploy(c, "autoscaling/v3", "apply")
         assert result.returncode == 0, f"apply v3 failed: {result.stderr}"
         assert live_strategy("scaled") is None, "expected the policy to be reset"
+
+
+def workflow_apply_all_role_ordering(
+    c: Composition, parser: WorkflowArgumentParser
+) -> None:
+    """`apply` (apply-all) must create project roles before clusters, because a
+    cluster file may grant a privilege to a project-defined role.
+
+    Before the ordering fix the clusters phase ran first and its
+    `GRANT USAGE ON CLUSTER reporting TO reader` failed with "unknown role
+    'reader'", and the failure was sticky across re-runs.
+    """
+    setup_base(c)
+
+    # The roles phase creates `reader`; grant the deploy role permission to do
+    # so. This isolates the phase-ordering bug from privilege setup.
+    c.sql("GRANT CREATEROLE ON SYSTEM TO deploy_user", user="mz_system", port=6877)
+
+    result = run_mz_deploy(c, "cluster-grant-role/v1", "apply", "--profile", "default")
+    assert result.returncode == 0, (
+        "apply-all must create roles before clusters so a cluster grant can "
+        f"reference a project role:\n{result.stdout}\n{result.stderr}"
+    )
+
+    rows = c.sql_query("SELECT name FROM mz_roles WHERE name = 'reader'")
+    assert len(rows) == 1, f"expected role 'reader' to exist, got {rows}"
+    rows = c.sql_query("SELECT name FROM mz_clusters WHERE name = 'reporting'")
+    assert len(rows) == 1, f"expected cluster 'reporting' to exist, got {rows}"

--- a/test/mz-deploy/projects/cluster-grant-role/v1/.mzprofile
+++ b/test/mz-deploy/projects/cluster-grant-role/v1/.mzprofile
@@ -1,0 +1,1 @@
+default

--- a/test/mz-deploy/projects/cluster-grant-role/v1/clusters/reporting.sql
+++ b/test/mz-deploy/projects/cluster-grant-role/v1/clusters/reporting.sql
@@ -1,0 +1,12 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE CLUSTER reporting SIZE = 'scale=1,workers=1';
+
+GRANT USAGE ON CLUSTER reporting TO reader;

--- a/test/mz-deploy/projects/cluster-grant-role/v1/models/app/public/marker.sql
+++ b/test/mz-deploy/projects/cluster-grant-role/v1/models/app/public/marker.sql
@@ -1,0 +1,10 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE TABLE marker (id int);

--- a/test/mz-deploy/projects/cluster-grant-role/v1/roles/reader.sql
+++ b/test/mz-deploy/projects/cluster-grant-role/v1/roles/reader.sql
@@ -1,0 +1,10 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE ROLE reader;


### PR DESCRIPTION
`apply-all` planned the clusters phase before roles, but a cluster file
may carry `GRANT ... ON CLUSTER ... TO <role>` referencing a
project-defined role. Those grants executed in the clusters phase before
the roles phase created the role, so a fresh `apply-all` failed with
"unknown role" and stayed stuck across re-runs. Plan roles first; roles
never reference clusters, so there is no reverse dependency.

Ticket: DEX-49

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAcnVpSQi8ZgF5LekQRwvw