### PR TITLE
catalog: count types and functions in Schema::has_items

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -3575,7 +3575,10 @@ impl mz_sql::catalog::CatalogSchema for Schema {
     }
 
     fn has_items(&self) -> bool {
-        !self.items.is_empty()
+        // A schema holds items, types, and functions in separate maps (see
+        // `item_ids`). All three keep the schema non-empty, so e.g. DROP SCHEMA
+        // without CASCADE must be rejected when only a type or function remains.
+        !self.items.is_empty() || !self.types.is_empty() || !self.functions.is_empty()
     }
 
     fn item_ids(&self) -> Box<dyn Iterator<Item = CatalogItemId> + '_> {

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -157,3 +157,18 @@ simple conn=mz_system,user=mz_system
 DROP SCHEMA mz_temp
 ----
 db error: ERROR: cannot drop schema mz_temp because it is a temporary schema
+
+# Regression: DROP SCHEMA without CASCADE must be rejected when the schema
+# contains only a type. Types live in a separate map from items, which the
+# emptiness check used to ignore, so the drop silently succeeded.
+statement ok
+CREATE SCHEMA type_only
+
+statement ok
+CREATE TYPE type_only.lt AS LIST (ELEMENT TYPE = int4)
+
+statement error cannot be dropped without CASCADE while it contains objects
+DROP SCHEMA type_only
+
+statement ok
+DROP SCHEMA type_only CASCADE


### PR DESCRIPTION
Fixes SQL-451

`has_items` only checked the `items` map, ignoring the separate `types` and `functions` maps. `DROP SCHEMA` without `CASCADE` uses it as the emptiness guard, so a schema containing only a user-defined type was treated as empty and silently dropped along with the type.
