### PR TITLE
storage: Add upsert cargo-fuzz targets

### DIFF
--- a/src/storage/fuzz/.gitignore
+++ b/src/storage/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/storage/fuzz/Cargo.toml
+++ b/src/storage/fuzz/Cargo.toml
@@ -1,0 +1,53 @@
+# Fuzz crate for mz-storage: exercise the upsert state machine's value
+# consolidation/encoding over untrusted source values. Excluded from the main
+# workspace because libFuzzer requires nightly Rust.
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-storage-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-storage = { path = "..", features = ["fuzzing"] }
+mz-repr = { path = "../../repr" }
+mz-storage-types = { path = "../../storage-types" }
+mz-row-spine = { path = "../../row-spine" }
+differential-dataflow = "0.24.0"
+timely = "0.30.0"
+tokio = { version = "1", features = ["rt"] }
+chrono = { version = "0.4.39", default-features = false, features = ["clock", "serde", "std"] }
+uuid = "1.19.0"
+
+[[bin]]
+name = "upsert_consolidate"
+path = "fuzz_targets/upsert_consolidate.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "upsert_value_roundtrip_v2"
+path = "fuzz_targets/upsert_value_roundtrip_v2.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "upsert_state_consolidate"
+path = "fuzz_targets/upsert_state_consolidate.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "upsert_runtime"
+path = "fuzz_targets/upsert_runtime.rs"
+test = false
+doc = false
+bench = false

--- a/src/storage/fuzz/fuzz_targets/upsert_consolidate.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_consolidate.rs
@@ -1,0 +1,350 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the upsert state machine's value consolidation
+//! (`StateValue::merge_update` + `ensure_decoded`). Upsert collapses a key's
+//! `(value, diff)` history into its current value using a XOR/length/checksum
+//! accumulator (so it never has to keep the unconsolidated history in memory),
+//! then `ensure_decoded` `bincode`-decodes the accumulated `value_xor` back into
+//! a `Row`. The *values* come from untrusted source data, so this exercises that
+//! accumulate-then-decode machinery against arbitrary `Row`s.
+//!
+//! The *diffs*, by contrast, are Materialize-controlled: a well-formed upsert
+//! collection has, per key, zero-or-more canceling `(prev, +1) (prev, -1)` pairs
+//! and at most one `(cur, +1)`. We only generate that shape (so `diff_sum` stays
+//! in `{0, 1}` and we never trip the intentional "invalid upsert state" invariant
+//! that guards against impossible diff sums), shuffle the updates, merge them,
+//! and check the consolidated result:
+//!
+//!   * with a current value, it must decode back to exactly that value (the
+//!     canceling pairs must XOR/sum away regardless of order or of colliding
+//!     with each other or the current value).
+//!   * with no current value, the key must consolidate to absent (a tombstone).
+//!
+//! A panic in `merge_update`/`ensure_decoded`, or a mismatch, is a finding.
+//!
+//! The values (`prev`s and the `cur`) are drawn from the tricky-encoding datum
+//! space (`Numeric`, `Date`, `Timestamp`/`TimestampTz`, `Interval`, `Uuid`,
+//! `MzTimestamp`, `Bytes`, long strings, `MzAclItem`, and the nested composites
+//! `Array`/`List`/`Map`/`Range`), and a fraction are `Err(UpsertError)` values
+//! (real upsert sources stage errored values alongside `Ok` rows). This stresses
+//! the XOR/len/checksum accumulator over bincode payloads of widely varying
+//! length, which is exactly what the accumulator's resize/zero-extend logic is
+//! sensitive to.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::range::{Range, RangeBound, RangeInner};
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::role_id::RoleId;
+use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
+use mz_storage::fuzz_exports::{StateValue, UpsertValue, upsert_bincode_opts};
+use mz_storage_types::errors::{
+    DecodeError, DecodeErrorKind, UpsertError, UpsertNullKeyError, UpsertValueError,
+};
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+/// An arbitrary in-range `NaiveDateTime`, or `None` if out of the supported range.
+fn gen_naive_dt(u: &mut Unstructured) -> arbitrary::Result<Option<NaiveDateTime>> {
+    let year = u.int_in_range(1i32..=9999)?;
+    let ord = u.int_in_range(1u32..=365)?;
+    let secs = u.int_in_range(0u32..=86_399)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    let date = NaiveDate::from_yo_opt(year, ord);
+    let time = NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos);
+    Ok(match (date, time) {
+        (Some(d), Some(t)) => Some(NaiveDateTime::new(d, t)),
+        _ => None,
+    })
+}
+
+fn gen_role_id(u: &mut Unstructured) -> arbitrary::Result<RoleId> {
+    Ok(match u.int_in_range(0u8..=2)? {
+        0 => RoleId::User(u64::arbitrary(u)?),
+        1 => RoleId::System(u64::arbitrary(u)?),
+        _ => RoleId::Public,
+    })
+}
+
+/// Push a single arbitrary scalar (non-composite) datum from the tricky space.
+fn push_scalar(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=14)? {
+        0 => packer.push(Datum::Null),
+        1 => packer.push(Datum::Int32(i32::arbitrary(u)?)),
+        2 => packer.push(Datum::Int64(i64::arbitrary(u)?)),
+        3 => packer.push(Datum::UInt8(u8::arbitrary(u)?)),
+        4 => packer.push(if bool::arbitrary(u)? {
+            Datum::True
+        } else {
+            Datum::False
+        }),
+        5 => packer.push(Datum::from(Numeric::from(i64::arbitrary(u)?))),
+        6 => {
+            let days = u.int_in_range(Date::LOW_DAYS..=Date::HIGH_DAYS)?;
+            packer.push(Datum::Date(Date::from_pg_epoch(days).unwrap()));
+        }
+        7 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                packer.push(Datum::Timestamp(
+                    CheckedTimestamp::from_timestamplike(dt).unwrap(),
+                ));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        8 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                let utc = DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc);
+                packer.push(Datum::TimestampTz(
+                    CheckedTimestamp::from_timestamplike(utc).unwrap(),
+                ));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        9 => packer.push(Datum::Interval(Interval::new(
+            i32::arbitrary(u)?,
+            i32::arbitrary(u)?,
+            i64::arbitrary(u)?,
+        ))),
+        10 => packer.push(Datum::Uuid(uuid::Uuid::from_bytes(
+            <[u8; 16]>::arbitrary(u)?,
+        ))),
+        11 => packer.push(Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?))),
+        12 => {
+            let len = u.int_in_range(0usize..=20)?;
+            let bytes = u.bytes(len)?;
+            packer.push(Datum::Bytes(bytes));
+        }
+        13 => packer.push(Datum::MzAclItem(MzAclItem {
+            grantee: gen_role_id(u)?,
+            grantor: gen_role_id(u)?,
+            acl_mode: AclMode::from_bits_truncate(u64::arbitrary(u)?),
+        })),
+        _ => {
+            // String length that may spill past the 1-byte tiny encoding.
+            let len = u.int_in_range(0usize..=300)?;
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                s.push(if bool::arbitrary(u)? { 'a' } else { 'é' });
+            }
+            packer.push(Datum::String(&s));
+        }
+    }
+    Ok(())
+}
+
+/// A vector of `'static`-safe scalar datums for use as composite elements.
+fn gen_scalar_vec(u: &mut Unstructured, n: usize) -> arbitrary::Result<Vec<Datum<'static>>> {
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        out.push(match u.int_in_range(0u8..=7)? {
+            0 => Datum::Null,
+            1 => Datum::Int32(i32::arbitrary(u)?),
+            2 => Datum::Int64(i64::arbitrary(u)?),
+            3 => Datum::UInt8(u8::arbitrary(u)?),
+            4 => Datum::from(Numeric::from(i64::arbitrary(u)?)),
+            5 => Datum::Interval(Interval::new(
+                i32::arbitrary(u)?,
+                i32::arbitrary(u)?,
+                i64::arbitrary(u)?,
+            )),
+            6 => Datum::Uuid(uuid::Uuid::from_bytes(<[u8; 16]>::arbitrary(u)?)),
+            _ => Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?)),
+        });
+    }
+    Ok(out)
+}
+
+/// Push a `Range` over `Int32` bounds (possibly empty or with infinite bounds).
+fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    if bool::arbitrary(u)? {
+        packer
+            .push_range(Range { inner: None })
+            .expect("empty range is valid");
+        return Ok(());
+    }
+    let lo = i32::arbitrary(u)?;
+    let hi = i32::arbitrary(u)?;
+    let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+    let lower = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(lo))
+        } else {
+            None
+        },
+    };
+    let upper = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(hi))
+        } else {
+            None
+        },
+    };
+    let range = Range {
+        inner: Some(RangeInner { lower, upper }),
+    };
+    if packer.push_range(range).is_err() {
+        packer.push(Datum::Int32(lo));
+    }
+    Ok(())
+}
+
+/// Push one datum: usually a scalar, occasionally a nested composite whose
+/// elements are themselves scalars. Always produces a valid `Row`.
+fn push_datum(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=9)? {
+        0..=5 => push_scalar(packer, u),
+        6 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            let dims = [ArrayDimension {
+                lower_bound: 1,
+                length: datums.len(),
+            }];
+            packer
+                .try_push_array(&dims, datums.iter())
+                .expect("single-dimension array is always valid");
+            Ok(())
+        }
+        7 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            packer.push_list(datums.iter());
+            Ok(())
+        }
+        8 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let mut keys: Vec<String> = Vec::with_capacity(n);
+            for _ in 0..n {
+                let len = u.int_in_range(0usize..=4)?;
+                let mut s = String::with_capacity(len);
+                for _ in 0..len {
+                    s.push(if bool::arbitrary(u)? { 'a' } else { 'b' });
+                }
+                keys.push(s);
+            }
+            keys.sort();
+            keys.dedup();
+            let vals = gen_scalar_vec(u, keys.len())?;
+            packer.push_dict(keys.iter().map(String::as_str).zip(vals.iter().copied()));
+            Ok(())
+        }
+        _ => push_range(packer, u),
+    }
+}
+
+/// A small arbitrary `Row` (the untrusted source value), covering the tricky
+/// scalar and nested-composite datum space.
+fn gen_row(u: &mut Unstructured) -> arbitrary::Result<Row> {
+    let n = u.int_in_range(0usize..=5)?;
+    let mut row = Row::default();
+    let mut packer = row.packer();
+    for _ in 0..n {
+        push_datum(&mut packer, u)?;
+    }
+    drop(packer);
+    Ok(row)
+}
+
+/// An arbitrary `DecodeError` payload for the error-arm variants.
+fn gen_decode_error(u: &mut Unstructured) -> arbitrary::Result<DecodeError> {
+    let msg = String::arbitrary(u)?;
+    let kind = if bool::arbitrary(u)? {
+        DecodeErrorKind::Text(msg.into_boxed_str())
+    } else {
+        DecodeErrorKind::Bytes(msg.into_boxed_str())
+    };
+    let raw = Vec::<u8>::arbitrary(u)?;
+    Ok(DecodeError { kind, raw })
+}
+
+/// An arbitrary `UpsertValue`: usually an `Ok(Row)`, occasionally an
+/// `Err(UpsertError)` spanning the whole variant space (real sources stage
+/// errored values alongside good rows).
+fn gen_value(u: &mut Unstructured) -> arbitrary::Result<UpsertValue> {
+    if u.ratio(1u8, 5u8)? {
+        let err = match u.int_in_range(0u8..=2)? {
+            0 => UpsertError::KeyDecode(gen_decode_error(u)?),
+            1 => UpsertError::Value(UpsertValueError {
+                inner: gen_decode_error(u)?,
+                for_key: gen_row(u)?,
+            }),
+            _ => UpsertError::NullKey(UpsertNullKeyError),
+        };
+        Ok(Err(Box::new(err)))
+    } else {
+        Ok(Ok(gen_row(u)?))
+    }
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let bincode_opts = upsert_bincode_opts();
+    let mut bincode_buffer = Vec::new();
+
+    // Build a well-formed history: canceling `(prev, +1) (prev, -1)` pairs plus
+    // at most one current `(cur, +1)`.
+    let mut updates: Vec<(UpsertValue, Diff)> = Vec::new();
+    let n_pairs = u.int_in_range(0usize..=6)?;
+    for _ in 0..n_pairs {
+        let prev: UpsertValue = gen_value(u)?;
+        updates.push((prev.clone(), Diff::ONE));
+        updates.push((prev, -Diff::ONE));
+    }
+    let current: Option<UpsertValue> = if bool::arbitrary(u)? {
+        Some(gen_value(u)?)
+    } else {
+        None
+    };
+    if let Some(cur) = &current {
+        updates.push((cur.clone(), Diff::ONE));
+    }
+
+    // Shuffle (Fisher-Yates). Consolidation must be order-independent.
+    for i in (1..updates.len()).rev() {
+        let j = u.int_in_range(0..=i)?;
+        updates.swap(i, j);
+    }
+
+    let mut state = StateValue::<(), ()>::default();
+    for (value, diff) in updates {
+        state.merge_update(value, diff, bincode_opts, &mut bincode_buffer);
+    }
+    state.ensure_decoded(bincode_opts, GlobalId::User(0), None);
+    let decoded = state.into_decoded();
+
+    match (current, decoded.finalized) {
+        (Some(cur), Some(got)) => {
+            assert_eq!(got, cur, "consolidation decoded the wrong current value")
+        }
+        (Some(_), None) => {
+            panic!("consolidation dropped the current value")
+        }
+        (None, None) => {}
+        (None, other) => {
+            panic!("consolidation invented a value from canceling pairs: {other:?}")
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/storage/fuzz/fuzz_targets/upsert_runtime.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_runtime.rs
@@ -1,0 +1,447 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the upsert operator's *runtime* processing, `drain_staged_input`.
+//! That is the per-timestamp `multi_get` -> order-keyed per-command processing ->
+//! `multi_put` loop that turns a batch of staged `(key, value, order)` commands
+//! at various timestamps into the differential retract/insert output, with
+//! last-write-wins resolved by an order key (`from_time`).
+//!
+//! Where `upsert_consolidate` / `upsert_state_consolidate` only exercise the
+//! snapshot-rehydration *consolidation* path, this drives the live runtime loop,
+//! which is where the hard-to-reproduce correctness issues live: multiple
+//! commands for the same `(timestamp, key)` (only the maximum-order one may
+//! survive), deletes, re-inserts of the same value, and a key changing across
+//! several timestamps in one drain.
+//!
+//! Because a single `ToUpper` drain always writes *finalized* values (so a
+//! later timestamp's `provisional_order` is `None` and the order-skip never
+//! fires across timestamps), the semantics reduce to something a simple,
+//! obviously-correct oracle can predict: per `(ts, key)` the maximum-order
+//! command wins, and processing those winners in timestamp order per key yields
+//! the output (retract the prior value, insert the new one) and the final state.
+//! We run the real `drain_staged_input` and assert both its emitted output
+//! (consolidated) and its final per-key state match that oracle. A divergence,
+//! a dropped/duplicated retraction, a wrong winner, a lost or invented value,
+//! is a correctness bug. A panic is an availability bug.
+//!
+//! To make the interesting cancellation paths fire frequently, each key draws
+//! its values from a *tiny per-key pool* (plus deletes): with only a handful of
+//! distinct values, re-inserting the same value, and delete-then-reinsert of an
+//! identical value, are common, exactly the retract/insert exact-cancellation
+//! cases. The values themselves cover the tricky-encoding datum space
+//! (`Numeric`, `Date`, `Timestamp`/`TimestampTz`, `Interval`, `Uuid`,
+//! `MzTimestamp`, `Bytes`, long strings, `MzAclItem`, nested
+//! `Array`/`List`/`Map`/`Range`), and a fraction of pool entries are
+//! `Err(UpsertError)` values (real sources stage errored values), which the
+//! oracle and output comparison handle directly as `UpsertValue`s.
+
+#![no_main]
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::range::{Range, RangeBound, RangeInner};
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::role_id::RoleId;
+use mz_repr::{Datum, Diff, Row, RowPacker, Timestamp};
+use mz_storage::fuzz_exports::{FuzzUpsertParts, UpsertKey, UpsertValue, fuzz_drain_staged_input};
+use mz_storage::source::SourceExportCreationConfig;
+use mz_storage_types::errors::{
+    DecodeError, DecodeErrorKind, UpsertError, UpsertNullKeyError, UpsertValueError,
+};
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+// The metrics plumbing is built once per process. `FuzzUpsertParts` is `Sync`
+// so it lives in a `static`. `SourceExportCreationConfig` holds a non-`Sync`
+// `SourceStatistics`, so it goes in a `thread_local` (built once, not per
+// iteration, because re-registering its Prometheus metrics each call was the
+// throughput bottleneck).
+static PARTS: OnceLock<FuzzUpsertParts> = OnceLock::new();
+thread_local! {
+    static CFG: SourceExportCreationConfig = PARTS.get_or_init(FuzzUpsertParts::new).source_config();
+}
+
+fn rt() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime")
+    })
+}
+
+/// An arbitrary in-range `NaiveDateTime`, or `None` if out of the supported range.
+fn gen_naive_dt(u: &mut Unstructured) -> arbitrary::Result<Option<NaiveDateTime>> {
+    let year = u.int_in_range(1i32..=9999)?;
+    let ord = u.int_in_range(1u32..=365)?;
+    let secs = u.int_in_range(0u32..=86_399)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    let date = NaiveDate::from_yo_opt(year, ord);
+    let time = NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos);
+    Ok(match (date, time) {
+        (Some(d), Some(t)) => Some(NaiveDateTime::new(d, t)),
+        _ => None,
+    })
+}
+
+fn gen_role_id(u: &mut Unstructured) -> arbitrary::Result<RoleId> {
+    Ok(match u.int_in_range(0u8..=2)? {
+        0 => RoleId::User(u64::arbitrary(u)?),
+        1 => RoleId::System(u64::arbitrary(u)?),
+        _ => RoleId::Public,
+    })
+}
+
+/// Push a single arbitrary scalar (non-composite) datum from the tricky space.
+fn push_scalar(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=14)? {
+        0 => packer.push(Datum::Null),
+        1 => packer.push(Datum::Int32(i32::arbitrary(u)?)),
+        2 => packer.push(Datum::Int64(i64::arbitrary(u)?)),
+        3 => packer.push(Datum::UInt8(u8::arbitrary(u)?)),
+        4 => packer.push(if bool::arbitrary(u)? {
+            Datum::True
+        } else {
+            Datum::False
+        }),
+        5 => packer.push(Datum::from(Numeric::from(i64::arbitrary(u)?))),
+        6 => {
+            let days = u.int_in_range(Date::LOW_DAYS..=Date::HIGH_DAYS)?;
+            packer.push(Datum::Date(Date::from_pg_epoch(days).unwrap()));
+        }
+        7 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                packer.push(Datum::Timestamp(
+                    CheckedTimestamp::from_timestamplike(dt).unwrap(),
+                ));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        8 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                let utc = DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc);
+                packer.push(Datum::TimestampTz(
+                    CheckedTimestamp::from_timestamplike(utc).unwrap(),
+                ));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        9 => packer.push(Datum::Interval(Interval::new(
+            i32::arbitrary(u)?,
+            i32::arbitrary(u)?,
+            i64::arbitrary(u)?,
+        ))),
+        10 => packer.push(Datum::Uuid(uuid::Uuid::from_bytes(
+            <[u8; 16]>::arbitrary(u)?,
+        ))),
+        11 => packer.push(Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?))),
+        12 => {
+            let len = u.int_in_range(0usize..=20)?;
+            let bytes = u.bytes(len)?;
+            packer.push(Datum::Bytes(bytes));
+        }
+        13 => packer.push(Datum::MzAclItem(MzAclItem {
+            grantee: gen_role_id(u)?,
+            grantor: gen_role_id(u)?,
+            acl_mode: AclMode::from_bits_truncate(u64::arbitrary(u)?),
+        })),
+        _ => {
+            let len = u.int_in_range(0usize..=300)?;
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                s.push(if bool::arbitrary(u)? { 'a' } else { 'é' });
+            }
+            packer.push(Datum::String(&s));
+        }
+    }
+    Ok(())
+}
+
+/// A vector of `'static`-safe scalar datums for use as composite elements.
+fn gen_scalar_vec(u: &mut Unstructured, n: usize) -> arbitrary::Result<Vec<Datum<'static>>> {
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        out.push(match u.int_in_range(0u8..=7)? {
+            0 => Datum::Null,
+            1 => Datum::Int32(i32::arbitrary(u)?),
+            2 => Datum::Int64(i64::arbitrary(u)?),
+            3 => Datum::UInt8(u8::arbitrary(u)?),
+            4 => Datum::from(Numeric::from(i64::arbitrary(u)?)),
+            5 => Datum::Interval(Interval::new(
+                i32::arbitrary(u)?,
+                i32::arbitrary(u)?,
+                i64::arbitrary(u)?,
+            )),
+            6 => Datum::Uuid(uuid::Uuid::from_bytes(<[u8; 16]>::arbitrary(u)?)),
+            _ => Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?)),
+        });
+    }
+    Ok(out)
+}
+
+/// Push a `Range` over `Int32` bounds (possibly empty or with infinite bounds).
+fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    if bool::arbitrary(u)? {
+        packer
+            .push_range(Range { inner: None })
+            .expect("empty range is valid");
+        return Ok(());
+    }
+    let lo = i32::arbitrary(u)?;
+    let hi = i32::arbitrary(u)?;
+    let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+    let lower = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(lo))
+        } else {
+            None
+        },
+    };
+    let upper = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(hi))
+        } else {
+            None
+        },
+    };
+    let range = Range {
+        inner: Some(RangeInner { lower, upper }),
+    };
+    if packer.push_range(range).is_err() {
+        packer.push(Datum::Int32(lo));
+    }
+    Ok(())
+}
+
+/// Push one datum: usually a scalar, occasionally a nested composite whose
+/// elements are themselves scalars. Always produces a valid `Row`.
+fn push_datum(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=9)? {
+        0..=5 => push_scalar(packer, u),
+        6 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            let dims = [ArrayDimension {
+                lower_bound: 1,
+                length: datums.len(),
+            }];
+            packer
+                .try_push_array(&dims, datums.iter())
+                .expect("single-dimension array is always valid");
+            Ok(())
+        }
+        7 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            packer.push_list(datums.iter());
+            Ok(())
+        }
+        8 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let mut keys: Vec<String> = Vec::with_capacity(n);
+            for _ in 0..n {
+                let len = u.int_in_range(0usize..=4)?;
+                let mut s = String::with_capacity(len);
+                for _ in 0..len {
+                    s.push(if bool::arbitrary(u)? { 'a' } else { 'b' });
+                }
+                keys.push(s);
+            }
+            keys.sort();
+            keys.dedup();
+            let vals = gen_scalar_vec(u, keys.len())?;
+            packer.push_dict(keys.iter().map(String::as_str).zip(vals.iter().copied()));
+            Ok(())
+        }
+        _ => push_range(packer, u),
+    }
+}
+
+/// A small arbitrary `Row` (the untrusted source value), covering the tricky
+/// scalar and nested-composite datum space.
+fn gen_row(u: &mut Unstructured) -> arbitrary::Result<Row> {
+    let n = u.int_in_range(0usize..=4)?;
+    let mut row = Row::default();
+    let mut packer = row.packer();
+    for _ in 0..n {
+        push_datum(&mut packer, u)?;
+    }
+    drop(packer);
+    Ok(row)
+}
+
+/// An arbitrary `DecodeError` payload for the error-arm variants.
+fn gen_decode_error(u: &mut Unstructured) -> arbitrary::Result<DecodeError> {
+    let msg = String::arbitrary(u)?;
+    let kind = if bool::arbitrary(u)? {
+        DecodeErrorKind::Text(msg.into_boxed_str())
+    } else {
+        DecodeErrorKind::Bytes(msg.into_boxed_str())
+    };
+    let raw = Vec::<u8>::arbitrary(u)?;
+    Ok(DecodeError { kind, raw })
+}
+
+/// An arbitrary `UpsertValue`: usually an `Ok(Row)`, occasionally an
+/// `Err(UpsertError)` spanning the whole variant space.
+fn gen_value(u: &mut Unstructured) -> arbitrary::Result<UpsertValue> {
+    if u.ratio(1u8, 5u8)? {
+        let err = match u.int_in_range(0u8..=2)? {
+            0 => UpsertError::KeyDecode(gen_decode_error(u)?),
+            1 => UpsertError::Value(UpsertValueError {
+                inner: gen_decode_error(u)?,
+                for_key: gen_row(u)?,
+            }),
+            _ => UpsertError::NullKey(UpsertNullKeyError),
+        };
+        Ok(Err(Box::new(err)))
+    } else {
+        Ok(Ok(gen_row(u)?))
+    }
+}
+
+/// Consolidate a differential output into a `(value, ts) -> net diff` map,
+/// dropping the entries that cancel out. Keys on the whole `UpsertValue` so both
+/// `Ok` rows and `Err` values are compared faithfully.
+fn consolidate(updates: &[(UpsertValue, u64, Diff)]) -> BTreeMap<(UpsertValue, u64), Diff> {
+    let mut m: BTreeMap<(UpsertValue, u64), Diff> = BTreeMap::new();
+    for (value, ts, diff) in updates {
+        *m.entry((value.clone(), *ts)).or_insert(Diff::ZERO) += *diff;
+    }
+    m.retain(|_, d| *d != Diff::ZERO);
+    m
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let parts = PARTS.get_or_init(FuzzUpsertParts::new);
+
+    let n_keys = u.int_in_range(1usize..=4)?;
+    let n_cmds = u.int_in_range(0usize..=20)?;
+
+    // Build a tiny per-key value pool. Commands draw their value from this small
+    // pool (or are deletes), so re-inserting the same value and
+    // delete-then-reinsert of an *identical* value are common, exactly the
+    // retract/insert exact-cancellation cases that are easy to miss with fresh
+    // random values every time.
+    let mut pools: Vec<Vec<UpsertValue>> = Vec::with_capacity(n_keys);
+    for _ in 0..n_keys {
+        let pool_size = u.int_in_range(1usize..=3)?;
+        let mut pool = Vec::with_capacity(pool_size);
+        for _ in 0..pool_size {
+            pool.push(gen_value(u)?);
+        }
+        pools.push(pool);
+    }
+
+    // Generate commands `(ts, key_idx, order, value)`. Orders are distinct (the
+    // generation index), so the max-order-per-(ts,key) winner is unambiguous,
+    // and multiple commands can target the same (ts, key) to exercise dedup.
+    let mut commands: Vec<(u64, usize, u64, Option<UpsertValue>)> = Vec::with_capacity(n_cmds);
+    for i in 0..n_cmds {
+        let ts = u.int_in_range(0u64..=4)?;
+        let key_idx = u.int_in_range(0usize..=n_keys - 1)?;
+        let value = if u.int_in_range(0u8..=3)? == 0 {
+            None // a delete
+        } else {
+            let pool = &pools[key_idx];
+            let pick = u.int_in_range(0usize..=pool.len() - 1)?;
+            Some(pool[pick].clone())
+        };
+        commands.push((ts, key_idx, i as u64, value));
+    }
+
+    let keys: Vec<UpsertKey> = (0..n_keys)
+        .map(|k| {
+            let key_row = Row::pack_slice(&[Datum::Int64(i64::try_from(k).unwrap())]);
+            UpsertKey::from_key(Ok(&key_row))
+        })
+        .collect();
+
+    let drain_to = commands.iter().map(|(ts, ..)| *ts).max().map_or(0, |m| m + 1);
+
+    let hook_commands: Vec<(u64, UpsertKey, u64, Option<UpsertValue>)> = commands
+        .iter()
+        .map(|(ts, k, o, v)| (*ts, keys[*k], *o, v.clone()))
+        .collect();
+
+    let (output, final_state) = CFG.with(|cfg| {
+        rt().block_on(fuzz_drain_staged_input(
+            parts,
+            cfg,
+            hook_commands,
+            drain_to,
+            &keys,
+        ))
+    });
+
+    // --- Oracle ---------------------------------------------------------------
+    // Per (key, ts), the maximum-order command wins.
+    let mut winner: BTreeMap<(usize, u64), (u64, Option<UpsertValue>)> = BTreeMap::new();
+    for (ts, k, o, v) in &commands {
+        let replace = match winner.get(&(*k, *ts)) {
+            Some((existing_order, _)) => existing_order < o,
+            None => true,
+        };
+        if replace {
+            winner.insert((*k, *ts), (*o, v.clone()));
+        }
+    }
+    // Process winners per key in timestamp order (the BTreeMap iterates
+    // key-major, ts-ascending): retract the prior value, insert the new one.
+    let mut oracle_output: Vec<(UpsertValue, u64, Diff)> = Vec::new();
+    let mut oracle_final: Vec<Option<UpsertValue>> = vec![None; n_keys];
+    let mut cur_key: Option<usize> = None;
+    let mut prev: Option<UpsertValue> = None;
+    for ((k, ts), (_order, value)) in &winner {
+        if cur_key != Some(*k) {
+            cur_key = Some(*k);
+            prev = None; // fresh state: this key has no prior value
+        }
+        if let Some(p) = &prev {
+            oracle_output.push((p.clone(), *ts, Diff::MINUS_ONE));
+        }
+        if let Some(nv) = value {
+            oracle_output.push((nv.clone(), *ts, Diff::ONE));
+        }
+        prev = value.clone();
+        oracle_final[*k] = value.clone();
+    }
+
+    // --- Checks ---------------------------------------------------------------
+    assert_eq!(
+        consolidate(&output),
+        consolidate(&oracle_output),
+        "drain_staged_input output diverged from the upsert oracle"
+    );
+    for (i, expected) in oracle_final.iter().enumerate() {
+        assert_eq!(
+            &final_state[i], expected,
+            "final state for key {i} diverged from the upsert oracle"
+        );
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/storage/fuzz/fuzz_targets/upsert_state_consolidate.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_state_consolidate.rs
@@ -1,0 +1,379 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the upsert state machine's snapshot consolidation
+//! (`UpsertState::consolidate_chunk` + `multi_get`) over the in-memory backend.
+//!
+//! Where `upsert_consolidate` exercises the XOR/checksum accumulator in
+//! isolation for a single key, this drives the whole state machine: a chunk of
+//! differential `(key, value, diff)` updates spanning several keys is fed to
+//! `consolidate_chunk` (which re-indexes them through `StateValue` and the
+//! backend), the snapshot is completed, and `multi_get` reads each key back.
+//!
+//! The diffs are Materialize-controlled, so per key we generate a *well-formed*
+//! history, zero-or-more canceling `(prev, +1) (prev, -1)` pairs plus at most
+//! one current `(cur, +1)`, and shuffle the whole multi-key chunk. After
+//! consolidation each key must read back exactly its current value (or absent
+//! if it had none): the canceling pairs must XOR/sum away across the chunk
+//! regardless of order or of colliding with each other. A panic in
+//! `consolidate_chunk`/`multi_get`, or a wrong/lost/invented value, is a finding.
+//!
+//! The values are drawn from the tricky-encoding datum space (`Numeric`,
+//! `Date`, `Timestamp`/`TimestampTz`, `Interval`, `Uuid`, `MzTimestamp`,
+//! `Bytes`, long strings, `MzAclItem`, and the nested composites
+//! `Array`/`List`/`Map`/`Range`), and a fraction are `Err(UpsertError)` values
+//! (real upsert sources stage errored values alongside `Ok` rows), so the
+//! state-machine consolidation path is exercised over bincode payloads of widely
+//! varying length and over both value arms.
+
+#![no_main]
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::range::{Range, RangeBound, RangeInner};
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::role_id::RoleId;
+use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
+use mz_storage::fuzz_exports::{
+    FuzzUpsertParts, UpsertKey, UpsertValue, UpsertValueAndSize, upsert_bincode_opts,
+};
+use mz_storage_types::errors::{
+    DecodeError, DecodeErrorKind, UpsertError, UpsertNullKeyError, UpsertValueError,
+};
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+fn rt() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime")
+    })
+}
+
+/// An arbitrary in-range `NaiveDateTime`, or `None` if out of the supported range.
+fn gen_naive_dt(u: &mut Unstructured) -> arbitrary::Result<Option<NaiveDateTime>> {
+    let year = u.int_in_range(1i32..=9999)?;
+    let ord = u.int_in_range(1u32..=365)?;
+    let secs = u.int_in_range(0u32..=86_399)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    let date = NaiveDate::from_yo_opt(year, ord);
+    let time = NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos);
+    Ok(match (date, time) {
+        (Some(d), Some(t)) => Some(NaiveDateTime::new(d, t)),
+        _ => None,
+    })
+}
+
+fn gen_role_id(u: &mut Unstructured) -> arbitrary::Result<RoleId> {
+    Ok(match u.int_in_range(0u8..=2)? {
+        0 => RoleId::User(u64::arbitrary(u)?),
+        1 => RoleId::System(u64::arbitrary(u)?),
+        _ => RoleId::Public,
+    })
+}
+
+/// Push a single arbitrary scalar (non-composite) datum from the tricky space.
+fn push_scalar(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=14)? {
+        0 => packer.push(Datum::Null),
+        1 => packer.push(Datum::Int32(i32::arbitrary(u)?)),
+        2 => packer.push(Datum::Int64(i64::arbitrary(u)?)),
+        3 => packer.push(Datum::UInt8(u8::arbitrary(u)?)),
+        4 => packer.push(if bool::arbitrary(u)? {
+            Datum::True
+        } else {
+            Datum::False
+        }),
+        5 => packer.push(Datum::from(Numeric::from(i64::arbitrary(u)?))),
+        6 => {
+            let days = u.int_in_range(Date::LOW_DAYS..=Date::HIGH_DAYS)?;
+            packer.push(Datum::Date(Date::from_pg_epoch(days).unwrap()));
+        }
+        7 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                packer.push(Datum::Timestamp(
+                    CheckedTimestamp::from_timestamplike(dt).unwrap(),
+                ));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        8 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                let utc = DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc);
+                packer.push(Datum::TimestampTz(
+                    CheckedTimestamp::from_timestamplike(utc).unwrap(),
+                ));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        9 => packer.push(Datum::Interval(Interval::new(
+            i32::arbitrary(u)?,
+            i32::arbitrary(u)?,
+            i64::arbitrary(u)?,
+        ))),
+        10 => packer.push(Datum::Uuid(uuid::Uuid::from_bytes(
+            <[u8; 16]>::arbitrary(u)?,
+        ))),
+        11 => packer.push(Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?))),
+        12 => {
+            let len = u.int_in_range(0usize..=20)?;
+            let bytes = u.bytes(len)?;
+            packer.push(Datum::Bytes(bytes));
+        }
+        13 => packer.push(Datum::MzAclItem(MzAclItem {
+            grantee: gen_role_id(u)?,
+            grantor: gen_role_id(u)?,
+            acl_mode: AclMode::from_bits_truncate(u64::arbitrary(u)?),
+        })),
+        _ => {
+            let len = u.int_in_range(0usize..=300)?;
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                s.push(if bool::arbitrary(u)? { 'a' } else { 'é' });
+            }
+            packer.push(Datum::String(&s));
+        }
+    }
+    Ok(())
+}
+
+/// A vector of `'static`-safe scalar datums for use as composite elements.
+fn gen_scalar_vec(u: &mut Unstructured, n: usize) -> arbitrary::Result<Vec<Datum<'static>>> {
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        out.push(match u.int_in_range(0u8..=7)? {
+            0 => Datum::Null,
+            1 => Datum::Int32(i32::arbitrary(u)?),
+            2 => Datum::Int64(i64::arbitrary(u)?),
+            3 => Datum::UInt8(u8::arbitrary(u)?),
+            4 => Datum::from(Numeric::from(i64::arbitrary(u)?)),
+            5 => Datum::Interval(Interval::new(
+                i32::arbitrary(u)?,
+                i32::arbitrary(u)?,
+                i64::arbitrary(u)?,
+            )),
+            6 => Datum::Uuid(uuid::Uuid::from_bytes(<[u8; 16]>::arbitrary(u)?)),
+            _ => Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?)),
+        });
+    }
+    Ok(out)
+}
+
+/// Push a `Range` over `Int32` bounds (possibly empty or with infinite bounds).
+fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    if bool::arbitrary(u)? {
+        packer
+            .push_range(Range { inner: None })
+            .expect("empty range is valid");
+        return Ok(());
+    }
+    let lo = i32::arbitrary(u)?;
+    let hi = i32::arbitrary(u)?;
+    let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+    let lower = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(lo))
+        } else {
+            None
+        },
+    };
+    let upper = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(hi))
+        } else {
+            None
+        },
+    };
+    let range = Range {
+        inner: Some(RangeInner { lower, upper }),
+    };
+    if packer.push_range(range).is_err() {
+        packer.push(Datum::Int32(lo));
+    }
+    Ok(())
+}
+
+/// Push one datum: usually a scalar, occasionally a nested composite whose
+/// elements are themselves scalars. Always produces a valid `Row`.
+fn push_datum(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=9)? {
+        0..=5 => push_scalar(packer, u),
+        6 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            let dims = [ArrayDimension {
+                lower_bound: 1,
+                length: datums.len(),
+            }];
+            packer
+                .try_push_array(&dims, datums.iter())
+                .expect("single-dimension array is always valid");
+            Ok(())
+        }
+        7 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            packer.push_list(datums.iter());
+            Ok(())
+        }
+        8 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let mut keys: Vec<String> = Vec::with_capacity(n);
+            for _ in 0..n {
+                let len = u.int_in_range(0usize..=4)?;
+                let mut s = String::with_capacity(len);
+                for _ in 0..len {
+                    s.push(if bool::arbitrary(u)? { 'a' } else { 'b' });
+                }
+                keys.push(s);
+            }
+            keys.sort();
+            keys.dedup();
+            let vals = gen_scalar_vec(u, keys.len())?;
+            packer.push_dict(keys.iter().map(String::as_str).zip(vals.iter().copied()));
+            Ok(())
+        }
+        _ => push_range(packer, u),
+    }
+}
+
+/// A small arbitrary `Row` (the untrusted source value), covering the tricky
+/// scalar and nested-composite datum space.
+fn gen_row(u: &mut Unstructured) -> arbitrary::Result<Row> {
+    let n = u.int_in_range(0usize..=5)?;
+    let mut row = Row::default();
+    let mut packer = row.packer();
+    for _ in 0..n {
+        push_datum(&mut packer, u)?;
+    }
+    drop(packer);
+    Ok(row)
+}
+
+/// An arbitrary `DecodeError` payload for the error-arm variants.
+fn gen_decode_error(u: &mut Unstructured) -> arbitrary::Result<DecodeError> {
+    let msg = String::arbitrary(u)?;
+    let kind = if bool::arbitrary(u)? {
+        DecodeErrorKind::Text(msg.into_boxed_str())
+    } else {
+        DecodeErrorKind::Bytes(msg.into_boxed_str())
+    };
+    let raw = Vec::<u8>::arbitrary(u)?;
+    Ok(DecodeError { kind, raw })
+}
+
+/// An arbitrary `UpsertValue`: usually an `Ok(Row)`, occasionally an
+/// `Err(UpsertError)` spanning the whole variant space.
+fn gen_value(u: &mut Unstructured) -> arbitrary::Result<UpsertValue> {
+    if u.ratio(1u8, 5u8)? {
+        let err = match u.int_in_range(0u8..=2)? {
+            0 => UpsertError::KeyDecode(gen_decode_error(u)?),
+            1 => UpsertError::Value(UpsertValueError {
+                inner: gen_decode_error(u)?,
+                for_key: gen_row(u)?,
+            }),
+            _ => UpsertError::NullKey(UpsertNullKeyError),
+        };
+        Ok(Err(Box::new(err)))
+    } else {
+        Ok(Ok(gen_row(u)?))
+    }
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    // The metrics/statistics plumbing is built once and reused across iterations.
+    static PARTS: OnceLock<FuzzUpsertParts> = OnceLock::new();
+    let parts = PARTS.get_or_init(FuzzUpsertParts::new);
+    let bincode_opts = upsert_bincode_opts();
+
+    let n_keys = u.int_in_range(1usize..=4)?;
+    let mut keys: Vec<UpsertKey> = Vec::with_capacity(n_keys);
+    let mut expected: HashMap<UpsertKey, Option<UpsertValue>> = HashMap::new();
+    let mut chunk: Vec<(UpsertKey, UpsertValue, Diff)> = Vec::new();
+
+    for k in 0..n_keys {
+        let key_row = Row::pack_slice(&[Datum::Int32(i32::try_from(k).unwrap())]);
+        let key = UpsertKey::from_key(Ok(&key_row));
+        keys.push(key);
+
+        let n_pairs = u.int_in_range(0usize..=4)?;
+        for _ in 0..n_pairs {
+            let prev: UpsertValue = gen_value(u)?;
+            chunk.push((key, prev.clone(), Diff::ONE));
+            chunk.push((key, prev, -Diff::ONE));
+        }
+        if bool::arbitrary(u)? {
+            let cur = gen_value(u)?;
+            chunk.push((key, cur.clone(), Diff::ONE));
+            expected.insert(key, Some(cur));
+        } else {
+            expected.insert(key, None);
+        }
+    }
+
+    // Shuffle the whole multi-key chunk. Consolidation must be order-independent.
+    for i in (1..chunk.len()).rev() {
+        let j = u.int_in_range(0..=i)?;
+        chunk.swap(i, j);
+    }
+
+    rt().block_on(async {
+        let mut state = parts.state();
+        state
+            .consolidate_chunk(chunk.into_iter(), true)
+            .await
+            .expect("consolidate_chunk should not error on well-formed input");
+
+        let mut results = vec![UpsertValueAndSize::default(); keys.len()];
+        state
+            .multi_get(keys.iter().copied(), results.iter_mut())
+            .await
+            .expect("multi_get should not error");
+
+        for (key, result) in keys.iter().zip(results) {
+            let finalized: Option<UpsertValue> = match result.value {
+                None => None,
+                Some(mut sv) => {
+                    sv.ensure_decoded(bincode_opts, GlobalId::User(0), None);
+                    sv.into_decoded().finalized
+                }
+            };
+            match (expected.get(key).unwrap(), finalized) {
+                (Some(cur), Some(got)) => {
+                    assert_eq!(&got, cur, "key consolidated to the wrong value")
+                }
+                (Some(_), None) => panic!("consolidation lost a key's value"),
+                (None, None) => {}
+                (None, other) => {
+                    panic!("consolidation invented a value for a canceled key: {other:?}")
+                }
+            }
+        }
+    });
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/storage/fuzz/fuzz_targets/upsert_value_roundtrip_v2.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_value_roundtrip_v2.rs
@@ -1,0 +1,346 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the v2 upsert operator's value encoding round-trips.
+//!
+//! Where the v1 upsert state machine consolidates with the XOR/checksum
+//! accumulator (see `upsert_consolidate`), the v2 operator
+//! (`upsert_continual_feedback_v2`) stores values in a differential
+//! `ValRowSpine` as packed `Row` bytes. An [`UpsertValue`] is
+//! `Result<Row, Box<UpsertError>>`, so it is folded into a single tagged `Row`
+//! by `upsert_value_to_row` (tag `0` + the row's datums for `Ok`, tag `1` + the
+//! bincode of the error for `Err`) and recovered from a spine cursor's
+//! `DatumSeq` by `datum_seq_to_upsert_value`. A bug in that encode/decode pair
+//! silently corrupts the value a v2 upsert source produces, so the round-trip
+//! must be the identity for any value (the values come from untrusted source
+//! data).
+//!
+//! We push the encoded `Row` through a real `DatumContainer` (the same byte
+//! storage the spine uses) and read it back as a `DatumSeq`, exactly as the
+//! operator does, then assert `decode(encode(v)) == v`.
+//!
+//! Both arms are generated with depth:
+//!
+//!   * the `Ok` arm draws from the *tricky-encoding* datum space (`Numeric`,
+//!     `Date`, `Timestamp`/`TimestampTz`, `Interval`, `Uuid`, `MzTimestamp`,
+//!     `Bytes`, long strings, `MzAclItem`, and the nested composites `Array`,
+//!     `List`, `Map`, and `Range`), so the tag-prefixed re-pack/extend round-trip
+//!     is exercised over every `Row` tag and over multi-byte length encodings,
+//!     not just the trivial scalars.
+//!   * the `Err` arm covers the whole [`UpsertError`] variant space
+//!     (`KeyDecode`, `Value`, `NullKey`) with non-trivial `DecodeError` payloads
+//!     and a real decoded key `Row`, so the tag-`1` bincode round-trip is
+//!     stressed across all error shapes, not just `NullKey`.
+
+#![no_main]
+
+use differential_dataflow::trace::implementations::BatchContainer;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::range::{Range, RangeBound, RangeInner};
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::role_id::RoleId;
+use mz_repr::{Datum, Row, RowPacker, Timestamp};
+use mz_row_spine::DatumContainer;
+use mz_storage::fuzz_exports::{UpsertValue, datum_seq_to_upsert_value, upsert_value_to_row};
+use mz_storage_types::errors::{
+    DecodeError, DecodeErrorKind, UpsertError, UpsertNullKeyError, UpsertValueError,
+};
+use timely::container::PushInto;
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+/// Push a single arbitrary *scalar* (non-composite) datum, drawn from the
+/// tricky-encoding space so we vary the `Row` tag and the bincode length.
+fn push_scalar(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=15)? {
+        0 => packer.push(Datum::Null),
+        1 => packer.push(Datum::Int32(i32::arbitrary(u)?)),
+        2 => packer.push(Datum::Int64(i64::arbitrary(u)?)),
+        // `upsert_value_to_row` tags `Ok` values with a leading `UInt8(0)`, so
+        // include `UInt8` data datums so a value can't be confused with the tag.
+        3 => packer.push(Datum::UInt8(u8::arbitrary(u)?)),
+        4 => packer.push(if bool::arbitrary(u)? {
+            Datum::True
+        } else {
+            Datum::False
+        }),
+        5 => packer.push(Datum::from(Numeric::from(i64::arbitrary(u)?))),
+        6 => {
+            let days = u.int_in_range(Date::LOW_DAYS..=Date::HIGH_DAYS)?;
+            packer.push(Datum::Date(Date::from_pg_epoch(days).unwrap()));
+        }
+        7 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                packer.push(Datum::Timestamp(CheckedTimestamp::from_timestamplike(dt).unwrap()));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        8 => {
+            if let Some(dt) = gen_naive_dt(u)? {
+                let utc = DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc);
+                packer.push(Datum::TimestampTz(
+                    CheckedTimestamp::from_timestamplike(utc).unwrap(),
+                ));
+            } else {
+                packer.push(Datum::Null);
+            }
+        }
+        9 => packer.push(Datum::Interval(Interval::new(
+            i32::arbitrary(u)?,
+            i32::arbitrary(u)?,
+            i64::arbitrary(u)?,
+        ))),
+        10 => packer.push(Datum::Uuid(uuid::Uuid::from_bytes(
+            <[u8; 16]>::arbitrary(u)?,
+        ))),
+        11 => packer.push(Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?))),
+        12 => {
+            let len = u.int_in_range(0usize..=20)?;
+            let bytes = u.bytes(len)?;
+            packer.push(Datum::Bytes(bytes));
+        }
+        13 => packer.push(Datum::MzAclItem(MzAclItem {
+            grantee: gen_role_id(u)?,
+            grantor: gen_role_id(u)?,
+            acl_mode: AclMode::from_bits_truncate(u64::arbitrary(u)?),
+        })),
+        14 => {
+            // A string whose length spills past the 1-byte tiny encoding, so the
+            // multi-byte length path is exercised. Mixes ASCII and multi-byte.
+            let len = u.int_in_range(0usize..=300)?;
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                s.push(if bool::arbitrary(u)? { 'a' } else { 'é' });
+            }
+            packer.push(Datum::String(&s));
+        }
+        _ => {
+            let len = u.int_in_range(0usize..=6)?;
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                s.push(if bool::arbitrary(u)? { 'a' } else { 'é' });
+            }
+            packer.push(Datum::String(&s));
+        }
+    }
+    Ok(())
+}
+
+/// An arbitrary in-range `NaiveDateTime`, or `None` if out of the supported range.
+fn gen_naive_dt(u: &mut Unstructured) -> arbitrary::Result<Option<NaiveDateTime>> {
+    // Stay comfortably inside chrono's representable range.
+    let year = u.int_in_range(1i32..=9999)?;
+    let ord = u.int_in_range(1u32..=365)?;
+    let secs = u.int_in_range(0u32..=86_399)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    let date = NaiveDate::from_yo_opt(year, ord);
+    let time = NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos);
+    Ok(match (date, time) {
+        (Some(d), Some(t)) => Some(NaiveDateTime::new(d, t)),
+        _ => None,
+    })
+}
+
+fn gen_role_id(u: &mut Unstructured) -> arbitrary::Result<RoleId> {
+    Ok(match u.int_in_range(0u8..=2)? {
+        0 => RoleId::User(u64::arbitrary(u)?),
+        1 => RoleId::System(u64::arbitrary(u)?),
+        _ => RoleId::Public,
+    })
+}
+
+/// Push one datum: usually a scalar, occasionally a nested composite
+/// (`Array`/`List`/`Map`/`Range`) whose elements are themselves scalars. Falls
+/// back to a scalar if a composite can't be constructed for the drawn shape (an
+/// invalid range, e.g.), so the caller always ends up with a valid `Row`.
+fn push_datum(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=9)? {
+        // Mostly scalars.
+        0..=5 => push_scalar(packer, u),
+        // A 1-D Array of scalars.
+        6 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            let dims = [ArrayDimension {
+                lower_bound: 1,
+                length: datums.len(),
+            }];
+            packer
+                .try_push_array(&dims, datums.iter())
+                .expect("single-dimension array is always valid");
+            Ok(())
+        }
+        // A List of scalars.
+        7 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let datums = gen_scalar_vec(u, n)?;
+            packer.push_list(datums.iter());
+            Ok(())
+        }
+        // A Map (dict) with sorted, unique string keys.
+        8 => {
+            let n = u.int_in_range(0usize..=4)?;
+            let mut keys: Vec<String> = Vec::with_capacity(n);
+            for _ in 0..n {
+                let len = u.int_in_range(0usize..=4)?;
+                let mut s = String::with_capacity(len);
+                for _ in 0..len {
+                    s.push(if bool::arbitrary(u)? { 'a' } else { 'b' });
+                }
+                keys.push(s);
+            }
+            keys.sort();
+            keys.dedup();
+            let vals = gen_scalar_vec(u, keys.len())?;
+            packer.push_dict(keys.iter().map(String::as_str).zip(vals.iter().copied()));
+            Ok(())
+        }
+        // A Range over Int32 bounds.
+        _ => {
+            push_range(packer, u)?;
+            Ok(())
+        }
+    }
+}
+
+/// Generate a vector of `n` scalar datums by packing them into a scratch row and
+/// borrowing them back. (Composite packers need an iterator of `Datum`.)
+fn gen_scalar_vec<'a>(
+    u: &mut Unstructured,
+    n: usize,
+) -> arbitrary::Result<Vec<Datum<'static>>> {
+    // We only emit `Copy`, `'static`-safe scalar datums here so the returned
+    // `Datum`s don't borrow from a scratch buffer. That covers ints, bools,
+    // numerics, dates, timestamps, intervals, uuids, and mz-timestamps.
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        out.push(match u.int_in_range(0u8..=7)? {
+            0 => Datum::Null,
+            1 => Datum::Int32(i32::arbitrary(u)?),
+            2 => Datum::Int64(i64::arbitrary(u)?),
+            3 => Datum::UInt8(u8::arbitrary(u)?),
+            4 => Datum::from(Numeric::from(i64::arbitrary(u)?)),
+            5 => Datum::Interval(Interval::new(
+                i32::arbitrary(u)?,
+                i32::arbitrary(u)?,
+                i64::arbitrary(u)?,
+            )),
+            6 => Datum::Uuid(uuid::Uuid::from_bytes(<[u8; 16]>::arbitrary(u)?)),
+            _ => Datum::MzTimestamp(Timestamp::from(u64::arbitrary(u)?)),
+        });
+    }
+    Ok(out)
+}
+
+/// Push a `Range` over `Int32` bounds (possibly empty or with infinite bounds).
+fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result<()> {
+    if bool::arbitrary(u)? {
+        // Empty range.
+        packer
+            .push_range(Range { inner: None })
+            .expect("empty range is valid");
+        return Ok(());
+    }
+    let lo = i32::arbitrary(u)?;
+    let hi = i32::arbitrary(u)?;
+    let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+    let lower = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(lo))
+        } else {
+            None
+        },
+    };
+    let upper = RangeBound {
+        inclusive: bool::arbitrary(u)?,
+        bound: if bool::arbitrary(u)? {
+            Some(Datum::Int32(hi))
+        } else {
+            None
+        },
+    };
+    let range = Range {
+        inner: Some(RangeInner { lower, upper }),
+    };
+    // `push_range` canonicalizes and may reject (e.g. a degenerate empty range).
+    // On rejection just push a plain scalar so the row is still valid.
+    if packer.push_range(range).is_err() {
+        packer.push(Datum::Int32(lo));
+    }
+    Ok(())
+}
+
+/// A small arbitrary `Row` (the untrusted source value), covering the tricky
+/// scalar and nested-composite datum space.
+fn gen_row(u: &mut Unstructured) -> arbitrary::Result<Row> {
+    let n = u.int_in_range(0usize..=5)?;
+    let mut row = Row::default();
+    let mut packer = row.packer();
+    for _ in 0..n {
+        push_datum(&mut packer, u)?;
+    }
+    drop(packer);
+    Ok(row)
+}
+
+/// An arbitrary `DecodeError` payload for the error-arm variants.
+fn gen_decode_error(u: &mut Unstructured) -> arbitrary::Result<DecodeError> {
+    let msg = String::arbitrary(u)?;
+    let kind = if bool::arbitrary(u)? {
+        DecodeErrorKind::Text(msg.into_boxed_str())
+    } else {
+        DecodeErrorKind::Bytes(msg.into_boxed_str())
+    };
+    let raw = Vec::<u8>::arbitrary(u)?;
+    Ok(DecodeError { kind, raw })
+}
+
+fn gen_value(u: &mut Unstructured) -> arbitrary::Result<UpsertValue> {
+    if u.ratio(1u8, 4u8)? {
+        // Exercise the error arm (tag `1` + bincode of the error) across the
+        // whole `UpsertError` variant space.
+        let err = match u.int_in_range(0u8..=2)? {
+            0 => UpsertError::KeyDecode(gen_decode_error(u)?),
+            1 => UpsertError::Value(UpsertValueError {
+                inner: gen_decode_error(u)?,
+                for_key: gen_row(u)?,
+            }),
+            _ => UpsertError::NullKey(UpsertNullKeyError),
+        };
+        Ok(Err(Box::new(err)))
+    } else {
+        Ok(Ok(gen_row(u)?))
+    }
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let value: UpsertValue = gen_value(u)?;
+
+    // Encode, store in the spine's byte container, read back, decode.
+    let row = upsert_value_to_row(&value);
+    let mut container = DatumContainer::with_capacity(1);
+    container.push_into(row);
+    let decoded = datum_seq_to_upsert_value(container.index(0));
+
+    assert_eq!(value, decoded, "v2 upsert value encoding did not round-trip");
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});


### PR DESCRIPTION
Replacement stack for #36982. This is part 9 of 10.

Summary:
- Adds storage cargo-fuzz crate.
- Adds upsert consolidation, runtime, state consolidation, and value round-trip targets.

Review notes:
- The targets use the fuzz-only upsert hook from part 2.
- Focus review on the modeled upsert state machine and the generated command sequences.

Verification:
- Split from original commit 082e197653 and reapplied onto current upstream/main.
- Top of stack has the same touched-file set as #36982 and passes git diff --check.

Stack:
1. #37381 tests: Add shared cargo-fuzz runner
2. #37382 tests: Expose fuzz-only internals
3. #37383 sql-parser: Add cargo-fuzz targets
4. #37384 expr, transform: Add cargo-fuzz targets
5. #37385 repr, pgwire: Add cargo-fuzz targets
6. #37386 avro, interchange: Add cargo-fuzz targets
7. #37387 storage-types: Add proto cargo-fuzz targets
8. #37388 persist-client: Add cargo-fuzz targets
9. #37389 storage: Add upsert cargo-fuzz targets
10. #37390 ci: Run cargo-fuzz in release qualification

The original monolithic PR is #36982.