### PR TITLE
console: use max heap percent for critical-path cluster memory metric

### DIFF
--- a/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
+++ b/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
@@ -232,7 +232,11 @@ const ReplicaMetricsRow = ({
   <SimpleGrid columns={2} spacing={3}>
     <ClusterMetricCard cluster={cluster} />
     <ReplicaInfoCard replica={replica} isDropped={isDropped} />
-    <MetricBarCard label="Memory" fraction={replica.maxMemory.percent} />
+    {/* Use maxHeap to match the "Memory Utilization" graph on the cluster
+        overview. heap_percent already falls back to size-based memory percent
+        when heap_limit is null (self-managed/emulator), so this is correct in
+        both environments. */}
+    <MetricBarCard label="Memory" fraction={replica.maxHeap.percent} />
     <MetricBarCard label="CPU" fraction={replica.maxCpu.percent} />
   </SimpleGrid>
 );


### PR DESCRIPTION
The maintained-objects critical-path panel labeled a card "Memory" but plotted maxMemory (container memory), while the cluster overview's "Memory Utilization" graph plots heapPercent.


### Motivation
[Fixes CNS-89](https://linear.app/materializeinc/issue/CNS-89/inconsistent-cluster-memory-usage-data-in-ui)

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification
Before this fix:
<img width="1024" height="1340" alt="image" src="https://github.com/user-attachments/assets/e29d6cd6-0d79-4693-a4ae-7c3dd29c2e51" />

After fix:
<img width="1030" height="1222" alt="image" src="https://github.com/user-attachments/assets/7b17b193-aa20-4cf6-9350-55646a128be1" />

<img width="2448" height="828" alt="image" src="https://github.com/user-attachments/assets/94d13406-ce86-4c21-ab71-5fc6aa46ef18" />

