### PR TITLE
console: read replica utilization history from indexed views + SUBSCRIBE

### DIFF
--- a/console/src/api/materialize/cluster/replicaUtilizationBinning.test.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationBinning.test.ts
@@ -144,6 +144,26 @@ describe("rebucketUtilizationSamples", () => {
     expect(rows[0].bucketStart).toEqual(new Date(0));
   });
 
+  it("splits a replica's samples across multiple buckets, maxing within each", () => {
+    const samples = [
+      // First bucket [0, MINUTE): the higher of two samples wins.
+      mkSample({ occurredAt: new Date(10_000), cpuPercent: 0.3 }),
+      mkSample({ occurredAt: new Date(50_000), cpuPercent: 0.7 }),
+      // A sample exactly on the boundary belongs to the second bucket.
+      mkSample({ occurredAt: new Date(MINUTE), cpuPercent: 0.4 }),
+      mkSample({ occurredAt: new Date(2 * MINUTE + 1_000), cpuPercent: 0.9 }),
+    ];
+    const rows = rebucketUtilizationSamples(samples, MINUTE, 0);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.bucketStart.getTime())).toEqual([
+      0,
+      MINUTE,
+      2 * MINUTE,
+    ]);
+    expect(rows.map((r) => r.maxCpuPercent)).toEqual([0.7, 0.4, 0.9]);
+    expect(rows[0].maxCpuAt).toEqual(new Date(50_000));
+  });
+
   it("separates buckets per replica and sorts by bucket start", () => {
     const samples = [
       mkSample({ replicaId: "u2", occurredAt: new Date(MINUTE + 1_000) }),

--- a/console/src/api/materialize/cluster/replicaUtilizationBinning.test.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationBinning.test.ts
@@ -1,0 +1,280 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Bucket,
+  bucketRowsToBucketsByReplicaId,
+  maxByMetric,
+  OfflineEvent,
+  rebucketUtilizationSamples,
+  toReplicaUtilizationGraphData,
+  UtilizationBucketRow,
+  UtilizationSample,
+} from "./replicaUtilizationBinning";
+
+// bucketRowsToBucketsByReplicaId reports malformed rows to Sentry before throwing;
+// stub it so the throw test doesn't depend on a Sentry client.
+vi.mock("@sentry/react");
+
+const MINUTE = 60_000;
+
+function mkSample(
+  overrides: Partial<UtilizationSample> = {},
+): UtilizationSample {
+  return {
+    replicaId: "u1",
+    clusterId: "c1",
+    size: "small",
+    name: "r1",
+    occurredAt: new Date(0),
+    cpuPercent: 0,
+    memoryPercent: 0,
+    diskPercent: 0,
+    heapPercent: 0,
+    memoryAndDiskPercent: 0,
+    ...overrides,
+  };
+}
+
+function mkBucketRow(
+  overrides: Partial<UtilizationBucketRow> = {},
+): UtilizationBucketRow {
+  return {
+    bucketStart: new Date(0),
+    bucketEnd: new Date(MINUTE),
+    replicaId: "u1",
+    clusterId: "c1",
+    size: "small",
+    name: "r1",
+    maxMemoryPercent: 0.5,
+    maxMemoryAt: new Date(0),
+    maxDiskPercent: 0.1,
+    maxDiskAt: new Date(0),
+    maxCpuPercent: 0.2,
+    maxCpuAt: new Date(0),
+    maxHeapPercent: 0.3,
+    maxHeapAt: new Date(0),
+    maxMemoryAndDiskPercent: 0.4,
+    maxMemoryAndDiskMemoryPercent: 0.5,
+    maxMemoryAndDiskDiskPercent: 0.1,
+    maxMemoryAndDiskAt: new Date(0),
+    offlineEvents: null,
+    ...overrides,
+  };
+}
+
+function mkBucket(overrides: Partial<Bucket> = {}): Bucket {
+  return {
+    size: "small",
+    bucketStart: new Date(0),
+    replicaId: "u1",
+    bucketEnd: new Date(MINUTE),
+    name: "r1",
+    currentDeploymentClusterId: "c1",
+    clusterId: "c1",
+    maxMemory: { percent: 0.1, occurredAt: new Date(0) },
+    maxDisk: { percent: 0.1, occurredAt: new Date(0) },
+    maxCpu: { percent: 0.1, occurredAt: new Date(0) },
+    maxHeap: { percent: 0.1, occurredAt: new Date(0) },
+    maxMemoryAndDisk: {
+      percent: 0.1,
+      memoryPercent: 0.1,
+      diskPercent: 0.1,
+      occurredAt: new Date(0),
+    },
+    offlineEvents: null,
+    ...overrides,
+  };
+}
+
+describe("maxByMetric", () => {
+  it("returns the sample with the highest metric value", () => {
+    const samples = [
+      mkSample({ cpuPercent: 0.1 }),
+      mkSample({ cpuPercent: 0.9 }),
+      mkSample({ cpuPercent: 0.5 }),
+    ];
+    expect(maxByMetric(samples, (s) => s.cpuPercent)).toBe(samples[1]);
+  });
+
+  it("treats null as the lowest value", () => {
+    const samples = [
+      mkSample({ cpuPercent: null }),
+      mkSample({ cpuPercent: 0.2 }),
+    ];
+    expect(maxByMetric(samples, (s) => s.cpuPercent)).toBe(samples[1]);
+  });
+});
+
+describe("rebucketUtilizationSamples", () => {
+  it("buckets samples into epoch-aligned windows and takes the max per metric", () => {
+    const samples = [
+      mkSample({
+        occurredAt: new Date(1_000),
+        cpuPercent: 0.2,
+        memoryPercent: 0.6,
+      }),
+      mkSample({
+        occurredAt: new Date(2_000),
+        cpuPercent: 0.8,
+        memoryPercent: 0.1,
+      }),
+    ];
+    const rows = rebucketUtilizationSamples(samples, MINUTE, 0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].bucketStart).toEqual(new Date(0));
+    expect(rows[0].bucketEnd).toEqual(new Date(MINUTE));
+    expect(rows[0].maxCpuPercent).toBe(0.8);
+    expect(rows[0].maxMemoryPercent).toBe(0.6);
+  });
+
+  it("drops samples before the window start", () => {
+    const samples = [
+      mkSample({ occurredAt: new Date(500) }),
+      mkSample({ occurredAt: new Date(5_000) }),
+    ];
+    const rows = rebucketUtilizationSamples(samples, MINUTE, 1_000);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].bucketStart).toEqual(new Date(0));
+  });
+
+  it("separates buckets per replica and sorts by bucket start", () => {
+    const samples = [
+      mkSample({ replicaId: "u2", occurredAt: new Date(MINUTE + 1_000) }),
+      mkSample({ replicaId: "u1", occurredAt: new Date(1_000) }),
+    ];
+    const rows = rebucketUtilizationSamples(samples, MINUTE, 0);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].replicaId).toBe("u1");
+    expect(rows[0].bucketStart.getTime()).toBeLessThan(
+      rows[1].bucketStart.getTime(),
+    );
+  });
+});
+
+describe("bucketRowsToBucketsByReplicaId", () => {
+  it("groups rows by replica and tracks the overall min/max bounds", () => {
+    const rows = [
+      mkBucketRow({ bucketStart: new Date(0), bucketEnd: new Date(1_000) }),
+      mkBucketRow({ bucketStart: new Date(1_000), bucketEnd: new Date(2_000) }),
+      mkBucketRow({
+        replicaId: "u2",
+        bucketStart: new Date(500),
+        bucketEnd: new Date(1_500),
+      }),
+    ];
+    const { bucketsByReplicaId, minBucketStartMs, maxBucketEndMs } =
+      bucketRowsToBucketsByReplicaId(rows);
+    expect(Object.keys(bucketsByReplicaId).sort()).toEqual(["u1", "u2"]);
+    expect(bucketsByReplicaId.u1).toHaveLength(2);
+    expect(minBucketStartMs).toBe(0);
+    expect(maxBucketEndMs).toBe(2_000);
+  });
+
+  it("defaults currentDeploymentClusterId to the row's clusterId without a resolver", () => {
+    const { bucketsByReplicaId } = bucketRowsToBucketsByReplicaId([
+      mkBucketRow({ clusterId: "c1" }),
+    ]);
+    expect(bucketsByReplicaId.u1[0].currentDeploymentClusterId).toBe("c1");
+  });
+
+  it("resolves currentDeploymentClusterId through the resolver", () => {
+    const { bucketsByReplicaId } = bucketRowsToBucketsByReplicaId(
+      [mkBucketRow({ clusterId: "past" })],
+      (id) => (id === "past" ? "current" : undefined),
+    );
+    expect(bucketsByReplicaId.u1[0].currentDeploymentClusterId).toBe("current");
+  });
+
+  it("throws when a row is missing name or clusterId", () => {
+    expect(() =>
+      bucketRowsToBucketsByReplicaId([mkBucketRow({ name: null })]),
+    ).toThrow();
+  });
+});
+
+describe("toReplicaUtilizationGraphData", () => {
+  it("scales bucket percents to a 0-100 range per replica", () => {
+    const data = {
+      bucketsByReplicaId: {
+        u1: [mkBucket({ maxCpu: { percent: 0.5, occurredAt: new Date(0) } })],
+      },
+      minBucketStartMs: 0,
+      maxBucketEndMs: MINUTE,
+    };
+    const result = toReplicaUtilizationGraphData(
+      data,
+      new Date(0),
+      new Date(MINUTE),
+    );
+    expect(result.graphData[0].id).toBe("u1");
+    expect(result.graphData[0].data[0].cpuPercent).toBe(50);
+  });
+
+  it("widens the axis to the data bounds and to the selected window", () => {
+    const data = {
+      bucketsByReplicaId: { u1: [mkBucket()] },
+      minBucketStartMs: 1_000,
+      maxBucketEndMs: 9_000,
+    };
+
+    // Selected window narrower than the data: axis grows out to the data bounds.
+    const narrow = toReplicaUtilizationGraphData(
+      data,
+      new Date(3_000),
+      new Date(7_000),
+    );
+    expect(narrow.startDate).toEqual(new Date(1_000));
+    expect(narrow.endDate).toEqual(new Date(9_000));
+
+    // Selected window wider than the data: axis keeps the selected window.
+    const wide = toReplicaUtilizationGraphData(
+      data,
+      new Date(0),
+      new Date(20_000),
+    );
+    expect(wide.startDate).toEqual(new Date(0));
+    expect(wide.endDate).toEqual(new Date(20_000));
+  });
+
+  it("collects only offline/not-ready events that are not oom-killed", () => {
+    const offlineEvents: OfflineEvent[] = [
+      {
+        replicaId: "u1",
+        occurredAt: "1970-01-01T00:00:00Z",
+        status: "offline",
+        reason: "crashed",
+      },
+      {
+        replicaId: "u1",
+        occurredAt: "1970-01-01T00:00:00Z",
+        status: "offline",
+        reason: "oom-killed",
+      },
+      {
+        replicaId: "u1",
+        occurredAt: "1970-01-01T00:00:00Z",
+        status: "online",
+        reason: "whatever",
+      },
+    ];
+    const data = {
+      bucketsByReplicaId: { u1: [mkBucket({ offlineEvents })] },
+      minBucketStartMs: 0,
+      maxBucketEndMs: MINUTE,
+    };
+    const result = toReplicaUtilizationGraphData(
+      data,
+      new Date(0),
+      new Date(MINUTE),
+    );
+    expect(result.offlineEvents).toHaveLength(1);
+    expect(result.offlineEvents[0].offlineReason).toBe("crashed");
+  });
+});

--- a/console/src/api/materialize/cluster/replicaUtilizationBinning.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationBinning.ts
@@ -1,0 +1,394 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import * as Sentry from "@sentry/react";
+import { flatGroup } from "d3";
+
+import { OfflineEvent as ChartOfflineEvent } from "~/platform/clusters/ClusterOverview/types";
+
+export type OfflineEvent = {
+  replicaId: string;
+  occurredAt: string;
+  status: string;
+  reason: string;
+};
+
+export type Bucket = {
+  size: string | null;
+  bucketStart: Date;
+  replicaId: string;
+  bucketEnd: Date;
+  name: string;
+  // The cluster ID of the replica's current blue-green deployment
+  currentDeploymentClusterId: string;
+  // The cluster ID of the replica. If the cluster was dropped,
+  // this will be different from currentDeploymentClusterId
+  clusterId: string;
+  maxMemory: {
+    percent: number | null;
+    occurredAt: Date;
+  };
+  maxDisk: {
+    percent: number | null;
+    occurredAt: Date;
+  };
+  maxCpu: {
+    percent: number | null;
+    occurredAt: Date;
+  };
+  maxHeap: {
+    percent: number | null;
+    occurredAt: Date;
+  };
+  maxMemoryAndDisk: {
+    memoryPercent: number | null;
+    diskPercent: number | null;
+    percent: number | null;
+    occurredAt: Date;
+  };
+
+  offlineEvents: OfflineEvent[] | null;
+};
+
+export interface UtilizationSample {
+  replicaId: string;
+  clusterId: string | null;
+  size: string | null;
+  name: string | null;
+  occurredAt: Date;
+  cpuPercent: number | null;
+  memoryPercent: number | null;
+  diskPercent: number | null;
+  heapPercent: number | null;
+  memoryAndDiskPercent: number | null;
+}
+
+/** A (replica, bucket) rollup, matching the binned `_overview*` views' output. */
+export interface UtilizationBucketRow {
+  bucketStart: Date;
+  bucketEnd: Date;
+  replicaId: string;
+  clusterId: string | null;
+  size: string | null;
+  name: string | null;
+  maxMemoryPercent: number | null;
+  maxMemoryAt: Date;
+  maxDiskPercent: number | null;
+  maxDiskAt: Date;
+  maxCpuPercent: number | null;
+  maxCpuAt: Date;
+  maxHeapPercent: number | null;
+  maxHeapAt: Date;
+  maxMemoryAndDiskPercent: number | null;
+  maxMemoryAndDiskMemoryPercent: number | null;
+  maxMemoryAndDiskDiskPercent: number | null;
+  maxMemoryAndDiskAt: Date;
+  offlineEvents: OfflineEvent[] | null;
+}
+
+/**
+ * Raw row from the binned 24h SUBSCRIBE, where the date columns arrive as ISO
+ * strings rather than `Date`s.
+ */
+export type BinnedSubscribeRow = Omit<
+  UtilizationBucketRow,
+  | "bucketStart"
+  | "bucketEnd"
+  | "maxMemoryAt"
+  | "maxDiskAt"
+  | "maxCpuAt"
+  | "maxHeapAt"
+  | "maxMemoryAndDiskAt"
+> & {
+  bucketStart: string;
+  bucketEnd: string;
+  maxMemoryAt: string;
+  maxDiskAt: string;
+  maxCpuAt: string;
+  maxHeapAt: string;
+  maxMemoryAndDiskAt: string;
+};
+
+/** Parse a binned 24h SUBSCRIBE row's string dates into a `UtilizationBucketRow`. */
+export function parseBinnedSubscribeRow(
+  raw: BinnedSubscribeRow,
+): UtilizationBucketRow {
+  return {
+    ...raw,
+    bucketStart: new Date(raw.bucketStart),
+    bucketEnd: new Date(raw.bucketEnd),
+    maxMemoryAt: new Date(raw.maxMemoryAt),
+    maxDiskAt: new Date(raw.maxDiskAt),
+    maxCpuAt: new Date(raw.maxCpuAt),
+    maxHeapAt: new Date(raw.maxHeapAt),
+    maxMemoryAndDiskAt: new Date(raw.maxMemoryAndDiskAt),
+  };
+}
+
+/** argmax over samples by a metric, treating null as the lowest value. */
+export function maxByMetric(
+  samples: UtilizationSample[],
+  metric: (s: UtilizationSample) => number | null,
+): UtilizationSample {
+  let best = samples[0];
+  let bestValue = metric(best) ?? Number.NEGATIVE_INFINITY;
+  for (let i = 1; i < samples.length; i++) {
+    const value = metric(samples[i]) ?? Number.NEGATIVE_INFINITY;
+    if (value > bestValue) {
+      best = samples[i];
+      bestValue = value;
+    }
+  }
+  return best;
+}
+
+/**
+ * Bins raw samples into per-(replica, bucket) maxima, client-side. Buckets are
+ * epoch-aligned to match the SQL `date_bin` 1970 origin. Offline events aren't in
+ * the un-binned base, so they are null here.
+ */
+export function rebucketUtilizationSamples(
+  samples: UtilizationSample[],
+  bucketSizeMs: number,
+  startDateMs: number,
+): UtilizationBucketRow[] {
+  const bucketStartOf = (s: UtilizationSample) =>
+    Math.floor(s.occurredAt.getTime() / bucketSizeMs) * bucketSizeMs;
+
+  // The 3h base covers more than shorter windows (e.g. "Last hour"); clip to the
+  // requested window so the chart doesn't show extra history.
+  const inWindow = samples.filter((s) => s.occurredAt.getTime() >= startDateMs);
+
+  const rows = flatGroup(inWindow, (s) => s.replicaId, bucketStartOf).map(
+    ([replicaId, bucketStartMs, group]): UtilizationBucketRow => {
+      const first = group[0];
+      const cpu = maxByMetric(group, (s) => s.cpuPercent);
+      const memory = maxByMetric(group, (s) => s.memoryPercent);
+      const disk = maxByMetric(group, (s) => s.diskPercent);
+      const heap = maxByMetric(group, (s) => s.heapPercent);
+      const memoryAndDisk = maxByMetric(group, (s) => s.memoryAndDiskPercent);
+      return {
+        bucketStart: new Date(bucketStartMs),
+        bucketEnd: new Date(bucketStartMs + bucketSizeMs),
+        replicaId,
+        clusterId: first.clusterId,
+        size: first.size,
+        name: first.name,
+        maxMemoryPercent: memory.memoryPercent,
+        maxMemoryAt: memory.occurredAt,
+        maxDiskPercent: disk.diskPercent,
+        maxDiskAt: disk.occurredAt,
+        maxCpuPercent: cpu.cpuPercent,
+        maxCpuAt: cpu.occurredAt,
+        maxHeapPercent: heap.heapPercent,
+        maxHeapAt: heap.occurredAt,
+        maxMemoryAndDiskPercent: memoryAndDisk.memoryAndDiskPercent,
+        maxMemoryAndDiskMemoryPercent: memoryAndDisk.memoryPercent,
+        maxMemoryAndDiskDiskPercent: memoryAndDisk.diskPercent,
+        maxMemoryAndDiskAt: memoryAndDisk.occurredAt,
+        offlineEvents: null,
+      };
+    },
+  );
+
+  rows.sort((a, b) => a.bucketStart.getTime() - b.bucketStart.getTime());
+  return rows;
+}
+
+/**
+ * Group per-(replica, bucket) rows into `Bucket[]` by replica, tracking the
+ * overall min/max bounds. `resolveCurrentDeployment` maps a past cluster id to its
+ * current blue-green deployment; omitted (the SUBSCRIBE path resolves lineage in
+ * SQL) it defaults to the row's own `clusterId`.
+ */
+export function bucketRowsToBucketsByReplicaId(
+  rows: UtilizationBucketRow[],
+  resolveCurrentDeployment?: (clusterId: string) => string | undefined,
+): {
+  bucketsByReplicaId: Record<string, Bucket[]>;
+  minBucketStartMs: number;
+  maxBucketEndMs: number;
+} {
+  const bucketsByReplicaId: Record<string, Bucket[]> = {};
+
+  let minBucketStartMs = Number.POSITIVE_INFINITY;
+  let maxBucketEndMs = Number.NEGATIVE_INFINITY;
+
+  for (const row of rows) {
+    minBucketStartMs = Math.min(minBucketStartMs, row.bucketStart.getTime());
+    maxBucketEndMs = Math.max(maxBucketEndMs, row.bucketEnd.getTime());
+
+    const {
+      replicaId,
+      size,
+      bucketStart,
+      bucketEnd,
+      name,
+      clusterId,
+      offlineEvents,
+    } = row;
+
+    const buckets = bucketsByReplicaId[replicaId];
+
+    if (name === null || clusterId === null) {
+      const err = new Error(
+        `Expected name: ${name} and clusterId: ${clusterId} to be defined`,
+      );
+
+      Sentry.captureException(err);
+      throw err;
+    }
+
+    const currentDeploymentClusterId =
+      resolveCurrentDeployment?.(clusterId) ?? clusterId;
+
+    const newBucket = {
+      size,
+      bucketStart,
+      bucketEnd,
+      offlineEvents,
+      name,
+      currentDeploymentClusterId,
+      clusterId,
+      replicaId,
+      maxMemory: {
+        percent: row.maxMemoryPercent,
+        occurredAt: row.maxMemoryAt,
+      },
+      maxDisk: {
+        percent: row.maxDiskPercent,
+        occurredAt: row.maxDiskAt,
+      },
+      maxCpu: {
+        percent: row.maxCpuPercent,
+        occurredAt: row.maxCpuAt,
+      },
+      maxHeap: {
+        percent: row.maxHeapPercent ?? null,
+        occurredAt: row.maxHeapAt ?? new Date(),
+      },
+      maxMemoryAndDisk: {
+        percent: row.maxMemoryAndDiskPercent,
+        memoryPercent: row.maxMemoryAndDiskMemoryPercent,
+        diskPercent: row.maxMemoryAndDiskDiskPercent,
+        occurredAt: row.maxMemoryAndDiskAt,
+      },
+    };
+
+    if (buckets) {
+      buckets.push(newBucket);
+    } else {
+      bucketsByReplicaId[replicaId] = [newBucket];
+    }
+  }
+
+  return {
+    minBucketStartMs,
+    maxBucketEndMs,
+    bucketsByReplicaId,
+  };
+}
+
+/**
+ * Shape `bucketsByReplicaId` into the chart's per-replica series plus the flat
+ * offline-event list, clamping the axis to the data bounds. Shared by the
+ * polling and SUBSCRIBE paths so both render identically.
+ */
+export function toReplicaUtilizationGraphData(
+  data: {
+    bucketsByReplicaId: Record<string, Bucket[]>;
+    minBucketStartMs: number;
+    maxBucketEndMs: number;
+  },
+  startDate: Date,
+  endDate: Date,
+) {
+  const graphData = Object.entries(data.bucketsByReplicaId).map(
+    ([replicaId, replicaData]) => {
+      return {
+        id: replicaId,
+        data: replicaData.map(
+          ({
+            bucketEnd,
+            bucketStart,
+            maxHeap,
+            maxMemory,
+            maxCpu,
+            maxDisk,
+            maxMemoryAndDisk,
+            size,
+            offlineEvents,
+            name,
+          }) => ({
+            id: replicaId,
+            name,
+            bucketEnd: bucketEnd.getTime(),
+            bucketStart: bucketStart.getTime(),
+            cpuPercent: maxCpu?.percent ? maxCpu.percent * 100 : null,
+            diskPercent: maxDisk?.percent ? maxDisk.percent * 100 : null,
+            memoryPercent: maxMemory?.percent ? maxMemory.percent * 100 : null,
+            // Memory utilization calculated in SQL: (memory_bytes + disk_bytes) / (available_memory + available_disk)
+            maxMemoryAndDiskPercent: maxMemoryAndDisk?.percent
+              ? maxMemoryAndDisk.percent * 100
+              : null,
+            heapPercent: maxHeap?.percent ? maxHeap.percent * 100 : null,
+            size,
+            offlineEvents:
+              offlineEvents?.map((event) => ({
+                id: event.replicaId,
+                offlineReason: event.reason,
+                status: event.status,
+                timestamp: new Date(event.occurredAt).getTime(),
+              })) ?? [],
+          }),
+        ),
+      };
+    },
+  );
+
+  const offlineEvents: Array<ChartOfflineEvent> = [];
+
+  for (const replica of graphData) {
+    for (const replicaDatum of replica.data) {
+      for (const {
+        status,
+        offlineReason,
+        timestamp,
+      } of replicaDatum.offlineEvents) {
+        if (
+          (status === "not-ready" || status === "offline") &&
+          offlineReason !== "oom-killed"
+        ) {
+          offlineEvents.push({
+            id: replicaDatum.id,
+            offlineReason,
+            status,
+            timestamp,
+          });
+        }
+      }
+    }
+  }
+
+  // Widen the axis to cover both the selected window and the actual data bounds,
+  // so edge buckets aren't clipped and a short history still fills the range.
+  const clampedStartDate = new Date(
+    Math.min(startDate.getTime(), data.minBucketStartMs),
+  );
+  const clampedEndDate = new Date(
+    Math.max(endDate.getTime(), data.maxBucketEndMs),
+  );
+
+  return {
+    startDate: clampedStartDate,
+    endDate: clampedEndDate,
+    graphData,
+    offlineEvents,
+  };
+}

--- a/console/src/api/materialize/cluster/replicaUtilizationBinning.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationBinning.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import * as Sentry from "@sentry/react";
-import { flatGroup } from "d3";
+import { flatGroup, greatest } from "d3";
 
 import { OfflineEvent as ChartOfflineEvent } from "~/platform/clusters/ClusterOverview/types";
 
@@ -136,16 +136,10 @@ export function maxByMetric(
   samples: UtilizationSample[],
   metric: (s: UtilizationSample) => number | null,
 ): UtilizationSample {
-  let best = samples[0];
-  let bestValue = metric(best) ?? Number.NEGATIVE_INFINITY;
-  for (let i = 1; i < samples.length; i++) {
-    const value = metric(samples[i]) ?? Number.NEGATIVE_INFINITY;
-    if (value > bestValue) {
-      best = samples[i];
-      bestValue = value;
-    }
-  }
-  return best;
+  return (
+    greatest(samples, (s) => metric(s) ?? Number.NEGATIVE_INFINITY) ??
+    samples[0]
+  );
 }
 
 /**

--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.test.sql.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.test.sql.ts
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+import { CompiledQuery } from "kysely";
+
 import { SEARCH_PATH } from "~/api/materialize";
 import {
   executeSqlHttp,
@@ -15,7 +17,11 @@ import {
 } from "~/test/sql/materializeSqlClient";
 import { testdrive } from "~/test/sql/mzcompose";
 
-import { buildReplicaUtilizationHistoryQuery } from "./replicaUtilizationHistory";
+import {
+  buildConsoleClusterUtilizationOverviewQuery,
+  buildConsoleClusterUtilizationUnbinned3hQuery,
+  buildReplicaUtilizationHistoryQuery,
+} from "./replicaUtilizationHistory";
 
 const size25cc = {
   cpuNanoCores: 500_000_000,
@@ -365,5 +371,137 @@ describe("replicaUtilizationHistory", () => {
       );
       await cleanup();
     }
+  });
+});
+
+// The indexed-view builders read the maintained `_overview*` views (point-lookup
+// by cluster_id) rather than recomputing from the base tables. We mock the views
+// as user tables in `internal_test` and shadow the real ones via search_path.
+describe("console cluster utilization indexed views", () => {
+  const mockedSearchPath = "internal_test, " + SEARCH_PATH;
+
+  const run = <T>(query: CompiledQuery<T>) =>
+    executeSqlHttp(query, {
+      sessionVariables: {
+        search_path: mockedSearchPath,
+        cluster: QUICKSTART_CLUSTER,
+      },
+    });
+
+  it("buildConsoleClusterUtilizationUnbinned3hQuery filters by cluster and optionally expands blue-green lineage", async () => {
+    const client = await getMaterializeClient();
+
+    await testdrive(`
+        > CREATE SCHEMA IF NOT EXISTS internal_test;
+        > SET schema = internal_test;
+        > DROP TABLE IF EXISTS mz_console_cluster_utilization_overview_3h;
+        > DROP TABLE IF EXISTS mz_cluster_deployment_lineage;
+        > CREATE TABLE mz_console_cluster_utilization_overview_3h (
+            replica_id TEXT,
+            cluster_id TEXT,
+            size TEXT,
+            name TEXT,
+            occurred_at TIMESTAMPTZ,
+            cpu_percent DOUBLE,
+            memory_percent DOUBLE,
+            disk_percent DOUBLE,
+            heap_percent DOUBLE,
+            memory_and_disk_percent DOUBLE
+          );
+        > CREATE TABLE mz_cluster_deployment_lineage (
+            cluster_id TEXT,
+            current_deployment_cluster_id TEXT,
+            cluster_name TEXT
+          );
+        > INSERT INTO internal_test.mz_console_cluster_utilization_overview_3h VALUES
+            ('r1', 'u1', 'small', 'r1', '2030-01-01T00:00:00Z', 0.5, 0.4, 0.3, 0.2, 0.6),
+            ('rOld', 'u1-old', 'small', 'rOld', '2030-01-01T00:00:00Z', 0.1, 0.1, 0.1, 0.1, 0.1),
+            ('r2', 'u2', 'small', 'r2', '2030-01-01T00:00:00Z', 0.9, 0.9, 0.9, 0.9, 0.9);
+        > INSERT INTO internal_test.mz_cluster_deployment_lineage VALUES ('u1-old', 'u1', 'a');
+    `);
+
+    await client.query(`SET search_path TO ${mockedSearchPath};`);
+
+    // Without lineage: only the requested cluster.
+    const direct = await run(
+      buildConsoleClusterUtilizationUnbinned3hQuery({
+        clusterIds: ["u1"],
+      }).compile(),
+    );
+    expect(direct.rows.map((r) => r.clusterId)).toEqual(["u1"]);
+    expect(direct.rows[0]).toMatchObject({
+      replicaId: "r1",
+      size: "small",
+      cpuPercent: 0.5,
+      memoryAndDiskPercent: 0.6,
+    });
+
+    // With lineage: also the cluster's past blue-green deployment (u1-old).
+    const withLineage = await run(
+      buildConsoleClusterUtilizationUnbinned3hQuery({
+        clusterIds: ["u1"],
+        resolveLineage: true,
+      }).compile(),
+    );
+    expect(withLineage.rows.map((r) => r.clusterId).sort()).toEqual([
+      "u1",
+      "u1-old",
+    ]);
+  });
+
+  it("buildConsoleClusterUtilizationOverviewQuery reads the 24h view, filters by cluster, and clips by startDate", async () => {
+    const client = await getMaterializeClient();
+
+    await testdrive(`
+        > CREATE SCHEMA IF NOT EXISTS internal_test;
+        > SET schema = internal_test;
+        > DROP TABLE IF EXISTS mz_console_cluster_utilization_overview_24h;
+        > CREATE TABLE mz_console_cluster_utilization_overview_24h (
+            bucket_start TIMESTAMPTZ,
+            bucket_end TIMESTAMPTZ,
+            replica_id TEXT,
+            cluster_id TEXT,
+            size TEXT,
+            name TEXT,
+            memory_percent DOUBLE,
+            max_memory_at TIMESTAMPTZ,
+            disk_percent DOUBLE,
+            max_disk_at TIMESTAMPTZ,
+            max_cpu_percent DOUBLE,
+            max_cpu_at TIMESTAMPTZ,
+            heap_percent DOUBLE,
+            max_heap_at TIMESTAMPTZ,
+            memory_and_disk_percent DOUBLE,
+            max_memory_and_disk_memory_percent DOUBLE,
+            max_memory_and_disk_disk_percent DOUBLE,
+            max_memory_and_disk_at TIMESTAMPTZ,
+            offline_events TEXT
+          );
+        > INSERT INTO internal_test.mz_console_cluster_utilization_overview_24h VALUES
+            ('2030-01-01T00:00:00Z','2030-01-01T00:05:00Z','r1','u1','small','r1',0.4,'2030-01-01T00:00:00Z',0.3,'2030-01-01T00:00:00Z',0.5,'2030-01-01T00:00:00Z',0.2,'2030-01-01T00:00:00Z',0.6,0.4,0.3,'2030-01-01T00:00:00Z',NULL),
+            ('2030-01-01T01:00:00Z','2030-01-01T01:05:00Z','r1','u1','small','r1',0.4,'2030-01-01T01:00:00Z',0.3,'2030-01-01T01:00:00Z',0.5,'2030-01-01T01:00:00Z',0.2,'2030-01-01T01:00:00Z',0.6,0.4,0.3,'2030-01-01T01:00:00Z',NULL),
+            ('2030-01-01T01:00:00Z','2030-01-01T01:05:00Z','r2','u2','small','r2',0.9,'2030-01-01T01:00:00Z',0.9,'2030-01-01T01:00:00Z',0.9,'2030-01-01T01:00:00Z',0.9,'2030-01-01T01:00:00Z',0.9,0.9,0.9,'2030-01-01T01:00:00Z',NULL);
+    `);
+
+    await client.query(`SET search_path TO ${mockedSearchPath};`);
+
+    const res = await run(
+      buildConsoleClusterUtilizationOverviewQuery({
+        view: "mz_console_cluster_utilization_overview_24h",
+        clusterIds: ["u1"],
+        startDate: "2030-01-01T00:30:00Z",
+      }).compile(),
+    );
+
+    // Only u1 (cluster filter), and only the 01:00 bucket (startDate clips 00:00).
+    expect(res.rows).toHaveLength(1);
+    expect(res.rows[0]).toMatchObject({
+      replicaId: "r1",
+      clusterId: "u1",
+      maxCpuPercent: 0.5,
+    });
+    expect(res.rows[0].bucketStart.toISOString()).toEqual(
+      "2030-01-01T01:00:00.000Z",
+    );
   });
 });

--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.test.sql.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.test.sql.ts
@@ -414,10 +414,13 @@ describe("console cluster utilization indexed views", () => {
             cluster_name TEXT
           );
         > INSERT INTO internal_test.mz_console_cluster_utilization_overview_3h VALUES
-            ('r1', 'u1', 'small', 'r1', '2030-01-01T00:00:00Z', 0.5, 0.4, 0.3, 0.2, 0.6),
-            ('rOld', 'u1-old', 'small', 'rOld', '2030-01-01T00:00:00Z', 0.1, 0.1, 0.1, 0.1, 0.1),
-            ('r2', 'u2', 'small', 'r2', '2030-01-01T00:00:00Z', 0.9, 0.9, 0.9, 0.9, 0.9);
-        > INSERT INTO internal_test.mz_cluster_deployment_lineage VALUES ('u1-old', 'u1', 'a');
+            ('u7', 'u3', '50cc', 'r1', '2030-01-01T00:00:00Z', 0.5, 0.4, 0.3, 0.2, 0.6),
+            ('u5', 'u2', '50cc', 'r1', '2030-01-01T00:00:00Z', 0.1, 0.1, 0.1, 0.1, 0.1),
+            ('u6', 'u4', '50cc', 'r1', '2030-01-01T00:00:00Z', 0.9, 0.9, 0.9, 0.9, 0.9);
+        > INSERT INTO internal_test.mz_cluster_deployment_lineage VALUES
+            ('u2', 'u3', 'blue_green'),
+            ('u3', 'u3', 'blue_green'),
+            ('u4', 'u4', 'non_blue_green');
     `);
 
     await client.query(`SET search_path TO ${mockedSearchPath};`);
@@ -425,27 +428,27 @@ describe("console cluster utilization indexed views", () => {
     // Without lineage: only the requested cluster.
     const direct = await run(
       buildConsoleClusterUtilizationUnbinned3hQuery({
-        clusterIds: ["u1"],
+        clusterIds: ["u3"],
       }).compile(),
     );
-    expect(direct.rows.map((r) => r.clusterId)).toEqual(["u1"]);
+    expect(direct.rows.map((r) => r.clusterId)).toEqual(["u3"]);
     expect(direct.rows[0]).toMatchObject({
-      replicaId: "r1",
-      size: "small",
+      replicaId: "u7",
+      size: "50cc",
       cpuPercent: 0.5,
       memoryAndDiskPercent: 0.6,
     });
 
-    // With lineage: also the cluster's past blue-green deployment (u1-old).
+    // With lineage: also the cluster's past blue-green deployment (u2).
     const withLineage = await run(
       buildConsoleClusterUtilizationUnbinned3hQuery({
-        clusterIds: ["u1"],
+        clusterIds: ["u3"],
         resolveLineage: true,
       }).compile(),
     );
     expect(withLineage.rows.map((r) => r.clusterId).sort()).toEqual([
-      "u1",
-      "u1-old",
+      "u2",
+      "u3",
     ]);
   });
 

--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
@@ -7,13 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import * as Sentry from "@sentry/react";
 import { QueryKey } from "@tanstack/react-query";
 import { sql } from "kysely";
 
 import { executeSqlV2, queryBuilder } from "~/api/materialize";
+import { buildSubscribeQuery } from "~/api/materialize/buildSubscribeQuery";
 
 import { fetchClusterDeploymentLineage } from "./clusterDeploymentLineage";
+import {
+  bucketRowsToBucketsByReplicaId,
+  rebucketUtilizationSamples,
+  UtilizationBucketRow,
+} from "./replicaUtilizationBinning";
+
+// Re-exported for existing importers of these data types.
+export type { Bucket, OfflineEvent } from "./replicaUtilizationBinning";
 
 export type ReplicaUtilizationHistoryParameters = {
   // Filter per cluster
@@ -27,11 +35,15 @@ export type ReplicaUtilizationHistoryParameters = {
   // Size of the time buckets in milliseconds
   bucketSizeMs: number;
 
-  // Whether to use the console cluster utilization overview view
+  // Whether to use the console cluster utilization overview view (14d/1h).
   shouldUseConsoleClusterUtilizationOverviewView?: boolean;
+  // Finer indexed-view tiers for shorter windows. "unbinned3h" reads the un-binned
+  // 3h base and bins client-side; "overview24h" reads the 24h/5min binned view.
+  // Unset (and `shouldUse...` false) falls back to the ad-hoc whole-fleet query.
+  utilizationView?: "unbinned3h" | "overview24h";
 };
-// We have an equivalent query in `builtin.rs` in the MaterializeInc/materialize.
-// This should query should be kept in sync with `mz_console_cluster_utilization_overview`.
+// We have an equivalent query in `builtin.rs` in MaterializeInc/materialize.
+// This query should be kept in sync with `mz_console_cluster_utilization_overview`.
 export function buildReplicaUtilizationHistoryQuery({
   clusterIds,
   replicaId,
@@ -433,18 +445,34 @@ export function buildReplicaUtilizationHistoryQuery({
 }
 
 /**
- * This is an optimized version of buildReplicaUtilizationHistoryQuery
- * that uses a time period of 14 days and a bucket of 8 hours via a built-in index+view.
+ * Optimized version of `buildReplicaUtilizationHistoryQuery` that reads a
+ * maintained overview index+view (`_overview` 14d or `_overview_24h` 24h).
  */
 export function buildConsoleClusterUtilizationOverviewQuery({
   clusterIds,
   replicaId,
+  startDate,
+  view = "mz_console_cluster_utilization_overview",
+  resolveLineage = false,
 }: {
   clusterIds?: string[];
   replicaId?: string;
+  // Clip to the requested window (the view retains more than shorter windows).
+  startDate?: string;
+  // The `_overview` (14d/1h) and `_overview_24h` (24h/5min) views share the same
+  // output columns, so one builder serves both.
+  view?:
+    | "mz_console_cluster_utilization_overview"
+    | "mz_console_cluster_utilization_overview_24h";
+  // When true, the query includes the cluster's earlier blue-green deployments
+  // (via a mz_cluster_deployment_lineage subquery) so history spans swaps. The
+  // SUBSCRIBE path needs this because it can't pre-resolve the ids in JS first.
+  resolveLineage?: boolean;
 }) {
   let query = queryBuilder
-    .selectFrom("mz_console_cluster_utilization_overview")
+    // `_overview_24h` isn't in the generated kysely schema yet; both views share
+    // the same columns, so type against `_overview`.
+    .selectFrom(view as "mz_console_cluster_utilization_overview")
     .select([
       "bucket_start as bucketStart",
       "replica_id as replicaId",
@@ -469,9 +497,99 @@ export function buildConsoleClusterUtilizationOverviewQuery({
     .orderBy("bucketStart");
 
   if (clusterIds !== undefined && clusterIds.length > 0) {
-    query = query.where("cluster_id", "in", clusterIds);
+    if (resolveLineage) {
+      // Include the cluster's past blue-green deployments (continuous history
+      // across a swap), plus the cluster itself (system clusters have no lineage).
+      query = query.where((eb) =>
+        eb.or([
+          eb(
+            "cluster_id",
+            "in",
+            eb
+              .selectFrom("mz_cluster_deployment_lineage")
+              .select("cluster_id")
+              .where("current_deployment_cluster_id", "in", clusterIds),
+          ),
+          eb("cluster_id", "in", clusterIds),
+        ]),
+      );
+    } else {
+      query = query.where("cluster_id", "in", clusterIds);
+    }
   }
 
+  if (replicaId) {
+    query = query.where("replica_id", "=", replicaId);
+  }
+
+  if (startDate) {
+    query = query.where(
+      "bucket_start",
+      ">=",
+      sql<Date>`${sql.lit(startDate)}::timestamptz`,
+    );
+  }
+
+  return query;
+}
+
+/**
+ * Point-lookup the un-binned 3h view (`_overview_3h`) by cluster. The Console
+ * bins the returned samples client-side (`rebucketUtilizationSamples`).
+ */
+export function buildConsoleClusterUtilizationUnbinned3hQuery({
+  clusterIds,
+  replicaId,
+  resolveLineage = false,
+}: {
+  clusterIds?: string[];
+  replicaId?: string;
+  // When true, the query includes the cluster's earlier blue-green deployments
+  // (via a mz_cluster_deployment_lineage subquery) so history spans swaps. The
+  // SUBSCRIBE path needs this because it can't pre-resolve the ids in JS first.
+  resolveLineage?: boolean;
+}) {
+  let query = queryBuilder
+    // Not yet in the generated kysely schema (gen:types predates the un-binned
+    // reshape); type as the sibling view (same key columns) and select raw.
+    .selectFrom(
+      "mz_console_cluster_utilization_overview_3h" as unknown as "mz_console_cluster_utilization_overview",
+    )
+    .select([
+      sql<string>`replica_id`.as("replicaId"),
+      sql<string | null>`cluster_id`.as("clusterId"),
+      sql<string | null>`size`.as("size"),
+      sql<string | null>`name`.as("name"),
+      sql<Date>`occurred_at`.as("occurredAt"),
+      sql<number | null>`cpu_percent`.as("cpuPercent"),
+      sql<number | null>`memory_percent`.as("memoryPercent"),
+      sql<number | null>`disk_percent`.as("diskPercent"),
+      sql<number | null>`heap_percent`.as("heapPercent"),
+      sql<number | null>`memory_and_disk_percent`.as("memoryAndDiskPercent"),
+    ]);
+
+  if (clusterIds !== undefined && clusterIds.length > 0) {
+    if (resolveLineage) {
+      // Include the cluster's past blue-green deployments (so history is
+      // continuous across a swap), plus the cluster itself (system clusters
+      // have no lineage row).
+      query = query.where((eb) =>
+        eb.or([
+          eb(
+            "cluster_id",
+            "in",
+            eb
+              .selectFrom("mz_cluster_deployment_lineage")
+              .select("cluster_id")
+              .where("current_deployment_cluster_id", "in", clusterIds),
+          ),
+          eb("cluster_id", "in", clusterIds),
+        ]),
+      );
+    } else {
+      query = query.where("cluster_id", "in", clusterIds);
+    }
+  }
   if (replicaId) {
     query = query.where("replica_id", "=", replicaId);
   }
@@ -479,49 +597,41 @@ export function buildConsoleClusterUtilizationOverviewQuery({
   return query;
 }
 
-export type OfflineEvent = {
-  replicaId: string;
-  occurredAt: string;
-  status: string;
-  reason: string;
-};
+/**
+ * Live SUBSCRIBE to the un-binned 3h view by cluster. The streamed samples are
+ * binned client-side (`rebucketUtilizationSamples`).
+ */
+export function buildConsoleClusterUtilizationUnbinned3hSubscribe<T>(
+  clusterIds: string[],
+  minDate: Date,
+) {
+  return buildSubscribeQuery<T>(
+    buildConsoleClusterUtilizationUnbinned3hQuery({
+      clusterIds,
+      resolveLineage: true,
+    }),
+    { asOfAtLeast: minDate, upsertKey: ["replicaId", "occurredAt"] },
+  );
+}
 
-export type Bucket = {
-  size: string | null;
-  bucketStart: Date;
-  replicaId: string;
-  bucketEnd: Date;
-  name: string;
-  // The cluster ID of the replica's current DBT deployment
-  currentDeploymentClusterId: string;
-  // The cluster ID of the replica. If the cluster was dropped,
-  // this will be different from currentDeploymentClusterId
-  clusterId: string;
-  maxMemory: {
-    percent: number | null;
-    occurredAt: Date;
-  };
-  maxDisk: {
-    percent: number | null;
-    occurredAt: Date;
-  };
-  maxCpu: {
-    percent: number | null;
-    occurredAt: Date;
-  };
-  maxHeap: {
-    percent: number | null;
-    occurredAt: Date;
-  };
-  maxMemoryAndDisk: {
-    memoryPercent: number | null;
-    diskPercent: number | null;
-    percent: number | null;
-    occurredAt: Date;
-  };
-
-  offlineEvents: OfflineEvent[] | null;
-};
+/**
+ * Live SUBSCRIBE to the server-binned 24h view by cluster. Its rows are already
+ * binned, so unlike the 3h path they need no client-side rebinning.
+ */
+export function buildConsoleClusterUtilizationOverview24hSubscribe<T>(
+  clusterIds: string[],
+  minDate: Date,
+) {
+  return buildSubscribeQuery<T>(
+    buildConsoleClusterUtilizationOverviewQuery({
+      view: "mz_console_cluster_utilization_overview_24h",
+      clusterIds,
+      resolveLineage: true,
+      startDate: minDate.toISOString(),
+    }),
+    { asOfAtLeast: minDate, upsertKey: ["replicaId", "bucketStart"] },
+  );
+}
 
 export async function fetchReplicaUtilizationHistory({
   params,
@@ -558,104 +668,64 @@ export async function fetchReplicaUtilizationHistory({
     return accum;
   }, [] as string[]);
 
-  let utilizationQuery = buildReplicaUtilizationHistoryQuery({
-    ...params,
-    clusterIds: clusterIdsFilter,
-  }).compile();
+  // Route to the cheapest indexed source for the requested window, falling back
+  // to the ad-hoc whole-fleet recompute only when no view covers it (>14d).
+  let rows: UtilizationBucketRow[];
 
-  if (params.shouldUseConsoleClusterUtilizationOverviewView) {
-    utilizationQuery = buildConsoleClusterUtilizationOverviewQuery({
-      clusterIds: clusterIdsFilter,
-      replicaId: params.replicaId,
-    }).compile();
-  }
-
-  const utilizationRes = await executeSqlV2({
-    queries: utilizationQuery,
-    queryKey: queryKey,
-    requestOptions,
-    sessionVariables: {
-      // We use serializable because we don't care about strict seriailizability and to get consistent performance
-      transaction_isolation: "serializable",
-    },
-  });
-
-  const bucketsByReplicaId: Record<string, Bucket[]> = {};
-
-  let minBucketStartMs = Number.POSITIVE_INFINITY;
-  let maxBucketEndMs = Number.NEGATIVE_INFINITY;
-
-  for (const row of utilizationRes.rows) {
-    minBucketStartMs = Math.min(minBucketStartMs, row.bucketStart.getTime());
-    maxBucketEndMs = Math.max(maxBucketEndMs, row.bucketEnd.getTime());
-
-    const {
-      replicaId,
-      size,
-      bucketStart,
-      bucketEnd,
-      name,
-      clusterId,
-      offlineEvents,
-    } = row;
-
-    const buckets = bucketsByReplicaId[replicaId];
-
-    if (name === null || clusterId === null) {
-      const err = new Error(
-        `Expected name: ${name} and clusterId: ${clusterId} to be defined`,
-      );
-
-      Sentry.captureException(err);
-      throw err;
-    }
-
-    const currentDeploymentClusterId =
-      currentDeploymentByPastDeployment.get(clusterId)
-        ?.currentDeploymentClusterId ?? clusterId;
-
-    const newBucket = {
-      size,
-      bucketStart,
-      bucketEnd,
-      offlineEvents,
-      name,
-      currentDeploymentClusterId,
-      clusterId,
-      replicaId,
-      maxMemory: {
-        percent: row.maxMemoryPercent,
-        occurredAt: row.maxMemoryAt,
-      },
-      maxDisk: {
-        percent: row.maxDiskPercent,
-        occurredAt: row.maxDiskAt,
-      },
-      maxCpu: {
-        percent: row.maxCpuPercent,
-        occurredAt: row.maxCpuAt,
-      },
-      maxHeap: {
-        percent: row.maxHeapPercent ?? null,
-        occurredAt: row.maxHeapAt ?? new Date(),
-      },
-      maxMemoryAndDisk: {
-        percent: row.maxMemoryAndDiskPercent,
-        memoryPercent: row.maxMemoryAndDiskMemoryPercent,
-        diskPercent: row.maxMemoryAndDiskDiskPercent,
-        occurredAt: row.maxMemoryAndDiskAt,
-      },
-    };
-
-    if (buckets) {
-      buckets.push(newBucket);
+  if (params.utilizationView === "unbinned3h") {
+    // Un-binned 3h base: cheap indexed point-lookup, then bin client-side.
+    const unbinnedRes = await executeSqlV2({
+      queries: buildConsoleClusterUtilizationUnbinned3hQuery({
+        clusterIds: clusterIdsFilter,
+        replicaId: params.replicaId,
+      }).compile(),
+      queryKey,
+      requestOptions,
+      sessionVariables: { transaction_isolation: "serializable" },
+    });
+    rows = rebucketUtilizationSamples(
+      unbinnedRes.rows,
+      params.bucketSizeMs,
+      new Date(params.startDate).getTime(),
+    );
+  } else {
+    let utilizationQuery;
+    if (params.utilizationView === "overview24h") {
+      utilizationQuery = buildConsoleClusterUtilizationOverviewQuery({
+        view: "mz_console_cluster_utilization_overview_24h",
+        clusterIds: clusterIdsFilter,
+        replicaId: params.replicaId,
+        startDate: params.startDate,
+      }).compile();
+    } else if (params.shouldUseConsoleClusterUtilizationOverviewView) {
+      utilizationQuery = buildConsoleClusterUtilizationOverviewQuery({
+        clusterIds: clusterIdsFilter,
+        replicaId: params.replicaId,
+        startDate: params.startDate,
+      }).compile();
     } else {
-      bucketsByReplicaId[replicaId] = [newBucket];
+      utilizationQuery = buildReplicaUtilizationHistoryQuery({
+        ...params,
+        clusterIds: clusterIdsFilter,
+      }).compile();
     }
+
+    const utilizationRes = await executeSqlV2({
+      queries: utilizationQuery,
+      queryKey: queryKey,
+      requestOptions,
+      sessionVariables: {
+        // We use serializable because we don't care about strict serializability and to get consistent performance
+        transaction_isolation: "serializable",
+      },
+    });
+    rows = utilizationRes.rows as UtilizationBucketRow[];
   }
-  return {
-    minBucketStartMs,
-    maxBucketEndMs,
-    bucketsByReplicaId,
-  };
+
+  return bucketRowsToBucketsByReplicaId(
+    rows,
+    (clusterId) =>
+      currentDeploymentByPastDeployment.get(clusterId)
+        ?.currentDeploymentClusterId,
+  );
 }

--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
@@ -464,15 +464,13 @@ export function buildConsoleClusterUtilizationOverviewQuery({
   view?:
     | "mz_console_cluster_utilization_overview"
     | "mz_console_cluster_utilization_overview_24h";
-  // When true, the query includes the cluster's earlier blue-green deployments
-  // (via a mz_cluster_deployment_lineage subquery) so history spans swaps. The
-  // SUBSCRIBE path needs this because it can't pre-resolve the ids in JS first.
+  // When true, expand clusterIds to past blue-green deployments in SQL. The
+  // poll path pre-resolves lineage in JS instead (it also needs the reverse
+  // map to relabel rows), so only the SUBSCRIBE paths set this.
   resolveLineage?: boolean;
 }) {
   let query = queryBuilder
-    // `_overview_24h` isn't in the generated kysely schema yet; both views share
-    // the same columns, so type against `_overview`.
-    .selectFrom(view as "mz_console_cluster_utilization_overview")
+    .selectFrom(view)
     .select([
       "bucket_start as bucketStart",
       "replica_id as replicaId",
@@ -544,28 +542,24 @@ export function buildConsoleClusterUtilizationUnbinned3hQuery({
 }: {
   clusterIds?: string[];
   replicaId?: string;
-  // When true, the query includes the cluster's earlier blue-green deployments
-  // (via a mz_cluster_deployment_lineage subquery) so history spans swaps. The
-  // SUBSCRIBE path needs this because it can't pre-resolve the ids in JS first.
+  // When true, expand clusterIds to past blue-green deployments in SQL. The
+  // poll path pre-resolves lineage in JS instead (it also needs the reverse
+  // map to relabel rows), so only the SUBSCRIBE paths set this.
   resolveLineage?: boolean;
 }) {
   let query = queryBuilder
-    // Not yet in the generated kysely schema (gen:types predates the un-binned
-    // reshape); type as the sibling view (same key columns) and select raw.
-    .selectFrom(
-      "mz_console_cluster_utilization_overview_3h" as unknown as "mz_console_cluster_utilization_overview",
-    )
+    .selectFrom("mz_console_cluster_utilization_overview_3h")
     .select([
-      sql<string>`replica_id`.as("replicaId"),
-      sql<string | null>`cluster_id`.as("clusterId"),
-      sql<string | null>`size`.as("size"),
-      sql<string | null>`name`.as("name"),
-      sql<Date>`occurred_at`.as("occurredAt"),
-      sql<number | null>`cpu_percent`.as("cpuPercent"),
-      sql<number | null>`memory_percent`.as("memoryPercent"),
-      sql<number | null>`disk_percent`.as("diskPercent"),
-      sql<number | null>`heap_percent`.as("heapPercent"),
-      sql<number | null>`memory_and_disk_percent`.as("memoryAndDiskPercent"),
+      "replica_id as replicaId",
+      "cluster_id as clusterId",
+      "size",
+      "name",
+      "occurred_at as occurredAt",
+      "cpu_percent as cpuPercent",
+      "memory_percent as memoryPercent",
+      "disk_percent as diskPercent",
+      "heap_percent as heapPercent",
+      "memory_and_disk_percent as memoryAndDiskPercent",
     ]);
 
   if (clusterIds !== undefined && clusterIds.length > 0) {

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -63,17 +63,27 @@ import {
   fetchClusterReplicasWithUtilization,
 } from "~/api/materialize/cluster/replicasWithUtilization";
 import {
+  BinnedSubscribeRow,
+  bucketRowsToBucketsByReplicaId,
+  parseBinnedSubscribeRow,
+  rebucketUtilizationSamples,
+  toReplicaUtilizationGraphData,
+  UtilizationSample,
+} from "~/api/materialize/cluster/replicaUtilizationBinning";
+import {
+  buildConsoleClusterUtilizationOverview24hSubscribe,
+  buildConsoleClusterUtilizationUnbinned3hSubscribe,
   fetchReplicaUtilizationHistory,
   ReplicaUtilizationHistoryParameters,
 } from "~/api/materialize/cluster/replicaUtilizationHistory";
 import { fetchLagHistory } from "~/api/materialize/freshness/lagHistory";
 import { assertNoMoreThanOneRow } from "~/api/materialize/MoreThanOneRowError";
+import { useSubscribe } from "~/api/materialize/useSubscribe";
 import { DataPoint, GraphLineSeries } from "~/components/FreshnessGraph/types";
-import { DEFAULT_OPTIONS as TIME_PERIOD_OPTIONS } from "~/hooks/useTimePeriodSelect";
+import { useEnvironmentGate } from "~/store/environments";
 import { notNullOrUndefined, sumPostgresIntervalMs } from "~/util";
 import { sortLagInfo } from "~/utils/freshness";
 
-import { OfflineEvent } from "./ClusterOverview/types";
 type ReplicaUtilizationHistoryFilters = {
   clusterIds: ReplicaUtilizationHistoryParameters["clusterIds"];
   replicaId: ReplicaUtilizationHistoryParameters["replicaId"];
@@ -441,140 +451,203 @@ export function useMaterializationLag(params: MaterializationLagParams) {
   });
 }
 
-type TimePeriodOptionValues =
-  (typeof TIME_PERIOD_OPTIONS)[keyof typeof TIME_PERIOD_OPTIONS];
+// Window tiers, bounded by the maintained view that serves each. Up to 24h is a
+// live SUBSCRIBE (push). Beyond that we poll. Bounds are the views' retentions.
+const SUBSCRIBE_UNBINNED_MAX_MINUTES = 180; // 3h: live un-binned base, client-binned
+const SUBSCRIBE_BINNED_MAX_MINUTES = 1440; // 24h: live 5-min binned view
+const OVERVIEW_MAX_MINUTES = 20160; // 14d: polled overview view; beyond, ad-hoc
 
 /**
- * Fetches a normalized table of an object, the lag between its direct parent, and
- * the lag between its source/table objects
+ * SUBSCRIBE variant for the live (≤3h) window: streams the un-binned 3h base
+ * (lineage resolved in SQL), bins client-side, shapes like the poll path.
+ * Subscribes by cluster (not replica) so the socket survives the replica dropdown.
+ *
+ * NOTE: when `enabled` is false the subscribe is undefined, so the socket opens
+ * but sends no query: an idle connection, not catalog-server load.
  */
+function useReplicaUtilizationHistorySubscribe(
+  params: ReplicaUtilizationHistoryFilters,
+  enabled: boolean,
+) {
+  const { replicaId, timePeriodMinutes, bucketSizeMs } = params;
+  // Key on content, not array identity (the caller passes a fresh array each
+  // render), so the socket survives re-renders. Ids contain no commas, so the
+  // comma join/split round-trips them.
+  const clusterIdsKey = (params.clusterIds ?? []).join(",");
+
+  const subscribe = useMemo(() => {
+    const clusterIds = clusterIdsKey ? clusterIdsKey.split(",") : [];
+    if (!enabled || clusterIds.length === 0) {
+      return undefined;
+    }
+    // The frontier only needs to reach back to the window start; the view itself
+    // retains the last 3h.
+    const minDate = subMinutes(new Date(), timePeriodMinutes);
+    return buildConsoleClusterUtilizationUnbinned3hSubscribe<UtilizationSample>(
+      clusterIds,
+      minDate,
+    );
+  }, [enabled, clusterIdsKey, timePeriodMinutes]);
+
+  const { data, isError, snapshotComplete } = useSubscribe({
+    subscribe,
+    upsertKey: (row) => `${row.data.replicaId} ${row.data.occurredAt}`,
+    select: (row) => ({
+      ...row.data,
+      occurredAt: new Date(row.data.occurredAt),
+    }),
+  });
+
+  const result = useMemo(() => {
+    const endDate = new Date();
+    const startDate = subMinutes(endDate, timePeriodMinutes);
+
+    const samples = replicaId
+      ? data.filter((sample) => sample.replicaId === replicaId)
+      : data;
+    const rows = rebucketUtilizationSamples(
+      samples,
+      bucketSizeMs,
+      startDate.getTime(),
+    );
+    return toReplicaUtilizationGraphData(
+      bucketRowsToBucketsByReplicaId(rows),
+      startDate,
+      endDate,
+    );
+  }, [data, replicaId, timePeriodMinutes, bucketSizeMs]);
+
+  return {
+    data: result,
+    isLoading: enabled && !snapshotComplete,
+    isError,
+  };
+}
+
+/**
+ * SUBSCRIBE variant for the 3h-24h window: streams the server-binned 24h view
+ * (lineage resolved in SQL). The rows are already binned, so they feed
+ * `bucketRowsToBucketsByReplicaId` directly with no client-side rebinning.
+ * ENVELOPE UPSERT yields an unordered keyed set, so we sort by bucket start.
+ */
+function useReplicaUtilizationHistoryBinnedSubscribe(
+  params: ReplicaUtilizationHistoryFilters,
+  enabled: boolean,
+) {
+  const { replicaId, timePeriodMinutes } = params;
+  const clusterIdsKey = (params.clusterIds ?? []).join(",");
+
+  const subscribe = useMemo(() => {
+    const clusterIds = clusterIdsKey ? clusterIdsKey.split(",") : [];
+    if (!enabled || clusterIds.length === 0) {
+      return undefined;
+    }
+    const minDate = subMinutes(new Date(), timePeriodMinutes);
+    return buildConsoleClusterUtilizationOverview24hSubscribe<BinnedSubscribeRow>(
+      clusterIds,
+      minDate,
+    );
+  }, [enabled, clusterIdsKey, timePeriodMinutes]);
+
+  const { data, isError, snapshotComplete } = useSubscribe({
+    subscribe,
+    upsertKey: (row) => `${row.data.replicaId} ${row.data.bucketStart}`,
+    select: (row) => parseBinnedSubscribeRow(row.data),
+  });
+
+  const result = useMemo(() => {
+    const endDate = new Date();
+    const startDate = subMinutes(endDate, timePeriodMinutes);
+
+    const rows = replicaId
+      ? data.filter((row) => row.replicaId === replicaId)
+      : [...data];
+    // ENVELOPE UPSERT yields an unordered keyed set; the chart needs time order.
+    rows.sort((a, b) => a.bucketStart.getTime() - b.bucketStart.getTime());
+
+    return toReplicaUtilizationGraphData(
+      bucketRowsToBucketsByReplicaId(rows),
+      startDate,
+      endDate,
+    );
+  }, [data, replicaId, timePeriodMinutes]);
+
+  return {
+    data: result,
+    isLoading: enabled && !snapshotComplete,
+    isError,
+  };
+}
+
 export function useReplicaUtilizationHistory(
   params: ReplicaUtilizationHistoryFilters,
   queryOptions?: { enabled?: boolean },
 ) {
-  return useQuery({
+  const enabled = queryOptions?.enabled ?? true;
+  const minutes = params.timePeriodMinutes;
+  // The un-binned 3h and 24h indexed views (and their SUBSCRIBEs) only exist on
+  // mz >= 26.32. On older environments (e.g. mid-rollout) these paths are gated
+  // off and everything falls back to the poll. The 14d `overview` view predates
+  // this, so its poll path is not gated.
+  // TODO: remove the gate once all environments are >= 26.32.
+  const hasIndexedViews = useEnvironmentGate("26.32.0") === true;
+
+  const useUnbinnedSubscribe =
+    hasIndexedViews && minutes <= SUBSCRIBE_UNBINNED_MAX_MINUTES;
+  const useBinnedSubscribe =
+    hasIndexedViews &&
+    minutes > SUBSCRIBE_UNBINNED_MAX_MINUTES &&
+    minutes <= SUBSCRIBE_BINNED_MAX_MINUTES;
+
+  const unbinnedResult = useReplicaUtilizationHistorySubscribe(
+    params,
+    enabled && useUnbinnedSubscribe,
+  );
+  const binnedResult = useReplicaUtilizationHistoryBinnedSubscribe(
+    params,
+    enabled && useBinnedSubscribe,
+  );
+
+  const queryResult = useQuery({
     queryKey: clusterQueryKeys.replicaUtilizationHistory(params),
     refetchInterval: 20_000,
-    enabled: queryOptions?.enabled,
+    // Poll whatever a subscribe isn't serving: >24h on new mz, and every window
+    // on old mz (where the subscribes are gated off).
+    enabled: enabled && !useUnbinnedSubscribe && !useBinnedSubscribe,
     queryFn: async ({ queryKey, signal }) => {
       const [, queryKeyParams] = queryKey;
 
       const endDate = new Date();
       const startDate = subMinutes(endDate, queryKeyParams.timePeriodMinutes);
 
-      const last14DaysOptionValue: TimePeriodOptionValues = "Last 14 days";
-
-      const last14DaysTimePeriodMinutes = Number(
-        Object.entries(TIME_PERIOD_OPTIONS).find(
-          ([_, option]) => option === last14DaysOptionValue,
-        )?.[0],
-      );
-
+      // The 14d `overview` view serves 24h..14d. Beyond 14d, and on old mz the
+      // <=24h windows a subscribe would cover, use the ad-hoc whole-fleet query.
       const data = await fetchReplicaUtilizationHistory({
         params: {
           ...queryKeyParams,
           startDate: startDate.toISOString(),
           shouldUseConsoleClusterUtilizationOverviewView:
-            queryKeyParams.timePeriodMinutes === last14DaysTimePeriodMinutes,
+            queryKeyParams.timePeriodMinutes > SUBSCRIBE_BINNED_MAX_MINUTES &&
+            queryKeyParams.timePeriodMinutes <= OVERVIEW_MAX_MINUTES,
         },
         queryKey,
         requestOptions: { signal },
       });
 
-      const graphData = Object.entries(data.bucketsByReplicaId).map(
-        ([replicaId, replicaData]) => {
-          return {
-            id: replicaId,
-            data: replicaData.map(
-              ({
-                bucketEnd,
-                bucketStart,
-                maxHeap,
-                maxMemory,
-                maxCpu,
-                maxDisk,
-                maxMemoryAndDisk,
-                size,
-                offlineEvents,
-                name,
-              }) => ({
-                id: replicaId,
-                name,
-                bucketEnd: bucketEnd.getTime(),
-                bucketStart: bucketStart.getTime(),
-                cpuPercent: maxCpu?.percent ? maxCpu.percent * 100 : null,
-                diskPercent: maxDisk?.percent ? maxDisk.percent * 100 : null,
-                memoryPercent: maxMemory?.percent
-                  ? maxMemory.percent * 100
-                  : null,
-                // Memory utilization calculated in SQL: (memory_bytes + disk_bytes) / (available_memory + available_disk)
-                maxMemoryAndDiskPercent: maxMemoryAndDisk?.percent
-                  ? maxMemoryAndDisk.percent * 100
-                  : null,
-                heapPercent: maxHeap?.percent ? maxHeap.percent * 100 : null,
-                size,
-                offlineEvents:
-                  offlineEvents?.map((event) => ({
-                    id: event.replicaId,
-                    offlineReason: event.reason,
-                    status: event.status,
-                    timestamp: new Date(event.occurredAt).getTime(),
-                  })) ?? [],
-              }),
-            ),
-          };
-        },
-      );
-
-      const offlineEvents: Array<OfflineEvent> = [];
-
-      for (const replicaId in graphData) {
-        const replica = graphData[replicaId];
-
-        for (const replicaDatum of replica?.data ?? []) {
-          for (const {
-            status,
-            offlineReason,
-            timestamp,
-          } of replicaDatum.offlineEvents) {
-            if (
-              (status === "not-ready" || status === "offline") &&
-              offlineReason !== "oom-killed"
-            ) {
-              offlineEvents.push({
-                id: replicaDatum.id,
-                offlineReason,
-                status,
-                timestamp,
-              });
-            }
-          }
-        }
-      }
-
-      /**
-       * If the selected range is within the bounds of the data, we clamp it to the data's min and
-       * max since we can have buckets outside the selected range so that each bucket has the same
-       * size. However, if the selected range is larger than the bounds of the data, we wanted the
-       * returned start date and end date to represent the selected range. For example, we might
-       * select the last 30 days but if the data only goes back 7 days, we still want the range
-       * in our graph to be the last 30 days.
-       */
-      const clampedStartDate = new Date(
-        Math.min(new Date(startDate).getTime(), data.minBucketStartMs),
-      );
-      const clampedEndDate = new Date(
-        Math.max(new Date(endDate).getTime(), data.maxBucketEndMs),
-      );
-
-      return {
-        startDate: clampedStartDate,
-        endDate: clampedEndDate,
-        graphData,
-        offlineEvents,
-      };
+      return toReplicaUtilizationGraphData(data, startDate, endDate);
     },
   });
+
+  const active = useUnbinnedSubscribe
+    ? unbinnedResult
+    : useBinnedSubscribe
+      ? binnedResult
+      : queryResult;
+  return {
+    data: active.data,
+    isLoading: active.isLoading,
+    isError: active.isError,
+  };
 }
 
 export const LINE_MAX_COUNT = 10;

--- a/console/types/materialize.d.ts
+++ b/console/types/materialize.d.ts
@@ -1047,6 +1047,41 @@ export interface MzConsoleClusterUtilizationOverview {
   size: string | null;
 }
 
+export interface MzConsoleClusterUtilizationOverview24h {
+  bucket_end: Timestamp;
+  bucket_start: Timestamp;
+  cluster_id: string | null;
+  disk_percent: number | null;
+  heap_percent: number | null;
+  max_cpu_at: Timestamp;
+  max_cpu_percent: number | null;
+  max_disk_at: Timestamp;
+  max_heap_at: Timestamp;
+  max_memory_and_disk_at: Timestamp;
+  max_memory_and_disk_disk_percent: number | null;
+  max_memory_and_disk_memory_percent: number | null;
+  max_memory_at: Timestamp;
+  memory_and_disk_percent: number | null;
+  memory_percent: number | null;
+  name: string | null;
+  offline_events: Json | null;
+  replica_id: string;
+  size: string | null;
+}
+
+export interface MzConsoleClusterUtilizationOverview3h {
+  cluster_id: string | null;
+  cpu_percent: number | null;
+  disk_percent: number | null;
+  heap_percent: number | null;
+  memory_and_disk_percent: number | null;
+  memory_percent: number | null;
+  name: string | null;
+  occurred_at: Timestamp;
+  replica_id: string;
+  size: string;
+}
+
 export interface MzDatabases {
   /**
    * Materialize's unique ID for the database.
@@ -4280,6 +4315,8 @@ export interface DB {
   mz_compute_operator_hydration_statuses_per_worker: MzComputeOperatorHydrationStatusesPerWorker;
   mz_connections: MzConnections;
   mz_console_cluster_utilization_overview: MzConsoleClusterUtilizationOverview;
+  mz_console_cluster_utilization_overview_24h: MzConsoleClusterUtilizationOverview24h;
+  mz_console_cluster_utilization_overview_3h: MzConsoleClusterUtilizationOverview3h;
   mz_databases: MzDatabases;
   mz_dataflow_addresses: MzDataflowAddresses;
   mz_dataflow_addresses_per_worker: MzDataflowAddressesPerWorker;


### PR DESCRIPTION
The cluster-detail replica-utilization chart recomputed the whole-fleet utilization rollup ad-hoc on every load and only filtered to the viewed cluster at the end, so its cost scaled with the size of the entire deployment. This routes each time window to the cheapest maintained, cluster_id-indexed catalog view instead, as a per-cluster point lookup:

- <=3h: SUBSCRIBE to the un-binned 3h view, binned client-side (fine granularity for short windows).
- 3h..24h: SUBSCRIBE to the server-binned 24h view (already binned, so no client-side rebinning).
- 24h..14d: poll the 14d overview view.
- >14d: fall back to the ad-hoc whole-fleet query (no view covers it).

The two SUBSCRIBE paths give live push updates for the common short windows instead of 20s polling.

The pure client-side binning (sample bucketing, per-metric argmax, per-replica grouping, chart shaping) is extracted into replicaUtilizationBinning.ts and unit-tested; the new query builders get SQL-level coverage in replicaUtilizationHistory.test.sql.ts. 
