### PR TITLE
avro, interchange: Add cargo-fuzz targets

### DIFF
--- a/src/avro/fuzz/.gitignore
+++ b/src/avro/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/avro/fuzz/Cargo.toml
+++ b/src/avro/fuzz/Cargo.toml
@@ -1,0 +1,43 @@
+# Fuzz crate for mz-avro decoders. Avro bytes arrive from Kafka, so a
+# decoder bug here is a crash/poisoning risk for source ingestion.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+# Run via the repo-wide runner: `bin/ci-builder run nightly ci/test/cargo-fuzz.sh`,
+# or locally:
+#     cd src/avro/fuzz
+#     cargo +nightly fuzz run reader_decode -- -max_total_time=60
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-avro-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-avro = { path = ".." }
+
+[[bin]]
+name = "reader_decode"
+path = "fuzz_targets/reader_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "schema_resolve"
+path = "fuzz_targets/schema_resolve.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "avro_schema_parse"
+path = "fuzz_targets/avro_schema_parse.rs"
+test = false
+doc = false
+bench = false

--- a/src/avro/fuzz/corpus.dict
+++ b/src/avro/fuzz/corpus.dict
@@ -1,0 +1,44 @@
+# libFuzzer dictionary for the Avro reader_decode target.
+#
+# An Avro object-container file starts with the 4-byte magic "Obj\x01" followed
+# by a map of metadata (notably "avro.schema" and "avro.codec") and a 16-byte
+# sync marker. Without the magic the decoder bails immediately, so the most
+# valuable token by far is the magic itself; the rest let the mutator build
+# plausible headers and schemas.
+
+# Object-container magic.
+"Obj\x01"
+# Header metadata keys / codecs.
+"avro.schema"
+"avro.codec"
+"null"
+"deflate"
+"snappy"
+"zstandard"
+"bzip2"
+# Schema JSON tokens.
+"\"type\""
+"\"name\""
+"\"fields\""
+"\"record\""
+"\"enum\""
+"\"array\""
+"\"map\""
+"\"union\""
+"\"fixed\""
+"\"symbols\""
+"\"items\""
+"\"values\""
+"\"size\""
+"\"namespace\""
+"\"default\""
+"\"logicalType\""
+"\"string\""
+"\"bytes\""
+"\"int\""
+"\"long\""
+"\"float\""
+"\"double\""
+"\"boolean\""
+"decimal"
+"timestamp-millis"

--- a/src/avro/fuzz/fuzz_targets/avro_schema_parse.rs
+++ b/src/avro/fuzz/fuzz_targets/avro_schema_parse.rs
@@ -1,0 +1,231 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `mz_avro::Schema::from_str` parses an Avro schema from JSON,
+//! the schema that arrives from an external, possibly hostile, schema registry
+//! (or straight from a user's `CREATE SOURCE … USING SCHEMA`). It is a
+//! hand-written recursive descent over the parsed JSON, with named-type
+//! definition/reference resolution, aliases, logical types, and a
+//! `MAX_SCHEMA_DEPTH` guard against stack overflow on deeply nested types.
+//!
+//! `schema_resolve` only parses the narrow set of schemas it generates (no
+//! logical types, no named back-references, shallow), and the decode targets
+//! cap nesting low. This one stresses the parser itself: it generates schema
+//! JSON that can nest *past* the depth limit (so the guard must fire cleanly
+//! rather than overflow the stack) and that re-references already-defined names
+//! (recursive definitions, a distinct resolution path).
+//!
+//! It also drives the parser's *naming* and *validation* paths:
+//!   * `namespace` fields and dotted/`a.b.C` names. The `FullName::from_parts`
+//!     split logic, including the documented edge case where a name has dots
+//!     *and* a `namespace` is also given (they may disagree).
+//!   * `aliases` arrays on named types, sometimes deliberately colliding with
+//!     another defined name or with the type's own name.
+//!   * structurally-valid-but-semantically-invalid schemas the parser is meant
+//!     to *reject* (not panic on): duplicate enum symbols, duplicate record
+//!     field names, decimal `scale > precision`, and `fixed` `size: 0`.
+//! Parsing must never panic. It returns `Ok`/`Err`.
+
+#![no_main]
+
+use std::str::FromStr;
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_avro::Schema;
+
+const PRIMITIVES: &[&str] = &[
+    "null", "boolean", "int", "long", "float", "double", "bytes", "string",
+];
+
+/// Generate the optional `name`-affecting JSON attributes for a named type:
+/// the `name` itself (sometimes dotted, i.e. namespace-qualified inline), an
+/// optional separate `namespace`, and an optional `aliases` array (sometimes
+/// colliding with another defined name or with the type's own name). The
+/// returned `name` is the bare leaf name to record in `defined` for later
+/// back-references. Exercises `Name::parse` / `FullName::from_parts`, including
+/// the dotted-name-plus-`namespace` edge case the source flags as `[XXX]`.
+fn gen_named_attrs(
+    u: &mut Unstructured,
+    leaf: &str,
+    defined: &[String],
+) -> arbitrary::Result<String> {
+    let mut attrs = String::new();
+
+    // The `name`: usually bare, sometimes dotted (carries an inline namespace),
+    // which drives the rfind('.') split in `FullName::from_parts`.
+    match u.int_in_range(0u8..=3)? {
+        0 => attrs.push_str(&format!("\"name\":\"{leaf}\"")),
+        1 => attrs.push_str(&format!("\"name\":\"ns.{leaf}\"")),
+        2 => attrs.push_str(&format!("\"name\":\"a.b.{leaf}\"")),
+        // Leading dot → empty namespace component.
+        _ => attrs.push_str(&format!("\"name\":\".{leaf}\"")),
+    }
+
+    // Optional separate `namespace`. Combined with a dotted name above, this
+    // hits the case where the computed and provided namespaces may disagree.
+    match u.int_in_range(0u8..=2)? {
+        0 => {}
+        1 => attrs.push_str(",\"namespace\":\"ns\""),
+        _ => attrs.push_str(",\"namespace\":\"other\""),
+    }
+
+    // Optional `aliases` array.
+    match u.int_in_range(0u8..=4)? {
+        0 | 1 => {}
+        2 => attrs.push_str(",\"aliases\":[\"AnAlias\"]"),
+        // Alias colliding with the type's own (leaf) name.
+        3 => attrs.push_str(&format!(",\"aliases\":[\"{leaf}\"]")),
+        // Alias colliding with some other already-defined name, if any.
+        _ => {
+            if let Some(other) = defined.last() {
+                attrs.push_str(&format!(",\"aliases\":[\"{other}\"]"));
+            } else {
+                attrs.push_str(",\"aliases\":[\"AnAlias\"]");
+            }
+        }
+    }
+
+    Ok(attrs)
+}
+
+/// Generate a schema that is *structurally* valid JSON for a named type but
+/// *semantically* invalid per the Avro spec. The parser must reject it with an
+/// error rather than panic.
+fn gen_invalid(u: &mut Unstructured, counter: &mut u32) -> arbitrary::Result<String> {
+    *counter += 1;
+    Ok(match u.int_in_range(0u8..=4)? {
+        // Enum with duplicate symbols.
+        0 => format!(
+            "{{\"type\":\"enum\",\"name\":\"E{counter}\",\"symbols\":[\"A\",\"B\",\"A\"]}}"
+        ),
+        // Record with duplicate field names.
+        1 => format!(
+            "{{\"type\":\"record\",\"name\":\"R{counter}\",\"fields\":[\
+             {{\"name\":\"dup\",\"type\":\"int\"}},\
+             {{\"name\":\"dup\",\"type\":\"string\"}}]}}"
+        ),
+        // Decimal with scale > precision.
+        2 => "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":2,\"scale\":9}"
+            .to_string(),
+        // Fixed with size 0.
+        3 => format!("{{\"type\":\"fixed\",\"name\":\"F{counter}\",\"size\":0}}"),
+        // Enum default not among the symbols.
+        _ => format!(
+            "{{\"type\":\"enum\",\"name\":\"E{counter}\",\"symbols\":[\"A\",\"B\"],\"default\":\"Z\"}}"
+        ),
+    })
+}
+
+/// A leaf type: a primitive, a logical type, or a reference to an
+/// already-defined named type (which makes the schema recursive).
+fn gen_leaf(u: &mut Unstructured, defined: &[String]) -> arbitrary::Result<String> {
+    Ok(match u.int_in_range(0u8..=7)? {
+        0 => format!("\"{}\"", u.choose(PRIMITIVES)?),
+        1 => "{\"type\":\"int\",\"logicalType\":\"date\"}".to_string(),
+        2 => "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}".to_string(),
+        3 => "{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}".to_string(),
+        4 => "{\"type\":\"string\",\"logicalType\":\"uuid\"}".to_string(),
+        5 => {
+            let precision = u.int_in_range(1u32..=38)?;
+            let scale = u.int_in_range(0u32..=precision)?;
+            format!(
+                "{{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":{precision},\"scale\":{scale}}}"
+            )
+        }
+        // Reference a previously-defined name when one exists (recursive
+        // definition), otherwise fall back to a primitive.
+        _ if !defined.is_empty() => format!("\"{}\"", u.choose(defined)?),
+        _ => format!("\"{}\"", u.choose(PRIMITIVES)?),
+    })
+}
+
+fn gen_type(
+    u: &mut Unstructured,
+    counter: &mut u32,
+    defined: &mut Vec<String>,
+    depth: u32,
+) -> arbitrary::Result<String> {
+    if depth == 0 || u.is_empty() {
+        return gen_leaf(u, defined);
+    }
+    Ok(match u.int_in_range(0u8..=11)? {
+        0 | 1 => gen_leaf(u, defined)?,
+        // Array / map / union: the cheap recursive wrappers that let the
+        // fuzzer drive nesting depth (potentially past MAX_SCHEMA_DEPTH).
+        2 => format!(
+            "{{\"type\":\"array\",\"items\":{}}}",
+            gen_type(u, counter, defined, depth - 1)?
+        ),
+        3 => format!(
+            "{{\"type\":\"map\",\"values\":{}}}",
+            gen_type(u, counter, defined, depth - 1)?
+        ),
+        4 => format!("[{}]", gen_type(u, counter, defined, depth - 1)?),
+        5 => format!("[\"null\",{}]", gen_type(u, counter, defined, depth - 1)?),
+        // Record: defines a new name (recorded so later leaves can reference
+        // it). The name may be dotted/namespaced and may carry `aliases`.
+        6 | 7 => {
+            *counter += 1;
+            let leaf = format!("R{counter}");
+            let attrs = gen_named_attrs(u, &leaf, defined)?;
+            defined.push(leaf);
+            let n = u.int_in_range(0u8..=3)?;
+            let mut fields = Vec::with_capacity(n.into());
+            for i in 0..n {
+                let ty = gen_type(u, counter, defined, depth - 1)?;
+                fields.push(format!("{{\"name\":\"f{i}\",\"type\":{ty}}}"));
+            }
+            format!(
+                "{{\"type\":\"record\",{attrs},\"fields\":[{}]}}",
+                fields.join(",")
+            )
+        }
+        // Enum: also name-attribute-bearing, sometimes with a `default` symbol.
+        8 => {
+            *counter += 1;
+            let leaf = format!("E{counter}");
+            let attrs = gen_named_attrs(u, &leaf, defined)?;
+            defined.push(leaf);
+            let default = if u.int_in_range(0u8..=1)? == 0 {
+                ",\"default\":\"B\""
+            } else {
+                ""
+            };
+            format!("{{\"type\":\"enum\",{attrs},\"symbols\":[\"A\",\"B\",\"C\"]{default}}}")
+        }
+        // Fixed.
+        9 => {
+            *counter += 1;
+            let leaf = format!("F{counter}");
+            let attrs = gen_named_attrs(u, &leaf, defined)?;
+            defined.push(leaf);
+            let size = u.int_in_range(0u32..=32)?;
+            format!("{{\"type\":\"fixed\",{attrs},\"size\":{size}}}")
+        }
+        // A structurally-valid-but-semantically-invalid named type: the parser
+        // must reject it cleanly rather than panic.
+        _ => gen_invalid(u, counter)?,
+    })
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut counter = 0u32;
+    let mut defined = Vec::new();
+    // Start deeper than MAX_SCHEMA_DEPTH (128) so the fuzzer can drive nesting
+    // past the limit and exercise the depth guard, not just shallow schemas.
+    let depth = u.int_in_range(1u32..=200)?;
+    let schema = gen_type(&mut u, &mut counter, &mut defined, depth)?;
+    let _ = Schema::from_str(&schema);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/avro/fuzz/fuzz_targets/reader_decode.rs
+++ b/src/avro/fuzz/fuzz_targets/reader_decode.rs
@@ -1,0 +1,379 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: decoding arbitrary bytes as an Avro object-container file
+//! (header + blocks) must not crash. Avro bytes arrive from Kafka and
+//! externally-managed schema registries, so any panic/SEGV reachable from
+//! the wire format is a real availability bug.
+//!
+//! An OCF starts with a 4-byte magic, a metadata map carrying the writer
+//! schema, and a 16-byte sync marker, then length-framed data blocks each
+//! terminated by that same sync marker. Random bytes fail the magic check on
+//! the first four bytes, so a raw-byte body never gets past `Reader::new`. The
+//! block iteration, sync-marker matching, and per-object value decode (the bulk
+//! of the surface) then stay completely unexercised. So we *build* a valid
+//! container: generate a structured writer schema (`Ty`), serialize it into the
+//! header's `avro.schema` metadata, and Avro-binary-encode the objects of each
+//! block against that schema.
+//!
+//! The compression codec is chosen per file rather than hardcoded to `null`,
+//! which exercises the otherwise-dead decompress dispatch in `read_block_next`:
+//!   * `null`: the encoded block bytes pass straight through.
+//!   * `deflate` with *correctly* compressed bytes: drives the happy-path
+//!     `Codec::decompress` (flate2) round-trip the writer normally produces.
+//!   * `deflate` with the *raw* (uncompressed) bytes left in place: the deflate
+//!     decoder hits a malformed stream, exercising the decompress-error path.
+//!   * an unrecognized codec string: the `UnrecognizedCodec` header-parse
+//!     error. (`snappy` is gated behind a Cargo feature that this fuzz crate
+//!     does not enable, so it is intentionally not generated.)
+//! We also corrupt the declared block framing: occasionally the object-count or
+//! byte-size prefix is replaced with a huge or wildly inconsistent value, which
+//! must be caught by the `safe_len` allocation guard rather than spinning or
+//! over-allocating. And we still hit the structural error paths, occasionally a
+//! corrupted trailing sync marker (the mismatch path) or a whole-file truncation
+//! mid-block (the short-read path). Decoding must never panic any of these ways.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_avro::{Codec, Reader};
+
+/// A generated Avro type. Structured (not straight-to-JSON) so the object
+/// encoder can walk the same type. An array is one item type in the schema but
+/// N item values in a block.
+enum Ty {
+    Null,
+    Bool,
+    Int,
+    Long,
+    Float,
+    Double,
+    String,
+    Bytes,
+    Fixed(u32, u32),
+    Enum(u32),
+    Record(u32, Vec<Ty>),
+    Array(Box<Ty>),
+    Map(Box<Ty>),
+    Nullable(Box<Ty>),
+}
+
+fn gen_ty(u: &mut Unstructured, counter: &mut u32, depth: u32) -> arbitrary::Result<Ty> {
+    let choice = if depth == 0 || u.is_empty() {
+        u.int_in_range(0u8..=9)?
+    } else {
+        u.int_in_range(0u8..=13)?
+    };
+    Ok(match choice {
+        0 => Ty::Null,
+        1 => Ty::Bool,
+        2 => Ty::Int,
+        3 => Ty::Long,
+        4 => Ty::Float,
+        5 => Ty::Double,
+        6 => Ty::String,
+        7 => Ty::Bytes,
+        8 => {
+            *counter += 1;
+            let size = u.int_in_range(0u32..=24)?;
+            Ty::Fixed(*counter, size)
+        }
+        9 => {
+            *counter += 1;
+            Ty::Enum(*counter)
+        }
+        10 => {
+            *counter += 1;
+            let name = *counter;
+            let n = u.int_in_range(0u8..=3)?;
+            let mut fields = Vec::with_capacity(n.into());
+            for _ in 0..n {
+                fields.push(gen_ty(u, counter, depth - 1)?);
+            }
+            Ty::Record(name, fields)
+        }
+        11 => Ty::Array(Box::new(gen_ty(u, counter, depth - 1)?)),
+        12 => Ty::Map(Box::new(gen_ty(u, counter, depth - 1)?)),
+        _ => Ty::Nullable(Box::new(gen_ty(u, counter, depth - 1)?)),
+    })
+}
+
+fn ty_to_json(ty: &Ty, out: &mut String) {
+    match ty {
+        Ty::Null => out.push_str("\"null\""),
+        Ty::Bool => out.push_str("\"boolean\""),
+        Ty::Int => out.push_str("\"int\""),
+        Ty::Long => out.push_str("\"long\""),
+        Ty::Float => out.push_str("\"float\""),
+        Ty::Double => out.push_str("\"double\""),
+        Ty::String => out.push_str("\"string\""),
+        Ty::Bytes => out.push_str("\"bytes\""),
+        Ty::Fixed(n, size) => {
+            out.push_str(&format!("{{\"type\":\"fixed\",\"name\":\"F{n}\",\"size\":{size}}}"))
+        }
+        Ty::Enum(n) => out.push_str(&format!(
+            "{{\"type\":\"enum\",\"name\":\"E{n}\",\"symbols\":[\"A\",\"B\",\"C\"]}}"
+        )),
+        Ty::Record(n, fields) => {
+            out.push_str(&format!("{{\"type\":\"record\",\"name\":\"R{n}\",\"fields\":["));
+            for (i, f) in fields.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&format!("{{\"name\":\"g{i}\",\"type\":"));
+                ty_to_json(f, out);
+                out.push('}');
+            }
+            out.push_str("]}");
+        }
+        Ty::Array(item) => {
+            out.push_str("{\"type\":\"array\",\"items\":");
+            ty_to_json(item, out);
+            out.push('}');
+        }
+        Ty::Map(values) => {
+            out.push_str("{\"type\":\"map\",\"values\":");
+            ty_to_json(values, out);
+            out.push('}');
+        }
+        Ty::Nullable(inner) => {
+            out.push_str("[\"null\",");
+            ty_to_json(inner, out);
+            out.push(']');
+        }
+    }
+}
+
+/// Avro encodes int/long (and all block counts and lengths) as zig-zag varints.
+fn encode_long(n: i64, out: &mut Vec<u8>) {
+    let mut z = ((n << 1) ^ (n >> 63)) as u64;
+    loop {
+        if z & !0x7f == 0 {
+            out.push(z as u8);
+            return;
+        }
+        out.push(((z & 0x7f) | 0x80) as u8);
+        z >>= 7;
+    }
+}
+
+/// Encode length-prefixed bytes (the wire form of both `string` and `bytes`,
+/// and of each Avro map/metadata entry).
+fn encode_blob(bytes: &[u8], out: &mut Vec<u8>) {
+    encode_long(bytes.len() as i64, out);
+    out.extend_from_slice(bytes);
+}
+
+fn encode_str(u: &mut Unstructured, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let n = u.int_in_range(0usize..=8)?;
+    let mut s = Vec::with_capacity(n);
+    for _ in 0..n {
+        s.push(u.int_in_range(0x20u8..=0x7e)?);
+    }
+    encode_blob(&s, out);
+    Ok(())
+}
+
+/// Avro-binary-encode one value of type `ty`.
+fn encode_value(u: &mut Unstructured, ty: &Ty, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    match ty {
+        Ty::Null => {}
+        Ty::Bool => out.push(u.int_in_range(0u8..=1)?),
+        Ty::Int => encode_long(i64::from(u.arbitrary::<i32>()?), out),
+        Ty::Long => encode_long(u.arbitrary::<i64>()?, out),
+        Ty::Float => out.extend_from_slice(&u.arbitrary::<f32>()?.to_le_bytes()),
+        Ty::Double => out.extend_from_slice(&u.arbitrary::<f64>()?.to_le_bytes()),
+        Ty::String => encode_str(u, out)?,
+        Ty::Bytes => {
+            let n = u.int_in_range(0usize..=12)?;
+            let mut b = Vec::with_capacity(n);
+            for _ in 0..n {
+                b.push(u.arbitrary::<u8>()?);
+            }
+            encode_blob(&b, out);
+        }
+        Ty::Fixed(_, size) => {
+            for _ in 0..*size {
+                out.push(u.arbitrary::<u8>()?);
+            }
+        }
+        Ty::Enum(_) => encode_long(u.int_in_range(0i64..=3)?, out),
+        Ty::Record(_, fields) => {
+            for f in fields {
+                encode_value(u, f, out)?;
+            }
+        }
+        Ty::Array(item) => {
+            let n = u.int_in_range(0i64..=3)?;
+            if n > 0 {
+                encode_long(n, out);
+                for _ in 0..n {
+                    encode_value(u, item, out)?;
+                }
+            }
+            encode_long(0, out);
+        }
+        Ty::Map(values) => {
+            let n = u.int_in_range(0i64..=3)?;
+            if n > 0 {
+                encode_long(n, out);
+                for _ in 0..n {
+                    encode_str(u, out)?; // key
+                    encode_value(u, values, out)?;
+                }
+            }
+            encode_long(0, out);
+        }
+        Ty::Nullable(inner) => {
+            if u.int_in_range(0u8..=3)? == 0 {
+                encode_long(0, out); // branch 0 = null
+            } else {
+                encode_long(1, out); // branch 1 = T
+                encode_value(u, inner, out)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A quarter of the time, feed the raw remaining bytes: this exercises the
+    // magic-byte rejection and the header-parse error paths that a well-formed
+    // container always skips.
+    if u.int_in_range(0u8..=3)? == 0 {
+        let data = u.take_rest();
+        if let Ok(reader) = Reader::new(data) {
+            for item in reader {
+                let _ = item;
+            }
+        }
+        return Ok(());
+    }
+
+    // Writer schema: a record (the usual OCF top-level), spanning the value
+    // types the general decoder walks.
+    let mut counter = 0u32;
+    let n = u.int_in_range(1u8..=6)?;
+    let mut fields = Vec::with_capacity(n.into());
+    for _ in 0..n {
+        fields.push(gen_ty(&mut u, &mut counter, 3)?);
+    }
+    let top = Ty::Record(0, fields);
+    let mut schema = String::new();
+    ty_to_json(&top, &mut schema);
+
+    // Pick a per-file codec. `CodecMode` says both what string goes in the
+    // header and how (or whether) each block's encoded bytes get compressed, so
+    // we can drive the happy-path decompress *and* the decompress-error path.
+    enum CodecMode {
+        Null,
+        /// Correctly deflate-compress each block (the writer's normal output).
+        Deflate,
+        /// Declare `deflate` but leave the bytes uncompressed (malformed stream).
+        DeflateGarbage,
+        /// An unrecognized codec name → `UnrecognizedCodec` at header parse.
+        Unrecognized,
+    }
+    let codec_mode = match u.int_in_range(0u8..=5)? {
+        0 | 1 => CodecMode::Null,
+        2 | 3 => CodecMode::Deflate,
+        4 => CodecMode::DeflateGarbage,
+        _ => CodecMode::Unrecognized,
+    };
+    let codec_name: &[u8] = match codec_mode {
+        CodecMode::Null => b"null",
+        CodecMode::Deflate | CodecMode::DeflateGarbage => b"deflate",
+        // A name that is never a real codec. `Reader::new` must reject it
+        // cleanly rather than panic.
+        CodecMode::Unrecognized => b"lz4-but-not-really",
+    };
+
+    let mut out = Vec::new();
+    out.extend_from_slice(b"Obj\x01"); // OCF magic
+    // File metadata: a map<string,bytes> with the writer schema and the chosen
+    // codec, as one block of two entries.
+    encode_long(2, &mut out);
+    encode_blob(b"avro.schema", &mut out);
+    encode_blob(schema.as_bytes(), &mut out);
+    encode_blob(b"avro.codec", &mut out);
+    encode_blob(codec_name, &mut out);
+    encode_long(0, &mut out); // end of metadata map
+    let sync: [u8; 16] = u.arbitrary()?;
+    out.extend_from_slice(&sync);
+
+    // Data blocks: each is object-count, byte-size, the (possibly compressed)
+    // encoded objects, then the file's sync marker.
+    let nblocks = u.int_in_range(0u8..=2)?;
+    for _ in 0..nblocks {
+        let nobj = u.int_in_range(1i64..=3)?;
+        let mut objs = Vec::new();
+        for _ in 0..nobj {
+            encode_value(&mut u, &top, &mut objs)?;
+        }
+        // Compress the block payload to match the declared codec. With
+        // `DeflateGarbage` we deliberately leave it uncompressed so the deflate
+        // decoder sees a malformed stream.
+        match codec_mode {
+            CodecMode::Deflate => {
+                // `compress` is infallible for in-memory deflate. If it ever
+                // errored we'd just skip this input.
+                if Codec::Deflate.compress(&mut objs).is_err() {
+                    return Ok(());
+                }
+            }
+            CodecMode::Null | CodecMode::DeflateGarbage | CodecMode::Unrecognized => {}
+        }
+
+        // The block framing prefixes. Usually honest, but occasionally we lie
+        // about the object count or the byte size, including absurdly large or
+        // negative (→ huge `usize`) values, to exercise the `safe_len` guard
+        // and the short-read handling, neither of which may panic.
+        let (count_prefix, size_prefix) = match u.int_in_range(0u8..=9)? {
+            // Honest framing (the common case).
+            0..=6 => (nobj, objs.len() as i64),
+            // Huge object count with the real byte size: the reader must cap
+            // the count via `safe_len` instead of trying to decode billions.
+            7 => (u.int_in_range(1i64 << 40..=i64::MAX)?, objs.len() as i64),
+            // Negative byte size (wraps to an enormous `usize`): `safe_len`
+            // must reject it rather than attempt a giant allocation.
+            8 => (nobj, -u.int_in_range(1i64..=i64::MAX)?),
+            // Byte size far larger than the bytes actually present → short read.
+            _ => (nobj, objs.len() as i64 + (1i64 << 30)),
+        };
+        encode_long(count_prefix, &mut out);
+        encode_long(size_prefix, &mut out);
+        out.extend_from_slice(&objs);
+        // Usually the correct sync, occasionally a wrong one to drive the
+        // sync-marker mismatch path.
+        if u.int_in_range(0u8..=7)? == 0 {
+            out.extend_from_slice(&u.arbitrary::<[u8; 16]>()?);
+        } else {
+            out.extend_from_slice(&sync);
+        }
+    }
+
+    // Occasionally truncate the whole file mid-block (short-read path).
+    if !out.is_empty() && u.int_in_range(0u8..=7)? == 0 {
+        let keep = u.int_in_range(0usize..=out.len())?;
+        out.truncate(keep);
+    }
+
+    let Ok(reader) = Reader::new(&out[..]) else {
+        return Ok(());
+    };
+    for item in reader {
+        let _ = item;
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/avro/fuzz/fuzz_targets/schema_resolve.rs
+++ b/src/avro/fuzz/fuzz_targets/schema_resolve.rs
@@ -1,0 +1,465 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `resolve_schemas` reconciles a writer schema with a reader
+//! schema (the core of decoding Kafka Avro data whose writer schema came from
+//! an external, possibly hostile, schema registry). It walks both schemas in
+//! lock-step doing type promotion, default substitution, and union matching, so
+//! a panic here is an availability bug for source ingestion.
+//!
+//! Random bytes almost never parse as an Avro schema, so we generate *valid*
+//! schema JSON from the fuzz input. Two independently-named random schemas
+//! almost never line up, so resolution would fail at the very first node (a
+//! record/enum/fixed name mismatch) and the interesting resolve branches would
+//! stay dead.
+//!
+//! Instead we generate one structured shape (`Shape`) and emit *two* JSON
+//! renderings of it: a writer rendering and a reader rendering that share all
+//! record/enum/fixed names but deliberately differ in ways the resolver is
+//! supposed to handle, so we actually reach its non-trivial paths:
+//!   * primitive promotion. A writer `int` rendered as reader `long`/`float`/
+//!     `double`, `long`→`float`/`double`, `float`→`double` (the `ResolveIntLong`
+//!     / `ResolveFloatDouble` / … machinery).
+//!   * default substitution. The reader record sometimes carries an *extra*
+//!     trailing field (absent from the writer) with a JSON `default`, driving
+//!     the "reader field not in writer, use default" branch in `resolve_named`.
+//!   * union matching. Multi-variant unions whose variants the resolver must
+//!     match up by type/name across writer and reader.
+//!   * enums with a `default` symbol.
+//! We resolve writer-against-itself (identity), and both cross-directions.
+//!
+//! A panic is not the only failure mode, though. `resolve_schemas` can return
+//! `Ok` while *deferring* a match failure into the resolved schema. It might
+//! store an `Err` inside a `ResolveUnionUnion` permutation, say, which then
+//! re-raises only when a record actually expresses that branch at decode time.
+//! That is exactly the shape of <https://github.com/MaterializeInc/materialize/pull/37087>:
+//! an `int`→`double` promotion inside a `["null", T]` union resolved to `Ok`
+//! but failed to decode. A "doesn't panic" oracle that discards the `Result`
+//! sees nothing wrong. So beyond requiring no panic, we add a *decode* oracle:
+//! the reader rendering only ever widens the writer, so every node, every
+//! union branch included, has a valid reader target, and decoding a
+//! writer-encoded value through the writer→reader resolved schema MUST succeed.
+//! A deferred mismatch turns that decode into an error, which this target
+//! treats as a finding.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_avro::schema::resolve_schemas;
+use mz_avro::{Schema, from_avro_datum};
+
+/// One of the primitive Avro types, ordered by promotability so the reader
+/// rendering can pick a "wider" target. `int` ⊑ `long` ⊑ `float` ⊑ `double`.
+const PROMO_CHAIN: &[&str] = &["int", "long", "float", "double"];
+const OTHER_PRIMS: &[&str] = &["null", "boolean", "bytes", "string"];
+
+/// A structured schema shape. Generated once, then rendered twice (writer /
+/// reader) with controlled per-rendering variation. `names` are stable across
+/// both renderings so named types line up during resolution.
+enum Shape {
+    /// A primitive on the promotion chain (index into `PROMO_CHAIN`).
+    Promotable(usize),
+    /// A primitive that has no promotion (rendered identically on both sides).
+    OtherPrim(&'static str),
+    /// `[..]` union with N>=1 variants.
+    Union(Vec<Shape>),
+    Array(Box<Shape>),
+    Map(Box<Shape>),
+    Record {
+        name: u32,
+        fields: Vec<Shape>,
+        /// Whether the reader rendering appends an extra defaulted field.
+        reader_extra_default: bool,
+    },
+    Enum {
+        name: u32,
+        /// Whether the reader rendering gives the enum a `default` symbol.
+        reader_default: bool,
+    },
+    Fixed {
+        name: u32,
+        size: u8,
+    },
+}
+
+fn gen_shape(u: &mut Unstructured, counter: &mut u32, depth: u32) -> arbitrary::Result<Shape> {
+    let choice = if depth == 0 || u.is_empty() {
+        u.int_in_range(0u8..=1)?
+    } else {
+        u.int_in_range(0u8..=8)?
+    };
+    Ok(match choice {
+        0 => Shape::Promotable(usize::from(u.int_in_range(0u8..=3)?)),
+        1 => Shape::OtherPrim(u.choose(OTHER_PRIMS)?),
+        2 => {
+            // Multi-variant union. We draw distinct primitive-ish variants so
+            // the union stays valid (Avro forbids duplicate non-named types).
+            let n = u.int_in_range(1u8..=3)?;
+            let mut variants = Vec::with_capacity(n.into());
+            // First variant is often null (the common nullable shape).
+            if u.int_in_range(0u8..=1)? == 0 {
+                variants.push(Shape::OtherPrim("null"));
+            }
+            // Then a small set of distinct promotable primitives.
+            let mut used = [false; 4];
+            for _ in 0..n {
+                let idx = usize::from(u.int_in_range(0u8..=3)?);
+                if !used[idx] {
+                    used[idx] = true;
+                    variants.push(Shape::Promotable(idx));
+                }
+            }
+            if variants.is_empty() {
+                variants.push(Shape::Promotable(0));
+            }
+            Shape::Union(variants)
+        }
+        3 => Shape::Array(Box::new(gen_shape(u, counter, depth - 1)?)),
+        4 => Shape::Map(Box::new(gen_shape(u, counter, depth - 1)?)),
+        5 | 6 => {
+            *counter += 1;
+            let name = *counter;
+            let n = u.int_in_range(0u8..=3)?;
+            let mut fields = Vec::with_capacity(n.into());
+            for _ in 0..n {
+                fields.push(gen_shape(u, counter, depth - 1)?);
+            }
+            Shape::Record {
+                name,
+                fields,
+                reader_extra_default: u.int_in_range(0u8..=1)? == 0,
+            }
+        }
+        7 => {
+            *counter += 1;
+            Shape::Enum {
+                name: *counter,
+                reader_default: u.int_in_range(0u8..=1)? == 0,
+            }
+        }
+        _ => {
+            *counter += 1;
+            Shape::Fixed {
+                name: *counter,
+                size: u.int_in_range(1u8..=16)?,
+            }
+        }
+    })
+}
+
+/// Render the *writer* version of `shape` to schema JSON: promotable
+/// primitives use their base type, records carry only their real fields, and
+/// enums have no default.
+fn render_writer(shape: &Shape, out: &mut String) {
+    match shape {
+        Shape::Promotable(idx) => {
+            out.push('"');
+            out.push_str(PROMO_CHAIN[*idx]);
+            out.push('"');
+        }
+        Shape::OtherPrim(p) => {
+            out.push('"');
+            out.push_str(p);
+            out.push('"');
+        }
+        Shape::Union(variants) => {
+            out.push('[');
+            for (i, v) in variants.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                render_writer(v, out);
+            }
+            out.push(']');
+        }
+        Shape::Array(item) => {
+            out.push_str("{\"type\":\"array\",\"items\":");
+            render_writer(item, out);
+            out.push('}');
+        }
+        Shape::Map(values) => {
+            out.push_str("{\"type\":\"map\",\"values\":");
+            render_writer(values, out);
+            out.push('}');
+        }
+        Shape::Record { name, fields, .. } => {
+            out.push_str(&format!("{{\"type\":\"record\",\"name\":\"N{name}\",\"fields\":["));
+            for (i, f) in fields.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&format!("{{\"name\":\"f{i}\",\"type\":"));
+                render_writer(f, out);
+                out.push('}');
+            }
+            out.push_str("]}");
+        }
+        Shape::Enum { name, .. } => {
+            out.push_str(&format!(
+                "{{\"type\":\"enum\",\"name\":\"N{name}\",\"symbols\":[\"A\",\"B\",\"C\"]}}"
+            ));
+        }
+        Shape::Fixed { name, size } => {
+            out.push_str(&format!(
+                "{{\"type\":\"fixed\",\"name\":\"N{name}\",\"size\":{size}}}"
+            ));
+        }
+    }
+}
+
+/// Render the *reader* version of `shape`: widens each promotable primitive to
+/// a (fuzz-chosen) wider type on the promotion chain, appends a defaulted
+/// `extra` record field, and gives enums a `default` symbol. These are all the
+/// schema-evolution shapes `resolve_schemas` handles.
+fn render_reader_promoted(
+    u: &mut Unstructured,
+    shape: &Shape,
+    out: &mut String,
+) -> arbitrary::Result<()> {
+    match shape {
+        Shape::Promotable(idx) => {
+            // Choose a target at or after `idx` on the chain, a valid
+            // promotion the resolver should accept.
+            let target = u.int_in_range(*idx..=PROMO_CHAIN.len() - 1)?;
+            out.push('"');
+            out.push_str(PROMO_CHAIN[target]);
+            out.push('"');
+        }
+        Shape::OtherPrim(p) => {
+            out.push('"');
+            out.push_str(p);
+            out.push('"');
+        }
+        Shape::Union(variants) => {
+            out.push('[');
+            for (i, v) in variants.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                render_reader_promoted(u, v, out)?;
+            }
+            out.push(']');
+        }
+        Shape::Array(item) => {
+            out.push_str("{\"type\":\"array\",\"items\":");
+            render_reader_promoted(u, item, out)?;
+            out.push('}');
+        }
+        Shape::Map(values) => {
+            out.push_str("{\"type\":\"map\",\"values\":");
+            render_reader_promoted(u, values, out)?;
+            out.push('}');
+        }
+        Shape::Record {
+            name,
+            fields,
+            reader_extra_default,
+        } => {
+            out.push_str(&format!("{{\"type\":\"record\",\"name\":\"N{name}\",\"fields\":["));
+            for (i, f) in fields.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&format!("{{\"name\":\"f{i}\",\"type\":"));
+                render_reader_promoted(u, f, out)?;
+                out.push('}');
+            }
+            if *reader_extra_default {
+                if !fields.is_empty() {
+                    out.push(',');
+                }
+                out.push_str("{\"name\":\"extra\",\"type\":\"long\",\"default\":7}");
+            }
+            out.push_str("]}");
+        }
+        Shape::Enum { name, reader_default } => {
+            out.push_str(&format!(
+                "{{\"type\":\"enum\",\"name\":\"N{name}\",\"symbols\":[\"A\",\"B\",\"C\"]"
+            ));
+            if *reader_default {
+                out.push_str(",\"default\":\"A\"");
+            }
+            out.push_str("}");
+        }
+        Shape::Fixed { name, size } => {
+            out.push_str(&format!(
+                "{{\"type\":\"fixed\",\"name\":\"N{name}\",\"size\":{size}}}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Avro encodes `int`/`long` (and union branch indices, array/map block
+/// counts, and blob lengths) as zig-zag varints.
+fn encode_long(n: i64, out: &mut Vec<u8>) {
+    let mut z = ((n << 1) ^ (n >> 63)) as u64;
+    loop {
+        if z & !0x7f == 0 {
+            out.push(z as u8);
+            return;
+        }
+        out.push(((z & 0x7f) | 0x80) as u8);
+        z >>= 7;
+    }
+}
+
+/// Length-prefixed bytes, the wire form of `string`, `bytes`, and each map key.
+fn encode_blob(bytes: &[u8], out: &mut Vec<u8>) {
+    encode_long(bytes.len() as i64, out);
+    out.extend_from_slice(bytes);
+}
+
+/// Avro-binary-encode one value matching the *writer* rendering of `shape`
+/// (i.e. `render_writer`'s wire format), so it can be decoded back through a
+/// resolved schema. For unions we deliberately pick a *promotable* branch:
+/// that is the branch whose resolved decode walks the numeric-promotion path,
+/// the exact spot where #37087 deferred a union match failure into the resolved
+/// schema and re-raised it here at decode time. Every generated union has at
+/// least one promotable variant, so the search never falls back.
+fn encode_writer_value(
+    u: &mut Unstructured,
+    shape: &Shape,
+    out: &mut Vec<u8>,
+) -> arbitrary::Result<()> {
+    match shape {
+        Shape::Promotable(idx) => match PROMO_CHAIN[*idx] {
+            "int" => encode_long(i64::from(u.arbitrary::<i32>()?), out),
+            "long" => encode_long(u.arbitrary::<i64>()?, out),
+            "float" => out.extend_from_slice(&u.arbitrary::<f32>()?.to_le_bytes()),
+            // "double"
+            _ => out.extend_from_slice(&u.arbitrary::<f64>()?.to_le_bytes()),
+        },
+        Shape::OtherPrim(p) => match *p {
+            "null" => {}
+            "boolean" => out.push(u.int_in_range(0u8..=1)?),
+            // "bytes" | "string": both length-prefixed on the wire.
+            _ => {
+                let n = u.int_in_range(0usize..=8)?;
+                let mut b = Vec::with_capacity(n);
+                for _ in 0..n {
+                    b.push(u.int_in_range(0x20u8..=0x7e)?);
+                }
+                encode_blob(&b, out);
+            }
+        },
+        Shape::Union(variants) => {
+            let branch = variants
+                .iter()
+                .position(|v| matches!(v, Shape::Promotable(_)))
+                .unwrap_or(0);
+            encode_long(branch as i64, out);
+            encode_writer_value(u, &variants[branch], out)?;
+        }
+        Shape::Array(item) => {
+            let n = u.int_in_range(0i64..=3)?;
+            if n > 0 {
+                encode_long(n, out);
+                for _ in 0..n {
+                    encode_writer_value(u, item, out)?;
+                }
+            }
+            encode_long(0, out); // end-of-array block marker
+        }
+        Shape::Map(values) => {
+            let n = u.int_in_range(0i64..=3)?;
+            if n > 0 {
+                encode_long(n, out);
+                for _ in 0..n {
+                    let k = u.int_in_range(0usize..=4)?;
+                    let mut key = Vec::with_capacity(k);
+                    for _ in 0..k {
+                        key.push(u.int_in_range(0x61u8..=0x7a)?);
+                    }
+                    encode_blob(&key, out);
+                    encode_writer_value(u, values, out)?;
+                }
+            }
+            encode_long(0, out); // end-of-map block marker
+        }
+        Shape::Record { fields, .. } => {
+            for f in fields {
+                encode_writer_value(u, f, out)?;
+            }
+        }
+        // The writer enum's symbols are always `["A","B","C"]`.
+        Shape::Enum { .. } => encode_long(u.int_in_range(0i64..=2)?, out),
+        Shape::Fixed { size, .. } => {
+            for _ in 0..*size {
+                out.push(u.arbitrary::<u8>()?);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut counter = 0u32;
+    // The top level of an OCF/registry schema is virtually always a record.
+    counter += 1;
+    let top_name = counter;
+    let n = u.int_in_range(0u8..=4)?;
+    let mut fields = Vec::with_capacity(n.into());
+    for _ in 0..n {
+        fields.push(gen_shape(&mut u, &mut counter, 3)?);
+    }
+    let shape = Shape::Record {
+        name: top_name,
+        fields,
+        reader_extra_default: u.int_in_range(0u8..=1)? == 0,
+    };
+
+    let mut writer_json = String::new();
+    render_writer(&shape, &mut writer_json);
+    let mut reader_json = String::new();
+    render_reader_promoted(&mut u, &shape, &mut reader_json)?;
+
+    let Ok(writer) = writer_json.parse::<Schema>() else {
+        return Ok(());
+    };
+
+    // Encode one value against the writer rendering. We decode it back through
+    // the resolved schemas below. The writer only ever widens into the reader,
+    // so every node, every union branch included, has a valid reader target
+    // and decoding the writer's own bytes through the resolved schema must
+    // succeed. A `resolve_schemas` that returned `Ok` but deferred a fixable
+    // mismatch (see the module comment / #37087) surfaces it here as a decode
+    // error rather than slipping past a panic-only oracle.
+    let mut writer_value = Vec::new();
+    encode_writer_value(&mut u, &shape, &mut writer_value)?;
+
+    // Identity resolution must succeed and decode the writer's own bytes.
+    if let Ok(resolved) = resolve_schemas(&writer, &writer) {
+        from_avro_datum(&resolved, &mut &writer_value[..])
+            .expect("decode through identity-resolved schema must succeed");
+    }
+    if let Ok(reader) = reader_json.parse::<Schema>() {
+        // Writer→reader is the *widening* direction: it hits the promotion /
+        // default / union-match branches, must resolve, and the resolved schema
+        // must decode the writer's bytes. A deferred promotion mismatch turns
+        // this `expect` into the fuzzer's signal.
+        if let Ok(resolved) = resolve_schemas(&writer, &reader) {
+            from_avro_datum(&resolved, &mut &writer_value[..]).expect(
+                "decode through writer→reader resolved schema must succeed; a failure means \
+                 resolution deferred a fixable mismatch into the resolved schema (see #37087)",
+            );
+        }
+        // The reverse (reader→writer) *narrows*, so its resolution may
+        // legitimately fail or defer a genuine mismatch. We only require that
+        // neither direction panics.
+        let _ = resolve_schemas(&reader, &writer);
+        let _ = resolve_schemas(&reader, &reader);
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/avro/fuzz/fuzz_targets/schema_resolve.rs
+++ b/src/avro/fuzz/fuzz_targets/schema_resolve.rs
@@ -53,7 +53,7 @@
 use libfuzzer_sys::arbitrary::{self, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use mz_avro::schema::resolve_schemas;
-use mz_avro::{Schema, from_avro_datum};
+use mz_avro::{from_avro_datum, Schema};
 
 /// One of the primitive Avro types, ordered by promotability so the reader
 /// rendering can pick a "wider" target. `int` ⊑ `long` ⊑ `float` ⊑ `double`.
@@ -190,7 +190,9 @@ fn render_writer(shape: &Shape, out: &mut String) {
             out.push('}');
         }
         Shape::Record { name, fields, .. } => {
-            out.push_str(&format!("{{\"type\":\"record\",\"name\":\"N{name}\",\"fields\":["));
+            out.push_str(&format!(
+                "{{\"type\":\"record\",\"name\":\"N{name}\",\"fields\":["
+            ));
             for (i, f) in fields.iter().enumerate() {
                 if i > 0 {
                     out.push(',');
@@ -238,12 +240,51 @@ fn render_reader_promoted(
             out.push('"');
         }
         Shape::Union(variants) => {
+            // Widen the promotable variants while keeping their types distinct.
+            // Widening each independently could collapse two variants onto the
+            // same type (`[int, long]` becoming `[long, long]`), which Avro
+            // rejects as a duplicate union type. That makes the whole reader
+            // schema unparseable, so the writer->reader decode oracle below is
+            // silently skipped for this input. We emit the non-promotable
+            // variants (only `null`, per `gen_shape`) first, then the
+            // promotables in ascending source order with strictly increasing
+            // targets. Reserving one chain slot for every later variant keeps a
+            // valid assignment reachable, since PROMO_CHAIN has one slot per
+            // possible source index.
             out.push('[');
-            for (i, v) in variants.iter().enumerate() {
-                if i > 0 {
+            let mut written = 0;
+            for v in variants
+                .iter()
+                .filter(|v| !matches!(v, Shape::Promotable(_)))
+            {
+                if written > 0 {
                     out.push(',');
                 }
                 render_reader_promoted(u, v, out)?;
+                written += 1;
+            }
+            let mut promo: Vec<usize> = variants
+                .iter()
+                .filter_map(|v| match v {
+                    Shape::Promotable(idx) => Some(*idx),
+                    _ => None,
+                })
+                .collect();
+            promo.sort_unstable();
+            let m = promo.len();
+            let mut min_target = 0;
+            for (k, idx) in promo.into_iter().enumerate() {
+                if written > 0 {
+                    out.push(',');
+                }
+                let lo = idx.max(min_target);
+                let hi = (PROMO_CHAIN.len() - 1) - (m - 1 - k);
+                let target = u.int_in_range(lo..=hi)?;
+                min_target = target + 1;
+                out.push('"');
+                out.push_str(PROMO_CHAIN[target]);
+                out.push('"');
+                written += 1;
             }
             out.push(']');
         }
@@ -262,7 +303,9 @@ fn render_reader_promoted(
             fields,
             reader_extra_default,
         } => {
-            out.push_str(&format!("{{\"type\":\"record\",\"name\":\"N{name}\",\"fields\":["));
+            out.push_str(&format!(
+                "{{\"type\":\"record\",\"name\":\"N{name}\",\"fields\":["
+            ));
             for (i, f) in fields.iter().enumerate() {
                 if i > 0 {
                     out.push(',');
@@ -279,7 +322,10 @@ fn render_reader_promoted(
             }
             out.push_str("]}");
         }
-        Shape::Enum { name, reader_default } => {
+        Shape::Enum {
+            name,
+            reader_default,
+        } => {
             out.push_str(&format!(
                 "{{\"type\":\"enum\",\"name\":\"N{name}\",\"symbols\":[\"A\",\"B\",\"C\"]"
             ));

--- a/src/avro/fuzz/prepare-corpus.sh
+++ b/src/avro/fuzz/prepare-corpus.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# prepare-corpus.sh: populate cargo-fuzz seed corpora with valid Avro
+# container files so the fuzzer doesn't waste cycles bouncing off the
+# magic-header check. libFuzzer mutates these into deeper structural
+# variants while still hitting real decoder code paths.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+mkdir -p corpus/reader_decode
+find corpus/reader_decode -maxdepth 1 -name 'seed_*.avro' -delete
+cp ../benches/quickstop-null.avro corpus/reader_decode/seed_01_quickstop_null.avro
+
+echo "Seeded:"
+for d in corpus/*/; do
+    count=$(find "$d" -maxdepth 1 -name '*.avro' | wc -l)
+    printf "  %-40s %4d seeds\n" "$d" "$count"
+done

--- a/src/interchange/fuzz/.gitignore
+++ b/src/interchange/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/interchange/fuzz/Cargo.toml
+++ b/src/interchange/fuzz/Cargo.toml
@@ -1,0 +1,48 @@
+# Fuzz crate for mz-interchange: decode untrusted source bytes (Kafka message
+# payloads, webhook bodies) into Materialize `Row`s. These decoders are the
+# first thing to touch external data, so a panic reachable from the wire is a
+# real availability bug for source ingestion.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-interchange-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+chrono = "0.4"
+libfuzzer-sys = "0.4"
+mz-interchange = { path = ".." }
+mz-repr = { path = "../../repr" }
+prost = "0.14.3"
+prost-types = "0.14.3"
+serde_json = "1"
+tokio = { version = "1", features = ["rt"] }
+uuid = "1"
+
+[[bin]]
+name = "avro_decode_fuzzed_schema"
+path = "fuzz_targets/avro_decode_fuzzed_schema.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "json_encode"
+path = "fuzz_targets/json_encode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "protobuf_decode_fuzzed_schema"
+path = "fuzz_targets/protobuf_decode_fuzzed_schema.rs"
+test = false
+doc = false
+bench = false

--- a/src/interchange/fuzz/fuzz_targets/avro_decode_fuzzed_schema.rs
+++ b/src/interchange/fuzz/fuzz_targets/avro_decode_fuzzed_schema.rs
@@ -1,0 +1,818 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `mz_interchange::avro::Decoder` decoding an untrusted Avro
+//! message body against a *fuzzer-generated* reader schema instead of one fixed
+//! schema. The decoder's behaviour is schema-directed, so a fixed schema only
+//! ever walks one set of `AvroFlatDecoder` paths. The bug-prone paths are the
+//! schema-dependent ones that a single schema barely touches: `decimal`
+//! (unscaled two's-complement
+//! bytes -> `Numeric`, where precision/scale and byte length interact), `fixed`
+//! (size-N byte runs), `enum` (symbol index -> string, an out-of-range index is
+//! attacker-controlled), the logical date/timestamp conversions, and deeply
+//! nested records/arrays/maps and unions.
+//!
+//! Critically, we don't just generate the schema and feed *random bytes* as the
+//! body: a strict binary decoder rejects almost all random bytes at the first
+//! field, so a random body never reaches the deep decode logic. Instead we
+//! generate a structured type (`Ty`), serialize it to the reader-schema JSON,
+//! and *Avro-binary-encode a random value against that same type*, so the body
+//! is valid by construction and the decoder walks all the way through. Coverage
+//! guidance then learns which byte streams produce which shapes. We don't lose
+//! the error-path coverage a random body gave, though: a quarter of the inputs
+//! feed the raw remaining bytes, and others truncate or single-byte-corrupt the
+//! valid encoding. Either way, an accepted schema must never panic.
+//!
+//! Beyond "never panic", we add one error oracle. Most bodies *should* be
+//! rejected (random bytes, truncations, an out-of-range `enum` index, an
+//! over-precision `decimal`, invalid `json`), so a decode `Err` is usually the
+//! correct outcome and is discarded. But when the body is a *clean* encoding of
+//! a type tree that is guaranteed decodable for any value the encoder emits
+//! (plain scalars, `fixed`, and structural composites over them, see
+//! `decode_infallible`), the decoder is round-tripping bytes it *must* accept,
+//! so there a decode error is a real bug and we assert success. A panic-only
+//! oracle never notices a "valid input wrongly rejected" regression (cf.
+//! #37087's deferred union-promotion error).
+//!
+//! A fraction of inputs instead drive a round-trip *correctness* oracle
+//! (`run_roundtrip`): a decode that succeeds but yields the *wrong* datum slips
+//! past both the panic and the decode-success oracles. So we build a record of
+//! plain scalars (bool/int/long/string/bytes and their `["null", T]` form) whose
+//! decoded `Datum` is exactly determined, encode it, decode it, and assert the
+//! decoded `Row` equals the values we put in.
+//!
+//! Rather than freeze the schema-dependent knobs at one value each, we vary the
+//! ones that drive distinct decode arithmetic: `decimal` precision (1..=39, the
+//! `NUMERIC_DATUM_MAX_PRECISION` boundary), scale (0..=precision, where
+//! `parse_decimal` rejects scale > precision and `twos_complement_be_to_numeric`
+//! interprets it), and the backing `fixed` size, so the two's-complement byte
+//! run and the precision/scale interaction are not pinned. The decimal
+//! *value* bytes are likewise biased (see `push_twos_complement` /
+//! `gen_decimal_len`) toward the patterns that stress that arithmetic rather
+//! than only uniform-random runs: the empty run (== 0), all-`0x00`/`0xFF` sign
+//! extension, the `0x80`/`0x7F` magnitude extremes, and lengths bracketing the
+//! narrow/wide split (17) and the wide/overflow regime. We also emit a
+//! `json` logical field (a `string` tagged `connect.name:io.debezium.data.Json`)
+//! whose body is real JSON text, reaching the `AvroFlatDecoder::json` ->
+//! `JsonbPacker` path that a plain string never touches. And multi-variant
+//! *essential* unions like `["int","string"]`, accepted only as a record field
+//! (each non-null variant expands to its own nullable column) and rejected
+//! elsewhere, exercising `get_union_columns`' field-invention/expansion logic
+//! that the `["null", T]` nullability pattern alone never reaches.
+
+#![no_main]
+
+use std::sync::OnceLock;
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_interchange::avro::{Decoder, WriterSchemaProvider};
+use mz_repr::{Datum, Row};
+
+fn rt() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime")
+    })
+}
+
+/// A generated Avro type. We keep it structured (rather than going straight to
+/// JSON) so that the *body* encoder can walk the exact same type. An array
+/// needs one item type in the schema but N encoded values in the body, so the
+/// schema and the body can't share a single recursive pass.
+enum Ty {
+    Bool,
+    Int,
+    Long,
+    Float,
+    Double,
+    String,
+    Bytes,
+    /// `decimal` logical type over `bytes`: (precision, scale). The unscaled
+    /// value is length-prefixed, so the byte-run length is unbounded.
+    DecimalBytes(u32, u32),
+    /// `decimal` logical type over a `fixed`: (unique-name counter, fixed size,
+    /// precision, scale). The wire body is exactly `size` bytes.
+    DecimalFixed(u32, u32, u32, u32),
+    Date,
+    TimestampMillis,
+    TimestampMicros,
+    Uuid,
+    /// `string` tagged with `connect.name = io.debezium.data.Json`, which the
+    /// avro schema parser maps to `SchemaPiece::Json` (-> SQL `Jsonb`). The wire
+    /// body is a length-prefixed run of valid JSON text.
+    Json,
+    /// Plain `fixed` byte run: (unique-name counter, size).
+    Fixed(u32, u32),
+    /// `enum` with symbols A/B/C (unique-name counter).
+    Enum(u32),
+    /// `record` (unique-name counter, fields). Each field is itself a `Ty`,
+    /// except that a field may be an `EssentialUnion`, which is only valid in
+    /// this position.
+    Record(u32, Vec<Ty>),
+    Array(Box<Ty>),
+    Map(Box<Ty>),
+    /// `["null", T]`, the nullability-pattern union, valid anywhere a single
+    /// column is expected (record field, array item, map value).
+    Nullable(Box<Ty>),
+    /// A multi-variant *essential* union of non-null variants, optionally with a
+    /// leading `null`: e.g. `["int","string"]` or `["null","int","string"]`.
+    /// `validate_schema_2` rejects this everywhere except as a record field,
+    /// where `get_union_columns` expands it to one nullable column per non-null
+    /// variant. Stored as (has_null, variants). Generated only as a record field.
+    EssentialUnion(bool, Vec<Ty>),
+}
+
+/// Generate a `decimal`'s precision/scale. `parse_decimal` requires
+/// `0 <= scale <= precision` and the SQL validator caps precision at
+/// `NUMERIC_DATUM_MAX_PRECISION` (39). Pick within those bounds so the schema is
+/// accepted and we vary the decode arithmetic across the whole legal range.
+fn gen_decimal_params(u: &mut Unstructured) -> arbitrary::Result<(u32, u32)> {
+    let precision = u.int_in_range(1u32..=39)?;
+    let scale = u.int_in_range(0u32..=precision)?;
+    Ok((precision, scale))
+}
+
+/// Generate one syntactically valid Avro type. `counter` keeps named types
+/// (record/enum/fixed) unique within the schema, since duplicate names make Avro
+/// schema parsing fail, wasting the whole input. This never returns an
+/// `EssentialUnion` (only valid as a record field, see `gen_field`).
+fn gen_ty(u: &mut Unstructured, counter: &mut u32, depth: u32) -> arbitrary::Result<Ty> {
+    // Without remaining input (or at max depth) fall back to a primitive so
+    // generation always terminates with a valid type.
+    let choice = if depth == 0 || u.is_empty() {
+        u.int_in_range(0u8..=9)?
+    } else {
+        u.int_in_range(0u8..=13)?
+    };
+    Ok(match choice {
+        0 => match u.int_in_range(0u8..=6)? {
+            0 => Ty::Bool,
+            1 => Ty::Int,
+            2 => Ty::Long,
+            3 => Ty::Float,
+            4 => Ty::Double,
+            5 => Ty::String,
+            _ => Ty::Bytes,
+        },
+        1 => {
+            let (p, s) = gen_decimal_params(u)?;
+            Ty::DecimalBytes(p, s)
+        }
+        2 => {
+            *counter += 1;
+            let (p, s) = gen_decimal_params(u)?;
+            // `fixed` requires a positive size. Allow runs both shorter and
+            // longer than the canonical 16/24 to vary the two's-complement path.
+            let size = u.int_in_range(1u32..=40)?;
+            Ty::DecimalFixed(*counter, size, p, s)
+        }
+        3 => Ty::Date,
+        4 => Ty::TimestampMillis,
+        5 => Ty::TimestampMicros,
+        6 => Ty::Uuid,
+        7 => {
+            *counter += 1;
+            let size = u.int_in_range(0u32..=24)?;
+            Ty::Fixed(*counter, size)
+        }
+        8 => {
+            *counter += 1;
+            Ty::Enum(*counter)
+        }
+        9 => Ty::Json,
+        10 => {
+            *counter += 1;
+            let name = *counter;
+            let n = u.int_in_range(0u8..=3)?;
+            let mut fields = Vec::with_capacity(n.into());
+            for _ in 0..n {
+                fields.push(gen_field(u, counter, depth - 1)?);
+            }
+            Ty::Record(name, fields)
+        }
+        11 => Ty::Array(Box::new(gen_ty(u, counter, depth - 1)?)),
+        12 => Ty::Map(Box::new(gen_ty(u, counter, depth - 1)?)),
+        _ => Ty::Nullable(Box::new(gen_ty(u, counter, depth - 1)?)),
+    })
+}
+
+/// Generate a single record field. Usually a plain `gen_ty`, but occasionally a
+/// multi-variant essential union, valid only here. Variants are drawn from a
+/// set of *distinct* Avro type kinds (Avro rejects a union with two branches of
+/// the same unnamed type), each a single-column `validate_schema_2` type.
+fn gen_field(u: &mut Unstructured, counter: &mut u32, depth: u32) -> arbitrary::Result<Ty> {
+    if depth == 0 || u.is_empty() || u.int_in_range(0u8..=4)? != 0 {
+        return gen_ty(u, counter, depth);
+    }
+    // Pool of distinct, single-column variant kinds (no duplicate Avro kind).
+    let pool: &[fn() -> Ty] = &[
+        || Ty::Bool,
+        || Ty::Int,
+        || Ty::Long,
+        || Ty::Float,
+        || Ty::Double,
+        || Ty::String,
+        || Ty::Bytes,
+    ];
+    let nvariants = u.int_in_range(2usize..=pool.len())?;
+    // Choose `nvariants` distinct indices into the pool, preserving order.
+    let mut chosen = Vec::with_capacity(nvariants);
+    let mut idx = 0usize;
+    let mut remaining = nvariants;
+    while remaining > 0 && idx < pool.len() {
+        let left = pool.len() - idx;
+        // Pick this index iff we still need as many as are left, or by coin flip.
+        if remaining == left || u.int_in_range(0u8..=1)? == 1 {
+            chosen.push(pool[idx]());
+            remaining -= 1;
+        }
+        idx += 1;
+    }
+    let has_null = u.int_in_range(0u8..=1)? == 1;
+    Ok(Ty::EssentialUnion(has_null, chosen))
+}
+
+/// Serialize a `Ty` to its reader-schema JSON fragment.
+fn ty_to_json(ty: &Ty, out: &mut String) {
+    match ty {
+        Ty::Bool => out.push_str("\"boolean\""),
+        Ty::Int => out.push_str("\"int\""),
+        Ty::Long => out.push_str("\"long\""),
+        Ty::Float => out.push_str("\"float\""),
+        Ty::Double => out.push_str("\"double\""),
+        Ty::String => out.push_str("\"string\""),
+        Ty::Bytes => out.push_str("\"bytes\""),
+        Ty::DecimalBytes(p, s) => out.push_str(&format!(
+            "{{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":{p},\"scale\":{s}}}"
+        )),
+        Ty::DecimalFixed(n, size, p, s) => out.push_str(&format!(
+            "{{\"type\":\"fixed\",\"name\":\"D{n}\",\"size\":{size},\"logicalType\":\"decimal\",\"precision\":{p},\"scale\":{s}}}"
+        )),
+        Ty::Date => out.push_str("{\"type\":\"int\",\"logicalType\":\"date\"}"),
+        Ty::TimestampMillis => {
+            out.push_str("{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}")
+        }
+        Ty::TimestampMicros => {
+            out.push_str("{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}")
+        }
+        Ty::Uuid => out.push_str("{\"type\":\"string\",\"logicalType\":\"uuid\"}"),
+        // The avro parser maps a `string` with this connect.name to
+        // `SchemaPiece::Json`.
+        Ty::Json => out.push_str(
+            "{\"type\":\"string\",\"connect.name\":\"io.debezium.data.Json\"}",
+        ),
+        Ty::Fixed(n, size) => {
+            out.push_str(&format!("{{\"type\":\"fixed\",\"name\":\"F{n}\",\"size\":{size}}}"))
+        }
+        Ty::Enum(n) => out.push_str(&format!(
+            "{{\"type\":\"enum\",\"name\":\"E{n}\",\"symbols\":[\"A\",\"B\",\"C\"]}}"
+        )),
+        Ty::Record(n, fields) => {
+            out.push_str(&format!("{{\"type\":\"record\",\"name\":\"R{n}\",\"fields\":["));
+            for (i, f) in fields.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&format!("{{\"name\":\"g{i}\",\"type\":"));
+                ty_to_json(f, out);
+                out.push('}');
+            }
+            out.push_str("]}");
+        }
+        Ty::Array(item) => {
+            out.push_str("{\"type\":\"array\",\"items\":");
+            ty_to_json(item, out);
+            out.push('}');
+        }
+        Ty::Map(values) => {
+            out.push_str("{\"type\":\"map\",\"values\":");
+            ty_to_json(values, out);
+            out.push('}');
+        }
+        Ty::Nullable(inner) => {
+            out.push_str("[\"null\",");
+            ty_to_json(inner, out);
+            out.push(']');
+        }
+        Ty::EssentialUnion(has_null, variants) => {
+            out.push('[');
+            if *has_null {
+                out.push_str("\"null\"");
+            }
+            for (i, v) in variants.iter().enumerate() {
+                if *has_null || i > 0 {
+                    out.push(',');
+                }
+                ty_to_json(v, out);
+            }
+            out.push(']');
+        }
+    }
+}
+
+/// Avro encodes int/long as zig-zag varints.
+fn encode_long(n: i64, out: &mut Vec<u8>) {
+    let mut z = ((n << 1) ^ (n >> 63)) as u64;
+    loop {
+        if z & !0x7f == 0 {
+            out.push(z as u8);
+            return;
+        }
+        out.push(((z & 0x7f) | 0x80) as u8);
+        z >>= 7;
+    }
+}
+
+/// Encode a length-prefixed run of printable ASCII (valid UTF-8 so `string`
+/// decode succeeds and we reach the deep paths).
+fn encode_str(u: &mut Unstructured, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let n = u.int_in_range(0usize..=8)?;
+    let mut s = Vec::with_capacity(n);
+    for _ in 0..n {
+        s.push(u.int_in_range(0x20u8..=0x7e)?);
+    }
+    encode_long(s.len() as i64, out);
+    out.extend_from_slice(&s);
+    Ok(())
+}
+
+/// Encode a length-prefixed run of arbitrary bytes.
+fn encode_bytes(u: &mut Unstructured, max: usize, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let n = u.int_in_range(0usize..=max)?;
+    encode_long(n as i64, out);
+    for _ in 0..n {
+        out.push(u.arbitrary::<u8>()?);
+    }
+    Ok(())
+}
+
+/// Encode a length-prefixed run of valid JSON text, the wire form of a `json`
+/// logical field, which the decoder feeds to `serde_json::from_slice`. A small
+/// menu of well-formed JSON values covers the `JsonbPacker` shapes (scalars,
+/// nested object/array). A fraction of the time we emit deliberately invalid
+/// text to keep the `BadJson` error path covered.
+fn encode_json(u: &mut Unstructured, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let s: String = match u.int_in_range(0u8..=8)? {
+        0 => "null".into(),
+        1 => "true".into(),
+        2 => format!("{}", u.arbitrary::<i64>()?),
+        3 => format!("{}.5", u.arbitrary::<i32>()?),
+        4 => {
+            let n = u.int_in_range(0usize..=6)?;
+            let mut t = String::from("\"");
+            for _ in 0..n {
+                t.push(char::from(u.int_in_range(0x20u8..=0x7e)?).max('a'));
+            }
+            t.push('"');
+            t
+        }
+        5 => "[]".into(),
+        6 => "{}".into(),
+        7 => format!("[{},{},null]", u.arbitrary::<i32>()?, u.arbitrary::<bool>()?),
+        // Not valid JSON: exercise the decoder's BadJson error path.
+        _ => "{".into(),
+    };
+    encode_long(s.len() as i64, out);
+    out.extend_from_slice(s.as_bytes());
+    Ok(())
+}
+
+/// Push `len` bytes of a two's-complement `decimal` value, biased toward the
+/// sign-extension and boundary patterns that exercise the most intricate decode
+/// arithmetic in `numeric::twos_complement_be_to_numeric`: the narrow/wide split
+/// (`len <= 17`), the `negate_twos_complement_le` path (any negative value), and
+/// the wide-representation precision-overflow handling. Most of the time it
+/// still emits a uniform-random run so coverage guidance keeps exploring.
+fn push_twos_complement(u: &mut Unstructured, len: usize, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    let fill = match u.int_in_range(0u8..=9)? {
+        0 => 0x00u8, // zero / positive sign-extension
+        1 => 0xFF,   // -1 / negative sign-extension
+        2 => 0x80,   // sign bit set: most-negative leading byte
+        3 => 0x7F,   // largest-magnitude positive leading byte
+        // Uniform-random run the majority of the time.
+        _ => {
+            for _ in 0..len {
+                out.push(u.arbitrary::<u8>()?);
+            }
+            return Ok(());
+        }
+    };
+    // A constant run, optionally with one differing leading byte to drop a
+    // boundary value into an otherwise sign-extended field.
+    let lead = if len > 0 && u.int_in_range(0u8..=1)? == 1 {
+        Some(u.arbitrary::<u8>()?)
+    } else {
+        None
+    };
+    for i in 0..len {
+        out.push(if i == 0 { lead.unwrap_or(fill) } else { fill });
+    }
+    Ok(())
+}
+
+/// Pick the length of a `decimal`-over-`bytes` run, biased to the lengths that
+/// bracket the narrow/wide split (17) and the wide/overflow regime, plus the
+/// degenerate empty and single-byte cases.
+fn gen_decimal_len(u: &mut Unstructured) -> arbitrary::Result<usize> {
+    Ok(match u.int_in_range(0u8..=9)? {
+        0 => 0,
+        1 => 1,
+        2 => 16,
+        3 => 17,
+        4 => 18,
+        5 => 40,
+        _ => u.int_in_range(0usize..=40)?,
+    })
+}
+
+/// Avro-binary-encode one random value of type `ty` into `out`.
+fn encode_value(u: &mut Unstructured, ty: &Ty, out: &mut Vec<u8>) -> arbitrary::Result<()> {
+    match ty {
+        Ty::Bool => out.push(u.int_in_range(0u8..=1)?),
+        Ty::Int | Ty::Date => encode_long(i64::from(u.arbitrary::<i32>()?), out),
+        Ty::Long | Ty::TimestampMillis | Ty::TimestampMicros => {
+            encode_long(u.arbitrary::<i64>()?, out)
+        }
+        Ty::Float => out.extend_from_slice(&u.arbitrary::<f32>()?.to_le_bytes()),
+        Ty::Double => out.extend_from_slice(&u.arbitrary::<f64>()?.to_le_bytes()),
+        Ty::String => encode_str(u, out)?,
+        Ty::Bytes => encode_bytes(u, 12, out)?,
+        // Length-prefixed unscaled two's-complement run. The length (incl. the
+        // empty and narrow/wide-boundary cases) and the byte pattern are both
+        // biased toward the values that stress the decimal decode arithmetic. A
+        // zero-length run is the empty-decimal == 0 case (regression for the
+        // numeric.rs out-of-bounds panic).
+        Ty::DecimalBytes(_, _) => {
+            let len = gen_decimal_len(u)?;
+            encode_long(len as i64, out);
+            push_twos_complement(u, len, out)?;
+        }
+        // The fixed-backed decimal reads exactly `size` bytes (no length prefix),
+        // so only the byte pattern varies.
+        Ty::DecimalFixed(_, size, _, _) => {
+            push_twos_complement(u, usize::try_from(*size).expect("fixed size fits usize"), out)?;
+        }
+        Ty::Json => encode_json(u, out)?,
+        Ty::Uuid => {
+            let b: [u8; 16] = u.arbitrary()?;
+            let mut s = String::with_capacity(36);
+            for (i, byte) in b.iter().enumerate() {
+                if matches!(i, 4 | 6 | 8 | 10) {
+                    s.push('-');
+                }
+                s.push_str(&format!("{byte:02x}"));
+            }
+            encode_long(s.len() as i64, out);
+            out.extend_from_slice(s.as_bytes());
+        }
+        Ty::Fixed(_, size) => {
+            for _ in 0..*size {
+                out.push(u.arbitrary::<u8>()?);
+            }
+        }
+        // Symbols are A/B/C (indices 0..=2). Index 3 is an out-of-range index
+        // the decoder must reject without panicking.
+        Ty::Enum(_) => encode_long(u.int_in_range(0i64..=3)?, out),
+        Ty::Record(_, fields) => {
+            for f in fields {
+                encode_value(u, f, out)?;
+            }
+        }
+        Ty::Array(item) => {
+            let n = u.int_in_range(0i64..=3)?;
+            if n > 0 {
+                encode_long(n, out);
+                for _ in 0..n {
+                    encode_value(u, item, out)?;
+                }
+            }
+            encode_long(0, out); // end-of-blocks marker
+        }
+        Ty::Map(values) => {
+            let n = u.int_in_range(0i64..=3)?;
+            if n > 0 {
+                encode_long(n, out);
+                for _ in 0..n {
+                    encode_str(u, out)?; // key
+                    encode_value(u, values, out)?;
+                }
+            }
+            encode_long(0, out);
+        }
+        // union ["null", T]: branch 0 = null (no bytes), branch 1 = T.
+        Ty::Nullable(inner) => {
+            if u.int_in_range(0u8..=3)? == 0 {
+                encode_long(0, out);
+            } else {
+                encode_long(1, out);
+                encode_value(u, inner, out)?;
+            }
+        }
+        // Essential union: branches are written in declaration order. With a
+        // leading `null`, branch 0 = null and branch `i+1` = variant `i`.
+        // Without, branch `i` = variant `i`. Pick one branch and encode it.
+        Ty::EssentialUnion(has_null, variants) => {
+            let nbranches = variants.len() + usize::from(*has_null);
+            let branch = u.int_in_range(0usize..=nbranches - 1)?;
+            encode_long(branch as i64, out);
+            if *has_null {
+                if branch > 0 {
+                    encode_value(u, &variants[branch - 1], out)?;
+                }
+            } else {
+                encode_value(u, &variants[branch], out)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Whether *every* value `encode_value` can emit for `ty` is guaranteed to
+/// decode without error, i.e. the type carries no value-level validation the
+/// encoder can (deliberately) violate. When this holds for an uncorrupted body,
+/// a decode failure is a real bug, not an expected error path, so the caller
+/// can assert success instead of falling back to the panic-only oracle.
+///
+/// This intentionally EXCLUDES the types the encoder can drive out of their
+/// target domain, each of which the decoder is *supposed* to reject:
+///   * `enum`: the encoder emits an out-of-range symbol index (3).
+///   * `json`: the encoder sometimes emits invalid JSON (the `BadJson` path).
+///   * `decimal` (bytes / fixed): an unscaled run can exceed the precision.
+///   * `date` / `timestamp-*`: an arbitrary `int` / `long` can fall outside the
+///     representable chrono range.
+///   * `uuid`: kept out for safety even though the encoder writes canonical
+///     hex (the decoder still UTF-8- and `Uuid::parse_str`-validates it).
+///
+/// Everything left always round-trips for any value the encoder produces:
+///   * plain scalars: `bool` (0/1), `int`/`long` (canonical varints),
+///     `float`/`double` (raw IEEE bytes, NaN included), `string` (the encoder
+///     writes printable ASCII, which is valid UTF-8), `bytes`, and `fixed`
+///     (raw byte runs, no validation).
+///   * structural composites: records, arrays, maps (the decoder dedups keys
+///     via a `BTreeMap`, so even colliding ASCII keys are fine), and the
+///     `["null", T]` / essential unions, provided their children are decodable.
+fn decode_infallible(ty: &Ty) -> bool {
+    match ty {
+        Ty::Bool
+        | Ty::Int
+        | Ty::Long
+        | Ty::Float
+        | Ty::Double
+        | Ty::String
+        | Ty::Bytes
+        | Ty::Fixed(_, _) => true,
+        Ty::DecimalBytes(_, _)
+        | Ty::DecimalFixed(_, _, _, _)
+        | Ty::Date
+        | Ty::TimestampMillis
+        | Ty::TimestampMicros
+        | Ty::Uuid
+        | Ty::Json
+        | Ty::Enum(_) => false,
+        Ty::Record(_, fields) => fields.iter().all(decode_infallible),
+        Ty::Array(item) | Ty::Map(item) | Ty::Nullable(item) => decode_infallible(item),
+        Ty::EssentialUnion(_, variants) => variants.iter().all(decode_infallible),
+    }
+}
+
+/// A plain-scalar column for the round-trip correctness oracle. Restricted to
+/// the types whose decoded `Datum` is exactly determined by the encoded value,
+/// with no float NaN, no logical-type conversion, no multi-column union
+/// expansion.
+#[derive(Clone)]
+enum RtVal {
+    Null,
+    Bool(bool),
+    Int(i32),
+    Long(i64),
+    Str(String),
+    Bytes(Vec<u8>),
+}
+
+impl RtVal {
+    /// The `Datum` the Avro decoder must produce for this value (see the
+    /// `AvroFlatDecoder` scalar handlers: `int`->`Int32`, `long`->`Int64`,
+    /// `boolean`->`True`/`False`, `string`->`String`, `bytes`->`Bytes`, and a
+    /// selected-null `["null", T]` branch -> a single `Datum::Null`).
+    fn datum(&self) -> Datum<'_> {
+        match self {
+            RtVal::Null => Datum::Null,
+            RtVal::Bool(true) => Datum::True,
+            RtVal::Bool(false) => Datum::False,
+            RtVal::Int(v) => Datum::Int32(*v),
+            RtVal::Long(v) => Datum::Int64(*v),
+            RtVal::Str(s) => Datum::String(s),
+            RtVal::Bytes(b) => Datum::Bytes(b),
+        }
+    }
+
+    /// Avro-binary-encode this value as the body of its column. `nullable`
+    /// columns are `["null", T]`: branch 0 = null, branch 1 = the value.
+    fn encode(&self, nullable: bool, out: &mut Vec<u8>) {
+        if nullable {
+            encode_long(if matches!(self, RtVal::Null) { 0 } else { 1 }, out);
+        }
+        match self {
+            RtVal::Null => {} // null branch already written
+            RtVal::Bool(b) => out.push(u8::from(*b)),
+            RtVal::Int(v) => encode_long(i64::from(*v), out),
+            RtVal::Long(v) => encode_long(*v, out),
+            RtVal::Str(s) => {
+                encode_long(s.len() as i64, out);
+                out.extend_from_slice(s.as_bytes());
+            }
+            RtVal::Bytes(b) => {
+                encode_long(b.len() as i64, out);
+                out.extend_from_slice(b);
+            }
+        }
+    }
+}
+
+/// Round-trip *correctness* oracle. The panic / decode-success oracles only see
+/// crashes and wrongly-rejected input. A decode that succeeds but yields the
+/// *wrong* datum slips past both. So: build a record of plain scalars whose
+/// decoded `Datum` is fully determined, encode it, decode it, and assert the
+/// decoded `Row` is exactly the values we put in. Restricted to
+/// bool/int/long/string/bytes (and their `["null", T]` form), trivial, exact
+/// `Datum` mappings with no float NaN, logical-type, or union-column-expansion
+/// ambiguity, so any mismatch is a real decoder bug, never a harness artifact.
+fn run_roundtrip(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let ncols = u.int_in_range(1usize..=8)?;
+    let mut cols: Vec<(RtVal, bool)> = Vec::with_capacity(ncols);
+    for _ in 0..ncols {
+        let nullable = u.int_in_range(0u8..=1)? == 1;
+        // A nullable column is null a quarter of the time.
+        let val = if nullable && u.int_in_range(0u8..=3)? == 0 {
+            RtVal::Null
+        } else {
+            match u.int_in_range(0u8..=4)? {
+                0 => RtVal::Bool(u.int_in_range(0u8..=1)? == 1),
+                1 => RtVal::Int(u.arbitrary::<i32>()?),
+                2 => RtVal::Long(u.arbitrary::<i64>()?),
+                3 => {
+                    let n = u.int_in_range(0usize..=8)?;
+                    let mut s = String::with_capacity(n);
+                    for _ in 0..n {
+                        s.push(char::from(u.int_in_range(0x20u8..=0x7e)?));
+                    }
+                    RtVal::Str(s)
+                }
+                _ => {
+                    let n = u.int_in_range(0usize..=8)?;
+                    let mut b = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        b.push(u.arbitrary::<u8>()?);
+                    }
+                    RtVal::Bytes(b)
+                }
+            }
+        };
+        cols.push((val, nullable));
+    }
+
+    // Reader schema: a record of the chosen columns.
+    let mut schema = String::from("{\"type\":\"record\",\"name\":\"RT\",\"fields\":[");
+    for (i, (val, nullable)) in cols.iter().enumerate() {
+        if i > 0 {
+            schema.push(',');
+        }
+        let t = match val {
+            // For a null cell the column type only needs to be *some* scalar.
+            // The decoded datum is `Null` regardless. Use `int` as a stand-in.
+            RtVal::Null | RtVal::Int(_) => "\"int\"",
+            RtVal::Bool(_) => "\"boolean\"",
+            RtVal::Long(_) => "\"long\"",
+            RtVal::Str(_) => "\"string\"",
+            RtVal::Bytes(_) => "\"bytes\"",
+        };
+        if *nullable {
+            schema.push_str(&format!("{{\"name\":\"c{i}\",\"type\":[\"null\",{t}]}}"));
+        } else {
+            schema.push_str(&format!("{{\"name\":\"c{i}\",\"type\":{t}}}"));
+        }
+    }
+    schema.push_str("]}");
+
+    let Ok(mut decoder) = Decoder::new(&schema, &[], WriterSchemaProvider::None, "fuzz".into()) else {
+        // A record of plain scalars always validates. If not, nothing to check.
+        return Ok(());
+    };
+
+    let mut body = Vec::new();
+    for (val, nullable) in &cols {
+        val.encode(*nullable, &mut body);
+    }
+
+    let mut expected = Row::default();
+    {
+        let mut packer = expected.packer();
+        for (val, _) in &cols {
+            packer.push(val.datum());
+        }
+    }
+
+    let mut bytes = body.as_slice();
+    match rt().block_on(decoder.decode(&mut bytes)) {
+        Ok(Ok(decoded)) => assert_eq!(
+            decoded, expected,
+            "Avro decode produced the wrong row for a plain-scalar record\nschema = {schema}",
+        ),
+        Ok(Err(e)) => panic!("plain-scalar record failed to decode (schema = {schema}): {e}"),
+        Err(e) => panic!("plain-scalar record hit a transient decode error (schema = {schema}): {e}"),
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    // A fraction of inputs go to the round-trip correctness oracle (decoded row
+    // must equal the encoded values). The rest drive the schema-directed
+    // panic / decode-success target below.
+    if u.int_in_range(0u8..=3)? == 0 {
+        return run_roundtrip(&mut u);
+    }
+
+    // Top-level reader schema: a record whose fields span everything
+    // `validate_schema_2` accepts.
+    let mut counter = 0u32;
+    let nfields = u.int_in_range(1u8..=8)?;
+    let mut fields = Vec::with_capacity(nfields.into());
+    for _ in 0..nfields {
+        // Record fields, so essential unions (`gen_field`) are reachable here.
+        fields.push(gen_field(&mut u, &mut counter, 3)?);
+    }
+    let row = Ty::Record(0, fields);
+
+    let mut schema = String::new();
+    ty_to_json(&row, &mut schema);
+
+    // No CSR client and confluent_wire_format = false, so decode is
+    // self-contained (no network) over the generated reader schema.
+    let Ok(mut decoder) = Decoder::new(&schema, &[], WriterSchemaProvider::None, "fuzz".into()) else {
+        return Ok(());
+    };
+
+    // Body: usually a valid encoding (so the decoder runs deep), but a quarter
+    // of the time the raw remaining bytes, and otherwise a valid encoding
+    // occasionally truncated or single-byte corrupted. The non-valid forms keep
+    // the decoder's error paths covered: short read, bad length/union tag,
+    // inconsistent content.
+    // `assert_success` is set only when the body is a *clean* (uncorrupted)
+    // encoding of a type tree every node of which is guaranteed to decode for
+    // any value the encoder can produce (see `decode_infallible`). In that one
+    // case the decoder is round-tripping bytes it must accept, so a decode
+    // *error* is a real bug. The panic-only oracle that the random-bytes,
+    // truncated, corrupted, and value-validated (`enum`/`decimal`/`json`/…)
+    // arms rely on would silently miss it, the same class of regression as the
+    // deferred union-promotion error in #37087.
+    let mut assert_success = false;
+    let body = if u.int_in_range(0u8..=3)? == 0 {
+        u.take_rest().to_vec()
+    } else {
+        let mut b = Vec::new();
+        encode_value(&mut u, &row, &mut b)?;
+        match u.int_in_range(0u8..=9)? {
+            0 if !b.is_empty() => {
+                let keep = u.int_in_range(0usize..=b.len())?;
+                b.truncate(keep);
+            }
+            1 if !b.is_empty() => {
+                let i = u.int_in_range(0usize..=b.len() - 1)?;
+                b[i] ^= u.arbitrary::<u8>()?;
+            }
+            // Uncorrupted body: if its type is guaranteed decodable, the decode
+            // below must succeed.
+            _ => assert_success = decode_infallible(&row),
+        }
+        b
+    };
+
+    let mut bytes = body.as_slice();
+    let result = rt().block_on(decoder.decode(&mut bytes));
+    if assert_success {
+        // `decode` returns `Result<Result<Row, Error>, Error>`: the outer layer
+        // is the transient error path, the inner layer the decode outcome. A
+        // body the decoder rejects surfaces as `Ok(Err(_))`, so both layers must
+        // be unwrapped for the oracle to fire.
+        result
+            .expect("clean Avro body hit a transient decode error")
+            .expect(
+                "decoder rejected a clean, in-range Avro body whose every field is guaranteed \
+                 decodable; such a round-trip must succeed",
+            );
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/interchange/fuzz/fuzz_targets/json_encode.rs
+++ b/src/interchange/fuzz/fuzz_targets/json_encode.rs
@@ -1,0 +1,430 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `mz_interchange::json::encode_datums_as_json` formats a `Row`'s
+//! datums as JSON, the output path of a `FORMAT JSON` Kafka sink. (The JSON
+//! *source* decoder is just `Jsonb::from_slice`, already covered by
+//! `repr::jsonb_from_slice`.) Each datum is rendered per its column type, which
+//! has real per-type logic: floats (a JSON `Number` can't be NaN/Infinity),
+//! numerics, intervals, timestamps, dates, bytes. A panic there, or a value
+//! that can't be serialized, corrupts/halts a sink, so encoding then serializing
+//! must never panic for any well-typed row.
+//!
+//! Beyond scalars, we generate *composite* column types (`List`, `Map`,
+//! `Record`, multi-dimensional `Array`, and `Jsonb`) plus the remaining scalar
+//! shapes with their own encode logic (`Uuid`, `Char`/`VarChar` padding,
+//! `Range`, `MzAclItem`/`AclItem`). These drive the recursive encode paths that
+//! a scalar-only schema never reaches: `encode_array`'s dimension walk, the
+//! `Record`/`Map` field iteration (a `zip_eq` against the column type), and the
+//! `Jsonb -> serde_json` conversion. A `Row` ultimately comes from a source, so
+//! the *values* are arbitrary (NaN/Infinity floats, huge collections, deeply
+//! nested records), but they must be *well-typed* against the schema: we
+//! generate the type and a structurally matching datum in lockstep, so any panic
+//! is in the encoder, not a type/datum mismatch.
+
+#![no_main]
+
+use chrono::{DateTime, NaiveTime, Utc};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_interchange::json::encode_datums_as_json;
+use mz_repr::adt::char::CharLength;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::jsonb::JsonbPacker;
+use mz_repr::adt::mz_acl_item::{AclItem, MzAclItem};
+use mz_repr::adt::range::Range;
+use mz_repr::adt::system::Oid;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::adt::varchar::VarCharMaxLength;
+use mz_repr::role_id::RoleId;
+use mz_repr::strconv::parse_numeric;
+use mz_repr::{ColumnName, Datum, Row, RowPacker, SqlColumnType, SqlScalarType, Timestamp};
+use uuid::Uuid;
+
+/// A generated column type. Scalars are the leaves. The composite variants nest
+/// (with a depth bound) to drive the recursive encode paths. We keep the type
+/// structured so that `push_typed` can pack a value that matches it exactly.
+enum GType {
+    Scalar(SqlScalarType),
+    /// SQL `Jsonb`, packed via `JsonbPacker`, rendered by `to_serde_json`.
+    Jsonb,
+    /// `LIST` of `(nullable element, element type)`.
+    List(bool, Box<GType>),
+    /// `MAP` of string -> `(nullable value, value type)`.
+    Map(bool, Box<GType>),
+    /// `RECORD` of `(field nullable, field type)` columns. Encoding `zip_eq`s
+    /// the field types against the packed list, so they must line up.
+    Record(Vec<(bool, GType)>),
+    /// Multi-dimensional `ARRAY` of a scalar element. `dims` are the per-axis
+    /// lengths. The total element count is their product.
+    Array(Vec<usize>, SqlScalarType),
+}
+
+fn gen_naive_ts(
+    u: &mut Unstructured,
+) -> arbitrary::Result<CheckedTimestamp<chrono::NaiveDateTime>> {
+    let secs = u.int_in_range(-8_000_000_000_000i64..=8_000_000_000_000)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    Ok(DateTime::from_timestamp(secs, nanos)
+        .and_then(|d| CheckedTimestamp::from_timestamplike(d.naive_utc()).ok())
+        .unwrap_or_else(|| {
+            CheckedTimestamp::from_timestamplike(
+                DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
+            )
+            .unwrap()
+        }))
+}
+
+fn gen_utc_ts(u: &mut Unstructured) -> arbitrary::Result<CheckedTimestamp<DateTime<Utc>>> {
+    let secs = u.int_in_range(-8_000_000_000_000i64..=8_000_000_000_000)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    Ok(DateTime::from_timestamp(secs, nanos)
+        .and_then(|d| CheckedTimestamp::from_timestamplike(d).ok())
+        .unwrap_or_else(|| {
+            CheckedTimestamp::from_timestamplike(DateTime::from_timestamp(0, 0).unwrap()).unwrap()
+        }))
+}
+
+/// Generate a scalar type (a leaf of the composite tree, and the element type of
+/// arrays). Every type here is handled by `push_scalar`.
+fn gen_scalar_type(u: &mut Unstructured) -> arbitrary::Result<SqlScalarType> {
+    Ok(match u.int_in_range(0u8..=24)? {
+        0 => SqlScalarType::Bool,
+        1 => SqlScalarType::Int16,
+        2 => SqlScalarType::Int32,
+        3 => SqlScalarType::Int64,
+        4 => SqlScalarType::UInt16,
+        5 => SqlScalarType::UInt32,
+        6 => SqlScalarType::UInt64,
+        7 => SqlScalarType::PgLegacyChar,
+        8 => SqlScalarType::Float32,
+        9 => SqlScalarType::Float64,
+        10 => SqlScalarType::String,
+        11 => SqlScalarType::Bytes,
+        12 => SqlScalarType::Numeric { max_scale: None },
+        13 => SqlScalarType::Date,
+        14 => SqlScalarType::Time,
+        15 => SqlScalarType::Timestamp { precision: None },
+        16 => SqlScalarType::TimestampTz { precision: None },
+        17 => SqlScalarType::Interval,
+        18 => SqlScalarType::MzTimestamp,
+        19 => SqlScalarType::Uuid,
+        20 => {
+            let length = CharLength::try_from(i64::from(u.int_in_range(1u8..=12)?)).ok();
+            SqlScalarType::Char { length }
+        }
+        21 => {
+            let max_length = VarCharMaxLength::try_from(i64::from(u.int_in_range(1u8..=12)?)).ok();
+            SqlScalarType::VarChar { max_length }
+        }
+        // Range over Int32. `unwrap_range().to_string()` is the only logic.
+        22 => SqlScalarType::Range {
+            element_type: Box::new(SqlScalarType::Int32),
+        },
+        23 => SqlScalarType::MzAclItem,
+        _ => SqlScalarType::AclItem,
+    })
+}
+
+/// Generate a (possibly composite) column type, bounded by `depth`.
+fn gen_type(u: &mut Unstructured, depth: u32) -> arbitrary::Result<GType> {
+    if depth == 0 || u.is_empty() {
+        return Ok(match u.int_in_range(0u8..=1)? {
+            0 => GType::Jsonb,
+            _ => GType::Scalar(gen_scalar_type(u)?),
+        });
+    }
+    Ok(match u.int_in_range(0u8..=6)? {
+        0 | 1 => GType::Scalar(gen_scalar_type(u)?),
+        2 => GType::Jsonb,
+        3 => GType::List(bool::arbitrary(u)?, Box::new(gen_type(u, depth - 1)?)),
+        4 => GType::Map(bool::arbitrary(u)?, Box::new(gen_type(u, depth - 1)?)),
+        5 => {
+            let n = u.int_in_range(0u8..=4)?;
+            let mut fields = Vec::with_capacity(n.into());
+            for _ in 0..n {
+                fields.push((bool::arbitrary(u)?, gen_type(u, depth - 1)?));
+            }
+            GType::Record(fields)
+        }
+        // Arrays nest only scalars (Materialize arrays don't hold collections),
+        // but can have multiple dimensions.
+        _ => {
+            let ndims = u.int_in_range(1usize..=3)?;
+            let mut dims = Vec::with_capacity(ndims);
+            for _ in 0..ndims {
+                dims.push(u.int_in_range(0usize..=3)?);
+            }
+            GType::Array(dims, gen_scalar_type(u)?)
+        }
+    })
+}
+
+/// The `SqlScalarType` corresponding to a `GType`, for the column schema.
+fn to_scalar_type(ty: &GType) -> SqlScalarType {
+    match ty {
+        GType::Scalar(s) => s.clone(),
+        GType::Jsonb => SqlScalarType::Jsonb,
+        GType::List(_, elem) => SqlScalarType::List {
+            element_type: Box::new(to_scalar_type(elem)),
+            custom_id: None,
+        },
+        GType::Map(_, value) => SqlScalarType::Map {
+            value_type: Box::new(to_scalar_type(value)),
+            custom_id: None,
+        },
+        GType::Record(fields) => SqlScalarType::Record {
+            fields: fields
+                .iter()
+                .enumerate()
+                .map(|(i, (nullable, ty))| {
+                    (
+                        ColumnName::from(format!("f{i}")),
+                        SqlColumnType {
+                            scalar_type: to_scalar_type(ty),
+                            nullable: *nullable,
+                        },
+                    )
+                })
+                .collect(),
+            custom_id: None,
+        },
+        GType::Array(_, elem) => SqlScalarType::Array(Box::new(elem.clone())),
+    }
+}
+
+/// Build a small, valid JSON string of bounded depth for the `Jsonb` path.
+fn gen_json_text(u: &mut Unstructured) -> arbitrary::Result<String> {
+    Ok(match u.int_in_range(0u8..=7)? {
+        0 => "null".into(),
+        1 => "true".into(),
+        2 => format!("{}", u.arbitrary::<i64>()?),
+        3 => format!("{}.25", u.arbitrary::<i32>()?),
+        4 => "\"s\"".into(),
+        5 => "[1,2,3]".into(),
+        6 => "{\"a\":1,\"b\":[true,null]}".into(),
+        _ => "[]".into(),
+    })
+}
+
+/// Push one scalar datum of `ty` (or NULL when allowed). Out-of-range
+/// constructed values fall back to a valid datum so the row always matches the
+/// column type.
+fn push_scalar(
+    packer: &mut RowPacker,
+    u: &mut Unstructured,
+    ty: &SqlScalarType,
+    nullable: bool,
+) -> arbitrary::Result<()> {
+    if nullable && u.ratio(1u8, 8u8)? {
+        packer.push(Datum::Null);
+        return Ok(());
+    }
+    match ty {
+        SqlScalarType::Bool => packer.push(if bool::arbitrary(u)? {
+            Datum::True
+        } else {
+            Datum::False
+        }),
+        SqlScalarType::Int16 => packer.push(Datum::Int16(i16::arbitrary(u)?)),
+        SqlScalarType::Int32 => packer.push(Datum::Int32(i32::arbitrary(u)?)),
+        SqlScalarType::Int64 => packer.push(Datum::Int64(i64::arbitrary(u)?)),
+        SqlScalarType::UInt16 => packer.push(Datum::UInt16(u16::arbitrary(u)?)),
+        SqlScalarType::UInt32 => packer.push(Datum::UInt32(u32::arbitrary(u)?)),
+        SqlScalarType::UInt64 => packer.push(Datum::UInt64(u64::arbitrary(u)?)),
+        SqlScalarType::PgLegacyChar => packer.push(Datum::UInt8(u8::arbitrary(u)?)),
+        // `f{32,64}::arbitrary` produces NaN/Infinity, which a JSON Number cannot
+        // represent, exactly the encoding edge we want to exercise.
+        SqlScalarType::Float32 => packer.push(Datum::Float32(f32::arbitrary(u)?.into())),
+        SqlScalarType::Float64 => packer.push(Datum::Float64(f64::arbitrary(u)?.into())),
+        SqlScalarType::String
+        | SqlScalarType::VarChar { .. }
+        | SqlScalarType::Char { .. } => packer.push(Datum::String(<&str>::arbitrary(u)?)),
+        SqlScalarType::Bytes => packer.push(Datum::Bytes(<&[u8]>::arbitrary(u)?)),
+        SqlScalarType::Numeric { .. } => {
+            let s = format!("{}.{}", i64::arbitrary(u)?, u32::arbitrary(u)?);
+            let n = parse_numeric(&s).unwrap_or_else(|_| parse_numeric("0").unwrap());
+            packer.push(Datum::Numeric(n));
+        }
+        SqlScalarType::Date => {
+            let d = Date::from_pg_epoch(i32::arbitrary(u)?)
+                .unwrap_or_else(|_| Date::from_pg_epoch(0).unwrap());
+            packer.push(Datum::Date(d));
+        }
+        SqlScalarType::Time => {
+            let secs = u.int_in_range(0u32..=86_399)?;
+            let nanos = u.int_in_range(0u32..=999_999_999)?;
+            let t = NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).unwrap();
+            packer.push(Datum::Time(t));
+        }
+        SqlScalarType::Timestamp { .. } => packer.push(Datum::Timestamp(gen_naive_ts(u)?)),
+        SqlScalarType::TimestampTz { .. } => packer.push(Datum::TimestampTz(gen_utc_ts(u)?)),
+        SqlScalarType::Interval => packer.push(Datum::Interval(Interval::new(
+            i32::arbitrary(u)?,
+            i32::arbitrary(u)?,
+            i64::arbitrary(u)?,
+        ))),
+        SqlScalarType::MzTimestamp => {
+            packer.push(Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?)))
+        }
+        SqlScalarType::Uuid => packer.push(Datum::Uuid(Uuid::from_u128(u.arbitrary::<u128>()?))),
+        // The empty range is always valid and its `to_string` is exercised.
+        SqlScalarType::Range { .. } => packer.push(Datum::Range(Range { inner: None })),
+        SqlScalarType::MzAclItem => {
+            let item = MzAclItem::empty(RoleId::User(u.arbitrary::<u64>()?), RoleId::Public);
+            packer.push(Datum::MzAclItem(item));
+        }
+        SqlScalarType::AclItem => {
+            let item = AclItem::empty(Oid(u.arbitrary::<u32>()?), Oid(u.arbitrary::<u32>()?));
+            packer.push(Datum::AclItem(item));
+        }
+        // `gen_scalar_type` never produces other types.
+        _ => packer.push(Datum::Null),
+    }
+    Ok(())
+}
+
+/// Push a value of `ty` (or NULL when allowed) into `packer`, recursing into
+/// composites so the packed structure matches `to_scalar_type(ty)` exactly.
+fn push_typed(
+    packer: &mut RowPacker,
+    u: &mut Unstructured,
+    ty: &GType,
+    nullable: bool,
+) -> arbitrary::Result<()> {
+    match ty {
+        GType::Scalar(s) => push_scalar(packer, u, s, nullable)?,
+        GType::Jsonb => {
+            if nullable && u.ratio(1u8, 8u8)? {
+                packer.push(Datum::Null);
+            } else {
+                let text = gen_json_text(u)?;
+                // The text is always valid JSON by construction.
+                JsonbPacker::new(packer)
+                    .pack_str(&text)
+                    .expect("generated valid json");
+            }
+        }
+        GType::List(elem_nullable, elem) => {
+            if nullable && u.ratio(1u8, 8u8)? {
+                packer.push(Datum::Null);
+            } else {
+                let n = u.int_in_range(0usize..=4)?;
+                packer.push_list_with(|packer| {
+                    for _ in 0..n {
+                        push_typed(packer, u, elem, *elem_nullable)?;
+                    }
+                    Ok::<_, arbitrary::Error>(())
+                })?;
+            }
+        }
+        GType::Map(value_nullable, value) => {
+            if nullable && u.ratio(1u8, 8u8)? {
+                packer.push(Datum::Null);
+            } else {
+                let n = u.int_in_range(0usize..=4)?;
+                packer.push_dict_with(|packer| {
+                    // Keys must be pushed in ascending order and be unique. The
+                    // zero-padded counter is lexically ascending.
+                    for i in 0..n {
+                        packer.push(Datum::String(&format!("k{i:03}")));
+                        push_typed(packer, u, value, *value_nullable)?;
+                    }
+                    Ok::<_, arbitrary::Error>(())
+                })?;
+            }
+        }
+        GType::Record(fields) => {
+            if nullable && u.ratio(1u8, 8u8)? {
+                packer.push(Datum::Null);
+            } else {
+                packer.push_list_with(|packer| {
+                    for (field_nullable, field_ty) in fields {
+                        push_typed(packer, u, field_ty, *field_nullable)?;
+                    }
+                    Ok::<_, arbitrary::Error>(())
+                })?;
+            }
+        }
+        GType::Array(dims, elem) => {
+            if nullable && u.ratio(1u8, 8u8)? {
+                packer.push(Datum::Null);
+                return Ok(());
+            }
+            // `try_push_array` requires exactly `prod(dims)` elements. A
+            // zero-length axis collapses the whole array to empty.
+            let nelements: usize = dims.iter().product();
+            let array_dims: Vec<mz_repr::adt::array::ArrayDimension> = dims
+                .iter()
+                .map(|&length| mz_repr::adt::array::ArrayDimension {
+                    lower_bound: 1,
+                    length,
+                })
+                .collect();
+            // Build the elements into a scratch row first (array elements are
+            // always nullable in the encoder).
+            let mut scratch = Row::default();
+            {
+                let mut sp = scratch.packer();
+                for _ in 0..nelements {
+                    push_scalar(&mut sp, u, elem, true)?;
+                }
+            }
+            let elems: Vec<Datum> = scratch.iter().collect();
+            // The dims and element count match by construction, so this can't
+            // return an error. If it somehow does, fall back to an empty array.
+            if packer.try_push_array(&array_dims, elems).is_err() {
+                packer.try_push_array(&[], std::iter::empty::<Datum>()).unwrap();
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let ncols = u.int_in_range(1usize..=6)?;
+    let mut types: Vec<(bool, GType)> = Vec::with_capacity(ncols);
+    for _ in 0..ncols {
+        types.push((bool::arbitrary(u)?, gen_type(u, 3)?));
+    }
+
+    let columns: Vec<(ColumnName, SqlColumnType)> = types
+        .iter()
+        .enumerate()
+        .map(|(i, (nullable, ty))| {
+            (
+                ColumnName::from(format!("c{i}")),
+                SqlColumnType {
+                    scalar_type: to_scalar_type(ty),
+                    nullable: *nullable,
+                },
+            )
+        })
+        .collect();
+
+    let mut row = Row::default();
+    {
+        let mut packer = row.packer();
+        for (nullable, ty) in &types {
+            push_typed(&mut packer, u, ty, *nullable)?;
+        }
+    }
+
+    // Encode the row's datums as JSON (the sink path) and serialize the result.
+    // Neither step may panic for any well-typed row.
+    let value = encode_datums_as_json(row.iter(), &columns);
+    let _ = serde_json::to_vec(&value);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/interchange/fuzz/fuzz_targets/protobuf_decode_fuzzed_schema.rs
+++ b/src/interchange/fuzz/fuzz_targets/protobuf_decode_fuzzed_schema.rs
@@ -1,0 +1,573 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `mz_interchange::protobuf` over a *fuzzer-generated* descriptor
+//! rather than a fixed one. A `FORMAT PROTOBUF` source carries a user-supplied
+//! `FileDescriptorSet` (the `USING SCHEMA` blob), so `DecodedDescriptors::from_bytes`
+//! and the hand-written `derive_inner_type` validator it runs are themselves an
+//! untrusted-input surface, and a fixed descriptor never exercises them with
+//! anything but one well-formed schema. The interesting paths are the ones a
+//! single descriptor can't reach: recursion detection (a message field
+//! referencing its own or a mutually-referencing message must be rejected, not
+//! stack-overflow), the full scalar `Kind` mapping, enums, and repeated fields.
+//!
+//! Critically, we don't feed *random bytes* as the body: prost reads a field
+//! tag then skips/short-circuits on most random bytes, so a random body rarely
+//! reaches the decode-to-`Row` conversion (scalar `Kind` mapping, enum -> string,
+//! repeated -> list, nested message -> record). Instead we keep the schema
+//! structured (`MsgDef`/`FieldTy`), build the `FileDescriptorSet` from it, and
+//! protobuf-binary-encode a valid body for the top message against that same
+//! structure, bounding recursion through cyclic message refs by emitting empty
+//! nested messages at the depth limit. Both wire formats are exercised: the
+//! Confluent variant gets the 5-byte schema-registry header prepended so its
+//! body decodes just as deeply. We keep the error-path coverage a random body
+//! gave, though: a quarter of the inputs feed the raw remaining bytes, and
+//! others truncate or single-byte-corrupt the valid encoding. Neither
+//! validation nor decoding may panic.
+//!
+//! Beyond the well-formed-schema happy path, we drive the descriptor-validation
+//! surface harder. Some schemas grow a `map<string,string>` field (a repeated
+//! field of a `map_entry`-tagged message): `derive_column_type` is supposed to
+//! *reject* maps (`field.is_map()`), so this exercises that rejection cleanly
+//! rather than only ever feeding it map-free input. Field numbers are
+//! fuzzer-chosen in a small range, so gaps, out-of-order, and duplicate numbers
+//! all occur. Duplicates are an invalid descriptor `DescriptorPool::decode`
+//! must reject without panicking. Packable repeated scalars are sometimes
+//! emitted in proto3's packed wire form (one length-delimited blob of
+//! back-to-back values) instead of tag-per-element, covering the packed decode
+//! path. Finally the *root* message the decoder is pointed at is fuzzer-chosen
+//! among the generated messages, not pinned to `M0`.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_interchange::protobuf::{DecodedDescriptors, Decoder};
+use prost::Message;
+use prost_types::field_descriptor_proto::{Label, Type};
+use prost_types::{
+    DescriptorProto, EnumDescriptorProto, EnumValueDescriptorProto, FieldDescriptorProto,
+    FileDescriptorProto, FileDescriptorSet, MessageOptions,
+};
+
+/// Name of the synthetic `map_entry` message that backs generated `map` fields.
+const MAP_ENTRY: &str = "MapEntry";
+
+/// A generated field type. Kept structured (rather than going straight to a
+/// `FieldDescriptorProto`) so the body encoder can walk the exact same shape.
+/// A repeated field is one descriptor entry but N encoded values, and a message
+/// field needs the referenced message's structure to encode a nested value.
+enum FieldTy {
+    Int32,
+    Int64,
+    Uint32,
+    Uint64,
+    Sint32,
+    Sint64,
+    Fixed32,
+    Fixed64,
+    Sfixed32,
+    Sfixed64,
+    Bool,
+    StringT,
+    Bytes,
+    Float,
+    Double,
+    /// Reference to enum `E{0}`.
+    Enum(u8),
+    /// Reference to message `M{0}`, may equal the containing message (a cycle).
+    Message(u8),
+    /// `map<string,string>`, a repeated reference to the `map_entry`-tagged
+    /// `MapEntry` message. `derive_column_type` rejects this, so the descriptor
+    /// it appears in fails validation (exercising the map-rejection path).
+    Map,
+}
+
+struct FieldDef {
+    number: i32,
+    ty: FieldTy,
+    repeated: bool,
+}
+
+struct MsgDef {
+    fields: Vec<FieldDef>,
+}
+
+/// Generate the message/enum structure. `enum_nvals[j]` is the number of values
+/// in enum `E{j}`.
+fn gen_schema(u: &mut Unstructured) -> arbitrary::Result<(Vec<MsgDef>, Vec<u8>)> {
+    let num_msgs = u.int_in_range(1u8..=4)?;
+    let num_enums = u.int_in_range(0u8..=2)?;
+
+    let mut enum_nvals = Vec::with_capacity(num_enums.into());
+    for _ in 0..num_enums {
+        enum_nvals.push(u.int_in_range(1u8..=3)?);
+    }
+
+    let mut msgs = Vec::with_capacity(num_msgs.into());
+    for _ in 0..num_msgs {
+        let nfields = u.int_in_range(0u8..=6)?;
+        let mut fields = Vec::with_capacity(nfields.into());
+        for fi in 0..nfields {
+            let repeated = bool::arbitrary(u)?;
+            let ty = match u.int_in_range(0u8..=17)? {
+                0 => FieldTy::Int32,
+                1 => FieldTy::Int64,
+                2 => FieldTy::Uint32,
+                3 => FieldTy::Uint64,
+                4 => FieldTy::Sint32,
+                5 => FieldTy::Sint64,
+                6 => FieldTy::Fixed32,
+                7 => FieldTy::Fixed64,
+                8 => FieldTy::Sfixed32,
+                9 => FieldTy::Sfixed64,
+                10 => FieldTy::Bool,
+                11 => FieldTy::StringT,
+                12 => FieldTy::Bytes,
+                13 => FieldTy::Float,
+                14 => FieldTy::Double,
+                15 if num_enums > 0 => FieldTy::Enum(u.int_in_range(0u8..=num_enums - 1)?),
+                16 => FieldTy::Map,
+                _ => FieldTy::Message(u.int_in_range(0u8..=num_msgs - 1)?),
+            };
+            // Field numbers are usually the sequential `fi + 1`, but sometimes a
+            // fuzzer-chosen small number, producing gaps, reordering, and
+            // duplicate numbers (the last being an invalid descriptor that
+            // `DescriptorPool::decode` must reject without panicking).
+            let number = if u.int_in_range(0u8..=3)? == 0 {
+                i32::from(u.int_in_range(1u8..=8)?)
+            } else {
+                i32::from(fi) + 1
+            };
+            fields.push(FieldDef {
+                number,
+                ty,
+                repeated,
+            });
+        }
+        msgs.push(MsgDef { fields });
+    }
+
+    Ok((msgs, enum_nvals))
+}
+
+fn field_proto(f: &FieldDef) -> FieldDescriptorProto {
+    let (ty, type_name) = match &f.ty {
+        FieldTy::Int32 => (Type::Int32, None),
+        FieldTy::Int64 => (Type::Int64, None),
+        FieldTy::Uint32 => (Type::Uint32, None),
+        FieldTy::Uint64 => (Type::Uint64, None),
+        FieldTy::Sint32 => (Type::Sint32, None),
+        FieldTy::Sint64 => (Type::Sint64, None),
+        FieldTy::Fixed32 => (Type::Fixed32, None),
+        FieldTy::Fixed64 => (Type::Fixed64, None),
+        FieldTy::Sfixed32 => (Type::Sfixed32, None),
+        FieldTy::Sfixed64 => (Type::Sfixed64, None),
+        FieldTy::Bool => (Type::Bool, None),
+        FieldTy::StringT => (Type::String, None),
+        FieldTy::Bytes => (Type::Bytes, None),
+        FieldTy::Float => (Type::Float, None),
+        FieldTy::Double => (Type::Double, None),
+        FieldTy::Enum(j) => (Type::Enum, Some(format!(".fuzz.E{j}"))),
+        FieldTy::Message(r) => (Type::Message, Some(format!(".fuzz.M{r}"))),
+        // A map field is a repeated reference to the map_entry message.
+        FieldTy::Map => (Type::Message, Some(format!(".fuzz.{MAP_ENTRY}"))),
+    };
+    // Map fields must be repeated for `is_map()` to fire.
+    let label = if f.repeated || matches!(f.ty, FieldTy::Map) {
+        Label::Repeated
+    } else {
+        Label::Optional
+    };
+    FieldDescriptorProto {
+        name: Some(format!("f{}", f.number - 1)),
+        number: Some(f.number),
+        label: Some(label as i32),
+        r#type: Some(ty as i32),
+        type_name,
+        ..Default::default()
+    }
+}
+
+/// Build the `FileDescriptorSet` blob (`USING SCHEMA`) from the structure.
+fn build_fds(msgs: &[MsgDef], enum_nvals: &[u8]) -> Vec<u8> {
+    let enums = enum_nvals
+        .iter()
+        .enumerate()
+        .map(|(j, &nvals)| EnumDescriptorProto {
+            name: Some(format!("E{j}")),
+            // proto3 requires the first enum value to be zero.
+            value: (0..nvals)
+                .map(|v| EnumValueDescriptorProto {
+                    name: Some(format!("E{j}_{v}")),
+                    number: Some(i32::from(v)),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        })
+        .collect();
+
+    let mut messages: Vec<DescriptorProto> = msgs
+        .iter()
+        .enumerate()
+        .map(|(mi, m)| DescriptorProto {
+            name: Some(format!("M{mi}")),
+            field: m.fields.iter().map(field_proto).collect(),
+            ..Default::default()
+        })
+        .collect();
+
+    // The synthetic `map_entry` message backing `map<string,string>` fields:
+    // key = 1, value = 2, with `MessageOptions.map_entry = true` so prost-reflect
+    // reports `is_map_entry()` (and the referencing field reports `is_map()`).
+    messages.push(DescriptorProto {
+        name: Some(MAP_ENTRY.to_owned()),
+        field: vec![
+            FieldDescriptorProto {
+                name: Some("key".to_owned()),
+                number: Some(1),
+                label: Some(Label::Optional as i32),
+                r#type: Some(Type::String as i32),
+                ..Default::default()
+            },
+            FieldDescriptorProto {
+                name: Some("value".to_owned()),
+                number: Some(2),
+                label: Some(Label::Optional as i32),
+                r#type: Some(Type::String as i32),
+                ..Default::default()
+            },
+        ],
+        options: Some(MessageOptions {
+            map_entry: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let file = FileDescriptorProto {
+        name: Some("fuzz.proto".to_owned()),
+        package: Some("fuzz".to_owned()),
+        message_type: messages,
+        enum_type: enums,
+        syntax: Some("proto3".to_owned()),
+        ..Default::default()
+    };
+    FileDescriptorSet { file: vec![file] }.encode_to_vec()
+}
+
+/// Encode an unsigned protobuf varint.
+fn encode_varint(mut v: u64, out: &mut Vec<u8>) {
+    loop {
+        if v < 0x80 {
+            out.push(v as u8);
+            return;
+        }
+        out.push((v as u8 & 0x7f) | 0x80);
+        v >>= 7;
+    }
+}
+
+/// Encode a field tag: `(field_number << 3) | wire_type`.
+fn encode_tag(number: i32, wire_type: u8, out: &mut Vec<u8>) {
+    encode_varint(((number as u64) << 3) | u64::from(wire_type), out);
+}
+
+fn encode_len_delimited(number: i32, bytes: &[u8], out: &mut Vec<u8>) {
+    encode_tag(number, 2, out);
+    encode_varint(bytes.len() as u64, out);
+    out.extend_from_slice(bytes);
+}
+
+/// Encode one occurrence of a field (tag + value).
+fn encode_field(
+    msgs: &[MsgDef],
+    enum_nvals: &[u8],
+    f: &FieldDef,
+    depth: u32,
+    u: &mut Unstructured,
+    out: &mut Vec<u8>,
+) -> arbitrary::Result<()> {
+    let n = f.number;
+    match &f.ty {
+        // wire type 0: varint.
+        FieldTy::Int32 => {
+            encode_tag(n, 0, out);
+            encode_varint(i64::from(u.arbitrary::<i32>()?) as u64, out);
+        }
+        FieldTy::Int64 => {
+            encode_tag(n, 0, out);
+            encode_varint(u.arbitrary::<i64>()? as u64, out);
+        }
+        FieldTy::Uint32 => {
+            encode_tag(n, 0, out);
+            encode_varint(u64::from(u.arbitrary::<u32>()?), out);
+        }
+        FieldTy::Uint64 => {
+            encode_tag(n, 0, out);
+            encode_varint(u.arbitrary::<u64>()?, out);
+        }
+        FieldTy::Sint32 => {
+            encode_tag(n, 0, out);
+            let v = u.arbitrary::<i32>()?;
+            encode_varint((((v << 1) ^ (v >> 31)) as u32).into(), out);
+        }
+        FieldTy::Sint64 => {
+            encode_tag(n, 0, out);
+            let v = u.arbitrary::<i64>()?;
+            encode_varint(((v << 1) ^ (v >> 63)) as u64, out);
+        }
+        FieldTy::Bool => {
+            encode_tag(n, 0, out);
+            encode_varint(u.int_in_range(0u64..=1)?, out);
+        }
+        FieldTy::Enum(j) => {
+            encode_tag(n, 0, out);
+            // Valid values are 0..nvals. `nvals` itself is one out-of-range
+            // index (proto3 open enums accept it, the decoder maps it).
+            let nvals = u64::from(enum_nvals[usize::from(*j)]);
+            encode_varint(u.int_in_range(0u64..=nvals)?, out);
+        }
+        // wire type 1: 64-bit.
+        FieldTy::Fixed64 => {
+            encode_tag(n, 1, out);
+            out.extend_from_slice(&u.arbitrary::<u64>()?.to_le_bytes());
+        }
+        FieldTy::Sfixed64 => {
+            encode_tag(n, 1, out);
+            out.extend_from_slice(&u.arbitrary::<i64>()?.to_le_bytes());
+        }
+        FieldTy::Double => {
+            encode_tag(n, 1, out);
+            out.extend_from_slice(&u.arbitrary::<f64>()?.to_le_bytes());
+        }
+        // wire type 5: 32-bit.
+        FieldTy::Fixed32 => {
+            encode_tag(n, 5, out);
+            out.extend_from_slice(&u.arbitrary::<u32>()?.to_le_bytes());
+        }
+        FieldTy::Sfixed32 => {
+            encode_tag(n, 5, out);
+            out.extend_from_slice(&u.arbitrary::<i32>()?.to_le_bytes());
+        }
+        FieldTy::Float => {
+            encode_tag(n, 5, out);
+            out.extend_from_slice(&u.arbitrary::<f32>()?.to_le_bytes());
+        }
+        // wire type 2: length-delimited.
+        FieldTy::StringT => {
+            let len = u.int_in_range(0usize..=8)?;
+            let mut s = Vec::with_capacity(len);
+            for _ in 0..len {
+                s.push(u.int_in_range(0x20u8..=0x7e)?);
+            }
+            encode_len_delimited(n, &s, out);
+        }
+        FieldTy::Bytes => {
+            let len = u.int_in_range(0usize..=8)?;
+            let mut b = Vec::with_capacity(len);
+            for _ in 0..len {
+                b.push(u.arbitrary::<u8>()?);
+            }
+            encode_len_delimited(n, &b, out);
+        }
+        FieldTy::Message(r) => {
+            // Bound recursion through cyclic refs: at the depth limit emit an
+            // empty (all-defaults) nested message.
+            let mut nested = Vec::new();
+            if depth > 0 {
+                encode_message(msgs, enum_nvals, usize::from(*r), depth - 1, u, &mut nested)?;
+            }
+            encode_len_delimited(n, &nested, out);
+        }
+        FieldTy::Map => {
+            // One map entry: a length-delimited message with key=1, value=2
+            // (both string). The descriptor with a map field never decodes (it's
+            // rejected at validation), but a valid body keeps generation honest.
+            let mut entry = Vec::new();
+            let mut k = Vec::new();
+            for _ in 0..u.int_in_range(0usize..=4)? {
+                k.push(u.int_in_range(0x20u8..=0x7e)?);
+            }
+            encode_len_delimited(1, &k, &mut entry);
+            let mut v = Vec::new();
+            for _ in 0..u.int_in_range(0usize..=4)? {
+                v.push(u.int_in_range(0x20u8..=0x7e)?);
+            }
+            encode_len_delimited(2, &v, &mut entry);
+            encode_len_delimited(n, &entry, out);
+        }
+    }
+    Ok(())
+}
+
+/// Whether a scalar field type can be encoded in proto3's packed wire form
+/// (varint / fixed32 / fixed64 scalars). Strings, bytes, messages, and maps
+/// cannot be packed.
+fn is_packable(ty: &FieldTy) -> bool {
+    matches!(
+        ty,
+        FieldTy::Int32
+            | FieldTy::Int64
+            | FieldTy::Uint32
+            | FieldTy::Uint64
+            | FieldTy::Sint32
+            | FieldTy::Sint64
+            | FieldTy::Bool
+            | FieldTy::Enum(_)
+            | FieldTy::Fixed32
+            | FieldTy::Fixed64
+            | FieldTy::Sfixed32
+            | FieldTy::Sfixed64
+            | FieldTy::Float
+            | FieldTy::Double
+    )
+}
+
+/// Encode just the value (no tag) of a packable scalar field, the element form
+/// inside a packed repeated field's length-delimited blob.
+fn encode_scalar_value(
+    enum_nvals: &[u8],
+    f: &FieldDef,
+    u: &mut Unstructured,
+    out: &mut Vec<u8>,
+) -> arbitrary::Result<()> {
+    match &f.ty {
+        FieldTy::Int32 => encode_varint(i64::from(u.arbitrary::<i32>()?) as u64, out),
+        FieldTy::Int64 => encode_varint(u.arbitrary::<i64>()? as u64, out),
+        FieldTy::Uint32 => encode_varint(u64::from(u.arbitrary::<u32>()?), out),
+        FieldTy::Uint64 => encode_varint(u.arbitrary::<u64>()?, out),
+        FieldTy::Sint32 => {
+            let v = u.arbitrary::<i32>()?;
+            encode_varint((((v << 1) ^ (v >> 31)) as u32).into(), out);
+        }
+        FieldTy::Sint64 => {
+            let v = u.arbitrary::<i64>()?;
+            encode_varint(((v << 1) ^ (v >> 63)) as u64, out);
+        }
+        FieldTy::Bool => encode_varint(u.int_in_range(0u64..=1)?, out),
+        FieldTy::Enum(j) => {
+            let nvals = u64::from(enum_nvals[usize::from(*j)]);
+            encode_varint(u.int_in_range(0u64..=nvals)?, out);
+        }
+        FieldTy::Fixed64 => out.extend_from_slice(&u.arbitrary::<u64>()?.to_le_bytes()),
+        FieldTy::Sfixed64 => out.extend_from_slice(&u.arbitrary::<i64>()?.to_le_bytes()),
+        FieldTy::Double => out.extend_from_slice(&u.arbitrary::<f64>()?.to_le_bytes()),
+        FieldTy::Fixed32 => out.extend_from_slice(&u.arbitrary::<u32>()?.to_le_bytes()),
+        FieldTy::Sfixed32 => out.extend_from_slice(&u.arbitrary::<i32>()?.to_le_bytes()),
+        FieldTy::Float => out.extend_from_slice(&u.arbitrary::<f32>()?.to_le_bytes()),
+        // Unreachable: callers gate on `is_packable`.
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Encode a valid body for message `M{idx}`.
+fn encode_message(
+    msgs: &[MsgDef],
+    enum_nvals: &[u8],
+    idx: usize,
+    depth: u32,
+    u: &mut Unstructured,
+    out: &mut Vec<u8>,
+) -> arbitrary::Result<()> {
+    let Some(msg) = msgs.get(idx) else {
+        return Ok(());
+    };
+    for f in &msg.fields {
+        // Repeated fields get 0..=3 occurrences, singular fields 0..=1
+        // (proto3 fields are optional). Message fields at the depth limit are
+        // omitted entirely to break cycles.
+        let max = if matches!(f.ty, FieldTy::Message(_)) && depth == 0 {
+            0
+        } else if f.repeated {
+            3
+        } else {
+            1
+        };
+        let count = u.int_in_range(0u8..=max)?;
+        // A repeated packable scalar is sometimes emitted in proto3's packed wire
+        // form (one length-delimited blob of back-to-back values) instead of a
+        // tag per element, to exercise the packed decode path. (`prost` accepts
+        // either encoding for a packed field.)
+        if f.repeated && count > 0 && is_packable(&f.ty) && u.int_in_range(0u8..=1)? == 0 {
+            let mut packed = Vec::new();
+            for _ in 0..count {
+                encode_scalar_value(enum_nvals, f, u, &mut packed)?;
+            }
+            encode_len_delimited(f.number, &packed, out);
+        } else {
+            for _ in 0..count {
+                encode_field(msgs, enum_nvals, f, depth, u, out)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let (msgs, enum_nvals) = gen_schema(&mut u)?;
+    let fds = build_fds(&msgs, &enum_nvals);
+
+    // The decoder's root message is fuzzer-chosen among the generated messages,
+    // not pinned to M0, so the various field shapes get exercised as the *top*
+    // message (where columns are derived directly) and not only when nested.
+    let root = usize::from(u.int_in_range(0u8..=u8::try_from(msgs.len() - 1).unwrap())?);
+    let root_name = format!("fuzz.M{root}");
+
+    // Body for the root message: usually a valid encoding (so prost decodes
+    // through to the Row conversion), but a quarter of the time the raw remaining
+    // bytes, and otherwise a valid encoding occasionally truncated or single-byte
+    // corrupted. The non-valid forms keep the decoder's error paths covered: bad
+    // tag/wire-type, length overrun, unexpected EOF.
+    let body = if u.int_in_range(0u8..=3)? == 0 {
+        u.take_rest().to_vec()
+    } else {
+        let mut b = Vec::new();
+        encode_message(&msgs, &enum_nvals, root, 3, &mut u, &mut b)?;
+        match u.int_in_range(0u8..=9)? {
+            0 if !b.is_empty() => {
+                let keep = u.int_in_range(0usize..=b.len())?;
+                b.truncate(keep);
+            }
+            1 if !b.is_empty() => {
+                let i = u.int_in_range(0usize..=b.len() - 1)?;
+                b[i] ^= u.arbitrary::<u8>()?;
+            }
+            _ => {}
+        }
+        b
+    };
+
+    for confluent_wire_format in [false, true] {
+        let Ok(descriptors) = DecodedDescriptors::from_bytes(&fds, root_name.clone()) else {
+            return Ok(());
+        };
+        let Ok(mut decoder) = Decoder::new(descriptors, confluent_wire_format) else {
+            return Ok(());
+        };
+        // The Confluent variant strips a 5-byte schema-registry header (magic
+        // byte 0 + 4-byte schema id) before the body. Prepend one so its body
+        // decodes just as deeply as the raw variant.
+        let payload = if confluent_wire_format {
+            let mut p = vec![0u8; 5];
+            p.extend_from_slice(&body);
+            p
+        } else {
+            body.clone()
+        };
+        let _ = decoder.decode(&payload);
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});


### PR DESCRIPTION
Replacement stack for #36982. This is part 6 of 10.

Summary:
- Adds avro fuzz targets for schema parsing, schema resolution, and reader decode.
- Adds interchange fuzz targets for Avro decode with fuzzed schema, Protobuf decode with fuzzed schema, and JSON encode.
- Adds avro corpus preparation and dictionaries.

Review notes:
- Focus review on decoder oracle boundaries and schema generation assumptions.

Verification:
- Split from original commit 082e197653 and reapplied onto current upstream/main.
- Top of stack has the same touched-file set as #36982 and passes git diff --check.

Stack:
1. #37381 tests: Add shared cargo-fuzz runner
2. #37382 tests: Expose fuzz-only internals
3. #37383 sql-parser: Add cargo-fuzz targets
4. #37384 expr, transform: Add cargo-fuzz targets
5. #37385 repr, pgwire: Add cargo-fuzz targets
6. #37386 avro, interchange: Add cargo-fuzz targets
7. #37387 storage-types: Add proto cargo-fuzz targets
8. #37388 persist-client: Add cargo-fuzz targets
9. #37389 storage: Add upsert cargo-fuzz targets
10. #37390 ci: Run cargo-fuzz in release qualification

The original monolithic PR is #36982.