### PR TITLE
expr: reject out-of-range 2^64 in float8-to-uint8 cast

### DIFF
--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -188,9 +188,13 @@ fn cast_float64_to_uint32(a: f64) -> Result<u32, EvalError> {
 )]
 fn cast_float64_to_uint64(a: f64) -> Result<u64, EvalError> {
     let f = round_float64(a);
+    // This condition is delicate because u64::MAX cannot be represented exactly by
+    // an f64: `u64::MAX as f64` rounds up to 2^64. A `<=` bound would therefore let
+    // 2^64 pass, and the subsequent `as u64` cast saturates it to u64::MAX. Comparing
+    // with `<` keeps 2^64 (and larger) out of range, mirroring the f64 -> i64 cast.
     // TODO(benesch): remove potentially dangerous usage of `as`.
     #[allow(clippy::as_conversions)]
-    if (f >= 0.0) && (f <= (u64::MAX as f64)) {
+    if (f >= 0.0) && (f < (u64::MAX as f64)) {
         Ok(f as u64)
     } else {
         Err(EvalError::UInt64OutOfRange(f.to_string().into()))

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -461,10 +461,9 @@ SELECT -12.0::float::uint8
 query error "18446744073709556000" uint8 out of range
 SELECT 18446744073709553665::float::uint8
 
-query I
+# This literal rounds to 2^64 in f64, which is out of range for uint8.
+query error "18446744073709552000" uint8 out of range
 SELECT 18446744073709553664.0::float::uint8
-----
-18446744073709551615
 
 query error "18446744073709556000" uint8 out of range
 SELECT 18446744073709553664.5::float::uint8
@@ -565,13 +564,20 @@ SELECT -12.0::double::uint8
 query error "18446744073709556000" uint8 out of range
 SELECT 18446744073709553665::double::uint8
 
-query I
+# This literal rounds to 2^64 in f64, which is out of range for uint8 (see the note below).
+query error "18446744073709552000" uint8 out of range
 SELECT 18446744073709553664.0::double::uint8
-----
-18446744073709551615
 
 query error "18446744073709556000" uint8 out of range
 SELECT 18446744073709553664.5::double::uint8
+
+# double_to_uint8 (src/expr/src/scalar/func/impls/float64.rs): 2^64 = 18446744073709551616 is
+# out of range for uint8 and must be rejected. `u64::MAX as f64` is not representable and
+# rounds up to exactly 2^64, so the range check compares against that bound with a strict `<`.
+# A `<=` bound would let 2^64 pass, and the following `as u64` cast would saturate it to
+# u64::MAX, silently returning 18446744073709551615.
+query error "18446744073709552000" uint8 out of range
+SELECT 18446744073709551616::float8::uint8
 
 # From text
 


### PR DESCRIPTION
The range check in cast_float64_to_uint64 used `f <= (u64::MAX as f64)`. u64::MAX is not representable as an f64, so `u64::MAX as f64` rounds up to 2^64, letting 2^64 pass the check. The subsequent `as u64` cast then saturated it to u64::MAX, so `18446744073709551616::float8::uint8` silently returned 18446744073709551615 instead of an out-of-range error.

Use a strict `<` bound so 2^64 and larger are rejected, matching the existing float8-to-int8 cast. Adds sqllogictest coverage in unsigned_int.slt.

Closes CLU-143