### PR TITLE
sql: Add in `LirAggregateExpr`

### DIFF
--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -60,8 +60,12 @@
 //! type, we can specialize and render the dataflow to compute those aggregations in the correct order, and
 //! return the output arrangement directly and avoid the extra collation arrangement.
 
+use std::fmt::Display;
+
+use mz_expr::explain::{HumanizeDisplay, HumanizedExpr, HumanizerMode};
 use mz_expr::{
-    AggregateExpr, AggregateFunc, MapFilterProject, MirScalarExpr, permutation_for_arrangement,
+    AggregateExpr, AggregateFunc, MapFilterProject, MirScalarExpr, UnmaterializableFunc,
+    permutation_for_arrangement,
 };
 use mz_ore::soft_assert_or_log;
 use serde::{Deserialize, Serialize};
@@ -135,6 +139,82 @@ pub enum ReducePlan {
     Basic(BasicPlan),
 }
 
+/// All reduce plans depend on a notion of aggregation.
+///
+/// We could use `mz_expr::AggregateExpr`, but it explicitly names `MirScalarExpr`
+/// and derives `MzReflect` (which cannot accommodate type parameters).
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Hash
+)]
+pub struct LirAggregateExpr {
+    /// Names the aggregation function.
+    pub func: AggregateFunc,
+    /// An expression which extracts from each row the input to `func`.
+    pub expr: LirScalarExpr,
+    /// Should the aggregation be applied only to distinct results in each group.
+    #[serde(default)]
+    pub distinct: bool,
+}
+
+impl LirAggregateExpr {
+    /// Translates an aggregate from MIR to LIR.
+    ///
+    /// Panics on unmaterializable functions.
+    pub fn from_mir(mir: AggregateExpr) -> Self {
+        Self::try_from(mir).expect("no unmaterializable functions in aggregates")
+    }
+
+    /// Determines whether this aggregate is `COUNT(*)`.
+    pub fn is_count_asterisk(&self) -> bool {
+        self.func == AggregateFunc::Count && self.expr.is_literal_true() && !self.distinct
+    }
+}
+
+impl TryFrom<AggregateExpr> for LirAggregateExpr {
+    type Error = Vec<UnmaterializableFunc>;
+
+    fn try_from(mir: AggregateExpr) -> Result<Self, Self::Error> {
+        let func = mir.func;
+        let expr = LirScalarExpr::try_from(&mir.expr)?;
+        let distinct = mir.distinct;
+
+        Ok(LirAggregateExpr {
+            func,
+            expr,
+            distinct,
+        })
+    }
+}
+
+impl HumanizeDisplay for LirAggregateExpr {
+    fn humanize<'a, M: HumanizerMode>(
+        e: &HumanizedExpr<'a, Self, M>,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        if e.expr.is_count_asterisk() {
+            return write!(f, "count(*)");
+        }
+
+        write!(
+            f,
+            "{}({}",
+            e.child(&e.expr.func),
+            if e.expr.distinct { "distinct " } else { "" }
+        )?;
+
+        e.child(&e.expr.expr).fmt(f)?;
+        write!(f, ")")
+    }
+}
+
 /// Plan for computing a set of accumulable aggregations.
 ///
 /// We fuse all of the accumulable aggregations together
@@ -147,14 +227,14 @@ pub enum ReducePlan {
 pub struct AccumulablePlan {
     /// All of the aggregations we were asked to compute, stored
     /// in order.
-    pub full_aggrs: Vec<AggregateExpr>,
+    pub full_aggrs: Vec<LirAggregateExpr>,
     /// All of the non-distinct accumulable aggregates.
     /// Each element represents:
     /// (index of the datum among inputs, aggregation expr)
     /// These will all be rendered together in one dataflow fragment.
-    pub simple_aggrs: Vec<(usize, AggregateExpr)>,
+    pub simple_aggrs: Vec<(usize, LirAggregateExpr)>,
     /// Same as above but for all of the `DISTINCT` accumulable aggregations.
-    pub distinct_aggrs: Vec<(usize, AggregateExpr)>,
+    pub distinct_aggrs: Vec<(usize, LirAggregateExpr)>,
 }
 
 /// Plan for computing a set of hierarchical aggregations.
@@ -272,7 +352,7 @@ pub enum BasicPlan {
     /// reduction. Each element represents the:
     /// `(index of the set of the input we are aggregating over,
     ///   the aggregation function)`
-    Multiple(Vec<AggregateExpr>),
+    Multiple(Vec<LirAggregateExpr>),
 }
 
 /// Plan for rendering a single basic aggregation, with possibly fusing a `FlatMap UnnestList` with
@@ -280,7 +360,7 @@ pub enum BasicPlan {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SingleBasicPlan {
     /// The aggregation that we should perform.
-    pub expr: AggregateExpr,
+    pub expr: LirAggregateExpr,
     /// Whether we fused a `FlatMap UnnestList` with this aggregation.
     pub fused_unnest_list: bool,
 }
@@ -341,7 +421,7 @@ impl ReducePlan {
         let mut aggregates = aggregates.into_iter();
         if let Some(aggregate) = aggregates.next() {
             let typ = reduction_type(&aggregate.func);
-            aggregates_list.push(aggregate);
+            aggregates_list.push(LirAggregateExpr::from_mir(aggregate));
 
             for aggregate in aggregates {
                 assert_eq!(
@@ -349,7 +429,7 @@ impl ReducePlan {
                     reduction_type(&aggregate.func),
                     "Multiple reduction types detected"
                 );
-                aggregates_list.push(aggregate);
+                aggregates_list.push(LirAggregateExpr::from_mir(aggregate));
             }
             ReducePlan::create_inner(
                 typ,
@@ -370,7 +450,7 @@ impl ReducePlan {
     /// actually of the correct reduction type.
     fn create_inner(
         typ: ReductionType,
-        aggregates_list: Vec<AggregateExpr>,
+        aggregates_list: Vec<LirAggregateExpr>,
         monotonic: bool,
         expected_group_size: Option<u64>,
         fused_unnest_list: bool,
@@ -382,6 +462,7 @@ impl ReducePlan {
             aggregates_list.len() > 0,
             "error: tried to render a reduce dataflow with no aggregates"
         );
+
         match typ {
             ReductionType::Accumulable => {
                 let mut simple_aggrs = vec![];

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -143,6 +143,9 @@ pub enum ReducePlan {
 ///
 /// We could use `mz_expr::AggregateExpr`, but it explicitly names `MirScalarExpr`
 /// and derives `MzReflect` (which cannot accommodate type parameters).
+///
+/// We don't build a separate `AggregateFunc`, since we'd only eliminate one variant
+/// and need to duplicate the evaluation code.
 #[derive(
     Clone,
     Debug,

--- a/src/compute-types/src/plan/scalar.rs
+++ b/src/compute-types/src/plan/scalar.rs
@@ -633,6 +633,7 @@ impl From<&LirScalarExpr> for MirScalarExpr {
 }
 
 impl TryFrom<&MirScalarExpr> for LirScalarExpr {
+    // MIR-to-LIR failures come from unmaterializable functions that haven't been dealt with yet.
     type Error = Vec<UnmaterializableFunc>;
 
     fn try_from(value: &MirScalarExpr) -> Result<Self, Self::Error> {

--- a/src/compute-types/src/plan/scalar.rs
+++ b/src/compute-types/src/plan/scalar.rs
@@ -106,6 +106,11 @@ impl LirScalarExpr {
         }
     }
 
+    /// Returns true if the expression is a literal true.
+    pub fn is_literal_true(&self) -> bool {
+        Some(Ok(Datum::True)) == self.as_literal()
+    }
+
     /// If the expression is an int64, returns the literal.
     pub fn as_literal_int64(&self) -> Option<i64> {
         match self.as_literal() {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -28,11 +28,11 @@ use itertools::Itertools;
 use mz_compute_types::dyncfgs::{ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY};
 use mz_compute_types::plan::ArrangementStrategy;
 use mz_compute_types::plan::reduce::{
-    AccumulablePlan, BasicPlan, BucketedPlan, HierarchicalPlan, KeyValPlan, MonotonicPlan,
-    ReducePlan, ReductionType, SingleBasicPlan, reduction_type,
+    AccumulablePlan, BasicPlan, BucketedPlan, HierarchicalPlan, KeyValPlan, LirAggregateExpr,
+    MonotonicPlan, ReducePlan, ReductionType, SingleBasicPlan, reduction_type,
 };
 use mz_compute_types::plan::scalar::LirScalarExpr;
-use mz_expr::{AggregateExpr, AggregateFunc, EvalError, SafeMfpPlan};
+use mz_expr::{AggregateFunc, EvalError, SafeMfpPlan};
 use mz_ore::cast::CastLossy;
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
 use mz_repr::fixed_length::ExtendDatums;
@@ -364,7 +364,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     fn build_basic_aggregates<'s>(
         &self,
         input: VecCollection<'s, T, (Row, Row), Diff>,
-        aggrs: Vec<AggregateExpr>,
+        aggrs: Vec<LirAggregateExpr>,
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan<LirScalarExpr>>,
     ) -> (
@@ -473,7 +473,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         &self,
         input: VecCollection<'s, T, (Row, Row), Diff>,
         index: usize,
-        aggr: &AggregateExpr,
+        aggr: &LirAggregateExpr,
         validating: bool,
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan<LirScalarExpr>>,
@@ -482,7 +482,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         RowRowArrangement<'s, T>,
         Option<VecCollection<'s, T, DataflowErrorSer, Diff>>,
     ) {
-        let AggregateExpr {
+        let LirAggregateExpr {
             func,
             expr: _,
             distinct,


### PR DESCRIPTION
### Motivation

Part of the stable LIR push.

### Description

Missed a spot! `AggregateExpr` has an `MirScalarExpr` in it. We can't parameterize, because we derive `MzReflect` on `AggregateExpr`.

### Verification

Should possibly see some rewrites in EXPLAIN, otherwise trivial refactor (CI green, nightly green).