### PR TITLE
repr, pgwire: Add cargo-fuzz targets

### DIFF
--- a/src/pgcopy/fuzz/.gitignore
+++ b/src/pgcopy/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/pgcopy/fuzz/Cargo.toml
+++ b/src/pgcopy/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+# Fuzz crate for mz-pgcopy: decode untrusted `COPY ... FROM` data. COPY input
+# arrives verbatim from a client, and the text/CSV field splitting plus the
+# per-type value decoding are hand-written byte/text parsers sitting at the
+# trust boundary, so any panic/SEGV reachable from the data is an availability
+# bug.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-pgcopy-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-pgcopy = { path = ".." }
+mz-pgrepr = { path = "../../pgrepr" }
+
+[[bin]]
+name = "copy_decode"
+path = "fuzz_targets/copy_decode.rs"
+test = false
+doc = false
+bench = false

--- a/src/pgcopy/fuzz/fuzz_targets/copy_decode.rs
+++ b/src/pgcopy/fuzz/fuzz_targets/copy_decode.rs
@@ -1,0 +1,297 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `mz_pgcopy::decode_copy_format` parses untrusted `COPY … FROM`
+//! data (text and CSV) into rows. COPY data comes straight from a client, and
+//! the field splitting plus per-type value decoding are hand-written parsers at
+//! the trust boundary, so any panic is an availability bug.
+//!
+//! The field splitter accepts almost any bytes, but the per-type value decoders
+//! (int/float/date/jsonb/uuid/bytea) reject random field text immediately, so
+//! raw bytes exercise the line/field framing but barely reach the value
+//! decoders. We instead consume the byte stream as grammar choices and emit a
+//! valid row set for the fixed 9-column schema so each value decoder runs
+//! through to its success path. Generation is tailored per format:
+//!
+//!   * Text: per-type values delimiter-joined with `\N` NULL tokens, and the
+//!     text column sometimes carries real COPY-text escape sequences (`a\tb`,
+//!     `\x41`, `\052`, embedded `\n`, `\b\f\v\r`) so the `consume_raw_value`
+//!     backslash/hex/octal escape decoder runs end to end (its decoded bytes
+//!     stay valid UTF-8 so the Text decode still succeeds).
+//!   * CSV: the format params themselves are fuzzed the way the product's
+//!     `impl Arbitrary for CopyCsvFormatParams` does it (quote derived to differ
+//!     from the delimiter, an optional distinct escape, optional header,
+//!     optional non-empty NULL token). Every field that could contain the
+//!     active delimiter/quote/escape (notably the text column and the NULL
+//!     token) is properly quoted and escaped so it survives the csv-core framing
+//!     layer and reaches the value decoder instead of erroring early. When a
+//!     header is configured we additionally emit a leading header row so the
+//!     header-skip path is exercised alongside data rows.
+//!
+//! A quarter of inputs feed the raw bytes through both formats so the
+//! framing/error paths stay covered.
+
+#![no_main]
+
+use std::borrow::Cow;
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_pgcopy::{CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams, decode_copy_format};
+use mz_pgrepr::Type;
+
+/// A fixed, type-diverse schema exercising many per-field value decoders.
+const COLS: [Type; 9] = [
+    Type::Int4,
+    Type::Text,
+    Type::Bool,
+    Type::Float8,
+    Type::Bytea,
+    Type::Date,
+    Type::Int8,
+    Type::Jsonb,
+    Type::Uuid,
+];
+
+const HEX: &[char] = &[
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+];
+
+/// Emit the *logical* (already-unescaped) text representation of column `col`.
+/// Callers escape the result as needed for the target format. `text_format`
+/// only affects bytea, which uses a literal backslash prefix that the text
+/// escaper will later double.
+fn push_value(
+    u: &mut Unstructured,
+    col: usize,
+    text_format: bool,
+    out: &mut String,
+) -> arbitrary::Result<()> {
+    match col {
+        0 => out.push_str(&u.arbitrary::<i32>()?.to_string()),
+        1 => {
+            let n = u.int_in_range(0usize..=6)?;
+            for _ in 0..n {
+                out.push(*u.choose(&['a', 'b', 'Z', '0', '9', ' '])?);
+            }
+        }
+        2 => out.push_str(u.choose(&["t", "f", "true", "false"])?),
+        3 => out.push_str(u.choose(&[
+            "0", "-1.5", "3.14", "1e10", "-2.5e-3", "Infinity", "-Infinity", "NaN",
+        ])?),
+        4 => {
+            // bytea hex: `\x<hex>`. In COPY text the backslash must be doubled.
+            out.push_str(if text_format { "\\\\x" } else { "\\x" });
+            for _ in 0..u.int_in_range(0usize..=6)? {
+                out.push(*u.choose(HEX)?);
+            }
+        }
+        5 => {
+            let y = u.int_in_range(2000u32..=2099)?;
+            let m = u.int_in_range(1u32..=12)?;
+            let d = u.int_in_range(1u32..=28)?;
+            out.push_str(&format!("{y:04}-{m:02}-{d:02}"));
+        }
+        6 => out.push_str(&u.arbitrary::<i64>()?.to_string()),
+        // Comma/tab/backslash-free JSON so the same value is valid in both formats.
+        7 => out.push_str(u.choose(&["1", "true", "null", "\"s\"", "{\"a\":1}", "[1]"])?),
+        _ => {
+            let b: [u8; 16] = u.arbitrary()?;
+            for (i, byte) in b.iter().enumerate() {
+                if matches!(i, 4 | 6 | 8 | 10) {
+                    out.push('-');
+                }
+                out.push_str(&format!("{byte:02x}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Append the text column (col 1) directly as COPY-text escape sequences, so
+/// the `consume_raw_value` backslash/hex/octal decoder runs through its escape
+/// branches. The chosen escapes all decode to valid-UTF-8 bytes that are not a
+/// delimiter or newline, so the field stays single, decodes as a `Text` value,
+/// and does not disturb the line framing.
+fn push_text_escapes(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    let n = u.int_in_range(0usize..=4)?;
+    for _ in 0..n {
+        out.push_str(u.choose(&[
+            // Literal chars (decode to themselves).
+            "a", "b", "Z", "0",
+            // Recognized C-style escapes (decode to control bytes).
+            "\\b", "\\f", "\\n", "\\r", "\\t", "\\v",
+            // Hex escapes in the printable ASCII range.
+            "\\x41", "\\x7e", "\\x2c",
+            // Octal escapes in the printable ASCII range.
+            "\\101", "\\052", "\\176",
+            // A backslash before a non-escape char drops the backslash.
+            "\\q", "\\\\",
+        ])?);
+    }
+    Ok(())
+}
+
+/// Append `field` to a CSV record, quoting+escaping it when it could otherwise
+/// confuse the framing layer: when it contains the delimiter, quote, escape,
+/// `\r`, or `\n`, when it is empty (so it is never mistaken for the empty-string
+/// NULL marker), or when it equals the active NULL token (so a data value that
+/// happens to match the NULL token is preserved as data rather than read as
+/// SQL NULL).
+fn push_csv_field(field: &str, params: &CopyCsvFormatParams, out: &mut String) {
+    let q = params.quote as char;
+    let esc = params.escape as char;
+    let delim = params.delimiter as char;
+    let needs_quote = field.is_empty()
+        || *field == *params.null
+        || field
+            .chars()
+            .any(|c| c == delim || c == q || c == esc || c == '\r' || c == '\n');
+    if needs_quote {
+        out.push(q);
+        for c in field.chars() {
+            if c == q || c == esc {
+                out.push(esc);
+            }
+            out.push(c);
+        }
+        out.push(q);
+    } else {
+        out.push_str(field);
+    }
+}
+
+fn decode_text(data: &[u8]) {
+    let _ = decode_copy_format(
+        data,
+        &COLS,
+        CopyFormatParams::Text(CopyTextFormatParams {
+            null: Cow::Borrowed("\\N"),
+            delimiter: b'\t',
+        }),
+    );
+}
+
+fn decode_csv(data: &[u8], params: CopyCsvFormatParams<'static>) {
+    let _ = decode_copy_format(data, &COLS, CopyFormatParams::Csv(params));
+}
+
+/// Build CSV params the way `impl Arbitrary for CopyCsvFormatParams` does:
+/// derive the quote so it differs from the delimiter, optionally a distinct
+/// escape, an optional header, and an optional non-empty NULL token. The result
+/// always satisfies the `try_new` invariant (quote != delimiter).
+fn arbitrary_csv_params(u: &mut Unstructured) -> arbitrary::Result<CopyCsvFormatParams<'static>> {
+    let delimiter: u8 = u.arbitrary()?;
+    // Mirror the proptest strategy: pick a non-zero difference and wrap-add it
+    // to the delimiter, guaranteeing quote != delimiter.
+    let diff = u.arbitrary::<u8>()?.saturating_sub(1).max(1);
+    let quote = delimiter.wrapping_add(diff);
+    // Half the time use a distinct escape (the non-double-quote csv-core path).
+    let escape = if u.arbitrary()? {
+        let ediff = u.arbitrary::<u8>()?.saturating_sub(1).max(1);
+        quote.wrapping_add(ediff)
+    } else {
+        quote
+    };
+    let header: bool = u.arbitrary()?;
+    let null = if u.arbitrary()? {
+        // A non-empty NULL token (e.g. the conventional `NULL` / `\N`).
+        u.choose(&["NULL", "\\N", "null", "NA", "-"])?.to_string()
+    } else {
+        String::new()
+    };
+    CopyCsvFormatParams::try_new(
+        Some(delimiter),
+        Some(quote),
+        Some(escape),
+        Some(header),
+        Some(null),
+    )
+    .map_err(|_| arbitrary::Error::IncorrectFormat)
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, feed the raw bytes through both formats: keeps the
+    // field/line framing and error paths covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        let rest = u.take_rest();
+        decode_text(rest);
+        decode_csv(rest, CopyCsvFormatParams::default());
+        return Ok(());
+    }
+
+    let text_format = u.int_in_range(0u8..=1)? == 0;
+
+    if text_format {
+        let mut s = String::new();
+        let rows = u.int_in_range(1usize..=4)?;
+        for _ in 0..rows {
+            for col in 0..COLS.len() {
+                if col > 0 {
+                    s.push('\t');
+                }
+                // 1-in-8 NULL via the `\N` token.
+                if u.int_in_range(0u8..=7)? == 0 {
+                    s.push_str("\\N");
+                } else if col == 1 && u.arbitrary()? {
+                    // Drive the escape decoder through the text column.
+                    push_text_escapes(&mut u, &mut s)?;
+                } else {
+                    push_value(&mut u, col, true, &mut s)?;
+                }
+            }
+            s.push('\n');
+        }
+        decode_text(s.as_bytes());
+        return Ok(());
+    }
+
+    // CSV: fuzz the format params, then emit data the params can actually frame.
+    let params = arbitrary_csv_params(&mut u)?;
+    let delim = params.delimiter as char;
+    let mut s = String::new();
+
+    // A configured header means the first record is column names that the
+    // decoder skips. Emit a plausible one so the header-skip path runs.
+    if params.header {
+        for col in 0..COLS.len() {
+            if col > 0 {
+                s.push(delim);
+            }
+            push_csv_field(&format!("col{col}"), &params, &mut s);
+        }
+        s.push('\n');
+    }
+
+    let rows = u.int_in_range(1usize..=4)?;
+    for _ in 0..rows {
+        for col in 0..COLS.len() {
+            if col > 0 {
+                s.push(delim);
+            }
+            // 1-in-8 NULL: emit the unquoted NULL token (empty field for the
+            // default empty marker), which the decoder reads as SQL NULL.
+            if u.int_in_range(0u8..=7)? == 0 {
+                s.push_str(&params.null);
+            } else {
+                let mut field = String::new();
+                push_value(&mut u, col, false, &mut field)?;
+                push_csv_field(&field, &params, &mut s);
+            }
+        }
+        s.push('\n');
+    }
+
+    decode_csv(s.as_bytes(), params);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/pgrepr/fuzz/.gitignore
+++ b/src/pgrepr/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/pgrepr/fuzz/Cargo.toml
+++ b/src/pgrepr/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+# Fuzz crate for mz-pgrepr: decode untrusted Postgres wire values. Bind
+# parameters arrive from clients in text or binary format and are decoded
+# per-type. The binary decoders (numeric base-10000, mz_acl_item, interval,
+# unsigned ints) and the strconv-backed text decoders are hand-written
+# byte/text parsers sitting at the client trust boundary, so any panic
+# reachable from a parameter value is an availability bug.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-pgrepr-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-pgrepr = { path = ".." }
+
+[[bin]]
+name = "value_decode_binary"
+path = "fuzz_targets/value_decode_binary.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "value_decode_text"
+path = "fuzz_targets/value_decode_text.rs"
+test = false
+doc = false
+bench = false

--- a/src/pgrepr/fuzz/fuzz_targets/value_decode_binary.rs
+++ b/src/pgrepr/fuzz/fuzz_targets/value_decode_binary.rs
@@ -1,0 +1,270 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Value::decode_binary` decodes a client-supplied bind-parameter
+//! value in Postgres *binary* format. The per-type decoders are hand-written
+//! big-endian byte parsers (numeric base-10000, mz_acl_item slice reads,
+//! interval, unsigned ints, jsonb). This is directly client-controlled input,
+//! so any panic is an availability bug. Must never panic.
+//!
+//! A random byte string almost never satisfies these strict decoders: an exact
+//! length check, a version byte, base-10000 digit bounds, a role-id variant tag.
+//! So feeding raw bytes leaves the decoders barely exercised. Instead we pick
+//! a type and *encode a valid binary value for it* (numeric header + digits, the
+//! 16-byte interval triple, the 26-byte mz_aclitem, a jsonb version byte plus
+//! real JSON, in-range date/time/timestamp), so the decoder runs all the way to
+//! the value-construction and range-check logic. We still occasionally truncate
+//! the valid encoding (to hit the length-validation / short-read paths) and, a
+//! quarter of the time, fall back to the "any OID, raw bytes" mode so the
+//! not-implemented branches and crafted-header paths stay covered.
+//!
+//! A few arms also reach past the "happy" shape on purpose: the numeric header
+//! sometimes carries an out-of-band weight/dscale or digit words outside
+//! `0..=9999` (negative or `>9999`) to exercise the base-10000 digit-bound and
+//! scale math, and the bytea/text bodies are occasionally multi-KB so the
+//! decoders' allocation/validation paths run on a large value rather than a
+//! handful of bytes.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_pgrepr::{Type, Value};
+
+/// Append a run of `0..=max` printable-ASCII bytes (valid UTF-8 for the string
+/// decoders).
+fn push_ascii(u: &mut Unstructured, b: &mut Vec<u8>, max: usize) -> arbitrary::Result<()> {
+    let n = u.int_in_range(0usize..=max)?;
+    for _ in 0..n {
+        b.push(u.int_in_range(0x20u8..=0x7e)?);
+    }
+    Ok(())
+}
+
+/// Append a binary `RoleId`: a variant tag byte (`s`/`g`/`u`/`p`) + u64 LE id.
+fn push_role_id(u: &mut Unstructured, b: &mut Vec<u8>) -> arbitrary::Result<()> {
+    b.push(*u.choose(&[b's', b'g', b'u', b'p'])?);
+    b.extend_from_slice(&u.arbitrary::<u64>()?.to_le_bytes());
+    Ok(())
+}
+
+/// Pick a type that has a binary decoder and encode a valid value for it.
+fn gen_typed_value(u: &mut Unstructured) -> arbitrary::Result<(Type, Vec<u8>)> {
+    let mut b = Vec::new();
+    let ty = match u.int_in_range(0u8..=25)? {
+        0 => {
+            b.push(u.int_in_range(0u8..=1)?);
+            Type::Bool
+        }
+        1 => {
+            // Usually a short body, but occasionally a multi-KB one so the
+            // bytea decoder's allocation/copy path runs on a large value.
+            let n = if u.int_in_range(0u8..=15)? == 0 {
+                u.int_in_range(1024usize..=8192)?
+            } else {
+                u.int_in_range(0usize..=16)?
+            };
+            for _ in 0..n {
+                b.push(u.arbitrary::<u8>()?);
+            }
+            Type::Bytea
+        }
+        2 => {
+            b.push(u.arbitrary::<u8>()?);
+            Type::Char
+        }
+        // Date: i32 BE days since 2000-01-01. from_pg_epoch range-checks.
+        3 => {
+            b.extend_from_slice(&u.arbitrary::<i32>()?.to_be_bytes());
+            Type::Date
+        }
+        4 => {
+            b.extend_from_slice(&u.arbitrary::<f32>()?.to_be_bytes());
+            Type::Float4
+        }
+        5 => {
+            b.extend_from_slice(&u.arbitrary::<f64>()?.to_be_bytes());
+            Type::Float8
+        }
+        6 => {
+            b.extend_from_slice(&u.arbitrary::<i16>()?.to_be_bytes());
+            Type::Int2
+        }
+        7 => {
+            b.extend_from_slice(&u.arbitrary::<i32>()?.to_be_bytes());
+            Type::Int4
+        }
+        8 => {
+            b.extend_from_slice(&u.arbitrary::<i64>()?.to_be_bytes());
+            Type::Int8
+        }
+        9 => {
+            b.extend_from_slice(&u.arbitrary::<u16>()?.to_be_bytes());
+            Type::UInt2
+        }
+        10 => {
+            b.extend_from_slice(&u.arbitrary::<u32>()?.to_be_bytes());
+            Type::UInt4
+        }
+        11 => {
+            b.extend_from_slice(&u.arbitrary::<u64>()?.to_be_bytes());
+            Type::UInt8
+        }
+        // Interval: i64 micros + i32 days + i32 months, all BE (16 bytes).
+        12 => {
+            b.extend_from_slice(&u.arbitrary::<i64>()?.to_be_bytes());
+            b.extend_from_slice(&u.arbitrary::<i32>()?.to_be_bytes());
+            b.extend_from_slice(&u.arbitrary::<i32>()?.to_be_bytes());
+            Type::Interval { constraints: None }
+        }
+        // Jsonb: a version byte (1) followed by real JSON text.
+        13 => {
+            b.push(1);
+            let json: &[u8] = match u.int_in_range(0u8..=7)? {
+                0 => b"null",
+                1 => b"true",
+                2 => b"123",
+                3 => b"-4.5",
+                4 => b"\"s\"",
+                5 => b"[1,2,3]",
+                6 => b"{\"a\":1}",
+                _ => b"[]",
+            };
+            b.extend_from_slice(json);
+            Type::Jsonb
+        }
+        14 => {
+            push_ascii(u, &mut b, 64)?;
+            Type::Name
+        }
+        // Numeric: i16 ndigits, i16 weight, u16 sign, u16 dscale, then ndigits
+        // base-10000 words (each 0..=9999).
+        15 => {
+            let nan = u.int_in_range(0u8..=5)? == 0;
+            let (ndigits, sign): (i16, u16) = if nan {
+                (0, 0xC000)
+            } else if u.int_in_range(0u8..=1)? == 0 {
+                (u.int_in_range(0i16..=4)?, 0x0000)
+            } else {
+                (u.int_in_range(0i16..=4)?, 0x4000)
+            };
+            // Mostly a well-formed in-range header so the decoder reaches value
+            // construction. Occasionally an out-of-band weight/dscale so the
+            // scale/precision math runs on extreme exponents.
+            let weight = if u.int_in_range(0u8..=7)? == 0 {
+                u.arbitrary::<i16>()?
+            } else {
+                u.int_in_range(-4i16..=4)?
+            };
+            let dscale = if u.int_in_range(0u8..=7)? == 0 {
+                u.arbitrary::<u16>()?
+            } else {
+                u.int_in_range(0u16..=10)?
+            };
+            b.extend_from_slice(&ndigits.to_be_bytes());
+            b.extend_from_slice(&weight.to_be_bytes());
+            b.extend_from_slice(&sign.to_be_bytes());
+            b.extend_from_slice(&dscale.to_be_bytes());
+            // Each base-10000 digit word should be 0..=9999. Occasionally emit
+            // an out-of-band word (>9999, or the full i16 range incl. negative)
+            // to exercise the digit-bound validation path.
+            let oob_words = u.int_in_range(0u8..=7)? == 0;
+            for _ in 0..ndigits {
+                let word = if oob_words {
+                    u.arbitrary::<i16>()?
+                } else {
+                    u.int_in_range(0i16..=9999)?
+                };
+                b.extend_from_slice(&word.to_be_bytes());
+            }
+            Type::Numeric { constraints: None }
+        }
+        16 => {
+            b.extend_from_slice(&u.arbitrary::<u32>()?.to_be_bytes());
+            Type::Oid
+        }
+        17 => {
+            // Occasionally a multi-KB UTF-8 body so the text decoder's
+            // validation/copy runs on a large value, not just a short one.
+            let max = if u.int_in_range(0u8..=15)? == 0 { 8192 } else { 16 };
+            push_ascii(u, &mut b, max)?;
+            Type::Text
+        }
+        18 => {
+            push_ascii(u, &mut b, 16)?;
+            Type::BpChar { length: None }
+        }
+        19 => {
+            push_ascii(u, &mut b, 16)?;
+            Type::VarChar { max_length: None }
+        }
+        // Time: i64 BE micros since midnight, in range.
+        20 => {
+            b.extend_from_slice(&u.int_in_range(0i64..=86_399_999_999)?.to_be_bytes());
+            Type::Time { precision: None }
+        }
+        // Timestamp(tz): i64 BE micros since 2000-01-01. Keep moderate so the
+        // CheckedTimestamp range check is reached on the accept path.
+        21 => {
+            let micros = u.int_in_range(-6_000_000_000_000_000i64..=6_000_000_000_000_000)?;
+            b.extend_from_slice(&micros.to_be_bytes());
+            Type::Timestamp { precision: None }
+        }
+        22 => {
+            let micros = u.int_in_range(-6_000_000_000_000_000i64..=6_000_000_000_000_000)?;
+            b.extend_from_slice(&micros.to_be_bytes());
+            Type::TimestampTz { precision: None }
+        }
+        23 => {
+            let uuid: [u8; 16] = u.arbitrary()?;
+            b.extend_from_slice(&uuid);
+            Type::Uuid
+        }
+        // mz_timestamp decodes a text u64.
+        24 => {
+            b.extend_from_slice(u.arbitrary::<u64>()?.to_string().as_bytes());
+            Type::MzTimestamp
+        }
+        // mz_aclitem: grantee role id, grantor role id, u64 LE acl mode.
+        _ => {
+            push_role_id(u, &mut b)?;
+            push_role_id(u, &mut b)?;
+            b.extend_from_slice(&u.arbitrary::<u64>()?.to_le_bytes());
+            Type::MzAclItem
+        }
+    };
+    Ok((ty, b))
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw mode: any OID + raw remaining bytes.
+    // This keeps the not-implemented branches and the crafted-header / wrong
+    // length error paths covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        let oid = u32::from(u.arbitrary::<u16>()?);
+        let rest = u.take_rest();
+        if let Ok(ty) = Type::from_oid(oid) {
+            let _ = Value::decode_binary(&ty, rest);
+        }
+        return Ok(());
+    }
+
+    let (ty, mut body) = gen_typed_value(&mut u)?;
+    // Occasionally truncate to hit the exact-length / short-read checks.
+    if !body.is_empty() && u.int_in_range(0u8..=7)? == 0 {
+        let keep = u.int_in_range(0usize..=body.len())?;
+        body.truncate(keep);
+    }
+    let _ = Value::decode_binary(&ty, &body);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/pgrepr/fuzz/fuzz_targets/value_decode_text.rs
+++ b/src/pgrepr/fuzz/fuzz_targets/value_decode_text.rs
@@ -1,0 +1,389 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Value::decode_text` decodes a client-supplied bind-parameter
+//! value in Postgres *text* format. It dispatches on the type and delegates to
+//! the `strconv` parsers (recursively, for array/list/map/record/range), all
+//! over untrusted client bytes. Must never panic.
+//!
+//! A random byte string almost never reaches the interesting recursive
+//! decoders: the array/list/map/range grammars need a leading brace/bracket and
+//! a comma-separated body of *parseable element literals*, and the scalar
+//! parsers (numeric, interval, timestamp, uuid, date) reject almost any random
+//! ASCII. Feeding raw bytes therefore leaves the parsers stuck on their first
+//! syntax check. Instead we build a `Type` directly (not via `from_oid`, which
+//! cannot even produce `List`/`Map`) and synthesize a *well-formed text literal*
+//! for it: scalar literals for the leaves, and properly braced, comma-separated,
+//! optionally quoted/escaped, optionally `NULL`-bearing, optionally nested
+//! bodies for `Array`/`List`/`Map`/`Range` (including the `empty` range and the
+//! unsupported-but-parsed `[lo:hi]=` array-dimension prefix). This drives the
+//! recursive element dispatch and the per-element scalar parsers all the way to
+//! value construction and range/normalization checks. We still spend a quarter
+//! of inputs in the "any OID, raw bytes" mode so the not-implemented branches
+//! and the syntax-error paths stay covered.
+//!
+//! Excluded from the main workspace because libFuzzer requires nightly Rust.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_pgrepr::{Type, Value};
+
+/// A well-formed text literal for a scalar leaf type, paired with that type.
+/// The literal is in the *unnested* representation (no extra quoting). The
+/// container builders re-quote/escape it as needed.
+fn gen_leaf(u: &mut Unstructured) -> arbitrary::Result<(Type, String)> {
+    Ok(match u.int_in_range(0u8..=14)? {
+        0 => (
+            Type::Bool,
+            (*u.choose(&["true", "false", "t", "f", "yes", "no", "on", "off", "1", "0"])?)
+                .to_string(),
+        ),
+        // Integers: in- and out-of-range so the parse-int overflow path is hit.
+        1 => (Type::Int2, gen_int_literal(u)?),
+        2 => (Type::Int4, gen_int_literal(u)?),
+        3 => (Type::Int8, gen_int_literal(u)?),
+        4 => (Type::UInt2, gen_int_literal(u)?),
+        5 => (Type::UInt4, gen_int_literal(u)?),
+        6 => (Type::UInt8, gen_int_literal(u)?),
+        7 => (Type::Oid, gen_int_literal(u)?),
+        // Floats, including the special-token branches.
+        8 => (
+            Type::Float8,
+            (*u.choose(&[
+                "0", "-0", "1.5", "-2.25", "3e10", "1.2e-3", "inf", "-inf", "Infinity", "NaN", ".5",
+                "1e400",
+            ])?)
+            .to_string(),
+        ),
+        9 => (Type::Float4, gen_int_literal(u)?),
+        // Numeric: feed digit strings, exponents, and out-of-band magnitudes.
+        10 => (Type::Numeric { constraints: None }, gen_numeric_literal(u)?),
+        // Interval: a grab bag of the unit/ISO/SQL-standard forms.
+        11 => (
+            Type::Interval { constraints: None },
+            (*u.choose(&[
+                "1 day",
+                "01:02:03",
+                "-1 year 2 mons",
+                "1-2",
+                "P1Y2M3DT4H5M6S",
+                "1 day 2:03:04.567",
+                "@ 5 hours ago",
+                "100000000 years",
+                "1.5 days",
+            ])?)
+            .to_string(),
+        ),
+        // Date / time / timestamp(tz): valid and edge-of-range forms.
+        12 => (
+            Type::Date,
+            (*u.choose(&[
+                "2000-01-01",
+                "0001-01-01 BC",
+                "294276-12-31",
+                "infinity",
+                "-infinity",
+                "1999-02-29",
+                "2024-02-29",
+            ])?)
+            .to_string(),
+        ),
+        13 => (
+            Type::Timestamp { precision: None },
+            (*u.choose(&[
+                "2000-01-01 00:00:00",
+                "1999-12-31 23:59:59.999999",
+                "294277-01-01 00:00:00",
+                "0001-01-01 00:00:00 BC",
+                "infinity",
+                "2024-02-29 12:34:56+05:30",
+            ])?)
+            .to_string(),
+        ),
+        // Uuid: canonical, braced, and hyphen-free spellings.
+        _ => (
+            Type::Uuid,
+            (*u.choose(&[
+                "00000000-0000-0000-0000-000000000000",
+                "ffffffffffffffffffffffffffffffff",
+                "{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}",
+                "A0EEBC999C0B4EF8BB6D6BB9BD380A11",
+            ])?)
+            .to_string(),
+        ),
+    })
+}
+
+/// An integer literal: small in-range values, boundary values, signs, leading
+/// zeros, whitespace, and clearly-overflowing magnitudes.
+fn gen_int_literal(u: &mut Unstructured) -> arbitrary::Result<String> {
+    Ok(match u.int_in_range(0u8..=6)? {
+        0 => u.int_in_range(-9i64..=9)?.to_string(),
+        1 => u.arbitrary::<i16>()?.to_string(),
+        2 => u.arbitrary::<i32>()?.to_string(),
+        3 => u.arbitrary::<i64>()?.to_string(),
+        4 => format!(" {} ", u.arbitrary::<i32>()?),
+        5 => format!("+{}", u.int_in_range(0u64..=u64::MAX)?),
+        // Way past i64/i128: forces the overflow error path.
+        _ => "999999999999999999999999999999".to_string(),
+    })
+}
+
+/// A numeric literal: plain digits, fractions, exponents, sign, and magnitudes
+/// well beyond the 39-digit / base-10000-word limits of the numeric decoder.
+fn gen_numeric_literal(u: &mut Unstructured) -> arbitrary::Result<String> {
+    Ok(match u.int_in_range(0u8..=7)? {
+        0 => "0".to_string(),
+        1 => u.arbitrary::<i64>()?.to_string(),
+        2 => format!("{}.{}", u.arbitrary::<u32>()?, u.arbitrary::<u16>()?),
+        3 => format!("{}e{}", u.int_in_range(1i32..=9)?, u.int_in_range(-40i32..=40)?),
+        4 => "NaN".to_string(),
+        5 => "-Infinity".to_string(),
+        // Long digit run (more than the 39 significant digits numeric keeps).
+        6 => "1".repeat(usize::from(u.int_in_range(40u8..=80)?)),
+        _ => format!("1e{}", u.int_in_range(100i32..=10000)?),
+    })
+}
+
+/// Escape an element body for embedding inside an array/list literal: optionally
+/// wrap in double quotes (escaping `"` and `\`) or backslash-escape the
+/// structural characters. Returns the body unchanged a third of the time so the
+/// unquoted lexer path is exercised too.
+fn escape_for_container(u: &mut Unstructured, body: &str) -> arbitrary::Result<String> {
+    Ok(match u.int_in_range(0u8..=2)? {
+        0 => body.to_string(),
+        1 => {
+            let mut out = String::with_capacity(body.len() + 2);
+            out.push('"');
+            for c in body.chars() {
+                if c == '"' || c == '\\' {
+                    out.push('\\');
+                }
+                out.push(c);
+            }
+            out.push('"');
+            out
+        }
+        _ => {
+            let mut out = String::with_capacity(body.len());
+            for c in body.chars() {
+                if matches!(c, '{' | '}' | ',' | '\\' | '"' | ' ') {
+                    out.push('\\');
+                }
+                out.push(c);
+            }
+            out
+        }
+    })
+}
+
+/// Recursively build a `(Type, literal)` pair, occasionally wrapping a value in
+/// an `Array`, `List`, `Map`, or `Range` container with a well-formed body.
+/// `depth` bounds the nesting so we always terminate.
+fn gen_value(u: &mut Unstructured, depth: u8) -> arbitrary::Result<(Type, String)> {
+    // At max depth, or randomly, emit a scalar leaf.
+    if depth == 0 || u.int_in_range(0u8..=2)? == 0 {
+        return gen_leaf(u);
+    }
+
+    Ok(match u.int_in_range(0u8..=3)? {
+        // Array: `{e1,e2,...}`, possibly multi-dimensional, possibly with NULLs,
+        // possibly prefixed with the (unsupported, but parsed) dimension syntax.
+        0 => {
+            let (elem_ty, _) = gen_value(u, depth - 1)?;
+            let n = u.int_in_range(0usize..=4)?;
+            let mut body = String::new();
+            // Occasionally emit the `[lo:hi]=` dimension prefix, which the parser
+            // recognizes and then rejects as unsupported.
+            if u.int_in_range(0u8..=7)? == 0 {
+                body.push_str(&format!("[{}:{}]=", u.int_in_range(-2i32..=2)?, n));
+            }
+            // Optionally wrap in extra braces for a multi-dimensional shape.
+            let extra_dims = u.int_in_range(0u8..=2)?;
+            for _ in 0..extra_dims {
+                body.push('{');
+            }
+            body.push('{');
+            for i in 0..n {
+                if i > 0 {
+                    body.push(',');
+                }
+                if u.int_in_range(0u8..=6)? == 0 {
+                    body.push_str(*u.choose(&["NULL", "null", "NuLl"])?);
+                } else {
+                    let (_, elem) = elem_literal(u, &elem_ty, depth - 1)?;
+                    body.push_str(&escape_for_container(u, &elem)?);
+                }
+            }
+            body.push('}');
+            for _ in 0..extra_dims {
+                body.push('}');
+            }
+            (Type::Array(Box::new(elem_ty)), body)
+        }
+        // List: `{e1,e2,...}`. Nested lists allowed via embedded braces.
+        1 => {
+            let (elem_ty, _) = gen_value(u, depth - 1)?;
+            let nested_list = matches!(elem_ty, Type::List(_));
+            let n = u.int_in_range(0usize..=4)?;
+            let mut body = String::from("{");
+            for i in 0..n {
+                if i > 0 {
+                    body.push(',');
+                }
+                if u.int_in_range(0u8..=6)? == 0 {
+                    body.push_str("NULL");
+                } else {
+                    let (_, elem) = elem_literal(u, &elem_ty, depth - 1)?;
+                    // A nested list element keeps its braces. Other elements are
+                    // quoted/escaped.
+                    if nested_list {
+                        body.push_str(&elem);
+                    } else {
+                        body.push_str(&escape_for_container(u, &elem)?);
+                    }
+                }
+            }
+            body.push('}');
+            (Type::List(Box::new(elem_ty)), body)
+        }
+        // Map: `{k1=>v1,k2=>v2,...}` with text keys.
+        2 => {
+            let (val_ty, _) = gen_value(u, depth - 1)?;
+            let nested_map = matches!(val_ty, Type::Map { .. });
+            let n = u.int_in_range(0usize..=4)?;
+            let mut body = String::from("{");
+            for i in 0..n {
+                if i > 0 {
+                    body.push(',');
+                }
+                let key = *u.choose(&["a", "b", "key one", "k\"q", "", "=>"])?;
+                body.push_str(&escape_for_container(u, key)?);
+                body.push_str("=>");
+                if u.int_in_range(0u8..=6)? == 0 {
+                    body.push_str("NULL");
+                } else {
+                    let (_, val) = elem_literal(u, &val_ty, depth - 1)?;
+                    if nested_map {
+                        body.push_str(&val);
+                    } else {
+                        body.push_str(&escape_for_container(u, &val)?);
+                    }
+                }
+            }
+            body.push('}');
+            (Type::Map { value_type: Box::new(val_ty) }, body)
+        }
+        // Range: `empty`, `[lo,hi)`, `(,hi]`, `[lo,)`, etc. Range elements must
+        // be a totally-ordered scalar, so restrict to one of the supported
+        // domains.
+        _ => {
+            let elem_ty = match u.int_in_range(0u8..=4)? {
+                0 => Type::Int4,
+                1 => Type::Int8,
+                2 => Type::Numeric { constraints: None },
+                3 => Type::Date,
+                _ => Type::Timestamp { precision: None },
+            };
+            if u.int_in_range(0u8..=5)? == 0 {
+                return Ok((Type::Range { element_type: Box::new(elem_ty) }, "empty".to_string()));
+            }
+            let lo_inc = u.arbitrary::<bool>()?;
+            let hi_inc = u.arbitrary::<bool>()?;
+            let lo = if u.int_in_range(0u8..=2)? == 0 {
+                String::new()
+            } else {
+                gen_range_bound(u, &elem_ty)?
+            };
+            let hi = if u.int_in_range(0u8..=2)? == 0 {
+                String::new()
+            } else {
+                gen_range_bound(u, &elem_ty)?
+            };
+            let body = format!(
+                "{}{},{}{}",
+                if lo_inc { '[' } else { '(' },
+                lo,
+                hi,
+                if hi_inc { ']' } else { ')' },
+            );
+            (Type::Range { element_type: Box::new(elem_ty) }, body)
+        }
+    })
+}
+
+/// Generate a literal for a *specific* element type (so container element types
+/// stay consistent), bottoming out via the generic builder for containers.
+fn elem_literal(u: &mut Unstructured, ty: &Type, depth: u8) -> arbitrary::Result<(Type, String)> {
+    match ty {
+        Type::Bool => Ok((ty.clone(), (*u.choose(&["t", "f", "true", "false"])?).to_string())),
+        Type::Int2 | Type::Int4 | Type::Int8 | Type::UInt2 | Type::UInt4 | Type::UInt8
+        | Type::Oid | Type::Float4 => Ok((ty.clone(), gen_int_literal(u)?)),
+        Type::Float8 => Ok((
+            ty.clone(),
+            (*u.choose(&["1.5", "-2.25", "inf", "NaN", "0"])?).to_string(),
+        )),
+        Type::Numeric { .. } => Ok((ty.clone(), gen_numeric_literal(u)?)),
+        Type::Date => Ok((
+            ty.clone(),
+            (*u.choose(&["2000-01-01", "1999-12-31", "infinity"])?).to_string(),
+        )),
+        Type::Timestamp { .. } => Ok((
+            ty.clone(),
+            (*u.choose(&["2000-01-01 00:00:00", "1999-12-31 23:59:59"])?).to_string(),
+        )),
+        Type::Uuid => Ok((
+            ty.clone(),
+            "00000000-0000-0000-0000-000000000000".to_string(),
+        )),
+        Type::Interval { .. } => {
+            Ok((ty.clone(), (*u.choose(&["1 day", "01:02:03", "1-2"])?).to_string()))
+        }
+        // Containers and everything else: delegate to the recursive builder,
+        // which will pick its own (possibly different) shape but keep it valid.
+        _ => gen_value(u, depth),
+    }
+}
+
+/// A scalar range-bound literal matching the range's element type.
+fn gen_range_bound(u: &mut Unstructured, ty: &Type) -> arbitrary::Result<String> {
+    Ok(match ty {
+        Type::Date => (*u.choose(&["2000-01-01", "1999-12-31", "2024-06-06"])?).to_string(),
+        Type::Timestamp { .. } => {
+            (*u.choose(&["2000-01-01 00:00:00", "2024-06-06 12:00:00"])?).to_string()
+        }
+        Type::Numeric { .. } => gen_numeric_literal(u)?,
+        // Int4 / Int8.
+        _ => gen_int_literal(u)?,
+    })
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw mode: any OID + raw remaining bytes.
+    // This keeps the not-implemented branches (json, record, timetz,
+    // int2vector) and the scalar syntax-error paths covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        let oid = u32::from(u.arbitrary::<u16>()?);
+        let rest = u.take_rest();
+        if let Ok(ty) = Type::from_oid(oid) {
+            let _ = Value::decode_text(&ty, rest);
+        }
+        return Ok(());
+    }
+
+    let (ty, body) = gen_value(&mut u, 3)?;
+    let _ = Value::decode_text(&ty, body.as_bytes());
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/pgtz/fuzz/.gitignore
+++ b/src/pgtz/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/pgtz/fuzz/Cargo.toml
+++ b/src/pgtz/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+# Fuzz crate for mz-pgtz: parse untrusted time-zone strings. `Timezone::parse`
+# is a hand-written tokenizer + offset builder over arbitrary user input (the
+# `AT TIME ZONE` / `SET timezone` value), so any panic is an availability bug.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-pgtz-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-pgtz = { path = ".." }
+
+[[bin]]
+name = "timezone_parse"
+path = "fuzz_targets/timezone_parse.rs"
+test = false
+doc = false
+bench = false

--- a/src/pgtz/fuzz/fuzz_targets/timezone_parse.rs
+++ b/src/pgtz/fuzz/fuzz_targets/timezone_parse.rs
@@ -1,0 +1,223 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `mz_pgtz::timezone::Timezone::parse` parses untrusted time-zone
+//! strings (the `AT TIME ZONE` / `SET timezone` value) with a hand-written
+//! tokenizer + offset builder, in both ISO and POSIX modes. Any panic is an
+//! availability bug.
+//!
+//! The interesting surface is the *offset tokenizer*: `tokenize_timezone`
+//! grabs the first alphabetic run as a single `TzName` and returns immediately
+//! (so any POSIX DST-rule tail is silently discarded, making fuzzing that
+//! grammar dead weight), while everything else flows through `parse_num`, which
+//! splits long all-digit runs into `[..hhhh]mm` chunks unless a `:` is present,
+//! plus the punctuation-as-delimiter trimming and the `z`/`Z`-only-at-end rule.
+//! `build_timezone_offset_second` then matches the token stream against twelve
+//! fixed `±H[H][:M[M][:S[S]]]` / `±HHH` / `TzName` / `Zulu` shapes and enforces
+//! the `hour<=15`, `min<60`, `sec<60` bounds. So we generate inputs that stress
+//! exactly that math: long all-digit runs (`+00000100`, `+0000001:000001`),
+//! the hour/min/sec boundaries (`+15:59:59`, `+16`, `+0:60`), the colon-vs-no-
+//! colon `split_nums` toggle, punctuation-delimited junk around a real offset,
+//! bare `z`/`Z` placed mid-string vs at the end, abbreviations drawn from
+//! `TIMEZONE_ABBREVS`, and case-mangled IANA names. A quarter of inputs stay
+//! the raw bytes so the tokenizer reject paths keep their coverage.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_pgtz::timezone::{Timezone, TimezoneSpec};
+
+/// IANA names exercising fractional-hour offsets and DST, in canonical casing.
+/// `gen_named` may re-case them to hit the case-insensitive lookup path.
+const NAMED: &[&str] = &[
+    "UTC",
+    "GMT",
+    "America/New_York",
+    "Europe/London",
+    "Asia/Kolkata",          // :30 offset
+    "Australia/Lord_Howe",   // :30 offset with DST
+    "Pacific/Chatham",       // :45 offset
+    "America/Argentina/Buenos_Aires",
+    "Etc/GMT+12",
+    "posixrules",
+];
+
+/// A spread of abbreviations from `TIMEZONE_ABBREVS`: fixed-offset ones, DST
+/// ones, and ones that alias to a `Tz`, so the abbrev lookup + fallback to
+/// `Tz::from_str_insensitive` both run. `EST`/`PST`/... also double as the
+/// leading `std` name of a POSIX-looking string (whose offset tail is what the
+/// tokenizer actually keeps).
+const ABBREVS: &[&str] = &[
+    "EST", "EDT", "PST", "PDT", "CST", "CDT", "MST", "MDT", "CET", "CEST", "EET",
+    "EEST", "BST", "IST", "JST", "ACDT", "ACST", "AEST", "AEDT", "NZST", "NZDT",
+    "CHADT", "CHAST", "HKT", "WET", "WEST", "UCT", "ZULU", "GMT", "UTC",
+];
+
+/// Emit a numeric UTC offset, biased toward the tokenizer/builder boundaries:
+/// `z`/`Z`, `±HH`, `±HH:MM`, `±HH:MM:SS`, long all-digit runs that `parse_num`
+/// must chunk, and the exact `hour<=15` / `min<60` / `sec<60` edges.
+fn gen_offset(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=8)? {
+        // Bare Zulu (only valid at end-of-string).
+        0 => {
+            out.push(if u.ratio(1, 2)? { 'z' } else { 'Z' });
+            return Ok(());
+        }
+        // Hour at/around the `<= 15` boundary.
+        1 => {
+            out.push(sign(u)?);
+            out.push_str(&format!("{:02}", u.int_in_range(13u32..=17)?));
+        }
+        // `±HH:MM` with minute at/around the `< 60` boundary.
+        2 => {
+            out.push(sign(u)?);
+            out.push_str(&format!(
+                "{:02}:{:02}",
+                u.int_in_range(0u32..=15)?,
+                u.int_in_range(57u32..=61)?
+            ));
+        }
+        // `±HH:MM:SS` with second at/around the `< 60` boundary, e.g. `+15:59:59`.
+        3 => {
+            out.push(sign(u)?);
+            out.push_str(&format!(
+                "{:02}:{:02}:{:02}",
+                u.int_in_range(0u32..=15)?,
+                u.int_in_range(0u32..=59)?,
+                u.int_in_range(57u32..=61)?
+            ));
+        }
+        // Long all-digit run (no colon): exercises the `split_nums` `[..hh]mm`
+        // chunking and leading-zero handling, e.g. `+00000100`, `+0000005`.
+        4 => {
+            out.push(sign(u)?);
+            let zeros = u.int_in_range(0u32..=8)?;
+            for _ in 0..zeros {
+                out.push('0');
+            }
+            out.push_str(&u.int_in_range(0u32..=999)?.to_string());
+        }
+        // Colon-delimited long all-digit runs (colon disables `split_nums`),
+        // e.g. `+0000001:000001:000001`.
+        5 => {
+            out.push(sign(u)?);
+            let parts = u.int_in_range(1u8..=3)?;
+            for p in 0..parts {
+                if p > 0 {
+                    out.push(':');
+                }
+                let zeros = u.int_in_range(0u32..=7)?;
+                for _ in 0..zeros {
+                    out.push('0');
+                }
+                out.push_str(&u.int_in_range(0u32..=99)?.to_string());
+            }
+        }
+        // Ordinary `±HH[:MM[:SS]]` across the full valid range.
+        _ => {
+            out.push(sign(u)?);
+            out.push_str(&format!("{:02}", u.int_in_range(0u32..=15)?));
+            match u.int_in_range(0u8..=2)? {
+                0 => {}
+                1 => out.push_str(&format!(":{:02}", *u.choose(&[0u32, 15, 30, 45])?)),
+                _ => out.push_str(&format!(
+                    ":{:02}:{:02}",
+                    *u.choose(&[0u32, 30, 45])?,
+                    u.int_in_range(0u32..=59)?
+                )),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn sign(u: &mut Unstructured) -> arbitrary::Result<char> {
+    Ok(if u.ratio(1, 2)? { '+' } else { '-' })
+}
+
+/// Emit an IANA name, sometimes case-mangled to hit `from_str_insensitive`.
+fn gen_named(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    let name = *u.choose(NAMED)?;
+    match u.int_in_range(0u8..=3)? {
+        0 => out.push_str(&name.to_lowercase()),
+        1 => out.push_str(&name.to_uppercase()),
+        2 => {
+            // Alternate-case mangling.
+            for (i, c) in name.chars().enumerate() {
+                if i % 2 == 0 {
+                    out.extend(c.to_lowercase());
+                } else {
+                    out.extend(c.to_uppercase());
+                }
+            }
+        }
+        _ => out.push_str(name),
+    }
+    Ok(())
+}
+
+/// Wrap an inner spec in leading/trailing whitespace and ASCII punctuation,
+/// which the tokenizer trims (except `+`/`-`) or treats as `Delim`. This keeps
+/// the `" ! ? ! - 5:15 ? ! ? "`-style paths covered.
+fn gen_punct_wrapped(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    const JUNK: &[char] = &[' ', '!', '?', '.', ',', '*', '/', '#', '~', '\t'];
+    let lead = u.int_in_range(0u8..=3)?;
+    for _ in 0..lead {
+        out.push(*u.choose(JUNK)?);
+    }
+    gen_offset(u, out)?;
+    let trail = u.int_in_range(0u8..=3)?;
+    for _ in 0..trail {
+        out.push(*u.choose(JUNK)?);
+    }
+    Ok(())
+}
+
+fn gen_tz(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=6)? {
+        0 => gen_named(u, out)?,
+        1 => out.push_str(u.choose(ABBREVS)?),
+        2 | 3 => gen_offset(u, out)?,
+        4 => gen_punct_wrapped(u, out)?,
+        // An abbreviation immediately followed by an offset: the tokenizer keeps
+        // the abbrev as a `TzName` and returns, so the offset tail is ignored,
+        // but this still stresses the "first alpha wins" early return.
+        5 => {
+            out.push_str(u.choose(ABBREVS)?);
+            gen_offset(u, out)?;
+        }
+        // A bare `z`/`Z` placed *before* more text, so it is NOT at end-of-string
+        // and must be tokenized as a `TzName`, not `Zulu`.
+        _ => {
+            out.push(if u.ratio(1, 2)? { 'z' } else { 'Z' });
+            gen_offset(u, out)?;
+        }
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw bytes: keeps the tokenizer reject paths
+    // covered.
+    let spec = if u.int_in_range(0u8..=3)? == 0 {
+        String::from_utf8_lossy(u.take_rest()).into_owned()
+    } else {
+        let mut s = String::new();
+        gen_tz(&mut u, &mut s)?;
+        s
+    };
+    let _ = Timezone::parse(&spec, TimezoneSpec::Iso);
+    let _ = Timezone::parse(&spec, TimezoneSpec::Posix);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/pgwire/fuzz/.gitignore
+++ b/src/pgwire/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/pgwire/fuzz/Cargo.toml
+++ b/src/pgwire/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+# Fuzz crate for mz-pgwire: drive the frontend-message decoder over random
+# bytes. The decoder sits at the trust boundary between an untrusted SQL
+# client and environmentd, so any panic/SEGV reachable from the wire format
+# is a real availability bug.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-pgwire-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-pgwire = { path = "..", features = ["fuzzing"] }
+bytes = "1"
+tokio-util = { version = "0.7", features = ["codec"] }
+
+[[bin]]
+name = "codec_decode"
+path = "fuzz_targets/codec_decode.rs"
+test = false
+doc = false
+bench = false

--- a/src/pgwire/fuzz/corpus.dict
+++ b/src/pgwire/fuzz/corpus.dict
@@ -1,0 +1,34 @@
+# libFuzzer dictionary for the pgwire codec_decode target.
+#
+# Frontend messages are a 1-byte type tag + 4-byte big-endian length + payload
+# (startup/SSL/cancel messages omit the tag). Seeding the type tags and the
+# special startup/SSL/cancel magic version codes lets the mutator reach the
+# per-message decoders instead of being rejected as an unknown tag.
+
+# Frontend message type tags.
+"Q"
+"P"
+"B"
+"E"
+"D"
+"C"
+"H"
+"S"
+"X"
+"d"
+"c"
+"f"
+"p"
+"F"
+# Untagged startup-phase length+version prefixes.
+"\x00\x00\x00\x08\x04\xd2\x16\x2f"
+"\x00\x00\x00\x10\x04\xd2\x16\x2e"
+"\x00\x03\x00\x00"
+# Common startup parameter keys.
+"user\x00"
+"database\x00"
+"application_name\x00"
+"client_encoding\x00"
+# SASL mechanism names.
+"SCRAM-SHA-256"
+"SCRAM-SHA-256-PLUS"

--- a/src/pgwire/fuzz/fuzz_targets/codec_decode.rs
+++ b/src/pgwire/fuzz/fuzz_targets/codec_decode.rs
@@ -1,0 +1,298 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: drive `mz_pgwire`'s frontend-message `Codec` over arbitrary
+//! bytes. The decoder lives at the trust boundary between SQL clients and
+//! environmentd, so any panic/SEGV reachable from the wire is a real
+//! availability bug.
+//!
+//! A frame is `[type:1][len:4 BE][body:len-4]`. Random bytes rarely have a
+//! length field that matches the bytes that follow, so the decoder bails in the
+//! header before reaching the per-message body parsers (Query/Parse/Bind/
+//! Describe/Execute/…), and once one frame errors, the streaming decoder stops,
+//! so later frames never decode either. So we consume the byte stream as grammar
+//! choices and emit correctly-framed messages: a valid type tag, the right
+//! length, and (usually) a valid body for that type, concatenating several so
+//! the decoder walks frame after frame. A quarter of inputs are still the raw
+//! bytes, and a quarter of frames carry an arbitrary body, so the header
+//! validation and per-message error paths stay covered.
+//!
+//! Beyond well-formed frames we deliberately stress two thin spots:
+//!
+//! * **Count-driven loops.** The body parsers for Parse and Bind read an `i16`
+//!   element count (param-type / format-code / parameter counts) and then loop
+//!   that many times reading from the body, and a Bind parameter declares its
+//!   own `i32` byte length. We sometimes emit a huge count or length (up to
+//!   `i16::MAX` / a large positive `i32`) backed by a body far too short to
+//!   satisfy it, so the loops read off the end of the cursor and must error out
+//!   gracefully rather than over-read, over-allocate, or panic. Long cstrings
+//!   feed the same idea on the string side.
+//!
+//! * **Streaming / partial-frame reassembly.** The codec is a `tokio_util`
+//!   `Decoder`: it advances `Head -> Data -> Head` across calls and returns
+//!   `Ok(None)` whenever the body promised by the length field hasn't fully
+//!   arrived yet. Feeding the whole stream in one `BytesMut` never lands mid
+//!   frame, so we (a) sometimes hand frames a length field that overstates the
+//!   real body, and (b) drip the byte stream into the decoder in arbitrary
+//!   chunks, so it parks in the `Data` await-more-bytes state and resumes when
+//!   the rest shows up.
+//!
+//! Errors are expected. What we assert is the absence of panics and
+//! memory-safety violations.
+
+#![no_main]
+
+use bytes::BytesMut;
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_pgwire::fuzz_exports::Codec;
+use tokio_util::codec::Decoder;
+
+/// Frontend message type tags the codec dispatches on.
+const TAGS: &[u8] = &[
+    b'Q', b'P', b'D', b'B', b'E', b'H', b'S', b'C', b'X', b'p', b'f', b'd', b'c',
+];
+
+fn push_cstr(u: &mut Unstructured, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let n = u.int_in_range(0usize..=8)?;
+    for _ in 0..n {
+        // Printable, non-NUL.
+        out.push(u.int_in_range(0x20u8..=0x7e)?);
+    }
+    out.push(0);
+    Ok(())
+}
+
+/// Append a long (but bounded) printable, NUL-terminated string. Stresses the
+/// `read_cstr` scan and downstream allocations without blowing past
+/// `MAX_REQUEST_SIZE`.
+fn push_long_cstr(u: &mut Unstructured, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let n = u.int_in_range(64usize..=4096)?;
+    let fill = u.int_in_range(0x20u8..=0x7e)?;
+    out.resize(out.len() + n, fill);
+    out.push(0);
+    Ok(())
+}
+
+fn be16(out: &mut Vec<u8>, v: i16) {
+    out.extend_from_slice(&v.to_be_bytes());
+}
+
+fn be32(out: &mut Vec<u8>, v: i32) {
+    out.extend_from_slice(&v.to_be_bytes());
+}
+
+/// Pick an element count for a count-driven loop. Usually small and matched by
+/// the body that follows, but sometimes a large value the body can't satisfy so
+/// the loop reads off the end of the cursor and must error rather than over-read
+/// or over-allocate. Returns `(declared_count, honest_count)`: `declared_count`
+/// is written to the wire, `honest_count` is how many elements we actually emit.
+fn count(u: &mut Unstructured) -> arbitrary::Result<(i16, i16)> {
+    match u.int_in_range(0u8..=7)? {
+        // Mostly: a small, honest count fully backed by the body.
+        0..=4 => {
+            let n = u.int_in_range(0i16..=3)?;
+            Ok((n, n))
+        }
+        // A large declared count with no/too-few backing elements: the loop
+        // should run out of buffer and bail.
+        5 => Ok((u.int_in_range(1i16..=i16::MAX)?, 0)),
+        6 => Ok((i16::MAX, u.int_in_range(0i16..=2)?)),
+        // A negative count: the `for _ in 0..n` loop runs zero times, so the
+        // remaining body is interpreted as the next field/frame.
+        7 => Ok((u.int_in_range(i16::MIN..=-1)?, 0)),
+        _ => unreachable!(),
+    }
+}
+
+/// Build a valid body for message `tag`.
+fn gen_body(u: &mut Unstructured, tag: u8, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    match tag {
+        // Empty-body messages.
+        b'X' | b'S' | b'H' | b'c' => {}
+        // Simple query / copy-fail: a single cstring.
+        b'Q' | b'f' => maybe_long_cstr(u, out)?,
+        // Password / generic auth: a cstring is a plausible password message.
+        b'p' => maybe_long_cstr(u, out)?,
+        // CopyData: arbitrary payload.
+        b'd' => {
+            for _ in 0..u.int_in_range(0usize..=16)? {
+                out.push(u.arbitrary::<u8>()?);
+            }
+        }
+        // Describe / Close: a 'S'tatement|'P'ortal byte then a name cstring.
+        b'D' | b'C' => {
+            out.push(if u.int_in_range(0u8..=1)? == 0 { b'S' } else { b'P' });
+            maybe_long_cstr(u, out)?;
+        }
+        // Execute: portal cstring + max-rows i32.
+        b'E' => {
+            maybe_long_cstr(u, out)?;
+            be32(out, u.arbitrary::<i32>()?);
+        }
+        // Parse: name + query cstrings + param-type oids.
+        b'P' => {
+            maybe_long_cstr(u, out)?;
+            maybe_long_cstr(u, out)?;
+            let (declared, honest) = count(u)?;
+            be16(out, declared);
+            for _ in 0..honest {
+                be32(out, u.arbitrary::<i32>()?);
+            }
+        }
+        // Bind: portal + stmt cstrings, format codes, parameters, result formats.
+        b'B' => {
+            maybe_long_cstr(u, out)?;
+            maybe_long_cstr(u, out)?;
+            let (declared, honest) = count(u)?;
+            be16(out, declared);
+            for _ in 0..honest {
+                be16(out, u.int_in_range(0i16..=1)?);
+            }
+            let (declared, honest) = count(u)?;
+            be16(out, declared);
+            for _ in 0..honest {
+                match u.int_in_range(0u8..=4)? {
+                    0 => be32(out, -1), // NULL parameter
+                    // A large declared length with a short (or empty) value: the
+                    // per-byte read loop should run out of buffer and bail.
+                    1 => {
+                        be32(out, u.int_in_range(1i32..=i32::MAX)?);
+                        for _ in 0..u.int_in_range(0usize..=2)? {
+                            out.push(u.arbitrary::<u8>()?);
+                        }
+                    }
+                    _ => {
+                        let len = u.int_in_range(0usize..=4)?;
+                        be32(out, len as i32);
+                        for _ in 0..len {
+                            out.push(u.arbitrary::<u8>()?);
+                        }
+                    }
+                }
+            }
+            let (declared, honest) = count(u)?;
+            be16(out, declared);
+            for _ in 0..honest {
+                be16(out, u.int_in_range(0i16..=1)?);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// A cstring that is usually short but occasionally long, to stress the scan
+/// and downstream string allocations.
+fn maybe_long_cstr(u: &mut Unstructured, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    if u.int_in_range(0u8..=7)? == 0 {
+        push_long_cstr(u, out)
+    } else {
+        push_cstr(u, out)
+    }
+}
+
+fn push_frame(u: &mut Unstructured, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let tag = *u.choose(TAGS)?;
+    let mut body = Vec::new();
+    // A quarter of frames carry an arbitrary body so the per-message parsers'
+    // error handling stays covered. The rest are valid for their type.
+    if u.int_in_range(0u8..=3)? == 0 {
+        for _ in 0..u.int_in_range(0usize..=16)? {
+            body.push(u.arbitrary::<u8>()?);
+        }
+    } else {
+        gen_body(u, tag, &mut body)?;
+    }
+    out.push(tag);
+    // Length field counts itself (4 bytes) plus the body, but not the tag.
+    // Usually honest, but occasionally we overstate it so the streaming decoder
+    // parks in the `Data` await-more-bytes state expecting bytes that may or may
+    // not arrive (a later frame's bytes get reinterpreted as this body, or the
+    // stream simply ends mid-frame).
+    let honest = (body.len() as u32) + 4;
+    let declared = if u.int_in_range(0u8..=7)? == 0 {
+        // Overstate by a bounded amount. `parse_frame_len` rejects anything over
+        // MAX_FRAME_SIZE (64 MiB), so keep the claim well under that.
+        honest.saturating_add(u.int_in_range(1u32..=4096)?)
+    } else {
+        honest
+    };
+    out.extend_from_slice(&declared.to_be_bytes());
+    out.extend_from_slice(&body);
+    Ok(())
+}
+
+/// Feed `data` to the codec. When `chunked`, drip it in arbitrary-sized slices
+/// so the decoder repeatedly parks in its partial-frame (`Ok(None)`) state and
+/// resumes when more bytes land, exercising the streaming reassembly path that
+/// a single all-at-once `BytesMut` never reaches mid-frame.
+fn pump(u: &mut Unstructured, data: &[u8], chunked: bool) -> arbitrary::Result<()> {
+    let mut codec = Codec::new();
+    let mut buf = BytesMut::new();
+
+    let mut feed_and_drain = |buf: &mut BytesMut| {
+        // The codec is a streaming decoder, so pump it until it stops returning
+        // complete messages or errors out. Errors are expected. What we care
+        // about is the absence of panics and memory-safety violations.
+        loop {
+            match codec.decode(buf) {
+                Ok(Some(_msg)) => continue,
+                Ok(None) => break,
+                // NOTE: this breaks out of the drain but does not latch the
+                // error, so in chunked mode the outer loop keeps feeding the
+                // same codec afterwards. Production `FramedConn` instead tears
+                // the connection down on the first error, leaving `decode_state`
+                // mid-frame. Continuing is intentional and harmless here: frame
+                // body parsing is stateless per frame, so anything reachable
+                // after an error is also reachable from a fresh stream.
+                Err(_) => break,
+            }
+        }
+    };
+
+    if chunked {
+        let mut rest = data;
+        while !rest.is_empty() {
+            let take = u.int_in_range(1usize..=rest.len())?;
+            buf.extend_from_slice(&rest[..take]);
+            rest = &rest[take..];
+            feed_and_drain(&mut buf);
+        }
+        // A final drain in case the last chunk completed a frame.
+        feed_and_drain(&mut buf);
+    } else {
+        buf.extend_from_slice(data);
+        feed_and_drain(&mut buf);
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw bytes: keeps the header-framing and
+    // unknown-tag error paths covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        let chunked = u.int_in_range(0u8..=1)? == 0;
+        let rest = u.take_rest();
+        return pump(&mut Unstructured::new(rest), rest, chunked);
+    }
+    let mut out = Vec::new();
+    let frames = u.int_in_range(1usize..=5)?;
+    for _ in 0..frames {
+        push_frame(&mut u, &mut out)?;
+    }
+    // Half the time, drip the assembled stream into the decoder in chunks to
+    // exercise the partial-frame await-more-bytes logic mid-stream.
+    let chunked = u.int_in_range(0u8..=1)? == 0;
+    pump(&mut u, &out, chunked)
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/pgwire/fuzz/prepare-corpus.sh
+++ b/src/pgwire/fuzz/prepare-corpus.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# prepare-corpus.sh populates the `codec_decode` corpus with hand-crafted
+# valid pgwire frontend frames. libFuzzer mutates these into adjacent
+# malformed variants while keeping enough structure to reach the deeper
+# parsing paths.
+#
+# The target drives `Codec::decode`, which dispatches only post-startup
+# frontend messages. The startup handshake (StartupMessage, SSLRequest,
+# CancelRequest) is parsed by a separate `decode_startup` path that this
+# target does not exercise, so no startup-phase seeds are included.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+corpus=corpus/codec_decode
+mkdir -p "$corpus"
+find "$corpus" -maxdepth 1 -name 'seed_*.bin' -delete
+
+python3 - "$corpus" <<'PY'
+import os, struct, sys
+corpus = sys.argv[1]
+
+def frame(tag: bytes, payload: bytes) -> bytes:
+    # Standard pgwire frame: 1-byte type tag + 4-byte BE length (incl
+    # itself) + payload.
+    return tag + struct.pack(">I", 4 + len(payload)) + payload
+
+def cstr(s: str) -> bytes:
+    return s.encode() + b"\x00"
+
+seeds = {
+    "01_query_select_1": frame(b"Q", cstr("SELECT 1")),
+    "02_query_empty": frame(b"Q", cstr("")),
+    "03_parse_named": frame(b"P", cstr("stmt1") + cstr("SELECT $1::int4") + struct.pack(">H", 0)),
+    "04_bind_unnamed": frame(b"B", cstr("") + cstr("") + struct.pack(">HHH", 0, 0, 0) + struct.pack(">H", 0)),
+    "05_execute": frame(b"E", cstr("") + struct.pack(">I", 0)),
+    "06_sync": frame(b"S", b""),
+    "07_terminate": frame(b"X", b""),
+    "08_describe_portal": frame(b"D", b"P" + cstr("")),
+    "09_describe_statement": frame(b"D", b"S" + cstr("")),
+    "10_close_portal": frame(b"C", b"P" + cstr("")),
+    "11_flush": frame(b"H", b""),
+    "12_copy_data": frame(b"d", b"some-bytes"),
+    "13_copy_done": frame(b"c", b""),
+    "14_copy_fail": frame(b"f", cstr("client gave up")),
+    "15_password": frame(b"p", cstr("hunter2")),
+    "16_sasl_initial": frame(b"p", cstr("SCRAM-SHA-256") + struct.pack(">I", 5) + b"hello"),
+}
+
+for name, blob in seeds.items():
+    with open(os.path.join(corpus, f"seed_{name}.bin"), "wb") as f:
+        f.write(blob)
+PY
+
+echo "Seeded:"
+count=$(find "$corpus" -maxdepth 1 -name '*.bin' | wc -l)
+printf "  %-40s %4d seeds\n" "$corpus" "$count"

--- a/src/repr/fuzz/.gitignore
+++ b/src/repr/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/repr/fuzz/Cargo.toml
+++ b/src/repr/fuzz/Cargo.toml
@@ -1,0 +1,203 @@
+# Fuzz crate for mz-repr proto round-trip properties. `Row` is the core
+# value representation in Materialize, serialized via prost as `ProtoRow`.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+# Run via the repo-wide runner: `bin/ci-builder run nightly ci/test/cargo-fuzz.sh`,
+# or locally:
+#     cd src/repr/fuzz
+#     cargo +nightly fuzz run row_proto_roundtrip -- -max_total_time=60
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-repr-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-persist-types = { path = "../../persist-types" }
+mz-proto = { path = "../../proto" }
+mz-repr = { path = "..", features = ["proptest"] }
+chrono = { version = "0.4", default-features = false }
+dec = "0.4.9"
+prost = "0.14.3"
+proptest = "1"
+
+[[bin]]
+name = "row_proto_roundtrip"
+path = "fuzz_targets/row_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "row_codec_roundtrip"
+path = "fuzz_targets/row_codec_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "scalar_type_proto_roundtrip"
+path = "fuzz_targets/scalar_type_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "column_type_proto_roundtrip"
+path = "fuzz_targets/column_type_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "relation_desc_proto_roundtrip"
+path = "fuzz_targets/relation_desc_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "interval_proto_roundtrip"
+path = "fuzz_targets/interval_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "mz_acl_item_proto_roundtrip"
+path = "fuzz_targets/mz_acl_item_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "acl_item_proto_roundtrip"
+path = "fuzz_targets/acl_item_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_array"
+path = "fuzz_targets/strconv_parse_array.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_list"
+path = "fuzz_targets/strconv_parse_list.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_map"
+path = "fuzz_targets/strconv_parse_map.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_range"
+path = "fuzz_targets/strconv_parse_range.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_numeric"
+path = "fuzz_targets/strconv_parse_numeric.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_interval"
+path = "fuzz_targets/strconv_parse_interval.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "jsonb_from_slice"
+path = "fuzz_targets/jsonb_from_slice.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_timestamp"
+path = "fuzz_targets/strconv_parse_timestamp.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_timestamptz"
+path = "fuzz_targets/strconv_parse_timestamptz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_date"
+path = "fuzz_targets/strconv_parse_date.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_time"
+path = "fuzz_targets/strconv_parse_time.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "interval_arith"
+path = "fuzz_targets/interval_arith.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "numeric_arith"
+path = "fuzz_targets/numeric_arith.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "range_ops"
+path = "fuzz_targets/range_ops.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "row_arrow_roundtrip"
+path = "fuzz_targets/row_arrow_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_bytes"
+path = "fuzz_targets/strconv_parse_bytes.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strconv_parse_uuid"
+path = "fuzz_targets/strconv_parse_uuid.rs"
+test = false
+doc = false
+bench = false

--- a/src/repr/fuzz/fuzz_targets/acl_item_proto_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/acl_item_proto_roundtrip.rs
@@ -1,0 +1,77 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `AclItem` proto round-trips losslessly.
+//! Distinct from `MzAclItem`: `AclItem` is the PostgreSQL-style ACL entry.
+//!
+//! Two arms (the first byte selects):
+//!  - Arbitrary arm: drive `AclItem`'s proptest `Arbitrary` strategy from the
+//!    fuzzer bytes to build a *valid* entry (grantee/grantor Oids + an arbitrary
+//!    `AclMode` bit flag) and assert `from_proto(into_proto(v)) == v`.
+//!  - Raw-bytes arm: decode arbitrary bytes as `ProtoAclItem`, into Rust, and
+//!    re-encode, keeping coverage of the bare wire decoder against hostile
+//!    input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::{ProtoType, RustType};
+use mz_repr::adt::mz_acl_item::{AclItem, ProtoAclItem};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+fn arbitrary_arm(seed: &[u8]) {
+    let mut buf = [0u8; 32];
+    for (dst, src) in buf.iter_mut().zip(seed.iter()) {
+        *dst = *src;
+    }
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &buf);
+    let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+    let value =
+        match <AclItem as proptest::arbitrary::Arbitrary>::arbitrary().new_tree(&mut runner) {
+            Ok(tree) => tree.current(),
+            Err(_) => return,
+        };
+
+    let proto = value.into_proto();
+    let back = AclItem::from_proto(proto).expect("valid AclItem must round-trip");
+    assert_eq!(value, back, "AclItem changed across proto roundtrip");
+}
+
+fn raw_arm(data: &[u8]) {
+    let Ok(proto) = ProtoAclItem::decode(data) else {
+        return;
+    };
+    let orig: AclItem = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let proto2 = <ProtoAclItem as ProtoType<AclItem>>::from_rust(&orig);
+    let bytes2 = proto2.encode_to_vec();
+    let proto3 = ProtoAclItem::decode(bytes2.as_slice())
+        .expect("re-encode of valid AclItem must decode");
+    let round: AclItem = proto3
+        .into_rust()
+        .expect("re-encoded AclItem must convert back to Rust");
+
+    assert_eq!(orig, round, "AclItem changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+    if mode & 1 == 0 {
+        arbitrary_arm(rest);
+    } else {
+        raw_arm(rest);
+    }
+});

--- a/src/repr/fuzz/fuzz_targets/column_type_proto_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/column_type_proto_roundtrip.rs
@@ -1,0 +1,79 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `SqlColumnType` proto round-trips losslessly.
+//!
+//! Two arms (the first byte selects):
+//!  - Arbitrary arm: drive `SqlColumnType`'s proptest `Arbitrary` strategy from
+//!    the fuzzer bytes to build a *valid* column type pairing a deeply-nested
+//!    `SqlScalarType` with a nullable flag, and assert
+//!    `from_proto(into_proto(v)) == v`. Random proto bytes leave the inner
+//!    scalar type near-empty. This arm reaches the recursive scalar variants.
+//!  - Raw-bytes arm: decode arbitrary bytes as `ProtoColumnType`, into Rust, and
+//!    re-encode, keeping coverage of the bare wire decoder against hostile
+//!    input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::{ProtoType, RustType};
+use mz_repr::{ProtoColumnType, SqlColumnType};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+fn arbitrary_arm(seed: &[u8]) {
+    let mut buf = [0u8; 32];
+    for (dst, src) in buf.iter_mut().zip(seed.iter()) {
+        *dst = *src;
+    }
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &buf);
+    let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+    let value = match <SqlColumnType as proptest::arbitrary::Arbitrary>::arbitrary()
+        .new_tree(&mut runner)
+    {
+        Ok(tree) => tree.current(),
+        Err(_) => return,
+    };
+
+    let proto = value.into_proto();
+    let back = SqlColumnType::from_proto(proto).expect("valid SqlColumnType must round-trip");
+    assert_eq!(value, back, "SqlColumnType changed across proto roundtrip");
+}
+
+fn raw_arm(data: &[u8]) {
+    let Ok(proto) = ProtoColumnType::decode(data) else {
+        return;
+    };
+    let orig: SqlColumnType = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let proto2 = <ProtoColumnType as ProtoType<SqlColumnType>>::from_rust(&orig);
+    let bytes2 = proto2.encode_to_vec();
+    let proto3 = ProtoColumnType::decode(bytes2.as_slice())
+        .expect("re-encode of valid SqlColumnType must decode");
+    let round: SqlColumnType = proto3
+        .into_rust()
+        .expect("re-encoded SqlColumnType must convert back to Rust");
+
+    assert_eq!(orig, round, "SqlColumnType changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+    if mode & 1 == 0 {
+        arbitrary_arm(rest);
+    } else {
+        raw_arm(rest);
+    }
+});

--- a/src/repr/fuzz/fuzz_targets/interval_arith.rs
+++ b/src/repr/fuzz/fuzz_targets/interval_arith.rs
@@ -1,0 +1,163 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Interval` arithmetic. Intervals are built from user input and
+//! combined with checked arithmetic that must never panic (overflow returns
+//! `None`/`Err`, not a crash) and must respect basic algebra.
+//!
+//! Oracles (beyond no-panic on every op):
+//!  * add is commutative;
+//!  * add is associative (`(a+b)+c == a+(b+c)`) whenever both groupings succeed;
+//!  * additive inverse: `a + (-a)` is the zero interval (when `checked_neg` and
+//!    the add both succeed);
+//!  * the sketchy fractional-carry `as`-cast path in `checked_mul`/`checked_op`
+//!    is cross-checked against an exact integer reference: for a small whole
+//!    factor `k`, `checked_mul(s, k)` must equal `k` repeated `checked_add`s,
+//!    and `checked_mul(s, 1.0) == s`. Because that path routes the i64 `micros`
+//!    through `f64`, the identity only holds while the fields and their products
+//!    stay inside `f64`'s exact-integer range (2^53). The cross-checked operand
+//!    `s` is masked into a small range so the comparison is sound (an unbounded
+//!    operand legitimately loses precision and is NOT a bug);
+//!  * `justify_days` / `justify_hours` / `justify_interval` preserve the
+//!    interval's total microseconds (they only redistribute fields using the
+//!    fixed 30-day-month / 24-hour-day ratios that `as_microseconds` also uses).
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::interval::Interval;
+
+/// Negate every field with checked arithmetic, mirroring `Interval`'s
+/// `CheckedNeg` impl without pulling in the `num-traits` trait. Returns `None`
+/// if any field is `MIN` (its negation overflows).
+fn checked_neg(a: &Interval) -> Option<Interval> {
+    Some(Interval::new(
+        a.months.checked_neg()?,
+        a.days.checked_neg()?,
+        a.micros.checked_neg()?,
+    ))
+}
+
+/// Add `a` to itself `k` times via `checked_add`, the exact integer reference
+/// for `checked_mul(a, k as f64)`. Returns `None` on any intermediate overflow.
+fn repeated_add(a: &Interval, k: u32) -> Option<Interval> {
+    let mut acc = Interval::new(0, 0, 0);
+    for _ in 0..k {
+        acc = acc.checked_add(a)?;
+    }
+    Some(acc)
+}
+
+/// Bounds chosen so that, for the small factor `k <= 16`, every field AND its
+/// product `field * k` stay (a) exactly representable in `f64` (< 2^53) and
+/// (b) inside the destination integer's range, so neither `checked_mul`'s
+/// `as`-cast path nor `repeated_add`'s integer path overflows. That makes the
+/// two computations a clean, exact reference for each other.
+const MONTHS_DAYS_BOUND: i32 = 1 << 26; // *16 = 2^30 < i32::MAX, f64-exact
+const MICROS_BOUND: i64 = 1 << 49; // *16 = 2^53, f64-exact, < i64::MAX
+
+fn check(a: Interval, b: Interval, c: Interval, s: Interval, factor: f64, small_k: u8) {
+    // --- Addition is commutative, and overflow is symmetric. --------------
+    assert_eq!(
+        a.checked_add(&b),
+        b.checked_add(&a),
+        "interval checked_add is not commutative"
+    );
+
+    // --- Addition is associative when both groupings succeed. -------------
+    let left = a.checked_add(&b).and_then(|ab| ab.checked_add(&c));
+    let right = b.checked_add(&c).and_then(|bc| a.checked_add(&bc));
+    // Only compare when neither side overflowed. If one overflows the other may
+    // legitimately not (intermediate sums differ in magnitude).
+    if let (Some(left), Some(right)) = (left, right) {
+        assert_eq!(left, right, "interval checked_add is not associative");
+    }
+
+    // --- Additive inverse: a + (-a) == 0. ---------------------------------
+    if let Some(neg_a) = checked_neg(&a) {
+        if let Some(sum) = a.checked_add(&neg_a) {
+            assert_eq!(
+                sum,
+                Interval::new(0, 0, 0),
+                "a + (-a) must be the zero interval"
+            );
+        }
+    }
+
+    // --- Multiply through the `as`-cast path, cross-checked exactly. ------
+    // `s` is masked so every field and its product with `k` fits exactly in
+    // `f64`. Otherwise the i64->f64->i64 round-trip in `checked_op` is lossy and
+    // the identities below would not hold (that loss is expected, not a bug).
+    let s = Interval::new(
+        s.months % MONTHS_DAYS_BOUND,
+        s.days % MONTHS_DAYS_BOUND,
+        s.micros % MICROS_BOUND,
+    );
+
+    // Multiply-by-one is the identity on the bounded operand.
+    if let Some(prod) = s.checked_mul(1.0) {
+        assert_eq!(prod, s, "checked_mul(s, 1.0) must equal s");
+    }
+
+    // checked_mul(s, k) == k repeated checked_adds, for small whole k. `k` is
+    // small so repeated_add stays cheap and the products stay f64-exact.
+    let k = u32::from(small_k % 17); // 0..=16
+    let by_mul = s.checked_mul(f64::from(k));
+    let by_add = repeated_add(&s, k);
+    // Both must agree on success/overflow and, on success, on the value.
+    assert_eq!(
+        by_mul, by_add,
+        "checked_mul(s, {k}) disagrees with {k} repeated checked_adds"
+    );
+
+    // --- justify_* preserve total microseconds. ---------------------------
+    let total = a.as_microseconds();
+    if let Ok(j) = a.justify_days() {
+        assert_eq!(
+            j.as_microseconds(),
+            total,
+            "justify_days changed total microseconds"
+        );
+    }
+    if let Ok(j) = a.justify_hours() {
+        assert_eq!(
+            j.as_microseconds(),
+            total,
+            "justify_hours changed total microseconds"
+        );
+    }
+    if let Ok(j) = a.justify_interval() {
+        assert_eq!(
+            j.as_microseconds(),
+            total,
+            "justify_interval changed total microseconds"
+        );
+    }
+
+    // --- Remaining ops just must not panic on any input, incl. NaN/inf. ---
+    let _ = a.checked_mul(factor);
+    let _ = a.checked_div(factor);
+    let _ = b.checked_mul(factor);
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let a = Interval::new(u.arbitrary()?, u.arbitrary()?, u.arbitrary()?);
+    let b = Interval::new(u.arbitrary()?, u.arbitrary()?, u.arbitrary()?);
+    let c = Interval::new(u.arbitrary()?, u.arbitrary()?, u.arbitrary()?);
+    let s = Interval::new(u.arbitrary()?, u.arbitrary()?, u.arbitrary()?);
+    let factor: f64 = u.arbitrary()?;
+    let small_k: u8 = u.arbitrary()?;
+    check(a, b, c, s, factor, small_k);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/interval_proto_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/interval_proto_roundtrip.rs
@@ -1,0 +1,76 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Interval` proto round-trips losslessly.
+//!
+//! Two arms (the first byte selects):
+//!  - Arbitrary arm: drive `Interval`'s proptest `Arbitrary` strategy from the
+//!    fuzzer bytes to build a *valid* interval (months/days/micros across the
+//!    full range) and assert `from_proto(into_proto(v)) == v`.
+//!  - Raw-bytes arm: decode arbitrary bytes as `ProtoInterval`, into Rust, and
+//!    re-encode, keeping coverage of the bare wire decoder against hostile
+//!    input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::{ProtoType, RustType};
+use mz_repr::adt::interval::{Interval, ProtoInterval};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+fn arbitrary_arm(seed: &[u8]) {
+    let mut buf = [0u8; 32];
+    for (dst, src) in buf.iter_mut().zip(seed.iter()) {
+        *dst = *src;
+    }
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &buf);
+    let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+    let value =
+        match <Interval as proptest::arbitrary::Arbitrary>::arbitrary().new_tree(&mut runner) {
+            Ok(tree) => tree.current(),
+            Err(_) => return,
+        };
+
+    let proto = value.into_proto();
+    let back = Interval::from_proto(proto).expect("valid Interval must round-trip");
+    assert_eq!(value, back, "Interval changed across proto roundtrip");
+}
+
+fn raw_arm(data: &[u8]) {
+    let Ok(proto) = ProtoInterval::decode(data) else {
+        return;
+    };
+    let orig: Interval = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let proto2 = <ProtoInterval as ProtoType<Interval>>::from_rust(&orig);
+    let bytes2 = proto2.encode_to_vec();
+    let proto3 = ProtoInterval::decode(bytes2.as_slice())
+        .expect("re-encode of valid Interval must decode");
+    let round: Interval = proto3
+        .into_rust()
+        .expect("re-encoded Interval must convert back to Rust");
+
+    assert_eq!(orig, round, "Interval changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+    if mode & 1 == 0 {
+        arbitrary_arm(rest);
+    } else {
+        raw_arm(rest);
+    }
+});

--- a/src/repr/fuzz/fuzz_targets/jsonb_from_slice.rs
+++ b/src/repr/fuzz/fuzz_targets/jsonb_from_slice.rs
@@ -1,0 +1,253 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Jsonb::from_slice` decodes untrusted JSON bytes (Kafka/webhook
+//! source bodies) into Materialize's JSONB `Row` representation, doing recursive
+//! object/array packing with key dedup and numeric coercion. Beyond not
+//! panicking, its `Display` rendering must re-parse to the same value.
+//!
+//! Random bytes almost never form valid JSON, so byte mutation barely reaches
+//! past the first token. The recursive packing, numeric coercion, and key dedup
+//! (and the Display round-trip oracle, which only runs on a value that parsed)
+//! stay shallow. So we consume the byte stream as grammar choices and emit valid
+//! JSON, biased toward the bug-prone paths: numbers that stress the
+//! arbitrary-precision coercion (huge exponents, long digit runs, `-0`), objects
+//! with duplicate keys (the dedup path), nested arrays/objects, and strings with
+//! escapes. A quarter of inputs are still the raw bytes, so the parser's reject
+//! paths and non-UTF-8 handling stay covered.
+//!
+//! Two extra shapes probe edges shallow generation misses: a deep single-spine
+//! nesting (`[[[…]]]` / `{"a":{"a":…}}`) that walks the recursive collector up
+//! toward serde_json's nesting limit (where it must `Err`, not overflow the
+//! stack), and an object whose key is literally `$serde_json::private::Number`,
+//! serde_json's private arbitrary-precision-number token. Such an object is
+//! reinterpreted as a number on the way back in, so we don't run the re-parse
+//! oracle on it. We only assert `from_slice` doesn't panic and that `Display`
+//! renders fully without panicking.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::jsonb::Jsonb;
+
+/// Valid JSON numbers chosen to stress the arbitrary-precision numeric coercion:
+/// big integers, tiny/huge exponents, negative zero, long fractions.
+const NUMBERS: &[&str] = &[
+    "0",
+    "-0",
+    "1",
+    "-1",
+    "42",
+    "3.14",
+    "-2.5",
+    "1e10",
+    "1e-10",
+    "1e308",
+    "1e1000",
+    "-1e-1000",
+    "1.7976931348623157e308",
+    "123456789012345678901234567890",
+    "0.00000000000000000001",
+    "9999999999999999999999999999999999999999",
+];
+
+/// Object keys, including the duplicate-prone short set (so dedup fires) and one
+/// that needs escaping.
+const KEYS: &[&str] = &["a", "b", "a", "k", "\"q\\\"x\"", "\"\""];
+
+fn push_string(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    out.push('"');
+    let n = u.int_in_range(0usize..=5)?;
+    for _ in 0..n {
+        match u.int_in_range(0u8..=6)? {
+            0 => out.push_str("\\\""),
+            1 => out.push_str("\\\\"),
+            2 => out.push_str("\\n"),
+            3 => out.push_str("\\u0041"),
+            4 => out.push_str("\\uD83D\\uDE00"), // surrogate pair
+            _ => out.push(*u.choose(&['a', 'z', '0', ' ', '!'])?),
+        }
+    }
+    out.push('"');
+    Ok(())
+}
+
+fn gen_json(u: &mut Unstructured, depth: u32, out: &mut String) -> arbitrary::Result<()> {
+    let leaf = depth == 0 || u.is_empty();
+    let choice = if leaf {
+        u.int_in_range(0u8..=4)?
+    } else {
+        u.int_in_range(0u8..=6)?
+    };
+    match choice {
+        0 => out.push_str("null"),
+        1 => out.push_str(if u.int_in_range(0u8..=1)? == 0 {
+            "true"
+        } else {
+            "false"
+        }),
+        2 => out.push_str(u.choose(NUMBERS)?),
+        3 => push_string(u, out)?,
+        4 => {
+            // A generated number (valid JSON: leading 1-9, optional frac/exp).
+            if u.int_in_range(0u8..=1)? == 0 {
+                out.push('-');
+            }
+            out.push(*u.choose(&['1', '2', '3', '4', '5', '6', '7', '8', '9'])?);
+            for _ in 0..u.int_in_range(0usize..=12)? {
+                out.push(*u.choose(&['0', '1', '5', '9'])?);
+            }
+            if u.int_in_range(0u8..=1)? == 0 {
+                out.push('.');
+                for _ in 0..u.int_in_range(1usize..=4)? {
+                    out.push(*u.choose(&['0', '1', '9'])?);
+                }
+            }
+        }
+        5 => {
+            out.push('[');
+            let n = u.int_in_range(0usize..=4)?;
+            for i in 0..n {
+                if i > 0 {
+                    out.push(',');
+                }
+                gen_json(u, depth - 1, out)?;
+            }
+            out.push(']');
+        }
+        _ => {
+            out.push('{');
+            let n = u.int_in_range(0usize..=4)?;
+            for i in 0..n {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(u.choose(KEYS)?); // may repeat -> dedup path
+                out.push(':');
+                gen_json(u, depth - 1, out)?;
+            }
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+/// Emit a deep single-spine nesting (`[[[…leaf…]]]` or `{"a":{"a":…leaf…}}`) to
+/// walk the recursive collector down toward serde_json's nesting limit. Beyond
+/// the limit `from_slice` must return an `Err` (handled by `check`), never
+/// overflow the stack.
+fn gen_deep_spine(u: &mut Unstructured, depth: u32, out: &mut String) -> arbitrary::Result<()> {
+    let use_obj = u.int_in_range(0u8..=1)? == 0;
+    for _ in 0..depth {
+        if use_obj {
+            out.push_str("{\"a\":");
+        } else {
+            out.push('[');
+        }
+    }
+    gen_json(u, 0, out)?;
+    for _ in 0..depth {
+        out.push(if use_obj { '}' } else { ']' });
+    }
+    Ok(())
+}
+
+/// Render the object `{"$serde_json::private::Number": <value>}`. serde_json
+/// (built with `arbitrary_precision`) treats this exact key as its private
+/// number token, so the object is reinterpreted as a number rather than packed
+/// as an object. That asymmetry defeats the strict re-parse oracle but must
+/// still not panic in `from_slice`/`Display`.
+fn gen_private_number(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    out.push_str("{\"$serde_json::private::Number\":");
+    // The value serde_json expects here is a string holding the digits, but feed
+    // a variety (string number, junk string, real number, nested) to probe how
+    // the number sniffer copes.
+    match u.int_in_range(0u8..=3)? {
+        0 => {
+            out.push('"');
+            out.push_str(u.choose(NUMBERS)?);
+            out.push('"');
+        }
+        1 => out.push_str("\"not-a-number\""),
+        2 => out.push_str(u.choose(NUMBERS)?),
+        _ => gen_json(u, 1, out)?,
+    }
+    out.push('}');
+    Ok(())
+}
+
+/// Parse, and only require that `Display` renders fully without panicking. Used
+/// for shapes whose round trip is inherently lossy (the private number token).
+fn check_no_panic(data: &[u8]) {
+    if let Ok(j) = Jsonb::from_slice(data) {
+        // Force the full Display rendering, which must not panic.
+        let _ = j.to_string();
+    }
+}
+
+fn check(data: &[u8]) {
+    let Ok(j) = Jsonb::from_slice(data) else {
+        return;
+    };
+    let formatted = j.to_string();
+    // serde_json (which mz-repr builds with `arbitrary_precision`) represents
+    // every JSON number internally as a single-key map
+    // `{"$serde_json::private::Number": "<digits>"}`. A JSON *object* that uses
+    // that exact key is therefore indistinguishable from a number on the way
+    // back in: JSONB sorts an object's keys for display, this `$`-prefixed token
+    // sorts ahead of ordinary keys, and the value is then reinterpreted as a
+    // (possibly invalid) number. That asymmetry is an inherent serde_json
+    // limitation, not a JSONB round-trip bug, and `from_slice` itself never
+    // panics on it. So skip the re-parse check whenever the rendering leans on
+    // serde_json's private number token.
+    const SERDE_JSON_NUMBER_TOKEN: &str = "$serde_json::private::Number";
+    if formatted.contains(SERDE_JSON_NUMBER_TOKEN) {
+        return;
+    }
+    let reparsed: Jsonb = formatted.parse().expect("jsonb Display must re-parse");
+    assert_eq!(j, reparsed, "jsonb changed across parse/format round trip");
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw bytes: keeps the parser's reject paths and
+    // non-UTF-8 handling covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        check(u.take_rest());
+        return Ok(());
+    }
+    match u.int_in_range(0u8..=9)? {
+        // A deep single-spine nesting that probes the recursion limit. Depth is
+        // chosen to straddle serde_json's default (~128): well within, right at,
+        // and past it (where it must `Err`, not overflow).
+        0 => {
+            let depth = u.int_in_range(1u32..=200)?;
+            let mut s = String::new();
+            gen_deep_spine(&mut u, depth, &mut s)?;
+            check(s.as_bytes());
+        }
+        // The private-number-token object: assert no panic + total Display only.
+        1 => {
+            let mut s = String::new();
+            gen_private_number(&mut u, &mut s)?;
+            check_no_panic(s.as_bytes());
+        }
+        // The common case: a wide, moderately deep random JSON value.
+        _ => {
+            let mut s = String::new();
+            gen_json(&mut u, 6, &mut s)?;
+            check(s.as_bytes());
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/mz_acl_item_proto_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/mz_acl_item_proto_roundtrip.rs
@@ -1,0 +1,80 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `MzAclItem` proto round-trips losslessly.
+//! ACL items are access-control data. A decoder bug here is a security
+//! concern (a malformed proto could decode into a value the rest of the
+//! catalog doesn't expect).
+//!
+//! Two arms (the first byte selects):
+//!  - Arbitrary arm: drive `MzAclItem`'s proptest `Arbitrary` strategy from the
+//!    fuzzer bytes to build a *valid* entry (grantee/grantor `RoleId`s across
+//!    all variants + an arbitrary `AclMode` bit flag) and assert
+//!    `from_proto(into_proto(v)) == v`.
+//!  - Raw-bytes arm: decode arbitrary bytes as `ProtoMzAclItem`, into Rust, and
+//!    re-encode, keeping coverage of the bare wire decoder against hostile
+//!    input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::{ProtoType, RustType};
+use mz_repr::adt::mz_acl_item::{MzAclItem, ProtoMzAclItem};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+fn arbitrary_arm(seed: &[u8]) {
+    let mut buf = [0u8; 32];
+    for (dst, src) in buf.iter_mut().zip(seed.iter()) {
+        *dst = *src;
+    }
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &buf);
+    let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+    let value =
+        match <MzAclItem as proptest::arbitrary::Arbitrary>::arbitrary().new_tree(&mut runner) {
+            Ok(tree) => tree.current(),
+            Err(_) => return,
+        };
+
+    let proto = value.into_proto();
+    let back = MzAclItem::from_proto(proto).expect("valid MzAclItem must round-trip");
+    assert_eq!(value, back, "MzAclItem changed across proto roundtrip");
+}
+
+fn raw_arm(data: &[u8]) {
+    let Ok(proto) = ProtoMzAclItem::decode(data) else {
+        return;
+    };
+    let orig: MzAclItem = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let proto2 = <ProtoMzAclItem as ProtoType<MzAclItem>>::from_rust(&orig);
+    let bytes2 = proto2.encode_to_vec();
+    let proto3 = ProtoMzAclItem::decode(bytes2.as_slice())
+        .expect("re-encode of valid MzAclItem must decode");
+    let round: MzAclItem = proto3
+        .into_rust()
+        .expect("re-encoded MzAclItem must convert back to Rust");
+
+    assert_eq!(orig, round, "MzAclItem changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+    if mode & 1 == 0 {
+        arbitrary_arm(rest);
+    } else {
+        raw_arm(rest);
+    }
+});

--- a/src/repr/fuzz/fuzz_targets/numeric_arith.rs
+++ b/src/repr/fuzz/fuzz_targets/numeric_arith.rs
@@ -1,0 +1,251 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Numeric` (128-bit decimal) arithmetic through the standard
+//! datum context.
+//!
+//! Operands are generated two ways so the fuzzer reaches values that decimal
+//! text rarely produces:
+//!  * parsed untrusted decimal text (`parse_numeric`), and
+//!  * raw coefficient + exponent pairs (`from_i128` then `scaleb`), which lets
+//!    the fuzzer pin a full 39-digit coefficient at an arbitrary scale, hitting
+//!    the precision/exponent extremes of `cx_datum` that random text misses.
+//!
+//! Oracles (beyond no-panic on every op, including `rem`/`div` by zero and
+//! `pow`/`ln`/`log10`/`sqrt`/`round`/`rescale` on every value):
+//!  * add/mul are commutative;
+//!  * add/mul are associative *when the involved ops were exact* (decimal
+//!    rounding legitimately breaks associativity, so an `inexact` flag guards
+//!    the assertion);
+//!  * additive inverse: `a + (-a) == 0`;
+//!  * cancellation: `(a + b) - b == a` when exact;
+//!  * identities `a + 0 == a`, `a * 1 == a`;
+//!  * `sqrt` of a non-negative value is non-negative, and `abs` is
+//!    non-negative.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::numeric::{cx_datum, Numeric};
+use mz_repr::strconv::parse_numeric;
+
+/// Generate one operand from the fuzzer's byte stream.
+///
+/// Half the time we parse decimal text (reaching NaN/Inf/scientific notation),
+/// the other half we build `coeff * 10^exponent` directly so a wide coefficient
+/// can be placed at any scale.
+fn gen_operand(u: &mut Unstructured) -> arbitrary::Result<Option<Numeric>> {
+    if u.int_in_range(0u8..=1)? == 0 {
+        // Parsed text. Borrow the rest of the buffer as UTF-8-ish text. On
+        // failure fall back to a short arbitrary string.
+        let s: &str = u.arbitrary()?;
+        Ok(parse_numeric(s).ok().map(|d| d.0))
+    } else {
+        let coeff: i128 = u.arbitrary()?;
+        // Bound the shift to bracket the datum context's [-39, 38] exponent
+        // window without forcing every value outside it.
+        let exponent: i16 = u.int_in_range(-60i16..=60)?;
+        let mut cx = cx_datum();
+        let mut n = cx.from_i128(coeff);
+        let shift = Numeric::from(i32::from(exponent));
+        // `scaleb` respects the context (clamps/flags rather than panicking).
+        cx.scaleb(&mut n, &shift);
+        // A finite value that overflowed to infinity isn't an interesting "raw"
+        // operand. Drop it so special-value handling has a clear contract.
+        if n.is_infinite() {
+            Ok(None)
+        } else {
+            Ok(Some(n))
+        }
+    }
+}
+
+/// Was the operation that just ran in `cx` exact (no rounding, overflow, or
+/// invalid operation)? Algebraic identities only hold when exact.
+fn op_exact(cx: &dec::Context<Numeric>) -> bool {
+    let s = cx.status();
+    !s.inexact() && !s.invalid_operation() && !s.overflow()
+}
+
+fn check(a: Numeric, b: Numeric) {
+    // NaN never equals itself, so equality-based oracles can't be asserted.
+    if a.is_nan() || b.is_nan() {
+        // Still exercise every operation for panics.
+        let mut cx = cx_datum();
+        let mut t = a;
+        cx.add(&mut t, &b);
+        cx.mul(&mut t, &b);
+        cx.sub(&mut t, &b);
+        cx.div(&mut t, &b);
+        cx.rem(&mut t, &b);
+        cx.pow(&mut t, &b);
+        cx.ln(&mut t);
+        cx.log10(&mut t);
+        let mut s = a;
+        cx.sqrt(&mut s);
+        cx.round(&mut t);
+        return;
+    }
+
+    let mut cx = cx_datum();
+
+    // --- Commutativity -----------------------------------------------------
+    let (mut ab, mut ba) = (a, b);
+    cx.add(&mut ab, &b);
+    cx.add(&mut ba, &a);
+    assert_eq!(ab, ba, "numeric add is not commutative");
+
+    let (mut am, mut bm) = (a, b);
+    cx.mul(&mut am, &b);
+    cx.mul(&mut bm, &a);
+    assert_eq!(am, bm, "numeric mul is not commutative");
+
+    // --- Additive inverse: a + (-a) == 0 (exact for all finite a) ----------
+    {
+        let mut neg_a = a;
+        cx.neg(&mut neg_a);
+        let mut sum = a;
+        cx.clear_status();
+        cx.add(&mut sum, &neg_a);
+        if op_exact(&cx) {
+            assert!(sum.is_zero(), "a + (-a) must be zero, got {}", sum);
+        }
+    }
+
+    // --- Identities a + 0 == a, a * 1 == a ---------------------------------
+    {
+        let zero = Numeric::from(0);
+        let mut t = a;
+        cx.clear_status();
+        cx.add(&mut t, &zero);
+        if op_exact(&cx) {
+            assert_eq!(t, a, "a + 0 must equal a");
+        }
+
+        let one = Numeric::from(1);
+        let mut t = a;
+        cx.clear_status();
+        cx.mul(&mut t, &one);
+        if op_exact(&cx) {
+            assert_eq!(t, a, "a * 1 must equal a");
+        }
+    }
+
+    // --- Cancellation: (a + b) - b == a, only when both ops were exact -----
+    {
+        cx.clear_status();
+        let mut s = a;
+        cx.add(&mut s, &b);
+        let sum_exact = op_exact(&cx);
+        cx.clear_status();
+        cx.sub(&mut s, &b);
+        let sub_exact = op_exact(&cx);
+        if sum_exact && sub_exact {
+            assert_eq!(s, a, "(a + b) - b must equal a when exact");
+        }
+    }
+
+    // --- Associativity of add: (a+b)+a vs a+(b+a) when exact ---------------
+    // Re-using `a` as the third operand keeps the target's input binary while
+    // still re-associating across distinct magnitudes.
+    {
+        cx.clear_status();
+        let mut left = a;
+        cx.add(&mut left, &b);
+        cx.add(&mut left, &a);
+        let left_exact = op_exact(&cx);
+
+        cx.clear_status();
+        let mut bc = b;
+        cx.add(&mut bc, &a);
+        let mut right = a;
+        cx.add(&mut right, &bc);
+        let right_exact = op_exact(&cx);
+
+        if left_exact && right_exact {
+            assert_eq!(left, right, "numeric add is not associative (exact)");
+        }
+    }
+
+    // --- Associativity of mul: (a*b)*a vs a*(b*a) when exact ---------------
+    {
+        cx.clear_status();
+        let mut left = a;
+        cx.mul(&mut left, &b);
+        cx.mul(&mut left, &a);
+        let left_exact = op_exact(&cx);
+
+        cx.clear_status();
+        let mut bc = b;
+        cx.mul(&mut bc, &a);
+        let mut right = a;
+        cx.mul(&mut right, &bc);
+        let right_exact = op_exact(&cx);
+
+        if left_exact && right_exact {
+            assert_eq!(left, right, "numeric mul is not associative (exact)");
+        }
+    }
+
+    // --- No-panic exercise of the remaining ops, plus sign properties ------
+    let mut s = a;
+    cx.sub(&mut s, &b);
+    let mut q = a;
+    cx.div(&mut q, &b); // includes divide-by-zero
+    let mut r = a;
+    cx.rem(&mut r, &b); // includes rem-by-zero
+    let mut p = a;
+    cx.pow(&mut p, &b);
+
+    // sqrt of a non-negative finite value is non-negative.
+    {
+        let mut x = a;
+        cx.clear_status();
+        cx.sqrt(&mut x);
+        if !a.is_negative() && !x.is_nan() && !x.is_infinite() {
+            assert!(
+                !x.is_negative(),
+                "sqrt of non-negative must be non-negative"
+            );
+        }
+    }
+
+    // abs is never negative (modulo NaN, already excluded).
+    {
+        let mut x = a;
+        cx.abs(&mut x);
+        if !x.is_nan() {
+            assert!(!x.is_negative(), "abs must be non-negative");
+        }
+    }
+
+    // ln / log10 / round / rescale just must not panic.
+    let mut l = a;
+    cx.ln(&mut l);
+    let mut l = a;
+    cx.log10(&mut l);
+    let mut rd = a;
+    cx.round(&mut rd);
+    let mut rsc = a;
+    let _ = mz_repr::adt::numeric::rescale(&mut rsc, (b.exponent().unsigned_abs() % 40) as u8);
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let a = gen_operand(&mut u)?;
+    let b = gen_operand(&mut u)?;
+    if let (Some(a), Some(b)) = (a, b) {
+        check(a, b);
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/range_ops.rs
+++ b/src/repr/fuzz/fuzz_targets/range_ops.rs
@@ -1,0 +1,146 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Range` set operations over `int4` bounds. Ranges are built
+//! from user input and canonicalized, then unioned/intersected/differenced.
+//! None of this may panic, and the results must satisfy set algebra. Bounds are
+//! all `int4` so the documented "finite bounds of different types" precondition
+//! panic in `canonicalize` stays unreachable.
+//!
+//! Oracles (beyond no-panic):
+//!  * union (when representable as one range) contains both operands. Union is
+//!    commutative and idempotent (`a ∪ a == a`);
+//!  * intersection is contained in both operands. Intersection is commutative
+//!    and idempotent (`a ∩ a == a`);
+//!  * difference algebra: when `a ∖ b` is representable, it is a subset of `a`
+//!    and is disjoint from `b` (empty intersection with `b`);
+//!  * `contains_elem(x)` agrees with "intersecting the point range `[x,x]` is
+//!    non-empty".
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::range::{Range, RangeBound};
+use mz_repr::Datum;
+
+// None = infinite bound. Some((inclusive, value)) = finite bound.
+type BoundSpec = Option<(bool, i32)>;
+// None = empty range. Some((lower, upper)) = a range with those bounds.
+type RangeSpec = Option<(BoundSpec, BoundSpec)>;
+
+fn make_range(spec: RangeSpec) -> Range<Datum<'static>> {
+    let inner = spec.map(|(lo, hi)| {
+        let lower = RangeBound {
+            inclusive: matches!(lo, Some((true, _))),
+            bound: lo.map(|(_, v)| Datum::Int32(v)),
+        };
+        let upper = RangeBound {
+            inclusive: matches!(hi, Some((true, _))),
+            bound: hi.map(|(_, v)| Datum::Int32(v)),
+        };
+        (lower, upper)
+    });
+    Range::new(inner)
+}
+
+/// Build a canonical operand, or `None` if the spec doesn't canonicalize
+/// (misordered bounds, etc.).
+fn canonical(spec: RangeSpec) -> Option<Range<Datum<'static>>> {
+    let mut r = make_range(spec);
+    r.canonicalize().ok()?;
+    Some(r)
+}
+
+/// Re-anchor a `Range<Datum<'_>>` (e.g. a `difference` result) to `'static`.
+/// All bounds here are `int4`, which own no borrowed data, so this is just a
+/// lifetime launder.
+fn to_static(r: Range<Datum<'_>>) -> Range<Datum<'static>> {
+    r.into_bounds(|d| match d {
+        Datum::Int32(v) => Datum::Int32(v),
+        other => unreachable!("non-int4 bound in int4 range: {other:?}"),
+    })
+}
+
+fn check(a: Range<Datum<'static>>, b: Range<Datum<'static>>, elem: i32) {
+    let _ = a.contains_elem(&elem);
+
+    // --- Union: contains both operands, commutative, idempotent. ----------
+    if let Ok(union) = a.union(&b) {
+        assert!(
+            union.contains_range(&a) && union.contains_range(&b),
+            "union must contain both operands"
+        );
+    }
+    assert_eq!(
+        a.union(&b),
+        b.union(&a),
+        "union must be commutative"
+    );
+    if let Ok(uaa) = a.union(&a) {
+        assert_eq!(uaa, a, "union must be idempotent (a ∪ a == a)");
+    }
+
+    // --- Intersection: contained in both, commutative, idempotent. --------
+    let intersection = a.intersection(&b);
+    assert!(
+        a.contains_range(&intersection) && b.contains_range(&intersection),
+        "intersection must be contained in both operands"
+    );
+    assert_eq!(
+        a.intersection(&b),
+        b.intersection(&a),
+        "intersection must be commutative"
+    );
+    assert_eq!(
+        a.intersection(&a),
+        a,
+        "intersection must be idempotent (a ∩ a == a)"
+    );
+
+    // --- Difference algebra: a ∖ b ⊆ a and disjoint from b. ---------------
+    if let Ok(diff) = a.difference(&b) {
+        let diff = to_static(diff);
+        assert!(
+            a.contains_range(&diff),
+            "a ∖ b must be a subset of a"
+        );
+        assert!(
+            diff.intersection(&b).inner.is_none(),
+            "a ∖ b must be disjoint from b"
+        );
+    }
+
+    // --- contains_elem(x) consistency vs the point range [x, x]. ----------
+    // `[x, x]` canonicalizes to the singleton {x}. If `x == i32::MAX` the upper
+    // bound's `step` overflows and canonicalization fails, in which case we
+    // simply skip the comparison.
+    if let Some(point) = canonical(Some((Some((true, elem)), Some((true, elem))))) {
+        let contains = a.contains_elem(&elem);
+        let intersects = a.intersection(&point).inner.is_some();
+        assert_eq!(
+            contains, intersects,
+            "contains_elem({elem}) must agree with [x,x] intersection"
+        );
+    }
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let ra: RangeSpec = u.arbitrary()?;
+    let rb: RangeSpec = u.arbitrary()?;
+    let elem: i32 = u.arbitrary()?;
+    if let (Some(a), Some(b)) = (canonical(ra), canonical(rb)) {
+        check(a, b, elem);
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/relation_desc_proto_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/relation_desc_proto_roundtrip.rs
@@ -1,0 +1,83 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `RelationDesc` proto round-trips losslessly.
+//! `RelationDesc` is the schema of every persisted collection, so a decoder
+//! bug here corrupts catalog/persist state.
+//!
+//! Two arms (the first byte selects):
+//!  - Arbitrary arm: drive `RelationDesc`'s proptest `Arbitrary` strategy from
+//!    the fuzzer bytes to build a *valid* desc: column names paired with
+//!    deeply-nested `SqlColumnType`s, where the names<->metadata length
+//!    invariant and the per-version migration metadata are well-formed. Assert
+//!    `from_proto(into_proto(v)) == v`. Random proto bytes never satisfy the
+//!    length invariant, so the encoder's rollup/migration-default paths are
+//!    only reached here.
+//!  - Raw-bytes arm: decode arbitrary bytes as `ProtoRelationDesc`, into Rust,
+//!    and re-encode, keeping coverage of the bare wire decoder against hostile
+//!    input (including descs that violate the length invariant on decode).
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::{ProtoType, RustType};
+use mz_repr::{ProtoRelationDesc, RelationDesc};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+fn arbitrary_arm(seed: &[u8]) {
+    let mut buf = [0u8; 32];
+    for (dst, src) in buf.iter_mut().zip(seed.iter()) {
+        *dst = *src;
+    }
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &buf);
+    let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+    let value = match <RelationDesc as proptest::arbitrary::Arbitrary>::arbitrary()
+        .new_tree(&mut runner)
+    {
+        Ok(tree) => tree.current(),
+        Err(_) => return,
+    };
+
+    let proto = value.into_proto();
+    let back = RelationDesc::from_proto(proto).expect("valid RelationDesc must round-trip");
+    assert_eq!(value, back, "RelationDesc changed across proto roundtrip");
+}
+
+fn raw_arm(data: &[u8]) {
+    let Ok(proto) = ProtoRelationDesc::decode(data) else {
+        return;
+    };
+    let orig: RelationDesc = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let proto2 = <ProtoRelationDesc as ProtoType<RelationDesc>>::from_rust(&orig);
+    let bytes2 = proto2.encode_to_vec();
+    let proto3 = ProtoRelationDesc::decode(bytes2.as_slice())
+        .expect("re-encode of valid RelationDesc must decode");
+    let round: RelationDesc = proto3
+        .into_rust()
+        .expect("re-encoded RelationDesc must convert back to Rust");
+
+    assert_eq!(orig, round, "RelationDesc changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+    if mode & 1 == 0 {
+        arbitrary_arm(rest);
+    } else {
+        raw_arm(rest);
+    }
+});

--- a/src/repr/fuzz/fuzz_targets/row_arrow_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/row_arrow_roundtrip.rs
@@ -1,0 +1,491 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: a `Row` survives persist's columnar Arrow encode/decode round
+//! trip. `RelationDesc`'s `Schema<Row>` impl encodes rows into Arrow arrays
+//! (the on-disk persist format) and decodes them back. A mismatch is silent
+//! data corruption. This is coverage-guided, complementing the existing
+//! `proptest_non_empty_relation_descs` property test.
+//!
+//! The generator focuses on the scalar types with non-trivial packed encodings
+//! (PackedNumeric, PackedNaiveDateTime, PackedInterval, PackedNaiveTime, ...),
+//! plus a few shapes that exercise interactions the bare-scalar columns can't:
+//!
+//!  * `Char { length }` / `VarChar { max_length }`: these decode through the
+//!    same Arrow `StringArray` as plain strings, but carry a length parameter
+//!    in the schema. We generate the parameter independently of the stored
+//!    string to stress the schema/value split.
+//!  * `Numeric { max_scale }` with the special values `NaN`, `Infinity`, and
+//!    `-Infinity` (round-tripped via `PackedNumeric`'s BCD bytes), in addition
+//!    to ordinary finite decimals, and a randomized `max_scale` in the schema.
+//!  * Shallow composites (`List`/`Array`/`Map` of a scalar element and
+//!    `Range` of a discrete scalar), placed alongside the packed-scalar columns
+//!    so the multi-column encoder builds nested Arrow arrays next to the flat
+//!    ones. The composite element is always a simple (non-composite) scalar to
+//!    keep nesting shallow. Deeper nesting already has proptest coverage.
+//!
+//! Leap seconds are excluded (a separate known encoding gap).
+
+#![no_main]
+
+use std::borrow::Borrow;
+
+use chrono::{DateTime, NaiveTime, Utc};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_persist_types::columnar::{ColumnDecoder, ColumnEncoder, Schema};
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::adt::char::CharLength;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::numeric::{cx_datum, Numeric, NumericMaxScale};
+use mz_repr::adt::range::{Range, RangeBound, RangeLowerBound, RangeUpperBound};
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::adt::varchar::VarCharMaxLength;
+use mz_repr::strconv::parse_numeric;
+use mz_repr::{Datum, RelationDesc, Row, SqlColumnType, SqlScalarType, Timestamp};
+
+/// Generate a "simple" scalar type: one that maps to a single flat Arrow array
+/// and can serve as a composite element type (no nesting).
+fn gen_simple_scalar_type(u: &mut Unstructured) -> arbitrary::Result<SqlScalarType> {
+    Ok(match u.int_in_range(0u8..=20)? {
+        0 => SqlScalarType::Bool,
+        1 => SqlScalarType::Int16,
+        2 => SqlScalarType::Int32,
+        3 => SqlScalarType::Int64,
+        4 => SqlScalarType::UInt16,
+        5 => SqlScalarType::UInt32,
+        6 => SqlScalarType::UInt64,
+        7 => SqlScalarType::PgLegacyChar, // a u8 datum
+        8 => SqlScalarType::Float32,
+        9 => SqlScalarType::Float64,
+        10 => SqlScalarType::String,
+        11 => SqlScalarType::Bytes,
+        12 => SqlScalarType::Numeric {
+            max_scale: gen_max_scale(u)?,
+        },
+        13 => SqlScalarType::Date,
+        14 => SqlScalarType::Time,
+        15 => SqlScalarType::Timestamp { precision: None },
+        16 => SqlScalarType::TimestampTz { precision: None },
+        17 => SqlScalarType::Interval,
+        18 => SqlScalarType::MzTimestamp,
+        19 => SqlScalarType::Char {
+            length: gen_char_length(u)?,
+        },
+        _ => SqlScalarType::VarChar {
+            max_length: gen_varchar_max_length(u)?,
+        },
+    })
+}
+
+/// Generate any column scalar type: a simple scalar, or a shallow composite
+/// (`List`/`Array`/`Map` of a simple scalar, or `Range` of a discrete scalar).
+fn gen_scalar_type(u: &mut Unstructured) -> arbitrary::Result<SqlScalarType> {
+    // Bias toward simple scalars (which carry the packed encodings we mostly
+    // care about) but reach the composites a meaningful fraction of the time.
+    Ok(match u.int_in_range(0u8..=11)? {
+        0..=7 => gen_simple_scalar_type(u)?,
+        8 => SqlScalarType::List {
+            element_type: Box::new(gen_element_type(u)?),
+            custom_id: None,
+        },
+        9 => SqlScalarType::Array(Box::new(gen_element_type(u)?)),
+        10 => SqlScalarType::Map {
+            value_type: Box::new(gen_element_type(u)?),
+            custom_id: None,
+        },
+        _ => SqlScalarType::Range {
+            element_type: Box::new(gen_range_element_type(u)?),
+        },
+    })
+}
+
+/// Composite element types. Restricted to scalars whose `Datum` is `Copy` (i.e.
+/// carries no borrow into the input buffer) so we can collect element datums
+/// into a `Vec` and push them without leaking backing storage. This still
+/// exercises the nested Arrow encoders for the packed-scalar element types.
+fn gen_element_type(u: &mut Unstructured) -> arbitrary::Result<SqlScalarType> {
+    Ok(match u.int_in_range(0u8..=11)? {
+        0 => SqlScalarType::Bool,
+        1 => SqlScalarType::Int16,
+        2 => SqlScalarType::Int32,
+        3 => SqlScalarType::Int64,
+        4 => SqlScalarType::UInt32,
+        5 => SqlScalarType::UInt64,
+        6 => SqlScalarType::Float64,
+        7 => SqlScalarType::Numeric {
+            max_scale: gen_max_scale(u)?,
+        },
+        8 => SqlScalarType::Date,
+        9 => SqlScalarType::Time,
+        10 => SqlScalarType::Timestamp { precision: None },
+        _ => SqlScalarType::Interval,
+    })
+}
+
+/// Range element types are restricted to the discrete/continuous types that
+/// `RangeBound::canonicalize` accepts. We use the two discrete integer types so
+/// canonicalization is exercised without dragging in continuous-type quirks.
+fn gen_range_element_type(u: &mut Unstructured) -> arbitrary::Result<SqlScalarType> {
+    Ok(if bool::arbitrary(u)? {
+        SqlScalarType::Int32
+    } else {
+        SqlScalarType::Int64
+    })
+}
+
+/// A `max_scale` for `Numeric`: `None` half the time, otherwise an in-range
+/// `0..=39` scale to stress the schema-side parameter.
+fn gen_max_scale(u: &mut Unstructured) -> arbitrary::Result<Option<NumericMaxScale>> {
+    if bool::arbitrary(u)? {
+        Ok(None)
+    } else {
+        let s = u.int_in_range(0i64..=39)?;
+        Ok(NumericMaxScale::try_from(s).ok())
+    }
+}
+
+/// A `Char` length: `None` (the "list element" form) some of the time,
+/// otherwise a small positive length.
+fn gen_char_length(u: &mut Unstructured) -> arbitrary::Result<Option<CharLength>> {
+    if u.ratio(1u8, 4u8)? {
+        Ok(None)
+    } else {
+        let n = u.int_in_range(1i64..=300)?;
+        Ok(CharLength::try_from(n).ok())
+    }
+}
+
+/// A `VarChar` max length: `None` some of the time, otherwise a small positive
+/// max length.
+fn gen_varchar_max_length(u: &mut Unstructured) -> arbitrary::Result<Option<VarCharMaxLength>> {
+    if u.ratio(1u8, 4u8)? {
+        Ok(None)
+    } else {
+        let n = u.int_in_range(1i64..=300)?;
+        Ok(VarCharMaxLength::try_from(n).ok())
+    }
+}
+
+fn gen_naive_ts(
+    u: &mut Unstructured,
+) -> arbitrary::Result<CheckedTimestamp<chrono::NaiveDateTime>> {
+    let secs = u.int_in_range(-8_000_000_000_000i64..=8_000_000_000_000)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?; // < 1s: no leap second
+    Ok(DateTime::from_timestamp(secs, nanos)
+        .and_then(|d| CheckedTimestamp::from_timestamplike(d.naive_utc()).ok())
+        .unwrap_or_else(|| {
+            CheckedTimestamp::from_timestamplike(
+                DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
+            )
+            .unwrap()
+        }))
+}
+
+fn gen_utc_ts(u: &mut Unstructured) -> arbitrary::Result<CheckedTimestamp<DateTime<Utc>>> {
+    let secs = u.int_in_range(-8_000_000_000_000i64..=8_000_000_000_000)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    Ok(DateTime::from_timestamp(secs, nanos)
+        .and_then(|d| CheckedTimestamp::from_timestamplike(d).ok())
+        .unwrap_or_else(|| {
+            CheckedTimestamp::from_timestamplike(DateTime::from_timestamp(0, 0).unwrap()).unwrap()
+        }))
+}
+
+/// Generate a `Numeric` datum value, reaching the special values that an Arrow
+/// `PackedNumeric` must round-trip (`NaN`, `±Infinity`) as well as ordinary
+/// finite decimals.
+///
+/// `parse_numeric` deliberately rejects directly-typed `NaN`/`Infinity` (it
+/// only allows infinities that arose from overflow), so the special values are
+/// constructed straight from the `dec` context instead of via text.
+fn gen_numeric(u: &mut Unstructured) -> arbitrary::Result<dec::OrderedDecimal<Numeric>> {
+    let n = match u.int_in_range(0u8..=5)? {
+        0 => Numeric::nan(),
+        1 => Numeric::infinity(),
+        2 => {
+            let mut cx = cx_datum();
+            let mut n = Numeric::infinity();
+            cx.neg(&mut n);
+            n
+        }
+        _ => {
+            let s = format!("{}.{}", i64::arbitrary(u)?, u32::arbitrary(u)?);
+            return Ok(parse_numeric(&s).unwrap_or_else(|_| parse_numeric("0").unwrap()));
+        }
+    };
+    Ok(dec::OrderedDecimal(n))
+}
+
+/// Push one datum of the given type (or NULL) into the row. Byte reads use `?`.
+/// Out-of-range constructed values fall back to a valid datum so the row always
+/// matches the column type.
+fn push_datum(
+    packer: &mut mz_repr::RowPacker,
+    u: &mut Unstructured,
+    ty: &SqlScalarType,
+    nullable: bool,
+) -> arbitrary::Result<()> {
+    if nullable && u.ratio(1u8, 8u8)? {
+        packer.push(Datum::Null);
+        return Ok(());
+    }
+    match ty {
+        SqlScalarType::Bool => packer.push(if bool::arbitrary(u)? {
+            Datum::True
+        } else {
+            Datum::False
+        }),
+        SqlScalarType::Int16 => packer.push(Datum::Int16(i16::arbitrary(u)?)),
+        SqlScalarType::Int32 => packer.push(Datum::Int32(i32::arbitrary(u)?)),
+        SqlScalarType::Int64 => packer.push(Datum::Int64(i64::arbitrary(u)?)),
+        SqlScalarType::UInt16 => packer.push(Datum::UInt16(u16::arbitrary(u)?)),
+        SqlScalarType::UInt32 => packer.push(Datum::UInt32(u32::arbitrary(u)?)),
+        SqlScalarType::UInt64 => packer.push(Datum::UInt64(u64::arbitrary(u)?)),
+        SqlScalarType::PgLegacyChar => packer.push(Datum::UInt8(u8::arbitrary(u)?)),
+        SqlScalarType::Float32 => packer.push(Datum::Float32(f32::arbitrary(u)?.into())),
+        SqlScalarType::Float64 => packer.push(Datum::Float64(f64::arbitrary(u)?.into())),
+        SqlScalarType::String => packer.push(Datum::String(<&str>::arbitrary(u)?)),
+        // Char/VarChar are stored as `Datum::String` and encode through the
+        // same Arrow `StringArray`. The schema-side length parameter does not
+        // truncate/pad here, so any string round-trips.
+        SqlScalarType::Char { .. } | SqlScalarType::VarChar { .. } => {
+            packer.push(Datum::String(<&str>::arbitrary(u)?))
+        }
+        SqlScalarType::Bytes => packer.push(Datum::Bytes(<&[u8]>::arbitrary(u)?)),
+        SqlScalarType::Numeric { .. } => {
+            packer.push(Datum::Numeric(gen_numeric(u)?));
+        }
+        SqlScalarType::Date => {
+            let d = Date::from_pg_epoch(i32::arbitrary(u)?)
+                .unwrap_or_else(|_| Date::from_pg_epoch(0).unwrap());
+            packer.push(Datum::Date(d));
+        }
+        SqlScalarType::Time => {
+            let secs = u.int_in_range(0u32..=86_399)?;
+            let nanos = u.int_in_range(0u32..=999_999_999)?;
+            let t = NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).unwrap();
+            packer.push(Datum::Time(t));
+        }
+        SqlScalarType::Timestamp { .. } => packer.push(Datum::Timestamp(gen_naive_ts(u)?)),
+        SqlScalarType::TimestampTz { .. } => packer.push(Datum::TimestampTz(gen_utc_ts(u)?)),
+        SqlScalarType::Interval => packer.push(Datum::Interval(Interval::new(
+            i32::arbitrary(u)?,
+            i32::arbitrary(u)?,
+            i64::arbitrary(u)?,
+        ))),
+        SqlScalarType::MzTimestamp => {
+            packer.push(Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?)))
+        }
+        // A `List` of `element_type`: a small run of element datums (each of
+        // which may itself be NULL since list elements are always nullable).
+        SqlScalarType::List { element_type, .. } => {
+            let elems = gen_scalar_datums(u, element_type)?;
+            packer.push_list(elems.iter().map(Borrow::borrow));
+        }
+        // A 1-D `Array` of `element_type`. The single dimension's length must
+        // match the number of pushed elements. `lower_bound` is arbitrary.
+        SqlScalarType::Array(element_type) => {
+            let elems = gen_scalar_datums(u, element_type)?;
+            let dims = if elems.is_empty() {
+                vec![]
+            } else {
+                vec![ArrayDimension {
+                    lower_bound: 1,
+                    length: elems.len(),
+                }]
+            };
+            // The element count always matches `dims`, so this can't fail. Fall
+            // back to an empty array out of an abundance of caution.
+            if packer
+                .try_push_array(&dims, elems.iter().map(Borrow::borrow))
+                .is_err()
+            {
+                packer.try_push_array(&[], std::iter::empty::<Datum>()).unwrap();
+            }
+        }
+        // A `Map` of string keys to `value_type` values. Keys must be unique
+        // and sorted, which `push_dict` does not enforce, so we dedup/sort here.
+        SqlScalarType::Map { value_type, .. } => {
+            let n = u.int_in_range(0usize..=6)?;
+            let mut entries: Vec<(String, Datum)> = Vec::with_capacity(n);
+            for _ in 0..n {
+                let k = String::arbitrary(u)?;
+                entries.push((k, gen_scalar_datum(u, value_type)?));
+            }
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            entries.dedup_by(|a, b| a.0 == b.0);
+            packer.push_dict(entries.iter().map(|(k, v)| (k.as_str(), v)));
+        }
+        // A `Range` over a discrete element type. Bounds are independently
+        // finite/infinite and inclusive/exclusive. `push_range` canonicalizes.
+        SqlScalarType::Range { element_type } => {
+            push_range(packer, u, element_type)?;
+        }
+        // gen_scalar_type only produces the types above.
+        _ => packer.push(Datum::Null),
+    }
+    Ok(())
+}
+
+/// Generate a small vector of owned datums of a simple scalar type, for use as
+/// the elements of a list/array. Elements may be NULL.
+fn gen_scalar_datums<'a>(
+    u: &mut Unstructured,
+    ty: &SqlScalarType,
+) -> arbitrary::Result<Vec<Datum<'a>>> {
+    let n = u.int_in_range(0usize..=6)?;
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        if u.ratio(1u8, 8u8)? {
+            out.push(Datum::Null);
+        } else {
+            out.push(gen_scalar_datum(u, ty)?);
+        }
+    }
+    Ok(out)
+}
+
+/// Generate a single owned (non-null) datum for a composite element type.
+/// Only the `Copy` `Datum` variants (those produced by `gen_element_type` /
+/// `gen_range_element_type`) are handled, so the returned `Datum` carries no
+/// borrow and the caller can collect it into a `Vec`.
+fn gen_scalar_datum<'a>(
+    u: &mut Unstructured,
+    ty: &SqlScalarType,
+) -> arbitrary::Result<Datum<'a>> {
+    Ok(match ty {
+        SqlScalarType::Bool => {
+            if bool::arbitrary(u)? {
+                Datum::True
+            } else {
+                Datum::False
+            }
+        }
+        SqlScalarType::Int16 => Datum::Int16(i16::arbitrary(u)?),
+        SqlScalarType::Int32 => Datum::Int32(i32::arbitrary(u)?),
+        SqlScalarType::Int64 => Datum::Int64(i64::arbitrary(u)?),
+        SqlScalarType::UInt32 => Datum::UInt32(u32::arbitrary(u)?),
+        SqlScalarType::UInt64 => Datum::UInt64(u64::arbitrary(u)?),
+        SqlScalarType::Float64 => Datum::Float64(f64::arbitrary(u)?.into()),
+        SqlScalarType::Numeric { .. } => Datum::Numeric(gen_numeric(u)?),
+        SqlScalarType::Date => Datum::Date(
+            Date::from_pg_epoch(i32::arbitrary(u)?).unwrap_or_else(|_| Date::from_pg_epoch(0).unwrap()),
+        ),
+        SqlScalarType::Time => {
+            let secs = u.int_in_range(0u32..=86_399)?;
+            let nanos = u.int_in_range(0u32..=999_999_999)?;
+            Datum::Time(NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).unwrap())
+        }
+        SqlScalarType::Timestamp { .. } => Datum::Timestamp(gen_naive_ts(u)?),
+        SqlScalarType::TimestampTz { .. } => Datum::TimestampTz(gen_utc_ts(u)?),
+        SqlScalarType::Interval => Datum::Interval(Interval::new(
+            i32::arbitrary(u)?,
+            i32::arbitrary(u)?,
+            i64::arbitrary(u)?,
+        )),
+        SqlScalarType::MzTimestamp => Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?)),
+        // gen_simple_scalar_type only produces the types above.
+        _ => Datum::Null,
+    })
+}
+
+/// Push a `Range` of the given discrete element type. Each bound is
+/// independently infinite (`Datum::Null` => infinite via `RangeBound::new`) or
+/// a finite element value, and independently inclusive/exclusive. Empty ranges
+/// are reached when `push_range`'s canonicalization collapses the bounds.
+fn push_range(
+    packer: &mut mz_repr::RowPacker,
+    u: &mut Unstructured,
+    element_type: &SqlScalarType,
+) -> arbitrary::Result<()> {
+    // ~1/8 of the time emit the explicitly-empty range.
+    if u.ratio(1u8, 8u8)? {
+        let _ = packer.push_range(Range { inner: None });
+        return Ok(());
+    }
+    let lower_d = if bool::arbitrary(u)? {
+        Datum::Null
+    } else {
+        gen_scalar_datum(u, element_type)?
+    };
+    let upper_d = if bool::arbitrary(u)? {
+        Datum::Null
+    } else {
+        gen_scalar_datum(u, element_type)?
+    };
+    let lower: RangeLowerBound<Datum> = RangeBound::new(lower_d, bool::arbitrary(u)?);
+    let upper: RangeUpperBound<Datum> = RangeBound::new(upper_d, bool::arbitrary(u)?);
+    // An out-of-order range (lower > upper) is an `InvalidRangeError`. On
+    // failure just fall back to the empty range so the column stays valid.
+    if packer
+        .push_range(Range::new(Some((lower, upper))))
+        .is_err()
+    {
+        let _ = packer.push_range(Range { inner: None });
+    }
+    Ok(())
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let ncols = u.int_in_range(1usize..=6)?;
+    let cols: Vec<SqlColumnType> = (0..ncols)
+        .map(|_| {
+            Ok(SqlColumnType {
+                scalar_type: gen_scalar_type(u)?,
+                nullable: bool::arbitrary(u)?,
+            })
+        })
+        .collect::<arbitrary::Result<_>>()?;
+
+    let mut builder = RelationDesc::builder();
+    for (i, c) in cols.iter().enumerate() {
+        builder = builder.with_column(format!("c{i}"), c.clone());
+    }
+    let desc = builder.finish();
+
+    let nrows = u.int_in_range(0usize..=10)?;
+    let mut rows = Vec::with_capacity(nrows);
+    for _ in 0..nrows {
+        let mut row = Row::default();
+        {
+            let mut packer = row.packer();
+            for c in &cols {
+                push_datum(&mut packer, u, &c.scalar_type, c.nullable)?;
+            }
+        }
+        rows.push(row);
+    }
+
+    let Ok(mut encoder) = <RelationDesc as Schema<Row>>::encoder(&desc) else {
+        return Ok(());
+    };
+    for row in &rows {
+        encoder.append(row);
+    }
+    let col = encoder.finish();
+    let Ok(decoder) = <RelationDesc as Schema<Row>>::decoder(&desc, col) else {
+        return Ok(());
+    };
+    for (i, orig) in rows.iter().enumerate() {
+        let mut out = Row::default();
+        decoder.decode(i, &mut out);
+        assert_eq!(
+            orig, &out,
+            "Row changed across Arrow columnar round trip (desc = {desc:?})"
+        );
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/repr/fuzz/fuzz_targets/row_codec_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/row_codec_roundtrip.rs
@@ -1,0 +1,95 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `Row`'s `Codec` impl (the persistence wrapper around
+//! `ProtoRow`) round-trips losslessly. This goes through `Codec::decode +
+//! Codec::encode`, which is the path persist actually uses on read/write. It is
+//! distinct from the bare `ProtoRow` path in `row_proto_roundtrip` because it
+//! threads the `RelationDesc` schema through.
+//!
+//! The schema is the whole point of this target, so we decode against a
+//! NON-empty, randomized `RelationDesc` rather than `RelationDesc::empty()`.
+//! With the empty schema the schema-directed decode loop
+//! (`Row::decode_from_proto`, which iterates `desc.iter_all()` and pulls each
+//! column's proto datum, padding missing columns with `Datum::Null`) never
+//! runs. It produces an empty `Row` for any input, so the round trip is
+//! trivially satisfied and the schema threading this target tests goes
+//! unexercised.
+//!
+//! Generation: the first few input bytes pick a column count and a column type
+//! per column (the type menu mirrors the scalar shapes persist stores). The
+//! remaining bytes are the encoded `ProtoRow` body. Note `decode_from_proto`
+//! does not type-check the proto datums against the column types, so the schema
+//! controls the column *count* and the per-column iteration / null-padding,
+//! which a non-empty schema exercises and the empty schema does not. The
+//! invariant under test is that decode(encode(decode(bytes))) == decode(bytes)
+//! for a fixed schema.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_persist_types::Codec;
+use mz_repr::{RelationDesc, Row, SqlColumnType, SqlScalarType};
+
+/// Build a small, randomized non-empty `RelationDesc` from a prefix of the
+/// input. The column types only affect the schema-directed decode via the
+/// column *count* and iteration order (decode does not validate proto datums
+/// against the types), but we still vary the types so the schema is realistic
+/// and any type-sensitive code reachable through the desc gets exercised.
+fn arb_relation_desc(u: &mut Unstructured) -> RelationDesc {
+    // 1..=8 columns. Fall back to a single column if the buffer is exhausted so
+    // we always test a genuinely non-empty schema.
+    let ncols = u.int_in_range(1usize..=8).unwrap_or(1);
+    let mut builder = RelationDesc::builder();
+    for i in 0..ncols {
+        let scalar_type = arb_scalar_type(u);
+        let nullable = bool::arbitrary(u).unwrap_or(true);
+        builder = builder.with_column(format!("c{i}"), SqlColumnType { scalar_type, nullable });
+    }
+    builder.finish()
+}
+
+/// Pick a scalar type for a schema column. Defaults to `String` when the buffer
+/// is exhausted.
+fn arb_scalar_type(u: &mut Unstructured) -> SqlScalarType {
+    match u.int_in_range(0u8..=14).unwrap_or(0) {
+        0 => SqlScalarType::Bool,
+        1 => SqlScalarType::Int16,
+        2 => SqlScalarType::Int32,
+        3 => SqlScalarType::Int64,
+        4 => SqlScalarType::UInt32,
+        5 => SqlScalarType::UInt64,
+        6 => SqlScalarType::Float32,
+        7 => SqlScalarType::Float64,
+        8 => SqlScalarType::String,
+        9 => SqlScalarType::Bytes,
+        10 => SqlScalarType::Date,
+        11 => SqlScalarType::Time,
+        12 => SqlScalarType::Timestamp { precision: None },
+        13 => SqlScalarType::Numeric { max_scale: None },
+        _ => SqlScalarType::Jsonb,
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    // Derive the schema from the front of the buffer, then decode the rest as a
+    // `ProtoRow` against that non-empty schema.
+    let schema = arb_relation_desc(&mut u);
+    let rest = u.take_rest();
+
+    let Ok(orig) = Row::decode(rest, &schema) else {
+        return;
+    };
+    let mut buf = Vec::new();
+    orig.encode(&mut buf);
+    let round = Row::decode(&buf, &schema).expect("re-encode of a valid Row must decode");
+    assert_eq!(orig, round, "Row changed across Codec roundtrip (schema = {schema:?})");
+});

--- a/src/repr/fuzz/fuzz_targets/row_proto_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/row_proto_roundtrip.rs
@@ -1,0 +1,41 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: every byte sequence that decodes as `ProtoRow` and then into
+//! a Rust `Row` must survive a proto re-encode + re-decode with the same
+//! value. `Row` is the core value representation in Materialize and the
+//! proto wire format is part of the persist on-disk format, so any decoder
+//! laxity that doesn't round-trip is a real correctness risk.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::ProtoType;
+use mz_repr::{ProtoRow, Row};
+use prost::Message;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(proto) = ProtoRow::decode(data) else {
+        return;
+    };
+    let orig: Row = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let proto2 = <ProtoRow as ProtoType<Row>>::from_rust(&orig);
+    let bytes2 = proto2.encode_to_vec();
+    let proto3 = ProtoRow::decode(bytes2.as_slice())
+        .expect("re-encode of valid Row must decode");
+    let round: Row = proto3
+        .into_rust()
+        .expect("re-encoded Row must convert back to Rust");
+
+    assert_eq!(orig, round, "Row changed across proto roundtrip");
+});

--- a/src/repr/fuzz/fuzz_targets/scalar_type_proto_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/scalar_type_proto_roundtrip.rs
@@ -1,0 +1,82 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `SqlScalarType` proto round-trips losslessly.
+//! `SqlScalarType` describes the type of every column in every relation, so
+//! any decoder bug here propagates through the type system.
+//!
+//! Two arms (the first byte selects):
+//!  - Arbitrary arm: drive `SqlScalarType`'s proptest `Arbitrary` strategy from
+//!    the fuzzer bytes to build a *valid, deeply-nested* type (the recursive
+//!    `List`/`Map`/`Array`/`Record`/`Range` variants, boundary `max_scale` and
+//!    char/varchar `length`, custom OIDs, etc.) and assert
+//!    `from_proto(into_proto(v)) == v`. Random proto bytes almost never reach
+//!    these variants, so this arm is what actually exercises the encoder.
+//!  - Raw-bytes arm: decode arbitrary bytes as `ProtoScalarType`, into Rust, and
+//!    re-encode, keeping coverage of the bare wire decoder against hostile
+//!    input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::{ProtoType, RustType};
+use mz_repr::{ProtoScalarType, SqlScalarType};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+fn arbitrary_arm(seed: &[u8]) {
+    let mut buf = [0u8; 32];
+    for (dst, src) in buf.iter_mut().zip(seed.iter()) {
+        *dst = *src;
+    }
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &buf);
+    let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+    let value = match <SqlScalarType as proptest::arbitrary::Arbitrary>::arbitrary()
+        .new_tree(&mut runner)
+    {
+        Ok(tree) => tree.current(),
+        Err(_) => return,
+    };
+
+    let proto = value.into_proto();
+    let back = SqlScalarType::from_proto(proto).expect("valid SqlScalarType must round-trip");
+    assert_eq!(value, back, "SqlScalarType changed across proto roundtrip");
+}
+
+fn raw_arm(data: &[u8]) {
+    let Ok(proto) = ProtoScalarType::decode(data) else {
+        return;
+    };
+    let orig: SqlScalarType = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let proto2 = <ProtoScalarType as ProtoType<SqlScalarType>>::from_rust(&orig);
+    let bytes2 = proto2.encode_to_vec();
+    let proto3 = ProtoScalarType::decode(bytes2.as_slice())
+        .expect("re-encode of valid SqlScalarType must decode");
+    let round: SqlScalarType = proto3
+        .into_rust()
+        .expect("re-encoded SqlScalarType must convert back to Rust");
+
+    assert_eq!(orig, round, "SqlScalarType changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+    if mode & 1 == 0 {
+        arbitrary_arm(rest);
+    } else {
+        raw_arm(rest);
+    }
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_array.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_array.rs
@@ -1,0 +1,92 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_array` parses untrusted SQL array literal text
+//! (`'{1,2,{3}}'::int[]`, COPY FROM) into elements + dimensions. It is a
+//! hand-written, recursive parser over quoting/escaping and nested `{…}`
+//! dimensions, a prime panic/OOM/stack-overflow surface. Element values are
+//! ignored. We fuzz the structural parser. Must never panic.
+//!
+//! Random text almost never forms a balanced, properly-quoted `{…}` nesting, so
+//! byte mutation barely reaches past the first dimension. We instead consume the
+//! byte stream as grammar choices and emit a valid nested array literal, with
+//! balanced braces, quoted elements with `\"`/`\\` escapes, and NULLs, so the
+//! recursive dimension walk and the quote/escape state machine run deep.
+//! A minority of inputs get structural noise spliced in (unbalanced braces,
+//! stray quotes/backslashes) so the parser's error paths stay covered too.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+/// Emit one scalar element: an unquoted token, a quoted string (with escapes
+/// and structural characters that *must* stay quoted), NULL, or empty.
+fn push_elem(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=3)? {
+        0 => {
+            let n = u.int_in_range(0usize..=4)?;
+            for _ in 0..n {
+                out.push(*u.choose(&['a', 'b', '0', '1', '_', '-', '.'])?);
+            }
+        }
+        1 => out.push_str("NULL"),
+        2 => {
+            out.push('"');
+            let n = u.int_in_range(0usize..=4)?;
+            for _ in 0..n {
+                match u.int_in_range(0u8..=4)? {
+                    0 => out.push_str("\\\""),
+                    1 => out.push_str("\\\\"),
+                    _ => out.push(*u.choose(&['a', '1', ' ', '{', '}', ','])?),
+                }
+            }
+            out.push('"');
+        }
+        _ => {} // empty element
+    }
+    Ok(())
+}
+
+fn gen_array(u: &mut Unstructured, depth: u32, out: &mut String) -> arbitrary::Result<()> {
+    out.push('{');
+    let n = u.int_in_range(0usize..=3)?;
+    for i in 0..n {
+        if i > 0 {
+            out.push(',');
+            if u.int_in_range(0u8..=2)? == 0 {
+                out.push(' ');
+            }
+        }
+        if depth > 0 && u.int_in_range(0u8..=2)? == 0 {
+            gen_array(u, depth - 1, out)?;
+        } else {
+            push_elem(u, out)?;
+        }
+    }
+    out.push('}');
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut s = String::new();
+    gen_array(&mut u, 3, &mut s)?;
+    // 1-in-6: splice structural noise to exercise the error paths.
+    if u.int_in_range(0u8..=5)? == 0 {
+        s.push_str(u.choose(&["{", "}", ",", "\"", "\\", "{{", "}}", " ", "NULL"])?);
+    }
+    let _ = mz_repr::strconv::parse_array(&s, String::new, |e| {
+        Ok::<_, std::convert::Infallible>(e.into_owned())
+    });
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_bytes.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_bytes.rs
@@ -1,0 +1,121 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_bytes` decodes untrusted `bytea` text (COPY
+//! FROM, a text-format `bytea` parameter on the wire). It dispatches between the
+//! hex form (`\x4a6b…`) and the hand-written "traditional" escape parser, which
+//! walks bytes looking for `\\` and three-digit octal escapes `\NNN`. This is
+//! exactly the byte-at-a-time escape-decoding shape that hid the CSV-decoder
+//! bug. Must never panic on any input.
+//!
+//! Random text rarely lands on the `\x` prefix or a well-formed `\NNN` octal
+//! triple, so byte mutation barely reaches either decoder. We instead consume
+//! the byte stream as grammar choices and emit `bytea` text biased at the
+//! decoders' edges:
+//!   * hex form: `\x` followed by hex-digit pairs, deliberately including
+//!     odd-length runs (the `OddLength` error), embedded whitespace (the
+//!     skip-whitespace arm), and stray non-hex digits;
+//!   * traditional form: octal escapes `\NNN` straddling the `\3xx`/`\4xx`
+//!     high-nibble boundary (only `\0..\3` lead bytes are valid), short octal
+//!     escapes, doubled `\\`, lone/trailing backslashes (the "ends with escape
+//!     character" arm), and raw literal bytes.
+//! A quarter of inputs are still the raw bytes, so the dispatch and reject paths
+//! stay covered.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+const HEX_DIGITS: &[char] = &[
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A', 'B', 'C',
+    'D', 'E', 'F',
+];
+
+/// Octal lead digits, biased to straddle the `\0..\3` (valid) / `\4..\7`
+/// (invalid high nibble) boundary that the traditional parser rejects.
+const OCTAL_DIGITS: &[char] = &['0', '1', '2', '3', '4', '5', '6', '7'];
+
+/// Emit a hex-form `bytea`: `\x` then a run of hex digits, with the occasional
+/// embedded whitespace (skipped) or stray non-hex byte. Odd-length runs hit the
+/// `OddLength` error.
+fn gen_hex(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    out.push_str("\\x");
+    let n = u.int_in_range(0usize..=12)?;
+    for _ in 0..n {
+        match u.int_in_range(0u8..=9)? {
+            0 => out.push(*u.choose(&[' ', '\n', '\t', '\r'])?),
+            1 => out.push(*u.choose(&['g', 'x', '_', '-'])?),
+            _ => out.push(*u.choose(HEX_DIGITS)?),
+        }
+    }
+    Ok(())
+}
+
+/// Emit traditional-form `bytea`: literal bytes interleaved with octal escapes
+/// (`\NNN`, including the invalid `\4xx..\7xx` high nibble and short forms),
+/// doubled backslashes, and lone/trailing backslashes.
+fn gen_traditional(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    let n = u.int_in_range(0usize..=10)?;
+    for _ in 0..n {
+        match u.int_in_range(0u8..=6)? {
+            // A full octal escape `\NNN`.
+            0 | 1 => {
+                out.push('\\');
+                for _ in 0..3 {
+                    out.push(*u.choose(OCTAL_DIGITS)?);
+                }
+            }
+            // A short/partial octal escape (invalid: too few digits).
+            2 => {
+                out.push('\\');
+                for _ in 0..u.int_in_range(0usize..=2)? {
+                    out.push(*u.choose(OCTAL_DIGITS)?);
+                }
+            }
+            // Doubled backslash (a literal `\`).
+            3 => out.push_str("\\\\"),
+            // A lone backslash followed by a non-octal byte (invalid escape).
+            4 => {
+                out.push('\\');
+                out.push(*u.choose(&['x', '8', '9', 'a', ' ', '\\'])?);
+            }
+            // Raw literal bytes.
+            _ => out.push(*u.choose(&['a', 'Z', '0', ' ', '\n', '~'])?),
+        }
+    }
+    // Sometimes leave a trailing escape char (the "ends with escape" arm).
+    if u.int_in_range(0u8..=4)? == 0 {
+        out.push('\\');
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw bytes (must be UTF-8 for `parse_bytes`):
+    // keeps the dispatch and reject paths covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        if let Ok(s) = std::str::from_utf8(u.take_rest()) {
+            let _ = mz_repr::strconv::parse_bytes(s);
+        }
+        return Ok(());
+    }
+    let mut s = String::new();
+    if u.int_in_range(0u8..=1)? == 0 {
+        gen_hex(&mut u, &mut s)?;
+    } else {
+        gen_traditional(&mut u, &mut s)?;
+    }
+    let _ = mz_repr::strconv::parse_bytes(&s);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_date.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_date.rs
@@ -1,0 +1,33 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_date` parses untrusted DATE literal text. A
+//! re-parseable rendering of a parsed value must yield the same value.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_repr::strconv::{format_date, parse_date};
+
+fuzz_target!(|data: &str| {
+    let Ok(d) = parse_date(data) else {
+        return;
+    };
+    let mut buf = String::new();
+    format_date(&mut buf, d);
+    // The renderer can emit text the parser rejects, a known cluster of
+    // date/time round-trip gaps (a leap second `:60` that PG carries, a
+    // >4-digit year, etc.), tracked separately, not panics. Tolerate those and
+    // only assert that a *re-parseable* rendering preserves the value (drift),
+    // and that nothing panics.
+    let Ok(reparsed) = parse_date(&buf) else {
+        return;
+    };
+    assert_eq!(d, reparsed, "date changed across parse/format round trip");
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_interval.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_interval.rs
@@ -1,0 +1,34 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_interval` parses untrusted INTERVAL literal
+//! text. It drives a complex datetime token state machine (the most intricate
+//! parser in strconv). Beyond not panicking, its `Display` rendering must
+//! re-parse to the same interval.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_repr::strconv::parse_interval;
+
+fuzz_target!(|data: &str| {
+    let Ok(iv) = parse_interval(data) else {
+        return;
+    };
+    let formatted = iv.to_string();
+    // `Display` collapses sub-day time into one unbounded hours field, and
+    // re-parsing multiplies that hour count back out with checked arithmetic. A
+    // valid interval with micros near `i64::MAX` formats to an hour count whose
+    // re-parse overflows, so re-parse is not total. Tolerate the failure and
+    // only assert the round trip preserves the value when it does re-parse.
+    let Ok(reparsed) = parse_interval(&formatted) else {
+        return;
+    };
+    assert_eq!(iv, reparsed, "interval changed across parse/format round trip");
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_list.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_list.rs
@@ -1,0 +1,92 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_list` parses untrusted SQL list literal text.
+//! Recursive embedded-element lexing with quoting/escaping. Run both the
+//! scalar-element and nested-list-element modes. Must never panic.
+//!
+//! Random text almost never forms a balanced, properly-quoted `{…}` list, so
+//! byte mutation barely reaches past the opening brace. We instead consume the
+//! byte stream as grammar choices and emit a valid nested list literal, with
+//! balanced braces, quoted elements with `\"`/`\\` escapes, and NULLs, so the
+//! recursive element lexer and its quote/escape state machine run deep, in both
+//! the scalar-element and nested-list-element modes. A minority of inputs get
+//! structural noise spliced in so the parser's error paths stay covered too.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+/// Emit one scalar element: an unquoted token, a quoted string (with escapes
+/// and structural characters that *must* stay quoted), NULL, or empty.
+fn push_elem(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=3)? {
+        0 => {
+            let n = u.int_in_range(0usize..=4)?;
+            for _ in 0..n {
+                out.push(*u.choose(&['a', 'b', '0', '1', '_', '-', '.'])?);
+            }
+        }
+        1 => out.push_str("NULL"),
+        2 => {
+            out.push('"');
+            let n = u.int_in_range(0usize..=4)?;
+            for _ in 0..n {
+                match u.int_in_range(0u8..=4)? {
+                    0 => out.push_str("\\\""),
+                    1 => out.push_str("\\\\"),
+                    _ => out.push(*u.choose(&['a', '1', ' ', '{', '}', ','])?),
+                }
+            }
+            out.push('"');
+        }
+        _ => {} // empty element
+    }
+    Ok(())
+}
+
+fn gen_list(u: &mut Unstructured, depth: u32, out: &mut String) -> arbitrary::Result<()> {
+    out.push('{');
+    let n = u.int_in_range(0usize..=3)?;
+    for i in 0..n {
+        if i > 0 {
+            out.push(',');
+            if u.int_in_range(0u8..=2)? == 0 {
+                out.push(' ');
+            }
+        }
+        if depth > 0 && u.int_in_range(0u8..=2)? == 0 {
+            gen_list(u, depth - 1, out)?;
+        } else {
+            push_elem(u, out)?;
+        }
+    }
+    out.push('}');
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut s = String::new();
+    gen_list(&mut u, 3, &mut s)?;
+    // 1-in-6: splice structural noise to exercise the error paths.
+    if u.int_in_range(0u8..=5)? == 0 {
+        s.push_str(u.choose(&["{", "}", ",", "\"", "\\", "{{", "}}", " ", "NULL"])?);
+    }
+    for is_element_type_list in [false, true] {
+        let _ = mz_repr::strconv::parse_list(&s, is_element_type_list, String::new, |e| {
+            Ok::<_, std::convert::Infallible>(e.into_owned())
+        });
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_map.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_map.rs
@@ -1,0 +1,91 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_map` parses untrusted SQL map literal text
+//! (`'{k=>v,…}'`). Key/value lexing with quoting/escaping and embedded maps.
+//! Run both the scalar-value and nested-map-value modes. Must never panic.
+//!
+//! Random text almost never forms a balanced `{k=>v,…}` map with the `=>`
+//! separators in the right places, so byte mutation barely reaches the value
+//! lexer. We instead consume the byte stream as grammar choices and emit a valid
+//! map literal, with balanced braces, quoted keys/values with `\"`/`\\`
+//! escapes, NULL values, and (in nested-value mode) embedded maps, so the
+//! key/value split, the quote/escape state machine, and the recursive value
+//! parse all run deep. A minority of inputs get structural noise spliced in so
+//! the parser's error paths stay covered too.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+/// Emit a quoted-or-unquoted token (used for both keys and scalar values).
+fn push_token(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    if u.int_in_range(0u8..=1)? == 0 {
+        let n = u.int_in_range(1usize..=4)?;
+        for _ in 0..n {
+            out.push(*u.choose(&['a', 'b', '0', '1', '_', '-'])?);
+        }
+    } else {
+        out.push('"');
+        let n = u.int_in_range(0usize..=4)?;
+        for _ in 0..n {
+            match u.int_in_range(0u8..=4)? {
+                0 => out.push_str("\\\""),
+                1 => out.push_str("\\\\"),
+                _ => out.push(*u.choose(&['a', '1', ' ', '{', '}', ',', '='])?),
+            }
+        }
+        out.push('"');
+    }
+    Ok(())
+}
+
+fn gen_map(u: &mut Unstructured, depth: u32, out: &mut String) -> arbitrary::Result<()> {
+    out.push('{');
+    let n = u.int_in_range(0usize..=3)?;
+    for i in 0..n {
+        if i > 0 {
+            out.push(',');
+            if u.int_in_range(0u8..=2)? == 0 {
+                out.push(' ');
+            }
+        }
+        push_token(u, out)?; // key
+        out.push_str("=>");
+        if depth > 0 && u.int_in_range(0u8..=2)? == 0 {
+            gen_map(u, depth - 1, out)?; // nested map value
+        } else if u.int_in_range(0u8..=4)? == 0 {
+            out.push_str("NULL");
+        } else {
+            push_token(u, out)?; // scalar value
+        }
+    }
+    out.push('}');
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut s = String::new();
+    gen_map(&mut u, 3, &mut s)?;
+    // 1-in-6: splice structural noise to exercise the error paths.
+    if u.int_in_range(0u8..=5)? == 0 {
+        s.push_str(u.choose(&["{", "}", ",", "=>", "=", "\"", "\\", " ", "NULL"])?);
+    }
+    for is_value_type_map in [false, true] {
+        let _ = mz_repr::strconv::parse_map(&s, is_value_type_map, |e| {
+            Ok::<_, std::convert::Infallible>(e.map(|v| v.into_owned()))
+        });
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_numeric.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_numeric.rs
@@ -1,0 +1,125 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_numeric` parses untrusted numeric literal text
+//! into a fixed-precision decimal. Beyond not panicking, the canonical
+//! standard-notation rendering must re-parse to the same value.
+//!
+//! Random text rarely lands near the interesting decimal edges, the 39-digit
+//! precision limit, the exponent over/underflow boundary, or the
+//! `NaN`/`Infinity` rejection arms, so byte mutation mostly bounces off the
+//! initial `cx.parse`. We instead consume the byte stream as grammar choices and
+//! emit numeric literals biased at those edges: long integer/fraction digit runs
+//! straddling the precision cap (which triggers `munge_numeric` rounding and the
+//! out-of-range arm), exponents near the representable range, optional signs and
+//! surrounding whitespace (`parse_numeric` trims), and the special
+//! `NaN`/`Infinity`/`-NaN`/signaling spellings that the post-parse validation
+//! rejects. The strict round-trip oracle, canonical rendering must re-parse to
+//! the same value, makes every parse that survives high signal. A quarter of
+//! inputs are still the raw string so the reject paths stay covered.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::strconv::parse_numeric;
+
+/// Special spellings: the infinity/NaN family the post-parse validation rejects
+/// (or accepts as overflow-`inf`), plus assorted casing.
+const SPECIALS: &[&str] = &[
+    "NaN", "nan", "-NaN", "+NaN", "sNaN", "Infinity", "-Infinity", "+Infinity", "inf", "-inf",
+    "Inf", "INFINITY",
+];
+
+fn push_digits(u: &mut Unstructured, out: &mut String, n: usize) -> arbitrary::Result<()> {
+    for _ in 0..n {
+        out.push(*u.choose(&['0', '1', '5', '7', '9'])?);
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw string: keeps the reject paths covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        if let Ok(s) = std::str::from_utf8(u.take_rest()) {
+            check(s);
+        }
+        return Ok(());
+    }
+
+    let mut s = String::new();
+    // Optional leading whitespace (`parse_numeric` trims).
+    if u.int_in_range(0u8..=3)? == 0 {
+        s.push(*u.choose(&[' ', '\t', '\n'])?);
+    }
+
+    match u.int_in_range(0u8..=5)? {
+        // A special infinity/NaN spelling (hits the rejection arms).
+        0 => s.push_str(u.choose(SPECIALS)?),
+        _ => {
+            // Optional sign.
+            match u.int_in_range(0u8..=2)? {
+                0 => s.push('-'),
+                1 => s.push('+'),
+                _ => {}
+            }
+            // Integer part: a digit run straddling the 39-digit precision cap.
+            let int_len = u.int_in_range(0usize..=45)?;
+            push_digits(&mut u, &mut s, int_len)?;
+            // Optional fraction, also able to push total significant digits past
+            // the precision limit.
+            if u.int_in_range(0u8..=1)? == 0 {
+                s.push('.');
+                let frac_len = u.int_in_range(0usize..=45)?;
+                // Guarantee at least one digit somewhere.
+                let frac_len = if int_len == 0 && frac_len == 0 {
+                    1
+                } else {
+                    frac_len
+                };
+                push_digits(&mut u, &mut s, frac_len)?;
+            } else if int_len == 0 {
+                s.push('0');
+            }
+            // Optional exponent near the representable range.
+            if u.int_in_range(0u8..=2)? == 0 {
+                s.push(*u.choose(&['e', 'E'])?);
+                match u.int_in_range(0u8..=2)? {
+                    0 => s.push('-'),
+                    1 => s.push('+'),
+                    _ => {}
+                }
+                // Magnitudes around the overflow/underflow boundary.
+                let exp = u.choose(&["0", "9", "38", "39", "308", "1000", "6144", "999999"])?;
+                s.push_str(exp);
+            }
+        }
+    }
+
+    // Optional trailing whitespace.
+    if u.int_in_range(0u8..=3)? == 0 {
+        s.push(*u.choose(&[' ', '\t', '\n'])?);
+    }
+
+    check(&s);
+    Ok(())
+}
+
+fn check(s: &str) {
+    let Ok(n) = parse_numeric(s) else {
+        return;
+    };
+    let formatted = n.0.to_standard_notation_string();
+    let reparsed = parse_numeric(&formatted).expect("canonical numeric rendering must re-parse");
+    assert_eq!(n, reparsed, "numeric changed across parse/format round trip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_range.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_range.rs
@@ -1,0 +1,97 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_range` parses untrusted SQL range literal text
+//! (`'[a,b)'`). Bound extraction with quoting/escaping. Must never panic.
+//!
+//! Random text rarely produces the `[`/`(` … `,` … `]`/`)` framing (or the
+//! `empty` keyword) the parser needs, so byte mutation barely reaches the bound
+//! lexer. We instead consume the byte stream as grammar choices and emit a
+//! range literal exercising the bound extraction's sharp edges:
+//!   * the lower bound is read with a naive `take_while(c != ',')` and the upper
+//!     with `take_while(c not in ')]')`, neither of which understands quoting,
+//!     so we deliberately embed `,`, `]`, `)` *inside* quoted bounds to drive
+//!     that truncation;
+//!   * matched and mismatched bracket/paren framing (`[..)`, `(..]`, dropped
+//!     closer);
+//!   * optional (unbounded) sides, quoted bounds with `\"`/`\\` escapes, and the
+//!     `empty` keyword followed by junk (the "Junk after empty" arm).
+//! A minority of inputs get extra structural noise spliced in so the parser's
+//! error paths stay covered too.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+/// Emit one range bound: empty (unbounded), an unquoted token, or a quoted
+/// string with escapes and structural delimiters (`,`/`]`/`)`) that the naive
+/// `take_while` extraction does *not* know to keep inside the quotes.
+fn push_bound(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=2)? {
+        0 => {} // unbounded
+        1 => {
+            let n = u.int_in_range(1usize..=4)?;
+            for _ in 0..n {
+                out.push(*u.choose(&['a', '0', '1', '-', '.', ':'])?);
+            }
+        }
+        _ => {
+            out.push('"');
+            let n = u.int_in_range(0usize..=6)?;
+            for _ in 0..n {
+                match u.int_in_range(0u8..=5)? {
+                    0 => out.push_str("\\\""),
+                    1 => out.push_str("\\\\"),
+                    // Bias toward the range delimiters so they land *inside* the
+                    // quotes, exercising the naive take_while truncation.
+                    2 | 3 => out.push(*u.choose(&[',', ']', ')', '['])?),
+                    _ => out.push(*u.choose(&['a', '1', ' ', '('])?),
+                }
+            }
+            out.push('"');
+        }
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut s = String::new();
+    if u.int_in_range(0u8..=6)? == 0 {
+        s.push_str("empty");
+        // Bias toward `empty` + trailing junk (the "Junk after empty" arm).
+        if u.int_in_range(0u8..=1)? == 0 {
+            for _ in 0..u.int_in_range(1usize..=3)? {
+                s.push(*u.choose(&[' ', ',', '[', ']', '(', ')', 'x', '"'])?);
+            }
+        }
+    } else {
+        // Independent open/close framing so mismatched brackets/parens arise.
+        s.push(if u.int_in_range(0u8..=1)? == 0 { '[' } else { '(' });
+        push_bound(&mut u, &mut s)?;
+        s.push(',');
+        push_bound(&mut u, &mut s)?;
+        // Sometimes drop the closer entirely (truncated framing).
+        if u.int_in_range(0u8..=5)? != 0 {
+            s.push(if u.int_in_range(0u8..=1)? == 0 { ']' } else { ')' });
+        }
+    }
+    // 1-in-5: splice extra structural noise to exercise the error paths.
+    if u.int_in_range(0u8..=4)? == 0 {
+        s.push_str(u.choose(&["[", "]", "(", ")", ",", "\"", "\\", " ", "empty"])?);
+    }
+    let _ = mz_repr::strconv::parse_range(&s, |e| {
+        Ok::<_, std::convert::Infallible>(e.into_owned())
+    });
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_time.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_time.rs
@@ -1,0 +1,36 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_time` parses untrusted TIME literal text.
+
+#![no_main]
+
+use chrono::Timelike;
+use libfuzzer_sys::fuzz_target;
+use mz_repr::strconv::{format_time, parse_time};
+
+fuzz_target!(|data: &str| {
+    let Ok(t) = parse_time(data) else {
+        return;
+    };
+    // mz TIME keeps nanosecond precision (its cast, unlike TIMESTAMP's, does not
+    // round) but renders microseconds, and the parser accepts a leap second
+    // (`:60`) the renderer can't round-trip. Both are known TIME/PG-compat gaps
+    // tracked separately. Skip sub-microsecond and leap-second values.
+    let nanos = t.nanosecond();
+    if nanos % 1_000 != 0 || nanos >= 1_000_000_000 {
+        return;
+    }
+    let mut buf = String::new();
+    format_time(&mut buf, t);
+    let Ok(reparsed) = parse_time(&buf) else {
+        return;
+    };
+    assert_eq!(t, reparsed, "time changed across parse/format round trip");
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_timestamp.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_timestamp.rs
@@ -1,0 +1,51 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_timestamp` parses untrusted TIMESTAMP literal
+//! text. `CastStringToTimestamp` rounds the parsed value to the type's
+//! precision (microseconds by default) before storage, so mirror that.
+
+#![no_main]
+
+use chrono::Timelike;
+use libfuzzer_sys::fuzz_target;
+use mz_repr::strconv::{format_timestamp, parse_timestamp};
+
+fuzz_target!(|data: &str| {
+    let Ok(ts) = parse_timestamp(data) else {
+        return;
+    };
+    // The parser accepts a leap second (`:60`), stored as chrono's leap
+    // representation (sub-second >= 1s). PostgreSQL carries `:60` to the next
+    // minute and our microsecond renderer mis-encodes the leap, so such values
+    // do not round-trip. This is a known parser/PG-compat gap tracked
+    // separately, not a panic. Skip them (rounding to precision below can't
+    // create a leap).
+    if ts.nanosecond() >= 1_000_000_000 {
+        return;
+    }
+    let Ok(ts) = ts.round_to_precision(None) else {
+        return;
+    };
+    let mut buf = String::new();
+    format_timestamp(&mut buf, &ts);
+    // The renderer can also emit text the parser rejects (e.g. a >4-digit
+    // year), also tracked separately. Tolerate that (re-parse failure) and only
+    // assert that a re-parseable rendering preserves the value, plus no panics.
+    let Ok(reparsed) = parse_timestamp(&buf) else {
+        return;
+    };
+    let Ok(reparsed) = reparsed.round_to_precision(None) else {
+        return;
+    };
+    assert_eq!(
+        ts, reparsed,
+        "timestamp changed across parse/format round trip"
+    );
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_timestamptz.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_timestamptz.rs
@@ -1,0 +1,51 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_timestamptz` parses untrusted TIMESTAMPTZ
+//! literal text. `CastStringToTimestampTz` rounds to the type's precision
+//! (microseconds by default) before storage, so mirror that.
+
+#![no_main]
+
+use chrono::Timelike;
+use libfuzzer_sys::fuzz_target;
+use mz_repr::strconv::{format_timestamptz, parse_timestamptz};
+
+fuzz_target!(|data: &str| {
+    let Ok(ts) = parse_timestamptz(data) else {
+        return;
+    };
+    // The parser accepts a leap second (`:60`), stored as chrono's leap
+    // representation (sub-second >= 1s). PostgreSQL carries `:60` to the next
+    // minute and our microsecond renderer mis-encodes the leap, so such values
+    // do not round-trip. This is a known parser/PG-compat gap tracked
+    // separately, not a panic. Skip them (rounding to precision below can't
+    // create a leap).
+    if ts.nanosecond() >= 1_000_000_000 {
+        return;
+    }
+    let Ok(ts) = ts.round_to_precision(None) else {
+        return;
+    };
+    let mut buf = String::new();
+    format_timestamptz(&mut buf, &ts);
+    // The renderer can also emit text the parser rejects (e.g. a >4-digit
+    // year), also tracked separately. Tolerate that (re-parse failure) and only
+    // assert that a re-parseable rendering preserves the value, plus no panics.
+    let Ok(reparsed) = parse_timestamptz(&buf) else {
+        return;
+    };
+    let Ok(reparsed) = reparsed.round_to_precision(None) else {
+        return;
+    };
+    assert_eq!(
+        ts, reparsed,
+        "timestamptz changed across parse/format round trip"
+    );
+});

--- a/src/repr/fuzz/fuzz_targets/strconv_parse_uuid.rs
+++ b/src/repr/fuzz/fuzz_targets/strconv_parse_uuid.rs
@@ -1,0 +1,117 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `strconv::parse_uuid` decodes untrusted `uuid` text (COPY FROM,
+//! a text-format `uuid` parameter on the wire). The `uuid` crate itself panics
+//! while *constructing a parse error* for some short, brace-wrapped inputs
+//! (e.g. `{}`, `{\0}`). It mis-slices the input, so `parse_uuid` pre-screens
+//! the string before delegating. This is a regression guard for that fix: no
+//! input may panic.
+//!
+//! Random text essentially never hits the `{`-wrapped / `urn:uuid:` / exactly-32
+//! / exactly-36-with-dashes shapes the crate special-cases (and the pre-screen
+//! gates on `len >= 32` + ASCII), so byte mutation barely reaches the crash
+//! boundary. We instead consume the byte stream as grammar choices and emit
+//! inputs biased right at it: brace-wrapped bodies of length 30-34 with embedded
+//! NUL / non-hex (the mis-slice trigger), `urn:uuid:` prefixes, exactly-32-hex
+//! and 36-char dashed forms with a few corrupted bytes, and surrounding
+//! whitespace (`parse_uuid` trims). A quarter of inputs are still the raw string
+//! so the pre-screen reject paths and non-ASCII handling stay covered.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+const HEX: &[char] = &[
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A', 'F',
+];
+
+/// Push one body character: usually a hex digit, occasionally a corrupting byte
+/// (NUL, non-hex ASCII, or a stray dash) to derail the crate's slicing.
+fn push_body_char(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=9)? {
+        0 => out.push('\0'),
+        1 => out.push(*u.choose(&['g', 'z', '-', ' ', '{', '}', ':'])?),
+        _ => out.push(*u.choose(HEX)?),
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, the raw string: keeps the pre-screen reject paths
+    // and non-ASCII handling covered.
+    if u.int_in_range(0u8..=3)? == 0 {
+        if let Ok(s) = std::str::from_utf8(u.take_rest()) {
+            let _ = mz_repr::strconv::parse_uuid(s);
+        }
+        return Ok(());
+    }
+
+    let mut s = String::new();
+    // Optional leading whitespace (`parse_uuid` trims).
+    if u.int_in_range(0u8..=4)? == 0 {
+        s.push(*u.choose(&[' ', '\t', '\n'])?);
+    }
+
+    match u.int_in_range(0u8..=4)? {
+        // Brace-wrapped body whose total length straddles the pre-screen's
+        // 32-byte floor, the historical mis-slice / panic boundary.
+        0 | 1 => {
+            s.push('{');
+            let n = u.int_in_range(28usize..=32)?;
+            for _ in 0..n {
+                push_body_char(&mut u, &mut s)?;
+            }
+            // Sometimes omit the closing brace (unbalanced framing).
+            if u.int_in_range(0u8..=2)? != 0 {
+                s.push('}');
+            }
+        }
+        // `urn:uuid:` prefixed form.
+        2 => {
+            s.push_str("urn:uuid:");
+            emit_canonical(&mut u, &mut s)?;
+        }
+        // Exactly-32 hex (simple form), with a few corrupted bytes.
+        3 => {
+            for _ in 0..32 {
+                push_body_char(&mut u, &mut s)?;
+            }
+        }
+        // 36-char dashed (hyphenated) form, with a few corrupted bytes.
+        _ => emit_canonical(&mut u, &mut s)?,
+    }
+
+    // Optional trailing whitespace.
+    if u.int_in_range(0u8..=4)? == 0 {
+        s.push(*u.choose(&[' ', '\t', '\n'])?);
+    }
+
+    let _ = mz_repr::strconv::parse_uuid(&s);
+    Ok(())
+}
+
+/// Emit the canonical `8-4-4-4-12` hyphenated form, with `push_body_char` so a
+/// few bytes can be corrupted.
+fn emit_canonical(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    for (i, &group) in [8usize, 4, 4, 4, 12].iter().enumerate() {
+        if i > 0 {
+            out.push('-');
+        }
+        for _ in 0..group {
+            push_body_char(u, out)?;
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});


### PR DESCRIPTION
Replacement stack for #36982. This is part 5 of 10.

Summary:
- Adds repr fuzz targets for row, proto, strconv, JSONB, numeric, interval, and range properties.
- Adds pgrepr, pgcopy, pgtz, and pgwire fuzz targets.
- Adds pgwire corpus preparation and dictionaries.

Review notes:
- Focus review on parser and codec assumptions for externally supplied bytes or text.
- The pgwire target depends on the fuzz-only exports from part 2.

Verification:
- Split from original commit 082e197653 and reapplied onto current upstream/main.
- Top of stack has the same touched-file set as #36982 and passes git diff --check.

Stack:
1. #37381 tests: Add shared cargo-fuzz runner
2. #37382 tests: Expose fuzz-only internals
3. #37383 sql-parser: Add cargo-fuzz targets
4. #37384 expr, transform: Add cargo-fuzz targets
5. #37385 repr, pgwire: Add cargo-fuzz targets
6. #37386 avro, interchange: Add cargo-fuzz targets
7. #37387 storage-types: Add proto cargo-fuzz targets
8. #37388 persist-client: Add cargo-fuzz targets
9. #37389 storage: Add upsert cargo-fuzz targets
10. #37390 ci: Run cargo-fuzz in release qualification

The original monolithic PR is #36982.