### PR TITLE
mz_sleep: Error on invalid values instead of panicking

### DIFF
--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -415,10 +415,14 @@ fn exp(a: f64) -> Result<f64, EvalError> {
 }
 
 #[sqlfunc(sqlname = "mz_sleep")]
-fn sleep(a: f64) -> Option<CheckedTimestamp<DateTime<Utc>>> {
-    let duration = std::time::Duration::from_secs_f64(a);
+fn sleep(a: f64) -> Result<Option<CheckedTimestamp<DateTime<Utc>>>, EvalError> {
+    let duration = std::time::Duration::try_from_secs_f64(a).map_err(|_| {
+        let mut val = String::new();
+        strconv::format_float64(&mut val, a);
+        EvalError::InvalidParameterValue(format!("cannot sleep for {val} seconds").into())
+    })?;
     std::thread::sleep(duration);
-    None
+    Ok(None)
 }
 
 #[sqlfunc(sqlname = "tots")]

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1680,6 +1680,22 @@ SELECT pg_stat_get_numscans('pg_views'::regclass::oid)
 ----
 -1
 
+# mz_sleep (src/expr/src/scalar/func/impls/float64.rs) must reject inputs that are not a
+# valid `Duration` with a clean evaluation error. `Duration::from_secs_f64` panics on
+# negative, NaN, infinite, and oversized-finite values, and the unary-eval path is not
+# wrapped in catch_unwind, so an unvalidated argument would crash the evaluating worker.
+statement error cannot sleep for -1 seconds
+SELECT mz_unsafe.mz_sleep(-1.0)
+
+statement error cannot sleep for NaN seconds
+SELECT mz_unsafe.mz_sleep('NaN'::float8)
+
+statement error cannot sleep for Infinity seconds
+SELECT mz_unsafe.mz_sleep('inf'::float8)
+
+statement error cannot sleep for 1e\+300 seconds
+SELECT mz_unsafe.mz_sleep('1e300'::float8)
+
 # mz_unsafe functions can't be executed with the enable_unsafe_functions flag turned off
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
Closes CLU-140