### PR TITLE
sql: Measure usage of `MapFilterProject::literal_constraints`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8309,6 +8309,7 @@ dependencies = [
  "mz-ccsr",
  "mz-cloud-provider",
  "mz-cloud-resources",
+ "mz-compute-types",
  "mz-controller-types",
  "mz-dyncfg",
  "mz-dyncfgs",

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1327,6 +1327,12 @@ metrics:
   - object_type
   source: src/sql/src/optimizer_metrics.rs
   visibility: internal
+- name: mz_optimizer_lowering_literal_constraints_total
+  help: How often the MFP-based literal-constraint detector succeeded, by call site.
+  labels:
+  - case
+  source: src/compute-types/src/plan.rs
+  visibility: internal
 - name: mz_otel_on_close
   help: count of on_close events sent to otel
   source: src/ore/src/tracing.rs

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -351,7 +351,11 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
         // Finalize the dataflow. This includes:
         // - MIR ⇒ LIR lowering
         // - LIR ⇒ LIR transforms
-        let df_desc = LirRelationExpr::finalize_dataflow(df_desc, &self.config.features)?;
+        let df_desc = LirRelationExpr::finalize_dataflow(
+            df_desc,
+            &self.config.features,
+            Some(self.metrics.lowering()),
+        )?;
 
         // Trace the pipeline output under `optimize`.
         trace_plan(&df_desc);

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -237,7 +237,11 @@ impl Optimize<GlobalMirPlan> for Optimizer {
         // Finalize the dataflow. This includes:
         // - MIR ⇒ LIR lowering
         // - LIR ⇒ LIR transforms
-        let df_desc = LirRelationExpr::finalize_dataflow(df_desc, &self.config.features)?;
+        let df_desc = LirRelationExpr::finalize_dataflow(
+            df_desc,
+            &self.config.features,
+            Some(self.metrics.lowering()),
+        )?;
 
         // Trace the pipeline output under `optimize`.
         trace_plan(&df_desc);

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -312,7 +312,11 @@ impl Optimize<GlobalMirPlan> for Optimizer {
         // Finalize the dataflow. This includes:
         // - MIR ⇒ LIR lowering
         // - LIR ⇒ LIR transforms
-        let df_desc = LirRelationExpr::finalize_dataflow(df_desc, &self.config.features)?;
+        let df_desc = LirRelationExpr::finalize_dataflow(
+            df_desc,
+            &self.config.features,
+            Some(self.metrics.lowering()),
+        )?;
 
         // Trace the pipeline output under `optimize`.
         trace_plan(&df_desc);

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -414,7 +414,11 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
                 // Finalize the dataflow. This includes:
                 // - MIR ⇒ LIR lowering
                 // - LIR ⇒ LIR transforms
-                let df_desc = LirRelationExpr::finalize_dataflow(df_desc, &self.config.features)?;
+                let df_desc = LirRelationExpr::finalize_dataflow(
+                    df_desc,
+                    &self.config.features,
+                    Some(self.metrics.lowering()),
+                )?;
 
                 // Trace the pipeline output under `optimize`.
                 trace_plan(&df_desc);

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -348,7 +348,11 @@ impl Optimize<GlobalMirPlan<Resolved>> for Optimizer {
         // Finalize the dataflow. This includes:
         // - MIR ⇒ LIR lowering
         // - LIR ⇒ LIR transforms
-        let df_desc = LirRelationExpr::finalize_dataflow(df_desc, &self.config.features)?;
+        let df_desc = LirRelationExpr::finalize_dataflow(
+            df_desc,
+            &self.config.features,
+            Some(self.metrics.lowering()),
+        )?;
 
         self.duration += time.elapsed();
         self.metrics

--- a/src/clusterd-test-driver/src/dataflow.rs
+++ b/src/clusterd-test-driver/src/dataflow.rs
@@ -440,7 +440,7 @@ impl DataflowBuilder {
         }
         // Lower MIR -> LIR. Deterministic and self-contained.
         let lowered: DataflowDescription<LirRelationExpr, ()> =
-            LirRelationExpr::finalize_dataflow(self.mir, &features)
+            LirRelationExpr::finalize_dataflow(self.mir, &features, None)
                 .map_err(|e| anyhow::anyhow!("lowering dataflow failed: {e}"))?;
         augment(lowered, &self.sources, &self.sinks)
     }

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -18,6 +18,9 @@ use mz_expr::{
     CollectionPlan, EvalError, Id, LetRecLimit, LocalId, MapFilterProject, MfpPlan, MirScalarExpr,
     OptimizedMirRelationExpr, SafeMfpPlan, TableFunc,
 };
+use mz_ore::metric;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::metrics::raw::IntCounterVec;
 use mz_ore::soft_assert_eq_no_log;
 use mz_ore::str::Indent;
 use mz_repr::explain::text::text_string_at;
@@ -44,6 +47,32 @@ pub mod scalar;
 pub mod threshold;
 pub mod top_k;
 pub mod transform;
+
+/// Metrics collected during MIR to LIR lowering.
+#[derive(Debug, Clone)]
+pub struct LoweringMetrics {
+    /// Counts non-`None` results of `MapFilterProject::literal_constraints` during lowering,
+    /// labeled by the call site (`"get"` or `"mfp"`).
+    literal_constraints: IntCounterVec,
+}
+
+impl LoweringMetrics {
+    /// Registers the lowering metrics into `registry`.
+    pub fn register_into(registry: &MetricsRegistry) -> Self {
+        Self {
+            literal_constraints: registry.register(metric!(
+                name: "mz_optimizer_lowering_literal_constraints_total",
+                help: "How often the MFP-based literal-constraint detector succeeded, by call site.",
+                var_labels: ["case"],
+            )),
+        }
+    }
+
+    /// Records that a `literal_constraints` call at `case` produced a usable constraint.
+    pub fn inc_literal_constraints(&self, case: &str) {
+        self.literal_constraints.with_label_values(&[case]).inc();
+    }
+}
 
 /// The forms in which an operator's output is available.
 ///
@@ -547,9 +576,10 @@ impl LirRelationExpr {
     pub fn finalize_dataflow(
         desc: DataflowDescription<OptimizedMirRelationExpr>,
         features: &OptimizerFeatures,
+        metrics: Option<&LoweringMetrics>,
     ) -> Result<DataflowDescription<Self>, String> {
         // First, we lower the dataflow description from MIR to LIR.
-        let mut dataflow = Self::lower_dataflow(desc, features)?;
+        let mut dataflow = Self::lower_dataflow(desc, features, metrics)?;
 
         // Subsequently, we perform plan refinements for the dataflow.
         Self::refine_source_mfps(&mut dataflow);
@@ -612,8 +642,9 @@ impl LirRelationExpr {
     fn lower_dataflow(
         desc: DataflowDescription<OptimizedMirRelationExpr>,
         features: &OptimizerFeatures,
+        metrics: Option<&LoweringMetrics>,
     ) -> Result<DataflowDescription<Self>, String> {
-        let context = lowering::Context::new(desc.debug_name.clone(), features);
+        let context = lowering::Context::new(desc.debug_name.clone(), features, metrics);
         let dataflow = context.lower(desc)?;
 
         mz_repr::explain::trace_plan(&dataflow);

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -30,6 +30,7 @@ use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::TopKPlan;
 use crate::plan::{
     ArrangementStrategy, AvailableCollections, GetPlan, LirId, LirRelationExpr, LirRelationNode,
+    LoweringMetrics,
 };
 
 /// Pick an [`ArrangementStrategy`] based on whether the input may contain future-stamped
@@ -68,10 +69,16 @@ pub(super) struct Context {
     debug_info: LirDebugInfo,
     /// Whether to enable fusion of MFPs in reductions.
     enable_reduce_mfp_fusion: bool,
+    /// Metrics recorded during lowering, if any are being collected.
+    metrics: Option<LoweringMetrics>,
 }
 
 impl Context {
-    pub fn new(debug_name: String, features: &OptimizerFeatures) -> Self {
+    pub fn new(
+        debug_name: String,
+        features: &OptimizerFeatures,
+        metrics: Option<&LoweringMetrics>,
+    ) -> Self {
         Self {
             arrangements: Default::default(),
             has_future_updates: Default::default(),
@@ -81,6 +88,7 @@ impl Context {
                 id: GlobalId::Transient(0),
             },
             enable_reduce_mfp_fusion: features.enable_reduce_mfp_fusion,
+            metrics: metrics.cloned(),
         }
     }
 
@@ -254,7 +262,12 @@ impl Context {
                         mfp.literal_constraints(
                             &key.0.iter().map(MirScalarExpr::from).collect_vec(),
                         )
-                        .map(|val| (key.clone(), val))
+                        .map(|val| {
+                            if let Some(metrics) = &self.metrics {
+                                metrics.inc_literal_constraints("get");
+                            }
+                            (key.clone(), val)
+                        })
                     })
                     .max_by_key(|(key, _val)| key.0.len());
 
@@ -1151,7 +1164,12 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     let mut mfp = mfp.clone();
                     mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
                     mfp.literal_constraints(&key.iter().map(MirScalarExpr::from).collect_vec())
-                        .map(|val| (key.clone(), permutation, thinning, val))
+                        .map(|val| {
+                            if let Some(metrics) = &self.metrics {
+                                metrics.inc_literal_constraints("mfp");
+                            }
+                            (key.clone(), permutation, thinning, val)
+                        })
                 })
                 .max_by_key(|(key, _, _, _)| key.len());
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -39,6 +39,7 @@ mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-provider = { path = "../cloud-provider", default-features = false }
 mz-cloud-resources = { path = "../cloud-resources" }
+mz-compute-types = { path = "../compute-types" }
 mz-controller-types = { path = "../controller-types" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-dyncfgs = { path = "../dyncfgs" }

--- a/src/sql/src/optimizer_metrics.rs
+++ b/src/sql/src/optimizer_metrics.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use mz_compute_types::plan::LoweringMetrics;
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::stats::histogram_seconds_buckets;
@@ -33,6 +34,8 @@ pub struct OptimizerMetrics {
     /// Local storage of transform times; these are emitted as part of the
     /// log-line when end-to-end optimization times exceed the configured threshold.
     transform_time_seconds: std::collections::BTreeMap<String, Vec<Duration>>,
+    /// Metrics recorded during MIR to LIR lowering.
+    lowering: LoweringMetrics,
 }
 
 impl OptimizerMetrics {
@@ -66,6 +69,7 @@ impl OptimizerMetrics {
                 var_labels: ["transform"],
             )),
             transform_time_seconds: std::collections::BTreeMap::new(),
+            lowering: LoweringMetrics::register_into(registry),
         }
     }
 
@@ -74,6 +78,11 @@ impl OptimizerMetrics {
     pub fn set_e2e_optimization_time_log_threshold(&self, threshold: Duration) {
         self.e2e_optimization_time_seconds_log_threshold
             .store(duration_to_nanos(threshold), Ordering::Relaxed);
+    }
+
+    /// The metrics recorded during MIR to LIR lowering.
+    pub fn lowering(&self) -> &LoweringMetrics {
+        &self.lowering
     }
 
     pub fn observe_e2e_optimization_time(&self, object_type: &str, duration: Duration) {


### PR DESCRIPTION
### Motivation

https://linear.app/materializeinc/issue/SQL-393/mapfilterprojectliteral-constraints-should-be-deprecated

### Description

Adds metrics for `MapFilterProject::literal_constraints`.

### Verification

Manual verification locally. Early tests indicate that the "get" case fires three times over the course of the sqllogictest suite.

- aggregates.slt in `SELECT t1.a, (SELECT t2.a FROM t t2 WHERE t2.b = 2 AND t1.b = t2.b GROUP BY t2.a) FROM t t1;`
- transform/is_null_propagation.slt twice in `EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR SELECT FROM t1 WHERE f2 IN ( SELECT agg1 FROM ( SELECT COUNT ( TRUE ) agg1 FROM t2 a1 JOIN ( SELECT a2.f2 FROM t1 LEFT JOIN t1 a2 ON TRUE ) a2 ON TRUE WHERE  a2.f2 IS NOT NULL AND a2.f2 > a1.f2 ) )`
