### PR TITLE
pgwire: Use 42704 error code instead of XX000 for undefined object in subscribe

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -842,6 +842,14 @@ fn test_pgtest_mz_raise() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_subscribe_dependency_dropped() {
+    pg_test_inner(
+        Path::new("../../test/pgtest-mz/subscribe-dependency-dropped.pt"),
+        true,
+    );
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_startup() {
     pg_test_inner(Path::new("../../test/pgtest-mz/startup.pt"), true);
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2624,10 +2624,18 @@ fn test_subscribe_on_dropped_source() {
 
     fn assert_subscribe_error(res: Result<(), tokio_postgres::error::Error>) {
         assert_err!(res);
+        let err = res.unwrap_db_error();
+        assert_eq!(
+            err.code(),
+            &SqlState::UNDEFINED_OBJECT,
+            "subscribe on a dropped dependency should report 42704, got {:?}: {}",
+            err.code(),
+            err.message()
+        );
         assert!(
-            res.unwrap_db_error()
-                .message()
-                .contains("query could not complete because relation")
+            err.message().contains("relation") && err.message().contains("was dropped"),
+            "unexpected error message: {}",
+            err.message()
         );
     }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -2410,9 +2410,14 @@ where
                     batch = rows.remaining.recv() => match batch {
                         None => FetchResult::Rows(None),
                         Some(PeekResponseUnary::Rows(rows)) => FetchResult::Rows(Some(rows)),
-                        Some(PeekResponseUnary::Error(err)) => FetchResult::Error(err),
+                        Some(PeekResponseUnary::Error(err)) => {
+                            FetchResult::Error(ErrorResponse::error(SqlState::INTERNAL_ERROR, err))
+                        }
                         Some(PeekResponseUnary::DependencyDropped(dep)) => {
-                            FetchResult::Error(dep.query_terminated_error())
+                            FetchResult::Error(
+                                dep.to_concurrent_dependency_drop()
+                                    .into_response(Severity::Error),
+                            )
                         }
                         Some(PeekResponseUnary::Canceled) => FetchResult::Canceled,
                     },
@@ -2484,12 +2489,10 @@ where
                     self.send(notice.into_response()).await?;
                     self.conn.flush().await?;
                 }
-                FetchResult::Error(text) => {
+                FetchResult::Error(err) => {
+                    let text = err.message.clone();
                     return self
-                        .send_error_and_get_state(ErrorResponse::error(
-                            SqlState::INTERNAL_ERROR,
-                            text.clone(),
-                        ))
+                        .send_error_and_get_state(err)
                         .await
                         .map(|state| (state, SendRowsEndedReason::Errored { error: text }));
                 }
@@ -3243,7 +3246,7 @@ fn is_txn_exit_stmt(stmt: Option<&Statement<Raw>>) -> bool {
 enum FetchResult {
     Rows(Option<Box<dyn RowIterator + Send + Sync>>),
     Canceled,
-    Error(String),
+    Error(ErrorResponse),
     Notice(AdapterNotice),
 }
 

--- a/test/pgtest-mz/subscribe-dependency-dropped.pt
+++ b/test/pgtest-mz/subscribe-dependency-dropped.pt
@@ -1,0 +1,93 @@
+# Regression test for the pgwire SQLSTATE reported when a query's dependency is
+# concurrently dropped while the query is streaming results.
+#
+# `DROP`-ing a relation that a streaming query reads surfaces the same logical
+# event ("relation X was dropped mid-flight") on two different pgwire code
+# paths:
+#
+#   * SUBSCRIBE streamed directly            -> src/pgwire/src/protocol.rs send_rows
+#   * COPY (SUBSCRIBE ...) TO STDOUT         -> src/pgwire/src/protocol.rs copy_rows
+#
+# `copy_rows` converts the drop via `DroppedDependency::to_concurrent_dependency_drop()`
+# into `AdapterError::ConcurrentDependencyDrop`, which maps to SQLSTATE 42704
+# (UNDEFINED_OBJECT). `send_rows` instead flattens the drop into a plain string
+# via `DroppedDependency::query_terminated_error()` and reuses the generic error
+# sink, which hard-codes SQLSTATE XX000 (INTERNAL_ERROR).
+#
+# Case 1: SUBSCRIBE streamed directly (send_rows).
+#
+
+send
+Query {"query": "CREATE TABLE t (a int)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send conn=sub
+Query {"query": "SUBSCRIBE t"}
+----
+
+until conn=sub ignore=RowDescription
+NoticeResponse
+----
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"streaming SUBSCRIBE rows directly requires a client that does not buffer output"}]}
+
+send
+Query {"query": "DROP TABLE t"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
+# Desired behavior, matching the COPY path in Case 2.
+# reports
+#   ErrorResponse {"fields":[..,{"typ":"C","value":"XX000"},{"typ":"M","value":"query could not complete because relation \"materialize.public.t\" was dropped"}]}
+until conn=sub ignore=DataRow
+ErrorResponse
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42704"},{"typ":"M","value":"relation 'materialize.public.t' was dropped"}]}
+
+#
+# Case 2: COPY (SUBSCRIBE ...) TO STDOUT (copy_rows).
+#
+
+send
+Query {"query": "CREATE TABLE t (a int)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send conn=copy
+Query {"query": "COPY (SUBSCRIBE t) TO STDOUT"}
+----
+
+until conn=copy
+CopyOut
+----
+CopyOut {"format":"text","column_formats":["text","text","text"]}
+
+send
+Query {"query": "DROP TABLE t"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
+until conn=copy ignore=CopyData
+ErrorResponse
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42704"},{"typ":"M","value":"relation 'materialize.public.t' was dropped"}]}


### PR DESCRIPTION
Since it's not an internal error. Behavior not matches regular non-streaming SELECTs