### PR TITLE
adapter: order temp item updates after persistent ones in catalog apply

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -941,8 +941,7 @@ class DropIndexAction(Action):
 
 class CreateTableAction(Action):
     def run(self, exe: Executor) -> bool:
-        # TODO: Also in rename when https://linear.app/materializeinc/issue/SQL-400 is fixed
-        temp = exe.db.scenario != Scenario.Rename and self.rng.choice([True, False])
+        temp = self.rng.choice([True, False])
         if (
             not temp
             and len([table for table in exe.db.tables if not table.temp]) >= MAX_TABLES
@@ -1003,6 +1002,12 @@ class DropTableAction(Action):
 
 
 class RenameTableAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        # Renaming a temporary item referenced by another temporary object is
+        # refused as ambiguous: temp references are only 2-part (mz_temp.item),
+        # and the item-rename check treats a non-3-part reference as ambiguous.
+        return ["potentially used ambiguously"] + super().errors_to_ignore(exe)
+
     def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
@@ -1056,6 +1061,12 @@ class AlterTableAddColumnAction(Action):
 
 
 class RenameViewAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        # Renaming a temporary item referenced by another temporary object is
+        # refused as ambiguous: temp references are only 2-part (mz_temp.item),
+        # and the item-rename check treats a non-3-part reference as ambiguous.
+        return ["potentially used ambiguously"] + super().errors_to_ignore(exe)
+
     def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
@@ -1951,8 +1962,7 @@ class CreateViewAction(Action):
         return errors
 
     def run(self, exe: Executor) -> bool:
-        # TODO: Also in rename when https://linear.app/materializeinc/issue/SQL-400 is fixed
-        temp = exe.db.scenario != Scenario.Rename and self.rng.choice([True, False])
+        temp = self.rng.choice([True, False])
         with exe.db.lock:
             if len(exe.db.views) >= MAX_VIEWS:
                 return False

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -2542,53 +2542,40 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
     let temp_item_retractions = sort_temp_item_updates(temp_item_retractions);
     let temp_item_additions = sort_temp_item_updates(temp_item_additions);
 
-    /// Merge sorted temporary and non-temp items.
+    /// Concatenate sorted persistent and temporary item updates, persistent
+    /// first.
+    ///
+    /// Both inputs are already in dependency (type-group) order internally. A
+    /// non-temporary item can never depend on a temporary one (enforced at
+    /// creation, see `ErrorKind::InvalidTemporaryDependency`), so emitting every
+    /// persistent item before every temporary item keeps dependencies ahead of
+    /// dependents for additions. (Retractions reuse this via a reversal by the
+    /// caller, which puts temporary items first. Also, a retraction only drops
+    /// the item and does not re-resolve `create_sql`.)
+    ///
+    /// NOTE: Do not interleave the two by raw id. The inputs are ordered by
+    /// dependency group, which is not id order, so an id merge can place a
+    /// temporary dependent ahead of the persistent item it references and panic
+    /// apply with an unresolvable id.
     fn merge_item_updates(
-        mut item_updates: VecDeque<(mz_catalog::durable::Item, Timestamp, StateDiff)>,
-        mut temp_item_updates: VecDeque<(TemporaryItem, Timestamp, StateDiff)>,
+        item_updates: VecDeque<(mz_catalog::durable::Item, Timestamp, StateDiff)>,
+        temp_item_updates: VecDeque<(TemporaryItem, Timestamp, StateDiff)>,
     ) -> Vec<StateUpdate> {
         let mut state_updates = Vec::with_capacity(item_updates.len() + temp_item_updates.len());
-
-        while let (Some((item, _, _)), Some((temp_item, _, _))) =
-            (item_updates.front(), temp_item_updates.front())
-        {
-            if item.id < temp_item.id {
-                let (item, ts, diff) = item_updates.pop_front().expect("non-empty");
-                state_updates.push(StateUpdate {
-                    kind: StateUpdateKind::Item(item),
-                    ts,
-                    diff,
-                });
-            } else if item.id > temp_item.id {
-                let (temp_item, ts, diff) = temp_item_updates.pop_front().expect("non-empty");
-                state_updates.push(StateUpdate {
-                    kind: StateUpdateKind::TemporaryItem(temp_item),
-                    ts,
-                    diff,
-                });
-            } else {
-                unreachable!(
-                    "two items cannot have the same ID: item={item:?}, temp_item={temp_item:?}"
-                );
-            }
-        }
-
-        while let Some((item, ts, diff)) = item_updates.pop_front() {
+        for (item, ts, diff) in item_updates {
             state_updates.push(StateUpdate {
                 kind: StateUpdateKind::Item(item),
                 ts,
                 diff,
             });
         }
-
-        while let Some((temp_item, ts, diff)) = temp_item_updates.pop_front() {
+        for (temp_item, ts, diff) in temp_item_updates {
             state_updates.push(StateUpdate {
                 kind: StateUpdateKind::TemporaryItem(temp_item),
                 ts,
                 diff,
             });
         }
-
         state_updates
     }
     let item_retractions = merge_item_updates(item_retractions, temp_item_retractions);

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -1213,6 +1213,17 @@ impl CatalogState {
                             // which temporary items are a bit weird. So, here
                             // we are ...
                             catalog_item.set_conn_id(conn_id);
+                            // Deserializing replans the SQL, and the planner's
+                            // canonical printing can differ from `create_sql`,
+                            // for example when a feature flag changed how
+                            // references are printed since `create_sql` was
+                            // produced. Keep the exact input. A later op in the
+                            // same transaction retracts this item by
+                            // re-serializing it, and that retraction must
+                            // cancel byte-for-byte against this addition during
+                            // consolidation, else two retractions of the same
+                            // id survive and applying them panics.
+                            catalog_item.set_create_sql(create_sql);
                             retraction.item = catalog_item;
                         }
 
@@ -1242,6 +1253,9 @@ impl CatalogState {
                         // in here, but it's but one of the ways in which
                         // temporary items are a bit weird. So, here we are ...
                         catalog_item.set_conn_id(conn_id);
+                        // Keep the exact input create_sql, not the replanned
+                        // printing. See the comment on the reparse above.
+                        catalog_item.set_create_sql(create_sql);
 
                         CatalogEntry {
                             item: catalog_item,

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2000,6 +2000,32 @@ impl CatalogItem {
         }
     }
 
+    /// Overwrites the `create_sql` of this item, without replanning.
+    ///
+    /// Only used when applying temporary item updates. A temporary item's
+    /// in-memory `create_sql` must stay byte-identical to the update that
+    /// created it, so that re-serializing the item, for example when a later
+    /// op in the same transaction retracts it, yields a value that
+    /// consolidates away against that update. Persistent items get this
+    /// guarantee from the durable catalog, which stores the exact bytes.
+    pub fn set_create_sql(&mut self, create_sql: String) {
+        match self {
+            CatalogItem::View(view) => view.create_sql = create_sql,
+            CatalogItem::Index(index) => index.create_sql = create_sql,
+            CatalogItem::Table(table) => table.create_sql = Some(create_sql),
+            CatalogItem::Log(_)
+            | CatalogItem::Source(_)
+            | CatalogItem::Sink(_)
+            | CatalogItem::MaterializedView(_)
+            | CatalogItem::Secret(_)
+            | CatalogItem::Type(_)
+            | CatalogItem::Func(_)
+            | CatalogItem::Connection(_) => {
+                unreachable!("only views, indexes, and tables can be temporary")
+            }
+        }
+    }
+
     /// Indicates whether this item is temporary or not.
     pub fn is_temporary(&self) -> bool {
         self.conn_id().is_some()

--- a/test/sqllogictest/rename.slt
+++ b/test/sqllogictest/rename.slt
@@ -903,3 +903,51 @@ query I
 SELECT count(*) FROM sql400_tv
 ----
 0
+
+# Regression test for ALTER SCHEMA SWAP panicking when a temporary object
+# depends on the swapped schema and catalog state changed how the planner
+# prints references since the temp object was created. The swap renames the
+# same schema twice in one transaction. The first rename's addition carries a
+# syntactic rewrite of the stored create_sql, while the second rename's
+# retraction used to re-serialize the in-memory item, whose create_sql had been
+# replaced by the replanned printing when the addition was applied. With
+# enable_alter_table_add_column turned on after the view was created,
+# replanning adds VERSION pinning to the view's table reference, so the
+# intermediate addition and retraction no longer cancelled during
+# consolidation, and the two surviving retractions of the same id panicked the
+# coordinator with "catalog out of sync, missing id".
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_alter_table_add_column = false
+----
+COMPLETE 0
+
+statement ok
+CREATE SCHEMA swapflag_a
+
+statement ok
+CREATE SCHEMA swapflag_b
+
+statement ok
+CREATE TABLE swapflag_a.t (a int)
+
+statement ok
+CREATE TEMPORARY VIEW swapflag_tv AS SELECT a FROM swapflag_a.t
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_alter_table_add_column = true
+----
+COMPLETE 0
+
+statement ok
+ALTER SCHEMA swapflag_a SWAP WITH swapflag_b
+
+query I
+SELECT count(*) FROM swapflag_tv
+----
+0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_alter_table_add_column
+----
+COMPLETE 0

--- a/test/sqllogictest/rename.slt
+++ b/test/sqllogictest/rename.slt
@@ -871,3 +871,35 @@ query I
 SELECT count(*) FROM tmp_two_tables
 ----
 0
+
+# Regression test for SQL-400: ALTER SCHEMA RENAME must not panic the
+# coordinator when a temporary object depends on an item in the renamed schema
+# that also holds an item from an earlier catalog-apply "type group" with a
+# higher id (here a secret, created after the temp view). Catalog apply used to
+# interleave persistent and temporary item updates by raw id, which could apply
+# the temp view's addition before the table it references was re-added, hitting
+# "invalid persisted SQL" (InvalidId). That aborted the rename with a coordinator
+# panic, so a plain `statement ok` on the ALTER is the regression check.
+
+statement ok
+CREATE SCHEMA sql400
+
+statement ok
+CREATE TABLE sql400.t (a int)
+
+statement ok
+CREATE TEMPORARY VIEW sql400_tv AS SELECT * FROM sql400.t
+
+statement ok
+CREATE SECRET sql400.sec AS 'x'
+
+statement ok
+ALTER SCHEMA sql400 RENAME TO sql400_renamed
+
+# The temporary view still resolves and is queryable after the rename. (Selecting
+# from a temp object is fine here because this file is exempt from
+# --auto-index-selects.)
+query I
+SELECT count(*) FROM sql400_tv
+----
+0


### PR DESCRIPTION
Fixes SQL-400. Edit: Also fixes SQL-454, see the 3rd commit, to unblock the relevant Parallel Workload test.

`merge_item_updates` interleaved the persistent and temporary item update queues by raw id, but both queues are ordered by dependency (type) group, not by id. That could emit a temporary dependent before the persistent item it references, so on ALTER SCHEMA RENAME the temp item's addition re-resolved its create_sql against a catalog where the referenced item was still retracted, panicking the coordinator with an unresolvable id.

A non-temporary item can never depend on a temporary one, so concatenate the queues with all persistent items first instead of merging by id. Additions then apply dependencies before dependents; retractions, which the caller reverses and which do not re-resolve create_sql, are unaffected.

Also reinstates those Parallel Workload tests that were blocked on SQL-400 and SQL-401.

Nightly:
- https://buildkite.com/materialize/nightly/builds/16935
- https://buildkite.com/materialize/nightly/builds/16936 (with the new error ignore, see last commit)
- https://buildkite.com/materialize/nightly/builds/16968 (after fixing SQL-454)