### PR TITLE
storage-types: Add proto cargo-fuzz targets

### DIFF
--- a/src/catalog-protos/fuzz/.gitignore
+++ b/src/catalog-protos/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/catalog-protos/fuzz/Cargo.toml
+++ b/src/catalog-protos/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+# Fuzz crate for mz-catalog-protos serde round-trip properties. Catalog
+# state is durable on-disk data, so a decoder bug here is a catalog-corruption
+# risk. mz-catalog-protos uses serde (not prost) for the on-wire form, so
+# the fuzz target is a serde_json round-trip rather than a proto one.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-catalog-protos-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-catalog-protos = { path = "..", features = ["proptest"] }
+proptest = "1"
+serde = "1.0"
+serde_json = "1.0"
+
+[[bin]]
+name = "catalog_objects_serde_roundtrip"
+path = "fuzz_targets/catalog_objects_serde_roundtrip.rs"
+test = false
+doc = false
+bench = false

--- a/src/catalog-protos/fuzz/fuzz_targets/catalog_objects_serde_roundtrip.rs
+++ b/src/catalog-protos/fuzz/fuzz_targets/catalog_objects_serde_roundtrip.rs
@@ -1,0 +1,134 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: catalog object serde JSON round-trip is idempotent. The
+//! catalog state is durable on-disk data, so a serde edge case that loses
+//! information through a JSON round trip is a catalog-corruption risk.
+//!
+//! Two complementary input arms (the first byte picks the arm, the next byte
+//! picks which catalog type to exercise):
+//!
+//!  * **Structured arm.** Drives the catalog type's proptest `Arbitrary`
+//!    (behind mz-catalog-protos' `proptest` feature) from the libFuzzer byte
+//!    stream to synthesize a *valid, deeply-populated* value, then asserts the
+//!    full `value -> JSON -> value -> JSON` chain is idempotent. We deliberately
+//!    target the genuinely nested catalog types: `ClusterValue`
+//!    (`RoleId` + `Vec<MzAclItem>` + the `ClusterConfig`/`ClusterVariant`/
+//!    `ManagedCluster`/`ClusterSchedule` tree), `ItemValue` (the `CatalogItem`
+//!    enum + `GlobalId` enum + `Vec<ItemVersion>`), `RoleValue` (the
+//!    `RoleAttributes`/`RoleMembership`/`RoleVars`/`RoleVar` tree),
+//!    `NetworkPolicyValue` (`Vec<NetworkPolicyRule>`), and `ClusterReplicaValue`
+//!    (the `ReplicaConfig`/`ReplicaLocation` enum). Random JSON bytes almost
+//!    never reach these inner enum variants, so this is where the interesting
+//!    serde branches actually get covered.
+//!  * **Raw-bytes arm.** Deserializes arbitrary bytes straight into the type,
+//!    exercising the deserializer against malformed/adversarial JSON input,
+//!    then re-serializes the recovered value.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_catalog_protos::objects::{
+    ClusterConfig, ClusterReplicaValue, ClusterValue, ConfigValue, GidMappingValue, ItemValue,
+    MzAclItem, NetworkPolicyValue, RoleId, RoleValue, SettingValue,
+};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+
+/// Build a 32-byte proptest seed from `bytes` (zero-padded / truncated).
+fn seed_from(bytes: &[u8]) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    let n = bytes.len().min(32);
+    seed[..n].copy_from_slice(&bytes[..n]);
+    seed
+}
+
+/// Synthesize a valid `T` via its proptest `Arbitrary`, then assert the serde
+/// JSON round trip is idempotent.
+fn structured_roundtrip<T>(seed: &[u8])
+where
+    T: serde::de::DeserializeOwned
+        + serde::Serialize
+        + PartialEq
+        + std::fmt::Debug
+        + proptest::arbitrary::Arbitrary,
+{
+    let mut runner = TestRunner::new_with_rng(
+        Config::default(),
+        TestRng::from_seed(RngAlgorithm::ChaCha, &seed_from(seed)),
+    );
+    let Ok(tree) = T::arbitrary().new_tree(&mut runner) else {
+        return;
+    };
+    assert_idempotent(tree.current());
+}
+
+/// `value -> JSON -> value` must be the identity, and re-serializing must
+/// produce byte-identical JSON.
+fn assert_idempotent<T>(orig: T)
+where
+    T: serde::de::DeserializeOwned + serde::Serialize + PartialEq + std::fmt::Debug,
+{
+    let json = serde_json::to_vec(&orig).expect("serialize of valid value must succeed");
+    let round: T = serde_json::from_slice(&json).expect("re-decode must round-trip");
+    assert_eq!(orig, round, "serde roundtrip changed value");
+    let json2 = serde_json::to_vec(&round).expect("re-serialize must succeed");
+    assert_eq!(json, json2, "serde re-serialize was not idempotent");
+}
+
+/// Decode adversarial JSON bytes straight into `T`, then assert the recovered
+/// value round-trips.
+fn raw_roundtrip<T>(data: &[u8])
+where
+    T: serde::de::DeserializeOwned + serde::Serialize + PartialEq + std::fmt::Debug,
+{
+    let Ok(orig) = serde_json::from_slice::<T>(data) else {
+        return;
+    };
+    assert_idempotent(orig);
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+    let Some((&which, rest)) = rest.split_first() else {
+        return;
+    };
+
+    if mode & 1 == 0 {
+        // Structured arm: synthesize a valid, deeply-nested value.
+        match which % 10 {
+            0 => structured_roundtrip::<ClusterValue>(rest),
+            1 => structured_roundtrip::<ItemValue>(rest),
+            2 => structured_roundtrip::<RoleValue>(rest),
+            3 => structured_roundtrip::<NetworkPolicyValue>(rest),
+            4 => structured_roundtrip::<ClusterReplicaValue>(rest),
+            5 => structured_roundtrip::<GidMappingValue>(rest),
+            6 => structured_roundtrip::<ClusterConfig>(rest),
+            7 => structured_roundtrip::<MzAclItem>(rest),
+            8 => structured_roundtrip::<RoleId>(rest),
+            _ => structured_roundtrip::<ConfigValue>(rest),
+        }
+    } else {
+        // Raw-bytes arm: decode adversarial JSON, then round-trip.
+        match which % 10 {
+            0 => raw_roundtrip::<ClusterValue>(rest),
+            1 => raw_roundtrip::<ItemValue>(rest),
+            2 => raw_roundtrip::<RoleValue>(rest),
+            3 => raw_roundtrip::<NetworkPolicyValue>(rest),
+            4 => raw_roundtrip::<ClusterReplicaValue>(rest),
+            5 => raw_roundtrip::<GidMappingValue>(rest),
+            6 => raw_roundtrip::<ConfigValue>(rest),
+            7 => raw_roundtrip::<SettingValue>(rest),
+            8 => raw_roundtrip::<MzAclItem>(rest),
+            _ => raw_roundtrip::<RoleId>(rest),
+        }
+    }
+});

--- a/src/mysql-util/fuzz/.gitignore
+++ b/src/mysql-util/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/mysql-util/fuzz/Cargo.toml
+++ b/src/mysql-util/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+# Fuzz crate for mz-mysql-util desc proto round-trip. `MySqlTableDesc`
+# describes external-database schemas, so a decoder bug here is reachable
+# from a compromised upstream MySQL or from on-disk catalog bytes.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-mysql-util-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-mysql-util = { path = "..", features = ["proptest"] }
+mz-proto = { path = "../../proto" }
+prost = "0.14.3"
+proptest = { version = "1.11.0", default-features = false, features = ["std"] }
+
+[[bin]]
+name = "mysql_table_desc_proto_roundtrip"
+path = "fuzz_targets/mysql_table_desc_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false

--- a/src/mysql-util/fuzz/fuzz_targets/mysql_table_desc_proto_roundtrip.rs
+++ b/src/mysql-util/fuzz/fuzz_targets/mysql_table_desc_proto_roundtrip.rs
@@ -1,0 +1,163 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `ProtoMySqlTableDesc` <-> `MySqlTableDesc` round-trip.
+//! Describes external-database schemas, so a decoder bug here is reachable
+//! from a compromised upstream MySQL or on-disk catalog bytes.
+//!
+//! Input generation is split across three arms keyed off the first input
+//! byte so a single byte stream exercises all of them over time:
+//!
+//! 1. **Valid-value arm.** A 32-byte seed (drawn from the input) drives
+//!    proptest's `Arbitrary for MySqlTableDesc` to build a *structurally
+//!    valid, deeply-populated* descriptor. Non-empty columns with real
+//!    `SqlColumnType`s, every `MySqlColumnMeta` variant, and a populated
+//!    `BTreeSet<MySqlKeyDesc>`. It asserts the canonical
+//!    `from_proto(into_proto(v)) == v` Rust round-trip, which a
+//!    random-bytes-only target almost never reaches (random protobuf
+//!    decodes to near-empty messages).
+//!
+//! 2. **Duplicate/unsorted-keys arm.** Crafts a `ProtoMySqlTableDesc`
+//!    whose `keys` field (a repeated proto `Vec`) contains duplicates and
+//!    out-of-order entries to probe the classic `Vec -> BTreeSet -> Vec`
+//!    round-trip trap: the *first* decode normalizes (dedups + sorts), so
+//!    we assert the conversion is a *fixed point* afterwards rather than
+//!    byte-identical to the crafted input.
+//!
+//! 3. **Raw-bytes arm.** Decode arbitrary bytes and, if they happen to form a
+//!    valid descriptor, check the proto round-trip is stable. This guards
+//!    robustness against the real wire/catalog format.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_mysql_util::{MySqlKeyDesc, MySqlTableDesc, ProtoMySqlKeyDesc, ProtoMySqlTableDesc};
+use mz_proto::{ProtoType, RustType};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+/// Assert that a `MySqlTableDesc` survives a full Rust round-trip through
+/// its proto representation unchanged, including a re-encode/decode of the
+/// wire bytes.
+fn assert_rust_roundtrip(orig: &MySqlTableDesc) {
+    let proto = orig.into_proto();
+    let bytes = proto.encode_to_vec();
+    let proto2 = ProtoMySqlTableDesc::decode(bytes.as_slice())
+        .expect("re-encode of valid MySqlTableDesc must decode");
+    let round: MySqlTableDesc = proto2
+        .into_rust()
+        .expect("re-encoded MySqlTableDesc must convert back to Rust");
+    assert_eq!(orig, &round, "MySqlTableDesc changed across proto roundtrip");
+}
+
+/// Decode `bytes` as a proto, and if it is a valid descriptor, assert the
+/// proto round-trip is stable. Used by both the crafted and raw-bytes arms,
+/// where the *first* decode may normalize a `Vec`-shaped field into a
+/// `BTreeSet`, so we only require idempotence from that normalized value on.
+fn check_decoded(bytes: &[u8]) {
+    let Ok(proto) = ProtoMySqlTableDesc::decode(bytes) else {
+        return;
+    };
+    let orig: MySqlTableDesc = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    assert_rust_roundtrip(&orig);
+}
+
+/// Build a proto whose `keys` Vec deliberately violates the `BTreeSet`
+/// invariants (duplicates and reverse order), seeded from `data` so the
+/// fuzzer can vary the contents while keeping the shape pathological.
+fn craft_unsorted_dup_keys(data: &[u8]) -> ProtoMySqlTableDesc {
+    // Derive a couple of distinct key bodies from the seed bytes.
+    let pick = |i: usize| -> String {
+        let b = data.get(i).copied().unwrap_or(i as u8);
+        format!("k{}", b % 5)
+    };
+    let key_a = ProtoMySqlKeyDesc {
+        name: pick(0),
+        is_primary: data.first().copied().unwrap_or(0) & 1 == 0,
+        columns: vec![pick(1), pick(2)],
+    };
+    let key_b = ProtoMySqlKeyDesc {
+        name: pick(3),
+        is_primary: data.get(1).copied().unwrap_or(0) & 1 == 0,
+        columns: vec![pick(4)],
+    };
+    // Emit duplicates and in deliberately non-sorted order. The decoder
+    // collapses these into a BTreeSet, which is the round-trip trap.
+    ProtoMySqlTableDesc {
+        name: "fuzz".to_string(),
+        schema_name: "fuzz".to_string(),
+        columns: vec![],
+        keys: vec![key_b.clone(), key_a.clone(), key_a.clone(), key_b],
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Reserve the first byte as a mode selector and the next 32 bytes as the
+    // proptest seed. Everything after that feeds the raw-bytes / crafting
+    // logic so a single input can drive any arm.
+    let mode = data.first().copied().unwrap_or(0);
+    let mut seed = [0u8; 32];
+    let seed_src = data.get(1..33).unwrap_or(&[]);
+    seed[..seed_src.len()].copy_from_slice(seed_src);
+    let rest = data.get(33..).unwrap_or(&[]);
+
+    match mode % 3 {
+        0 => {
+            // Valid-value arm: drive proptest's Arbitrary from the seed.
+            let mut runner = TestRunner::new_with_rng(
+                Config::default(),
+                TestRng::from_seed(RngAlgorithm::ChaCha, &seed),
+            );
+            let value = match <MySqlTableDesc as proptest::arbitrary::Arbitrary>::arbitrary()
+                .new_tree(&mut runner)
+            {
+                Ok(tree) => tree.current(),
+                Err(_) => return,
+            };
+            assert_rust_roundtrip(&value);
+
+            // The proptest-built value is already normalized (its keys come
+            // from a BTreeSet). Sanity-check that the BTreeSet semantics hold
+            // after a wire decode by encoding and re-decoding, then confirm
+            // re-collecting the keys into a fresh set is idempotent.
+            let decoded: MySqlTableDesc = value
+                .into_proto()
+                .encode_to_vec()
+                .as_slice()
+                .pipe(ProtoMySqlTableDesc::decode)
+                .expect("decode")
+                .into_rust()
+                .expect("into_rust");
+            let recollected: std::collections::BTreeSet<MySqlKeyDesc> =
+                decoded.keys.iter().cloned().collect();
+            assert_eq!(decoded.keys, recollected, "key set not idempotent");
+        }
+        1 => {
+            // Duplicate/unsorted-keys arm.
+            let proto = craft_unsorted_dup_keys(rest);
+            check_decoded(proto.encode_to_vec().as_slice());
+        }
+        _ => {
+            // Raw-bytes arm: decode arbitrary bytes directly.
+            check_decoded(rest);
+        }
+    }
+});
+
+/// Tiny extension trait so the valid-value arm can read top-to-bottom.
+trait Pipe: Sized {
+    fn pipe<R>(self, f: impl FnOnce(Self) -> R) -> R {
+        f(self)
+    }
+}
+impl<T> Pipe for T {}

--- a/src/postgres-util/fuzz/.gitignore
+++ b/src/postgres-util/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/postgres-util/fuzz/Cargo.toml
+++ b/src/postgres-util/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+# Fuzz crate for mz-postgres-util desc proto round-trip. `PostgresTableDesc`
+# describes external-database schemas, so a decoder bug here is reachable from
+# a compromised upstream Postgres or from on-disk catalog bytes.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-postgres-util-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+# `schemas` (a default feature) is what gates `desc` + its proptest `Arbitrary`
+# impls. Make the dependency explicit so the structured arm always builds.
+mz-postgres-util = { path = "..", features = ["schemas"] }
+mz-proto = { path = "../../proto" }
+proptest = "1"
+prost = "0.14.3"
+
+[[bin]]
+name = "postgres_table_desc_proto_roundtrip"
+path = "fuzz_targets/postgres_table_desc_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false

--- a/src/postgres-util/fuzz/fuzz_targets/postgres_table_desc_proto_roundtrip.rs
+++ b/src/postgres-util/fuzz/fuzz_targets/postgres_table_desc_proto_roundtrip.rs
@@ -1,0 +1,184 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `ProtoPostgresTableDesc` <-> `PostgresTableDesc` round-trip.
+//! `PostgresTableDesc` describes external-database schemas, so a decoder bug
+//! here is reachable from a compromised upstream Postgres or on-disk catalog
+//! bytes.
+//!
+//! The first input byte selects the arm. The rest feeds it:
+//!
+//!  * **Structured arm.** Drives `PostgresTableDesc`'s proptest `Arbitrary`
+//!    (behind mz-postgres-util's `schemas` feature) from the libFuzzer byte
+//!    stream to synthesize a *valid, fully-populated* value, then asserts the
+//!    `value -> proto -> value` chain is the identity AND that re-encoding the
+//!    proto is byte-idempotent. This is what actually reaches the deep shape:
+//!    several `PostgresColumnDesc`s with arbitrary `col_num`/`type_oid`/
+//!    `type_mod`/`nullable`, and a `BTreeSet` of several `PostgresKeyDesc`s,
+//!    each with a `Vec<u16>` of `cols`. Random proto bytes decode to a
+//!    near-empty desc, so the populated branches never get covered otherwise.
+//!  * **Raw-bytes arm.** Decodes arbitrary bytes straight into the proto then
+//!    `into_rust`, exercising the decoder against malformed/adversarial input,
+//!    then re-encodes the recovered value. This is where the untrusted-bytes
+//!    invariants live: the `u32 -> u16` narrowing for
+//!    `ProtoPostgresColumnDesc::col_num` and `ProtoPostgresKeyDesc::cols` must
+//!    return `Err`, not panic, and the wire's repeated `keys` field with
+//!    duplicate / unsorted entries must collapse cleanly into the Rust
+//!    `BTreeSet` rather than trip an ordering assertion.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_postgres_util::desc::{
+    PostgresTableDesc, ProtoPostgresColumnDesc, ProtoPostgresKeyDesc, ProtoPostgresTableDesc,
+};
+use mz_proto::ProtoType;
+use proptest::arbitrary::Arbitrary;
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+/// Build a 32-byte proptest seed from `bytes` (zero-padded / truncated).
+fn seed_from(bytes: &[u8]) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    let n = bytes.len().min(32);
+    seed[..n].copy_from_slice(&bytes[..n]);
+    seed
+}
+
+/// Assert the `value -> proto -> value` chain is the identity and that
+/// re-encoding the proto is byte-idempotent.
+fn assert_roundtrip(orig: PostgresTableDesc) {
+    let proto = <ProtoPostgresTableDesc as ProtoType<PostgresTableDesc>>::from_rust(&orig);
+    let bytes = proto.encode_to_vec();
+    let proto2 = ProtoPostgresTableDesc::decode(bytes.as_slice())
+        .expect("re-encode of valid PostgresTableDesc must decode");
+    let round: PostgresTableDesc = proto2
+        .into_rust()
+        .expect("re-encoded PostgresTableDesc must convert back to Rust");
+    assert_eq!(orig, round, "PostgresTableDesc changed across proto roundtrip");
+
+    // Encoding the recovered value must reproduce the same wire bytes.
+    let bytes2 = <ProtoPostgresTableDesc as ProtoType<PostgresTableDesc>>::from_rust(&round)
+        .encode_to_vec();
+    assert_eq!(bytes, bytes2, "proto re-encode was not idempotent");
+}
+
+/// Decode adversarial proto bytes, convert to Rust, then round-trip.
+fn raw_roundtrip(data: &[u8]) {
+    let Ok(proto) = ProtoPostgresTableDesc::decode(data) else {
+        return;
+    };
+    // `into_rust` may legitimately reject (e.g. a `col_num`/`cols` value that
+    // overflows `u16`). It must do so via `Err`, never a panic.
+    let Ok(orig): Result<PostgresTableDesc, _> = proto.into_rust() else {
+        return;
+    };
+    assert_roundtrip(orig);
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+
+    match mode % 4 {
+        // Structured arm: synthesize a valid, fully-populated desc.
+        0 => {
+            let mut runner = TestRunner::new_with_rng(
+                Config::default(),
+                TestRng::from_seed(RngAlgorithm::ChaCha, &seed_from(rest)),
+            );
+            if let Ok(tree) = PostgresTableDesc::arbitrary().new_tree(&mut runner) {
+                assert_roundtrip(tree.current());
+            }
+        }
+        // Targeted arm: hand-build a proto whose `col_num` / `cols` values
+        // straddle the u16 boundary, confirming the u32 -> u16 narrowing in
+        // `from_proto` returns `Err` (not a panic) for the out-of-range cases
+        // and succeeds for the in-range ones.
+        1 => {
+            // Use the first few bytes as little-endian u32 candidates so the
+            // fuzzer can search both sides of the 65535 boundary.
+            let take_u32 = |i: usize| -> u32 {
+                let mut buf = [0u8; 4];
+                let n = rest.len().saturating_sub(i * 4).min(4);
+                if n > 0 {
+                    buf[..n].copy_from_slice(&rest[i * 4..i * 4 + n]);
+                }
+                u32::from_le_bytes(buf)
+            };
+            let col_num = take_u32(0);
+            let key_col = take_u32(1);
+
+            let proto = ProtoPostgresTableDesc {
+                name: "t".into(),
+                namespace: "n".into(),
+                oid: 1,
+                columns: vec![ProtoPostgresColumnDesc {
+                    name: "c".into(),
+                    type_oid: 23,
+                    type_mod: -1,
+                    nullable: true,
+                    col_num: Some(col_num),
+                }],
+                keys: vec![ProtoPostgresKeyDesc {
+                    oid: 2,
+                    name: "k".into(),
+                    cols: vec![key_col],
+                    is_primary: true,
+                    nulls_not_distinct: false,
+                }],
+            };
+            let bytes = proto.encode_to_vec();
+            let decoded = ProtoPostgresTableDesc::decode(bytes.as_slice())
+                .expect("hand-built proto must decode");
+            // Whether the narrowing fits, the only requirement is no panic. If
+            // it converts, the value must round-trip.
+            let converted: Result<PostgresTableDesc, _> = decoded.into_rust();
+            if let Ok(orig) = converted {
+                assert_roundtrip(orig);
+            }
+        }
+        // Targeted arm: a wire proto with duplicate and unsorted `keys`. The
+        // repeated field maps to a Rust `BTreeSet`, which dedups + sorts. This
+        // must collapse cleanly with no ordering/dup assertion firing.
+        2 => {
+            let mk = |oid: u32, col: u16| ProtoPostgresKeyDesc {
+                oid,
+                name: "k".into(),
+                cols: vec![u32::from(col)],
+                is_primary: false,
+                nulls_not_distinct: false,
+            };
+            // Intentionally out of order with a duplicate entry.
+            let proto = ProtoPostgresTableDesc {
+                name: "t".into(),
+                namespace: "n".into(),
+                oid: 7,
+                columns: vec![ProtoPostgresColumnDesc {
+                    name: "c".into(),
+                    type_oid: 23,
+                    type_mod: -1,
+                    nullable: false,
+                    col_num: Some(1),
+                }],
+                keys: vec![mk(3, 2), mk(1, 9), mk(3, 2), mk(2, 0)],
+            };
+            let bytes = proto.encode_to_vec();
+            let decoded = ProtoPostgresTableDesc::decode(bytes.as_slice())
+                .expect("hand-built proto must decode");
+            let orig: PostgresTableDesc =
+                decoded.into_rust().expect("duplicate/unsorted keys must convert");
+            assert_roundtrip(orig);
+        }
+        // Raw-bytes arm: decode adversarial proto bytes, then round-trip.
+        _ => raw_roundtrip(rest),
+    }
+});

--- a/src/sql-server-util/fuzz/.gitignore
+++ b/src/sql-server-util/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/sql-server-util/fuzz/Cargo.toml
+++ b/src/sql-server-util/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+# Fuzz crate for mz-sql-server-util desc proto round-trip.
+# `SqlServerTableDesc` describes external-database schemas, so a decoder bug
+# here is reachable from a compromised upstream SQL Server or from on-disk
+# catalog bytes.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-sql-server-util-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-sql-server-util = { path = "..", features = ["proptest"] }
+mz-proto = { path = "../../proto" }
+prost = "0.14.3"
+proptest = { version = "1.11.0", default-features = false, features = ["std"] }
+
+[[bin]]
+name = "sql_server_table_desc_proto_roundtrip"
+path = "fuzz_targets/sql_server_table_desc_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false

--- a/src/sql-server-util/fuzz/fuzz_targets/sql_server_table_desc_proto_roundtrip.rs
+++ b/src/sql-server-util/fuzz/fuzz_targets/sql_server_table_desc_proto_roundtrip.rs
@@ -1,0 +1,263 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `ProtoSqlServerTableDesc` <-> `SqlServerTableDesc` round-trip.
+//! Describes external-database schemas, so a decoder bug here is reachable
+//! from a compromised upstream SQL Server or on-disk catalog bytes.
+//!
+//! Input generation is split across four arms keyed off the first input
+//! byte so a single byte stream exercises all of them over time:
+//!
+//! 1. **Valid-value arm.** A 32-byte seed (drawn from the input) drives
+//!    proptest's `Arbitrary for SqlServerTableDesc` to build a *structurally
+//!    valid, deeply-populated* descriptor. Non-empty columns with real
+//!    `SqlColumnType`s, every `SqlServerColumnDecodeType` variant (including
+//!    `Unsupported { context }`), `primary_key_constraint`, and populated
+//!    `SqlServerTableConstraint`s. It asserts the canonical
+//!    `from_proto(into_proto(v)) == v` Rust round-trip, which a
+//!    random-bytes-only target almost never reaches (random protobuf
+//!    decodes to near-empty messages).
+//!
+//! 2. **Constraint-string arm.** Drives the *raw-ingest* path
+//!    `SqlServerTableConstraint::try_from(SqlServerTableConstraintRaw)`,
+//!    which parses the `constraint_type` *string* (`"PRIMARY KEY"` /
+//!    `"UNIQUE"` are accepted, everything else is rejected). It feeds both
+//!    the two valid strings and fuzzer-controlled garbage, and proto
+//!    round-trips any constraint that parses. This covers the
+//!    string-validation boundary that the proto oneof never sees.
+//!
+//! 3. **Decode-type arm.** Builds a `SqlServerColumnRaw` from a real SQL
+//!    Server type name (`bit`, `tinyint`, `uniqueidentifier`, `xml`,
+//!    `datetime2`, ...) covering every supported `SqlServerColumnDecodeType`
+//!    plus an unsupported sentinel, runs the product `SqlServerColumnDesc::new`
+//!    type-mapping logic, assembles a full table desc, and proto round-trips
+//!    it. This reaches the `parse_data_type` mapping that the catalog format
+//!    is the persisted output of.
+//!
+//! 4. **Raw-bytes arm.** Decode arbitrary bytes and, if they happen to form a
+//!    valid descriptor, check the proto round-trip is stable. This guards
+//!    robustness against the real wire/catalog format.
+
+#![no_main]
+
+use std::sync::Arc;
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::{ProtoType, RustType};
+use mz_sql_server_util::desc::{
+    SqlServerColumnRaw, SqlServerTableConstraint, SqlServerTableConstraintRaw, SqlServerTableDesc,
+};
+use mz_sql_server_util::{ProtoSqlServerColumnDesc, ProtoSqlServerTableDesc};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+/// Real SQL Server data-type spellings, chosen to exercise every branch of the
+/// product `parse_data_type` mapping and therefore every supported
+/// `SqlServerColumnDecodeType`. The trailing entries deliberately steer into
+/// the unsupported / error path.
+const DATA_TYPES: &[&str] = &[
+    "bit",              // Bool
+    "tinyint",          // U8
+    "smallint",         // I16
+    "int",              // I32
+    "bigint",           // I64
+    "real",             // F32 (precision <= 24)
+    "float",            // F64
+    "char",             // String
+    "varchar",          // String
+    "nvarchar",         // String
+    "text",             // String
+    "json",             // String
+    "varbinary",        // Bytes
+    "binary",           // Bytes
+    "image",            // Bytes
+    "uniqueidentifier", // Uuid
+    "decimal",          // Numeric
+    "numeric",          // Numeric
+    "money",            // Numeric
+    "xml",              // Xml
+    "date",             // NaiveDate
+    "time",             // NaiveTime
+    "datetime2",        // NaiveDateTime
+    "datetimeoffset",   // DateTime
+    "sql_variant",      // Unsupported
+    "geography",        // Unsupported
+    "totally_bogus",    // Unsupported
+];
+
+/// Constraint-type strings: the two the product accepts, plus garbage that
+/// `SqlServerTableConstraint::try_from` must reject.
+const CONSTRAINT_TYPES: &[&str] = &[
+    "PRIMARY KEY",
+    "UNIQUE",
+    "primary key",   // wrong case -> rejected
+    "FOREIGN KEY",   // unsupported -> rejected
+    "CHECK",         // unsupported -> rejected
+    "",              // empty -> rejected
+    "PRIMARY KEY ",  // trailing space -> rejected
+    "\u{1f600}junk", // non-ascii garbage -> rejected
+];
+
+/// Assert that a `SqlServerTableDesc` survives a full Rust round-trip through
+/// its proto representation unchanged, including a re-encode/decode of the
+/// wire bytes.
+fn assert_rust_roundtrip(orig: &SqlServerTableDesc) {
+    let proto = orig.into_proto();
+    let bytes = proto.encode_to_vec();
+    let proto2 = ProtoSqlServerTableDesc::decode(bytes.as_slice())
+        .expect("re-encode of valid SqlServerTableDesc must decode");
+    let round: SqlServerTableDesc = proto2
+        .into_rust()
+        .expect("re-encoded SqlServerTableDesc must convert back to Rust");
+    assert_eq!(
+        orig, &round,
+        "SqlServerTableDesc changed across proto roundtrip"
+    );
+}
+
+/// Decode `bytes` as a proto, and if it is a valid descriptor, assert the
+/// proto round-trip is stable. Used by the raw-bytes arm.
+fn check_decoded(bytes: &[u8]) {
+    let Ok(proto) = ProtoSqlServerTableDesc::decode(bytes) else {
+        return;
+    };
+    let orig: SqlServerTableDesc = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    assert_rust_roundtrip(&orig);
+}
+
+/// Build a `SqlServerColumnRaw` from the fuzzer bytes, picking a real type name
+/// so the product type-mapping logic runs end-to-end.
+fn craft_column(data: &[u8], idx: usize) -> SqlServerColumnRaw {
+    let pick = |off: usize| data.get(off).copied().unwrap_or(idx as u8);
+    let data_type = DATA_TYPES[pick(0) as usize % DATA_TYPES.len()];
+    // For the LOB types `text`/`ntext`/`image`, SQL Server's `sys.columns`
+    // invariably reports `max_length = 16` (the size of the in-row root
+    // pointer, not the data length), and `SqlServerColumnDesc::new` soft-asserts
+    // exactly that. That assertion is a correct developer tripwire for a real
+    // upstream invariant, so we must feed these types the length a live SQL
+    // Server would actually report rather than synthesizing one it never
+    // could, otherwise we trip the assertion on structurally-impossible input.
+    // Every other type legitimately carries a range of lengths, so keep
+    // fuzzing those across -1 (max), 16, and assorted small/arbitrary values.
+    let max_length = if matches!(data_type, "text" | "ntext" | "image") {
+        16
+    } else {
+        match pick(2) % 4 {
+            0 => -1,
+            1 => 16,
+            2 => i16::from(pick(3)),
+            _ => i16::from_le_bytes([pick(3), pick(4)]),
+        }
+    };
+    SqlServerColumnRaw {
+        name: format!("col{idx}").into(),
+        data_type: data_type.into(),
+        is_nullable: pick(1) & 1 == 0,
+        max_length,
+        precision: pick(5) % 39,
+        scale: pick(6) % 39,
+        is_computed: pick(7) & 1 == 0,
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Reserve the first byte as a mode selector and the next 32 bytes as the
+    // proptest seed. Everything after that feeds the raw-bytes / crafting
+    // logic so a single input can drive any arm.
+    let mode = data.first().copied().unwrap_or(0);
+    let mut seed = [0u8; 32];
+    let seed_src = data.get(1..33).unwrap_or(&[]);
+    seed[..seed_src.len()].copy_from_slice(seed_src);
+    let rest = data.get(33..).unwrap_or(&[]);
+
+    match mode % 4 {
+        0 => {
+            // Valid-value arm: drive proptest's Arbitrary from the seed.
+            let mut runner = TestRunner::new_with_rng(
+                Config::default(),
+                TestRng::from_seed(RngAlgorithm::ChaCha, &seed),
+            );
+            let value = match <SqlServerTableDesc as proptest::arbitrary::Arbitrary>::arbitrary()
+                .new_tree(&mut runner)
+            {
+                Ok(tree) => tree.current(),
+                Err(_) => return,
+            };
+            assert_rust_roundtrip(&value);
+        }
+        1 => {
+            // Constraint-string arm: exercise the raw-ingest string parser for
+            // both accepted and rejected `constraint_type` spellings.
+            let ty_idx = rest.first().copied().unwrap_or(0) as usize % CONSTRAINT_TYPES.len();
+            let n_cols = (rest.get(1).copied().unwrap_or(0) % 4) as usize;
+            let columns: Vec<String> = (0..n_cols).map(|i| format!("c{i}")).collect();
+            let raw = SqlServerTableConstraintRaw {
+                constraint_name: "fuzz_constraint".to_string(),
+                constraint_type: CONSTRAINT_TYPES[ty_idx].to_string(),
+                columns,
+            };
+            // Garbage strings must be rejected. Valid ones must parse and then
+            // survive a proto round-trip inside a table desc.
+            let Ok(constraint) = SqlServerTableConstraint::try_from(raw) else {
+                return;
+            };
+            let desc = SqlServerTableDesc {
+                schema_name: "dbo".into(),
+                name: "fuzz".into(),
+                columns: Box::new([]),
+                constraints: vec![constraint],
+            };
+            assert_rust_roundtrip(&desc);
+        }
+        2 => {
+            // Decode-type arm: run the product type-mapping over real type
+            // spellings and round-trip the resulting columns.
+            let n_cols = 1 + (rest.first().copied().unwrap_or(0) % 6) as usize;
+            let mut columns = Vec::with_capacity(n_cols);
+            for i in 0..n_cols {
+                // Give each column a distinct 8-byte window of the input.
+                let off = 1 + i * 8;
+                let window = rest.get(off..).unwrap_or(&[]);
+                let raw = craft_column(window, i);
+                let mut desc = mz_sql_server_util::desc::SqlServerColumnDesc::new(&raw);
+                // Occasionally populate the deprecated PK-constraint field so
+                // the `Option<Arc<str>>` round-trip is covered too.
+                if rest.get(off).copied().unwrap_or(0) & 0x80 != 0 {
+                    desc.primary_key_constraint = Some(Arc::from("pk_fuzz"));
+                }
+                columns.push(desc);
+            }
+            let desc = SqlServerTableDesc {
+                schema_name: "dbo".into(),
+                name: "fuzz".into(),
+                columns: columns.into_boxed_slice(),
+                constraints: vec![],
+            };
+            assert_rust_roundtrip(&desc);
+
+            // Also assert the per-column proto leaf round-trips independently,
+            // which isolates the `decode_type` oneof + `column_type` mapping.
+            for col in desc.columns.iter() {
+                let proto: ProtoSqlServerColumnDesc = col.into_proto();
+                let back: mz_sql_server_util::desc::SqlServerColumnDesc = proto
+                    .into_rust()
+                    .expect("column desc must convert back to Rust");
+                assert_eq!(col, &back, "SqlServerColumnDesc changed across roundtrip");
+            }
+        }
+        _ => {
+            // Raw-bytes arm: decode arbitrary bytes directly.
+            check_decoded(rest);
+        }
+    }
+});

--- a/src/storage-types/fuzz/.gitignore
+++ b/src/storage-types/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/storage-types/fuzz/Cargo.toml
+++ b/src/storage-types/fuzz/Cargo.toml
@@ -1,0 +1,70 @@
+# Fuzz crate for mz-storage-types proto round-trip properties. Covers the
+# top-level wire types that travel between storage controller and clusterd
+# (source descriptors and dataflow errors). A decoder bug here is a crash
+# or corruption risk for the storage path.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+# Run via the repo-wide runner: `bin/ci-builder run nightly ci/test/cargo-fuzz.sh`,
+# or locally:
+#     cd src/storage-types/fuzz
+#     cargo +nightly fuzz run source_data_proto_roundtrip -- -max_total_time=60
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-storage-types-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-storage-types = { path = "..", features = ["proptest"] }
+mz-proto = { path = "../../proto" }
+mz-repr = { path = "../../repr", features = ["proptest"] }
+# The `proptest` feature on these source-descriptor crates activates the
+# `Arbitrary` derives used by the structured arm of
+# source_export_statement_details_proto_roundtrip. (postgres-util gates them
+# behind its `schemas` feature, which is on by default.)
+mz-mysql-util = { path = "../../mysql-util", features = ["proptest"] }
+mz-postgres-util = { path = "../../postgres-util" }
+mz-sql-server-util = { path = "../../sql-server-util", features = ["proptest"] }
+prost = "0.14.3"
+proptest = "1"
+
+[[bin]]
+name = "csv_decode"
+path = "fuzz_targets/csv_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "source_data_proto_roundtrip"
+path = "fuzz_targets/source_data_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "dataflow_error_proto_roundtrip"
+path = "fuzz_targets/dataflow_error_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "postgres_publication_details_proto_roundtrip"
+path = "fuzz_targets/postgres_publication_details_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "source_export_statement_details_proto_roundtrip"
+path = "fuzz_targets/source_export_statement_details_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false

--- a/src/storage-types/fuzz/fuzz_targets/csv_decode.rs
+++ b/src/storage-types/fuzz/fuzz_targets/csv_decode.rs
@@ -1,0 +1,61 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `CsvDecoderState` decodes untrusted CSV bytes (a source object's
+//! contents) into `Row`s. This is the `FORMAT CSV` source decoder, the first to
+//! touch external data. A panic reachable from the bytes is a source-ingestion
+//! availability bug. Decoding must only ever return `Ok`/`Err`.
+//!
+//! The first two bytes pick the decoder config (column count 1..=4, the field
+//! delimiter, and whether the first row is a validated header). The rest is fed
+//! as the CSV stream, draining it through `decode` exactly as the storage decode
+//! operator does. This exercises the buffer-growth (`OutputFull`/`OutputEndsFull`),
+//! column-count-mismatch, invalid-UTF-8, and header-validation paths.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_storage_types::sources::encoding::{ColumnSpec, CsvDecoderState, CsvEncoding};
+
+fuzz_target!(|data: &[u8]| {
+    // First two bytes are the config, the remainder is the CSV stream.
+    if data.len() < 2 {
+        return;
+    }
+    let (cfg, mut chunk) = data.split_at(2);
+    let n_cols = usize::from(cfg[0] % 4) + 1;
+    // Usually the standard comma, but sometimes an arbitrary delimiter byte
+    // (which csv_core accepts) to reach unusual framing.
+    let delimiter = if cfg[1] & 1 == 0 { b',' } else { cfg[1] };
+    let columns = if cfg[1] & 2 != 0 {
+        ColumnSpec::Header {
+            names: (0..n_cols).map(|i| format!("c{i}")).collect(),
+        }
+    } else {
+        ColumnSpec::Count(n_cols)
+    };
+
+    let mut state = CsvDecoderState::new(CsvEncoding { columns, delimiter });
+
+    // Drain the stream a record at a time, like the decode operator. Each call
+    // returns one decoded record (or an error for a malformed one, having
+    // consumed it) until the input is exhausted (`Ok(None)`). The progress guard
+    // is belt-and-suspenders against a non-advancing call.
+    loop {
+        let before = chunk.len();
+        match state.decode(&mut chunk) {
+            Ok(None) => break,
+            Ok(Some(_)) | Err(_) => {
+                if chunk.len() == before {
+                    break;
+                }
+            }
+        }
+    }
+});

--- a/src/storage-types/fuzz/fuzz_targets/dataflow_error_proto_roundtrip.rs
+++ b/src/storage-types/fuzz/fuzz_targets/dataflow_error_proto_roundtrip.rs
@@ -1,0 +1,86 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `DataflowError`s must survive a proto encode + decode round trip
+//! losslessly. `DataflowError`s travel between the storage controller and
+//! clusterd, so a decoder bug here is a crash/poisoning risk for the storage
+//! path.
+//!
+//! Two complementary input arms (the first byte picks):
+//!
+//!  * **Structured arm.** Drives `DataflowError`'s proptest `Arbitrary` from the
+//!    libFuzzer byte stream to synthesize a *valid, deeply-populated* value
+//!    (the 4-arm oneof, including the nested `EvalError` / `SourceError` /
+//!    `EnvelopeError` / `DecodeError` trees). Random proto bytes almost never
+//!    reach these inner variants, so this is where the interesting branches of
+//!    `into_proto`/`from_proto` actually get covered. We assert the full
+//!    `Rust -> Proto -> Rust` round trip is the identity.
+//!  * **Raw-bytes arm.** Decodes arbitrary bytes straight into
+//!    `ProtoDataflowError`, exercising the decoder against malformed/adversarial
+//!    wire input, then re-encodes the recovered value.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::ProtoType;
+use mz_storage_types::errors::{DataflowError, ProtoDataflowError};
+use prost::Message;
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+
+/// Build a 32-byte proptest seed from `bytes` (zero-padded / truncated).
+fn seed_from(bytes: &[u8]) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    let n = bytes.len().min(32);
+    seed[..n].copy_from_slice(&bytes[..n]);
+    seed
+}
+
+/// `Rust -> Proto -> Rust` must be the identity for any valid `DataflowError`.
+fn assert_roundtrip(orig: DataflowError) {
+    let proto = <ProtoDataflowError as ProtoType<DataflowError>>::from_rust(&orig);
+    let bytes = proto.encode_to_vec();
+    let proto2 = ProtoDataflowError::decode(bytes.as_slice())
+        .expect("re-encode of valid DataflowError must decode");
+    let round: DataflowError = proto2
+        .into_rust()
+        .expect("re-encoded DataflowError must convert back to Rust");
+    assert_eq!(orig, round, "DataflowError changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+
+    if mode & 1 == 0 {
+        // Structured arm: synthesize a valid, deep value via proptest Arbitrary.
+        let seed = seed_from(rest);
+        let mut runner = TestRunner::new_with_rng(
+            Config::default(),
+            TestRng::from_seed(RngAlgorithm::ChaCha, &seed),
+        );
+        let Ok(tree) = <DataflowError as proptest::arbitrary::Arbitrary>::arbitrary()
+            .new_tree(&mut runner)
+        else {
+            return;
+        };
+        assert_roundtrip(tree.current());
+    } else {
+        // Raw-bytes arm: decode adversarial wire bytes, then round-trip.
+        let Ok(proto) = ProtoDataflowError::decode(rest) else {
+            return;
+        };
+        let orig: DataflowError = match proto.into_rust() {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        assert_roundtrip(orig);
+    }
+});

--- a/src/storage-types/fuzz/fuzz_targets/postgres_publication_details_proto_roundtrip.rs
+++ b/src/storage-types/fuzz/fuzz_targets/postgres_publication_details_proto_roundtrip.rs
@@ -1,0 +1,97 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: a `PostgresSourcePublicationDetails` must survive a proto
+//! encode + decode round trip losslessly. These descriptors travel between the
+//! storage controller and clusterd and persist replication state, so a decoder
+//! bug here is reachable via the storage RPC and on-disk format.
+//!
+//! The Rust type is near-trivial (two `String`s plus an `Option<u64>`), so
+//! rather than wiring up proptest we synthesize a valid value directly from the
+//! input bytes. Two complementary input arms (the first byte picks):
+//!
+//!  * **Structured arm.** Splits the remaining bytes into the `slot` and
+//!    `database` strings (lossy UTF-8 so arbitrary bytes always yield a valid
+//!    `String`) and derives `timeline_id` from a length byte, then asserts the
+//!    full `Rust -> Proto -> Rust` round trip is the identity. This guarantees
+//!    non-empty fields and a populated `Option`, which random proto bytes rarely
+//!    produce.
+//!  * **Raw-bytes arm.** Decodes arbitrary bytes straight into the proto,
+//!    exercising the decoder against malformed/adversarial wire input, then
+//!    re-encodes the recovered value.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::ProtoType;
+use mz_storage_types::sources::postgres::{
+    PostgresSourcePublicationDetails, ProtoPostgresSourcePublicationDetails,
+};
+use prost::Message;
+
+/// `Rust -> Proto -> Rust` must be the identity for any valid value.
+fn assert_roundtrip(orig: PostgresSourcePublicationDetails) {
+    let proto = <ProtoPostgresSourcePublicationDetails as ProtoType<
+        PostgresSourcePublicationDetails,
+    >>::from_rust(&orig);
+    let bytes = proto.encode_to_vec();
+    let proto2 = ProtoPostgresSourcePublicationDetails::decode(bytes.as_slice())
+        .expect("re-encode of valid PostgresSourcePublicationDetails must decode");
+    let round: PostgresSourcePublicationDetails = proto2
+        .into_rust()
+        .expect("re-encoded PostgresSourcePublicationDetails must convert back to Rust");
+    assert_eq!(
+        orig, round,
+        "PostgresSourcePublicationDetails changed across proto roundtrip"
+    );
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+
+    if mode & 1 == 0 {
+        // Structured arm: build a valid value directly from the bytes.
+        let mid = rest.len() / 2;
+        let (slot_bytes, db_bytes) = rest.split_at(mid);
+        let timeline_id = if mode & 2 == 0 {
+            None
+        } else {
+            // Pack up to 8 bytes of the input into the u64 timeline id.
+            let mut buf = [0u8; 8];
+            let n = rest.len().min(8);
+            buf[..n].copy_from_slice(&rest[..n]);
+            Some(u64::from_le_bytes(buf))
+        };
+        // `None` exercises the pre-field default; bits 2 and 3 of `mode` pick
+        // between an absent value and a recorded `false`/`true`.
+        let is_physical_replica = if mode & 4 == 0 {
+            None
+        } else {
+            Some(mode & 8 != 0)
+        };
+        assert_roundtrip(PostgresSourcePublicationDetails {
+            slot: String::from_utf8_lossy(slot_bytes).into_owned(),
+            timeline_id,
+            database: String::from_utf8_lossy(db_bytes).into_owned(),
+            is_physical_replica,
+        });
+    } else {
+        // Raw-bytes arm: decode adversarial wire bytes, then round-trip.
+        let Ok(proto) = ProtoPostgresSourcePublicationDetails::decode(rest) else {
+            return;
+        };
+        let orig: PostgresSourcePublicationDetails = match proto.into_rust() {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        assert_roundtrip(orig);
+    }
+});

--- a/src/storage-types/fuzz/fuzz_targets/source_data_proto_roundtrip.rs
+++ b/src/storage-types/fuzz/fuzz_targets/source_data_proto_roundtrip.rs
@@ -1,0 +1,100 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: a `SourceData` must survive a proto encode + decode round trip
+//! losslessly. `SourceData` is the persisted/wire payload of every storage
+//! collection, so a decoder bug here corrupts source output.
+//!
+//! `SourceData` wraps a `Result<Row, DataflowError>`. Two complementary input
+//! arms (the first byte picks):
+//!
+//!  * **Structured arm.** Drives proptest `Arbitrary` from the libFuzzer byte
+//!    stream to synthesize a *valid, populated* value. The `Ok` branch packs a
+//!    full random `Row` (every datum kind, including the tricky numeric / date /
+//!    array / map encodings). The `Err` branch synthesizes a deep
+//!    `DataflowError` (the 4-arm oneof with nested EvalError/Source/Envelope
+//!    trees). Random proto bytes essentially never reach a non-empty Row or a
+//!    deep error, so this is where `Row::into_proto`/`from_proto` and the error
+//!    conversions actually get exercised. We assert the full
+//!    `Rust -> Proto -> Rust` round trip is the identity.
+//!  * **Raw-bytes arm.** Decodes arbitrary bytes straight into
+//!    `ProtoSourceData`, exercising the decoder against malformed/adversarial
+//!    wire input, then re-encodes the recovered value.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_proto::ProtoType;
+use mz_repr::Row;
+use mz_storage_types::errors::DataflowError;
+use mz_storage_types::sources::{ProtoSourceData, SourceData};
+use prost::Message;
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+
+/// Build a 32-byte proptest seed from `bytes` (zero-padded / truncated).
+fn seed_from(bytes: &[u8]) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    let n = bytes.len().min(32);
+    seed[..n].copy_from_slice(&bytes[..n]);
+    seed
+}
+
+/// `Rust -> Proto -> Rust` must be the identity for any valid `SourceData`.
+fn assert_roundtrip(orig: SourceData) {
+    let proto = <ProtoSourceData as ProtoType<SourceData>>::from_rust(&orig);
+    let bytes = proto.encode_to_vec();
+    let proto2 = ProtoSourceData::decode(bytes.as_slice())
+        .expect("re-encode of valid SourceData must decode");
+    let round: SourceData = proto2
+        .into_rust()
+        .expect("re-encoded SourceData must convert back to Rust");
+    assert_eq!(orig, round, "SourceData changed across proto roundtrip");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+
+    if mode & 1 == 0 {
+        // Structured arm: synthesize a valid value via proptest Arbitrary. The
+        // low bit of `mode` selected this arm, the next bit picks Ok vs Err.
+        let seed = seed_from(rest);
+        let mut runner = TestRunner::new_with_rng(
+            Config::default(),
+            TestRng::from_seed(RngAlgorithm::ChaCha, &seed),
+        );
+        let value = if mode & 2 == 0 {
+            let Ok(tree) = <Row as proptest::arbitrary::Arbitrary>::arbitrary().new_tree(&mut runner)
+            else {
+                return;
+            };
+            SourceData(Ok(tree.current()))
+        } else {
+            let Ok(tree) =
+                <DataflowError as proptest::arbitrary::Arbitrary>::arbitrary().new_tree(&mut runner)
+            else {
+                return;
+            };
+            SourceData(Err(tree.current()))
+        };
+        assert_roundtrip(value);
+    } else {
+        // Raw-bytes arm: decode adversarial wire bytes, then round-trip.
+        let Ok(proto) = ProtoSourceData::decode(rest) else {
+            return;
+        };
+        let orig: SourceData = match proto.into_rust() {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        assert_roundtrip(orig);
+    }
+});

--- a/src/storage-types/fuzz/fuzz_targets/source_export_statement_details_proto_roundtrip.rs
+++ b/src/storage-types/fuzz/fuzz_targets/source_export_statement_details_proto_roundtrip.rs
@@ -1,0 +1,166 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: a `SourceExportStatementDetails` must survive a proto encode +
+//! decode round trip losslessly. The Rust side is a 5-variant enum
+//! (Postgres / MySql / SqlServer / LoadGenerator / Kafka), so the conversion
+//! has plenty of branches that need to round-trip. This value is serialized to
+//! the catalog, so a decoder bug here is a corruption/migration risk.
+//!
+//! Two complementary input arms (the first byte picks):
+//!
+//!  * **Structured arm.** Synthesizes a *valid, populated* value. The
+//!    Postgres / MySql / SqlServer variants carry a full table descriptor, which
+//!    we generate with each `*TableDesc`'s proptest `Arbitrary` (driven from the
+//!    libFuzzer byte stream). The load-generator output and the empty Kafka
+//!    variant are picked directly. Random proto bytes essentially never produce
+//!    a non-empty table descriptor, so this is where the nested column /
+//!    constraint / key conversions actually get exercised.
+//!  * **Raw-bytes arm.** Decodes arbitrary bytes straight into the proto,
+//!    exercising the decoder against malformed/adversarial wire input (including
+//!    the SQL Server `Lsn` `try_from` length guard, which is only reachable from
+//!    raw bytes since a re-encoded `Lsn` is always exactly 10 bytes).
+//!
+//! `SourceExportStatementDetails` doesn't derive `PartialEq`/`Debug`, so
+//! losslessness is asserted by comparing the canonical re-encoded bytes from
+//! two successive `Rust -> Proto` round trips.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_mysql_util::MySqlTableDesc;
+use mz_postgres_util::desc::PostgresTableDesc;
+use mz_proto::ProtoType;
+use mz_sql_server_util::desc::SqlServerTableDesc;
+use mz_storage_types::sources::load_generator::LoadGeneratorOutput;
+use mz_storage_types::sources::{ProtoSourceExportStatementDetails, SourceExportStatementDetails};
+use prost::Message;
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+
+/// Build a 32-byte proptest seed from `bytes` (zero-padded / truncated).
+fn seed_from(bytes: &[u8]) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    let n = bytes.len().min(32);
+    seed[..n].copy_from_slice(&bytes[..n]);
+    seed
+}
+
+/// Generate one value of `T` via its proptest `Arbitrary`, or `None` if the
+/// strategy fails.
+fn arb<T: proptest::arbitrary::Arbitrary>(runner: &mut TestRunner) -> Option<T> {
+    T::arbitrary().new_tree(runner).ok().map(|t| t.current())
+}
+
+/// The canonical proto encoding of `details`.
+fn encode(details: &SourceExportStatementDetails) -> Vec<u8> {
+    <ProtoSourceExportStatementDetails as ProtoType<SourceExportStatementDetails>>::from_rust(
+        details,
+    )
+    .encode_to_vec()
+}
+
+/// `Rust -> Proto -> Rust -> Proto` must reproduce the same canonical bytes.
+fn assert_roundtrip(orig: SourceExportStatementDetails) {
+    let canonical = encode(&orig);
+    let reparsed = ProtoSourceExportStatementDetails::decode(canonical.as_slice())
+        .expect("re-encode of valid SourceExportStatementDetails must decode");
+    let round: SourceExportStatementDetails = reparsed
+        .into_rust()
+        .expect("re-encoded SourceExportStatementDetails must convert back to Rust");
+    assert_eq!(
+        canonical,
+        encode(&round),
+        "SourceExportStatementDetails changed across proto roundtrip"
+    );
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+
+    if mode & 1 == 0 {
+        // Structured arm: synthesize a valid value. Upper bits of `mode` select
+        // which of the 5 variants to build.
+        let seed = seed_from(rest);
+        let mut runner = TestRunner::new_with_rng(
+            Config::default(),
+            TestRng::from_seed(RngAlgorithm::ChaCha, &seed),
+        );
+        let value = match (mode >> 1) % 5 {
+            0 => {
+                let Some(table) = arb::<PostgresTableDesc>(&mut runner) else {
+                    return;
+                };
+                SourceExportStatementDetails::Postgres { table }
+            }
+            1 => {
+                let Some(table) = arb::<MySqlTableDesc>(&mut runner) else {
+                    return;
+                };
+                let Some(initial_gtid_set) = arb::<String>(&mut runner) else {
+                    return;
+                };
+                let Some(binlog_full_metadata) = arb::<bool>(&mut runner) else {
+                    return;
+                };
+                SourceExportStatementDetails::MySql {
+                    table,
+                    initial_gtid_set,
+                    binlog_full_metadata,
+                }
+            }
+            2 => {
+                let Some(table) = arb::<SqlServerTableDesc>(&mut runner) else {
+                    return;
+                };
+                let Some(capture_instance) = arb::<String>(&mut runner) else {
+                    return;
+                };
+                let Some(initial_lsn) = arb::<mz_sql_server_util::cdc::Lsn>(&mut runner) else {
+                    return;
+                };
+                SourceExportStatementDetails::SqlServer {
+                    table,
+                    capture_instance: capture_instance.into(),
+                    initial_lsn,
+                }
+            }
+            3 => {
+                // Cover every `LoadGeneratorOutput` discriminant.
+                let output = match rest.first().copied().unwrap_or(0) % 4 {
+                    0 => LoadGeneratorOutput::Default,
+                    1 => LoadGeneratorOutput::Auction(
+                        mz_storage_types::sources::load_generator::AuctionView::Bids,
+                    ),
+                    2 => LoadGeneratorOutput::Marketing(
+                        mz_storage_types::sources::load_generator::MarketingView::Leads,
+                    ),
+                    _ => LoadGeneratorOutput::Tpch(
+                        mz_storage_types::sources::load_generator::TpchView::Customer,
+                    ),
+                };
+                SourceExportStatementDetails::LoadGenerator { output }
+            }
+            _ => SourceExportStatementDetails::Kafka {},
+        };
+        assert_roundtrip(value);
+    } else {
+        // Raw-bytes arm: decode adversarial wire bytes, then round-trip.
+        let Ok(proto) = ProtoSourceExportStatementDetails::decode(rest) else {
+            return;
+        };
+        let orig: SourceExportStatementDetails = match proto.into_rust() {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        assert_roundtrip(orig);
+    }
+});


### PR DESCRIPTION
Replacement stack for #36982. This is part 7 of 10.

Summary:
- Adds proto round-trip fuzz targets for catalog-protos and storage-types.
- Adds external table-desc proto round-trip targets for MySQL, PostgreSQL, and SQL Server utilities.
- Adds a CSV decode target in storage-types.

Review notes:
- Focus review on round-trip invariants and decode error handling for serialized metadata.

Verification:
- Split from original commit 082e197653 and reapplied onto current upstream/main.
- Top of stack has the same touched-file set as #36982 and passes git diff --check.

Stack:
1. #37381 tests: Add shared cargo-fuzz runner
2. #37382 tests: Expose fuzz-only internals
3. #37383 sql-parser: Add cargo-fuzz targets
4. #37384 expr, transform: Add cargo-fuzz targets
5. #37385 repr, pgwire: Add cargo-fuzz targets
6. #37386 avro, interchange: Add cargo-fuzz targets
7. #37387 storage-types: Add proto cargo-fuzz targets
8. #37388 persist-client: Add cargo-fuzz targets
9. #37389 storage: Add upsert cargo-fuzz targets
10. #37390 ci: Run cargo-fuzz in release qualification

The original monolithic PR is #36982.