### PR TITLE
transform: fix TopK fusion writing expected_group_size to discarded field

### DIFF
--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -124,11 +124,12 @@ impl TopK {
                     // might actually be large would be bad.
                     //
                     // rust-lang/rust#70086 would allow a.zip_with(b, max) here.
-                    *inner_expected_group_size =
-                        match (&expected_group_size, &inner_expected_group_size) {
+                    let new_expected_group_size =
+                        match (&*expected_group_size, &*inner_expected_group_size) {
                             (Some(a), Some(b)) => Some(std::cmp::max(*a, *b)),
                             _ => None,
                         };
+                    *expected_group_size = new_expected_group_size;
 
                     **input = inner_input.take_dangerous();
                 } else {


### PR DESCRIPTION
When fusing two chained TopK operators, the merged expected_group_size hint (max of the two hints) was assigned to the inner TopK's field, which is discarded on the next line when the inner TopK is replaced by its own input. The fused TopK therefore kept the outer's original hint, ignoring a larger hint the inner operator may have provided.

This is the opposite of the intent noted in the adjacent comment: a hint set too small forces extra hierarchical levels in TopK rendering, hurting runtime and memory. It is a silent performance-only regression (the hint never affects correctness) that fires after fusion and is hard to diagnose.

Assign the merged value to the surviving outer TopK's expected_group_size instead. Values are read into a local before assignment to avoid reborrowing the field being written.