### PR TITLE
expr: Terminate timestamp `generate_series` on non-progressing steps

### DIFF
--- a/doc/user/content/sql/functions/table-functions.md
+++ b/doc/user/content/sql/functions/table-functions.md
@@ -233,6 +233,16 @@ However, table functions in a `SELECT` clause have a number of restrictions (sim
 
 You can also call ordinary scalar functions in the `FROM` clause as if they were table functions. In that case, their output will be considered a table with a single row and column.
 
+## `generate_series` over timestamps
+
+{{< note >}}
+A timestamp `step` that mixes months and days, such as
+`INTERVAL '1 month -29 days'`, can fail making progress toward `stop` because
+adding a month saturates to the last day of a shorter month. Unlike PostgreSQL,
+which loops indefinitely on such input, Materialize terminates the series when
+it can no longer make progress.
+{{< /note >}}
+
 ## See also
 
 See a list of table functions in the [function reference](/sql/functions/#table-functions).

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3066,7 +3066,22 @@ impl<T: TimestampLike> Iterator for TimestampRangeStepInclusive<T> {
             match add_timestamp_months(self.state.deref(), self.step.months) {
                 Ok(state) => match state.checked_add_signed(self.step.duration_as_chrono()) {
                     Some(v) => match CheckedTimestamp::from_timestamplike(v) {
-                        Ok(v) => self.state = v,
+                        Ok(v) => {
+                            // Advance only if the step makes progress toward `stop`. A mixed
+                            // month/day step can reach an in-bounds fixed point (month addition
+                            // saturates a short month back onto the start day), which would
+                            // otherwise loop forever.
+                            let progressed = if self.rev {
+                                v < self.state
+                            } else {
+                                v > self.state
+                            };
+                            if progressed {
+                                self.state = v
+                            } else {
+                                self.done = true
+                            }
+                        }
                         Err(_) => self.done = true,
                     },
                     None => self.done = true,

--- a/test/sqllogictest/statement_timeout.slt
+++ b/test/sqllogictest/statement_timeout.slt
@@ -40,3 +40,27 @@ query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM t WHERE value > 10;
 ----
 materialize.public.t  0  0  0  0
+
+# Regression: generate_series over timestamps must terminate on a mixed-sign
+# month/day step. INTERVAL '1 month -29 days' looks ascending (as_microseconds
+# treats a month as 30 days, so 30 - 29 = +1 day), but the iterator adds a
+# calendar month with end-of-month saturation: from 2021-01-31, +1 month
+# saturates to 2021-02-28, then -29 days returns to 2021-01-30, which is <= the
+# start. The series stops advancing there, so it yields only the start row.
+
+statement ok
+CREATE TABLE gen_sink (ts timestamp)
+
+statement ok
+SET statement_timeout = '30s'
+
+statement ok
+INSERT INTO gen_sink SELECT * FROM generate_series(TIMESTAMP '2021-01-31 03:00:00', TIMESTAMP '2021-02-10', INTERVAL '1 month -29 days')
+
+query T
+SELECT * FROM gen_sink
+----
+2021-01-31 03:00:00
+
+statement ok
+SET statement_timeout = 0


### PR DESCRIPTION
### Motivation

A timestamp `generate_series(start, stop, step)` step that mixes months and days
can reach a value that no longer moves toward `stop`. From `2021-01-31` with
`INTERVAL '1 month -29 days'`, adding a month saturates to `2021-02-28` and
subtracting 29 days returns to `2021-01-30`, a fixed point, so the iterator spun
forever. The direction is chosen by treating a month as 30 days
(`as_microseconds`), so such a step counts as ascending even though a single
step can move backward.

### Fix

Detect the lack of progress at each step and end the series there. This matches
the existing convention of silently ending on timestamp overflow rather than
erroring, and it never truncates a series that would otherwise be finite:
non-progress means a fixed point or a backward march that PostgreSQL itself
never returns from.

### PostgreSQL divergence (deliberate)

PostgreSQL loops indefinitely on this input. We diverge on purpose: in
Materialize the loop is reachable in materialized views and indexes, where no
`statement_timeout` can interrupt it and a wedged dataflow worker is an
availability problem, not just a hung session. Documented in the table-functions
reference.

Closes: CLU-144