### PR TITLE
expr: Fix range check in cast_float_32_to_uint32/64

### DIFF
--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -159,8 +159,11 @@ fn cast_float32_to_uint16(a: f32) -> Result<u16, EvalError> {
 fn cast_float32_to_uint32(a: f32) -> Result<u32, EvalError> {
     let f = round_float32(a);
     // TODO(benesch): remove potentially dangerous usage of `as`.
+    // NOTE: `u32::MAX` is not representable as f32 and rounds up to 2^32, so the
+    // bound must be strict. A `<=` here would admit 2^32, which the `as` cast
+    // below then saturates to `u32::MAX` instead of erroring.
     #[allow(clippy::as_conversions)]
-    if (f >= 0.0) && (f <= (u32::MAX as f32)) {
+    if (f >= 0.0) && (f < (u32::MAX as f32)) {
         Ok(f as u32)
     } else {
         Err(EvalError::UInt32OutOfRange(f.to_string().into()))
@@ -176,8 +179,11 @@ fn cast_float32_to_uint32(a: f32) -> Result<u32, EvalError> {
 fn cast_float32_to_uint64(a: f32) -> Result<u64, EvalError> {
     let f = round_float32(a);
     // TODO(benesch): remove potentially dangerous usage of `as`.
+    // NOTE: `u64::MAX` is not representable as f32 and rounds up to 2^64, so the
+    // bound must be strict. A `<=` here would admit 2^64, which the `as` cast
+    // below then saturates to `u64::MAX` instead of erroring.
     #[allow(clippy::as_conversions)]
-    if (f >= 0.0) && (f <= (u64::MAX as f32)) {
+    if (f >= 0.0) && (f < (u64::MAX as f32)) {
         Ok(f as u64)
     } else {
         Err(EvalError::UInt64OutOfRange(f.to_string().into()))

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -469,6 +469,19 @@ SELECT 18446744073709553664.0::float::uint8
 query error "18446744073709556000" uint8 out of range
 SELECT 18446744073709553664.5::float::uint8
 
+# From real (float4)
+#
+# The "From float32" section above casts through `float` (= float8), so it does
+# not exercise real -> uint4/uint8. 2^32 and 2^64 are exactly representable as
+# f32 and must overflow, but u32::MAX/u64::MAX round up to them as f32, so a
+# `f <= (u32::MAX as f32)` guard lets them through and `as` saturates instead.
+
+query error "4294967300" uint4 out of range
+SELECT 4294967296.0::real::uint4
+
+query error "18446744000000000000" uint8 out of range
+SELECT 18446744073709551616.0::real::uint8
+
 # From float64
 
 query I


### PR DESCRIPTION
The `f <= (u32::MAX as f32)` and `f <= (u64::MAX as f32)` guards were not exact. u32::MAX and u64::MAX are not representable as f32 and round up to 2^32 and 2^64, which are exactly representable. Those values passed the guard, and the saturating `as` cast then returned u32::MAX / u64::MAX instead of raising the out-of-range error. Use a strict `<` so 2^32 and 2^64 are rejected. uint2 was unaffected because u16::MAX is exact as f32.

Closes CLU-139