### PR TITLE
expr: stop cast inversion from dropping uint4 narrowing-cast errors

### DIFF
--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -53,7 +53,11 @@ fn cast_uint32_to_float64(a: u32) -> f64 {
 
 #[sqlfunc(
     sqlname = "uint4_to_uint2",
-    preserves_uniqueness = true,
+    // Partial: errors for `u32` values above `u16::MAX`. Marking this as
+    // uniqueness-preserving would let cast inversion rewrite `col::uint2 = lit`
+    // into an index lookup on `col`, skipping the cast and dropping its
+    // out-of-range error.
+    preserves_uniqueness = false,
     inverse = to_unary!(super::CastUint16ToUint32),
     is_monotone = true
 )]
@@ -73,7 +77,8 @@ fn cast_uint32_to_uint64(a: u32) -> u64 {
 
 #[sqlfunc(
     sqlname = "uint4_to_smallint",
-    preserves_uniqueness = true,
+    // Partial: errors for `u32` values above `i16::MAX`. See `uint4_to_uint2`.
+    preserves_uniqueness = false,
     inverse = to_unary!(super::CastInt16ToUint32),
     is_monotone = true
 )]
@@ -83,7 +88,8 @@ fn cast_uint32_to_int16(a: u32) -> Result<i16, EvalError> {
 
 #[sqlfunc(
     sqlname = "uint4_to_integer",
-    preserves_uniqueness = true,
+    // Partial: errors for `u32` values above `i32::MAX`. See `uint4_to_uint2`.
+    preserves_uniqueness = false,
     inverse = to_unary!(super::CastInt32ToUint32),
     is_monotone = true
 )]

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -1464,3 +1464,29 @@ query T rowsort
 SELECT b FROM t_bytea_cast WHERE b::text = '\x41'
 ----
 A
+
+# Regression test: `uint4_to_uint2`, `uint4_to_smallint`, and `uint4_to_integer`
+# are injective but partial (they error for `u32` values above the target range).
+# Cast inversion in `invert_casts_on_expr_eq_literal_inner` must NOT rewrite
+# `cast(col) = lit` into an `IndexedFilter` lookup on `col`, because the lookup
+# skips the cast and silently drops the out-of-range error. Each query below must
+# error on the row 3000000000, not complete with it filtered out. The literals
+# are typed to the target so the cast stays single-layered and the rewrite fires.
+
+statement ok
+CREATE TABLE t_uint_cast (u uint4)
+
+statement ok
+INSERT INTO t_uint_cast VALUES (3000000000)
+
+statement ok
+CREATE DEFAULT INDEX ON t_uint_cast
+
+query error "3000000000" integer out of range
+SELECT u FROM t_uint_cast WHERE u::int4 = 5
+
+query error "3000000000" smallint out of range
+SELECT u FROM t_uint_cast WHERE u::int2 = 5::int2
+
+query error "3000000000" uint2 out of range
+SELECT u FROM t_uint_cast WHERE u::uint2 = 5::uint2


### PR DESCRIPTION
The narrowing casts uint4_to_uint2, uint4_to_smallint, and uint4_to_integer are injective but partial: they raise an out-of-range error for u32 values above the target type's range. They were marked preserves_uniqueness = true with an inverse, which let invert_casts_on_expr_eq_literal_inner rewrite `cast(col) = lit` into `col = inverse(lit)` and build an IndexedFilter index lookup on col. That lookup never evaluates the cast, so it silently dropped the error for rows outside the target range: a query that should fail instead completed with the offending row filtered out.

Mark the three casts preserves_uniqueness = false so the predicate stays a per-row filter that correctly errors, matching the existing remedy for the non-injective text_to_"char" and text_to_bytea casts. Add regression tests to test/sqllogictest/transform/literal_constraints.slt.

Closes CLU-142