### PR TITLE
expr: don't overcount memory in RowSetFinishing max_result_size check

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3611,12 +3611,10 @@ impl RowSetFinishing {
         max_result_size: u64,
         max_returned_query_size: Option<u64>,
     ) -> Result<(RowCollectionIter, usize), String> {
-        // How much additional memory is required to make a sorted view.
-        let sorted_view_mem = rows.entries().saturating_mul(std::mem::size_of::<usize>());
-        let required_memory = rows.byte_len().saturating_add(sorted_view_mem);
-
-        // Bail if creating the sorted view would require us to use too much memory.
-        if required_memory > usize::cast_from(max_result_size) {
+        // Bail if the already-materialized collection is larger than the cap.
+        // `byte_len` includes the per-row offset metadata, and finishing does
+        // not allocate any additional per-entry structure.
+        if rows.byte_len() > usize::cast_from(max_result_size) {
             let max_bytes = ByteSize::b(max_result_size);
             return Err(format!("result exceeds max size of {max_bytes}",));
         }
@@ -3724,12 +3722,10 @@ impl RowSetFinishingIncremental {
         rows: RowCollection,
         max_result_size: u64,
     ) -> Result<RowCollectionIter, String> {
-        // How much additional memory is required to make a sorted view.
-        let sorted_view_mem = rows.entries().saturating_mul(std::mem::size_of::<usize>());
-        let required_memory = rows.byte_len().saturating_add(sorted_view_mem);
-
-        // Bail if creating the sorted view would require us to use too much memory.
-        if required_memory > usize::cast_from(max_result_size) {
+        // Bail if the already-materialized collection is larger than the cap.
+        // `byte_len` includes the per-row offset metadata, and finishing does
+        // not allocate any additional per-entry structure.
+        if rows.byte_len() > usize::cast_from(max_result_size) {
             let max_bytes = ByteSize::b(max_result_size);
             return Err(format!("total result exceeds max size of {max_bytes}",));
         }

--- a/test/sqllogictest/max_result_size.slt
+++ b/test/sqllogictest/max_result_size.slt
@@ -52,3 +52,20 @@ SELECT * FROM t1;
 # For SUBSCRIBE, we need to add a GROUP BY to force an exchange in the dataflow.
 query error total result exceeds max size of 1\.0 MiB
 SUBSCRIBE (SELECT * FROM t1 GROUP BY a, b)
+
+# Regression: `RowSetFinishing` must not reject a result that fits within
+# `max_result_size`. This folds to a fast-path Constant of 10000 rows with a
+# `byte_len()` of 1100000, which fits under the 1140000 cap. The finishing path
+# used to also charge for a per-entry array it never builds (10000 * 8 bytes),
+# pushing the accounting to 1180000 and wrongly rejecting the query.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET max_result_size TO 1140000;
+----
+COMPLETE 0
+
+query TT
+SELECT lpad(g::text, 10, '0'), repeat('a', 80) FROM generate_series(1, 10000) g ORDER BY 1 LIMIT 3;
+----
+0000000001  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+0000000002  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+0000000003  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
Both finishing paths charged an extra `entries() * size_of::<usize>()` for a sorted-side array they never build, on top of `byte_len()` which already accounts for the per-row offset metadata. Results that fit within `max_result_size` were wrongly rejected, with the overshoot growing linearly in row count. Compare `byte_len()` directly instead.

Closes: CLU-141