### PR TITLE
tests: Expose fuzz-only internals

### DIFF
--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -81,5 +81,8 @@ tonic-prost-build.workspace = true
 
 [features]
 default = ["mz-build-tools/default"]
+# Re-exports internal durable-state types (see `fuzz_exports`) for the
+# `src/persist-client/fuzz` cargo-fuzz crate. Not for production use.
+fuzzing = []
 turmoil = []
 foundationdb = ["mz-persist/foundationdb"]

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -9,7 +9,13 @@
 
 //! An abstraction presenting as a durable time-varying collection (aka shard)
 
-#![warn(missing_docs, missing_debug_implementations)]
+// The `fuzzing` feature re-exports internal types (see `fuzz_exports`) that are
+// intentionally undocumented. Don't require docs/Debug for them in that
+// test-only build. The normal public API is still linted.
+#![cfg_attr(
+    not(feature = "fuzzing"),
+    warn(missing_docs, missing_debug_implementations)
+)]
 // #[track_caller] is currently a no-op on async functions, but that hopefully won't be the case
 // forever. So we already annotate those functions now and ignore the compiler warning until
 // https://github.com/rust-lang/rust/issues/87417 pans out.
@@ -97,6 +103,17 @@ pub mod schema;
 pub mod stats;
 pub mod usage;
 pub mod write;
+
+/// Internal durable-state types re-exported under `cfg(feature = "fuzzing")` so
+/// the fuzz crate can drive their proto round-trips (`ProtoRollup`/`ProtoStateDiff`
+/// are decoded from blob/consensus on every state load). Not part of the public
+/// API.
+#[cfg(feature = "fuzzing")]
+pub mod fuzz_exports {
+    pub use crate::internal::encoding::Rollup;
+    pub use crate::internal::state::{ProtoRollup, ProtoStateDiff};
+    pub use crate::internal::state_diff::StateDiff;
+}
 
 /// An implementation of the public crate interface.
 mod internal {

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -45,3 +45,6 @@ uuid = { workspace = true, features = ["v4"] }
 
 [features]
 default = []
+# Re-exports internal types (`codec::Codec` etc.) so the fuzz crate can
+# drive the frontend-message decoder directly. Not for production use.
+fuzzing = []

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -33,3 +33,11 @@ mod server;
 pub use metrics::MetricsConfig;
 pub use protocol::match_handshake;
 pub use server::{Config, Server};
+
+/// Internal types re-exported under `cfg(feature = "fuzzing")` so the fuzz
+/// crate can drive the frontend-message decoder directly. Not for
+/// production use.
+#[cfg(feature = "fuzzing")]
+pub mod fuzz_exports {
+    pub use crate::codec::Codec;
+}

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -109,6 +109,9 @@ tokio.workspace = true
 
 [features]
 default = []
+# Exposes the in-memory upsert backend and `FuzzUpsertParts` so the fuzz crate
+# can drive the upsert state machine. Not enabled in production builds.
+fuzzing = []
 
 [package.metadata.cargo-udeps.ignore]
 # only used on linux

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -9,7 +9,10 @@
 
 //! Materialize's storage layer.
 
-#![warn(missing_docs)]
+// The `fuzzing` feature re-exports internal upsert types (see `fuzz_exports`)
+// that are intentionally undocumented. Don't require docs for them in that
+// build. The normal public API is still linted.
+#![cfg_attr(not(feature = "fuzzing"), warn(missing_docs))]
 
 pub mod decode;
 pub mod internal_control;
@@ -23,6 +26,20 @@ pub mod storage_state;
 pub(crate) mod upsert;
 mod upsert_continual_feedback;
 mod upsert_continual_feedback_v2;
+
+/// Internal upsert types re-exported under `cfg(feature = "fuzzing")` so the
+/// storage fuzz crate can drive the upsert state machine and value encodings
+/// directly. The modules themselves stay crate-private; this facade exposes
+/// only the items the fuzz targets need (mirroring `mz-persist-client` and
+/// `mz-pgwire`). Not part of the public API.
+#[cfg(feature = "fuzzing")]
+pub mod fuzz_exports {
+    pub use crate::upsert::types::{
+        FuzzUpsertParts, StateValue, UpsertValueAndSize, upsert_bincode_opts,
+    };
+    pub use crate::upsert::{UpsertKey, UpsertValue, fuzz_drain_staged_input};
+    pub use crate::upsert_continual_feedback_v2::{datum_seq_to_upsert_value, upsert_value_to_row};
+}
 
 pub(crate) mod healthcheck;
 

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -121,7 +121,7 @@ use timely::PartialOrder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::vec::Broadcast;
-use timely::dataflow::operators::{Capability, CapabilitySet, Inspect};
+use timely::dataflow::operators::{Capability, CapabilitySet, InspectCore};
 use timely::dataflow::{Scope, Stream, StreamVec};
 use timely::progress::{Antichain, Timestamp};
 use tokio::sync::Semaphore;
@@ -847,8 +847,21 @@ fn write_batches<'scope>(
         }
     });
 
+    // Use `InspectCore::inspect_container` instead of `Inspect::inspect`.
+    // `Inspect` carries a `where for<'a> &'a C: IntoIterator` bound, and on
+    // macOS the solver can satisfy that bound by chasing objc2's
+    // `&Retained<T>: IntoIterator` blanket impl into an endless
+    // `Retained<Retained<…>>` chain, overflowing the recursion limit.
+    // `InspectCore` has no such bound, so the cascade never starts. We
+    // iterate the container by hand to recover the per-item callback.
     let output_stream = if collection_id.is_user() {
-        output_stream.inspect(|d| trace!("batch: {:?}", d))
+        InspectCore::inspect_container(output_stream, |event| {
+            if let Ok((_, data)) = event {
+                for d in data {
+                    trace!("batch: {:?}", d);
+                }
+            }
+        })
     } else {
         output_stream
     };

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -55,7 +55,7 @@ use timely::dataflow::operators::core::Map as _;
 use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::vec::Broadcast;
-use timely::dataflow::operators::{CapabilitySet, Inspect, Leave};
+use timely::dataflow::operators::{CapabilitySet, InspectCore, Leave};
 use timely::dataflow::{Scope, StreamVec};
 use timely::order::TotalOrder;
 use timely::progress::frontier::MutableAntichain;
@@ -381,9 +381,20 @@ where
     // Broadcasting does more work than necessary, which would be to exchange the probes to the
     // worker that will be the one minting the bindings but we'd have to thread this information
     // through and couple the two functions enough that it's not worth the optimization (I think).
-    probe_stream.broadcast().inspect(move |probe| {
-        // We don't care if the receiver is gone
-        let _ = probed_upper_tx.send(Some(probe.clone()));
+    // Use `InspectCore::inspect_container` instead of `Inspect::inspect`.
+    // `Inspect` carries a `where for<'a> &'a C: IntoIterator` bound, and on
+    // macOS the solver can satisfy that bound by chasing objc2's
+    // `&Retained<T>: IntoIterator` blanket impl into an endless
+    // `Retained<Retained<…>>` chain, overflowing the recursion limit.
+    // `InspectCore` has no such bound, so the cascade never starts. We
+    // iterate the container by hand to recover the per-item callback.
+    probe_stream.broadcast().inspect_container(move |event| {
+        if let Ok((_, data)) = event {
+            for probe in data {
+                // We don't care if the receiver is gone
+                let _ = probed_upper_tx.send(Some(probe.clone()));
+            }
+        }
     });
 
     (

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -55,7 +55,7 @@ use types::{
     upsert_bincode_opts,
 };
 
-#[cfg(test)]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod memory;
 pub(crate) mod rocksdb;
 // TODO(aljoscha): Move next to upsert module, rename to upsert_types.
@@ -967,6 +967,76 @@ async fn drain_staged_input<S, T, FromTime, E>(
                 .await;
         }
     }
+}
+
+/// A no-op-ish error emitter for the fuzzing hook. With the in-memory backend
+/// and the well-formed inputs the fuzzer builds, `multi_get`/`multi_put` never
+/// error, so reaching this is itself a finding.
+#[cfg(feature = "fuzzing")]
+struct PanicErrorEmitter;
+
+#[cfg(feature = "fuzzing")]
+#[async_trait::async_trait(?Send)]
+impl<T> UpsertErrorEmitter<T> for PanicErrorEmitter {
+    async fn emit(&mut self, context: String, e: anyhow::Error) {
+        panic!("unexpected upsert state error during fuzzing: {context}: {e}");
+    }
+}
+
+/// Fuzzing hook: run a single `drain_staged_input` over `commands` (each a
+/// `(timestamp, key, order, value)`, where `value == None` is a delete) against
+/// a fresh empty in-memory state, draining everything strictly below
+/// `drain_to`. Returns the emitted output updates and the final finalized value
+/// of each key in `all_keys`. Exposed only for fuzzing. Not a stable public
+/// API.
+#[cfg(feature = "fuzzing")]
+pub async fn fuzz_drain_staged_input(
+    parts: &types::FuzzUpsertParts,
+    source_config: &crate::source::SourceExportCreationConfig,
+    commands: Vec<(u64, UpsertKey, u64, Option<UpsertValue>)>,
+    drain_to: u64,
+    all_keys: &[UpsertKey],
+) -> (Vec<(UpsertValue, u64, Diff)>, Vec<Option<UpsertValue>>) {
+    let mut state = parts.state();
+    let mut stash: Vec<(u64, UpsertKey, Reverse<u64>, Option<UpsertValue>)> = commands
+        .into_iter()
+        .map(|(ts, key, order, value)| (ts, key, Reverse(order), value))
+        .collect();
+    let mut commands_state = indexmap::IndexMap::new();
+    let mut output = Vec::new();
+    let mut multi_get_scratch = Vec::new();
+    let mut emitter = PanicErrorEmitter;
+
+    drain_staged_input(
+        &mut stash,
+        &mut commands_state,
+        &mut output,
+        &mut multi_get_scratch,
+        DrainStyle::ToUpper(&Antichain::from_elem(drain_to)),
+        &mut emitter,
+        &mut state,
+        source_config,
+    )
+    .await;
+
+    let bincode_opts = types::upsert_bincode_opts();
+    let mut results = vec![types::UpsertValueAndSize::default(); all_keys.len()];
+    state
+        .multi_get(all_keys.iter().copied(), results.iter_mut())
+        .await
+        .expect("multi_get in fuzz hook should not error");
+    let final_state = results
+        .into_iter()
+        .map(|r| match r.value {
+            None => None,
+            Some(mut sv) => {
+                sv.ensure_decoded(bincode_opts, GlobalId::User(0), None);
+                sv.into_decoded().finalized
+            }
+        })
+        .collect();
+
+    (output, final_state)
 }
 
 // Created a struct to hold the configs for upserts.

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -304,7 +304,7 @@ impl<T, O> StateValue<T, O> {
     /// 2. An estimate (it only looks at value sizes, and not errors)
     ///
     /// Other implementations may use more accurate accounting.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn memory_size(&self) -> usize {
         use mz_repr::Row;
         use std::mem::size_of;
@@ -1018,6 +1018,90 @@ impl<'metrics, S, T, O> UpsertState<'metrics, S, T, O> {
             multi_get_scratch: Vec::new(),
             shrink_upsert_unused_buffers_by_ratio,
         }
+    }
+}
+
+/// Owns the metrics/statistics plumbing an [`UpsertState`] requires, so a fuzz
+/// target can build fresh in-memory `UpsertState`s without reconstructing it
+/// each iteration (or leaking it). Construct once. Call [`Self::state`] per
+/// iteration. Exposed only for fuzzing. Not a stable public API.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub struct FuzzUpsertParts {
+    shared: std::sync::Arc<UpsertSharedMetrics>,
+    worker: UpsertMetrics,
+    stats_defs: crate::statistics::SourceStatisticsMetricDefs,
+}
+
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+impl FuzzUpsertParts {
+    pub fn new() -> Self {
+        let registry = mz_ore::metrics::MetricsRegistry::new();
+        let upsert_defs = crate::metrics::upsert::UpsertMetricDefs::register_with(&registry);
+        let id = GlobalId::User(0);
+        let shared = upsert_defs.shared(&id);
+        let worker = UpsertMetrics::new(&upsert_defs, id, 0, None);
+        let stats_defs = crate::statistics::SourceStatisticsMetricDefs::register_with(&registry);
+        FuzzUpsertParts {
+            shared,
+            worker,
+            stats_defs,
+        }
+    }
+
+    /// A fresh, empty in-memory `UpsertState` borrowing the shared metrics.
+    pub fn state(
+        &self,
+    ) -> UpsertState<'_, crate::upsert::memory::InMemoryHashMap<u64, u64>, u64, u64> {
+        let id = GlobalId::User(0);
+        let stats = crate::statistics::SourceStatistics::new(
+            id,
+            0,
+            &self.stats_defs,
+            id,
+            &mz_persist_client::ShardId::new(),
+            mz_storage_types::sources::SourceEnvelope::CdcV2,
+            timely::progress::Antichain::from_elem(mz_repr::Timestamp::MIN),
+        );
+        UpsertState::new(
+            crate::upsert::memory::InMemoryHashMap::default(),
+            std::sync::Arc::clone(&self.shared),
+            &self.worker,
+            stats,
+            0,
+        )
+    }
+
+    /// A `SourceExportCreationConfig` for driving `drain_staged_input` directly.
+    /// `drain_staged_input` only reads `.id` from it, but the struct requires the
+    /// full metrics/statistics plumbing, which this builds.
+    pub fn source_config(&self) -> crate::source::SourceExportCreationConfig {
+        let id = GlobalId::User(0);
+        let registry = mz_ore::metrics::MetricsRegistry::new();
+        let metrics = crate::metrics::StorageMetrics::register_with(&registry);
+        let source_statistics = crate::statistics::SourceStatistics::new(
+            id,
+            0,
+            &self.stats_defs,
+            id,
+            &mz_persist_client::ShardId::new(),
+            mz_storage_types::sources::SourceEnvelope::CdcV2,
+            timely::progress::Antichain::from_elem(mz_repr::Timestamp::MIN),
+        );
+        crate::source::SourceExportCreationConfig {
+            id,
+            worker_id: 0,
+            metrics,
+            source_statistics,
+        }
+    }
+}
+
+#[cfg(feature = "fuzzing")]
+impl Default for FuzzUpsertParts {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/storage/src/upsert_continual_feedback_v2.rs
+++ b/src/storage/src/upsert_continual_feedback_v2.rs
@@ -29,7 +29,7 @@
 //! ## Operator loop (each iteration)
 //!
 //! 1. **Ingest source data.** Read upsert commands from the source input,
-//!    wrap each in an [`UpsertDiff`] (carrying a columnar order key projected
+//!    wrap each in an `UpsertDiff` (carrying a columnar order key projected
 //!    from `FromTime` via [`UpsertSourceTime`] for dedup), and push into the
 //!    source-stash batcher. The batcher is a paged columnar merge batcher: it
 //!    consolidates entries for the same `(key, time)` via the `UpsertDiff`
@@ -52,7 +52,7 @@
 //!      caught up yet. Push back into the batcher for the next iteration.
 //!    - **Already persisted** (below the persist frontier): some writer has
 //!      already advanced the shard past this time, so it is dropped. See
-//!      [`drain_sealed_input`] for why re-stashing it would strand the data
+//!      `drain_sealed_input` for why re-stashing it would strand the data
 //!      and pin the output frontier below the shard upper.
 //!
 //! 4. **Capability management.** Downgrade the output capability to the
@@ -82,6 +82,9 @@ use differential_dataflow::trace::{Batcher, Cursor, Description, TraceReader};
 use differential_dataflow::{AsCollection, VecCollection};
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_row_spine::{ValRowColPagedBuilder, ValRowSpine};
+// Only the fuzzing-gated `datum_seq_to_upsert_value` takes a `DatumSeq`.
+#[cfg(feature = "fuzzing")]
+use mz_row_spine::DatumSeq;
 use mz_storage_types::errors::{DataflowError, EnvelopeError, UpsertError};
 use mz_timely_util::builder_async::{
     AsyncOutputHandle, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
@@ -273,7 +276,13 @@ type UpsertOutputHandle<T> =
 
 /// Encode an [`UpsertValue`] as a `Row` with a leading tag column so both `Ok`
 /// and `Err` payloads round-trip through `Row` byte storage.
-fn upsert_value_to_row(value: &UpsertValue) -> Row {
+///
+/// Used on the render path. `pub` only so [`crate::fuzz_exports`] can re-export
+/// it under the `fuzzing` feature for the storage fuzz crate. The enclosing
+/// module is crate-private, so it is not otherwise reachable. Not a stable
+/// public API.
+#[doc(hidden)]
+pub fn upsert_value_to_row(value: &UpsertValue) -> Row {
     let mut row = Row::default();
     let mut packer = row.packer();
     match value {
@@ -298,6 +307,17 @@ fn upsert_value_byte_len(value: &UpsertValue) -> usize {
         Ok(row) => row.byte_len(),
         Err(err) => std::mem::size_of_val(err.as_ref()),
     }
+}
+
+/// Decode an [`UpsertValue`] produced by [`upsert_value_to_row`] back from the
+/// `DatumSeq` view returned by a `ValRowSpine` cursor.
+///
+/// Exists only for the storage fuzz crate, so it is gated behind the `fuzzing`
+/// feature. Not a stable public API.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub fn datum_seq_to_upsert_value(seq: DatumSeq<'_>) -> UpsertValue {
+    decode_upsert_value(seq)
 }
 
 /// Decode an [`UpsertValue`] produced by [`upsert_value_to_row`] from any datum


### PR DESCRIPTION
Replacement stack for #36982. This is part 2 of 10.

Summary:
- Adds fuzzing Cargo features for pgwire, persist-client, and storage.
- Adds cfg-gated fuzz_exports modules for fuzz targets.
- Switches two storage Inspect uses to InspectCore to avoid the macOS trait-solver overflow hit by fuzz builds.

Review notes:
- This is the production-code review unit in the stack.
- The new APIs are feature-gated and documented as not being stable public API.

Verification:
- Split from original commit 082e197653 and reapplied onto current upstream/main.
- Top of stack has the same touched-file set as #36982 and passes git diff --check.

Stack:
1. #37381 tests: Add shared cargo-fuzz runner
2. #37382 tests: Expose fuzz-only internals
3. #37383 sql-parser: Add cargo-fuzz targets
4. #37384 expr, transform: Add cargo-fuzz targets
5. #37385 repr, pgwire: Add cargo-fuzz targets
6. #37386 avro, interchange: Add cargo-fuzz targets
7. #37387 storage-types: Add proto cargo-fuzz targets
8. #37388 persist-client: Add cargo-fuzz targets
9. #37389 storage: Add upsert cargo-fuzz targets
10. #37390 ci: Run cargo-fuzz in release qualification

The original monolithic PR is #36982.