### PR TITLE
WIP: Invariants test

### DIFF
--- a/.agents/skills/mz-test/SKILL.md
+++ b/.agents/skills/mz-test/SKILL.md
@@ -220,6 +220,7 @@ Determine the right framework based on what you're testing:
   See `doc/developer/platform-checks.md`, especially the "Writing a Check" section.
   Do not use the old Legacy Upgrade tests.
 * **Panics or unexpected query errors under concurrency**: extend Parallel Workload actions in `misc/python/materialize/parallel_workload/action.py`.
+* **Result correctness under disruptions** (wrong data, lost or duplicated writes, while connections are cut and processes are killed): the invariants framework in `misc/python/materialize/invariants/` (scenarios in `scenarios/`, entry point `test/invariants/mzcompose.py`). Unlike Parallel Workload it verifies exact results, continuously during the disruptions.
 * **Many objects / limits**: add a `Generator` subclass in `test/limits/mzcompose.py`.
 * **OOM / bounded memory**: add a `Scenario` in `test/bounded-memory/mzcompose.py`.
 * **Performance micro-benchmarks**: Feature Benchmark scenarios in `misc/python/materialize/feature_benchmark/scenarios`.

--- a/.agents/skills/mz-test/SKILL.md
+++ b/.agents/skills/mz-test/SKILL.md
@@ -232,6 +232,7 @@ Determine the right framework based on what you're testing:
   See `doc/developer/platform-checks.md`, especially the "Writing a Check" section.
   Do not use the old Legacy Upgrade tests.
 * **Panics or unexpected query errors under concurrency**: extend Parallel Workload actions in `misc/python/materialize/parallel_workload/action.py`.
+* **Result correctness under disruptions** (wrong data, lost or duplicated writes, while connections are cut and processes are killed): the invariants framework in `misc/python/materialize/invariants/` (scenarios in `scenarios/`, entry point `test/invariants/mzcompose.py`). Unlike Parallel Workload it verifies exact results, continuously during the disruptions.
 * **Many objects / limits**: add a `Generator` subclass in `test/limits/mzcompose.py`.
 * **OOM / bounded memory**: add a `Scenario` in `test/bounded-memory/mzcompose.py`.
 * **Performance micro-benchmarks**: Feature Benchmark scenarios in `misc/python/materialize/feature_benchmark/scenarios`.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules
 /test/**/tmp_*.toml
 /test/**/fdb_*.cluster
 junit_*.xml
+invariants-events.log
 parallel-workload-queries.log
 perf.data*
 *.rej

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -55,6 +55,7 @@ psycopg-binary==3.3.3
 pydantic==2.12.5
 pyelftools==0.33
 pyjwt==2.13.0
+pymssql==2.3.7
 PyMySQL==1.2.0
 pytest==9.0.3
 pytest-split==0.11.0

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2144,7 +2144,7 @@ steps:
                   --scenario=table-bank,
                   --complexity=high,
                   --runtime=1200,
-                  --upgrade-from=materialize/materialized:v26.31.1,
+                  --upgrade-from=latest,
                 ]
 
       - id: invariants-table-bank

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2112,6 +2112,126 @@ steps:
             # Don't run with Azurite since it's pretty slow, see https://github.com/MaterializeInc/database-issues/issues/8892 for details
             args: [--replicas=8]
 
+  - group: Invariants
+    key: invariants
+    steps:
+      - id: invariants-table-bank-large
+        label: "Invariants (table-bank, large)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=table-bank, --complexity=large, --runtime=1200]
+
+      - id: invariants-table-bank-upgrade
+        label: "Invariants (table-bank, upgrade under load)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args:
+                [
+                  --scenario=table-bank,
+                  --complexity=high,
+                  --runtime=1200,
+                  --upgrade-from=materialize/materialized:v26.31.1,
+                ]
+
+      - id: invariants-table-bank
+        label: "Invariants (table-bank)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=table-bank, --complexity=high, --runtime=1200]
+
+      - id: invariants-pg-cdc-bank
+        label: "Invariants (pg-cdc-bank)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=pg-cdc-bank, --complexity=high, --runtime=1200]
+
+      - id: invariants-mysql-cdc-bank
+        label: "Invariants (mysql-cdc-bank)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=mysql-cdc-bank, --complexity=high, --runtime=1200]
+
+      - id: invariants-sqlserver-cdc-bank
+        label: "Invariants (sqlserver-cdc-bank)"
+        depends_on: build-x86_64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          # The SQL Server Docker image isn't available on ARM.
+          #
+          # See: <https://github.com/microsoft/mssql-docker/issues/864>
+          queue: hetzner-x86-64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=sqlserver-cdc-bank, --complexity=high, --runtime=1200]
+
+      - id: invariants-kafka-ledger
+        label: "Invariants (kafka-ledger)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=kafka-ledger, --complexity=high, --runtime=1200]
+
+      - id: invariants-kafka-upsert
+        label: "Invariants (kafka-upsert)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=kafka-upsert, --complexity=high, --runtime=1200]
+
+      - id: invariants-sink-roundtrip
+        label: "Invariants (sink-roundtrip)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=sink-roundtrip, --complexity=high, --runtime=1200]
+
   - group: "Parallel Workload"
     key: parallel-workload
     steps:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2116,7 +2116,7 @@ steps:
     key: invariants
     steps:
       - id: invariants-table-bank-large
-        topics: [kafka, mysql, postgres, sql-server]
+        topics: [copy-to-s3, kafka, mysql, postgres, sql-server]
         label: "Invariants (table-bank, large)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2129,7 +2129,7 @@ steps:
               args: [--scenario=table-bank, --complexity=large, --runtime=1200]
 
       - id: invariants-table-bank-upgrade
-        topics: [kafka, mysql, postgres, sql-server]
+        topics: [copy-to-s3, kafka, mysql, postgres, sql-server, upgrade]
         label: "Invariants (table-bank, upgrade under load)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2148,7 +2148,7 @@ steps:
                 ]
 
       - id: invariants-table-bank
-        topics: [kafka, mysql, postgres, sql-server]
+        topics: [copy-to-s3, kafka, mysql, postgres, sql-server]
         label: "Invariants (table-bank)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2229,7 +2229,7 @@ steps:
               args: [--scenario=kafka-upsert, --complexity=high, --runtime=1200]
 
       - id: invariants-sink-roundtrip
-        topics: [kafka, mysql, postgres, sql-server]
+        topics: [kafka, kafka-sink, mysql, postgres, sql-server]
         label: "Invariants (sink-roundtrip)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2255,7 +2255,7 @@ steps:
               args: [--scenario=webhook-set, --complexity=high, --runtime=1200]
 
       - id: invariants-avro-loopback
-        topics: [kafka, mysql, postgres, sql-server]
+        topics: [kafka, kafka-sink, mysql, postgres, sql-server]
         label: "Invariants (avro-loopback)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2135,6 +2135,206 @@ steps:
             # Don't run with Azurite since it's pretty slow, see https://github.com/MaterializeInc/database-issues/issues/8892 for details
             args: [--replicas=8]
 
+  - group: Invariants
+    key: invariants
+    steps:
+      - id: invariants-table-bank-large
+        topics: [copy-to-s3, kafka, mysql, postgres, sql-server]
+        label: "Invariants (table-bank, large)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=table-bank, --complexity=large, --runtime=1800]
+
+      - id: invariants-table-bank-upgrade
+        topics: [copy-to-s3, kafka, mysql, postgres, sql-server, upgrade]
+        label: "Invariants (table-bank, upgrade under load)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args:
+                [
+                  --scenario=table-bank,
+                  --complexity=high,
+                  --runtime=1800,
+                  --upgrade-from=latest,
+                ]
+
+      - id: invariants-table-bank-soak
+        topics: [copy-to-s3, kafka, mysql, postgres, sql-server]
+        label: "Invariants (table-bank, soak past the reader lease)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args:
+                [
+                  --scenario=table-bank,
+                  --complexity=high,
+                  --runtime=2400,
+                  --persist-churn,
+                ]
+
+      - id: invariants-table-bank
+        topics: [copy-to-s3, kafka, mysql, postgres, sql-server]
+        label: "Invariants (table-bank)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=table-bank, --complexity=high, --runtime=1800]
+
+      - id: invariants-txn-probe
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (txn-probe)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=txn-probe, --complexity=high, --runtime=1800]
+
+      - id: invariants-graph
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (graph)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=graph, --complexity=high, --runtime=1800]
+
+      - id: invariants-pg-cdc-bank
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (pg-cdc-bank)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=pg-cdc-bank, --complexity=high, --runtime=1800]
+
+      - id: invariants-mysql-cdc-bank
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (mysql-cdc-bank)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=mysql-cdc-bank, --complexity=high, --runtime=1800]
+
+      - id: invariants-sqlserver-cdc-bank
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (sqlserver-cdc-bank)"
+        depends_on: build-x86_64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          # The SQL Server Docker image isn't available on ARM.
+          #
+          # See: <https://github.com/microsoft/mssql-docker/issues/864>
+          queue: hetzner-x86-64-12cpu-24gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=sqlserver-cdc-bank, --complexity=high, --runtime=1800]
+
+      - id: invariants-kafka-ledger
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (kafka-ledger)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=kafka-ledger, --complexity=high, --runtime=1800]
+
+      - id: invariants-kafka-upsert
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (kafka-upsert)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=kafka-upsert, --complexity=high, --runtime=1800]
+
+      - id: invariants-sink-roundtrip
+        topics: [kafka, kafka-sink, mysql, postgres, sql-server]
+        label: "Invariants (sink-roundtrip)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=sink-roundtrip, --complexity=high, --runtime=1800]
+
+      - id: invariants-webhook-set
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (webhook-set)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=webhook-set, --complexity=high, --runtime=1800]
+
+      - id: invariants-avro-loopback
+        topics: [kafka, kafka-sink, mysql, postgres, sql-server]
+        label: "Invariants (avro-loopback)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=avro-loopback, --complexity=high, --runtime=1800]
+
   - group: "Parallel Workload"
     key: parallel-workload
     steps:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2116,6 +2116,7 @@ steps:
     key: invariants
     steps:
       - id: invariants-table-bank-large
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (table-bank, large)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2128,6 +2129,7 @@ steps:
               args: [--scenario=table-bank, --complexity=large, --runtime=1200]
 
       - id: invariants-table-bank-upgrade
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (table-bank, upgrade under load)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2146,6 +2148,7 @@ steps:
                 ]
 
       - id: invariants-table-bank
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (table-bank)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2158,6 +2161,7 @@ steps:
               args: [--scenario=table-bank, --complexity=high, --runtime=1200]
 
       - id: invariants-pg-cdc-bank
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (pg-cdc-bank)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2170,6 +2174,7 @@ steps:
               args: [--scenario=pg-cdc-bank, --complexity=high, --runtime=1200]
 
       - id: invariants-mysql-cdc-bank
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (mysql-cdc-bank)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2182,6 +2187,7 @@ steps:
               args: [--scenario=mysql-cdc-bank, --complexity=high, --runtime=1200]
 
       - id: invariants-sqlserver-cdc-bank
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (sqlserver-cdc-bank)"
         depends_on: build-x86_64
         artifact_paths: [invariants-events.log]
@@ -2197,6 +2203,7 @@ steps:
               args: [--scenario=sqlserver-cdc-bank, --complexity=high, --runtime=1200]
 
       - id: invariants-kafka-ledger
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (kafka-ledger)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2209,6 +2216,7 @@ steps:
               args: [--scenario=kafka-ledger, --complexity=high, --runtime=1200]
 
       - id: invariants-kafka-upsert
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (kafka-upsert)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2221,6 +2229,7 @@ steps:
               args: [--scenario=kafka-upsert, --complexity=high, --runtime=1200]
 
       - id: invariants-sink-roundtrip
+        topics: [kafka, mysql, postgres, sql-server]
         label: "Invariants (sink-roundtrip)"
         depends_on: build-aarch64
         artifact_paths: [invariants-events.log]
@@ -2231,6 +2240,32 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: invariants
               args: [--scenario=sink-roundtrip, --complexity=high, --runtime=1200]
+
+      - id: invariants-webhook-set
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (webhook-set)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=webhook-set, --complexity=high, --runtime=1200]
+
+      - id: invariants-avro-loopback
+        topics: [kafka, mysql, postgres, sql-server]
+        label: "Invariants (avro-loopback)"
+        depends_on: build-aarch64
+        artifact_paths: [invariants-events.log]
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: invariants
+              args: [--scenario=avro-loopback, --complexity=high, --runtime=1200]
 
   - group: "Parallel Workload"
     key: parallel-workload

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -65,7 +65,7 @@ STEP_START_TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
 
 # Clean up cores here so that just killed processes' core files are ignored
 cores="$HOME"/cores
-rm -rf "$cores" parallel-workload-queries.log parallel-workload-queries.log.zst
+rm -rf "$cores" parallel-workload-queries.log parallel-workload-queries.log.zst invariants-events.log
 mkdir -m 777 "$cores"
 # Max 128 characters, so don't use $PWD which will make it too long
 # Ignore SIGABRT

--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -222,6 +222,25 @@ documented at the [pgtest crate][pgtest-docs].
 
 [pgtest-docs]: https://dev.materialize.com/api/rust/mz_pgtest/index.html
 
+### Invariants
+
+The invariants framework in
+[misc/python/materialize/invariants/](/misc/python/materialize/invariants)
+verifies result *correctness* under disruptions: multi-threaded scenarios
+(e.g. bank transfers that conserve a total balance) run concurrent writes
+whose invariants hold no matter which individual operations succeed, fail, or
+end up in an unknown state, while toxiproxy cuts the connections between
+environmentd, clusterd, the metadata store, and sources/sinks, and processes
+are killed and restarted. Checker threads verify the invariants continuously
+during the disruptions, and strictly again after healing. Unlike
+parallel-workload (which hunts panics and unexpected errors) it checks exact
+results. The entry point is
+[test/invariants/mzcompose.py](/test/invariants/mzcompose.py):
+
+```shell
+bin/mzcompose --find invariants run default --scenario=table-bank --runtime=120
+```
+
 ## Long-running tests
 
 These are still a work in progress. The beginning of the orchestration has

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -206,6 +206,10 @@ IGNORE_RE = re.compile(
     | limits-materialized-.* \| .* very\ slow\ coordinator\ message
     | zippy-materialized.* \| .* very\ slow\ coordinator\ message
     | sqlsmith-mz.* \| .* very\ slow\ coordinator\ message
+    # Invariants cuts persist consensus and blob for tens of seconds on
+    # purpose, so a coordinator message blocked that long is the condition
+    # under test, not a symptom
+    | invariants-materialized-.* \| .* very\ slow\ coordinator\ message
     | sqlsmith-mz.* \| .* panicked\ at\ src/ore/src/overflowing.rs.*\ Overflow
     # Expected on AWS in RQG because of build
     | comm="check"\ exe="/usr/bin/qemu-

--- a/misc/python/materialize/invariants/__init__.py
+++ b/misc/python/materialize/invariants/__init__.py
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Invariant-checking workload framework.
+
+Runs fine-grained scenarios whose actions preserve a checkable invariant
+regardless of whether each individual action succeeds, fails, or has an
+unknown outcome (e.g. a bank transfer that debits one account and credits
+another keeps the total constant either way). Invariants are verified
+continuously by checker threads while toxiproxy disruptions are injected on
+the envd<->clusterd, envd<->metadata-store, source, and sink connections,
+plus once more strictly after healing.
+
+Unlike parallel-workload (which hunts panics and unexpected errors) this
+framework verifies result *correctness*. Unlike zippy it is multi-threaded
+and checks invariants during disruptions, not only after quiescing.
+
+Entry point: test/invariants/mzcompose.py.
+"""

--- a/misc/python/materialize/invariants/checkers.py
+++ b/misc/python/materialize/invariants/checkers.py
@@ -1,0 +1,247 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Reusable checker building blocks: bounded peeks and SUBSCRIBE tailing."""
+
+import random
+from abc import abstractmethod
+from collections import Counter
+
+from materialize.invariants.framework import (
+    Checker,
+    InvariantViolation,
+    ScenarioContext,
+    TransientError,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+
+
+class PeekChecker(Checker):
+    """Base for checkers that verify invariants with one-shot SELECTs.
+
+    Peeks round-robin over the given clusters so that a disrupted cluster is
+    probed (it must serve correct data or nothing) while an undisrupted
+    cluster keeps providing coverage. Reads of objects maintained on a
+    disrupted cluster legitimately hang on every cluster (the persist upper
+    stalls), which surfaces as a skipped round via the client watchdog.
+    """
+
+    def __init__(
+        self, rng: random.Random, ctx: ScenarioContext, name: str, clusters: list[str]
+    ) -> None:
+        super().__init__(rng)
+        self.name = name
+        self.ctx = ctx
+        self.clusters = clusters
+        self._round = 0
+        self.client = MzClient(ctx, name)
+
+    def peek(self, sql: str) -> list[tuple]:
+        cluster = self.clusters[self._round % len(self.clusters)]
+        self._round += 1
+        self.client.query(f"SET cluster = {cluster}")
+        return self.client.query(sql)
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class SubscribeChecker(Checker):
+    """Base for checkers that tail a query via SUBSCRIBE ... WITH (PROGRESS).
+
+    Maintains the result multiset from the diff stream and calls
+    `validate_state` at progress boundaries, where the accumulated state is a
+    transactionally consistent snapshot. Timestamps must be non-decreasing
+    within one SUBSCRIBE session. After any transient error the subscription
+    restarts from a fresh snapshot and all session state is reset, since no
+    cross-session continuity is guaranteed.
+
+    Updates at time t may arrive interleaved around a progress row at p <= t,
+    so updates are buffered per timestamp and only folded into the state once
+    a progress row proves their timestamp complete.
+    """
+
+    pause = (0.0, 0.2)
+
+    def __init__(
+        self,
+        rng: random.Random,
+        ctx: ScenarioContext,
+        name: str,
+        inner_query: str,
+        cluster: str = "quickstart",
+        durable: bool = False,
+    ) -> None:
+        super().__init__(rng)
+        self.name = name
+        self.ctx = ctx
+        self.inner_query = inner_query
+        self.cluster = cluster
+        # When True, a restarted session resumes from the last validated
+        # progress timestamp instead of taking a fresh snapshot, carrying
+        # the reconstructed state across reconnects (the documented durable
+        # subscription pattern). The subscribed object needs RETAIN HISTORY
+        # so the resume timestamp stays readable.
+        self.durable = durable
+        # Fresh sessions may pin a historical start, e.g. the end-of-run
+        # history audit replays from the earliest retained timestamp.
+        self.as_of_clause = ""
+        self.client = MzClient(ctx, name)
+        self._cursor = "c_" + name.replace("-", "_")
+        self._active = False
+        self.last_validated_ts: int | None = None
+        self.resumes = 0
+        self._reset_session()
+
+    def _reset_session(self) -> None:
+        self._state: Counter[tuple] = Counter()
+        self._pending: list[tuple[int, int, tuple]] = []
+        self._last_ts: int | None = None
+        self._as_of: int | None = None
+        self._resumed = False
+
+    def check_once(self) -> None:
+        try:
+            if not self._active:
+                self._start_session()
+                self._active = True
+            rows = self.client.query(
+                f"FETCH ALL {self._cursor} WITH (timeout = '1s')",
+                timeout=max(30.0, self.ctx.complexity.query_timeout),
+            )
+        except TransientError:
+            self._active = False
+            raise
+        self._process(rows)
+
+    def _start_session(self) -> None:
+        resume_from = self.last_validated_ts if self.durable else None
+        if resume_from is not None:
+            # Reset the per-session fields but keep the carried state: a
+            # transiently failing resume (e.g. envd still restarting) must
+            # not lose it, the next round retries the resume with it.
+            self._pending = []
+            self._last_ts = None
+            self._as_of = None
+            self._resumed = True
+            try:
+                self.client.query(f"SET cluster = {self.cluster}")
+                self.client.query("BEGIN")
+                # AS OF resume_from - 1 with SNAPSHOT false emits exactly the
+                # updates with ts >= resume_from, which is the suffix the
+                # carried state (complete below resume_from) is missing.
+                self.client.query(
+                    f"DECLARE {self._cursor} CURSOR FOR"
+                    f" SUBSCRIBE ({self.inner_query})"
+                    f" WITH (PROGRESS, SNAPSHOT = false) AS OF {resume_from - 1}"
+                )
+                self.resumes += 1
+                return
+            except UnexpectedQueryError as e:
+                # The resume timestamp was compacted away. Fall back to a
+                # fresh snapshot. The failed DECLARE dropped the connection,
+                # so start over from a clean session.
+                self.ctx.log.log(
+                    "check", f"{self.name}: resume failed, fresh snapshot: {e}"
+                )
+                self.last_validated_ts = None
+        self._reset_session()
+        self.client.query(f"SET cluster = {self.cluster}")
+        self.client.query("BEGIN")
+        self.client.query(
+            f"DECLARE {self._cursor} CURSOR FOR"
+            f" SUBSCRIBE ({self.inner_query}) WITH (PROGRESS) {self.as_of_clause}"
+        )
+
+    def _process(self, rows: list[tuple]) -> None:
+        for row in rows:
+            ts = int(row[0])
+            progressed = bool(row[1])
+            if self._last_ts is not None and ts < self._last_ts:
+                raise InvariantViolation(
+                    f"{self.name}: SUBSCRIBE timestamp went backwards:"
+                    f" {ts} < {self._last_ts}"
+                )
+            self._last_ts = ts
+            if self._as_of is None:
+                # The first row is guaranteed to be a progress message at the
+                # subscription's as_of.
+                self._as_of = ts
+            if progressed:
+                self._apply_pending(ts)
+            else:
+                self._pending.append((ts, int(row[2]), tuple(row[3:])))
+
+    def _apply_pending(self, progress_ts: int) -> None:
+        ready = sorted(
+            (p for p in self._pending if p[0] < progress_ts), key=lambda p: p[0]
+        )
+        self._pending = [p for p in self._pending if p[0] >= progress_ts]
+        # A progress row only proves completeness strictly below its
+        # timestamp, and snapshot updates carry the as_of itself, so states
+        # are validatable snapshots only for progress strictly beyond the
+        # as_of.
+        gate_open = self._as_of is not None and progress_ts > self._as_of
+        # Validate after every distinct proven-complete timestamp, not just
+        # at progress rows: a dataflow catching up from a historical as_of
+        # (the history audit) advances its frontier in giant steps, and the
+        # per-timestamp states in between must be consistent too.
+        index = 0
+        while index < len(ready):
+            ts = ready[index][0]
+            while index < len(ready) and ready[index][0] == ts:
+                _, diff, data = ready[index]
+                self._state[data] += diff
+                if self._state[data] == 0:
+                    del self._state[data]
+                index += 1
+            if gate_open:
+                self._validate_snapshot(ts)
+        if not gate_open:
+            return
+        self._validate_snapshot(progress_ts)
+        self.last_validated_ts = progress_ts
+
+    def _validate_snapshot(self, ts: int) -> None:
+        for data, count in self._state.items():
+            if count < 0:
+                raise InvariantViolation(
+                    f"{self.name}: negative multiplicity {count} for row"
+                    f" {data} at {ts}"
+                )
+        try:
+            self.validate_state(dict(self._state), ts)
+        except InvariantViolation as e:
+            # Attach what triage needs to classify the violation: a direct
+            # read of the same query at the violating timestamp (on a fresh
+            # connection, the subscribe connection is inside a transaction)
+            # distinguishes an inconsistent shard from an inconsistent
+            # subscribe stream, and the session context shows whether a
+            # durable resume was involved.
+            probe: object = "unavailable"
+            try:
+                probe_client = MzClient(self.ctx, f"{self.name}-probe")
+                probe = probe_client.query(f"{self.inner_query} AS OF {ts}", timeout=30)
+                probe_client.reset()
+            except Exception as probe_error:
+                probe = f"failed: {probe_error}"
+            raise InvariantViolation(
+                f"{e} [session={'resumed' if self._resumed else 'fresh'}"
+                f" as_of={self._as_of} resumes={self.resumes}"
+                f" last_validated={self.last_validated_ts};"
+                f" direct read AS OF {ts}: {probe}]"
+            ) from None
+        self.validations += 1
+
+    @abstractmethod
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        """Verify one transactionally consistent snapshot of the query."""
+
+    def close(self) -> None:
+        self.client.reset()

--- a/misc/python/materialize/invariants/checkers.py
+++ b/misc/python/materialize/invariants/checkers.py
@@ -92,6 +92,10 @@ class SubscribeChecker(Checker):
         # Fresh sessions may pin a historical start, e.g. the end-of-run
         # history audit replays from the earliest retained timestamp.
         self.as_of_clause = ""
+        # Optional "WITHIN TIMESTAMP ORDER BY <expr>" clause plus the index
+        # into the data tuple to assert the documented in-timestamp ordering.
+        self.order_clause = ""
+        self.order_index: int | None = None
         self.client = MzClient(ctx, name)
         self._cursor = "c_" + name.replace("-", "_")
         self._active = False
@@ -105,6 +109,7 @@ class SubscribeChecker(Checker):
         self._last_ts: int | None = None
         self._as_of: int | None = None
         self._resumed = False
+        self._last_order_key: tuple[int, tuple] | None = None
 
     def check_once(self) -> None:
         try:
@@ -156,7 +161,8 @@ class SubscribeChecker(Checker):
         self.client.query("BEGIN")
         self.client.query(
             f"DECLARE {self._cursor} CURSOR FOR"
-            f" SUBSCRIBE ({self.inner_query}) WITH (PROGRESS) {self.as_of_clause}"
+            f" SUBSCRIBE ({self.inner_query}) {self.order_clause}"
+            f" WITH (PROGRESS) {self.as_of_clause}"
         )
 
     def _process(self, rows: list[tuple]) -> None:
@@ -176,7 +182,19 @@ class SubscribeChecker(Checker):
             if progressed:
                 self._apply_pending(ts)
             else:
-                self._pending.append((ts, int(row[2]), tuple(row[3:])))
+                data = tuple(row[3:])
+                if self.order_index is not None:
+                    # WITHIN TIMESTAMP ORDER BY: rows of one timestamp must
+                    # arrive sorted by the ordering expression.
+                    key = (ts, (data[self.order_index],))
+                    last = self._last_order_key
+                    if last is not None and last[0] == ts and key[1] < last[1]:
+                        raise InvariantViolation(
+                            f"{self.name}: rows within timestamp {ts} out of"
+                            f" order: {key[1]} after {last[1]}"
+                        )
+                    self._last_order_key = key
+                self._pending.append((ts, int(row[2]), data))
 
     def _apply_pending(self, progress_ts: int) -> None:
         ready = sorted(
@@ -245,3 +263,42 @@ class SubscribeChecker(Checker):
 
     def close(self) -> None:
         self.client.reset()
+
+
+class ProgressPeek(PeekChecker):
+    """A source's ingestion progress must never move backwards.
+
+    NOTE: doc/user documents a `<name>_progress` relation per source, but
+    sources created with the current syntax do not create one (see
+    FINDINGS-BUGS.md B2), so this reads the source's write frontier from
+    mz_internal.mz_frontiers instead. Reads run on one session under the
+    default strict serializable isolation, so two consecutive reads are
+    ordered in real time and the frontier must be non-decreasing.
+    """
+
+    pause = (1.0, 4.0)
+
+    def __init__(self, rng, ctx, object_name: str, name: str = "progress-peek") -> None:
+        super().__init__(rng, ctx, name, ["quickstart"])
+        self.query = (
+            "SELECT f.write_frontier::text::numeric"
+            " FROM mz_internal.mz_frontiers f"
+            " JOIN mz_objects o ON f.object_id = o.id"
+            f" WHERE o.name = '{object_name}'"
+        )
+        self.last: int | None = None
+
+    def check_once(self) -> None:
+        rows = self.peek(self.query)
+        if len(rows) != 1 or rows[0][0] is None:
+            # The catalog row can lag object creation, and a NULL frontier
+            # (the empty frontier) only occurs for completed collections.
+            raise TransientError(f"{self.name}: no frontier row: {rows}")
+        value = int(rows[0][0])
+        if self.last is not None and value < self.last:
+            raise InvariantViolation(
+                f"{self.name}: write frontier moved backwards:"
+                f" {value} < {self.last}"
+            )
+        self.last = value
+        self.validations += 1

--- a/misc/python/materialize/invariants/checkers.py
+++ b/misc/python/materialize/invariants/checkers.py
@@ -1,0 +1,568 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Reusable checker building blocks: bounded peeks and SUBSCRIBE tailing."""
+
+import random
+from abc import abstractmethod
+from collections import Counter
+from collections.abc import Callable
+
+from materialize.invariants.framework import (
+    Checker,
+    InvariantViolation,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+
+
+class PeekChecker(Checker):
+    """Base for checkers that verify invariants with one-shot SELECTs.
+
+    Peeks round-robin over the given clusters so that a disrupted cluster is
+    probed (it must serve correct data or nothing) while an undisrupted
+    cluster keeps providing coverage. Reads of objects maintained on a
+    disrupted cluster legitimately hang on every cluster (the persist upper
+    stalls), which surfaces as a skipped round via the client watchdog.
+    """
+
+    def __init__(
+        self, rng: random.Random, ctx: ScenarioContext, name: str, clusters: list[str]
+    ) -> None:
+        super().__init__(rng)
+        self.name = name
+        self.ctx = ctx
+        self.clusters = clusters
+        self._round = 0
+        self.last_cluster: str | None = None
+        self.client = MzClient(ctx, name)
+
+    def peek(self, sql: str) -> list[tuple]:
+        cluster = self.clusters[self._round % len(self.clusters)]
+        self._round += 1
+        # Recorded so a violation can name the cluster that produced it.
+        self.last_cluster = cluster
+        self.client.query(f"SET cluster = {cluster}")
+        return self.client.query(sql)
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class SubscribeChecker(Checker):
+    """Base for checkers that tail a query via SUBSCRIBE ... WITH (PROGRESS).
+
+    Maintains the result multiset from the diff stream and calls
+    `validate_state` at progress boundaries, where the accumulated state is a
+    transactionally consistent snapshot. Timestamps must be non-decreasing
+    within one SUBSCRIBE session. After any transient error the subscription
+    restarts from a fresh snapshot and all session state is reset, since no
+    cross-session continuity is guaranteed.
+
+    Updates at time t may arrive interleaved around a progress row at p <= t,
+    so updates are buffered per timestamp and only folded into the state once
+    a progress row proves their timestamp complete.
+    """
+
+    pause = (0.0, 0.2)
+
+    def __init__(
+        self,
+        rng: random.Random,
+        ctx: ScenarioContext,
+        name: str,
+        inner_query: str,
+        cluster: str = "quickstart",
+        durable: bool = False,
+        snapshot: bool = True,
+        append_only: bool = False,
+    ) -> None:
+        super().__init__(rng)
+        self.name = name
+        self.ctx = ctx
+        self.inner_query = inner_query
+        self.cluster = cluster
+        # False subscribes to the changes from the subscription's as_of on,
+        # which is the only affordable way to watch a relation whose snapshot
+        # is large.
+        self.snapshot = snapshot
+        # For a relation nothing ever deletes from, a retraction in the change
+        # stream is a bug on its own, no matter what the folded state says: an
+        # insert and its bogus retraction cancel out and leave the state
+        # looking right.
+        self.append_only = append_only
+        # When True, a restarted session resumes from the last validated
+        # progress timestamp instead of taking a fresh snapshot, carrying
+        # the reconstructed state across reconnects (the documented durable
+        # subscription pattern). The subscribed object needs RETAIN HISTORY
+        # so the resume timestamp stays readable.
+        self.durable = durable
+        # Fresh sessions may pin a historical start, e.g. the end-of-run
+        # history audit replays from the earliest retained timestamp.
+        self.as_of_clause = ""
+        # Optional "WITHIN TIMESTAMP ORDER BY <expr>" clause plus the index
+        # into the data tuple to assert the documented in-timestamp ordering.
+        self.order_clause = ""
+        self.order_index: int | None = None
+        self.client = MzClient(ctx, name)
+        self._cursor = "c_" + name.replace("-", "_")
+        self._active = False
+        self.last_validated_ts: int | None = None
+        self.resumes = 0
+        self._reset_session()
+
+    def _reset_session(self) -> None:
+        self._state: Counter[tuple] = Counter()
+        self._pending: list[tuple[int, int, tuple]] = []
+        self._last_ts: int | None = None
+        self._as_of: int | None = None
+        self._resumed = False
+        self._last_order_key: tuple[int, tuple] | None = None
+
+    def check_once(self) -> None:
+        try:
+            if not self._active:
+                self._start_session()
+                self._active = True
+            rows = self.client.query(
+                f"FETCH ALL {self._cursor} WITH (timeout = '1s')",
+                timeout=max(30.0, self.ctx.complexity.query_timeout),
+            )
+        except TransientError:
+            self._active = False
+            raise
+        self._process(rows)
+
+    def drop_session(self) -> None:
+        """Drop the connection while keeping the carried state.
+
+        The next round reconnects, which for a durable subscriber is the
+        resume path, so a caller can exercise that path without waiting for a
+        disruption to happen to break this particular session.
+        """
+        self._active = False
+        self.client.reset()
+
+    def _start_session(self) -> None:
+        resume_from = self.last_validated_ts if self.durable else None
+        if resume_from is not None:
+            # Reset the per-session fields but keep the carried state: a
+            # transiently failing resume (e.g. envd still restarting) must
+            # not lose it, the next round retries the resume with it.
+            self._pending = []
+            self._last_ts = None
+            self._as_of = None
+            self._last_order_key = None
+            self._resumed = True
+            try:
+                self.client.query(f"SET cluster = {self.cluster}")
+                self.client.query("BEGIN")
+                # AS OF resume_from - 1 with SNAPSHOT false emits exactly the
+                # updates with ts >= resume_from, which is the suffix the
+                # carried state (complete below resume_from) is missing.
+                self.client.query(
+                    f"DECLARE {self._cursor} CURSOR FOR"
+                    f" SUBSCRIBE ({self.inner_query})"
+                    f" WITH (PROGRESS, SNAPSHOT = false) AS OF {resume_from - 1}"
+                )
+                self.resumes += 1
+                return
+            except UnexpectedQueryError as e:
+                # The resume timestamp was compacted away. Fall back to a
+                # fresh snapshot. The failed DECLARE dropped the connection,
+                # so start over from a clean session.
+                self.ctx.log.log(
+                    "check", f"{self.name}: resume failed, fresh snapshot: {e}"
+                )
+                self.last_validated_ts = None
+        self._reset_session()
+        self.client.query(f"SET cluster = {self.cluster}")
+        self.client.query("BEGIN")
+        snapshot_clause = "" if self.snapshot else ", SNAPSHOT = false"
+        self.client.query(
+            f"DECLARE {self._cursor} CURSOR FOR"
+            f" SUBSCRIBE ({self.inner_query}) {self.order_clause}"
+            f" WITH (PROGRESS{snapshot_clause}) {self.as_of_clause}"
+        )
+
+    def _process(self, rows: list[tuple]) -> None:
+        for row in rows:
+            ts = int(row[0])
+            progressed = bool(row[1])
+            if self._last_ts is not None and ts < self._last_ts:
+                raise InvariantViolation(
+                    f"{self.name}: SUBSCRIBE timestamp went backwards:"
+                    f" {ts} < {self._last_ts}"
+                )
+            self._last_ts = ts
+            if self._as_of is None:
+                # The first row is guaranteed to be a progress message at the
+                # subscription's as_of.
+                self._as_of = ts
+            if progressed:
+                self._apply_pending(ts)
+            else:
+                data = tuple(row[3:])
+                diff = int(row[2])
+                if self.append_only and diff < 0:
+                    raise InvariantViolation(
+                        f"{self.name}: retraction {diff} of row {data} at {ts}"
+                        " in an append-only relation"
+                    )
+                if self.order_index is not None:
+                    # WITHIN TIMESTAMP ORDER BY: rows of one timestamp must
+                    # arrive sorted by the ordering expression.
+                    key = (ts, (data[self.order_index],))
+                    last = self._last_order_key
+                    if last is not None and last[0] == ts and key[1] < last[1]:
+                        raise InvariantViolation(
+                            f"{self.name}: rows within timestamp {ts} out of"
+                            f" order: {key[1]} after {last[1]}"
+                        )
+                    self._last_order_key = key
+                self._pending.append((ts, int(row[2]), data))
+
+    def _apply_pending(self, progress_ts: int) -> None:
+        ready = sorted(
+            (p for p in self._pending if p[0] < progress_ts), key=lambda p: p[0]
+        )
+        self._pending = [p for p in self._pending if p[0] >= progress_ts]
+        # A progress row only proves completeness strictly below its
+        # timestamp, and snapshot updates carry the as_of itself, so states
+        # are validatable snapshots only for progress strictly beyond the
+        # as_of.
+        gate_open = self._as_of is not None and progress_ts > self._as_of
+        # Validate after every distinct proven-complete timestamp, not just
+        # at progress rows: a dataflow catching up from a historical as_of
+        # (the history audit) advances its frontier in giant steps, and the
+        # per-timestamp states in between must be consistent too.
+        index = 0
+        validated_ready = False
+        while index < len(ready):
+            ts = ready[index][0]
+            while index < len(ready) and ready[index][0] == ts:
+                _, diff, data = ready[index]
+                self._state[data] += diff
+                if self._state[data] == 0:
+                    del self._state[data]
+                index += 1
+            if gate_open:
+                self._validate_snapshot(ts)
+                validated_ready = True
+        if not gate_open:
+            return
+        # The state at progress_ts equals the state after the last folded
+        # timestamp, so only progress rows that folded nothing validate here.
+        if not validated_ready:
+            self._validate_snapshot(progress_ts)
+        self.last_validated_ts = progress_ts
+
+    def _validate_snapshot(self, ts: int) -> None:
+        for data, count in self._state.items():
+            if count < 0:
+                raise InvariantViolation(
+                    f"{self.name}: negative multiplicity {count} for row"
+                    f" {data} at {ts}"
+                )
+        try:
+            self.validate_state(dict(self._state), ts)
+        except InvariantViolation as e:
+            # Attach what triage needs to classify the violation: a direct
+            # read of the same query at the violating timestamp (on a fresh
+            # connection, the subscribe connection is inside a transaction)
+            # distinguishes an inconsistent shard from an inconsistent
+            # subscribe stream, and the session context shows whether a
+            # durable resume was involved.
+            probe: object = "unavailable"
+            try:
+                probe_client = MzClient(self.ctx, f"{self.name}-probe")
+                probe = probe_client.query(f"{self.inner_query} AS OF {ts}", timeout=30)
+                probe_client.reset()
+            except Exception as probe_error:
+                probe = f"failed: {probe_error}"
+            raise InvariantViolation(
+                f"{e} [session={'resumed' if self._resumed else 'fresh'}"
+                f" as_of={self._as_of} resumes={self.resumes}"
+                f" last_validated={self.last_validated_ts};"
+                f" direct read AS OF {ts}: {probe}]"
+            ) from None
+        self.validations += 1
+
+    @abstractmethod
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        """Verify one transactionally consistent snapshot of the query."""
+
+    def recycle(self) -> None:
+        """Start over with a fresh subscription and no carried state.
+
+        A snapshot-free subscription accumulates every change it has seen, so a
+        checker that validates the whole accumulated state has to bound it.
+        """
+        self.client.reset()
+        self._active = False
+        self.last_validated_ts = None
+        self._reset_session()
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class ProgressPeek(PeekChecker):
+    """A source's ingestion progress must never move backwards.
+
+    NOTE: doc/user documents a `<name>_progress` relation per source, but
+    sources created with the current syntax do not create one (see
+    FINDINGS-BUGS.md B2), so this reads the source's write frontier from
+    mz_internal.mz_frontiers instead. Reads run on one session under the
+    default strict serializable isolation, so two consecutive reads are
+    ordered in real time and the frontier must be non-decreasing.
+    """
+
+    pause = (1.0, 4.0)
+
+    def __init__(self, rng, ctx, object_name: str, name: str = "progress-peek") -> None:
+        super().__init__(rng, ctx, name, ["quickstart"])
+        self.query = (
+            "SELECT f.write_frontier::text::numeric"
+            " FROM mz_internal.mz_frontiers f"
+            " JOIN mz_objects o ON f.object_id = o.id"
+            f" WHERE o.name = '{object_name}'"
+        )
+        self.last: int | None = None
+
+    def check_once(self) -> None:
+        rows = self.peek(self.query)
+        if len(rows) != 1 or rows[0][0] is None:
+            # The catalog row can lag object creation, and a NULL frontier
+            # (the empty frontier) only occurs for completed collections.
+            raise TransientError(f"{self.name}: no frontier row: {rows}")
+        value = int(rows[0][0])
+        if self.last is not None and value < self.last:
+            raise InvariantViolation(
+                f"{self.name}: write frontier moved backwards:"
+                f" {value} < {self.last}"
+            )
+        self.last = value
+        self.validations += 1
+
+
+class GroupCompletenessPeek(PeekChecker):
+    """Every group written by one upstream transaction must be whole.
+
+    A write that spans several rows is only atomic if all of its rows become
+    visible at the same timestamp. Per-row checks cannot see a violation of
+    that, and a conserved-sum check only sees the ones that happen to change
+    the sum, so this asks the question directly: group the rows by the
+    transaction that wrote them and require every group to have the size that
+    transaction gave it.
+
+    The invariant is carried by the data rather than by the checker, so
+    nothing here has to know which transactions ran or which of them
+    committed. That is what makes it usable during chaos, where most op
+    outcomes are unknown. It also holds at every timestamp, so it can be
+    asked of retained history, where a tear that has since healed is still
+    recorded.
+
+    `predicate` must select the offending groups and return no rows when the
+    invariant holds.
+    """
+
+    pause = (0.5, 2.0)
+
+    def __init__(
+        self,
+        rng,
+        ctx,
+        name: str,
+        predicate: str,
+        clusters: list[str] | None = None,
+        history: Watermark | None = None,
+    ) -> None:
+        super().__init__(rng, ctx, name, clusters or ["quickstart", "compute"])
+        self.predicate = predicate
+        # When given, some rounds ask the same question of a past timestamp.
+        # A torn transaction is durable in the shard's history even after the
+        # live state has converged, which turns a race that reproduces once a
+        # week into an artifact that can be found after the fact.
+        self.history = history
+
+    def check_once(self) -> None:
+        query, at = self.predicate, "now"
+        recent = self.history.get() if self.history is not None else 0
+        if recent > 0 and self.rng.random() < 0.25:
+            as_of = self.rng.randint(max(recent - 120_000, 1), recent)
+            query, at = f"{self.predicate} AS OF {as_of}", str(as_of)
+        try:
+            rows = self.peek(query)
+        except UnexpectedQueryError as e:
+            # The probed timestamp can fall behind the since while a
+            # disruption stalls this round, the same race the other history
+            # probes hit. Unreadable is a skip, a torn group is not.
+            if "could not find a valid timestamp" in str(e):
+                raise TransientError(f"{at} no longer readable") from None
+            raise
+        if rows:
+            raise InvariantViolation(
+                f"{self.name}: transaction not applied atomically at {at} on"
+                f" {self.last_cluster}: {rows[:5]}"
+            )
+        self.validations += 1
+
+
+class TernaryPartitionPeek(PeekChecker):
+    """Splitting a relation by a predicate must not create or lose rows.
+
+    For any total predicate p, the rows where p holds, where it does not, and
+    where it is NULL partition the relation exactly, at every timestamp and
+    whatever the data is. So this holds without knowing anything about the
+    workload or which of its operations committed, which is what lets it run
+    during a disruption, and it is a different question from the conserved
+    totals the scenarios otherwise assert: it is about whether predicates are
+    evaluated correctly, including when persist skips parts by their
+    statistics rather than reading them.
+
+    Both the row count and a summed value are partitioned, because a filter
+    that drops one row and duplicates another keeps the count.
+
+    `predicate` must produce **total** expressions. Anything that can raise,
+    a division or a fallible cast, breaks the comparison: the three branches
+    would fail differently rather than disagree.
+    """
+
+    pause = (0.5, 2.0)
+
+    def __init__(
+        self,
+        rng,
+        ctx,
+        name: str,
+        relation: str,
+        predicate: Callable[[random.Random], str],
+        value: str,
+        history: Watermark | None = None,
+    ) -> None:
+        super().__init__(rng, ctx, name, ["quickstart", "compute"])
+        self.relation = relation
+        self.predicate = predicate
+        self.value = value
+        self.history = history
+
+    def check_once(self) -> None:
+        p = self.predicate(self.rng)
+        # One statement, so all four reads share a timestamp. Written as
+        # differences so the check is "both zero" rather than a comparison of
+        # four numbers that a disruption could interleave.
+        query = (
+            f"SELECT (SELECT count(*) FROM {self.relation})"
+            f" - (SELECT count(*) FROM {self.relation} WHERE {p})"
+            f" - (SELECT count(*) FROM {self.relation} WHERE NOT ({p}))"
+            f" - (SELECT count(*) FROM {self.relation} WHERE ({p}) IS NULL),"
+            f" (SELECT coalesce(sum({self.value}), 0) FROM {self.relation})"
+            f" - (SELECT coalesce(sum({self.value}), 0) FROM {self.relation}"
+            f" WHERE {p})"
+            f" - (SELECT coalesce(sum({self.value}), 0) FROM {self.relation}"
+            f" WHERE NOT ({p}))"
+            f" - (SELECT coalesce(sum({self.value}), 0) FROM {self.relation}"
+            f" WHERE ({p}) IS NULL)"
+        )
+        at = "now"
+        recent = self.history.get() if self.history is not None else 0
+        if recent > 0 and self.rng.random() < 0.25:
+            as_of = self.rng.randint(max(recent - 120_000, 1), recent)
+            query, at = f"{query} AS OF {as_of}", str(as_of)
+        try:
+            rows = self.peek(query)
+        except UnexpectedQueryError as e:
+            if "could not find a valid timestamp" in str(e):
+                raise TransientError(f"{at} no longer readable") from None
+            raise
+        count_diff, value_diff = int(rows[0][0]), int(rows[0][1])
+        if count_diff or value_diff:
+            raise InvariantViolation(
+                f"{self.name}: `{p}` does not partition {self.relation} at {at}"
+                f" on {self.last_cluster}: {count_diff} rows and {value_diff}"
+                f" of {self.value} unaccounted for"
+            )
+        self.validations += 1
+
+
+class ReplicaDivergence(Checker):
+    """Both replicas of a cluster must answer identically.
+
+    The other checkers read through the cluster, so whichever replica the
+    coordinator picks is the one that gets verified, and a replica that
+    computes the wrong answer is caught only if it happens to be chosen. This
+    asks each replica directly, at one explicit timestamp, so the two answers
+    are comparable by construction: same query, same logical time, different
+    process. Any difference is a compute determinism bug, not a race.
+
+    The queries must read objects the cluster maintains, so each replica
+    computes the answer independently, unlike a table read which every
+    replica serves from persist. Those objects also need a RETAIN HISTORY
+    long enough to cover the probed timestamp.
+
+    A disrupted replica cannot serve the timestamp and the round is skipped,
+    which is the same contract every other checker follows.
+    """
+
+    name = "replica-divergence"
+    pause = (1.0, 3.0)
+
+    def __init__(
+        self,
+        rng: random.Random,
+        ctx: ScenarioContext,
+        queries: tuple[str, ...],
+        cluster: str = "compute",
+        replicas: tuple[str, ...] = ("r1", "r2"),
+    ) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.client = MzClient(ctx, self.name)
+        self.queries = queries
+        self.cluster = cluster
+        self.replicas = replicas
+
+    def check_once(self) -> None:
+        self.client.query(f"SET cluster = {self.cluster}")
+        # One timestamp for every read of a round. Slightly in the past so it
+        # is already readable rather than something both replicas have to wait
+        # for, and well inside the RETAIN HISTORY of the objects involved.
+        now = int(self.client.query("SELECT mz_now()::text")[0][0])
+        as_of = now - 1000
+        for sql in self.queries:
+            answers = {}
+            for replica in self.replicas:
+                self.client.query(f"SET cluster_replica = {replica}")
+                try:
+                    rows = self.client.query(f"{sql} AS OF {as_of}")
+                except UnexpectedQueryError as e:
+                    # Same race the history probes hit: a timestamp that was
+                    # readable when it was chosen can fall behind the since
+                    # while a disruption stalls this round. Unreadable is a
+                    # skip, disagreement at a readable one stays fatal.
+                    if "could not find a valid timestamp" in str(e):
+                        raise TransientError(f"{as_of} no longer readable") from None
+                    raise
+                answers[replica] = tuple(tuple(row) for row in rows)
+            self.validations += 1
+            first = self.replicas[0]
+            for replica in self.replicas[1:]:
+                if answers[replica] != answers[first]:
+                    raise InvariantViolation(
+                        f"replicas disagree at {as_of} on `{sql}`:"
+                        f" {first}={answers[first]} {replica}={answers[replica]}"
+                    )
+        # Later rounds must not inherit a pin to one replica.
+        self.client.query("RESET cluster_replica")
+
+    def close(self) -> None:
+        self.client.reset()

--- a/misc/python/materialize/invariants/checkers.py
+++ b/misc/python/materialize/invariants/checkers.py
@@ -134,6 +134,7 @@ class SubscribeChecker(Checker):
             self._pending = []
             self._last_ts = None
             self._as_of = None
+            self._last_order_key = None
             self._resumed = True
             try:
                 self.client.query(f"SET cluster = {self.cluster}")
@@ -211,6 +212,7 @@ class SubscribeChecker(Checker):
         # (the history audit) advances its frontier in giant steps, and the
         # per-timestamp states in between must be consistent too.
         index = 0
+        validated_ready = False
         while index < len(ready):
             ts = ready[index][0]
             while index < len(ready) and ready[index][0] == ts:
@@ -221,9 +223,13 @@ class SubscribeChecker(Checker):
                 index += 1
             if gate_open:
                 self._validate_snapshot(ts)
+                validated_ready = True
         if not gate_open:
             return
-        self._validate_snapshot(progress_ts)
+        # The state at progress_ts equals the state after the last folded
+        # timestamp, so only progress rows that folded nothing validate here.
+        if not validated_ready:
+            self._validate_snapshot(progress_ts)
         self.last_validated_ts = progress_ts
 
     def _validate_snapshot(self, ts: int) -> None:

--- a/misc/python/materialize/invariants/checkers.py
+++ b/misc/python/materialize/invariants/checkers.py
@@ -40,11 +40,14 @@ class PeekChecker(Checker):
         self.ctx = ctx
         self.clusters = clusters
         self._round = 0
+        self.last_cluster: str | None = None
         self.client = MzClient(ctx, name)
 
     def peek(self, sql: str) -> list[tuple]:
         cluster = self.clusters[self._round % len(self.clusters)]
         self._round += 1
+        # Recorded so a violation can name the cluster that produced it.
+        self.last_cluster = cluster
         self.client.query(f"SET cluster = {cluster}")
         return self.client.query(sql)
 
@@ -77,12 +80,23 @@ class SubscribeChecker(Checker):
         inner_query: str,
         cluster: str = "quickstart",
         durable: bool = False,
+        snapshot: bool = True,
+        append_only: bool = False,
     ) -> None:
         super().__init__(rng)
         self.name = name
         self.ctx = ctx
         self.inner_query = inner_query
         self.cluster = cluster
+        # False subscribes to the changes from the subscription's as_of on,
+        # which is the only affordable way to watch a relation whose snapshot
+        # is large.
+        self.snapshot = snapshot
+        # For a relation nothing ever deletes from, a retraction in the change
+        # stream is a bug on its own, no matter what the folded state says: an
+        # insert and its bogus retraction cancel out and leave the state
+        # looking right.
+        self.append_only = append_only
         # When True, a restarted session resumes from the last validated
         # progress timestamp instead of taking a fresh snapshot, carrying
         # the reconstructed state across reconnects (the documented durable
@@ -160,10 +174,11 @@ class SubscribeChecker(Checker):
         self._reset_session()
         self.client.query(f"SET cluster = {self.cluster}")
         self.client.query("BEGIN")
+        snapshot_clause = "" if self.snapshot else ", SNAPSHOT = false"
         self.client.query(
             f"DECLARE {self._cursor} CURSOR FOR"
             f" SUBSCRIBE ({self.inner_query}) {self.order_clause}"
-            f" WITH (PROGRESS) {self.as_of_clause}"
+            f" WITH (PROGRESS{snapshot_clause}) {self.as_of_clause}"
         )
 
     def _process(self, rows: list[tuple]) -> None:
@@ -184,6 +199,12 @@ class SubscribeChecker(Checker):
                 self._apply_pending(ts)
             else:
                 data = tuple(row[3:])
+                diff = int(row[2])
+                if self.append_only and diff < 0:
+                    raise InvariantViolation(
+                        f"{self.name}: retraction {diff} of row {data} at {ts}"
+                        " in an append-only relation"
+                    )
                 if self.order_index is not None:
                     # WITHIN TIMESTAMP ORDER BY: rows of one timestamp must
                     # arrive sorted by the ordering expression.
@@ -266,6 +287,17 @@ class SubscribeChecker(Checker):
     @abstractmethod
     def validate_state(self, state: dict[tuple, int], ts: int) -> None:
         """Verify one transactionally consistent snapshot of the query."""
+
+    def recycle(self) -> None:
+        """Start over with a fresh subscription and no carried state.
+
+        A snapshot-free subscription accumulates every change it has seen, so a
+        checker that validates the whole accumulated state has to bound it.
+        """
+        self.client.reset()
+        self._active = False
+        self.last_validated_ts = None
+        self._reset_session()
 
     def close(self) -> None:
         self.client.reset()

--- a/misc/python/materialize/invariants/executor.py
+++ b/misc/python/materialize/invariants/executor.py
@@ -1,0 +1,509 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Thread orchestration and the phases of one scenario run.
+
+Phases: chaos (workers + checkers + disruptor race for --runtime seconds) ->
+heal (disruptor stops and heals all legs) -> shutdown ladder (stop threads,
+unblock stragglers by cancelling their connections) -> converge (bounded
+liveness check) -> final check (strong assertions) -> vacuity check.
+
+Failure model: the first thread to hit an InvariantViolation or unexpected
+error records it and stops the run. Threads stuck after healing are
+themselves a liveness failure, never silently abandoned.
+"""
+
+import faulthandler
+import random
+import threading
+import time
+from collections import Counter
+
+from materialize.invariants.framework import (
+    SEED_RANGE,
+    Checker,
+    InvariantViolation,
+    Outcome,
+    Scenario,
+    TransientError,
+    WorkerBundle,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.toxiproxy import (
+    Disruptor,
+    Leg,
+    ProcessTarget,
+    ToxiproxyApi,
+)
+
+REPORT_INTERVAL = 10.0
+
+# Behavior-preserving system flags the agitator flips mid-run, a subset of
+# parallel-workload's FlipFlagsAction catalog. Plan- and performance-affecting
+# flags are fair game, results-changing ones are not: every invariant must
+# hold under any combination of these.
+AGITATOR_FLAGS: dict[str, list[str]] = {
+    "persist_blob_target_size": ["1048576", "16777216", "134217728"],
+    "persist_batch_max_run_len": ["2", "4", "16", "1000"],
+    "persist_compaction_memory_bound_bytes": [
+        "67108864",
+        "134217728",
+        "1073741824",
+    ],
+    "persist_part_decode_format": ["row_with_validate", "arrow"],
+    "persist_encoding_enable_dictionary": ["true", "false"],
+    "persist_enable_incremental_compaction": ["true", "false"],
+    "persist_claim_unclaimed_compactions": ["true", "false"],
+    "persist_optimize_ignored_data_fetch": ["true", "false"],
+    "enable_variadic_left_join_lowering": ["true", "false"],
+    "enable_eager_delta_joins": ["true", "false"],
+    "persist_use_critical_since_catalog": ["true", "false"],
+    "persist_use_critical_since_source": ["true", "false"],
+    "persist_use_critical_since_snapshot": ["true", "false"],
+    "persist_use_critical_since_txn": ["true", "false"],
+    "persist_batch_structured_key_lower_len": ["0", "1", "512", "50000"],
+}
+
+
+class Agitator(threading.Thread):
+    """Random session cancellations and system-flag flips during chaos.
+
+    Cancellations exercise the UNKNOWN outcome paths: a cancelled write must
+    never half-apply, which the scenario invariants then verify. Flag flips
+    reconfigure plan and persist behavior mid-run, and results must stay
+    exact under every combination. All flipped flags are reset at the end so
+    converge and the final check run under defaults.
+    """
+
+    def __init__(self, ctx, rng: random.Random, on_error) -> None:
+        super().__init__(name="agitator")
+        self.ctx = ctx
+        self.rng = rng
+        self.on_error = on_error
+        # ALTER SYSTEM needs mz_system, while pg_cancel_backend requires
+        # membership of the target session's role, so cancellations go
+        # through a regular materialize connection.
+        self.system_client = MzClient(
+            ctx, "agitator-system", user="mz_system", port=ctx.endpoints.mz_system_port
+        )
+        self.cancel_client = MzClient(ctx, "agitator-cancel")
+        self.cancels = 0
+        self.flips = 0
+        self.flipped: set[str] = set()
+
+    def run(self) -> None:
+        ctx = self.ctx
+        assert ctx.complexity.agitation_interval is not None
+        try:
+            while not ctx.stop.wait(
+                self.rng.uniform(*ctx.complexity.agitation_interval)
+            ):
+                try:
+                    if self.rng.random() < 0.7:
+                        self._cancel_random_session()
+                    else:
+                        self._flip_random_flag()
+                except TransientError as e:
+                    ctx.log.log("agitate", f"skipped: {e}", echo=False)
+        except BaseException as e:
+            self.on_error(e)
+        finally:
+            self._reset_flags()
+            self.system_client.reset()
+            self.cancel_client.reset()
+
+    def _cancel_random_session(self) -> None:
+        rows = self.cancel_client.query(
+            "SELECT s.connection_id FROM mz_internal.mz_sessions s"
+            " JOIN mz_roles r ON s.role_id = r.id WHERE r.name = 'materialize'"
+        )
+        if not rows:
+            return
+        # Sorted before choosing: the server returns rows in arbitrary order.
+        target = self.rng.choice(sorted(int(row[0]) for row in rows))
+        self.cancel_client.query(f"SELECT pg_cancel_backend({target})")
+        self.cancels += 1
+        self.ctx.log.log("agitate", f"cancelled connection {target}", echo=False)
+
+    def _flip_random_flag(self) -> None:
+        flag = self.rng.choice(sorted(AGITATOR_FLAGS))
+        value = self.rng.choice(AGITATOR_FLAGS[flag])
+        self.system_client.query(f"ALTER SYSTEM SET {flag} = '{value}'")
+        self.flipped.add(flag)
+        self.flips += 1
+        self.ctx.log.log("agitate", f"set {flag} = {value}")
+
+    def _reset_flags(self) -> None:
+        # Best-effort with one shared budget: this runs during shutdown, and
+        # against a stalled envd every RESET would otherwise burn its full
+        # watchdog timeout, blowing the join ladder. The flags are
+        # results-preserving, so leaving some flipped is acceptable.
+        deadline = time.monotonic() + 20
+        for flag in sorted(self.flipped):
+            if time.monotonic() > deadline:
+                self.ctx.log.log(
+                    "agitate", f"flag reset budget exhausted, {flag}+ left flipped"
+                )
+                return
+            try:
+                self.system_client.query(f"ALTER SYSTEM RESET {flag}", timeout=10)
+            except Exception:
+                pass
+
+
+class Runner:
+    def __init__(
+        self,
+        scenario: Scenario,
+        runtime: float,
+        toxiproxy: ToxiproxyApi,
+        legs: list[Leg],
+        processes: list[ProcessTarget] | None = None,
+        midrun_event=None,
+    ) -> None:
+        self.scenario = scenario
+        self.ctx = scenario.ctx
+        self.runtime = runtime
+        self.toxiproxy = toxiproxy
+        self.legs = legs
+        self.processes = processes or []
+        self.midrun_event = midrun_event
+        self.failure: BaseException | None = None
+        self._failure_lock = threading.Lock()
+        self.worker_stats: list[Counter[tuple[str, str]]] = []
+        self.checkers: list[Checker] = []
+        self.disruptor: Disruptor | None = None
+        self.agitator: Agitator | None = None
+        # Checker validations and committed ops at the chaos midpoint, for
+        # the progress assertions.
+        self._half_marks: tuple[list[int], int] | None = None
+
+    def fail(self, exc: BaseException) -> None:
+        with self._failure_lock:
+            if self.failure is None:
+                self.failure = exc
+        # Stop before logging so threads halt even if logging itself fails.
+        self.ctx.stop.set()
+        self.ctx.log.log("FAILURE", f"{type(exc).__name__}: {exc}")
+
+    def run(self) -> None:
+        ctx = self.ctx
+        threads: list[threading.Thread] = []
+
+        # Draw all child seeds in a fixed order so a given --seed yields the
+        # same per-thread action/disruption sequences across runs.
+        worker_rngs = [
+            random.Random(ctx.rng.randrange(SEED_RANGE))
+            for _ in range(ctx.complexity.workers)
+        ]
+        self.checkers = self.scenario.checkers()
+        checker_rngs = [
+            random.Random(ctx.rng.randrange(SEED_RANGE)) for _ in self.checkers
+        ]
+        disruptor_rng = random.Random(ctx.rng.randrange(SEED_RANGE))
+        agitator_rng = random.Random(ctx.rng.randrange(SEED_RANGE))
+
+        for i, rng in enumerate(worker_rngs):
+            bundle = self.scenario.make_worker(i, rng)
+            stats: Counter[tuple[str, str]] = Counter()
+            self.worker_stats.append(stats)
+            thread = threading.Thread(
+                name=f"worker-{i}", target=self._worker_loop, args=(bundle, rng, stats)
+            )
+            threads.append(thread)
+        for checker, rng in zip(self.checkers, checker_rngs):
+            thread = threading.Thread(
+                name=f"checker-{checker.name}",
+                target=self._checker_loop,
+                args=(checker, rng),
+            )
+            threads.append(thread)
+        if self.legs:
+            self.disruptor = Disruptor(
+                api=self.toxiproxy,
+                legs=self.legs,
+                rng=disruptor_rng,
+                log=ctx.log,
+                interval=ctx.complexity.disruption_interval,
+                duration=ctx.complexity.disruption_duration,
+                concurrent=ctx.complexity.concurrent_disruptions,
+                on_error=self.fail,
+                processes=self.processes,
+            )
+            if ctx.complexity.agitation_interval is not None:
+                self.agitator = Agitator(ctx, agitator_rng, self.fail)
+                threads.append(self.agitator)
+
+        ctx.log.log("phase", f"chaos: running for {self.runtime}s")
+        # The finally clause guarantees heal/stop/join even when the monitor
+        # itself fails, so no scenario ever leaves disruptions applied or
+        # threads running.
+        try:
+            for thread in threads:
+                thread.start()
+            if self.disruptor:
+                self.disruptor.start()
+            self._monitor()
+        finally:
+            ctx.log.log("phase", "heal: stopping disruptions")
+            if self.disruptor is not None and self.disruptor.ident is not None:
+                self.disruptor.stop_and_heal()
+            ctx.stop.set()
+            self._join_threads([t for t in threads if t.ident is not None])
+
+        if self.failure is not None:
+            self._dump_diagnostics()
+            raise self.failure
+
+        ctx.log.log("phase", "converge: waiting for all data paths to catch up")
+        try:
+            self.scenario.converge()
+            ctx.log.log("phase", "final check")
+            self.scenario.final_check()
+            self._check_vacuity()
+        except BaseException as e:
+            self.fail(e)
+            self._dump_diagnostics()
+            raise
+
+        self._report(final=True)
+        ctx.log.log("phase", "success")
+
+    def _monitor(self) -> None:
+        end = time.monotonic() + self.runtime
+        half = end - self.runtime / 2
+        last_report = time.monotonic()
+        while time.monotonic() < end and not self.ctx.stop.is_set():
+            time.sleep(1)
+            if self._half_marks is None and time.monotonic() >= half:
+                self._half_marks = (
+                    [checker.validations for checker in self.checkers],
+                    self._committed_total(),
+                )
+                if self.midrun_event is not None:
+                    self.ctx.log.log("phase", "midrun event: upgrade swap")
+                    try:
+                        self.midrun_event()
+                    except Exception as e:
+                        self.fail(e)
+            if time.monotonic() - last_report >= REPORT_INTERVAL:
+                last_report = time.monotonic()
+                self._report(final=False)
+
+    def _join_threads(self, threads: list[threading.Thread]) -> None:
+        deadline = time.monotonic() + 60
+        for thread in threads:
+            thread.join(timeout=max(0.1, deadline - time.monotonic()))
+        stragglers = [t for t in threads if t.is_alive()]
+        if stragglers:
+            self.ctx.log.log(
+                "shutdown",
+                f"cancelling connections of stuck threads: {[t.name for t in stragglers]}",
+            )
+            for client in self.ctx.clients:
+                try:
+                    client.hard_close()
+                except Exception:
+                    pass
+            deadline = time.monotonic() + 30
+            for thread in stragglers:
+                thread.join(timeout=max(0.1, deadline - time.monotonic()))
+            stragglers = [t for t in stragglers if t.is_alive()]
+        if stragglers:
+            # A thread that is still stuck after all disruptions were healed
+            # and its connection was torn down is a liveness bug.
+            faulthandler.dump_traceback()
+            self.fail(
+                InvariantViolation(
+                    f"threads stuck after healing: {[t.name for t in stragglers]}"
+                )
+            )
+
+    def _worker_loop(
+        self, bundle: WorkerBundle, rng: random.Random, stats: Counter
+    ) -> None:
+        ctx = self.ctx
+        try:
+            while not ctx.stop.is_set():
+                action = rng.choices(bundle.actions, bundle.weights)[0]
+                try:
+                    outcome = action.run()
+                    key = outcome.value if outcome is not None else "ok"
+                    stats[(action.name, key)] += 1
+                    if outcome in (Outcome.UNKNOWN, Outcome.FAILED):
+                        ctx.log.log("op", f"{action.name}: {outcome.value}", echo=False)
+                except TransientError as e:
+                    stats[(action.name, "transient")] += 1
+                    ctx.log.log("op", f"{action.name} transient: {e}", echo=False)
+                if ctx.stop.wait(rng.uniform(*ctx.complexity.op_delay)):
+                    break
+        except BaseException as e:
+            self.fail(e)
+        finally:
+            try:
+                bundle.close()
+            except Exception:
+                pass
+
+    def _checker_loop(self, checker: Checker, rng: random.Random) -> None:
+        ctx = self.ctx
+        opened = False
+        try:
+            while not ctx.stop.is_set():
+                try:
+                    if not opened:
+                        checker.open()
+                        opened = True
+                    before = checker.validations
+                    checker.check_once()
+                    checker.rounds += 1
+                    if (
+                        checker.validations > before
+                        and self.disruptor is not None
+                        and self.disruptor.active.is_set()
+                    ):
+                        checker.validations_during += 1
+                except TransientError as e:
+                    checker.skipped += 1
+                    ctx.log.log("check", f"{checker.name} skipped: {e}", echo=False)
+                if ctx.stop.wait(rng.uniform(*checker.pause)):
+                    break
+        except BaseException as e:
+            self.fail(e)
+        finally:
+            try:
+                checker.close()
+            except Exception:
+                pass
+
+    def _report(self, final: bool) -> None:
+        ops: Counter[str] = Counter()
+        for stats in self.worker_stats:
+            # dict(stats) snapshots in one C-level step: the owning worker
+            # thread concurrently inserts new keys, and iterating the live
+            # Counter would racily raise "dictionary changed size".
+            for (_, key), count in dict(stats).items():
+                ops[key] += count
+        checks = ", ".join(
+            f"{c.name}: {c.rounds} rounds/{c.validations} checks/{c.skipped} skipped"
+            for c in self.checkers
+        )
+        cycles = self.disruptor.cycles if self.disruptor else 0
+        agitation = (
+            f" cancels={self.agitator.cancels} flag_flips={self.agitator.flips}"
+            if self.agitator
+            else ""
+        )
+        self.ctx.log.log(
+            "stats",
+            f"ops={dict(ops)} checkers=[{checks}]"
+            f" disruption_cycles={cycles}{agitation}",
+        )
+        if final:
+            for i, stats in enumerate(self.worker_stats):
+                self.ctx.log.log("stats", f"worker-{i}: {dict(stats)}", echo=False)
+            if self.disruptor is not None:
+                coverage = ", ".join(
+                    f"{target}/{kind}: {count}"
+                    for (target, kind), count in sorted(self.disruptor.coverage.items())
+                )
+                self.ctx.log.log("stats", f"disruption coverage: [{coverage}]")
+                during = ", ".join(
+                    f"{c2.name}: {c2.validations_during}" for c2 in self.checkers
+                )
+                self.ctx.log.log("stats", f"validations during disruptions: [{during}]")
+
+    def _committed_total(self) -> int:
+        return sum(
+            count
+            for stats in self.worker_stats
+            for (_, key), count in dict(stats).items()
+            if key in ("ok", Outcome.COMMITTED.value)
+        )
+
+    def _check_vacuity(self) -> None:
+        """A run that stopped verifying anything must not pass silently.
+
+        Beyond "verified at least once", every checker and the workers must
+        have made progress in BOTH halves of the chaos phase: a thread that
+        wedges midway would otherwise still pass, and disruptions are capped
+        well below a half, so a healthy run always progresses in each.
+        """
+        committed = self._committed_total()
+        if committed == 0:
+            raise InvariantViolation("vacuous run: no worker op ever committed")
+        for checker in self.checkers:
+            if checker.validations == 0:
+                raise InvariantViolation(
+                    f"vacuous run: checker {checker.name} never verified its"
+                    " invariant"
+                )
+        # Only meaningful at CI-scale runtimes: in short local runs a single
+        # watchdog-bounded hung peek can legitimately eat most of a half.
+        if self._half_marks is not None and self.runtime >= 600:
+            half_validations, half_committed = self._half_marks
+            for checker, at_half in zip(self.checkers, half_validations):
+                if at_half == 0 or checker.validations <= at_half:
+                    raise InvariantViolation(
+                        f"stalled run: checker {checker.name} verified"
+                        f" {at_half} times in the first half but"
+                        f" {checker.validations - at_half} in the second"
+                    )
+            if half_committed == 0 or committed <= half_committed:
+                raise InvariantViolation(
+                    f"stalled run: {half_committed} ops committed in the first"
+                    f" half, {committed - half_committed} in the second"
+                )
+        if self.disruptor is not None and self.disruptor.cycles < 2:
+            raise InvariantViolation(
+                f"vacuous run: only {self.disruptor.cycles} disruption cycles"
+            )
+        if (
+            self.agitator is not None
+            and self.agitator.cancels + self.agitator.flips == 0
+        ):
+            raise InvariantViolation("vacuous run: the agitator never acted")
+
+    def _dump_diagnostics(self) -> None:
+        log = self.ctx.log
+        log.log("phase", "diagnostics")
+        if self.disruptor:
+            for line in self.disruptor.history:
+                log.log("diag", f"disruption: {line}")
+        try:
+            for name, proxy in self.toxiproxy.proxies().items():
+                log.log(
+                    "diag",
+                    f"proxy {name}: enabled={proxy['enabled']}"
+                    f" toxics={proxy['toxics']}",
+                )
+        except Exception as e:
+            log.log("diag", f"toxiproxy state unavailable: {e}")
+        client = MzClient(self.ctx, "diagnostics")
+        for what, sql in [
+            (
+                "source statuses",
+                "SELECT name, status, error FROM mz_internal.mz_source_statuses",
+            ),
+            (
+                "sink statuses",
+                "SELECT name, status, error FROM mz_internal.mz_sink_statuses",
+            ),
+        ]:
+            try:
+                for row in client.query(sql, timeout=30):
+                    log.log("diag", f"{what}: {row}")
+            except Exception as e:
+                log.log("diag", f"{what} unavailable: {e}")
+        try:
+            self.scenario.diagnostics()
+        except Exception as e:
+            log.log("diag", f"scenario diagnostics failed: {e}")
+        client.reset()
+        self._report(final=True)

--- a/misc/python/materialize/invariants/executor.py
+++ b/misc/python/materialize/invariants/executor.py
@@ -39,6 +39,7 @@ from materialize.invariants.toxiproxy import (
     Disruptor,
     Leg,
     ProcessTarget,
+    Proxy,
     ToxiproxyApi,
 )
 
@@ -166,6 +167,7 @@ class Runner:
         legs: list[Leg],
         processes: list[ProcessTarget] | None = None,
         midrun_event=None,
+        restore_proxies: list[Proxy] | None = None,
     ) -> None:
         self.scenario = scenario
         self.ctx = scenario.ctx
@@ -174,6 +176,7 @@ class Runner:
         self.legs = legs
         self.processes = processes or []
         self.midrun_event = midrun_event
+        self.restore_proxies = restore_proxies
         self.failure: BaseException | None = None
         self._failure_lock = threading.Lock()
         self.worker_stats: list[Counter[tuple[str, str]]] = []
@@ -235,6 +238,7 @@ class Runner:
                 concurrent=ctx.complexity.concurrent_disruptions,
                 on_error=self.fail,
                 processes=self.processes,
+                restore_proxies=self.restore_proxies,
             )
             if ctx.complexity.agitation_interval is not None:
                 self.agitator = Agitator(ctx, agitator_rng, self.fail)

--- a/misc/python/materialize/invariants/executor.py
+++ b/misc/python/materialize/invariants/executor.py
@@ -1,0 +1,556 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Thread orchestration and the phases of one scenario run.
+
+Phases: chaos (workers + checkers + disruptor race for --runtime seconds) ->
+heal (disruptor stops and heals all legs) -> shutdown ladder (stop threads,
+unblock stragglers by cancelling their connections) -> converge (bounded
+liveness check) -> final check (strong assertions) -> vacuity check.
+
+Failure model: the first thread to hit an InvariantViolation or unexpected
+error records it and stops the run. Threads stuck after healing are
+themselves a liveness failure, never silently abandoned.
+"""
+
+import faulthandler
+import random
+import threading
+import time
+from collections import Counter
+from collections.abc import Callable
+
+from materialize.invariants.framework import (
+    SEED_RANGE,
+    Checker,
+    InvariantViolation,
+    Outcome,
+    Scenario,
+    TransientError,
+    WorkerBundle,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.toxiproxy import (
+    Disruptor,
+    Leg,
+    ProcessTarget,
+    Proxy,
+    ToxiproxyApi,
+)
+
+REPORT_INTERVAL = 10.0
+
+# Behavior-preserving system flags the agitator flips mid-run, a subset of
+# parallel-workload's FlipFlagsAction catalog. Plan- and performance-affecting
+# flags are fair game, results-changing ones are not: every invariant must
+# hold under any combination of these.
+AGITATOR_FLAGS: dict[str, list[str]] = {
+    # The small value keeps batches many-parted, so compaction, GC part
+    # deletion, and the run/part boundaries do real work on small tables too.
+    "persist_blob_target_size": ["65536", "1048576", "16777216", "134217728"],
+    "persist_batch_max_run_len": ["2", "4", "16", "1000"],
+    "persist_compaction_memory_bound_bytes": [
+        "67108864",
+        "134217728",
+        "1073741824",
+    ],
+    "persist_part_decode_format": ["row_with_validate", "arrow"],
+    "persist_encoding_enable_dictionary": ["true", "false"],
+    "persist_enable_incremental_compaction": ["true", "false"],
+    "persist_claim_unclaimed_compactions": ["true", "false"],
+    "persist_optimize_ignored_data_fetch": ["true", "false"],
+    "enable_variadic_left_join_lowering": ["true", "false"],
+    "enable_eager_delta_joins": ["true", "false"],
+    "persist_use_critical_since_catalog": ["true", "false"],
+    "persist_use_critical_since_source": ["true", "false"],
+    "persist_use_critical_since_snapshot": ["true", "false"],
+    "persist_use_critical_since_txn": ["true", "false"],
+    "persist_batch_structured_key_lower_len": ["0", "1", "512", "50000"],
+}
+
+
+class Agitator(threading.Thread):
+    """Random session cancellations and system-flag flips during chaos.
+
+    Cancellations exercise the UNKNOWN outcome paths: a cancelled write must
+    never half-apply, which the scenario invariants then verify. Flag flips
+    reconfigure plan and persist behavior mid-run, and results must stay
+    exact under every combination. All flipped flags are reset at the end so
+    converge and the final check run under defaults.
+    """
+
+    def __init__(self, ctx, rng: random.Random, on_error) -> None:
+        super().__init__(name="agitator")
+        self.ctx = ctx
+        self.rng = rng
+        self.on_error = on_error
+        # ALTER SYSTEM needs mz_system, while pg_cancel_backend requires
+        # membership of the target session's role, so cancellations go
+        # through a regular materialize connection.
+        self.system_client = MzClient(
+            ctx, "agitator-system", user="mz_system", port=ctx.endpoints.mz_system_port
+        )
+        self.cancel_client = MzClient(ctx, "agitator-cancel")
+        self.cancels = 0
+        self.flips = 0
+        self.flipped: set[str] = set()
+
+    def run(self) -> None:
+        ctx = self.ctx
+        assert ctx.complexity.agitation_interval is not None
+        try:
+            while not ctx.stop.wait(
+                self.rng.uniform(*ctx.complexity.agitation_interval)
+            ):
+                try:
+                    if self.rng.random() < 0.7:
+                        self._cancel_random_session()
+                    else:
+                        self._flip_random_flag()
+                except TransientError as e:
+                    ctx.log.log("agitate", f"skipped: {e}", echo=False)
+        except BaseException as e:
+            self.on_error(e)
+        finally:
+            self._reset_flags()
+            self.system_client.reset()
+            self.cancel_client.reset()
+
+    def _cancel_random_session(self) -> None:
+        rows = self.cancel_client.query(
+            "SELECT s.connection_id FROM mz_internal.mz_sessions s"
+            " JOIN mz_roles r ON s.role_id = r.id WHERE r.name = 'materialize'"
+        )
+        if not rows:
+            return
+        # Sorted before choosing: the server returns rows in arbitrary order.
+        target = self.rng.choice(sorted(int(row[0]) for row in rows))
+        self.cancel_client.query(f"SELECT pg_cancel_backend({target})")
+        self.cancels += 1
+        self.ctx.log.log("agitate", f"cancelled connection {target}", echo=False)
+
+    def _flip_random_flag(self) -> None:
+        flag = self.rng.choice(sorted(AGITATOR_FLAGS))
+        value = self.rng.choice(AGITATOR_FLAGS[flag])
+        self.system_client.query(f"ALTER SYSTEM SET {flag} = '{value}'")
+        self.flipped.add(flag)
+        self.flips += 1
+        self.ctx.log.log("agitate", f"set {flag} = {value}")
+
+    def _reset_flags(self) -> None:
+        # Best-effort with one shared budget: this runs during shutdown, and
+        # against a stalled envd every RESET would otherwise burn its full
+        # watchdog timeout, blowing the join ladder. The flags are
+        # results-preserving, so leaving some flipped is acceptable.
+        deadline = time.monotonic() + 20
+        for flag in sorted(self.flipped):
+            if time.monotonic() > deadline:
+                self.ctx.log.log(
+                    "agitate", f"flag reset budget exhausted, {flag}+ left flipped"
+                )
+                return
+            try:
+                self.system_client.query(f"ALTER SYSTEM RESET {flag}", timeout=10)
+            except Exception:
+                pass
+
+
+class Runner:
+    def __init__(
+        self,
+        scenario: Scenario,
+        runtime: float,
+        toxiproxy: ToxiproxyApi,
+        legs: list[Leg],
+        processes: list[ProcessTarget] | None = None,
+        midrun_event=None,
+        restore_proxies: list[Proxy] | None = None,
+        restart_toxiproxy: Callable[[], None] | None = None,
+        kind_filter: set[str] | None = None,
+    ) -> None:
+        self.scenario = scenario
+        self.ctx = scenario.ctx
+        self.runtime = runtime
+        self.toxiproxy = toxiproxy
+        self.legs = legs
+        self.processes = processes or []
+        self.midrun_event = midrun_event
+        self.restore_proxies = restore_proxies
+        self.restart_toxiproxy = restart_toxiproxy
+        self.kind_filter = kind_filter
+        self.failure: BaseException | None = None
+        self._failure_lock = threading.Lock()
+        self.worker_stats: list[Counter[tuple[str, str]]] = []
+        self.checkers: list[Checker] = []
+        self.disruptor: Disruptor | None = None
+        self.agitator: Agitator | None = None
+        # Checker threads held back until the version swap, see run().
+        self._deferred: list[threading.Thread] = []
+        # Checker validations and committed ops at the chaos midpoint, for
+        # the progress assertions.
+        self._half_marks: tuple[list[int], int] | None = None
+
+    def fail(self, exc: BaseException) -> None:
+        with self._failure_lock:
+            if self.failure is None:
+                self.failure = exc
+        # Stop before logging so threads halt even if logging itself fails.
+        self.ctx.stop.set()
+        self.ctx.log.log("FAILURE", f"{type(exc).__name__}: {exc}")
+
+    def run(self) -> None:
+        ctx = self.ctx
+        threads: list[threading.Thread] = []
+
+        # Draw all child seeds in a fixed order so a given --seed yields the
+        # same per-thread action/disruption sequences across runs.
+        # A scenario may cap the worker count below the complexity's, see
+        # Scenario.max_workers.
+        workers = ctx.complexity.workers
+        if self.scenario.max_workers is not None:
+            workers = min(workers, self.scenario.max_workers)
+        worker_rngs = [
+            random.Random(ctx.rng.randrange(SEED_RANGE)) for _ in range(workers)
+        ]
+        self.checkers = self.scenario.checkers()
+        checker_rngs = [
+            random.Random(ctx.rng.randrange(SEED_RANGE)) for _ in self.checkers
+        ]
+        disruptor_rng = random.Random(ctx.rng.randrange(SEED_RANGE))
+        agitator_rng = random.Random(ctx.rng.randrange(SEED_RANGE))
+
+        for i, rng in enumerate(worker_rngs):
+            bundle = self.scenario.make_worker(i, rng)
+            stats: Counter[tuple[str, str]] = Counter()
+            self.worker_stats.append(stats)
+            thread = threading.Thread(
+                name=f"worker-{i}", target=self._worker_loop, args=(bundle, rng, stats)
+            )
+            threads.append(thread)
+        # On an --upgrade-from run the checkers only start at the swap, so
+        # nothing is asserted against the older release, and the swap window
+        # itself is still covered.
+        defer = self.midrun_event is not None
+        for checker, rng in zip(self.checkers, checker_rngs):
+            thread = threading.Thread(
+                name=f"checker-{checker.name}",
+                target=self._checker_loop,
+                args=(checker, rng),
+            )
+            threads.append(thread)
+            if defer:
+                self._deferred.append(thread)
+        if self.legs:
+            self.disruptor = Disruptor(
+                api=self.toxiproxy,
+                legs=self.legs,
+                rng=disruptor_rng,
+                log=ctx.log,
+                interval=ctx.complexity.disruption_interval,
+                duration=ctx.complexity.disruption_duration,
+                concurrent=ctx.complexity.concurrent_disruptions,
+                on_error=self.fail,
+                processes=self.processes,
+                restore_proxies=self.restore_proxies,
+                restart_toxiproxy=self.restart_toxiproxy,
+                kind_filter=self.kind_filter,
+            )
+            # Let the workload aim a cut at a state only it knows it is in.
+            ctx.request_disruption = self.disruptor.request_cycle
+            if ctx.complexity.agitation_interval is not None:
+                self.agitator = Agitator(ctx, agitator_rng, self.fail)
+                threads.append(self.agitator)
+
+        ctx.log.log("phase", f"chaos: running for {self.runtime}s")
+        # The finally clause guarantees heal/stop/join even when the monitor
+        # itself fails, so no scenario ever leaves disruptions applied or
+        # threads running.
+        if not self._deferred:
+            # Nothing to wait for: the build under test is already serving.
+            ctx.checking.set()
+        else:
+            ctx.log.log(
+                "phase",
+                "chaos: invariants are checked from the version swap on,"
+                " the run starts on the older release",
+            )
+        try:
+            for thread in threads:
+                if thread not in self._deferred:
+                    thread.start()
+            if self.disruptor:
+                self.disruptor.start()
+            self._monitor()
+        finally:
+            ctx.log.log("phase", "heal: stopping disruptions")
+            if self.disruptor is not None and self.disruptor.ident is not None:
+                self.disruptor.stop_and_heal()
+            ctx.stop.set()
+            self._join_threads([t for t in threads if t.ident is not None])
+
+        if self.failure is not None:
+            self._dump_diagnostics()
+            raise self.failure
+
+        ctx.log.log("phase", "converge: waiting for all data paths to catch up")
+        try:
+            self.scenario.converge()
+            ctx.log.log("phase", "final check")
+            self.scenario.final_check()
+            self._check_vacuity()
+        except BaseException as e:
+            self.fail(e)
+            self._dump_diagnostics()
+            raise
+
+        self._report(final=True)
+        ctx.log.log("phase", "success")
+
+    def _monitor(self) -> None:
+        end = time.monotonic() + self.runtime
+        half = end - self.runtime / 2
+        last_report = time.monotonic()
+        while time.monotonic() < end and not self.ctx.stop.is_set():
+            time.sleep(1)
+            if self._half_marks is None and time.monotonic() >= half:
+                self._half_marks = (
+                    [checker.validations for checker in self.checkers],
+                    self._committed_total(),
+                )
+                if self.midrun_event is not None:
+                    # Started before the swap runs, so the transition itself is
+                    # checked: what the new build makes of the old build's
+                    # state is the point of this scenario.
+                    self.ctx.checking.set()
+                    for thread in self._deferred:
+                        thread.start()
+                    self.ctx.log.log("phase", "midrun event: upgrade swap")
+                    try:
+                        self.midrun_event()
+                    except Exception as e:
+                        self.fail(e)
+            if time.monotonic() - last_report >= REPORT_INTERVAL:
+                last_report = time.monotonic()
+                self._report(final=False)
+
+    def _join_threads(self, threads: list[threading.Thread]) -> None:
+        deadline = time.monotonic() + 60
+        for thread in threads:
+            thread.join(timeout=max(0.1, deadline - time.monotonic()))
+        stragglers = [t for t in threads if t.is_alive()]
+        if stragglers:
+            self.ctx.log.log(
+                "shutdown",
+                f"cancelling connections of stuck threads: {[t.name for t in stragglers]}",
+            )
+            for client in self.ctx.clients:
+                try:
+                    client.hard_close()
+                except Exception:
+                    pass
+            deadline = time.monotonic() + 30
+            for thread in stragglers:
+                thread.join(timeout=max(0.1, deadline - time.monotonic()))
+            stragglers = [t for t in stragglers if t.is_alive()]
+        if stragglers:
+            # A thread that is still stuck after all disruptions were healed
+            # and its connection was torn down is a liveness bug.
+            faulthandler.dump_traceback()
+            self.fail(
+                InvariantViolation(
+                    f"threads stuck after healing: {[t.name for t in stragglers]}"
+                )
+            )
+
+    def _worker_loop(
+        self, bundle: WorkerBundle, rng: random.Random, stats: Counter
+    ) -> None:
+        ctx = self.ctx
+        try:
+            while not ctx.stop.is_set():
+                action = rng.choices(bundle.actions, bundle.weights)[0]
+                try:
+                    outcome = action.run()
+                    key = outcome.value if outcome is not None else "ok"
+                    stats[(action.name, key)] += 1
+                    if outcome in (Outcome.UNKNOWN, Outcome.FAILED):
+                        ctx.log.log("op", f"{action.name}: {outcome.value}", echo=False)
+                except TransientError as e:
+                    stats[(action.name, "transient")] += 1
+                    ctx.log.log("op", f"{action.name} transient: {e}", echo=False)
+                if ctx.stop.wait(rng.uniform(*ctx.complexity.op_delay)):
+                    break
+        except BaseException as e:
+            self.fail(e)
+        finally:
+            try:
+                bundle.close()
+            except Exception:
+                pass
+
+    def _checker_loop(self, checker: Checker, rng: random.Random) -> None:
+        ctx = self.ctx
+        opened = False
+        try:
+            while not ctx.stop.is_set():
+                try:
+                    if not opened:
+                        checker.open()
+                        opened = True
+                    before = checker.validations
+                    checker.check_once()
+                    checker.rounds += 1
+                    if (
+                        checker.validations > before
+                        and self.disruptor is not None
+                        and self.disruptor.active.is_set()
+                    ):
+                        checker.validations_during += 1
+                except TransientError as e:
+                    checker.skipped += 1
+                    ctx.log.log("check", f"{checker.name} skipped: {e}", echo=False)
+                if ctx.stop.wait(rng.uniform(*checker.pause)):
+                    break
+        except BaseException as e:
+            self.fail(e)
+        finally:
+            try:
+                checker.close()
+            except Exception:
+                pass
+
+    def _report(self, final: bool) -> None:
+        ops: Counter[str] = Counter()
+        for stats in self.worker_stats:
+            # dict(stats) snapshots in one C-level step: the owning worker
+            # thread concurrently inserts new keys, and iterating the live
+            # Counter would racily raise "dictionary changed size".
+            for (_, key), count in dict(stats).items():
+                ops[key] += count
+        checks = ", ".join(
+            f"{c.name}: {c.rounds} rounds/{c.validations} checks/{c.skipped} skipped"
+            for c in self.checkers
+        )
+        cycles = self.disruptor.cycles if self.disruptor else 0
+        agitation = (
+            f" cancels={self.agitator.cancels} flag_flips={self.agitator.flips}"
+            if self.agitator
+            else ""
+        )
+        self.ctx.log.log(
+            "stats",
+            f"ops={dict(ops)} checkers=[{checks}]"
+            f" disruption_cycles={cycles}{agitation}",
+        )
+        if final:
+            for i, stats in enumerate(self.worker_stats):
+                self.ctx.log.log("stats", f"worker-{i}: {dict(stats)}", echo=False)
+            if self.disruptor is not None:
+                coverage = ", ".join(
+                    f"{target}/{kind}: {count}"
+                    for (target, kind), count in sorted(self.disruptor.coverage.items())
+                )
+                self.ctx.log.log("stats", f"disruption coverage: [{coverage}]")
+                during = ", ".join(
+                    f"{c2.name}: {c2.validations_during}" for c2 in self.checkers
+                )
+                self.ctx.log.log("stats", f"validations during disruptions: [{during}]")
+
+    def _committed_total(self) -> int:
+        return sum(
+            count
+            for stats in self.worker_stats
+            for (_, key), count in dict(stats).items()
+            if key in ("ok", Outcome.COMMITTED.value)
+        )
+
+    def _check_vacuity(self) -> None:
+        """A run that stopped verifying anything must not pass silently.
+
+        Beyond "verified at least once", every checker and the workers must
+        have made progress in BOTH halves of the chaos phase: a thread that
+        wedges midway would otherwise still pass, and disruptions are capped
+        well below a half, so a healthy run always progresses in each.
+        """
+        committed = self._committed_total()
+        if committed == 0:
+            raise InvariantViolation("vacuous run: no worker op ever committed")
+        for checker in self.checkers:
+            if checker.validations == 0:
+                raise InvariantViolation(
+                    f"vacuous run: checker {checker.name} never verified its"
+                    " invariant"
+                )
+        # Only meaningful at CI-scale runtimes: in short local runs a single
+        # watchdog-bounded hung peek can legitimately eat most of a half.
+        if self._half_marks is not None and self.runtime >= 600:
+            half_validations, half_committed = self._half_marks
+            # Deferred checkers have no first half to compare against, their
+            # coverage is asserted by the vacuity check above.
+            for checker, at_half in zip(self.checkers, half_validations):
+                if self._deferred:
+                    continue
+                if at_half == 0 or checker.validations <= at_half:
+                    raise InvariantViolation(
+                        f"stalled run: checker {checker.name} verified"
+                        f" {at_half} times in the first half but"
+                        f" {checker.validations - at_half} in the second"
+                    )
+            if half_committed == 0 or committed <= half_committed:
+                raise InvariantViolation(
+                    f"stalled run: {half_committed} ops committed in the first"
+                    f" half, {committed - half_committed} in the second"
+                )
+        if self.disruptor is not None and self.disruptor.cycles < 2:
+            raise InvariantViolation(
+                f"vacuous run: only {self.disruptor.cycles} disruption cycles"
+            )
+        if (
+            self.agitator is not None
+            and self.agitator.cancels + self.agitator.flips == 0
+        ):
+            raise InvariantViolation("vacuous run: the agitator never acted")
+
+    def _dump_diagnostics(self) -> None:
+        log = self.ctx.log
+        log.log("phase", "diagnostics")
+        if self.disruptor:
+            for line in self.disruptor.history:
+                log.log("diag", f"disruption: {line}")
+        try:
+            for name, proxy in self.toxiproxy.proxies().items():
+                log.log(
+                    "diag",
+                    f"proxy {name}: enabled={proxy['enabled']}"
+                    f" toxics={proxy['toxics']}",
+                )
+        except Exception as e:
+            log.log("diag", f"toxiproxy state unavailable: {e}")
+        client = MzClient(self.ctx, "diagnostics")
+        for what, sql in [
+            (
+                "source statuses",
+                "SELECT name, status, error FROM mz_internal.mz_source_statuses",
+            ),
+            (
+                "sink statuses",
+                "SELECT name, status, error FROM mz_internal.mz_sink_statuses",
+            ),
+        ]:
+            try:
+                for row in client.query(sql, timeout=30):
+                    log.log("diag", f"{what}: {row}")
+            except Exception as e:
+                log.log("diag", f"{what} unavailable: {e}")
+        try:
+            self.scenario.diagnostics()
+        except Exception as e:
+            log.log("diag", f"scenario diagnostics failed: {e}")
+        client.reset()
+        self._report(final=True)

--- a/misc/python/materialize/invariants/executor.py
+++ b/misc/python/materialize/invariants/executor.py
@@ -24,6 +24,7 @@ import random
 import threading
 import time
 from collections import Counter
+from collections.abc import Callable
 
 from materialize.invariants.framework import (
     SEED_RANGE,
@@ -168,6 +169,7 @@ class Runner:
         processes: list[ProcessTarget] | None = None,
         midrun_event=None,
         restore_proxies: list[Proxy] | None = None,
+        restart_toxiproxy: Callable[[], None] | None = None,
     ) -> None:
         self.scenario = scenario
         self.ctx = scenario.ctx
@@ -177,6 +179,7 @@ class Runner:
         self.processes = processes or []
         self.midrun_event = midrun_event
         self.restore_proxies = restore_proxies
+        self.restart_toxiproxy = restart_toxiproxy
         self.failure: BaseException | None = None
         self._failure_lock = threading.Lock()
         self.worker_stats: list[Counter[tuple[str, str]]] = []
@@ -239,6 +242,7 @@ class Runner:
                 on_error=self.fail,
                 processes=self.processes,
                 restore_proxies=self.restore_proxies,
+                restart_toxiproxy=self.restart_toxiproxy,
             )
             if ctx.complexity.agitation_interval is not None:
                 self.agitator = Agitator(ctx, agitator_rng, self.fail)

--- a/misc/python/materialize/invariants/executor.py
+++ b/misc/python/materialize/invariants/executor.py
@@ -186,6 +186,8 @@ class Runner:
         self.checkers: list[Checker] = []
         self.disruptor: Disruptor | None = None
         self.agitator: Agitator | None = None
+        # Checker threads held back until the version swap, see run().
+        self._deferred: list[threading.Thread] = []
         # Checker validations and committed ops at the chaos midpoint, for
         # the progress assertions.
         self._half_marks: tuple[list[int], int] | None = None
@@ -223,6 +225,10 @@ class Runner:
                 name=f"worker-{i}", target=self._worker_loop, args=(bundle, rng, stats)
             )
             threads.append(thread)
+        # On an --upgrade-from run the checkers only start at the swap, so
+        # nothing is asserted against the older release, and the swap window
+        # itself is still covered.
+        defer = self.midrun_event is not None
         for checker, rng in zip(self.checkers, checker_rngs):
             thread = threading.Thread(
                 name=f"checker-{checker.name}",
@@ -230,6 +236,8 @@ class Runner:
                 args=(checker, rng),
             )
             threads.append(thread)
+            if defer:
+                self._deferred.append(thread)
         if self.legs:
             self.disruptor = Disruptor(
                 api=self.toxiproxy,
@@ -252,9 +260,19 @@ class Runner:
         # The finally clause guarantees heal/stop/join even when the monitor
         # itself fails, so no scenario ever leaves disruptions applied or
         # threads running.
+        if not self._deferred:
+            # Nothing to wait for: the build under test is already serving.
+            ctx.checking.set()
+        else:
+            ctx.log.log(
+                "phase",
+                "chaos: invariants are checked from the version swap on,"
+                " the run starts on the older release",
+            )
         try:
             for thread in threads:
-                thread.start()
+                if thread not in self._deferred:
+                    thread.start()
             if self.disruptor:
                 self.disruptor.start()
             self._monitor()
@@ -295,6 +313,12 @@ class Runner:
                     self._committed_total(),
                 )
                 if self.midrun_event is not None:
+                    # Started before the swap runs, so the transition itself is
+                    # checked: what the new build makes of the old build's
+                    # state is the point of this scenario.
+                    self.ctx.checking.set()
+                    for thread in self._deferred:
+                        thread.start()
                     self.ctx.log.log("phase", "midrun event: upgrade swap")
                     try:
                         self.midrun_event()
@@ -456,7 +480,11 @@ class Runner:
         # watchdog-bounded hung peek can legitimately eat most of a half.
         if self._half_marks is not None and self.runtime >= 600:
             half_validations, half_committed = self._half_marks
+            # Deferred checkers have no first half to compare against, their
+            # coverage is asserted by the vacuity check above.
             for checker, at_half in zip(self.checkers, half_validations):
+                if self._deferred:
+                    continue
                 if at_half == 0 or checker.validations <= at_half:
                     raise InvariantViolation(
                         f"stalled run: checker {checker.name} verified"

--- a/misc/python/materialize/invariants/framework.py
+++ b/misc/python/materialize/invariants/framework.py
@@ -305,6 +305,8 @@ class Endpoints:
     mz_host: str
     mz_port: int
     mz_system_port: int
+    mz_http_port: int | None = None
+    minio_port: int | None = None
     pg_port: int | None = None
     mysql_port: int | None = None
     sqlserver_port: int | None = None

--- a/misc/python/materialize/invariants/framework.py
+++ b/misc/python/materialize/invariants/framework.py
@@ -1,0 +1,391 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Core types of the invariants framework.
+
+The correctness model: every write action is atomic on the system-under-test
+side, so scenario invariants hold whether an individual action applied or
+not. Where per-op bookkeeping is needed, each op resolves to one of three
+outcomes. Only COMMITTED ops create lower bounds ("must be visible"), UNKNOWN
+ops join every upper bound ("may be visible"), FAILED ops must have no
+visible effect. Wrong data is always fatal, while errors and hangs during a
+disruption are tolerated (liveness is verified after healing).
+"""
+
+import random
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections import Counter
+from dataclasses import dataclass, field
+from enum import Enum
+
+SEED_RANGE = 2**31
+
+# Bounded wait for the system to recover and all data paths to converge after
+# all disruptions have been healed. Exceeding it is a liveness failure.
+CONVERGE_TIMEOUT = 300
+
+
+class Outcome(Enum):
+    COMMITTED = "committed"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+class InvariantViolation(AssertionError):
+    """Wrong data or lost/duplicated writes. Always fails the run."""
+
+
+class TransientError(Exception):
+    """Connection loss, timeout, or cancellation, expected during disruptions.
+
+    Loops that hit this skip the current round and retry, they never fail the
+    run. Liveness is enforced separately by the converge phase.
+    """
+
+
+@dataclass(frozen=True)
+class Complexity:
+    name: str
+    workers: int
+    accounts: int
+    # Delay range between two actions of one worker, seconds.
+    op_delay: tuple[float, float]
+    # Calm window between disruption cycles / duration of one disruption.
+    disruption_interval: tuple[float, float]
+    disruption_duration: tuple[float, float]
+    # How many legs one disruption cycle may hit at once.
+    concurrent_disruptions: int
+    # Client-side watchdog for single queries and writes. Not a server
+    # setting: statement_timeout does not bound plain SELECTs, so checkers
+    # cancel hung queries themselves.
+    query_timeout: float
+    # Delay range between agitator ticks (random query cancellations and
+    # system-flag flips), None to disable.
+    agitation_interval: tuple[float, float] | None
+
+
+COMPLEXITIES = {
+    "low": Complexity(
+        name="low",
+        workers=2,
+        accounts=8,
+        op_delay=(0.01, 0.05),
+        disruption_interval=(20.0, 40.0),
+        disruption_duration=(5.0, 15.0),
+        concurrent_disruptions=1,
+        query_timeout=30.0,
+        agitation_interval=(5.0, 15.0),
+    ),
+    "medium": Complexity(
+        name="medium",
+        workers=4,
+        accounts=16,
+        op_delay=(0.005, 0.02),
+        disruption_interval=(15.0, 30.0),
+        disruption_duration=(10.0, 45.0),
+        concurrent_disruptions=1,
+        query_timeout=60.0,
+        agitation_interval=(3.0, 10.0),
+    ),
+    "high": Complexity(
+        name="high",
+        workers=8,
+        accounts=32,
+        op_delay=(0.001, 0.01),
+        disruption_interval=(10.0, 20.0),
+        disruption_duration=(15.0, 90.0),
+        concurrent_disruptions=2,
+        query_timeout=90.0,
+        agitation_interval=(1.0, 5.0),
+    ),
+    # Like high, but with a large account table: persist batches stop being
+    # trivial, so compaction, spills, and the AS OF probes do real work.
+    "large": Complexity(
+        name="large",
+        workers=8,
+        accounts=200_000,
+        op_delay=(0.001, 0.01),
+        disruption_interval=(10.0, 20.0),
+        disruption_duration=(15.0, 90.0),
+        concurrent_disruptions=2,
+        query_timeout=90.0,
+        agitation_interval=(1.0, 5.0),
+    ),
+}
+
+
+class EventLog:
+    """Thread-safe event log, written to a file and selectively echoed.
+
+    High-volume events (individual ops) are sampled, everything else (checker
+    findings, disruptions, phase changes) is logged in full so a failure can
+    be correlated with the active disruptions without rerunning.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._lock = threading.Lock()
+        self._file = open(path, "w")
+        self._start = time.monotonic()
+
+    def log(self, kind: str, message: str, echo: bool = True) -> None:
+        elapsed = time.monotonic() - self._start
+        thread = threading.current_thread().name
+        line = f"{elapsed:9.3f} [{thread}] {kind}: {message}"
+        with self._lock:
+            try:
+                self._file.write(line + "\n")
+                self._file.flush()
+            except ValueError:
+                # A thread that outlived its join deadline may log after
+                # close(). Its message still matters, never raise from here.
+                pass
+            if echo:
+                print(line, flush=True)
+
+    def close(self) -> None:
+        with self._lock:
+            self._file.close()
+
+
+class Watermark:
+    """Thread-safe monotonically increasing value.
+
+    Sampling rule for sound monotonicity checks under concurrency: `get()`
+    BEFORE issuing a read, compare the read's result against that snapshot,
+    `advance()` with the result AFTER the read completed. Strict
+    serializability only orders transactions that do not overlap in real
+    time, so comparing a read against a watermark advanced by a concurrent
+    read would false-positive.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._value = 0
+
+    def get(self) -> int:
+        with self._lock:
+            return self._value
+
+    def advance(self, value: int) -> None:
+        with self._lock:
+            if value > self._value:
+                self._value = value
+
+
+class OpLog:
+    """Ledger of per-op outcomes, keyed by the unique id (worker, seq).
+
+    Sampling rule for sound bounds checks: `committed_count()` (lower bound)
+    must be sampled BEFORE a read is issued, `attempted_count()` (upper
+    bound) AFTER the read result is received.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._outcomes: dict[tuple[int, int], Outcome] = {}
+        self._counts: Counter[Outcome] = Counter()
+
+    def record(self, worker: int, seq: int, outcome: Outcome) -> None:
+        with self._lock:
+            previous = self._outcomes.get((worker, seq))
+            if previous is not None:
+                self._counts[previous] -= 1
+            self._outcomes[(worker, seq)] = outcome
+            self._counts[outcome] += 1
+
+    def committed_count(self) -> int:
+        with self._lock:
+            return self._counts[Outcome.COMMITTED]
+
+    def attempted_count(self) -> int:
+        with self._lock:
+            return self._counts[Outcome.COMMITTED] + self._counts[Outcome.UNKNOWN]
+
+    def seqs(self, worker: int, outcome: Outcome) -> set[int]:
+        with self._lock:
+            return {
+                s
+                for (w, s), o in self._outcomes.items()
+                if w == worker and o == outcome
+            }
+
+    def counts(self) -> dict[Outcome, int]:
+        with self._lock:
+            return dict(self._counts)
+
+
+class Action(ABC):
+    """One kind of write op, executed repeatedly by a worker thread.
+
+    Implementations hold their own resources (connections, producers) and
+    must be safe to call from exactly one thread. `run` reports per-op
+    outcomes to the scenario's OpLog where bookkeeping is needed and raises
+    TransientError for expected connection trouble. Any other exception fails
+    the run.
+    """
+
+    name: str
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+
+    @abstractmethod
+    def run(self) -> Outcome | None:
+        """Execute one op. Returns the outcome, or None if not applicable."""
+
+    def close(self) -> None:
+        pass
+
+
+@dataclass
+class WorkerBundle:
+    """The weighted actions of one worker thread plus shared resources."""
+
+    actions: list[Action]
+    weights: list[int]
+
+    def close(self) -> None:
+        for action in self.actions:
+            action.close()
+
+
+class Checker(ABC):
+    """Continuously verifies one invariant on its own thread.
+
+    `check_once` raises InvariantViolation on wrong data (fatal) and
+    TransientError when the system is unreachable (skipped round). The
+    executor calls `open` lazily and retries it after transient errors, so
+    checkers keep working across disruptions by reconnecting.
+    """
+
+    name: str
+    # Delay range between two check rounds, seconds.
+    pause: tuple[float, float] = (0.5, 2.0)
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+        self.rounds = 0
+        self.skipped = 0
+        # How often an invariant was actually verified. Rounds alone can be
+        # vacuous, e.g. a SUBSCRIBE session that dies before its first
+        # validatable boundary still completes rounds.
+        self.validations = 0
+        # The subset of validations that completed while a disruption was
+        # actively applied.
+        self.validations_during = 0
+
+    def open(self) -> None:
+        pass
+
+    @abstractmethod
+    def check_once(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+@dataclass(frozen=True)
+class Endpoints:
+    """Host-side connection info for the system under test and its oracles.
+
+    The harness always connects directly (host-mapped ports), bypassing
+    toxiproxy: disruptions target Materialize's connections, never the
+    oracle's view of the external systems.
+    """
+
+    mz_host: str
+    mz_port: int
+    mz_system_port: int
+    pg_port: int | None = None
+    mysql_port: int | None = None
+    sqlserver_port: int | None = None
+    kafka_bootstrap: str | None = None
+
+
+@dataclass
+class ScenarioContext:
+    endpoints: Endpoints
+    complexity: Complexity
+    rng: random.Random
+    log: EventLog
+    seed: str
+    stop: threading.Event = field(default_factory=threading.Event)
+    # All MzClients ever created, so the shutdown ladder can unblock
+    # stragglers by cancelling/closing their connections cross-thread.
+    clients: list = field(default_factory=list)
+
+
+class Scenario(ABC):
+    """A self-contained workload with invariants that hold under disruption.
+
+    Lifecycle: setup() -> worker/checker/disruptor threads run for the chaos
+    phase -> all disruptions healed, workers stopped -> converge() (bounded
+    liveness check) -> final_check() (strong assertions using the OpLog).
+    """
+
+    name: str
+    # Extra mzcompose services to bring up, e.g. ["postgres"].
+    services: list[str] = []
+    # Toxiproxy legs this scenario disrupts, by leg name.
+    legs: list[str] = []
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        self.ctx = ctx
+
+    @abstractmethod
+    def setup(self) -> None:
+        pass
+
+    @abstractmethod
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        pass
+
+    @abstractmethod
+    def checkers(self) -> list[Checker]:
+        pass
+
+    @abstractmethod
+    def converge(self) -> None:
+        """Wait (bounded) until all data paths caught up after healing."""
+
+    @abstractmethod
+    def final_check(self) -> None:
+        pass
+
+    def diagnostics(self) -> None:
+        """Best-effort post-failure state dump, called after healing."""
+
+    def teardown(self) -> None:
+        pass
+
+
+def wait_until(
+    condition, timeout: float, description: str, interval: float = 1.0
+) -> None:
+    """Poll `condition` until it returns True, tolerating TransientErrors.
+
+    Raises InvariantViolation on timeout: after healing, the system is
+    expected to recover, so failing to converge is a liveness bug.
+    """
+    deadline = time.monotonic() + timeout
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            if condition():
+                return
+        except TransientError as e:
+            last_error = e
+        time.sleep(interval)
+    raise InvariantViolation(
+        f"liveness: {description} did not converge within {timeout}s"
+        + (f" (last transient error: {last_error})" if last_error else "")
+    )

--- a/misc/python/materialize/invariants/framework.py
+++ b/misc/python/materialize/invariants/framework.py
@@ -1,0 +1,444 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Core types of the invariants framework.
+
+The correctness model: every write action is atomic on the system-under-test
+side, so scenario invariants hold whether an individual action applied or
+not. Where per-op bookkeeping is needed, each op resolves to one of three
+outcomes. Only COMMITTED ops create lower bounds ("must be visible"), UNKNOWN
+ops join every upper bound ("may be visible"), FAILED ops must have no
+visible effect. Wrong data is always fatal, while errors and hangs during a
+disruption are tolerated (liveness is verified after healing).
+"""
+
+import random
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+
+SEED_RANGE = 2**31
+
+# Bounded wait for the system to recover and all data paths to converge after
+# all disruptions have been healed. Exceeding it is a liveness failure.
+CONVERGE_TIMEOUT = 300
+
+
+class Outcome(Enum):
+    COMMITTED = "committed"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+class InvariantViolation(AssertionError):
+    """Wrong data or lost/duplicated writes. Always fails the run."""
+
+
+class TransientError(Exception):
+    """Connection loss, timeout, or cancellation, expected during disruptions.
+
+    Loops that hit this skip the current round and retry, they never fail the
+    run. Liveness is enforced separately by the converge phase.
+    """
+
+
+@dataclass(frozen=True)
+class Complexity:
+    name: str
+    workers: int
+    accounts: int
+    # Delay range between two actions of one worker, seconds.
+    op_delay: tuple[float, float]
+    # Calm window between disruption cycles / duration of one disruption.
+    disruption_interval: tuple[float, float]
+    disruption_duration: tuple[float, float]
+    # How many legs one disruption cycle may hit at once.
+    concurrent_disruptions: int
+    # Client-side watchdog for single queries and writes. Not a server
+    # setting: statement_timeout does not bound plain SELECTs, so checkers
+    # cancel hung queries themselves.
+    query_timeout: float
+    # Delay range between agitator ticks (random query cancellations and
+    # system-flag flips), None to disable.
+    agitation_interval: tuple[float, float] | None
+
+
+COMPLEXITIES = {
+    "low": Complexity(
+        name="low",
+        workers=2,
+        accounts=8,
+        op_delay=(0.01, 0.05),
+        disruption_interval=(20.0, 40.0),
+        disruption_duration=(5.0, 15.0),
+        concurrent_disruptions=1,
+        query_timeout=30.0,
+        agitation_interval=(5.0, 15.0),
+    ),
+    "medium": Complexity(
+        name="medium",
+        workers=4,
+        accounts=16,
+        op_delay=(0.005, 0.02),
+        disruption_interval=(15.0, 30.0),
+        disruption_duration=(10.0, 45.0),
+        concurrent_disruptions=1,
+        query_timeout=60.0,
+        agitation_interval=(3.0, 10.0),
+    ),
+    # Nightly's default. Sized against the measured skipped-round rate: a
+    # checker that cannot get an answer during an outage skips, and at these
+    # settings the scenarios lose 10-20% of their rounds that way, which
+    # leaves headroom for the disruptions to be this frequent.
+    "high": Complexity(
+        name="high",
+        workers=12,
+        accounts=32,
+        op_delay=(0.001, 0.01),
+        disruption_interval=(6.0, 14.0),
+        disruption_duration=(15.0, 90.0),
+        concurrent_disruptions=3,
+        query_timeout=90.0,
+        agitation_interval=(1.0, 5.0),
+    ),
+    # Like high, but with a large account table: persist batches stop being
+    # trivial, so compaction, spills, and the AS OF probes do real work.
+    "large": Complexity(
+        name="large",
+        workers=12,
+        accounts=200_000,
+        op_delay=(0.001, 0.01),
+        disruption_interval=(6.0, 14.0),
+        disruption_duration=(15.0, 90.0),
+        concurrent_disruptions=3,
+        query_timeout=90.0,
+        agitation_interval=(1.0, 5.0),
+    ),
+}
+
+
+class EventLog:
+    """Thread-safe event log, written to a file and selectively echoed.
+
+    High-volume events (individual ops) are sampled, everything else (checker
+    findings, disruptions, phase changes) is logged in full so a failure can
+    be correlated with the active disruptions without rerunning.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._lock = threading.Lock()
+        self._file = open(path, "w")
+        self._start = time.monotonic()
+
+    def log(self, kind: str, message: str, echo: bool = True) -> None:
+        elapsed = time.monotonic() - self._start
+        thread = threading.current_thread().name
+        line = f"{elapsed:9.3f} [{thread}] {kind}: {message}"
+        with self._lock:
+            try:
+                self._file.write(line + "\n")
+                self._file.flush()
+            except ValueError:
+                # A thread that outlived its join deadline may log after
+                # close(). Its message still matters, never raise from here.
+                pass
+            if echo:
+                print(line, flush=True)
+
+    def close(self) -> None:
+        with self._lock:
+            self._file.close()
+
+
+class Watermark:
+    """Thread-safe monotonically increasing value.
+
+    Sampling rule for sound monotonicity checks under concurrency: `get()`
+    BEFORE issuing a read, compare the read's result against that snapshot,
+    `advance()` with the result AFTER the read completed. Strict
+    serializability only orders transactions that do not overlap in real
+    time, so comparing a read against a watermark advanced by a concurrent
+    read would false-positive.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._value = 0
+
+    def get(self) -> int:
+        with self._lock:
+            return self._value
+
+    def advance(self, value: int) -> None:
+        with self._lock:
+            if value > self._value:
+                self._value = value
+
+
+class OpLog:
+    """Ledger of per-op outcomes, keyed by the unique id (worker, seq).
+
+    Sampling rule for sound bounds checks: `committed_count()` (lower bound)
+    must be sampled BEFORE a read is issued, `attempted_count()` (upper
+    bound) AFTER the read result is received.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._outcomes: dict[tuple[int, int], Outcome] = {}
+        self._counts: Counter[Outcome] = Counter()
+        # Per worker, so a checker's lookups cost its own worker's ops rather
+        # than every op the run ever issued. Checkers query this on the hot
+        # path, holding the same lock every writer needs.
+        self._by_worker: dict[int, dict[int, Outcome]] = {}
+
+    def record(self, worker: int, seq: int, outcome: Outcome) -> None:
+        with self._lock:
+            previous = self._outcomes.get((worker, seq))
+            if previous is not None:
+                self._counts[previous] -= 1
+            self._outcomes[(worker, seq)] = outcome
+            self._counts[outcome] += 1
+            self._by_worker.setdefault(worker, {})[seq] = outcome
+
+    def committed_count(self) -> int:
+        with self._lock:
+            return self._counts[Outcome.COMMITTED]
+
+    def attempted_count(self) -> int:
+        with self._lock:
+            return self._counts[Outcome.COMMITTED] + self._counts[Outcome.UNKNOWN]
+
+    def seqs(self, worker: int, outcome: Outcome) -> set[int]:
+        with self._lock:
+            return {
+                s for s, o in self._by_worker.get(worker, {}).items() if o == outcome
+            }
+
+    def issued(self, worker: int) -> set[int]:
+        """Every op of this worker that may exist, in one snapshot.
+
+        Sampling COMMITTED and UNKNOWN separately is not sound: an op that
+        moves from UNKNOWN to COMMITTED between the two reads is in neither
+        result, and a check for rows that were never issued then reports it.
+        """
+        with self._lock:
+            return {
+                s
+                for s, o in self._by_worker.get(worker, {}).items()
+                if o in (Outcome.COMMITTED, Outcome.UNKNOWN)
+            }
+
+    def was_issued(self, worker: int, seq: int) -> bool:
+        """Whether this op may exist, without materializing a set.
+
+        The change-stream checkers ask per row, so building a set per question
+        would cost the whole worker's history each time.
+        """
+        with self._lock:
+            return self._by_worker.get(worker, {}).get(seq) in (
+                Outcome.COMMITTED,
+                Outcome.UNKNOWN,
+            )
+
+    def counts(self) -> dict[Outcome, int]:
+        with self._lock:
+            return dict(self._counts)
+
+
+class Action(ABC):
+    """One kind of write op, executed repeatedly by a worker thread.
+
+    Implementations hold their own resources (connections, producers) and
+    must be safe to call from exactly one thread. `run` reports per-op
+    outcomes to the scenario's OpLog where bookkeeping is needed and raises
+    TransientError for expected connection trouble. Any other exception fails
+    the run.
+    """
+
+    name: str
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+
+    @abstractmethod
+    def run(self) -> Outcome | None:
+        """Execute one op. Returns the outcome, or None if not applicable."""
+
+    def close(self) -> None:
+        pass
+
+
+@dataclass
+class WorkerBundle:
+    """The weighted actions of one worker thread plus shared resources."""
+
+    actions: list[Action]
+    weights: list[int]
+
+    def close(self) -> None:
+        for action in self.actions:
+            action.close()
+
+
+class Checker(ABC):
+    """Continuously verifies one invariant on its own thread.
+
+    `check_once` raises InvariantViolation on wrong data (fatal) and
+    TransientError when the system is unreachable (skipped round). The
+    executor calls `open` lazily and retries it after transient errors, so
+    checkers keep working across disruptions by reconnecting.
+    """
+
+    name: str
+    # Delay range between two check rounds, seconds.
+    pause: tuple[float, float] = (0.5, 2.0)
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+        self.rounds = 0
+        self.skipped = 0
+        # How often an invariant was actually verified. Rounds alone can be
+        # vacuous, e.g. a SUBSCRIBE session that dies before its first
+        # validatable boundary still completes rounds.
+        self.validations = 0
+        # The subset of validations that completed while a disruption was
+        # actively applied.
+        self.validations_during = 0
+
+    def open(self) -> None:
+        pass
+
+    @abstractmethod
+    def check_once(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+@dataclass(frozen=True)
+class Endpoints:
+    """Host-side connection info for the system under test and its oracles.
+
+    The harness always connects directly (host-mapped ports), bypassing
+    toxiproxy: disruptions target Materialize's connections, never the
+    oracle's view of the external systems.
+    """
+
+    mz_host: str
+    mz_port: int
+    mz_system_port: int
+    mz_http_port: int | None = None
+    minio_port: int | None = None
+    pg_port: int | None = None
+    mysql_port: int | None = None
+    sqlserver_port: int | None = None
+    kafka_bootstrap: str | None = None
+
+
+@dataclass
+class ScenarioContext:
+    endpoints: Endpoints
+    complexity: Complexity
+    rng: random.Random
+    log: EventLog
+    seed: str
+    stop: threading.Event = field(default_factory=threading.Event)
+    # Set once the build under test is the one serving. An --upgrade-from run
+    # starts on an older release, and asserting there only rediscovers bugs
+    # that release already has, so nothing checks invariants until the swap.
+    # Set from the start for every other run.
+    checking: threading.Event = field(default_factory=threading.Event)
+    # All MzClients ever created, so the shutdown ladder can unblock
+    # stragglers by cancelling/closing their connections cross-thread.
+    clients: list = field(default_factory=list)
+    # Ask for a disruption right now, naming the state being entered. Actions
+    # call this when they are about to do something worth cutting through,
+    # since only the workload knows when it is inside such a moment. A no-op
+    # when nothing is being disrupted, and rate limited by the disruptor, so
+    # callers may invoke it freely.
+    request_disruption: Callable[[str], None] = lambda reason: None
+
+
+class Scenario(ABC):
+    """A self-contained workload with invariants that hold under disruption.
+
+    Lifecycle: setup() -> worker/checker/disruptor threads run for the chaos
+    phase -> all disruptions healed, workers stopped -> converge() (bounded
+    liveness check) -> final_check() (strong assertions using the OpLog).
+    """
+
+    name: str
+    # Extra mzcompose services to bring up, e.g. ["postgres"].
+    services: list[str] = []
+    # Toxiproxy legs this scenario disrupts, by leg name.
+    legs: list[str] = []
+    # Cap on concurrent writers, below the complexity's worker count. For
+    # scenarios whose write path is bounded by something outside Materialize:
+    # more writers than the upstream can absorb only moves the bottleneck out
+    # of the system under test, and leaves a backlog the converge phase then
+    # has to drain.
+    max_workers: int | None = None
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        self.ctx = ctx
+
+    @abstractmethod
+    def setup(self) -> None:
+        pass
+
+    @abstractmethod
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        pass
+
+    @abstractmethod
+    def checkers(self) -> list[Checker]:
+        pass
+
+    @abstractmethod
+    def converge(self) -> None:
+        """Wait (bounded) until all data paths caught up after healing."""
+
+    @abstractmethod
+    def final_check(self) -> None:
+        pass
+
+    def diagnostics(self) -> None:
+        """Best-effort post-failure state dump, called after healing."""
+
+    def teardown(self) -> None:
+        pass
+
+
+def wait_until(
+    condition, timeout: float, description: str, interval: float = 1.0
+) -> None:
+    """Poll `condition` until it returns True, tolerating TransientErrors.
+
+    Raises InvariantViolation on timeout: after healing, the system is
+    expected to recover, so failing to converge is a liveness bug.
+    """
+    deadline = time.monotonic() + timeout
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            if condition():
+                return
+        except TransientError as e:
+            last_error = e
+        time.sleep(interval)
+    raise InvariantViolation(
+        f"liveness: {description} did not converge within {timeout}s"
+        + (f" (last transient error: {last_error})" if last_error else "")
+    )

--- a/misc/python/materialize/invariants/framework.py
+++ b/misc/python/materialize/invariants/framework.py
@@ -192,6 +192,10 @@ class OpLog:
         self._lock = threading.Lock()
         self._outcomes: dict[tuple[int, int], Outcome] = {}
         self._counts: Counter[Outcome] = Counter()
+        # Per worker, so a checker's lookups cost its own worker's ops rather
+        # than every op the run ever issued. Checkers query this on the hot
+        # path, holding the same lock every writer needs.
+        self._by_worker: dict[int, dict[int, Outcome]] = {}
 
     def record(self, worker: int, seq: int, outcome: Outcome) -> None:
         with self._lock:
@@ -200,6 +204,7 @@ class OpLog:
                 self._counts[previous] -= 1
             self._outcomes[(worker, seq)] = outcome
             self._counts[outcome] += 1
+            self._by_worker.setdefault(worker, {})[seq] = outcome
 
     def committed_count(self) -> int:
         with self._lock:
@@ -212,10 +217,34 @@ class OpLog:
     def seqs(self, worker: int, outcome: Outcome) -> set[int]:
         with self._lock:
             return {
-                s
-                for (w, s), o in self._outcomes.items()
-                if w == worker and o == outcome
+                s for s, o in self._by_worker.get(worker, {}).items() if o == outcome
             }
+
+    def issued(self, worker: int) -> set[int]:
+        """Every op of this worker that may exist, in one snapshot.
+
+        Sampling COMMITTED and UNKNOWN separately is not sound: an op that
+        moves from UNKNOWN to COMMITTED between the two reads is in neither
+        result, and a check for rows that were never issued then reports it.
+        """
+        with self._lock:
+            return {
+                s
+                for s, o in self._by_worker.get(worker, {}).items()
+                if o in (Outcome.COMMITTED, Outcome.UNKNOWN)
+            }
+
+    def was_issued(self, worker: int, seq: int) -> bool:
+        """Whether this op may exist, without materializing a set.
+
+        The change-stream checkers ask per row, so building a set per question
+        would cost the whole worker's history each time.
+        """
+        with self._lock:
+            return self._by_worker.get(worker, {}).get(seq) in (
+                Outcome.COMMITTED,
+                Outcome.UNKNOWN,
+            )
 
     def counts(self) -> dict[Outcome, int]:
         with self._lock:
@@ -321,6 +350,11 @@ class ScenarioContext:
     log: EventLog
     seed: str
     stop: threading.Event = field(default_factory=threading.Event)
+    # Set once the build under test is the one serving. An --upgrade-from run
+    # starts on an older release, and asserting there only rediscovers bugs
+    # that release already has, so nothing checks invariants until the swap.
+    # Set from the start for every other run.
+    checking: threading.Event = field(default_factory=threading.Event)
     # All MzClients ever created, so the shutdown ladder can unblock
     # stragglers by cancelling/closing their connections cross-thread.
     clients: list = field(default_factory=list)

--- a/misc/python/materialize/invariants/mz.py
+++ b/misc/python/materialize/invariants/mz.py
@@ -26,7 +26,7 @@ import time
 from typing import Any
 
 import psycopg
-from psycopg.errors import QueryCanceled
+from psycopg.errors import QueryCanceled, SerializationFailure
 
 from materialize.invariants.framework import (
     Outcome,
@@ -196,9 +196,68 @@ class MzClient:
                 raise
             if isinstance(e, QueryCanceled) or _is_connection_error(e):
                 raise TransientError(f"{type(e).__name__}: {e}") from e
+            if isinstance(e, SerializationFailure):
+                # SQLSTATE 40001, the documented retryable class, e.g. a
+                # bounded staleness read with no readable timestamp in bound.
+                raise TransientError(f"{type(e).__name__}: {e}") from e
             if any(snippet in str(e) for snippet in CONCURRENT_DDL_ERROR_SNIPPETS):
                 raise TransientError(f"{type(e).__name__}: {e}") from e
             raise UnexpectedQueryError(f"query failed: {sql[:200]}: {e}") from e
+
+    def copy_out(self, sql: str, timeout: float | None = None) -> list[tuple[str, ...]]:
+        """Run `COPY (..) TO STDOUT` and return the tab-split text rows.
+
+        Same error classification as query().
+        """
+        conn = self._connect()
+        with self._lock:
+            self._deadline = time.monotonic() + (timeout or self.default_timeout)
+        try:
+            rows = []
+            with conn.cursor() as cur, cur.copy(sql.encode()) as copy:
+                for row in copy.rows():
+                    rows.append(tuple("" if c is None else str(c) for c in row))
+            return rows
+        except Exception as e:
+            self.reset()
+            if isinstance(
+                e, QueryCanceled | SerializationFailure
+            ) or _is_connection_error(e):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            if any(snippet in str(e) for snippet in CONCURRENT_DDL_ERROR_SNIPPETS):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            raise UnexpectedQueryError(f"copy out failed: {sql[:200]}: {e}") from e
+        finally:
+            with self._lock:
+                self._deadline = None
+
+    def copy_in(self, sql: str, data: str, timeout: float | None = None) -> Outcome:
+        """Run `COPY .. FROM STDIN`, feed `data`, and classify the outcome.
+
+        A COPY is a single statement, so it applies atomically. Cancellation
+        or connection loss leaves the outcome UNKNOWN. A definite server
+        rejection surfaces as UnexpectedQueryError, since none of our
+        fixed-shape COPYs have a legitimate reason to be rejected.
+        """
+        try:
+            conn = self._connect()
+            with self._lock:
+                self._deadline = time.monotonic() + (timeout or self.default_timeout)
+            with conn.cursor() as cur, cur.copy(sql.encode()) as copy:
+                copy.write(data)
+            return Outcome.COMMITTED
+        except TransientError:
+            return Outcome.UNKNOWN
+        except Exception as e:
+            self.reset()
+            if isinstance(e, QueryCanceled) or "canceling statement due to" in str(e):
+                return Outcome.UNKNOWN
+            if _is_connection_error(e):
+                return Outcome.UNKNOWN
+            raise UnexpectedQueryError(f"copy in rejected: {sql[:200]}: {e}") from e
+        finally:
+            with self._lock:
+                self._deadline = None
 
     def write(
         self, sql: str, params: Any = None, timeout: float | None = None

--- a/misc/python/materialize/invariants/mz.py
+++ b/misc/python/materialize/invariants/mz.py
@@ -1,0 +1,251 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""SQL client for the system under test with bounded, classified operations.
+
+Every query and write is bounded by a client-side watchdog that cancels the
+statement server-side: statement_timeout does not bound plain SELECTs, and
+during a metadata-store outage even writes block in group commit, so without
+this no thread would be guaranteed to terminate.
+
+Outcome contract for writes: COMMITTED only on a success reply. FAILED only
+when the server definitely did not apply the write (an error reply to a
+single autocommit statement, or any failure strictly before COMMIT was
+submitted in an explicit transaction). Everything else (cancellation,
+connection loss, timeout) is UNKNOWN.
+"""
+
+import threading
+import time
+from typing import Any
+
+import psycopg
+from psycopg.errors import QueryCanceled
+
+from materialize.invariants.framework import (
+    Outcome,
+    ScenarioContext,
+    TransientError,
+)
+
+# Reads racing concurrent DDL legitimately error, e.g. when a peek planned
+# against an index that the DDL churn dropped mid-flight. The data is never
+# wrong, the checker round is just skipped.
+CONCURRENT_DDL_ERROR_SNIPPETS = [
+    "was dropped",
+    "unknown catalog item",
+    "is not readable at any timestamp",
+]
+
+# Substrings of psycopg error messages that indicate the connection (not the
+# statement) failed. Mirrors parallel-workload's classification.
+CONNECTION_ERROR_SNIPPETS = [
+    "server closed the connection unexpectedly",
+    "Can't create a connection to host",
+    "Connection refused",
+    "connection timeout expired",
+    "the connection is lost",
+    "connection is closed",
+    "EOF detected",
+    "connection failed",
+    "consuming input failed",
+    "terminating connection",
+    "current transaction is aborted",
+]
+
+
+class UnexpectedQueryError(Exception):
+    """A definite server error we did not expect. Fails the run."""
+
+
+def _is_connection_error(e: Exception) -> bool:
+    if isinstance(e, psycopg.OperationalError):
+        return True
+    msg = str(e)
+    return any(snippet in msg for snippet in CONNECTION_ERROR_SNIPPETS)
+
+
+class _Watchdog(threading.Thread):
+    """Cancels its client's running statement once the deadline passes.
+
+    One persistent daemon thread per client instead of a timer per query,
+    since workers issue hundreds of ops per second. Daemon so it never blocks
+    process exit.
+    """
+
+    def __init__(self, client: "MzClient") -> None:
+        super().__init__(name=f"watchdog-{client.name}", daemon=True)
+        self.client = client
+
+    def run(self) -> None:
+        while True:
+            time.sleep(0.5)
+            self.client.maybe_cancel()
+
+
+class MzClient:
+    """One psycopg connection to Materialize, owned by a single thread.
+
+    Reconnects lazily. Any transient failure drops the connection so the next
+    use starts from a clean slate (no half-open transactions).
+    """
+
+    def __init__(
+        self,
+        ctx: ScenarioContext,
+        name: str,
+        user: str = "materialize",
+        database: str = "materialize",
+        port: int | None = None,
+    ) -> None:
+        self.host = ctx.endpoints.mz_host
+        self.port = port if port is not None else ctx.endpoints.mz_port
+        self.user = user
+        self.database = database
+        self.name = name
+        self.log = ctx.log
+        self.default_timeout = ctx.complexity.query_timeout
+        self._conn: psycopg.Connection | None = None
+        self._lock = threading.Lock()
+        self._deadline: float | None = None
+        ctx.clients.append(self)
+        _Watchdog(self).start()
+
+    def _connect(self) -> psycopg.Connection:
+        if self._conn is None or self._conn.closed:
+            try:
+                conn = psycopg.connect(
+                    host=self.host,
+                    port=self.port,
+                    user=self.user,
+                    dbname=self.database,
+                    connect_timeout=10,
+                    autocommit=True,
+                )
+            except Exception as e:
+                raise TransientError(f"connect failed: {e}") from e
+            with self._lock:
+                self._conn = conn
+        return self._conn
+
+    def reset(self) -> None:
+        with self._lock:
+            conn, self._conn = self._conn, None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def hard_close(self) -> None:
+        """Cross-thread escape hatch used by the shutdown ladder."""
+        self.maybe_cancel(force=True)
+        self.reset()
+
+    def maybe_cancel(self, force: bool = False) -> None:
+        with self._lock:
+            conn = self._conn
+            due = force or (
+                self._deadline is not None and time.monotonic() > self._deadline
+            )
+            if due:
+                self._deadline = None
+        if conn is None or not due:
+            return
+        try:
+            conn.cancel_safe(timeout=5.0)
+        except Exception:
+            # Cancellation itself needs a working network path. Cutting the
+            # connection is the fallback that always unblocks the owner.
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def _bounded(self, sql: str, params: Any, timeout: float | None) -> list[tuple]:
+        """Execute with the watchdog armed. Raises psycopg errors verbatim."""
+        conn = self._connect()
+        with self._lock:
+            self._deadline = time.monotonic() + (timeout or self.default_timeout)
+        try:
+            cur = conn.execute(sql.encode(), params)
+            return cur.fetchall() if cur.description is not None else []
+        finally:
+            with self._lock:
+                self._deadline = None
+
+    def query(
+        self, sql: str, params: Any = None, timeout: float | None = None
+    ) -> list[tuple]:
+        """Run a read (or session command). Transient trouble drops the conn.
+
+        Raises TransientError on connection loss, cancellation, or timeout,
+        and UnexpectedQueryError on any other server error.
+        """
+        try:
+            return self._bounded(sql, params, timeout)
+        except Exception as e:
+            self.reset()
+            if isinstance(e, TransientError):
+                raise
+            if isinstance(e, QueryCanceled) or _is_connection_error(e):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            if any(snippet in str(e) for snippet in CONCURRENT_DDL_ERROR_SNIPPETS):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            raise UnexpectedQueryError(f"query failed: {sql[:200]}: {e}") from e
+
+    def write(
+        self, sql: str, params: Any = None, timeout: float | None = None
+    ) -> Outcome:
+        """Run one autocommit write statement and classify its outcome."""
+        try:
+            self._bounded(sql, params, timeout)
+            return Outcome.COMMITTED
+        except TransientError:
+            self.reset()
+            return Outcome.UNKNOWN
+        except Exception as e:
+            self.reset()
+            if isinstance(e, QueryCanceled) or "canceling statement due to" in str(e):
+                return Outcome.UNKNOWN
+            if _is_connection_error(e):
+                return Outcome.UNKNOWN
+            # A definite server error reply: the statement was not applied.
+            # We still surface it, since none of our fixed-shape writes have
+            # a legitimate reason to be rejected.
+            raise UnexpectedQueryError(f"write rejected: {sql[:200]}: {e}") from e
+
+    def write_txn(
+        self, statements: list[tuple[str, Any]], timeout: float | None = None
+    ) -> Outcome:
+        """Run BEGIN; <statements>; COMMIT and classify the outcome.
+
+        FAILED is only sound before COMMIT is submitted: Materialize buffers
+        INSERT-only transactions until commit, so any earlier failure means
+        no effect. Once COMMIT is on the wire, any non-success is UNKNOWN.
+        """
+        try:
+            self._bounded("BEGIN", None, timeout)
+            for sql, params in statements:
+                self._bounded(sql, params, timeout)
+        except Exception as e:
+            try:
+                self._bounded("ROLLBACK", None, 10.0)
+            except Exception:
+                self.reset()
+            if isinstance(e, TransientError | QueryCanceled) or _is_connection_error(e):
+                return Outcome.FAILED
+            self.reset()
+            raise UnexpectedQueryError(f"txn statement rejected: {e}") from e
+        try:
+            self._bounded("COMMIT", None, timeout)
+            return Outcome.COMMITTED
+        except Exception:
+            self.reset()
+            return Outcome.UNKNOWN

--- a/misc/python/materialize/invariants/mz.py
+++ b/misc/python/materialize/invariants/mz.py
@@ -35,12 +35,15 @@ from materialize.invariants.framework import (
 )
 
 # Reads racing concurrent DDL legitimately error, e.g. when a peek planned
-# against an index that the DDL churn dropped mid-flight. The data is never
-# wrong, the checker round is just skipped.
+# against an index that the DDL churn dropped mid-flight, or when the second
+# statement of a read-only transaction plans against an index created after
+# the transaction pinned its timedomain. The data is never wrong, the
+# checker round is just skipped.
 CONCURRENT_DDL_ERROR_SNIPPETS = [
     "was dropped",
     "unknown catalog item",
     "is not readable at any timestamp",
+    "same timedomain",
 ]
 
 # Substrings of psycopg error messages that indicate the connection (not the
@@ -52,6 +55,7 @@ CONNECTION_ERROR_SNIPPETS = [
     "connection timeout expired",
     "the connection is lost",
     "connection is closed",
+    "connection closed",
     "EOF detected",
     "connection failed",
     "consuming input failed",
@@ -253,6 +257,13 @@ class MzClient:
             if isinstance(e, QueryCanceled) or "canceling statement due to" in str(e):
                 return Outcome.UNKNOWN
             if _is_connection_error(e):
+                return Outcome.UNKNOWN
+            if not isinstance(e, psycopg.Error):
+                # psycopg's COPY teardown surfaces client-side artifacts
+                # (e.g. ValueError "too many values to unpack") when the
+                # watchdog cancels mid-COPY. No success reply arrived, so
+                # the outcome is unknown. Only definite server rejections
+                # (psycopg.Error with an error response) stay fatal.
                 return Outcome.UNKNOWN
             raise UnexpectedQueryError(f"copy in rejected: {sql[:200]}: {e}") from e
         finally:

--- a/misc/python/materialize/invariants/mz.py
+++ b/misc/python/materialize/invariants/mz.py
@@ -115,6 +115,7 @@ class MzClient:
         self.user = user
         self.database = database
         self.name = name
+        self.ctx = ctx
         self.log = ctx.log
         self.default_timeout = ctx.complexity.query_timeout
         self._conn: psycopg.Connection | None = None

--- a/misc/python/materialize/invariants/mz.py
+++ b/misc/python/materialize/invariants/mz.py
@@ -34,11 +34,13 @@ from materialize.invariants.framework import (
     TransientError,
 )
 
-# Reads racing concurrent DDL legitimately error, e.g. when a peek planned
-# against an index that the DDL churn dropped mid-flight, or when the second
+# Statements racing concurrent DDL legitimately error, e.g. when a peek planned
+# against an index that the DDL churn dropped mid-flight, when the second
 # statement of a read-only transaction plans against an index created after
-# the transaction pinned its timedomain. The data is never wrong, the
-# checker round is just skipped.
+# the transaction pinned its timedomain, or when a DDL resolved a name to an
+# item that another DDL retired before the plan was installed. The data is
+# never wrong, the checker round is just skipped and the write counts as
+# rejected.
 CONCURRENT_DDL_ERROR_SNIPPETS = [
     "was dropped",
     "unknown catalog item",
@@ -286,9 +288,18 @@ class MzClient:
                 return Outcome.UNKNOWN
             if _is_connection_error(e):
                 return Outcome.UNKNOWN
+            if any(snippet in str(e) for snippet in CONCURRENT_DDL_ERROR_SNIPPETS):
+                # DDL racing DDL: a name resolved to an item that another
+                # action retired before this plan was installed, e.g. an index
+                # on the total MV while a replacement is applied to it. The
+                # coordinator rejects such a plan before its catalog
+                # transaction, so the statement definitely did not apply.
+                # Data writes cannot reach here, their tables are never
+                # dropped.
+                return Outcome.FAILED
             # A definite server error reply: the statement was not applied.
-            # We still surface it, since none of our fixed-shape writes have
-            # a legitimate reason to be rejected.
+            # We still surface it, since none of our other fixed-shape writes
+            # have a legitimate reason to be rejected.
             raise UnexpectedQueryError(f"write rejected: {sql[:200]}: {e}") from e
 
     def write_txn(

--- a/misc/python/materialize/invariants/mz.py
+++ b/misc/python/materialize/invariants/mz.py
@@ -1,0 +1,355 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""SQL client for the system under test with bounded, classified operations.
+
+Every query and write is bounded by a client-side watchdog that cancels the
+statement server-side: statement_timeout does not bound plain SELECTs, and
+during a metadata-store outage even writes block in group commit, so without
+this no thread would be guaranteed to terminate.
+
+Outcome contract for writes: COMMITTED only on a success reply. FAILED only
+when the server definitely did not apply the write (an error reply to a
+single autocommit statement, or any failure strictly before COMMIT was
+submitted in an explicit transaction). Everything else (cancellation,
+connection loss, timeout) is UNKNOWN.
+"""
+
+import threading
+import time
+from typing import Any
+
+import psycopg
+from psycopg.errors import QueryCanceled, SerializationFailure
+
+from materialize.invariants.framework import (
+    Outcome,
+    ScenarioContext,
+    TransientError,
+)
+
+# Statements racing concurrent DDL legitimately error, e.g. when a peek planned
+# against an index that the DDL churn dropped mid-flight, when the second
+# statement of a read-only transaction plans against an index created after
+# the transaction pinned its timedomain, or when a DDL resolved a name to an
+# item that another DDL retired before the plan was installed. The data is
+# never wrong, the checker round is just skipped and the write counts as
+# rejected.
+CONCURRENT_DDL_ERROR_SNIPPETS = [
+    "was dropped",
+    "unknown catalog item",
+    "is not readable at any timestamp",
+    "same timedomain",
+]
+
+# Substrings of psycopg error messages that indicate the connection (not the
+# statement) failed. Mirrors parallel-workload's classification.
+CONNECTION_ERROR_SNIPPETS = [
+    "server closed the connection unexpectedly",
+    "Can't create a connection to host",
+    "Connection refused",
+    "connection timeout expired",
+    "the connection is lost",
+    "connection is closed",
+    "connection closed",
+    "EOF detected",
+    "connection failed",
+    "consuming input failed",
+    "terminating connection",
+    "current transaction is aborted",
+    # A peer that RSTs rather than closing cleanly, which is what the
+    # reset_peer toxic produces and what a SIGKILLed process leaves behind.
+    # Materialize surfaces these as its own error when the connection it
+    # cannot reach is an upstream source or the metadata store, so the text
+    # arrives as a server error reply rather than a psycopg OperationalError.
+    "Connection reset by peer",
+    "Broken pipe",
+]
+
+
+class UnexpectedQueryError(Exception):
+    """A definite server error we did not expect. Fails the run."""
+
+
+def _is_connection_error(e: Exception) -> bool:
+    if isinstance(e, psycopg.OperationalError):
+        return True
+    msg = str(e)
+    return any(snippet in msg for snippet in CONNECTION_ERROR_SNIPPETS)
+
+
+class _Watchdog(threading.Thread):
+    """Cancels its client's running statement once the deadline passes.
+
+    One persistent daemon thread per client instead of a timer per query,
+    since workers issue hundreds of ops per second. Daemon so it never blocks
+    process exit.
+    """
+
+    def __init__(self, client: "MzClient") -> None:
+        super().__init__(name=f"watchdog-{client.name}", daemon=True)
+        self.client = client
+
+    def run(self) -> None:
+        while True:
+            time.sleep(0.5)
+            self.client.maybe_cancel()
+
+
+class ConnectFailed(TransientError):
+    """No connection could be established, so nothing was sent.
+
+    Worth distinguishing from every other transient failure: those leave the
+    outcome genuinely unknown, while a statement that never reached the
+    server definitely did not apply. Every unknown widens an op-log bound
+    permanently, so classifying these as failed is what keeps a bounds check
+    able to detect anything at all under heavy disruption.
+    """
+
+
+class MzClient:
+    """One psycopg connection to Materialize, owned by a single thread.
+
+    Reconnects lazily. Any transient failure drops the connection so the next
+    use starts from a clean slate (no half-open transactions).
+    """
+
+    def __init__(
+        self,
+        ctx: ScenarioContext,
+        name: str,
+        user: str = "materialize",
+        database: str = "materialize",
+        port: int | None = None,
+    ) -> None:
+        self.host = ctx.endpoints.mz_host
+        self.port = port if port is not None else ctx.endpoints.mz_port
+        self.user = user
+        self.database = database
+        self.name = name
+        self.ctx = ctx
+        self.log = ctx.log
+        self.default_timeout = ctx.complexity.query_timeout
+        self._conn: psycopg.Connection | None = None
+        self._lock = threading.Lock()
+        self._deadline: float | None = None
+        ctx.clients.append(self)
+        _Watchdog(self).start()
+
+    def _connect(self) -> psycopg.Connection:
+        if self._conn is None or self._conn.closed:
+            try:
+                conn = psycopg.connect(
+                    host=self.host,
+                    port=self.port,
+                    user=self.user,
+                    dbname=self.database,
+                    connect_timeout=10,
+                    autocommit=True,
+                )
+            except Exception as e:
+                raise ConnectFailed(f"connect failed: {e}") from e
+            with self._lock:
+                self._conn = conn
+        return self._conn
+
+    def reset(self) -> None:
+        with self._lock:
+            conn, self._conn = self._conn, None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def hard_close(self) -> None:
+        """Cross-thread escape hatch used by the shutdown ladder."""
+        self.maybe_cancel(force=True)
+        self.reset()
+
+    def maybe_cancel(self, force: bool = False) -> None:
+        with self._lock:
+            conn = self._conn
+            due = force or (
+                self._deadline is not None and time.monotonic() > self._deadline
+            )
+            if due:
+                self._deadline = None
+        if conn is None or not due:
+            return
+        try:
+            conn.cancel_safe(timeout=5.0)
+        except Exception:
+            # Cancellation itself needs a working network path. Cutting the
+            # connection is the fallback that always unblocks the owner.
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def _bounded(self, sql: str, params: Any, timeout: float | None) -> list[tuple]:
+        """Execute with the watchdog armed. Raises psycopg errors verbatim."""
+        conn = self._connect()
+        with self._lock:
+            self._deadline = time.monotonic() + (timeout or self.default_timeout)
+        try:
+            cur = conn.execute(sql.encode(), params)
+            return cur.fetchall() if cur.description is not None else []
+        finally:
+            with self._lock:
+                self._deadline = None
+
+    def query(
+        self, sql: str, params: Any = None, timeout: float | None = None
+    ) -> list[tuple]:
+        """Run a read (or session command). Transient trouble drops the conn.
+
+        Raises TransientError on connection loss, cancellation, or timeout,
+        and UnexpectedQueryError on any other server error.
+        """
+        try:
+            return self._bounded(sql, params, timeout)
+        except Exception as e:
+            self.reset()
+            if isinstance(e, TransientError):
+                raise
+            if isinstance(e, QueryCanceled) or _is_connection_error(e):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            if isinstance(e, SerializationFailure):
+                # SQLSTATE 40001, the documented retryable class, e.g. a
+                # bounded staleness read with no readable timestamp in bound.
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            if any(snippet in str(e) for snippet in CONCURRENT_DDL_ERROR_SNIPPETS):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            raise UnexpectedQueryError(f"query failed: {sql[:200]}: {e}") from e
+
+    def copy_out(self, sql: str, timeout: float | None = None) -> list[tuple[str, ...]]:
+        """Run `COPY (..) TO STDOUT` and return the tab-split text rows.
+
+        Same error classification as query().
+        """
+        conn = self._connect()
+        with self._lock:
+            self._deadline = time.monotonic() + (timeout or self.default_timeout)
+        try:
+            rows = []
+            with conn.cursor() as cur, cur.copy(sql.encode()) as copy:
+                for row in copy.rows():
+                    rows.append(tuple("" if c is None else str(c) for c in row))
+            return rows
+        except Exception as e:
+            self.reset()
+            if isinstance(
+                e, QueryCanceled | SerializationFailure
+            ) or _is_connection_error(e):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            if any(snippet in str(e) for snippet in CONCURRENT_DDL_ERROR_SNIPPETS):
+                raise TransientError(f"{type(e).__name__}: {e}") from e
+            raise UnexpectedQueryError(f"copy out failed: {sql[:200]}: {e}") from e
+        finally:
+            with self._lock:
+                self._deadline = None
+
+    def copy_in(self, sql: str, data: str, timeout: float | None = None) -> Outcome:
+        """Run `COPY .. FROM STDIN`, feed `data`, and classify the outcome.
+
+        A COPY is a single statement, so it applies atomically. Cancellation
+        or connection loss leaves the outcome UNKNOWN. A definite server
+        rejection surfaces as UnexpectedQueryError, since none of our
+        fixed-shape COPYs have a legitimate reason to be rejected.
+        """
+        try:
+            conn = self._connect()
+            with self._lock:
+                self._deadline = time.monotonic() + (timeout or self.default_timeout)
+            with conn.cursor() as cur, cur.copy(sql.encode()) as copy:
+                copy.write(data)
+            return Outcome.COMMITTED
+        except TransientError:
+            return Outcome.UNKNOWN
+        except Exception as e:
+            self.reset()
+            if isinstance(e, QueryCanceled) or "canceling statement due to" in str(e):
+                return Outcome.UNKNOWN
+            if _is_connection_error(e):
+                return Outcome.UNKNOWN
+            if not isinstance(e, psycopg.Error):
+                # psycopg's COPY teardown surfaces client-side artifacts
+                # (e.g. ValueError "too many values to unpack") when the
+                # watchdog cancels mid-COPY. No success reply arrived, so
+                # the outcome is unknown. Only definite server rejections
+                # (psycopg.Error with an error response) stay fatal.
+                return Outcome.UNKNOWN
+            raise UnexpectedQueryError(f"copy in rejected: {sql[:200]}: {e}") from e
+        finally:
+            with self._lock:
+                self._deadline = None
+
+    def write(
+        self, sql: str, params: Any = None, timeout: float | None = None
+    ) -> Outcome:
+        """Run one autocommit write statement and classify its outcome."""
+        try:
+            self._bounded(sql, params, timeout)
+            return Outcome.COMMITTED
+        except ConnectFailed:
+            # Never sent, so it cannot have applied.
+            self.reset()
+            return Outcome.FAILED
+        except TransientError:
+            self.reset()
+            return Outcome.UNKNOWN
+        except Exception as e:
+            self.reset()
+            if isinstance(e, QueryCanceled) or "canceling statement due to" in str(e):
+                return Outcome.UNKNOWN
+            if _is_connection_error(e):
+                return Outcome.UNKNOWN
+            if any(snippet in str(e) for snippet in CONCURRENT_DDL_ERROR_SNIPPETS):
+                # DDL racing DDL: a name resolved to an item that another
+                # action retired before this plan was installed, e.g. an index
+                # on the total MV while a replacement is applied to it. The
+                # coordinator rejects such a plan before its catalog
+                # transaction, so the statement definitely did not apply.
+                # Data writes cannot reach here, their tables are never
+                # dropped.
+                return Outcome.FAILED
+            # A definite server error reply: the statement was not applied.
+            # We still surface it, since none of our other fixed-shape writes
+            # have a legitimate reason to be rejected.
+            raise UnexpectedQueryError(f"write rejected: {sql[:200]}: {e}") from e
+
+    def write_txn(
+        self, statements: list[tuple[str, Any]], timeout: float | None = None
+    ) -> Outcome:
+        """Run BEGIN; <statements>; COMMIT and classify the outcome.
+
+        FAILED is only sound before COMMIT is submitted: Materialize buffers
+        INSERT-only transactions until commit, so any earlier failure means
+        no effect. Once COMMIT is on the wire, any non-success is UNKNOWN.
+        """
+        try:
+            self._bounded("BEGIN", None, timeout)
+            for sql, params in statements:
+                self._bounded(sql, params, timeout)
+        except Exception as e:
+            try:
+                self._bounded("ROLLBACK", None, 10.0)
+            except Exception:
+                self.reset()
+            if isinstance(e, TransientError | QueryCanceled) or _is_connection_error(e):
+                return Outcome.FAILED
+            self.reset()
+            raise UnexpectedQueryError(f"txn statement rejected: {e}") from e
+        try:
+            self._bounded("COMMIT", None, timeout)
+            return Outcome.COMMITTED
+        except Exception:
+            self.reset()
+            return Outcome.UNKNOWN

--- a/misc/python/materialize/invariants/scenarios/__init__.py
+++ b/misc/python/materialize/invariants/scenarios/__init__.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 from materialize.invariants.framework import Scenario
+from materialize.invariants.scenarios.avro_loopback import AvroLoopback
 from materialize.invariants.scenarios.cdc_bank import (
     MySqlCdcBank,
     PgCdcBank,
@@ -17,6 +18,7 @@ from materialize.invariants.scenarios.kafka_ledger import KafkaLedger
 from materialize.invariants.scenarios.kafka_upsert import KafkaUpsert
 from materialize.invariants.scenarios.sink_roundtrip import SinkRoundtrip
 from materialize.invariants.scenarios.table_bank import TableBank
+from materialize.invariants.scenarios.webhook_set import WebhookSet
 
 SCENARIOS: dict[str, type[Scenario]] = {
     scenario.name: scenario
@@ -28,5 +30,7 @@ SCENARIOS: dict[str, type[Scenario]] = {
         KafkaLedger,
         KafkaUpsert,
         SinkRoundtrip,
+        WebhookSet,
+        AvroLoopback,
     ]
 }

--- a/misc/python/materialize/invariants/scenarios/__init__.py
+++ b/misc/python/materialize/invariants/scenarios/__init__.py
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.invariants.framework import Scenario
+from materialize.invariants.scenarios.cdc_bank import (
+    MySqlCdcBank,
+    PgCdcBank,
+    SqlServerCdcBank,
+)
+from materialize.invariants.scenarios.kafka_ledger import KafkaLedger
+from materialize.invariants.scenarios.kafka_upsert import KafkaUpsert
+from materialize.invariants.scenarios.sink_roundtrip import SinkRoundtrip
+from materialize.invariants.scenarios.table_bank import TableBank
+
+SCENARIOS: dict[str, type[Scenario]] = {
+    scenario.name: scenario
+    for scenario in [
+        TableBank,
+        PgCdcBank,
+        MySqlCdcBank,
+        SqlServerCdcBank,
+        KafkaLedger,
+        KafkaUpsert,
+        SinkRoundtrip,
+    ]
+}

--- a/misc/python/materialize/invariants/scenarios/__init__.py
+++ b/misc/python/materialize/invariants/scenarios/__init__.py
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.invariants.framework import Scenario
+from materialize.invariants.scenarios.avro_loopback import AvroLoopback
+from materialize.invariants.scenarios.cdc_bank import (
+    MySqlCdcBank,
+    PgCdcBank,
+    SqlServerCdcBank,
+)
+from materialize.invariants.scenarios.graph import Graph
+from materialize.invariants.scenarios.kafka_ledger import KafkaLedger
+from materialize.invariants.scenarios.kafka_upsert import KafkaUpsert
+from materialize.invariants.scenarios.sink_roundtrip import SinkRoundtrip
+from materialize.invariants.scenarios.table_bank import TableBank
+from materialize.invariants.scenarios.txn_probe import TxnProbe
+from materialize.invariants.scenarios.webhook_set import WebhookSet
+
+SCENARIOS: dict[str, type[Scenario]] = {
+    scenario.name: scenario
+    for scenario in [
+        TableBank,
+        TxnProbe,
+        Graph,
+        PgCdcBank,
+        MySqlCdcBank,
+        SqlServerCdcBank,
+        KafkaLedger,
+        KafkaUpsert,
+        SinkRoundtrip,
+        WebhookSet,
+        AvroLoopback,
+    ]
+}

--- a/misc/python/materialize/invariants/scenarios/avro_loopback.py
+++ b/misc/python/materialize/invariants/scenarios/avro_loopback.py
@@ -1,0 +1,267 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Balances looped through Kafka as Avro Debezium, and re-ingested.
+
+Ledger transfers feed a balances MV that a Kafka sink exports with FORMAT
+AVRO USING CONFLUENT SCHEMA REGISTRY and ENVELOPE DEBEZIUM, and a Kafka
+source re-ingests the same topic with the same format and envelope into a
+table. This covers Avro encoding and decoding, CSR schema publishing and
+fetching, and DEBEZIUM-envelope ingestion, all across their own disrupted
+legs (source, sink, and schema registry).
+
+Kafka sources promise no cross-message transaction atomicity, so the
+continuous invariant is the DEBEZIUM state machine itself: applied
+before/after pairs must never produce duplicate (or negative) per-account
+multiplicities in the re-ingested table. A lost or duplicated message
+surfaces there immediately. After quiescing, the re-ingested state must
+exactly equal the balances MV (the sink's exactly-once guarantee through
+the whole loop), and the ledger is reconciled against the op log.
+"""
+
+import random
+
+from materialize.invariants.checkers import (
+    PeekChecker,
+    ProgressPeek,
+    SubscribeChecker,
+)
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+from materialize.invariants.scenarios.table_bank import LedgerTransfer
+
+TOPIC = "invariants-loopback"
+
+
+class LoopStatePeek(PeekChecker):
+    """The re-ingested DEBEZIUM state holds at most one row per account."""
+
+    def __init__(self, rng, ctx, scenario: "AvroLoopback") -> None:
+        super().__init__(rng, ctx, "loop-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        duplicated = self.peek(
+            "SELECT account FROM balances_rt GROUP BY account" " HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"re-ingested state holds duplicate accounts (a message was"
+                f" duplicated or lost): {duplicated[:20]}"
+            )
+        rows = self.peek("SELECT count(*) FROM balances_rt")
+        if int(rows[0][0]) > self.scenario.accounts:
+            raise InvariantViolation(
+                f"re-ingested state holds {rows[0][0]} accounts, only"
+                f" {self.scenario.accounts} exist"
+            )
+        self.validations += 1
+
+
+class LoopStateSubscribe(SubscribeChecker):
+    """Every consistent snapshot of the re-ingested state is per-key sane."""
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(
+            rng,
+            ctx,
+            "loop-subscribe",
+            "SELECT account, balance FROM balances_rt",
+        )
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        seen: set = set()
+        for (account, _balance), multiplicity in state.items():
+            if multiplicity != 1 or account in seen:
+                raise InvariantViolation(
+                    f"re-ingested state at {ts}: duplicate rows for account"
+                    f" {account}"
+                )
+            seen.add(account)
+
+
+class AvroLoopback(Scenario):
+    name = "avro-loopback"
+    services = ["kafka", "schema-registry"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "kafka-source",
+        "kafka-sink",
+        "csr",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.oplog = OpLog()
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE ledger (worker int, seq bigint, account int,"
+            " amount bigint, at timestamptz)",
+            # HAVING drops zero balances so accounts also get deleted and
+            # re-created, exercising Debezium deletes through the loop.
+            "CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
+            " SELECT account, sum(amount) AS balance FROM ledger"
+            " GROUP BY account HAVING sum(amount) <> 0",
+            "CREATE CONNECTION kafka_sink_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9192', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE CONNECTION kafka_src_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY"
+            " (URL 'http://toxiproxy:8081')",
+            "CREATE SINK loop_sink IN CLUSTER storage FROM balances"
+            " INTO KAFKA CONNECTION kafka_sink_conn"
+            f" (TOPIC '{TOPIC}', TOPIC PARTITION COUNT 1,"
+            " TOPIC REPLICATION FACTOR 1)"
+            " KEY (account)"
+            " FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn"
+            " ENVELOPE DEBEZIUM",
+        ]:
+            client.query(sql, timeout=120)
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        wait_until(
+            lambda: TOPIC in admin.list_topics(timeout=10).topics,
+            CONVERGE_TIMEOUT,
+            "sink topic creation",
+        )
+        client.query(
+            "CREATE SOURCE loop_source IN CLUSTER storage"
+            f" FROM KAFKA CONNECTION kafka_src_conn (TOPIC '{TOPIC}')",
+            timeout=120,
+        )
+
+        # The source table resolves the value schema from the registry at
+        # creation time, so it can only be created once the sink has
+        # published it.
+        def reingest_table_created() -> bool:
+            try:
+                client.query(
+                    "CREATE TABLE balances_rt FROM SOURCE loop_source"
+                    f' (REFERENCE "{TOPIC}")'
+                    " FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY"
+                    " CONNECTION csr_conn ENVELOPE DEBEZIUM",
+                    timeout=60,
+                )
+                return True
+            except UnexpectedQueryError as e:
+                if "not found" in str(e) or "No subject" in str(e):
+                    raise TransientError(str(e)) from e
+                raise
+
+        wait_until(reingest_table_created, CONVERGE_TIMEOUT, "sink schema publication")
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        client = MzClient(self.ctx, f"worker-{index}")
+        return WorkerBundle(
+            actions=[LedgerTransfer(rng, index, self.accounts, client, self.oplog)],
+            weights=[1],
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(3)]
+        return [
+            LoopStatePeek(rngs[0], self.ctx, self),
+            LoopStateSubscribe(rngs[1], self.ctx),
+            ProgressPeek(rngs[2], self.ctx, "loop_source"),
+        ]
+
+    def _balances(self, client: MzClient, relation: str) -> dict[int, int]:
+        client.query("SET cluster = quickstart")
+        return {
+            int(row[0]): int(row[1])
+            for row in client.query(f"SELECT account, balance FROM {relation}")
+        }
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            return self._balances(client, "balances_rt") == self._balances(
+                client, "balances"
+            )
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "loopback catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        upstream = self._balances(client, "balances")
+        reingested = self._balances(client, "balances_rt")
+        if reingested != upstream:
+            diff = {
+                account: (upstream.get(account), reingested.get(account))
+                for account in set(upstream) | set(reingested)
+                if upstream.get(account) != reingested.get(account)
+            }
+            raise InvariantViolation(
+                f"re-ingested balances diverged: {dict(list(diff.items())[:20])}"
+            )
+        if sum(upstream.values()) != 0:
+            raise InvariantViolation(f"balances sum to {sum(upstream.values())} != 0")
+        client.query("SET cluster = quickstart")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM ledger WHERE worker = {worker} GROUP BY seq"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost:"
+                    f" {sorted(missing)[:20]}"
+                )
+            phantom = present - committed - unknown
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            upstream = self._balances(client, "balances")
+            reingested = self._balances(client, "balances_rt")
+            verdict = "converged" if upstream == reingested else "still diverged"
+            self.ctx.log.log(
+                "diag",
+                f"post-heal: balances={len(upstream)}"
+                f" reingested={len(reingested)} ({verdict})",
+            )
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal comparison failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/avro_loopback.py
+++ b/misc/python/materialize/invariants/scenarios/avro_loopback.py
@@ -1,0 +1,267 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Balances looped through Kafka as Avro Debezium, and re-ingested.
+
+Ledger transfers feed a balances MV that a Kafka sink exports with FORMAT
+AVRO USING CONFLUENT SCHEMA REGISTRY and ENVELOPE DEBEZIUM, and a Kafka
+source re-ingests the same topic with the same format and envelope into a
+table. This covers Avro encoding and decoding, CSR schema publishing and
+fetching, and DEBEZIUM-envelope ingestion, all across their own disrupted
+legs (source, sink, and schema registry).
+
+Kafka sources promise no cross-message transaction atomicity, so the
+continuous invariant is the DEBEZIUM state machine itself: applied
+before/after pairs must never produce duplicate (or negative) per-account
+multiplicities in the re-ingested table. A lost or duplicated message
+surfaces there immediately. After quiescing, the re-ingested state must
+exactly equal the balances MV (the sink's exactly-once guarantee through
+the whole loop), and the ledger is reconciled against the op log.
+"""
+
+import random
+
+from materialize.invariants.checkers import (
+    PeekChecker,
+    ProgressPeek,
+    SubscribeChecker,
+)
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+from materialize.invariants.scenarios.sink_roundtrip import BALANCES_DEF
+from materialize.invariants.scenarios.table_bank import LedgerTransfer
+
+TOPIC = "invariants-loopback"
+
+
+class LoopStatePeek(PeekChecker):
+    """The re-ingested DEBEZIUM state holds at most one row per account."""
+
+    def __init__(self, rng, ctx, scenario: "AvroLoopback") -> None:
+        super().__init__(rng, ctx, "loop-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        duplicated = self.peek(
+            "SELECT account FROM balances_rt GROUP BY account" " HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"re-ingested state holds duplicate accounts (a message was"
+                f" duplicated or lost): {duplicated[:20]}"
+            )
+        rows = self.peek("SELECT count(*) FROM balances_rt")
+        if int(rows[0][0]) > self.scenario.accounts:
+            raise InvariantViolation(
+                f"re-ingested state holds {rows[0][0]} accounts, only"
+                f" {self.scenario.accounts} exist"
+            )
+        self.validations += 1
+
+
+class LoopStateSubscribe(SubscribeChecker):
+    """Every consistent snapshot of the re-ingested state is per-key sane."""
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(
+            rng,
+            ctx,
+            "loop-subscribe",
+            "SELECT account, balance FROM balances_rt",
+        )
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        seen: set = set()
+        for (account, _balance), multiplicity in state.items():
+            if multiplicity != 1 or account in seen:
+                raise InvariantViolation(
+                    f"re-ingested state at {ts}: duplicate rows for account"
+                    f" {account}"
+                )
+            seen.add(account)
+
+
+class AvroLoopback(Scenario):
+    name = "avro-loopback"
+    services = ["kafka", "schema-registry"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "kafka-source",
+        "kafka-sink",
+        "csr",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.oplog = OpLog()
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE ledger (worker int, seq bigint, account int,"
+            " amount bigint, at timestamptz)",
+            # HAVING drops zero balances so accounts also get deleted and
+            # re-created, exercising Debezium deletes through the loop.
+            "CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
+            f" {BALANCES_DEF}",
+            "CREATE CONNECTION kafka_sink_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9192', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE CONNECTION kafka_src_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY"
+            " (URL 'http://toxiproxy:8081')",
+            "CREATE SINK loop_sink IN CLUSTER storage FROM balances"
+            " INTO KAFKA CONNECTION kafka_sink_conn"
+            f" (TOPIC '{TOPIC}', TOPIC PARTITION COUNT 1,"
+            " TOPIC REPLICATION FACTOR 1)"
+            " KEY (account)"
+            " FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn"
+            " ENVELOPE DEBEZIUM",
+        ]:
+            client.query(sql, timeout=120)
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        wait_until(
+            lambda: TOPIC in admin.list_topics(timeout=10).topics,
+            CONVERGE_TIMEOUT,
+            "sink topic creation",
+        )
+        client.query(
+            "CREATE SOURCE loop_source IN CLUSTER storage"
+            f" FROM KAFKA CONNECTION kafka_src_conn (TOPIC '{TOPIC}')",
+            timeout=120,
+        )
+
+        # The source table resolves the value schema from the registry at
+        # creation time, so it can only be created once the sink has
+        # published it.
+        def reingest_table_created() -> bool:
+            try:
+                client.query(
+                    "CREATE TABLE balances_rt FROM SOURCE loop_source"
+                    f' (REFERENCE "{TOPIC}")'
+                    " FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY"
+                    " CONNECTION csr_conn ENVELOPE DEBEZIUM",
+                    timeout=60,
+                )
+                return True
+            except UnexpectedQueryError as e:
+                if "not found" in str(e) or "No subject" in str(e):
+                    raise TransientError(str(e)) from e
+                raise
+
+        wait_until(reingest_table_created, CONVERGE_TIMEOUT, "sink schema publication")
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        client = MzClient(self.ctx, f"worker-{index}")
+        return WorkerBundle(
+            actions=[LedgerTransfer(rng, index, self.accounts, client, self.oplog)],
+            weights=[1],
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(3)]
+        return [
+            LoopStatePeek(rngs[0], self.ctx, self),
+            LoopStateSubscribe(rngs[1], self.ctx),
+            ProgressPeek(rngs[2], self.ctx, "loop_source"),
+        ]
+
+    def _balances(self, client: MzClient, relation: str) -> dict[int, int]:
+        client.query("SET cluster = quickstart")
+        return {
+            int(row[0]): int(row[1])
+            for row in client.query(f"SELECT account, balance FROM {relation}")
+        }
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            return self._balances(client, "balances_rt") == self._balances(
+                client, "balances"
+            )
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "loopback catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        upstream = self._balances(client, "balances")
+        reingested = self._balances(client, "balances_rt")
+        if reingested != upstream:
+            diff = {
+                account: (upstream.get(account), reingested.get(account))
+                for account in set(upstream) | set(reingested)
+                if upstream.get(account) != reingested.get(account)
+            }
+            raise InvariantViolation(
+                f"re-ingested balances diverged: {dict(list(diff.items())[:20])}"
+            )
+        if sum(upstream.values()) != 0:
+            raise InvariantViolation(f"balances sum to {sum(upstream.values())} != 0")
+        client.query("SET cluster = quickstart")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM ledger WHERE worker = {worker} GROUP BY seq"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            issued = self.oplog.issued(worker)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost:"
+                    f" {sorted(missing)[:20]}"
+                )
+            phantom = present - issued
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            upstream = self._balances(client, "balances")
+            reingested = self._balances(client, "balances_rt")
+            verdict = "converged" if upstream == reingested else "still diverged"
+            self.ctx.log.log(
+                "diag",
+                f"post-heal: balances={len(upstream)}"
+                f" reingested={len(reingested)} ({verdict})",
+            )
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal comparison failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/avro_loopback.py
+++ b/misc/python/materialize/invariants/scenarios/avro_loopback.py
@@ -46,6 +46,7 @@ from materialize.invariants.framework import (
     wait_until,
 )
 from materialize.invariants.mz import MzClient, UnexpectedQueryError
+from materialize.invariants.scenarios.sink_roundtrip import BALANCES_DEF
 from materialize.invariants.scenarios.table_bank import LedgerTransfer
 
 TOPIC = "invariants-loopback"
@@ -129,8 +130,7 @@ class AvroLoopback(Scenario):
             # HAVING drops zero balances so accounts also get deleted and
             # re-created, exercising Debezium deletes through the loop.
             "CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
-            " SELECT account, sum(amount) AS balance FROM ledger"
-            " GROUP BY account HAVING sum(amount) <> 0",
+            f" {BALANCES_DEF}",
             "CREATE CONNECTION kafka_sink_conn TO KAFKA"
             " (BROKER 'toxiproxy:9192', SECURITY PROTOCOL PLAINTEXT)",
             "CREATE CONNECTION kafka_src_conn TO KAFKA"

--- a/misc/python/materialize/invariants/scenarios/avro_loopback.py
+++ b/misc/python/materialize/invariants/scenarios/avro_loopback.py
@@ -236,14 +236,14 @@ class AvroLoopback(Scenario):
                 )
             }
             committed = self.oplog.seqs(worker, Outcome.COMMITTED)
-            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            issued = self.oplog.issued(worker)
             missing = committed - present
             if missing:
                 raise InvariantViolation(
                     f"worker {worker}: committed transfers lost:"
                     f" {sorted(missing)[:20]}"
                 )
-            phantom = present - committed - unknown
+            phantom = present - issued
             if phantom:
                 raise InvariantViolation(
                     f"worker {worker}: transfers present that never committed:"

--- a/misc/python/materialize/invariants/scenarios/cdc_bank.py
+++ b/misc/python/materialize/invariants/scenarios/cdc_bank.py
@@ -51,6 +51,15 @@ BALANCE_PER_ACCOUNT = 1000
 # Negative so the per-worker reconciliation and count bounds never see them.
 RTR_MARKER_WORKER = -2
 
+# Purification of CREATE TABLE .. FROM SOURCE connects to the upstream database
+# over the (possibly disrupted) source leg to validate the reference. These
+# plan-time connect failures are expected chaos, not a rejected write.
+UPSTREAM_CONNECT_ERROR_SNIPPETS = (
+    "failed to connect to PostgreSQL database",
+    "failed to connect to MySQL database",
+    "failed to connect to SQL Server database",
+)
+
 
 class UpstreamTransfer(Action):
     """One upstream transaction: debit, credit, and a transfers-log row.
@@ -155,10 +164,17 @@ class SourceTableChurn(Action):
             self.client.write(f"DROP TABLE IF EXISTS accounts_v{self.nonce}")
         self.nonce += 1
         name = f"accounts_v{self.nonce}"
-        outcome = self.client.write(
-            f"CREATE TABLE {name} FROM SOURCE bank_source"
-            f" (REFERENCE {self.scenario.accounts_reference})"
-        )
+        try:
+            outcome = self.client.write(
+                f"CREATE TABLE {name} FROM SOURCE bank_source"
+                f" (REFERENCE {self.scenario.accounts_reference})"
+            )
+        except UnexpectedQueryError as e:
+            # Purification reaches the upstream over the disrupted source leg,
+            # so a plan-time connect failure is expected chaos, not a bug.
+            if any(s in str(e) for s in UPSTREAM_CONNECT_ERROR_SNIPPETS):
+                raise TransientError(str(e)) from e
+            raise
         if outcome != Outcome.COMMITTED:
             return outcome
         deadline = time.monotonic() + 120.0

--- a/misc/python/materialize/invariants/scenarios/cdc_bank.py
+++ b/misc/python/materialize/invariants/scenarios/cdc_bank.py
@@ -19,10 +19,15 @@ op ids for exact final reconciliation against the upstream oracle.
 """
 
 import random
+import time
 from abc import abstractmethod
 from typing import Any
 
-from materialize.invariants.checkers import PeekChecker, SubscribeChecker
+from materialize.invariants.checkers import (
+    PeekChecker,
+    ProgressPeek,
+    SubscribeChecker,
+)
 from materialize.invariants.framework import (
     CONVERGE_TIMEOUT,
     SEED_RANGE,
@@ -116,6 +121,116 @@ class UpstreamTransfer(Action):
 
     def close(self) -> None:
         self._drop_conn()
+
+
+class SourceTableChurn(Action):
+    """Source versioning: add and drop tables on the running source.
+
+    CREATE TABLE .. FROM SOURCE snapshots just the new table while the
+    existing tables keep serving (their ingestion may pause during the
+    snapshot, which surfaces as skipped checker rounds). Reads on the new
+    table block until its snapshot completes, so the first value a read
+    returns is a transactionally consistent state and must show the
+    conserved total.
+    """
+
+    name = "source-table"
+
+    def __init__(
+        self, rng: random.Random, client: MzClient, scenario: "CdcBank"
+    ) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.scenario = scenario
+        self.nonce = 0
+        self.next_at = time.monotonic() + 20.0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(45.0, 90.0)
+        # A leftover from a cycle whose drop had an UNKNOWN outcome.
+        if self.nonce > 0:
+            self.client.write(f"DROP TABLE IF EXISTS accounts_v{self.nonce}")
+        self.nonce += 1
+        name = f"accounts_v{self.nonce}"
+        outcome = self.client.write(
+            f"CREATE TABLE {name} FROM SOURCE bank_source"
+            f" (REFERENCE {self.scenario.accounts_reference})"
+        )
+        if outcome != Outcome.COMMITTED:
+            return outcome
+        deadline = time.monotonic() + 120.0
+        validated = False
+        while time.monotonic() < deadline:
+            try:
+                rows = self.client.query(
+                    f"SELECT coalesce(sum(balance), 0) FROM {name}", timeout=30
+                )
+            except TransientError:
+                continue
+            total = int(rows[0][0])
+            if total != self.scenario.total:
+                raise InvariantViolation(
+                    f"snapshot of {name} shows a non-conserved total:"
+                    f" {total} != {self.scenario.total}"
+                )
+            validated = True
+            break
+        if not validated:
+            self.scenario.ctx.log.log(
+                "op", f"{name} snapshot did not become readable in time"
+            )
+        self.client.write(f"DROP TABLE IF EXISTS {name}")
+        return Outcome.COMMITTED if validated else Outcome.UNKNOWN
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class UpstreamSchemaChurn(Action):
+    """Documented-compatible upstream schema changes on the transfers table.
+
+    Adding a column upstream, and dropping a column that was added after
+    source creation, must not disturb ingestion (the column is simply not
+    ingested). Upstream connection trouble is oracle-side and transient.
+    """
+
+    name = "upstream-ddl"
+
+    def __init__(self, rng: random.Random, scenario: "CdcBank") -> None:
+        super().__init__(rng)
+        self.scenario = scenario
+        self.nonce = 0
+        self.next_at = time.monotonic() + 30.0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(30.0, 60.0)
+        self.nonce += 1
+        statements = [f"ALTER TABLE transfers ADD COLUMN extra_{self.nonce} int"]
+        if self.nonce > 1:
+            statements.insert(
+                0, f"ALTER TABLE transfers DROP COLUMN extra_{self.nonce - 1}"
+            )
+        try:
+            conn = self.scenario.connect_upstream()
+            try:
+                cur = conn.cursor()
+                for sql in statements:
+                    cur.execute(sql)
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            # The previous cycle's ADD may not have applied (its connection
+            # died), making this DROP fail. The next cycle moves on to a
+            # fresh column name either way.
+            raise TransientError(f"upstream DDL failed: {e}") from e
+        return Outcome.COMMITTED
 
 
 class CdcTotalPeek(PeekChecker):
@@ -277,6 +392,13 @@ class CdcBank(Scenario):
     # Real-time recency is documented for Kafka, PostgreSQL, and MySQL
     # sources only.
     rtr_supported = True
+    # Whether the documented-compatible upstream schema changes (add
+    # column, drop later-added column) are exercised. SQL Server is
+    # excluded: its CDC capture instances pin the captured column list, so
+    # column changes are a different, heavier operation there.
+    upstream_ddl_supported = True
+    # The CREATE TABLE .. FROM SOURCE reference for the accounts table.
+    accounts_reference: str
 
     def __init__(self, ctx: ScenarioContext) -> None:
         super().__init__(ctx)
@@ -315,17 +437,28 @@ class CdcBank(Scenario):
         client.reset()
 
     def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
-        return WorkerBundle(actions=[UpstreamTransfer(rng, index, self)], weights=[1])
+        actions: list[Action] = [UpstreamTransfer(rng, index, self)]
+        weights = [20]
+        if index == 0:
+            actions.append(
+                SourceTableChurn(rng, MzClient(self.ctx, "source-table"), self)
+            )
+            weights.append(1)
+            if self.upstream_ddl_supported:
+                actions.append(UpstreamSchemaChurn(rng, self))
+                weights.append(1)
+        return WorkerBundle(actions=actions, weights=weights)
 
     def checkers(self) -> list[Checker]:
-        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(4)]
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(5)]
         checkers: list[Checker] = [
             CdcTotalPeek(rngs[0], self.ctx, self),
             TransferCountPeek(rngs[1], self.ctx, self),
             CdcTotalSubscribe(rngs[2], self.ctx, self),
+            ProgressPeek(rngs[3], self.ctx, "bank_source"),
         ]
         if self.rtr_supported:
-            checkers.append(RtrPeek(rngs[3], self.ctx, self))
+            checkers.append(RtrPeek(rngs[4], self.ctx, self))
         return checkers
 
     def _upstream_state(self) -> tuple[list[tuple[int, int]], int]:
@@ -422,6 +555,7 @@ class CdcBank(Scenario):
 
 class PgCdcBank(CdcBank):
     name = "pg-cdc-bank"
+    accounts_reference = "accounts"
     services = ["postgres"]
     legs = [
         "metadata",
@@ -476,6 +610,7 @@ class PgCdcBank(CdcBank):
 
 class MySqlCdcBank(CdcBank):
     name = "mysql-cdc-bank"
+    accounts_reference = "bank.accounts"
     services = ["mysql"]
     legs = [
         "metadata",
@@ -549,6 +684,8 @@ class MySqlCdcBank(CdcBank):
 class SqlServerCdcBank(CdcBank):
     name = "sqlserver-cdc-bank"
     rtr_supported = False
+    upstream_ddl_supported = False
+    accounts_reference = "dbo.accounts"
     services = ["sql-server"]
     legs = [
         "metadata",

--- a/misc/python/materialize/invariants/scenarios/cdc_bank.py
+++ b/misc/python/materialize/invariants/scenarios/cdc_bank.py
@@ -1,0 +1,644 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Bank transfers in an upstream database, ingested via a CDC source.
+
+Transfers are real upstream transactions (two balance UPDATEs plus a row in
+a transfers log). Materialize documents transactional consistency for
+PostgreSQL and MySQL sources: an upstream transaction is applied at a single
+Materialize timestamp, so sum(balance) must equal the initial total at every
+timestamp, including while the source connection, the clusterd connections,
+or the metadata store are disrupted. The transfers log carries (worker, seq)
+op ids for exact final reconciliation against the upstream oracle.
+"""
+
+import random
+from abc import abstractmethod
+from typing import Any
+
+from materialize.invariants.checkers import PeekChecker, SubscribeChecker
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+
+BALANCE_PER_ACCOUNT = 1000
+
+# Worker id used for real-time recency marker rows in the transfers log.
+# Negative so the per-worker reconciliation and count bounds never see them.
+RTR_MARKER_WORKER = -2
+
+
+class UpstreamTransfer(Action):
+    """One upstream transaction: debit, credit, and a transfers-log row.
+
+    Accounts are locked in id order so concurrent transfers cannot deadlock.
+    Outcome contract: any failure before COMMIT is FAILED (the upstream
+    database aborts the transaction), a failed COMMIT is UNKNOWN.
+    """
+
+    name = "cdc-transfer"
+
+    def __init__(self, rng: random.Random, worker: int, scenario: "CdcBank") -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.scenario = scenario
+        self.conn: Any = None
+        self.seq = 0
+
+    def _ensure_conn(self) -> Any:
+        if self.conn is None:
+            try:
+                self.conn = self.scenario.connect_upstream()
+            except Exception as e:
+                raise TransientError(f"upstream connect failed: {e}") from e
+        return self.conn
+
+    def _drop_conn(self) -> None:
+        conn, self.conn = self.conn, None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def run(self) -> Outcome | None:
+        conn = self._ensure_conn()
+        self.seq += 1
+        seq = self.seq
+        src, dst = self.rng.sample(range(self.scenario.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        self.scenario.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        try:
+            cur = conn.cursor()
+            for account in sorted((src, dst)):
+                delta = -amount if account == src else amount
+                cur.execute(
+                    f"UPDATE accounts SET balance = balance + {delta}"
+                    f" WHERE id = {account}"
+                )
+            cur.execute(
+                "INSERT INTO transfers (worker, seq, src, dst, amount)"
+                f" VALUES ({self.worker}, {seq}, {src}, {dst}, {amount})"
+            )
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                self._drop_conn()
+            self.scenario.oplog.record(self.worker, seq, Outcome.FAILED)
+            return Outcome.FAILED
+        try:
+            conn.commit()
+        except Exception:
+            self._drop_conn()
+            return Outcome.UNKNOWN
+        self.scenario.oplog.record(self.worker, seq, Outcome.COMMITTED)
+        return Outcome.COMMITTED
+
+    def close(self) -> None:
+        self._drop_conn()
+
+
+class CdcTotalPeek(PeekChecker):
+    """Verifies the total through the maintained MV, an ad-hoc query, and a
+    single query spanning both (which must observe one consistent snapshot
+    across the two objects)."""
+
+    QUERIES = [
+        ("SELECT total FROM bank_total", 1),
+        ("SELECT coalesce(sum(balance), 0) AS total FROM accounts_tbl", 1),
+        (
+            "SELECT total FROM bank_total UNION ALL"
+            " SELECT coalesce(sum(balance), 0) FROM accounts_tbl",
+            2,
+        ),
+    ]
+
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng, ctx, "total-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        # rng, not round-robin: the cluster rotation has the same period as
+        # the query list, round-robin would pin each form to one cluster.
+        query, expected_rows = self.rng.choice(self.QUERIES)
+        rows = self.peek(query)
+        if len(rows) != expected_rows or any(
+            int(row[0]) != self.scenario.total for row in rows
+        ):
+            raise InvariantViolation(
+                f"upstream-transaction atomicity broken via {query!r}: expected"
+                f" {expected_rows}x total {self.scenario.total}, got {rows}"
+            )
+        self.validations += 1
+
+
+class TransferCountPeek(PeekChecker):
+    """Transfer count: monotonic, and bounded by the op ledger."""
+
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng, ctx, "transfers-peek", ["quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        watermark = self.scenario.transfer_rows.get()
+        rows = self.peek("SELECT count(*) FROM transfers_tbl WHERE worker >= 0")
+        high = oplog.attempted_count()
+        count = int(rows[0][0])
+        if count < watermark:
+            raise InvariantViolation(
+                f"transfer count went backwards: {count} < watermark {watermark}"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"transfer count {count} exceeds attempted transfers {high}"
+            )
+        # NOTE: no lower bound against committed transfers: ingestion lags the
+        # upstream commit (linearizability does not cover source data), so
+        # committed transfers are only guaranteed visible after converge.
+        self.scenario.transfer_rows.advance(count)
+        self.validations += 1
+
+
+class CdcTotalSubscribe(SubscribeChecker):
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng, ctx, "total-subscribe", "SELECT total FROM bank_total")
+        self.scenario = scenario
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        expected = {(self.scenario.total,): 1}
+        got = {(int(k[0]),): v for k, v in state.items()}
+        if got != expected:
+            raise InvariantViolation(
+                f"total via SUBSCRIBE at {ts}: expected {expected}, got {got}"
+                " (an upstream transaction was applied non-atomically)"
+            )
+
+
+class RtrPeek(Checker):
+    """Real-time recency: a read issued after an upstream commit was
+    acknowledged must include that commit.
+
+    This is RTR's documented "at least" guarantee under strict serializable.
+    RTR queries legitimately error or time out while the source connection
+    is disrupted, which skips the round, but a read that succeeds while
+    missing acknowledged upstream data is a violation.
+    """
+
+    name = "rtr-peek"
+    pause = (2.0, 6.0)
+
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.scenario = scenario
+        self.client = MzClient(ctx, "rtr-peek")
+        self.markers = 0
+        self._session_ready = False
+
+    def check_once(self) -> None:
+        conn = None
+        marker = self.markers + 1
+        try:
+            conn = self.scenario.connect_upstream()
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO transfers (worker, seq, src, dst, amount)"
+                f" VALUES ({RTR_MARKER_WORKER}, {marker}, 0, 0, 0)"
+            )
+            conn.commit()
+        except Exception as e:
+            raise TransientError(f"upstream marker insert failed: {e}") from e
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        # The marker is acknowledged upstream. If the commit had failed with
+        # an unknown outcome we would not get here, and an unknown commit
+        # that still landed only increases the count, which the >= check
+        # tolerates.
+        self.markers = marker
+        try:
+            if not self._session_ready:
+                self.client.query("SET real_time_recency = true")
+                self._session_ready = True
+            rows = self.client.query(
+                "SELECT count(*) FROM transfers_tbl"
+                f" WHERE worker = {RTR_MARKER_WORKER}"
+            )
+        except TransientError:
+            # The connection was dropped, so the session setting is gone.
+            self._session_ready = False
+            raise
+        except UnexpectedQueryError as e:
+            self._session_ready = False
+            # The recency probe contacts the upstream database over the
+            # disrupted leg, so besides the RTR timeout it can surface the
+            # storage layer's connection failures. Both are expected chaos,
+            # only a successful read with missing data is a violation.
+            if "timed out before ingesting" in str(e) or "storage error" in str(e):
+                raise TransientError(str(e)) from e
+            raise
+        count = int(rows[0][0])
+        if count < self.markers:
+            raise InvariantViolation(
+                f"real-time recency violated: read issued after upstream ack"
+                f" saw {count} markers, expected at least {self.markers}"
+            )
+        self.validations += 1
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class CdcBank(Scenario):
+    # Real-time recency is documented for Kafka, PostgreSQL, and MySQL
+    # sources only.
+    rtr_supported = True
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.total = self.accounts * BALANCE_PER_ACCOUNT
+        self.oplog = OpLog()
+        self.transfer_rows = Watermark()
+
+    @abstractmethod
+    def connect_upstream(self) -> Any:
+        """A new connection to the upstream database (direct, not proxied)."""
+
+    @abstractmethod
+    def setup_upstream(self) -> None:
+        pass
+
+    @abstractmethod
+    def mz_setup_sql(self) -> list[str]:
+        pass
+
+    def setup(self) -> None:
+        self.setup_upstream()
+        client = MzClient(self.ctx, "setup")
+        for sql in self.mz_setup_sql() + [
+            "CREATE MATERIALIZED VIEW bank_total IN CLUSTER compute AS"
+            " SELECT coalesce(sum(balance), 0) AS total FROM accounts_tbl",
+            "CREATE INDEX bank_total_idx IN CLUSTER compute ON bank_total (total)",
+        ]:
+            client.query(sql, timeout=120)
+
+        def snapshot_done() -> bool:
+            rows = client.query("SELECT count(*) FROM accounts_tbl")
+            return int(rows[0][0]) == self.accounts
+
+        wait_until(snapshot_done, CONVERGE_TIMEOUT, "source snapshot")
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        return WorkerBundle(actions=[UpstreamTransfer(rng, index, self)], weights=[1])
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(4)]
+        checkers: list[Checker] = [
+            CdcTotalPeek(rngs[0], self.ctx, self),
+            TransferCountPeek(rngs[1], self.ctx, self),
+            CdcTotalSubscribe(rngs[2], self.ctx, self),
+        ]
+        if self.rtr_supported:
+            checkers.append(RtrPeek(rngs[3], self.ctx, self))
+        return checkers
+
+    def _upstream_state(self) -> tuple[list[tuple[int, int]], int]:
+        conn = self.connect_upstream()
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT id, balance FROM accounts ORDER BY id")
+            accounts = [(int(r[0]), int(r[1])) for r in cur.fetchall()]
+            cur.execute("SELECT count(*) FROM transfers")
+            transfers = int(cur.fetchone()[0])
+            return accounts, transfers
+        finally:
+            conn.close()
+
+    def _mz_state(self, client: MzClient) -> tuple[list[tuple[int, int]], int]:
+        client.query("SET cluster = quickstart")
+        accounts = [
+            (int(r[0]), int(r[1]))
+            for r in client.query("SELECT id, balance FROM accounts_tbl ORDER BY id")
+        ]
+        transfers = int(client.query("SELECT count(*) FROM transfers_tbl")[0][0])
+        return accounts, transfers
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+        upstream = self._upstream_state()
+
+        def caught_up() -> bool:
+            return self._mz_state(client) == upstream
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "CDC ingestion catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        upstream_accounts, upstream_transfers = self._upstream_state()
+        mz_accounts, mz_transfers = self._mz_state(client)
+        if mz_accounts != upstream_accounts:
+            diff = [
+                (up, mz) for up, mz in zip(upstream_accounts, mz_accounts) if up != mz
+            ]
+            raise InvariantViolation(
+                f"account state diverged from upstream: {diff[:20]}"
+            )
+        if mz_transfers != upstream_transfers:
+            raise InvariantViolation(
+                f"transfer count diverged: mz {mz_transfers} !="
+                f" upstream {upstream_transfers}"
+            )
+        if sum(balance for _, balance in mz_accounts) != self.total:
+            raise InvariantViolation(f"final balances do not sum to {self.total}")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM transfers_tbl WHERE worker = {worker}"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - committed - unknown
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            mz_accounts, mz_transfers = self._mz_state(client)
+            upstream_accounts, upstream_transfers = self._upstream_state()
+            verdict = (
+                "converged"
+                if (mz_accounts, mz_transfers)
+                == (upstream_accounts, upstream_transfers)
+                else "still diverged"
+            )
+            self.ctx.log.log(
+                "diag",
+                f"post-heal: mz transfers={mz_transfers}"
+                f" upstream={upstream_transfers}, accounts {verdict}",
+            )
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal comparison failed: {e}")
+        client.reset()
+
+
+class PgCdcBank(CdcBank):
+    name = "pg-cdc-bank"
+    services = ["postgres"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "pg",
+    ]
+
+    def connect_upstream(self) -> Any:
+        import psycopg
+
+        return psycopg.connect(
+            host=self.ctx.endpoints.mz_host,
+            port=self.ctx.endpoints.pg_port,
+            user="postgres",
+            password="postgres",
+            dbname="postgres",
+            connect_timeout=10,
+        )
+
+    def setup_upstream(self) -> None:
+        conn = self.connect_upstream()
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE accounts (id int PRIMARY KEY, balance bigint)")
+        cur.execute(
+            "CREATE TABLE transfers (worker int, seq bigint, src int, dst int,"
+            " amount bigint)"
+        )
+        cur.execute("ALTER TABLE accounts REPLICA IDENTITY FULL")
+        cur.execute("ALTER TABLE transfers REPLICA IDENTITY FULL")
+        cur.execute(
+            "INSERT INTO accounts SELECT generate_series(0, %s), %s",
+            (self.accounts - 1, BALANCE_PER_ACCOUNT),
+        )
+        cur.execute("CREATE PUBLICATION bank_pub FOR TABLE accounts, transfers")
+        conn.commit()
+        conn.close()
+
+    def mz_setup_sql(self) -> list[str]:
+        return [
+            "CREATE SECRET pgpass AS 'postgres'",
+            "CREATE CONNECTION pg_conn TO POSTGRES (HOST 'toxiproxy', PORT 5432,"
+            " DATABASE postgres, USER postgres, PASSWORD SECRET pgpass)",
+            "CREATE SOURCE bank_source IN CLUSTER storage"
+            " FROM POSTGRES CONNECTION pg_conn (PUBLICATION 'bank_pub')",
+            "CREATE TABLE accounts_tbl FROM SOURCE bank_source (REFERENCE accounts)",
+            "CREATE TABLE transfers_tbl FROM SOURCE bank_source (REFERENCE transfers)",
+        ]
+
+
+class MySqlCdcBank(CdcBank):
+    name = "mysql-cdc-bank"
+    services = ["mysql"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "mysql",
+    ]
+
+    def connect_upstream(self) -> Any:
+        import pymysql
+
+        from materialize.mzcompose.services.mysql import MySql
+
+        assert self.ctx.endpoints.mysql_port is not None
+        return pymysql.connect(
+            host=self.ctx.endpoints.mz_host,
+            port=self.ctx.endpoints.mysql_port,
+            user="root",
+            password=MySql.DEFAULT_ROOT_PASSWORD,
+            database="bank",
+            connect_timeout=10,
+        )
+
+    def setup_upstream(self) -> None:
+        import pymysql
+
+        from materialize.mzcompose.services.mysql import MySql
+
+        assert self.ctx.endpoints.mysql_port is not None
+        admin = pymysql.connect(
+            host=self.ctx.endpoints.mz_host,
+            port=self.ctx.endpoints.mysql_port,
+            user="root",
+            password=MySql.DEFAULT_ROOT_PASSWORD,
+            connect_timeout=10,
+        )
+        admin.cursor().execute("CREATE DATABASE bank")
+        admin.close()
+        conn = self.connect_upstream()
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE accounts (id int PRIMARY KEY, balance bigint)")
+        cur.execute(
+            "CREATE TABLE transfers (worker int, seq bigint, src int, dst int,"
+            " amount bigint)"
+        )
+        for account in range(self.accounts):
+            cur.execute(
+                f"INSERT INTO accounts VALUES ({account}, {BALANCE_PER_ACCOUNT})"
+            )
+        conn.commit()
+        conn.close()
+
+    def mz_setup_sql(self) -> list[str]:
+        from materialize.mzcompose.services.mysql import MySql
+
+        return [
+            f"CREATE SECRET mysqlpass AS '{MySql.DEFAULT_ROOT_PASSWORD}'",
+            "CREATE CONNECTION mysql_conn TO MYSQL (HOST 'toxiproxy', PORT 3306,"
+            " USER root, PASSWORD SECRET mysqlpass)",
+            "CREATE SOURCE bank_source IN CLUSTER storage"
+            " FROM MYSQL CONNECTION mysql_conn",
+            "CREATE TABLE accounts_tbl FROM SOURCE bank_source"
+            " (REFERENCE bank.accounts)",
+            "CREATE TABLE transfers_tbl FROM SOURCE bank_source"
+            " (REFERENCE bank.transfers)",
+        ]
+
+
+class SqlServerCdcBank(CdcBank):
+    name = "sqlserver-cdc-bank"
+    rtr_supported = False
+    services = ["sql-server"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "sql-server",
+    ]
+
+    def _connect(self, database: str, autocommit: bool) -> Any:
+        import pymssql
+
+        from materialize.mzcompose.services.sql_server import SqlServer
+
+        assert self.ctx.endpoints.sqlserver_port is not None
+        return pymssql.connect(
+            server=self.ctx.endpoints.mz_host,
+            port=str(self.ctx.endpoints.sqlserver_port),
+            user=SqlServer.DEFAULT_USER,
+            password=SqlServer.DEFAULT_SA_PASSWORD,
+            database=database,
+            autocommit=autocommit,
+            login_timeout=10,
+            timeout=60,
+        )
+
+    def connect_upstream(self) -> Any:
+        return self._connect("bank", autocommit=False)
+
+    def setup_upstream(self) -> None:
+        admin = self._connect("master", autocommit=True)
+        cur = admin.cursor()
+        initial_accounts = ", ".join(
+            f"({account}, {BALANCE_PER_ACCOUNT})" for account in range(self.accounts)
+        )
+        for sql in [
+            "CREATE DATABASE bank",
+            "USE bank",
+            "EXEC sys.sp_cdc_enable_db",
+            "ALTER DATABASE bank SET ALLOW_SNAPSHOT_ISOLATION ON",
+            "CREATE TABLE accounts (id int PRIMARY KEY, balance bigint NOT NULL)",
+            "CREATE TABLE transfers (worker int NOT NULL, seq bigint NOT NULL,"
+            " src int, dst int, amount bigint, PRIMARY KEY (worker, seq))",
+            f"INSERT INTO accounts VALUES {initial_accounts}",
+            "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
+            " @source_name = 'accounts', @role_name = 'SA',"
+            " @supports_net_changes = 0",
+            "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
+            " @source_name = 'transfers', @role_name = 'SA',"
+            " @supports_net_changes = 0",
+            # SQL Server CDC only advances its LSN watermark with new log
+            # activity. Without a ticker the source frontier stalls as soon
+            # as the workers quiesce and converge can never finish, so an
+            # agent job keeps updating a dummy CDC-enabled table, mirroring
+            # test/sql-server-cdc/setup/setup.td.
+            "CREATE TABLE ticker (t datetime)",
+            "INSERT INTO ticker VALUES (CURRENT_TIMESTAMP)",
+            "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
+            " @source_name = 'ticker', @role_name = 'SA',"
+            " @supports_net_changes = 0",
+            # NOTE: the procedure name must differ from the ticker table's,
+            # SQL Server names are case-insensitive under the default
+            # collation.
+            "CREATE OR ALTER PROCEDURE dbo.TickerJob AS BEGIN SET NOCOUNT ON;"
+            " WHILE 1 = 1 BEGIN UPDATE dbo.ticker SET t = CURRENT_TIMESTAMP;"
+            " WAITFOR DELAY '00:00:01'; END END",
+            "USE msdb",
+            "EXEC sp_add_job @job_name = N'TickerJob', @enabled = 1",
+            "EXEC sp_add_jobstep @job_name = N'TickerJob', @step_name = N'run',"
+            " @subsystem = N'TSQL', @database_name = N'bank',"
+            " @command = N'EXEC dbo.TickerJob;'",
+            "EXEC sp_add_jobserver @job_name = N'TickerJob'",
+            "EXEC msdb.dbo.sp_start_job N'TickerJob'",
+        ]:
+            cur.execute(sql)
+        admin.close()
+
+    def mz_setup_sql(self) -> list[str]:
+        from materialize.mzcompose.services.sql_server import SqlServer
+
+        return [
+            f"CREATE SECRET sqlserverpass AS '{SqlServer.DEFAULT_SA_PASSWORD}'",
+            "CREATE CONNECTION sqlserver_conn TO SQL SERVER (HOST 'toxiproxy',"
+            " PORT 1433, DATABASE bank, USER 'SA',"
+            " PASSWORD = SECRET sqlserverpass)",
+            "CREATE SOURCE bank_source IN CLUSTER storage"
+            " FROM SQL SERVER CONNECTION sqlserver_conn",
+            "CREATE TABLE accounts_tbl FROM SOURCE bank_source"
+            " (REFERENCE dbo.accounts)",
+            "CREATE TABLE transfers_tbl FROM SOURCE bank_source"
+            " (REFERENCE dbo.transfers)",
+        ]

--- a/misc/python/materialize/invariants/scenarios/cdc_bank.py
+++ b/misc/python/materialize/invariants/scenarios/cdc_bank.py
@@ -536,13 +536,13 @@ class CdcBank(Scenario):
                 )
             }
             committed = self.oplog.seqs(worker, Outcome.COMMITTED)
-            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            issued = self.oplog.issued(worker)
             missing = committed - present
             if missing:
                 raise InvariantViolation(
                     f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
                 )
-            phantom = present - committed - unknown
+            phantom = present - issued
             if phantom:
                 raise InvariantViolation(
                     f"worker {worker}: transfers present that never committed:"

--- a/misc/python/materialize/invariants/scenarios/cdc_bank.py
+++ b/misc/python/materialize/invariants/scenarios/cdc_bank.py
@@ -177,9 +177,11 @@ class SourceTableChurn(Action):
             raise
         if outcome != Outcome.COMMITTED:
             return outcome
+        # Also bail on stop: this poll can outlast the executor's join
+        # ladder and would read as a stuck thread.
         deadline = time.monotonic() + 120.0
         validated = False
-        while time.monotonic() < deadline:
+        while time.monotonic() < deadline and not self.scenario.ctx.stop.is_set():
             try:
                 rows = self.client.query(
                     f"SELECT coalesce(sum(balance), 0) FROM {name}", timeout=30
@@ -674,10 +676,13 @@ class MySqlCdcBank(CdcBank):
             "CREATE TABLE transfers (worker int, seq bigint, src int, dst int,"
             " amount bigint)"
         )
-        for account in range(self.accounts):
-            cur.execute(
-                f"INSERT INTO accounts VALUES ({account}, {BALANCE_PER_ACCOUNT})"
+        # Batched so the large complexity does not pay one round trip per row.
+        for start in range(0, self.accounts, 1000):
+            values = ", ".join(
+                f"({account}, {BALANCE_PER_ACCOUNT})"
+                for account in range(start, min(start + 1000, self.accounts))
             )
+            cur.execute(f"INSERT INTO accounts VALUES {values}")
         conn.commit()
         conn.close()
 
@@ -735,9 +740,15 @@ class SqlServerCdcBank(CdcBank):
     def setup_upstream(self) -> None:
         admin = self._connect("master", autocommit=True)
         cur = admin.cursor()
-        initial_accounts = ", ".join(
-            f"({account}, {BALANCE_PER_ACCOUNT})" for account in range(self.accounts)
-        )
+        # SQL Server caps a VALUES constructor at 1000 rows.
+        inserts = [
+            "INSERT INTO accounts VALUES "
+            + ", ".join(
+                f"({account}, {BALANCE_PER_ACCOUNT})"
+                for account in range(start, min(start + 1000, self.accounts))
+            )
+            for start in range(0, self.accounts, 1000)
+        ]
         for sql in [
             "CREATE DATABASE bank",
             "USE bank",
@@ -746,7 +757,7 @@ class SqlServerCdcBank(CdcBank):
             "CREATE TABLE accounts (id int PRIMARY KEY, balance bigint NOT NULL)",
             "CREATE TABLE transfers (worker int NOT NULL, seq bigint NOT NULL,"
             " src int, dst int, amount bigint, PRIMARY KEY (worker, seq))",
-            f"INSERT INTO accounts VALUES {initial_accounts}",
+            *inserts,
             "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
             " @source_name = 'accounts', @role_name = 'SA',"
             " @supports_net_changes = 0",

--- a/misc/python/materialize/invariants/scenarios/cdc_bank.py
+++ b/misc/python/materialize/invariants/scenarios/cdc_bank.py
@@ -1,0 +1,950 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Bank transfers in an upstream database, ingested via a CDC source.
+
+Transfers are real upstream transactions (two balance UPDATEs plus a row in
+a transfers log). Materialize documents transactional consistency for
+PostgreSQL and MySQL sources: an upstream transaction is applied at a single
+Materialize timestamp, so sum(balance) must equal the initial total at every
+timestamp, including while the source connection, the clusterd connections,
+or the metadata store are disrupted. The transfers log carries (worker, seq)
+op ids for exact final reconciliation against the upstream oracle.
+"""
+
+import random
+import time
+from abc import abstractmethod
+from typing import Any
+
+from materialize.invariants.checkers import (
+    GroupCompletenessPeek,
+    PeekChecker,
+    ProgressPeek,
+    SubscribeChecker,
+)
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+
+BALANCE_PER_ACCOUNT = 1000
+
+# Worker id used for real-time recency marker rows in the transfers log.
+# Negative so the per-worker reconciliation and count bounds never see them.
+RTR_MARKER_WORKER = -2
+
+# Purification of CREATE TABLE .. FROM SOURCE connects to the upstream database
+# over the (possibly disrupted) source leg to validate the reference. These
+# plan-time connect failures are expected chaos, not a rejected write.
+UPSTREAM_CONNECT_ERROR_SNIPPETS = (
+    "failed to connect to PostgreSQL database",
+    "failed to connect to MySQL database",
+    "failed to connect to SQL Server database",
+)
+
+
+class UpstreamTransfer(Action):
+    """One upstream transaction: debit, credit, and a transfers-log row.
+
+    Accounts are locked in id order so concurrent transfers cannot deadlock.
+    Outcome contract: any failure before COMMIT is FAILED (the upstream
+    database aborts the transaction), a failed COMMIT is UNKNOWN.
+    """
+
+    name = "cdc-transfer"
+
+    def __init__(self, rng: random.Random, worker: int, scenario: "CdcBank") -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.scenario = scenario
+        self.conn: Any = None
+        self.seq = 0
+
+    def _ensure_conn(self) -> Any:
+        if self.conn is None:
+            try:
+                self.conn = self.scenario.connect_upstream()
+            except Exception as e:
+                raise TransientError(f"upstream connect failed: {e}") from e
+        return self.conn
+
+    def _drop_conn(self) -> None:
+        conn, self.conn = self.conn, None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def run(self) -> Outcome | None:
+        conn = self._ensure_conn()
+        self.seq += 1
+        seq = self.seq
+        src, dst = self.rng.sample(range(self.scenario.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        self.scenario.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        try:
+            cur = conn.cursor()
+            for account in sorted((src, dst)):
+                delta = -amount if account == src else amount
+                cur.execute(
+                    f"UPDATE accounts SET balance = balance + {delta}"
+                    f" WHERE id = {account}"
+                )
+            cur.execute(
+                "INSERT INTO transfers (worker, seq, src, dst, amount)"
+                f" VALUES ({self.worker}, {seq}, {src}, {dst}, {amount})"
+            )
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                self._drop_conn()
+            self.scenario.oplog.record(self.worker, seq, Outcome.FAILED)
+            return Outcome.FAILED
+        try:
+            conn.commit()
+        except Exception:
+            self._drop_conn()
+            return Outcome.UNKNOWN
+        self.scenario.oplog.record(self.worker, seq, Outcome.COMMITTED)
+        return Outcome.COMMITTED
+
+    def close(self) -> None:
+        self._drop_conn()
+
+
+class SourceTableChurn(Action):
+    """Source versioning: add and drop tables on the running source.
+
+    CREATE TABLE .. FROM SOURCE snapshots just the new table while the
+    existing tables keep serving (their ingestion may pause during the
+    snapshot, which surfaces as skipped checker rounds). Reads on the new
+    table block until its snapshot completes, so the first value a read
+    returns is a transactionally consistent state and must show the
+    conserved total.
+    """
+
+    name = "source-table"
+
+    def __init__(
+        self, rng: random.Random, client: MzClient, scenario: "CdcBank"
+    ) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.scenario = scenario
+        self.nonce = 0
+        self.next_at = time.monotonic() + 20.0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(45.0, 90.0)
+        # A leftover from a cycle whose drop had an UNKNOWN outcome.
+        if self.nonce > 0:
+            self.client.write(f"DROP TABLE IF EXISTS accounts_v{self.nonce}")
+        self.nonce += 1
+        name = f"accounts_v{self.nonce}"
+        try:
+            outcome = self.client.write(
+                f"CREATE TABLE {name} FROM SOURCE bank_source"
+                f" (REFERENCE {self.scenario.accounts_reference})"
+            )
+        except UnexpectedQueryError as e:
+            # Purification reaches the upstream over the disrupted source leg,
+            # so a plan-time connect failure is expected chaos, not a bug.
+            if any(s in str(e) for s in UPSTREAM_CONNECT_ERROR_SNIPPETS):
+                raise TransientError(str(e)) from e
+            raise
+        if outcome != Outcome.COMMITTED:
+            return outcome
+        # Also bail on stop: this poll can outlast the executor's join
+        # ladder and would read as a stuck thread.
+        deadline = time.monotonic() + 120.0
+        validated = False
+        while time.monotonic() < deadline and not self.scenario.ctx.stop.is_set():
+            try:
+                rows = self.client.query(
+                    f"SELECT coalesce(sum(balance), 0) FROM {name}", timeout=30
+                )
+            except TransientError:
+                continue
+            total = int(rows[0][0])
+            if total != self.scenario.total:
+                if not self.scenario.snapshot_conservation_checked:
+                    self.scenario.ctx.log.log(
+                        "op",
+                        f"SS-427: snapshot of {name} shows a non-conserved"
+                        f" total: {total} != {self.scenario.total}",
+                    )
+                    break
+                raise InvariantViolation(
+                    f"snapshot of {name} shows a non-conserved total:"
+                    f" {total} != {self.scenario.total}"
+                )
+            validated = True
+            break
+        if not validated:
+            self.scenario.ctx.log.log(
+                "op", f"{name} snapshot did not become readable in time"
+            )
+        self.client.write(f"DROP TABLE IF EXISTS {name}")
+        return Outcome.COMMITTED if validated else Outcome.UNKNOWN
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class UpstreamSchemaChurn(Action):
+    """Documented-compatible upstream schema changes on the transfers table.
+
+    Adding a column upstream, and dropping a column that was added after
+    source creation, must not disturb ingestion (the column is simply not
+    ingested). Upstream connection trouble is oracle-side and transient.
+    """
+
+    name = "upstream-ddl"
+
+    def __init__(self, rng: random.Random, scenario: "CdcBank") -> None:
+        super().__init__(rng)
+        self.scenario = scenario
+        self.nonce = 0
+        self.next_at = time.monotonic() + 30.0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(30.0, 60.0)
+        self.nonce += 1
+        statements = [f"ALTER TABLE transfers ADD COLUMN extra_{self.nonce} int"]
+        if self.nonce > 1:
+            statements.insert(
+                0, f"ALTER TABLE transfers DROP COLUMN extra_{self.nonce - 1}"
+            )
+        try:
+            conn = self.scenario.connect_upstream()
+            try:
+                cur = conn.cursor()
+                for sql in statements:
+                    cur.execute(sql)
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            # The previous cycle's ADD may not have applied (its connection
+            # died), making this DROP fail. The next cycle moves on to a
+            # fresh column name either way.
+            raise TransientError(f"upstream DDL failed: {e}") from e
+        return Outcome.COMMITTED
+
+
+class CdcTotalPeek(PeekChecker):
+    """Verifies the total through the maintained MV, an ad-hoc query, and a
+    single query spanning both (which must observe one consistent snapshot
+    across the two objects)."""
+
+    QUERIES = [
+        ("SELECT total FROM bank_total", 1),
+        ("SELECT coalesce(sum(balance), 0) AS total FROM accounts_tbl", 1),
+        (
+            "SELECT total FROM bank_total UNION ALL"
+            " SELECT coalesce(sum(balance), 0) FROM accounts_tbl",
+            2,
+        ),
+    ]
+
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng, ctx, "total-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        # rng, not round-robin: the cluster rotation has the same period as
+        # the query list, round-robin would pin each form to one cluster.
+        query, expected_rows = self.rng.choice(self.QUERIES)
+        recent = self.scenario.recent_ts.get()
+        if recent > 0 and self.rng.random() < 0.25:
+            # Time travel into retained history. Conservation is
+            # timestamp-free, so it must hold at every past timestamp too,
+            # and a tear that the live state has already healed is still
+            # recorded there.
+            as_of = self.rng.randint(max(recent - 120_000, 1), recent)
+            query, expected_rows = f"SELECT total FROM bank_total AS OF {as_of}", 1
+        try:
+            rows = self.peek(query)
+        except UnexpectedQueryError as e:
+            if "could not find a valid timestamp" in str(e):
+                raise TransientError(f"{as_of} no longer readable") from None
+            raise
+        if len(rows) != expected_rows or any(
+            int(row[0]) != self.scenario.total for row in rows
+        ):
+            raise InvariantViolation(
+                f"upstream-transaction atomicity broken via {query!r}: expected"
+                f" {expected_rows}x total {self.scenario.total}, got {rows}"
+            )
+        self.scenario.recent_ts.advance(
+            int(self.client.query("SELECT mz_now()::text")[0][0])
+        )
+        self.validations += 1
+
+
+class TransferCountPeek(PeekChecker):
+    """Transfer count: monotonic, and bounded by the op ledger."""
+
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng, ctx, "transfers-peek", ["quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        watermark = self.scenario.transfer_rows.get()
+        rows = self.peek("SELECT count(*) FROM transfers_tbl WHERE worker >= 0")
+        high = oplog.attempted_count()
+        count = int(rows[0][0])
+        if count < watermark:
+            raise InvariantViolation(
+                f"transfer count went backwards: {count} < watermark {watermark}"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"transfer count {count} exceeds attempted transfers {high}"
+            )
+        # NOTE: no lower bound against committed transfers: ingestion lags the
+        # upstream commit (linearizability does not cover source data), so
+        # committed transfers are only guaranteed visible after converge.
+        self.scenario.transfer_rows.advance(count)
+        self.validations += 1
+
+
+class CdcTotalSubscribe(SubscribeChecker):
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng, ctx, "total-subscribe", "SELECT total FROM bank_total")
+        self.scenario = scenario
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        expected = {(self.scenario.total,): 1}
+        got = {(int(k[0]),): v for k, v in state.items()}
+        if got != expected:
+            raise InvariantViolation(
+                f"total via SUBSCRIBE at {ts}: expected {expected}, got {got}"
+                " (an upstream transaction was applied non-atomically)"
+            )
+
+
+class RtrPeek(Checker):
+    """Real-time recency: a read issued after an upstream commit was
+    acknowledged must include that commit.
+
+    This is RTR's documented "at least" guarantee under strict serializable.
+    RTR queries legitimately error or time out while the source connection
+    is disrupted, which skips the round, but a read that succeeds while
+    missing acknowledged upstream data is a violation.
+    """
+
+    name = "rtr-peek"
+    pause = (2.0, 6.0)
+
+    def __init__(self, rng, ctx, scenario: "CdcBank") -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.scenario = scenario
+        self.client = MzClient(ctx, "rtr-peek")
+        self.markers = 0
+        self._session_ready = False
+
+    def check_once(self) -> None:
+        conn = None
+        marker = self.markers + 1
+        try:
+            conn = self.scenario.connect_upstream()
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO transfers (worker, seq, src, dst, amount)"
+                f" VALUES ({RTR_MARKER_WORKER}, {marker}, 0, 0, 0)"
+            )
+            conn.commit()
+        except Exception as e:
+            raise TransientError(f"upstream marker insert failed: {e}") from e
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        # The marker is acknowledged upstream. If the commit had failed with
+        # an unknown outcome we would not get here, and an unknown commit
+        # that still landed only increases the count, which the >= check
+        # tolerates.
+        self.markers = marker
+        try:
+            if not self._session_ready:
+                self.client.query("SET real_time_recency = true")
+                self._session_ready = True
+            rows = self.client.query(
+                "SELECT count(*) FROM transfers_tbl"
+                f" WHERE worker = {RTR_MARKER_WORKER}"
+            )
+        except TransientError:
+            # The connection was dropped, so the session setting is gone.
+            self._session_ready = False
+            raise
+        except UnexpectedQueryError as e:
+            self._session_ready = False
+            # The recency probe contacts the upstream database over the
+            # disrupted leg, so besides the RTR timeout it can surface the
+            # storage layer's connection failures. Both are expected chaos,
+            # only a successful read with missing data is a violation.
+            if "timed out before ingesting" in str(e) or "storage error" in str(e):
+                raise TransientError(str(e)) from e
+            raise
+        count = int(rows[0][0])
+        if count < self.markers:
+            raise InvariantViolation(
+                f"real-time recency violated: read issued after upstream ack"
+                f" saw {count} markers, expected at least {self.markers}"
+            )
+        self.validations += 1
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+# A transaction's rows say how many of them there should be, so a group of
+# any other size means the transaction became visible in pieces.
+WIDE_TXN_TORN_SQL = (
+    "SELECT txn_id, count(*), txn_rows FROM wide_txn_tbl"
+    " GROUP BY txn_id, txn_rows HAVING count(*) <> txn_rows"
+)
+
+
+class WideTransaction(Action):
+    """One upstream transaction writing many self-describing rows.
+
+    The transfer workload commits two rows at a time, and a two-row
+    transaction is a small target: an interrupted snapshot or a resumption has
+    to land exactly between them to tear. These transactions are tens of rows
+    wide, so the window a reader can fall into is correspondingly wider.
+
+    Every row carries the id of its transaction and the number of rows that
+    transaction wrote, which makes the atomicity invariant self-contained: no
+    checker state, no knowledge of which transactions committed, and it holds
+    at every timestamp, including ones in retained history.
+    """
+
+    name = "wide-txn"
+
+    def __init__(self, rng: random.Random, worker: int, scenario: "CdcBank") -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.scenario = scenario
+        self.conn: Any = None
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        if self.conn is None:
+            try:
+                self.conn = self.scenario.connect_upstream()
+            except Exception as e:
+                raise TransientError(f"upstream connect failed: {e}") from e
+        self.seq += 1
+        # Unique across workers without coordination.
+        txn_id = self.worker * 10_000_000 + self.seq
+        rows = self.rng.randint(5, 50)
+        values = ", ".join(f"({txn_id}, {rows}, {i})" for i in range(rows))
+        try:
+            self.conn.cursor().execute(
+                f"INSERT INTO wide_txn (txn_id, txn_rows, idx) VALUES {values}"
+            )
+        except Exception:
+            try:
+                self.conn.rollback()
+            except Exception:
+                self._drop()
+            return Outcome.FAILED
+        try:
+            self.conn.commit()
+        except Exception:
+            self._drop()
+            return Outcome.UNKNOWN
+        return Outcome.COMMITTED
+
+    def _drop(self) -> None:
+        conn, self.conn = self.conn, None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        self._drop()
+
+
+class CdcBank(Scenario):
+    # Real-time recency is documented for Kafka, PostgreSQL, and MySQL
+    # sources only.
+    rtr_supported = True
+    # Whether the documented-compatible upstream schema changes (add
+    # column, drop later-added column) are exercised. SQL Server is
+    # excluded: its CDC capture instances pin the captured column list, so
+    # column changes are a different, heavier operation there.
+    upstream_ddl_supported = True
+    # The CREATE TABLE .. FROM SOURCE reference for the accounts table.
+    accounts_reference: str
+    # TODO: Reenable when SS-427 is fixed. A MySQL snapshot taken while the
+    # upstream connection is being truncated can expose half of an upstream
+    # transaction, which shows up here as a non-conserved total.
+    snapshot_conservation_checked = True
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.total = self.accounts * BALANCE_PER_ACCOUNT
+        self.oplog = OpLog()
+        self.transfer_rows = Watermark()
+        # Recent timestamps observed by the conservation peeks, so the same
+        # invariant can be re-asked of retained history.
+        self.recent_ts = Watermark()
+
+    @abstractmethod
+    def connect_upstream(self) -> Any:
+        """A new connection to the upstream database (direct, not proxied)."""
+
+    @abstractmethod
+    def setup_upstream(self) -> None:
+        pass
+
+    @abstractmethod
+    def mz_setup_sql(self) -> list[str]:
+        pass
+
+    def setup(self) -> None:
+        self.setup_upstream()
+        client = MzClient(self.ctx, "setup")
+        for sql in self.mz_setup_sql() + [
+            # RETAIN HISTORY so the conservation oracle can be asked of past
+            # timestamps: a torn upstream transaction is durable in the
+            # shard's history even once the live state has converged, which
+            # is how SS-427 stayed findable after the fact.
+            "CREATE MATERIALIZED VIEW bank_total IN CLUSTER compute"
+            " WITH (RETAIN HISTORY = FOR '600s') AS"
+            " SELECT coalesce(sum(balance), 0) AS total FROM accounts_tbl",
+            "CREATE INDEX bank_total_idx IN CLUSTER compute ON bank_total (total)",
+        ]:
+            client.query(sql, timeout=120)
+
+        def snapshot_done() -> bool:
+            rows = client.query("SELECT count(*) FROM accounts_tbl")
+            return int(rows[0][0]) == self.accounts
+
+        wait_until(snapshot_done, CONVERGE_TIMEOUT, "source snapshot")
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        actions: list[Action] = [
+            UpstreamTransfer(rng, index, self),
+            WideTransaction(rng, index, self),
+        ]
+        weights = [20, 4]
+        if index == 0:
+            actions.append(
+                SourceTableChurn(rng, MzClient(self.ctx, "source-table"), self)
+            )
+            weights.append(1)
+            if self.upstream_ddl_supported:
+                actions.append(UpstreamSchemaChurn(rng, self))
+                weights.append(1)
+        return WorkerBundle(actions=actions, weights=weights)
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(6)]
+        checkers: list[Checker] = [
+            CdcTotalPeek(rngs[0], self.ctx, self),
+            GroupCompletenessPeek(
+                rngs[5],
+                self.ctx,
+                "wide-txn-atomicity",
+                WIDE_TXN_TORN_SQL,
+                clusters=["quickstart"],
+                history=self.recent_ts,
+            ),
+            TransferCountPeek(rngs[1], self.ctx, self),
+            CdcTotalSubscribe(rngs[2], self.ctx, self),
+            ProgressPeek(rngs[3], self.ctx, "bank_source"),
+        ]
+        if self.rtr_supported:
+            checkers.append(RtrPeek(rngs[4], self.ctx, self))
+        return checkers
+
+    def _upstream_state(self) -> tuple[list[tuple[int, int]], int]:
+        conn = self.connect_upstream()
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT id, balance FROM accounts ORDER BY id")
+            accounts = [(int(r[0]), int(r[1])) for r in cur.fetchall()]
+            cur.execute("SELECT count(*) FROM transfers")
+            transfers = int(cur.fetchone()[0])
+            return accounts, transfers
+        finally:
+            conn.close()
+
+    def _mz_state(self, client: MzClient) -> tuple[list[tuple[int, int]], int]:
+        client.query("SET cluster = quickstart")
+        accounts = [
+            (int(r[0]), int(r[1]))
+            for r in client.query("SELECT id, balance FROM accounts_tbl ORDER BY id")
+        ]
+        transfers = int(client.query("SELECT count(*) FROM transfers_tbl")[0][0])
+        return accounts, transfers
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+        upstream = self._upstream_state()
+
+        def caught_up() -> bool:
+            return self._mz_state(client) == upstream
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "CDC ingestion catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        upstream_accounts, upstream_transfers = self._upstream_state()
+        mz_accounts, mz_transfers = self._mz_state(client)
+        if mz_accounts != upstream_accounts:
+            diff = [
+                (up, mz) for up, mz in zip(upstream_accounts, mz_accounts) if up != mz
+            ]
+            raise InvariantViolation(
+                f"account state diverged from upstream: {diff[:20]}"
+            )
+        if mz_transfers != upstream_transfers:
+            raise InvariantViolation(
+                f"transfer count diverged: mz {mz_transfers} !="
+                f" upstream {upstream_transfers}"
+            )
+        if sum(balance for _, balance in mz_accounts) != self.total:
+            raise InvariantViolation(f"final balances do not sum to {self.total}")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM transfers_tbl WHERE worker = {worker}"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            issued = self.oplog.issued(worker)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - issued
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            mz_accounts, mz_transfers = self._mz_state(client)
+            upstream_accounts, upstream_transfers = self._upstream_state()
+            verdict = (
+                "converged"
+                if (mz_accounts, mz_transfers)
+                == (upstream_accounts, upstream_transfers)
+                else "still diverged"
+            )
+            self.ctx.log.log(
+                "diag",
+                f"post-heal: mz transfers={mz_transfers}"
+                f" upstream={upstream_transfers}, accounts {verdict}",
+            )
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal comparison failed: {e}")
+        client.reset()
+
+
+class PgCdcBank(CdcBank):
+    name = "pg-cdc-bank"
+    accounts_reference = "accounts"
+    services = ["postgres"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "pg",
+    ]
+
+    def connect_upstream(self) -> Any:
+        import psycopg
+
+        return psycopg.connect(
+            host=self.ctx.endpoints.mz_host,
+            port=self.ctx.endpoints.pg_port,
+            user="postgres",
+            password="postgres",
+            dbname="postgres",
+            connect_timeout=10,
+        )
+
+    def setup_upstream(self) -> None:
+        conn = self.connect_upstream()
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE accounts (id int PRIMARY KEY, balance bigint)")
+        cur.execute(
+            "CREATE TABLE transfers (worker int, seq bigint, src int, dst int,"
+            " amount bigint)"
+        )
+        cur.execute("CREATE TABLE wide_txn (txn_id bigint, txn_rows int, idx int)")
+        cur.execute("ALTER TABLE accounts REPLICA IDENTITY FULL")
+        cur.execute("ALTER TABLE transfers REPLICA IDENTITY FULL")
+        cur.execute("ALTER TABLE wide_txn REPLICA IDENTITY FULL")
+        cur.execute(
+            "INSERT INTO accounts SELECT generate_series(0, %s), %s",
+            (self.accounts - 1, BALANCE_PER_ACCOUNT),
+        )
+        cur.execute(
+            "CREATE PUBLICATION bank_pub FOR TABLE accounts, transfers, wide_txn"
+        )
+        conn.commit()
+        conn.close()
+
+    def mz_setup_sql(self) -> list[str]:
+        return [
+            "CREATE SECRET pgpass AS 'postgres'",
+            "CREATE CONNECTION pg_conn TO POSTGRES (HOST 'toxiproxy', PORT 5432,"
+            " DATABASE postgres, USER postgres, PASSWORD SECRET pgpass)",
+            "CREATE SOURCE bank_source IN CLUSTER storage"
+            " FROM POSTGRES CONNECTION pg_conn (PUBLICATION 'bank_pub')",
+            "CREATE TABLE accounts_tbl FROM SOURCE bank_source (REFERENCE accounts)",
+            "CREATE TABLE transfers_tbl FROM SOURCE bank_source (REFERENCE transfers)",
+            "CREATE TABLE wide_txn_tbl FROM SOURCE bank_source (REFERENCE wide_txn)",
+        ]
+
+
+class MySqlCdcBank(CdcBank):
+    name = "mysql-cdc-bank"
+    snapshot_conservation_checked = False
+    accounts_reference = "bank.accounts"
+    services = ["mysql"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "mysql",
+    ]
+
+    def connect_upstream(self) -> Any:
+        import pymysql
+
+        from materialize.mzcompose.services.mysql import MySql
+
+        assert self.ctx.endpoints.mysql_port is not None
+        return pymysql.connect(
+            host=self.ctx.endpoints.mz_host,
+            port=self.ctx.endpoints.mysql_port,
+            user="root",
+            password=MySql.DEFAULT_ROOT_PASSWORD,
+            database="bank",
+            connect_timeout=10,
+        )
+
+    def setup_upstream(self) -> None:
+        import pymysql
+
+        from materialize.mzcompose.services.mysql import MySql
+
+        assert self.ctx.endpoints.mysql_port is not None
+        admin = pymysql.connect(
+            host=self.ctx.endpoints.mz_host,
+            port=self.ctx.endpoints.mysql_port,
+            user="root",
+            password=MySql.DEFAULT_ROOT_PASSWORD,
+            connect_timeout=10,
+        )
+        admin.cursor().execute("CREATE DATABASE bank")
+        admin.close()
+        conn = self.connect_upstream()
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE accounts (id int PRIMARY KEY, balance bigint)")
+        cur.execute(
+            "CREATE TABLE transfers (worker int, seq bigint, src int, dst int,"
+            " amount bigint)"
+        )
+        cur.execute("CREATE TABLE wide_txn (txn_id bigint, txn_rows int, idx int)")
+        # Batched so the large complexity does not pay one round trip per row.
+        for start in range(0, self.accounts, 1000):
+            values = ", ".join(
+                f"({account}, {BALANCE_PER_ACCOUNT})"
+                for account in range(start, min(start + 1000, self.accounts))
+            )
+            cur.execute(f"INSERT INTO accounts VALUES {values}")
+        conn.commit()
+        conn.close()
+
+    def mz_setup_sql(self) -> list[str]:
+        from materialize.mzcompose.services.mysql import MySql
+
+        return [
+            f"CREATE SECRET mysqlpass AS '{MySql.DEFAULT_ROOT_PASSWORD}'",
+            "CREATE CONNECTION mysql_conn TO MYSQL (HOST 'toxiproxy', PORT 3306,"
+            " USER root, PASSWORD SECRET mysqlpass)",
+            "CREATE SOURCE bank_source IN CLUSTER storage"
+            " FROM MYSQL CONNECTION mysql_conn",
+            "CREATE TABLE accounts_tbl FROM SOURCE bank_source"
+            " (REFERENCE bank.accounts)",
+            "CREATE TABLE transfers_tbl FROM SOURCE bank_source"
+            " (REFERENCE bank.transfers)",
+            "CREATE TABLE wide_txn_tbl FROM SOURCE bank_source"
+            " (REFERENCE bank.wide_txn)",
+        ]
+
+
+class SqlServerCdcBank(CdcBank):
+    name = "sqlserver-cdc-bank"
+    rtr_supported = False
+    upstream_ddl_supported = False
+    # SQL Server captures changes with a polling agent that scans the
+    # transaction log on a schedule, rather than streaming it the way Postgres
+    # logical replication and the MySQL binlog do. Its capture rate is
+    # therefore a ceiling the writers can exceed, and once they do the lag
+    # grows for the rest of the run and converge has to drain all of it.
+    # Fewer writers keeps the bottleneck inside Materialize, which is what
+    # this test is about.
+    max_workers = 6
+    accounts_reference = "dbo.accounts"
+    services = ["sql-server"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "sql-server",
+    ]
+
+    def _connect(self, database: str, autocommit: bool) -> Any:
+        import pymssql
+
+        from materialize.mzcompose.services.sql_server import SqlServer
+
+        assert self.ctx.endpoints.sqlserver_port is not None
+        return pymssql.connect(
+            server=self.ctx.endpoints.mz_host,
+            port=str(self.ctx.endpoints.sqlserver_port),
+            user=SqlServer.DEFAULT_USER,
+            password=SqlServer.DEFAULT_SA_PASSWORD,
+            database=database,
+            autocommit=autocommit,
+            login_timeout=10,
+            timeout=60,
+        )
+
+    def connect_upstream(self) -> Any:
+        return self._connect("bank", autocommit=False)
+
+    def setup_upstream(self) -> None:
+        admin = self._connect("master", autocommit=True)
+        cur = admin.cursor()
+        # SQL Server caps a VALUES constructor at 1000 rows.
+        inserts = [
+            "INSERT INTO accounts VALUES "
+            + ", ".join(
+                f"({account}, {BALANCE_PER_ACCOUNT})"
+                for account in range(start, min(start + 1000, self.accounts))
+            )
+            for start in range(0, self.accounts, 1000)
+        ]
+        for sql in [
+            "CREATE DATABASE bank",
+            "USE bank",
+            "EXEC sys.sp_cdc_enable_db",
+            "ALTER DATABASE bank SET ALLOW_SNAPSHOT_ISOLATION ON",
+            "CREATE TABLE accounts (id int PRIMARY KEY, balance bigint NOT NULL)",
+            "CREATE TABLE transfers (worker int NOT NULL, seq bigint NOT NULL,"
+            " src int, dst int, amount bigint, PRIMARY KEY (worker, seq))",
+            "CREATE TABLE wide_txn (txn_id bigint NOT NULL, txn_rows int NOT NULL,"
+            " idx int NOT NULL)",
+            *inserts,
+            "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
+            " @source_name = 'accounts', @role_name = 'SA',"
+            " @supports_net_changes = 0",
+            "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
+            " @source_name = 'transfers', @role_name = 'SA',"
+            " @supports_net_changes = 0",
+            "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
+            " @source_name = 'wide_txn', @role_name = 'SA',"
+            " @supports_net_changes = 0",
+            # SQL Server CDC only advances its LSN watermark with new log
+            # activity. Without a ticker the source frontier stalls as soon
+            # as the workers quiesce and converge can never finish, so an
+            # agent job keeps updating a dummy CDC-enabled table, mirroring
+            # test/sql-server-cdc/setup/setup.td.
+            "CREATE TABLE ticker (t datetime)",
+            "INSERT INTO ticker VALUES (CURRENT_TIMESTAMP)",
+            "EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',"
+            " @source_name = 'ticker', @role_name = 'SA',"
+            " @supports_net_changes = 0",
+            # NOTE: the procedure name must differ from the ticker table's,
+            # SQL Server names are case-insensitive under the default
+            # collation.
+            "CREATE OR ALTER PROCEDURE dbo.TickerJob AS BEGIN SET NOCOUNT ON;"
+            " WHILE 1 = 1 BEGIN UPDATE dbo.ticker SET t = CURRENT_TIMESTAMP;"
+            " WAITFOR DELAY '00:00:01'; END END",
+            "USE msdb",
+            "EXEC sp_add_job @job_name = N'TickerJob', @enabled = 1",
+            "EXEC sp_add_jobstep @job_name = N'TickerJob', @step_name = N'run',"
+            " @subsystem = N'TSQL', @database_name = N'bank',"
+            " @command = N'EXEC dbo.TickerJob;'",
+            "EXEC sp_add_jobserver @job_name = N'TickerJob'",
+            "EXEC msdb.dbo.sp_start_job N'TickerJob'",
+        ]:
+            cur.execute(sql)
+        admin.close()
+
+    def mz_setup_sql(self) -> list[str]:
+        from materialize.mzcompose.services.sql_server import SqlServer
+
+        return [
+            f"CREATE SECRET sqlserverpass AS '{SqlServer.DEFAULT_SA_PASSWORD}'",
+            "CREATE CONNECTION sqlserver_conn TO SQL SERVER (HOST 'toxiproxy',"
+            " PORT 1433, DATABASE bank, USER 'SA',"
+            " PASSWORD = SECRET sqlserverpass)",
+            "CREATE SOURCE bank_source IN CLUSTER storage"
+            " FROM SQL SERVER CONNECTION sqlserver_conn",
+            "CREATE TABLE accounts_tbl FROM SOURCE bank_source"
+            " (REFERENCE dbo.accounts)",
+            "CREATE TABLE transfers_tbl FROM SOURCE bank_source"
+            " (REFERENCE dbo.transfers)",
+            "CREATE TABLE wide_txn_tbl FROM SOURCE bank_source"
+            " (REFERENCE dbo.wide_txn)",
+        ]

--- a/misc/python/materialize/invariants/scenarios/graph.py
+++ b/misc/python/materialize/invariants/scenarios/graph.py
@@ -1,0 +1,249 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Transitive closure of a churning graph, maintained by a recursive dataflow.
+
+Every other scenario reduces or joins its input once. This one iterates: a
+WITH MUTUALLY RECURSIVE materialized view maintains the reachability closure
+of an edge table that workers insert into and delete from continuously.
+
+Deletions are the point. An insert only ever grows the closure, which an
+iterative dataflow can get right by accumulating, while a delete has to
+retract every path that went through the removed edge, including paths
+discovered several iterations deep.
+
+The invariants need no bookkeeping and hold at every timestamp, so they are
+checkable while most op outcomes are unknown: the visible closure must be
+transitively closed, must contain every visible edge, must contain no self
+loop (edges only ever point from a lower node to a higher one, so no subset
+of the operations can produce a cycle), and must equal the same reachability
+question recomputed from scratch at the same timestamp.
+"""
+
+import random
+
+from materialize.invariants.checkers import (
+    GroupCompletenessPeek,
+    ProgressPeek,
+    ReplicaDivergence,
+)
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    Outcome,
+    Scenario,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+
+# The final check runs on a quiesced system and legitimately scans everything
+# the run wrote, which the per-query watchdog is not sized for: that watchdog
+# exists to stop a checker hanging during chaos, and cancelling a final-check
+# query instead reports a wedge that is really just a big honest query.
+FINAL_TIMEOUT = 600
+
+# A DAG whose edges only ever point from a lower node to a higher one, so the
+# graph is acyclic no matter which inserts and deletes committed, and the
+# closure of whatever edges are currently visible is the thing to check. Small
+# enough that a dense closure stays bounded.
+GRAPH_NODES = 40
+
+# Reachability recomputed from scratch, for comparison against the maintained
+# view. UNION rather than UNION ALL so the iteration converges.
+GRAPH_REACH_CTE = (
+    "WITH MUTUALLY RECURSIVE reach (src int, dst int) AS ("
+    " SELECT src, dst FROM edges"
+    " UNION"
+    " SELECT r.src, e.dst FROM reach r JOIN edges e ON r.dst = e.src"
+    ")"
+)
+GRAPH_CLOSURE_SQL = f"{GRAPH_REACH_CTE} SELECT src, dst FROM reach"
+
+# Three properties of the closure of whatever edges are visible right now.
+# None of them depend on which operations succeeded, and each fails for a
+# different reason: a missing transitive pair means the iteration stopped
+# early, a missing edge means the base case was lost, and a self-loop means a
+# retraction left a cycle behind in a graph that cannot contain one.
+GRAPH_NOT_CLOSED_SQL = (
+    "SELECT a.src, a.dst, b.dst FROM closure a"
+    " JOIN closure b ON a.dst = b.src"
+    " LEFT JOIN closure c ON c.src = a.src AND c.dst = b.dst"
+    " WHERE c.src IS NULL LIMIT 5"
+)
+GRAPH_MISSING_EDGE_SQL = (
+    "SELECT e.src, e.dst FROM edges e"
+    " LEFT JOIN closure c ON c.src = e.src AND c.dst = e.dst"
+    " WHERE c.src IS NULL LIMIT 5"
+)
+GRAPH_SELF_LOOP_SQL = "SELECT src, dst FROM closure WHERE src = dst LIMIT 5"
+
+# The maintained view against the same question recomputed in one shot, at one
+# timestamp. This is the one that catches the incremental iteration diverging
+# from the batch answer, which is what retractions through a recursive
+# dataflow are most likely to get wrong.
+# The recursion is defined once and referenced from both sides: a WITH cannot
+# be an operand of a set operation, and this keeps it to one statement, so
+# both sides are answered at one timestamp.
+GRAPH_DIFFERENTIAL_SQL = (
+    f"{GRAPH_REACH_CTE}"
+    " (SELECT src, dst FROM closure EXCEPT ALL SELECT src, dst FROM reach)"
+    " UNION ALL"
+    " (SELECT src, dst FROM reach EXCEPT ALL SELECT src, dst FROM closure)"
+)
+
+GRAPH_REACH_COUNT_SQL = f"{GRAPH_REACH_CTE} SELECT count(*) FROM reach"
+
+
+class GraphChurn(Action):
+    """Insert and delete edges of an acyclic graph.
+
+    Edges always point from a lower node to a higher one, so the graph stays
+    acyclic whatever subset of the operations applied, which is what lets the
+    self-loop check be an invariant rather than a race.
+    """
+
+    name = "graph-churn"
+
+    def __init__(self, rng: random.Random, client: MzClient) -> None:
+        super().__init__(rng)
+        self.client = client
+
+    def run(self) -> Outcome | None:
+        if self.rng.random() < 0.4:
+            # Delete by predicate rather than by a remembered edge: an
+            # UNKNOWN insert may or may not exist, and this is correct either
+            # way. Clearing a whole node at once retracts many paths.
+            src = self.rng.randrange(GRAPH_NODES - 1)
+            return self.client.write(f"DELETE FROM edges WHERE src = {src}")
+        if self.rng.random() < 0.2:
+            # A chain in one transaction, which creates paths several
+            # iterations deep in a single update, so the next delete has
+            # something long to retract.
+            start = self.rng.randrange(GRAPH_NODES - 4)
+            nodes = sorted(
+                self.rng.sample(range(start + 1, GRAPH_NODES), self.rng.randint(2, 4))
+            )
+            chain = [start] + nodes
+            values = ", ".join(
+                f"({a}, {b})" for a, b in zip(chain, chain[1:], strict=False)
+            )
+            return self.client.write(f"INSERT INTO edges VALUES {values}")
+        src = self.rng.randrange(GRAPH_NODES - 1)
+        dst = self.rng.randrange(src + 1, GRAPH_NODES)
+        return self.client.write(f"INSERT INTO edges VALUES ({src}, {dst})")
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class Graph(Scenario):
+    name = "graph"
+    services: list[str] = []
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "pubsub-compute",
+        "pubsub-compute2",
+    ]
+
+    def setup(self) -> None:
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE edges (src int, dst int)",
+            # A spanning chain, so the closure is deep from the first
+            # timestamp on and the checkers are never vacuous while the
+            # workers are still warming up.
+            f"INSERT INTO edges SELECT g, g + 1 FROM generate_series(0, {GRAPH_NODES - 2}) g",
+            # RETAIN HISTORY covers the timestamp the replica comparison
+            # probes, which is deliberately slightly in the past.
+            "CREATE MATERIALIZED VIEW closure IN CLUSTER compute"
+            f" WITH (RETAIN HISTORY = FOR '600s') AS {GRAPH_CLOSURE_SQL}",
+            "CREATE INDEX closure_idx IN CLUSTER compute ON closure (src)",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        return WorkerBundle(
+            actions=[GraphChurn(rng, MzClient(self.ctx, f"worker-{index}"))],
+            weights=[1],
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(6)]
+        return [
+            GroupCompletenessPeek(
+                rngs[0], self.ctx, "closure-transitive", GRAPH_NOT_CLOSED_SQL
+            ),
+            GroupCompletenessPeek(
+                rngs[1], self.ctx, "closure-has-edges", GRAPH_MISSING_EDGE_SQL
+            ),
+            GroupCompletenessPeek(
+                rngs[2], self.ctx, "closure-acyclic", GRAPH_SELF_LOOP_SQL
+            ),
+            # Recomputing the recursion is the expensive one, and it can only
+            # run where a dataflow can be installed, not on the storage
+            # cluster's default replica.
+            GroupCompletenessPeek(
+                rngs[3],
+                self.ctx,
+                "closure-differential",
+                GRAPH_DIFFERENTIAL_SQL,
+                clusters=["compute"],
+            ),
+            ReplicaDivergence(rngs[4], self.ctx, ("SELECT count(*) FROM closure",)),
+            ProgressPeek(rngs[5], self.ctx, "closure", name="closure-progress"),
+        ]
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            client.query("SET cluster = compute")
+            maintained = int(client.query("SELECT count(*) FROM closure")[0][0])
+            recomputed = int(client.query(GRAPH_REACH_COUNT_SQL)[0][0])
+            return maintained == recomputed
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "the closure catching up to the edges")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = compute")
+        # Churn can leave an arbitrarily sparse graph behind, and every oracle
+        # here passes trivially on a closure with no paths in it. Restoring
+        # the spanning chain pins the end state: with every consecutive edge
+        # present, reachability is exactly the pairs (i, j) with i < j, so the
+        # closure is both maximally dense and known in advance.
+        client.query(
+            f"INSERT INTO edges SELECT g, g + 1"
+            f" FROM generate_series(0, {GRAPH_NODES - 2}) g"
+        )
+        expected = GRAPH_NODES * (GRAPH_NODES - 1) // 2
+        wait_until(
+            lambda: int(client.query("SELECT count(*) FROM closure")[0][0]) == expected,
+            CONVERGE_TIMEOUT,
+            f"the closure reaching all {expected} pairs of the restored chain",
+        )
+        for name, sql in (
+            ("not transitively closed", GRAPH_NOT_CLOSED_SQL),
+            ("missing an edge", GRAPH_MISSING_EDGE_SQL),
+            ("has a self loop", GRAPH_SELF_LOOP_SQL),
+            ("disagrees with a recomputation", GRAPH_DIFFERENTIAL_SQL),
+        ):
+            bad = client.query(sql, timeout=FINAL_TIMEOUT)
+            if bad:
+                raise InvariantViolation(f"closure {name}: {bad[:10]}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/kafka_ledger.py
+++ b/misc/python/materialize/invariants/scenarios/kafka_ledger.py
@@ -20,7 +20,11 @@ cannot legitimately duplicate an event, which makes "exactly once" checkable.
 import json
 import random
 
-from materialize.invariants.checkers import PeekChecker, SubscribeChecker
+from materialize.invariants.checkers import (
+    PeekChecker,
+    ProgressPeek,
+    SubscribeChecker,
+)
 from materialize.invariants.framework import (
     CONVERGE_TIMEOUT,
     SEED_RANGE,
@@ -36,13 +40,16 @@ from materialize.invariants.framework import (
     WorkerBundle,
     wait_until,
 )
-from materialize.invariants.mz import MzClient
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
 
 TOPIC = "invariants-ledger"
 PARTITIONS = 3
 # Bounds how long an unresolved produce can straddle the converge phase.
 MESSAGE_TIMEOUT_MS = 30_000
 SENTINEL_WORKER = -1
+# Worker id used for real-time recency marker events. Negative so the
+# regular count bounds and reconciliation never see them.
+RTR_MARKER_WORKER = -2
 
 
 def make_producer(bootstrap: str):
@@ -117,8 +124,7 @@ class EventCountPeek(PeekChecker):
     def check_once(self) -> None:
         watermark = self.scenario.event_rows.get()
         rows = self.peek(
-            "SELECT count(*) FROM events"
-            f" WHERE (data->>'worker')::int <> {SENTINEL_WORKER}"
+            "SELECT count(*) FROM events WHERE (data->>'worker')::int >= 0"
         )
         high = self.scenario.oplog.attempted_count()
         count = int(rows[0][0])
@@ -135,17 +141,140 @@ class EventCountPeek(PeekChecker):
         self.validations += 1
 
 
-class WorkerStatsSubscribe(SubscribeChecker):
-    """Per-worker count and max seq must never move backwards in-session."""
+class EventMetadataPeek(PeekChecker):
+    """The documented INCLUDE metadata columns must be sound.
 
-    def __init__(self, rng, ctx, scenario: "KafkaLedger") -> None:
+    (partition, offset) identifies one Kafka message, so a duplicated pair
+    means an event was ingested twice, which detects duplication directly
+    instead of only through count bounds. The included key must match the
+    payload's worker id (producers key every message that way), offsets per
+    partition never move backwards, and the broker timestamp is never in
+    the future beyond clock skew.
+    """
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "metadata-peek", ["quickstart", "compute"])
+        self.max_offsets: dict[int, int] = {}
+
+    def check_once(self) -> None:
+        duplicated = self.peek(
+            "SELECT part, kafka_offset FROM events"
+            " GROUP BY part, kafka_offset HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"duplicate (partition, offset) pairs ingested: {duplicated[:20]}"
+            )
+        mismatched = self.peek(
+            "SELECT count(*) FROM events"
+            " WHERE msg_key IS DISTINCT FROM data->>'worker'"
+        )
+        if int(mismatched[0][0]) != 0:
+            raise InvariantViolation(
+                f"{mismatched[0][0]} events whose INCLUDE KEY does not match"
+                " the payload's worker id"
+            )
+        skewed = self.peek(
+            "SELECT count(*) FROM events"
+            " WHERE kafka_ts > now() + INTERVAL '5 minutes'"
+        )
+        if int(skewed[0][0]) != 0:
+            raise InvariantViolation(
+                f"{skewed[0][0]} events with a far-future INCLUDE TIMESTAMP"
+            )
+        watermarks = dict(self.max_offsets)
+        rows = self.peek("SELECT part, max(kafka_offset) FROM events GROUP BY part")
+        for row in rows:
+            part, max_offset = int(row[0]), int(row[1])
+            if watermarks.get(part, -1) > max_offset:
+                raise InvariantViolation(
+                    f"partition {part} max offset moved backwards:"
+                    f" {max_offset} < {watermarks[part]}"
+                )
+            if max_offset > self.max_offsets.get(part, -1):
+                self.max_offsets[part] = max_offset
+        self.validations += 1
+
+
+class KafkaRtrPeek(Checker):
+    """Real-time recency for Kafka sources: a read issued after the broker
+    acknowledged a produce must include that event.
+
+    Mirrors the CDC scenarios' RTR checker. RTR queries legitimately error
+    or time out while the source leg is disrupted (skipped round), but a
+    successful read missing an acknowledged event is a violation.
+    """
+
+    name = "rtr-peek"
+    pause = (2.0, 6.0)
+
+    def __init__(self, rng, ctx, bootstrap: str) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.client = MzClient(ctx, "rtr-peek")
+        self.bootstrap = bootstrap
+        self.producer = None
+        self.markers = 0
+        self._session_ready = False
+
+    def check_once(self) -> None:
+        if self.producer is None:
+            self.producer = make_producer(self.bootstrap)
+        marker = self.markers + 1
+        self.producer.produce(
+            TOPIC,
+            value=json.dumps({"worker": RTR_MARKER_WORKER, "seq": marker}).encode(),
+            key=str(RTR_MARKER_WORKER).encode(),
+        )
+        if self.producer.flush(30) != 0:
+            # The marker was not acknowledged, so it creates no lower bound.
+            self.producer = None
+            raise TransientError("RTR marker produce not acknowledged")
+        self.markers = marker
+        try:
+            if not self._session_ready:
+                self.client.query("SET real_time_recency = true")
+                self._session_ready = True
+            rows = self.client.query(
+                "SELECT count(*) FROM events"
+                f" WHERE (data->>'worker')::int = {RTR_MARKER_WORKER}"
+            )
+        except TransientError:
+            self._session_ready = False
+            raise
+        except UnexpectedQueryError as e:
+            self._session_ready = False
+            if "timed out before ingesting" in str(e) or "storage error" in str(e):
+                raise TransientError(str(e)) from e
+            raise
+        count = int(rows[0][0])
+        if count < self.markers:
+            raise InvariantViolation(
+                f"real-time recency violated: read issued after broker ack"
+                f" saw {count} markers, expected at least {self.markers}"
+            )
+        self.validations += 1
+
+    def close(self) -> None:
+        if self.producer is not None:
+            self.producer.flush(10)
+        self.client.reset()
+
+
+class WorkerStatsSubscribe(SubscribeChecker):
+    """Per-worker count and max seq must never move backwards in-session.
+
+    Works against any scenario that maintains a worker_stats relation with
+    (worker, cnt, max_seq) columns.
+    """
+
+    def __init__(self, rng, ctx) -> None:
         super().__init__(
             rng,
             ctx,
             "stats-subscribe",
             "SELECT worker, cnt, max_seq FROM worker_stats",
         )
-        self.scenario = scenario
         self.last: dict[int, tuple[int, int]] = {}
 
     def check_once(self) -> None:
@@ -210,11 +339,14 @@ class KafkaLedger(Scenario):
             "CREATE SOURCE ledger_source IN CLUSTER storage"
             f" FROM KAFKA CONNECTION kafka_src_conn (TOPIC '{TOPIC}')",
             f'CREATE TABLE events FROM SOURCE ledger_source (REFERENCE "{TOPIC}")'
-            " FORMAT JSON ENVELOPE NONE",
+            " KEY FORMAT TEXT VALUE FORMAT JSON"
+            " INCLUDE KEY AS msg_key, PARTITION AS part,"
+            " OFFSET AS kafka_offset, TIMESTAMP AS kafka_ts"
+            " ENVELOPE NONE",
             "CREATE MATERIALIZED VIEW worker_stats IN CLUSTER compute AS"
             " SELECT (data->>'worker')::int AS worker, count(*) AS cnt,"
             " max((data->>'seq')::bigint) AS max_seq FROM events"
-            f" WHERE (data->>'worker')::int <> {SENTINEL_WORKER} GROUP BY 1",
+            " WHERE (data->>'worker')::int >= 0 GROUP BY 1",
             "CREATE INDEX worker_stats_idx IN CLUSTER compute"
             " ON worker_stats (worker)",
         ]:
@@ -228,10 +360,13 @@ class KafkaLedger(Scenario):
         )
 
     def checkers(self) -> list[Checker]:
-        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(2)]
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(5)]
         return [
             EventCountPeek(rngs[0], self.ctx, self),
-            WorkerStatsSubscribe(rngs[1], self.ctx, self),
+            WorkerStatsSubscribe(rngs[1], self.ctx),
+            EventMetadataPeek(rngs[2], self.ctx),
+            KafkaRtrPeek(rngs[3], self.ctx, self.bootstrap),
+            ProgressPeek(rngs[4], self.ctx, "ledger_source"),
         ]
 
     def converge(self) -> None:
@@ -245,6 +380,9 @@ class KafkaLedger(Scenario):
                 value=json.dumps(
                     {"worker": SENTINEL_WORKER, "seq": partition}
                 ).encode(),
+                # Keyed like every other message so the INCLUDE KEY checker
+                # holds for sentinels too.
+                key=str(SENTINEL_WORKER).encode(),
                 partition=partition,
             )
         if producer.flush(60) != 0:

--- a/misc/python/materialize/invariants/scenarios/kafka_ledger.py
+++ b/misc/python/materialize/invariants/scenarios/kafka_ledger.py
@@ -1,0 +1,304 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Uniquely-numbered events produced to Kafka and ingested by a source.
+
+Kafka sources make no transaction-atomicity promise, so instead of a
+conservation invariant this scenario uses set semantics: every acknowledged
+event must eventually be ingested exactly once, no event may appear that was
+never attempted, and per-worker counts and sequence numbers must never move
+backwards. Producers are idempotent so that librdkafka's internal retries
+cannot legitimately duplicate an event, which makes "exactly once" checkable.
+"""
+
+import json
+import random
+
+from materialize.invariants.checkers import PeekChecker, SubscribeChecker
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+
+TOPIC = "invariants-ledger"
+PARTITIONS = 3
+# Bounds how long an unresolved produce can straddle the converge phase.
+MESSAGE_TIMEOUT_MS = 30_000
+SENTINEL_WORKER = -1
+
+
+def make_producer(bootstrap: str):
+    from confluent_kafka import Producer
+
+    return Producer(
+        {
+            "bootstrap.servers": bootstrap,
+            "enable.idempotence": True,
+            "message.timeout.ms": MESSAGE_TIMEOUT_MS,
+        }
+    )
+
+
+class ProduceEvent(Action):
+    """Produce one uniquely-numbered event, resolving its outcome async.
+
+    The op is registered as UNKNOWN before the send. The delivery callback
+    upgrades it to COMMITTED on a broker ack. A delivery error leaves it
+    UNKNOWN: an earlier attempt may still have been appended.
+    """
+
+    name = "produce"
+
+    def __init__(self, rng: random.Random, worker: int, oplog: OpLog, producer) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.oplog = oplog
+        self.producer = producer
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        seq = self.seq
+        worker = self.worker
+        payload = json.dumps(
+            {"worker": worker, "seq": seq, "amount": self.rng.randint(1, 100)}
+        )
+        self.oplog.record(worker, seq, Outcome.UNKNOWN)
+
+        def on_delivery(err, msg, worker=worker, seq=seq) -> None:
+            if err is None:
+                self.oplog.record(worker, seq, Outcome.COMMITTED)
+
+        try:
+            self.producer.produce(
+                TOPIC,
+                value=payload.encode(),
+                key=str(worker).encode(),
+                on_delivery=on_delivery,
+            )
+        except BufferError as e:
+            # The local queue is full and nothing was sent.
+            self.oplog.record(worker, seq, Outcome.FAILED)
+            self.producer.poll(1)
+            raise TransientError(f"producer queue full: {e}") from e
+        # Serve delivery callbacks for previously sent events.
+        self.producer.poll(0)
+        return None
+
+    def close(self) -> None:
+        self.producer.flush(60)
+
+
+class EventCountPeek(PeekChecker):
+    """Event count: monotonic and never above what was attempted."""
+
+    def __init__(self, rng, ctx, scenario: "KafkaLedger") -> None:
+        super().__init__(rng, ctx, "events-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        watermark = self.scenario.event_rows.get()
+        rows = self.peek(
+            "SELECT count(*) FROM events"
+            f" WHERE (data->>'worker')::int <> {SENTINEL_WORKER}"
+        )
+        high = self.scenario.oplog.attempted_count()
+        count = int(rows[0][0])
+        if count < watermark:
+            raise InvariantViolation(
+                f"event count went backwards: {count} < watermark {watermark}"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"event count {count} exceeds attempted produces {high}:"
+                " events were duplicated"
+            )
+        self.scenario.event_rows.advance(count)
+        self.validations += 1
+
+
+class WorkerStatsSubscribe(SubscribeChecker):
+    """Per-worker count and max seq must never move backwards in-session."""
+
+    def __init__(self, rng, ctx, scenario: "KafkaLedger") -> None:
+        super().__init__(
+            rng,
+            ctx,
+            "stats-subscribe",
+            "SELECT worker, cnt, max_seq FROM worker_stats",
+        )
+        self.scenario = scenario
+        self.last: dict[int, tuple[int, int]] = {}
+
+    def check_once(self) -> None:
+        if not self._active:
+            # Fresh session, no cross-session continuity is guaranteed.
+            self.last = {}
+        super().check_once()
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        seen: dict[int, tuple[int, int]] = {}
+        for (worker, cnt, max_seq), multiplicity in state.items():
+            if multiplicity != 1 or int(worker) in seen:
+                raise InvariantViolation(
+                    f"worker_stats at {ts}: duplicate group for worker {worker}:"
+                    f" {state}"
+                )
+            seen[int(worker)] = (int(cnt), int(max_seq))
+        for worker, (cnt, max_seq) in seen.items():
+            if worker in self.last:
+                last_cnt, last_max = self.last[worker]
+                if cnt < last_cnt or max_seq < last_max:
+                    raise InvariantViolation(
+                        f"worker {worker} stats moved backwards at {ts}:"
+                        f" ({cnt}, {max_seq}) < ({last_cnt}, {last_max})"
+                    )
+            self.last[worker] = (cnt, max_seq)
+
+
+class KafkaLedger(Scenario):
+    name = "kafka-ledger"
+    services = ["kafka"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "kafka-source",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.oplog = OpLog()
+        self.event_rows = Watermark()
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+        from confluent_kafka.cimpl import NewTopic
+
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        futures = admin.create_topics(
+            [NewTopic(TOPIC, num_partitions=PARTITIONS, replication_factor=1)]
+        )
+        for future in futures.values():
+            future.result(timeout=60)
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE CONNECTION kafka_src_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE SOURCE ledger_source IN CLUSTER storage"
+            f" FROM KAFKA CONNECTION kafka_src_conn (TOPIC '{TOPIC}')",
+            f'CREATE TABLE events FROM SOURCE ledger_source (REFERENCE "{TOPIC}")'
+            " FORMAT JSON ENVELOPE NONE",
+            "CREATE MATERIALIZED VIEW worker_stats IN CLUSTER compute AS"
+            " SELECT (data->>'worker')::int AS worker, count(*) AS cnt,"
+            " max((data->>'seq')::bigint) AS max_seq FROM events"
+            f" WHERE (data->>'worker')::int <> {SENTINEL_WORKER} GROUP BY 1",
+            "CREATE INDEX worker_stats_idx IN CLUSTER compute"
+            " ON worker_stats (worker)",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        producer = make_producer(self.bootstrap)
+        return WorkerBundle(
+            actions=[ProduceEvent(rng, index, self.oplog, producer)], weights=[1]
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(2)]
+        return [
+            EventCountPeek(rngs[0], self.ctx, self),
+            WorkerStatsSubscribe(rngs[1], self.ctx, self),
+        ]
+
+    def converge(self) -> None:
+        # Workers already flushed their producers on close, so the topic's
+        # regular contents are frozen. One sentinel per partition proves MZ
+        # ingested everything before them.
+        producer = make_producer(self.bootstrap)
+        for partition in range(PARTITIONS):
+            producer.produce(
+                TOPIC,
+                value=json.dumps(
+                    {"worker": SENTINEL_WORKER, "seq": partition}
+                ).encode(),
+                partition=partition,
+            )
+        if producer.flush(60) != 0:
+            raise InvariantViolation("liveness: sentinel produce did not flush")
+        client = MzClient(self.ctx, "converge")
+
+        def sentinels_visible() -> bool:
+            client.query("SET cluster = quickstart")
+            rows = client.query(
+                "SELECT count(*) FROM events"
+                f" WHERE (data->>'worker')::int = {SENTINEL_WORKER}"
+            )
+            return int(rows[0][0]) == PARTITIONS
+
+        wait_until(sentinels_visible, CONVERGE_TIMEOUT, "kafka source catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        for worker in range(self.ctx.complexity.workers):
+            rows = client.query(
+                "SELECT (data->>'seq')::bigint, count(*) FROM events"
+                f" WHERE (data->>'worker')::int = {worker} GROUP BY 1"
+            )
+            duplicated = [(int(r[0]), int(r[1])) for r in rows if int(r[1]) != 1]
+            if duplicated:
+                raise InvariantViolation(
+                    f"worker {worker}: events ingested more than once:"
+                    f" {duplicated[:20]}"
+                )
+            present = {int(r[0]) for r in rows}
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: acknowledged events lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - committed - unknown
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: events present that were never attempted:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            client.query("SET cluster = quickstart")
+            rows = client.query("SELECT count(*) FROM events", timeout=60)
+            counts = self.oplog.counts()
+            self.ctx.log.log("diag", f"post-heal: events={rows[0][0]} oplog={counts}")
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal event count failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/kafka_ledger.py
+++ b/misc/python/materialize/invariants/scenarios/kafka_ledger.py
@@ -1,0 +1,442 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Uniquely-numbered events produced to Kafka and ingested by a source.
+
+Kafka sources make no transaction-atomicity promise, so instead of a
+conservation invariant this scenario uses set semantics: every acknowledged
+event must eventually be ingested exactly once, no event may appear that was
+never attempted, and per-worker counts and sequence numbers must never move
+backwards. Producers are idempotent so that librdkafka's internal retries
+cannot legitimately duplicate an event, which makes "exactly once" checkable.
+"""
+
+import json
+import random
+
+from materialize.invariants.checkers import (
+    PeekChecker,
+    ProgressPeek,
+    SubscribeChecker,
+)
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+
+TOPIC = "invariants-ledger"
+PARTITIONS = 3
+# Bounds how long an unresolved produce can straddle the converge phase.
+MESSAGE_TIMEOUT_MS = 30_000
+SENTINEL_WORKER = -1
+# Worker id used for real-time recency marker events. Negative so the
+# regular count bounds and reconciliation never see them.
+RTR_MARKER_WORKER = -2
+
+
+def make_producer(bootstrap: str):
+    from confluent_kafka import Producer
+
+    return Producer(
+        {
+            "bootstrap.servers": bootstrap,
+            "enable.idempotence": True,
+            "message.timeout.ms": MESSAGE_TIMEOUT_MS,
+        }
+    )
+
+
+class ProduceEvent(Action):
+    """Produce one uniquely-numbered event, resolving its outcome async.
+
+    The op is registered as UNKNOWN before the send. The delivery callback
+    upgrades it to COMMITTED on a broker ack. A delivery error leaves it
+    UNKNOWN: an earlier attempt may still have been appended.
+    """
+
+    name = "produce"
+
+    def __init__(self, rng: random.Random, worker: int, oplog: OpLog, producer) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.oplog = oplog
+        self.producer = producer
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        seq = self.seq
+        worker = self.worker
+        payload = json.dumps(
+            {"worker": worker, "seq": seq, "amount": self.rng.randint(1, 100)}
+        )
+        self.oplog.record(worker, seq, Outcome.UNKNOWN)
+
+        def on_delivery(err, msg, worker=worker, seq=seq) -> None:
+            if err is None:
+                self.oplog.record(worker, seq, Outcome.COMMITTED)
+
+        try:
+            self.producer.produce(
+                TOPIC,
+                value=payload.encode(),
+                key=str(worker).encode(),
+                on_delivery=on_delivery,
+            )
+        except BufferError as e:
+            # The local queue is full and nothing was sent.
+            self.oplog.record(worker, seq, Outcome.FAILED)
+            self.producer.poll(1)
+            raise TransientError(f"producer queue full: {e}") from e
+        # Serve delivery callbacks for previously sent events.
+        self.producer.poll(0)
+        return None
+
+    def close(self) -> None:
+        self.producer.flush(60)
+
+
+class EventCountPeek(PeekChecker):
+    """Event count: monotonic and never above what was attempted."""
+
+    def __init__(self, rng, ctx, scenario: "KafkaLedger") -> None:
+        super().__init__(rng, ctx, "events-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        watermark = self.scenario.event_rows.get()
+        rows = self.peek(
+            "SELECT count(*) FROM events WHERE (data->>'worker')::int >= 0"
+        )
+        high = self.scenario.oplog.attempted_count()
+        count = int(rows[0][0])
+        if count < watermark:
+            raise InvariantViolation(
+                f"event count went backwards: {count} < watermark {watermark}"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"event count {count} exceeds attempted produces {high}:"
+                " events were duplicated"
+            )
+        self.scenario.event_rows.advance(count)
+        self.validations += 1
+
+
+class EventMetadataPeek(PeekChecker):
+    """The documented INCLUDE metadata columns must be sound.
+
+    (partition, offset) identifies one Kafka message, so a duplicated pair
+    means an event was ingested twice, which detects duplication directly
+    instead of only through count bounds. The included key must match the
+    payload's worker id (producers key every message that way), offsets per
+    partition never move backwards, and the broker timestamp is never in
+    the future beyond clock skew.
+    """
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "metadata-peek", ["quickstart", "compute"])
+        self.max_offsets: dict[int, int] = {}
+
+    def check_once(self) -> None:
+        duplicated = self.peek(
+            "SELECT part, kafka_offset FROM events"
+            " GROUP BY part, kafka_offset HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"duplicate (partition, offset) pairs ingested: {duplicated[:20]}"
+            )
+        mismatched = self.peek(
+            "SELECT count(*) FROM events"
+            " WHERE msg_key IS DISTINCT FROM data->>'worker'"
+        )
+        if int(mismatched[0][0]) != 0:
+            raise InvariantViolation(
+                f"{mismatched[0][0]} events whose INCLUDE KEY does not match"
+                " the payload's worker id"
+            )
+        skewed = self.peek(
+            "SELECT count(*) FROM events"
+            " WHERE kafka_ts > now() + INTERVAL '5 minutes'"
+        )
+        if int(skewed[0][0]) != 0:
+            raise InvariantViolation(
+                f"{skewed[0][0]} events with a far-future INCLUDE TIMESTAMP"
+            )
+        watermarks = dict(self.max_offsets)
+        rows = self.peek("SELECT part, max(kafka_offset) FROM events GROUP BY part")
+        for row in rows:
+            part, max_offset = int(row[0]), int(row[1])
+            if watermarks.get(part, -1) > max_offset:
+                raise InvariantViolation(
+                    f"partition {part} max offset moved backwards:"
+                    f" {max_offset} < {watermarks[part]}"
+                )
+            if max_offset > self.max_offsets.get(part, -1):
+                self.max_offsets[part] = max_offset
+        self.validations += 1
+
+
+class KafkaRtrPeek(Checker):
+    """Real-time recency for Kafka sources: a read issued after the broker
+    acknowledged a produce must include that event.
+
+    Mirrors the CDC scenarios' RTR checker. RTR queries legitimately error
+    or time out while the source leg is disrupted (skipped round), but a
+    successful read missing an acknowledged event is a violation.
+    """
+
+    name = "rtr-peek"
+    pause = (2.0, 6.0)
+
+    def __init__(self, rng, ctx, bootstrap: str) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.client = MzClient(ctx, "rtr-peek")
+        self.bootstrap = bootstrap
+        self.producer = None
+        self.markers = 0
+        self._session_ready = False
+
+    def check_once(self) -> None:
+        if self.producer is None:
+            self.producer = make_producer(self.bootstrap)
+        marker = self.markers + 1
+        self.producer.produce(
+            TOPIC,
+            value=json.dumps({"worker": RTR_MARKER_WORKER, "seq": marker}).encode(),
+            key=str(RTR_MARKER_WORKER).encode(),
+        )
+        if self.producer.flush(30) != 0:
+            # The marker was not acknowledged, so it creates no lower bound.
+            self.producer = None
+            raise TransientError("RTR marker produce not acknowledged")
+        self.markers = marker
+        try:
+            if not self._session_ready:
+                self.client.query("SET real_time_recency = true")
+                self._session_ready = True
+            rows = self.client.query(
+                "SELECT count(*) FROM events"
+                f" WHERE (data->>'worker')::int = {RTR_MARKER_WORKER}"
+            )
+        except TransientError:
+            self._session_ready = False
+            raise
+        except UnexpectedQueryError as e:
+            self._session_ready = False
+            if "timed out before ingesting" in str(e) or "storage error" in str(e):
+                raise TransientError(str(e)) from e
+            raise
+        count = int(rows[0][0])
+        if count < self.markers:
+            raise InvariantViolation(
+                f"real-time recency violated: read issued after broker ack"
+                f" saw {count} markers, expected at least {self.markers}"
+            )
+        self.validations += 1
+
+    def close(self) -> None:
+        if self.producer is not None:
+            self.producer.flush(10)
+        self.client.reset()
+
+
+class WorkerStatsSubscribe(SubscribeChecker):
+    """Per-worker count and max seq must never move backwards in-session.
+
+    Works against any scenario that maintains a worker_stats relation with
+    (worker, cnt, max_seq) columns.
+    """
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(
+            rng,
+            ctx,
+            "stats-subscribe",
+            "SELECT worker, cnt, max_seq FROM worker_stats",
+        )
+        self.last: dict[int, tuple[int, int]] = {}
+
+    def check_once(self) -> None:
+        if not self._active:
+            # Fresh session, no cross-session continuity is guaranteed.
+            self.last = {}
+        super().check_once()
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        seen: dict[int, tuple[int, int]] = {}
+        for (worker, cnt, max_seq), multiplicity in state.items():
+            if multiplicity != 1 or int(worker) in seen:
+                raise InvariantViolation(
+                    f"worker_stats at {ts}: duplicate group for worker {worker}:"
+                    f" {state}"
+                )
+            seen[int(worker)] = (int(cnt), int(max_seq))
+        for worker, (cnt, max_seq) in seen.items():
+            if worker in self.last:
+                last_cnt, last_max = self.last[worker]
+                if cnt < last_cnt or max_seq < last_max:
+                    raise InvariantViolation(
+                        f"worker {worker} stats moved backwards at {ts}:"
+                        f" ({cnt}, {max_seq}) < ({last_cnt}, {last_max})"
+                    )
+            self.last[worker] = (cnt, max_seq)
+
+
+class KafkaLedger(Scenario):
+    name = "kafka-ledger"
+    services = ["kafka"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "kafka-source",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.oplog = OpLog()
+        self.event_rows = Watermark()
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+        from confluent_kafka.cimpl import NewTopic
+
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        futures = admin.create_topics(
+            [NewTopic(TOPIC, num_partitions=PARTITIONS, replication_factor=1)]
+        )
+        for future in futures.values():
+            future.result(timeout=60)
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE CONNECTION kafka_src_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE SOURCE ledger_source IN CLUSTER storage"
+            f" FROM KAFKA CONNECTION kafka_src_conn (TOPIC '{TOPIC}')",
+            f'CREATE TABLE events FROM SOURCE ledger_source (REFERENCE "{TOPIC}")'
+            " KEY FORMAT TEXT VALUE FORMAT JSON"
+            " INCLUDE KEY AS msg_key, PARTITION AS part,"
+            " OFFSET AS kafka_offset, TIMESTAMP AS kafka_ts"
+            " ENVELOPE NONE",
+            "CREATE MATERIALIZED VIEW worker_stats IN CLUSTER compute AS"
+            " SELECT (data->>'worker')::int AS worker, count(*) AS cnt,"
+            " max((data->>'seq')::bigint) AS max_seq FROM events"
+            " WHERE (data->>'worker')::int >= 0 GROUP BY 1",
+            "CREATE INDEX worker_stats_idx IN CLUSTER compute"
+            " ON worker_stats (worker)",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        producer = make_producer(self.bootstrap)
+        return WorkerBundle(
+            actions=[ProduceEvent(rng, index, self.oplog, producer)], weights=[1]
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(5)]
+        return [
+            EventCountPeek(rngs[0], self.ctx, self),
+            WorkerStatsSubscribe(rngs[1], self.ctx),
+            EventMetadataPeek(rngs[2], self.ctx),
+            KafkaRtrPeek(rngs[3], self.ctx, self.bootstrap),
+            ProgressPeek(rngs[4], self.ctx, "ledger_source"),
+        ]
+
+    def converge(self) -> None:
+        # Workers already flushed their producers on close, so the topic's
+        # regular contents are frozen. One sentinel per partition proves MZ
+        # ingested everything before them.
+        producer = make_producer(self.bootstrap)
+        for partition in range(PARTITIONS):
+            producer.produce(
+                TOPIC,
+                value=json.dumps(
+                    {"worker": SENTINEL_WORKER, "seq": partition}
+                ).encode(),
+                # Keyed like every other message so the INCLUDE KEY checker
+                # holds for sentinels too.
+                key=str(SENTINEL_WORKER).encode(),
+                partition=partition,
+            )
+        if producer.flush(60) != 0:
+            raise InvariantViolation("liveness: sentinel produce did not flush")
+        client = MzClient(self.ctx, "converge")
+
+        def sentinels_visible() -> bool:
+            client.query("SET cluster = quickstart")
+            rows = client.query(
+                "SELECT count(*) FROM events"
+                f" WHERE (data->>'worker')::int = {SENTINEL_WORKER}"
+            )
+            return int(rows[0][0]) == PARTITIONS
+
+        wait_until(sentinels_visible, CONVERGE_TIMEOUT, "kafka source catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        for worker in range(self.ctx.complexity.workers):
+            rows = client.query(
+                "SELECT (data->>'seq')::bigint, count(*) FROM events"
+                f" WHERE (data->>'worker')::int = {worker} GROUP BY 1"
+            )
+            duplicated = [(int(r[0]), int(r[1])) for r in rows if int(r[1]) != 1]
+            if duplicated:
+                raise InvariantViolation(
+                    f"worker {worker}: events ingested more than once:"
+                    f" {duplicated[:20]}"
+                )
+            present = {int(r[0]) for r in rows}
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            issued = self.oplog.issued(worker)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: acknowledged events lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - issued
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: events present that were never attempted:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            client.query("SET cluster = quickstart")
+            rows = client.query("SELECT count(*) FROM events", timeout=60)
+            counts = self.oplog.counts()
+            self.ctx.log.log("diag", f"post-heal: events={rows[0][0]} oplog={counts}")
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal event count failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/kafka_ledger.py
+++ b/misc/python/materialize/invariants/scenarios/kafka_ledger.py
@@ -416,13 +416,13 @@ class KafkaLedger(Scenario):
                 )
             present = {int(r[0]) for r in rows}
             committed = self.oplog.seqs(worker, Outcome.COMMITTED)
-            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            issued = self.oplog.issued(worker)
             missing = committed - present
             if missing:
                 raise InvariantViolation(
                     f"worker {worker}: acknowledged events lost: {sorted(missing)[:20]}"
                 )
-            phantom = present - committed - unknown
+            phantom = present - issued
             if phantom:
                 raise InvariantViolation(
                     f"worker {worker}: events present that were never attempted:"

--- a/misc/python/materialize/invariants/scenarios/kafka_upsert.py
+++ b/misc/python/materialize/invariants/scenarios/kafka_upsert.py
@@ -1,0 +1,294 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Keyed events with per-key versions through an ENVELOPE UPSERT source.
+
+Each key is owned by exactly one producer worker, which writes strictly
+increasing versions and occasional tombstones. That makes the upsert state
+machine checkable without any transaction-atomicity assumption: at every
+timestamp the ingested state must hold at most one row per key, per-key
+versions must never move backwards, and after quiescing each key must show
+the effect of the last message that landed. With an idempotent producer the
+per-partition order is preserved, so "the last message that landed" is the
+last acknowledged write or one of the unacknowledged writes queued after it.
+"""
+
+import json
+import random
+from typing import Any
+
+from materialize.invariants.checkers import PeekChecker, SubscribeChecker
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.scenarios.kafka_ledger import make_producer
+
+TOPIC = "invariants-upsert"
+PARTITIONS = 3
+TOMBSTONE_PROBABILITY = 0.15
+SENTINEL_KEYS = ["s-0", "s-1", "s-2"]
+
+
+class UpsertEvent(Action):
+    """Write the next version (or a tombstone) for one owned key.
+
+    Every write is logged as {effect, outcome} in the scenario's per-key
+    log. The delivery callback upgrades the outcome to COMMITTED, so the
+    final check can compute the admissible final values per key.
+    """
+
+    name = "upsert"
+
+    def __init__(
+        self, rng: random.Random, worker: int, scenario: "KafkaUpsert", producer
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.scenario = scenario
+        self.producer = producer
+        self.versions = [0] * scenario.keys_per_worker
+
+    def run(self) -> Outcome | None:
+        k = self.rng.randrange(self.scenario.keys_per_worker)
+        key = f"{self.worker}-{k}"
+        self.versions[k] += 1
+        version = self.versions[k]
+        tombstone = self.rng.random() < TOMBSTONE_PROBABILITY
+        entry: dict[str, Any] = {
+            "effect": None if tombstone else version,
+            "outcome": Outcome.UNKNOWN,
+        }
+        self.scenario.key_log[(self.worker, k)].append(entry)
+
+        def on_delivery(err, msg, entry=entry) -> None:
+            if err is None:
+                entry["outcome"] = Outcome.COMMITTED
+
+        value = None if tombstone else json.dumps({"ver": version}).encode()
+        try:
+            self.producer.produce(
+                TOPIC, value=value, key=key.encode(), on_delivery=on_delivery
+            )
+        except BufferError as e:
+            entry["outcome"] = Outcome.FAILED
+            self.producer.poll(1)
+            raise TransientError(f"producer queue full: {e}") from e
+        self.producer.poll(0)
+        return None
+
+    def close(self) -> None:
+        self.producer.flush(60)
+
+
+class UpsertUniquePeek(PeekChecker):
+    """The core upsert invariant: never more than one row per key."""
+
+    def __init__(self, rng, ctx, scenario: "KafkaUpsert") -> None:
+        super().__init__(rng, ctx, "unique-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        duplicated = self.peek("SELECT key FROM state GROUP BY key HAVING count(*) > 1")
+        if duplicated:
+            raise InvariantViolation(
+                f"upsert produced multiple rows per key: {duplicated[:20]}"
+            )
+        rows = self.peek("SELECT count(*) FROM state")
+        limit = self.ctx.complexity.workers * self.scenario.keys_per_worker + len(
+            SENTINEL_KEYS
+        )
+        if int(rows[0][0]) > limit:
+            raise InvariantViolation(
+                f"upsert state holds {rows[0][0]} keys, only {limit} exist"
+            )
+        self.validations += 1
+
+
+class KeyStateSubscribe(SubscribeChecker):
+    """Per-key versions must never move backwards within a session."""
+
+    def __init__(self, rng, ctx, scenario: "KafkaUpsert") -> None:
+        super().__init__(rng, ctx, "state-subscribe", "SELECT key, ver FROM key_state")
+        self.scenario = scenario
+        self.last: dict[str, int] = {}
+
+    def check_once(self) -> None:
+        if not self._active:
+            # Fresh session, no cross-session continuity is guaranteed.
+            self.last = {}
+        super().check_once()
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        seen: dict[str, int] = {}
+        for (key, version), multiplicity in state.items():
+            if multiplicity != 1 or key in seen:
+                raise InvariantViolation(
+                    f"upsert state at {ts}: multiple rows for key {key}: {state}"
+                )
+            seen[str(key)] = int(version)
+        for key, version in seen.items():
+            if key in self.last and version < self.last[key]:
+                raise InvariantViolation(
+                    f"key {key} version moved backwards at {ts}:"
+                    f" {version} < {self.last[key]}"
+                )
+            self.last[key] = version
+
+
+class KafkaUpsert(Scenario):
+    name = "kafka-upsert"
+    services = ["kafka"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "kafka-source",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.keys_per_worker = ctx.complexity.accounts
+        # (worker, key index) -> ordered write log, appended by the owning
+        # worker thread only and read after all workers stopped.
+        self.key_log: dict[tuple[int, int], list[dict[str, Any]]] = {
+            (worker, k): []
+            for worker in range(ctx.complexity.workers)
+            for k in range(self.keys_per_worker)
+        }
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+        from confluent_kafka.cimpl import NewTopic
+
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        futures = admin.create_topics(
+            [NewTopic(TOPIC, num_partitions=PARTITIONS, replication_factor=1)]
+        )
+        for future in futures.values():
+            future.result(timeout=60)
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE CONNECTION kafka_src_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE SOURCE upsert_source IN CLUSTER storage"
+            f" FROM KAFKA CONNECTION kafka_src_conn (TOPIC '{TOPIC}')",
+            f'CREATE TABLE state FROM SOURCE upsert_source (REFERENCE "{TOPIC}")'
+            " KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT",
+            "CREATE MATERIALIZED VIEW key_state IN CLUSTER compute AS"
+            " SELECT key, (data->>'ver')::bigint AS ver FROM state",
+            "CREATE INDEX key_state_idx IN CLUSTER compute ON key_state (key)",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        producer = make_producer(self.bootstrap)
+        return WorkerBundle(
+            actions=[UpsertEvent(rng, index, self, producer)], weights=[1]
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(2)]
+        return [
+            UpsertUniquePeek(rngs[0], self.ctx, self),
+            KeyStateSubscribe(rngs[1], self.ctx, self),
+        ]
+
+    def converge(self) -> None:
+        # Workers flushed their producers on close, so the topic's regular
+        # contents are frozen. One committed sentinel per partition proves
+        # everything before them was ingested.
+        producer = make_producer(self.bootstrap)
+        for partition, key in enumerate(SENTINEL_KEYS):
+            producer.produce(
+                TOPIC,
+                value=json.dumps({"ver": 0}).encode(),
+                key=key.encode(),
+                partition=partition,
+            )
+        if producer.flush(60) != 0:
+            raise InvariantViolation("liveness: sentinel produce did not flush")
+        client = MzClient(self.ctx, "converge")
+        sentinels = ", ".join(f"'{key}'" for key in SENTINEL_KEYS)
+
+        def sentinels_visible() -> bool:
+            client.query("SET cluster = quickstart")
+            rows = client.query(
+                f"SELECT count(*) FROM state WHERE key IN ({sentinels})"
+            )
+            return int(rows[0][0]) == len(SENTINEL_KEYS)
+
+        wait_until(sentinels_visible, CONVERGE_TIMEOUT, "kafka source catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        actual = {
+            str(row[0]): int(row[1]) if row[1] is not None else None
+            for row in client.query(
+                "SELECT key, (data->>'ver')::bigint FROM state"
+                " WHERE key NOT LIKE 's-%'"
+            )
+        }
+        for (worker, k), log in self.key_log.items():
+            key = f"{worker}-{k}"
+            # The final value is the effect of the last message that landed:
+            # the last acknowledged write, or any unacknowledged write
+            # queued after it (order is preserved per partition). FAILED
+            # writes were never sent.
+            admissible: set[int | None] = set()
+            last_committed = None
+            for index, entry in enumerate(log):
+                if entry["outcome"] == Outcome.COMMITTED:
+                    last_committed = index
+            if last_committed is None:
+                admissible.add(None)
+                tail = log
+            else:
+                admissible.add(log[last_committed]["effect"])
+                tail = log[last_committed + 1 :]
+            for entry in tail:
+                if entry["outcome"] == Outcome.UNKNOWN:
+                    admissible.add(entry["effect"])
+            got = actual.get(key)
+            if got not in admissible:
+                raise InvariantViolation(
+                    f"key {key}: final state {got} not admissible"
+                    f" ({sorted(str(a) for a in admissible)})"
+                )
+        phantom = set(actual) - {f"{worker}-{k}" for worker, k in self.key_log.keys()}
+        if phantom:
+            raise InvariantViolation(f"keys that were never written: {phantom}")
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            client.query("SET cluster = quickstart")
+            rows = client.query("SELECT count(*) FROM state", timeout=60)
+            self.ctx.log.log("diag", f"post-heal: upsert state keys={rows[0][0]}")
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal state count failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/kafka_upsert.py
+++ b/misc/python/materialize/invariants/scenarios/kafka_upsert.py
@@ -122,10 +122,16 @@ class UpsertUniquePeek(PeekChecker):
 
 
 class KeyStateSubscribe(SubscribeChecker):
-    """Per-key versions must never move backwards within a session."""
+    """Per-key versions must never move backwards within a session.
+
+    Uses WITHIN TIMESTAMP ORDER BY, so the base checker additionally
+    asserts the documented in-timestamp arrival order by key.
+    """
 
     def __init__(self, rng, ctx, scenario: "KafkaUpsert") -> None:
         super().__init__(rng, ctx, "state-subscribe", "SELECT key, ver FROM key_state")
+        self.order_clause = "WITHIN TIMESTAMP ORDER BY key"
+        self.order_index = 0
         self.scenario = scenario
         self.last: dict[str, int] = {}
 
@@ -150,6 +156,97 @@ class KeyStateSubscribe(SubscribeChecker):
                     f" {version} < {self.last[key]}"
                 )
             self.last[key] = version
+
+
+class UpsertEnvelopeSubscribe(Checker):
+    """SUBSCRIBE .. ENVELOPE UPSERT emits a sound per-key state machine.
+
+    The documented envelope output: `mz_state` is `upsert` with the new
+    value, `delete` with nulled value columns, or `key_violation` if the
+    query held more than one live row per key (which key_state never
+    legitimately does). Per session: timestamps never decrease, a delete
+    only follows a live key, and versions never move backwards (the single
+    owner only writes increasing versions).
+    """
+
+    name = "envelope-subscribe"
+    pause = (0.0, 0.2)
+
+    def __init__(self, rng: random.Random, ctx: ScenarioContext) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.client = MzClient(ctx, self.name)
+        self._cursor = "c_envelope"
+        self._active = False
+        self.last_ts: int | None = None
+        self.live: set[str] = set()
+        self.high_water: dict[str, int] = {}
+
+    def check_once(self) -> None:
+        try:
+            if not self._active:
+                # Fresh session, no cross-session continuity is guaranteed.
+                self.last_ts = None
+                self.live = set()
+                self.high_water = {}
+                self.client.query("BEGIN")
+                self.client.query(
+                    f"DECLARE {self._cursor} CURSOR FOR"
+                    " SUBSCRIBE (SELECT key, ver FROM key_state)"
+                    " ENVELOPE UPSERT (KEY (key)) WITH (PROGRESS)"
+                )
+                self._active = True
+            rows = self.client.query(
+                f"FETCH ALL {self._cursor} WITH (timeout = '1s')",
+                timeout=max(30.0, self.ctx.complexity.query_timeout),
+            )
+        except TransientError:
+            self._active = False
+            raise
+        validated = False
+        for row in rows:
+            ts, progressed, state = int(row[0]), bool(row[1]), row[2]
+            if self.last_ts is not None and ts < self.last_ts:
+                raise InvariantViolation(
+                    f"{self.name}: timestamp went backwards: {ts} < {self.last_ts}"
+                )
+            self.last_ts = ts
+            if progressed:
+                continue
+            key, ver = row[3], row[4]
+            if state == "upsert":
+                if ver is None:
+                    raise InvariantViolation(
+                        f"{self.name}: upsert for {key} at {ts} without a value"
+                    )
+                version = int(ver)
+                if version < self.high_water.get(str(key), -1):
+                    raise InvariantViolation(
+                        f"{self.name}: key {key} version moved backwards at"
+                        f" {ts}: {version} < {self.high_water[str(key)]}"
+                    )
+                self.high_water[str(key)] = version
+                self.live.add(str(key))
+                validated = True
+            elif state == "delete":
+                if str(key) not in self.live:
+                    raise InvariantViolation(
+                        f"{self.name}: delete for key {key} at {ts} that was"
+                        " never live in this session"
+                    )
+                self.live.discard(str(key))
+                validated = True
+            else:
+                # key_violation means the subscribed query held more than
+                # one live row per key, which key_state never does.
+                raise InvariantViolation(
+                    f"{self.name}: mz_state {state!r} for key {key} at {ts}"
+                )
+        if validated:
+            self.validations += 1
+
+    def close(self) -> None:
+        self.client.reset()
 
 
 class KafkaUpsert(Scenario):
@@ -209,10 +306,11 @@ class KafkaUpsert(Scenario):
         )
 
     def checkers(self) -> list[Checker]:
-        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(2)]
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(3)]
         return [
             UpsertUniquePeek(rngs[0], self.ctx, self),
             KeyStateSubscribe(rngs[1], self.ctx, self),
+            UpsertEnvelopeSubscribe(rngs[2], self.ctx),
         ]
 
     def converge(self) -> None:

--- a/misc/python/materialize/invariants/scenarios/kafka_upsert.py
+++ b/misc/python/materialize/invariants/scenarios/kafka_upsert.py
@@ -1,0 +1,392 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Keyed events with per-key versions through an ENVELOPE UPSERT source.
+
+Each key is owned by exactly one producer worker, which writes strictly
+increasing versions and occasional tombstones. That makes the upsert state
+machine checkable without any transaction-atomicity assumption: at every
+timestamp the ingested state must hold at most one row per key, per-key
+versions must never move backwards, and after quiescing each key must show
+the effect of the last message that landed. With an idempotent producer the
+per-partition order is preserved, so "the last message that landed" is the
+last acknowledged write or one of the unacknowledged writes queued after it.
+"""
+
+import json
+import random
+from typing import Any
+
+from materialize.invariants.checkers import PeekChecker, SubscribeChecker
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.scenarios.kafka_ledger import make_producer
+
+TOPIC = "invariants-upsert"
+PARTITIONS = 3
+TOMBSTONE_PROBABILITY = 0.15
+SENTINEL_KEYS = ["s-0", "s-1", "s-2"]
+
+
+class UpsertEvent(Action):
+    """Write the next version (or a tombstone) for one owned key.
+
+    Every write is logged as {effect, outcome} in the scenario's per-key
+    log. The delivery callback upgrades the outcome to COMMITTED, so the
+    final check can compute the admissible final values per key.
+    """
+
+    name = "upsert"
+
+    def __init__(
+        self, rng: random.Random, worker: int, scenario: "KafkaUpsert", producer
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.scenario = scenario
+        self.producer = producer
+        self.versions = [0] * scenario.keys_per_worker
+
+    def run(self) -> Outcome | None:
+        k = self.rng.randrange(self.scenario.keys_per_worker)
+        key = f"{self.worker}-{k}"
+        self.versions[k] += 1
+        version = self.versions[k]
+        tombstone = self.rng.random() < TOMBSTONE_PROBABILITY
+        entry: dict[str, Any] = {
+            "effect": None if tombstone else version,
+            "outcome": Outcome.UNKNOWN,
+        }
+        self.scenario.key_log[(self.worker, k)].append(entry)
+
+        def on_delivery(err, msg, entry=entry) -> None:
+            if err is None:
+                entry["outcome"] = Outcome.COMMITTED
+
+        value = None if tombstone else json.dumps({"ver": version}).encode()
+        try:
+            self.producer.produce(
+                TOPIC, value=value, key=key.encode(), on_delivery=on_delivery
+            )
+        except BufferError as e:
+            entry["outcome"] = Outcome.FAILED
+            self.producer.poll(1)
+            raise TransientError(f"producer queue full: {e}") from e
+        self.producer.poll(0)
+        return None
+
+    def close(self) -> None:
+        self.producer.flush(60)
+
+
+class UpsertUniquePeek(PeekChecker):
+    """The core upsert invariant: never more than one row per key."""
+
+    def __init__(self, rng, ctx, scenario: "KafkaUpsert") -> None:
+        super().__init__(rng, ctx, "unique-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        duplicated = self.peek("SELECT key FROM state GROUP BY key HAVING count(*) > 1")
+        if duplicated:
+            raise InvariantViolation(
+                f"upsert produced multiple rows per key: {duplicated[:20]}"
+            )
+        rows = self.peek("SELECT count(*) FROM state")
+        limit = self.ctx.complexity.workers * self.scenario.keys_per_worker + len(
+            SENTINEL_KEYS
+        )
+        if int(rows[0][0]) > limit:
+            raise InvariantViolation(
+                f"upsert state holds {rows[0][0]} keys, only {limit} exist"
+            )
+        self.validations += 1
+
+
+class KeyStateSubscribe(SubscribeChecker):
+    """Per-key versions must never move backwards within a session.
+
+    Uses WITHIN TIMESTAMP ORDER BY, so the base checker additionally
+    asserts the documented in-timestamp arrival order by key.
+    """
+
+    def __init__(self, rng, ctx, scenario: "KafkaUpsert") -> None:
+        super().__init__(rng, ctx, "state-subscribe", "SELECT key, ver FROM key_state")
+        self.order_clause = "WITHIN TIMESTAMP ORDER BY key"
+        self.order_index = 0
+        self.scenario = scenario
+        self.last: dict[str, int] = {}
+
+    def check_once(self) -> None:
+        if not self._active:
+            # Fresh session, no cross-session continuity is guaranteed.
+            self.last = {}
+        super().check_once()
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        seen: dict[str, int] = {}
+        for (key, version), multiplicity in state.items():
+            if multiplicity != 1 or key in seen:
+                raise InvariantViolation(
+                    f"upsert state at {ts}: multiple rows for key {key}: {state}"
+                )
+            seen[str(key)] = int(version)
+        for key, version in seen.items():
+            if key in self.last and version < self.last[key]:
+                raise InvariantViolation(
+                    f"key {key} version moved backwards at {ts}:"
+                    f" {version} < {self.last[key]}"
+                )
+            self.last[key] = version
+
+
+class UpsertEnvelopeSubscribe(Checker):
+    """SUBSCRIBE .. ENVELOPE UPSERT emits a sound per-key state machine.
+
+    The documented envelope output: `mz_state` is `upsert` with the new
+    value, `delete` with nulled value columns, or `key_violation` if the
+    query held more than one live row per key (which key_state never
+    legitimately does). Per session: timestamps never decrease, a delete
+    only follows a live key, and versions never move backwards (the single
+    owner only writes increasing versions).
+    """
+
+    name = "envelope-subscribe"
+    pause = (0.0, 0.2)
+
+    def __init__(self, rng: random.Random, ctx: ScenarioContext) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.client = MzClient(ctx, self.name)
+        self._cursor = "c_envelope"
+        self._active = False
+        self.last_ts: int | None = None
+        self.live: set[str] = set()
+        self.high_water: dict[str, int] = {}
+
+    def check_once(self) -> None:
+        try:
+            if not self._active:
+                # Fresh session, no cross-session continuity is guaranteed.
+                self.last_ts = None
+                self.live = set()
+                self.high_water = {}
+                self.client.query("BEGIN")
+                self.client.query(
+                    f"DECLARE {self._cursor} CURSOR FOR"
+                    " SUBSCRIBE (SELECT key, ver FROM key_state)"
+                    " ENVELOPE UPSERT (KEY (key)) WITH (PROGRESS)"
+                )
+                self._active = True
+            rows = self.client.query(
+                f"FETCH ALL {self._cursor} WITH (timeout = '1s')",
+                timeout=max(30.0, self.ctx.complexity.query_timeout),
+            )
+        except TransientError:
+            self._active = False
+            raise
+        validated = False
+        for row in rows:
+            ts, progressed, state = int(row[0]), bool(row[1]), row[2]
+            if self.last_ts is not None and ts < self.last_ts:
+                raise InvariantViolation(
+                    f"{self.name}: timestamp went backwards: {ts} < {self.last_ts}"
+                )
+            self.last_ts = ts
+            if progressed:
+                continue
+            key, ver = row[3], row[4]
+            if state == "upsert":
+                if ver is None:
+                    raise InvariantViolation(
+                        f"{self.name}: upsert for {key} at {ts} without a value"
+                    )
+                version = int(ver)
+                if version < self.high_water.get(str(key), -1):
+                    raise InvariantViolation(
+                        f"{self.name}: key {key} version moved backwards at"
+                        f" {ts}: {version} < {self.high_water[str(key)]}"
+                    )
+                self.high_water[str(key)] = version
+                self.live.add(str(key))
+                validated = True
+            elif state == "delete":
+                if str(key) not in self.live:
+                    raise InvariantViolation(
+                        f"{self.name}: delete for key {key} at {ts} that was"
+                        " never live in this session"
+                    )
+                self.live.discard(str(key))
+                validated = True
+            else:
+                # key_violation means the subscribed query held more than
+                # one live row per key, which key_state never does.
+                raise InvariantViolation(
+                    f"{self.name}: mz_state {state!r} for key {key} at {ts}"
+                )
+        if validated:
+            self.validations += 1
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class KafkaUpsert(Scenario):
+    name = "kafka-upsert"
+    services = ["kafka"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "kafka-source",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.keys_per_worker = ctx.complexity.accounts
+        # (worker, key index) -> ordered write log, appended by the owning
+        # worker thread only and read after all workers stopped.
+        self.key_log: dict[tuple[int, int], list[dict[str, Any]]] = {
+            (worker, k): []
+            for worker in range(ctx.complexity.workers)
+            for k in range(self.keys_per_worker)
+        }
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+        from confluent_kafka.cimpl import NewTopic
+
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        futures = admin.create_topics(
+            [NewTopic(TOPIC, num_partitions=PARTITIONS, replication_factor=1)]
+        )
+        for future in futures.values():
+            future.result(timeout=60)
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE CONNECTION kafka_src_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE SOURCE upsert_source IN CLUSTER storage"
+            f" FROM KAFKA CONNECTION kafka_src_conn (TOPIC '{TOPIC}')",
+            f'CREATE TABLE state FROM SOURCE upsert_source (REFERENCE "{TOPIC}")'
+            " KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT",
+            "CREATE MATERIALIZED VIEW key_state IN CLUSTER compute AS"
+            " SELECT key, (data->>'ver')::bigint AS ver FROM state",
+            "CREATE INDEX key_state_idx IN CLUSTER compute ON key_state (key)",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        producer = make_producer(self.bootstrap)
+        return WorkerBundle(
+            actions=[UpsertEvent(rng, index, self, producer)], weights=[1]
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(3)]
+        return [
+            UpsertUniquePeek(rngs[0], self.ctx, self),
+            KeyStateSubscribe(rngs[1], self.ctx, self),
+            UpsertEnvelopeSubscribe(rngs[2], self.ctx),
+        ]
+
+    def converge(self) -> None:
+        # Workers flushed their producers on close, so the topic's regular
+        # contents are frozen. One committed sentinel per partition proves
+        # everything before them was ingested.
+        producer = make_producer(self.bootstrap)
+        for partition, key in enumerate(SENTINEL_KEYS):
+            producer.produce(
+                TOPIC,
+                value=json.dumps({"ver": 0}).encode(),
+                key=key.encode(),
+                partition=partition,
+            )
+        if producer.flush(60) != 0:
+            raise InvariantViolation("liveness: sentinel produce did not flush")
+        client = MzClient(self.ctx, "converge")
+        sentinels = ", ".join(f"'{key}'" for key in SENTINEL_KEYS)
+
+        def sentinels_visible() -> bool:
+            client.query("SET cluster = quickstart")
+            rows = client.query(
+                f"SELECT count(*) FROM state WHERE key IN ({sentinels})"
+            )
+            return int(rows[0][0]) == len(SENTINEL_KEYS)
+
+        wait_until(sentinels_visible, CONVERGE_TIMEOUT, "kafka source catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        actual = {
+            str(row[0]): int(row[1]) if row[1] is not None else None
+            for row in client.query(
+                "SELECT key, (data->>'ver')::bigint FROM state"
+                " WHERE key NOT LIKE 's-%'"
+            )
+        }
+        for (worker, k), log in self.key_log.items():
+            key = f"{worker}-{k}"
+            # The final value is the effect of the last message that landed:
+            # the last acknowledged write, or any unacknowledged write
+            # queued after it (order is preserved per partition). FAILED
+            # writes were never sent.
+            admissible: set[int | None] = set()
+            last_committed = None
+            for index, entry in enumerate(log):
+                if entry["outcome"] == Outcome.COMMITTED:
+                    last_committed = index
+            if last_committed is None:
+                admissible.add(None)
+                tail = log
+            else:
+                admissible.add(log[last_committed]["effect"])
+                tail = log[last_committed + 1 :]
+            for entry in tail:
+                if entry["outcome"] == Outcome.UNKNOWN:
+                    admissible.add(entry["effect"])
+            got = actual.get(key)
+            if got not in admissible:
+                raise InvariantViolation(
+                    f"key {key}: final state {got} not admissible"
+                    f" ({sorted(str(a) for a in admissible)})"
+                )
+        phantom = set(actual) - {f"{worker}-{k}" for worker, k in self.key_log.keys()}
+        if phantom:
+            raise InvariantViolation(f"keys that were never written: {phantom}")
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            client.query("SET cluster = quickstart")
+            rows = client.query("SELECT count(*) FROM state", timeout=60)
+            self.ctx.log.log("diag", f"post-heal: upsert state keys={rows[0][0]}")
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal state count failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
+++ b/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
@@ -7,30 +7,37 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-"""Bank balances exported through a Kafka sink, verified by a consumer.
+"""Bank balances exported through Kafka sinks, verified by consumers.
 
-Ledger transfers (as in table-bank) feed a per-account balances MV that a
-Kafka sink exports with ENVELOPE DEBEZIUM into a single-partition topic. A
-read_committed consumer reconstructs the balances from the before/after
-pairs. Soundness of the checks relies on documented sink behavior: every
-message carries a materialize-timestamp header, updates for one timestamp
-never straddle two Kafka transactions, and within one partition timestamps
-are non-decreasing, so a header change proves the previous timestamp
-complete.
+Ledger transfers (as in table-bank) feed a per-account balances MV (only
+nonzero balances, so account rows also get deleted and re-created) that two
+Kafka sinks export: ENVELOPE DEBEZIUM into a single-partition topic, and
+ENVELOPE UPSERT into a two-partition topic routed by PARTITION BY.
+read_committed consumers reconstruct the balances. Soundness of the checks
+relies on documented sink behavior: every message carries a
+materialize-timestamp header, updates for one timestamp never straddle two
+Kafka transactions, and within one partition timestamps are non-decreasing,
+so a header change proves the previous timestamp complete.
 
-Invariants: at every timestamp boundary the reconstructed balances sum to
-zero (transfers pass through the sink atomically), each message's `before`
-matches the reconstructed state (the exactly-once check: a duplicated or
-lost message breaks the chain), and after quiescing the reconstructed state
-equals the balances MV.
+Invariants: at every timestamp boundary the reconstructed DEBEZIUM balances
+sum to zero (transfers pass through the sink atomically), each message's
+`before` matches the reconstructed state (the exactly-once check: a
+duplicated or lost message breaks the chain), the upsert sink routes every
+key to its stable PARTITION BY partition, and after quiescing both
+reconstructed states equal the balances MV. A churn action additionally
+flips the DEBEZIUM sink between two identical relations via ALTER SINK ..
+SET FROM: the documented cutover has no double emission and no gap, so the
+before/after chain must survive it unbroken.
 """
 
 import json
 import random
+import time
 
 from materialize.invariants.framework import (
     CONVERGE_TIMEOUT,
     SEED_RANGE,
+    Action,
     Checker,
     InvariantViolation,
     OpLog,
@@ -45,6 +52,8 @@ from materialize.invariants.mz import MzClient
 from materialize.invariants.scenarios.table_bank import LedgerTransfer
 
 TOPIC = "invariants-balances"
+UPSERT_TOPIC = "invariants-balances-upsert"
+UPSERT_PARTITIONS = 2
 
 
 class SinkConsumerChecker(Checker):
@@ -148,6 +157,131 @@ class SinkConsumerChecker(Checker):
             self.consumer = None
 
 
+class UpsertSinkChecker(Checker):
+    """Tails the ENVELOPE UPSERT sink topic across its two partitions.
+
+    Per documented upsert-sink semantics: each message carries the latest
+    value for its key (or a null-value tombstone on delete), so
+    last-write-wins reconstruction per key yields the sinked relation. Per
+    partition the materialize-timestamp headers never decrease, and with
+    PARTITION BY every key maps to one stable partition, verified both as
+    constancy while tailing and against Materialize's own hash in the final
+    check.
+    """
+
+    name = "upsert-sink-consumer"
+    pause = (0.0, 0.2)
+
+    def __init__(
+        self, rng: random.Random, ctx: ScenarioContext, bootstrap: str
+    ) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.bootstrap = bootstrap
+        self.consumer = None
+        self.state: dict[int, int] = {}
+        self.partition_of: dict[int, int] = {}
+        self.partition_ts: dict[int, int] = {}
+
+    def open(self) -> None:
+        from confluent_kafka import OFFSET_BEGINNING, Consumer, TopicPartition
+
+        self.close()
+        self.state = {}
+        self.partition_of = {}
+        self.partition_ts = {}
+        self.consumer = Consumer(
+            {
+                "bootstrap.servers": self.bootstrap,
+                "group.id": f"invariants-upsert-{self.ctx.seed}",
+                "enable.auto.commit": False,
+                "isolation.level": "read_committed",
+            }
+        )
+        self.consumer.assign(
+            [
+                TopicPartition(UPSERT_TOPIC, partition, OFFSET_BEGINNING)
+                for partition in range(UPSERT_PARTITIONS)
+            ]
+        )
+
+    def check_once(self) -> None:
+        self.drain(max_messages=1000)
+
+    def drain(self, max_messages: int = 100_000) -> None:
+        assert self.consumer is not None
+        for _ in range(max_messages):
+            message = self.consumer.poll(0.1)
+            if message is None:
+                return
+            if message.error() is not None:
+                raise TransientError(f"consumer error: {message.error()}")
+            self._handle(message)
+            self.validations += 1
+
+    def _handle(self, message) -> None:
+        headers = dict(message.headers() or [])
+        ts = int(headers["materialize-timestamp"].decode())
+        partition = message.partition()
+        if ts < self.partition_ts.get(partition, 0):
+            raise InvariantViolation(
+                f"upsert sink timestamps went backwards on partition"
+                f" {partition}: {ts} < {self.partition_ts[partition]}"
+            )
+        self.partition_ts[partition] = ts
+        account = int(json.loads(message.key())["account"])
+        known = self.partition_of.setdefault(account, partition)
+        if known != partition:
+            raise InvariantViolation(
+                f"PARTITION BY routed account {account} to partition"
+                f" {partition} after {known}"
+            )
+        raw_value = message.value()
+        if raw_value is None:
+            self.state.pop(account, None)
+        else:
+            self.state[account] = int(json.loads(raw_value)["balance"])
+
+    def close(self) -> None:
+        if self.consumer is not None:
+            try:
+                self.consumer.close()
+            except Exception:
+                pass
+            self.consumer = None
+
+
+class AlterSinkFlip(Action):
+    """Flip the DEBEZIUM sink between two identical relations.
+
+    ALTER SINK .. SET FROM cuts over at a timestamp with everything before
+    it from the old relation and everything after from the new one. The
+    relations are identical, so the consumer's before/after chain must
+    survive every cutover unbroken: a re-emission or gap breaks it. The
+    statement legitimately times out while the sink is unhealthy (UNKNOWN).
+    """
+
+    name = "alter-sink"
+
+    def __init__(self, rng: random.Random, client: MzClient) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.next_at = time.monotonic() + 15.0
+        self.flips = 0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(20.0, 40.0)
+        self.flips += 1
+        target = "balances_alt" if self.flips % 2 else "balances"
+        return self.client.write(f"ALTER SINK bank_sink SET FROM {target}")
+
+    def close(self) -> None:
+        self.client.reset()
+
+
 class SinkRoundtrip(Scenario):
     name = "sink-roundtrip"
     services = ["kafka"]
@@ -165,44 +299,71 @@ class SinkRoundtrip(Scenario):
         self.accounts = ctx.complexity.accounts
         self.oplog = OpLog()
         self.sink_checker: SinkConsumerChecker | None = None
+        self.upsert_checker: UpsertSinkChecker | None = None
         assert ctx.endpoints.kafka_bootstrap is not None
         self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    # HAVING drops zero balances, so accounts also leave the relation and
+    # both sinks exercise their delete paths (Debezium after: null, upsert
+    # tombstones). Dropping zero terms does not change the conserved sum.
+    BALANCES_DEF = (
+        "SELECT account, sum(amount) AS balance FROM ledger"
+        " GROUP BY account HAVING sum(amount) <> 0"
+    )
 
     def setup(self) -> None:
         from confluent_kafka.admin import AdminClient
 
         client = MzClient(self.ctx, "setup")
         for sql in [
-            "CREATE TABLE ledger (worker int, seq bigint, account int, amount bigint)",
-            "CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
-            " SELECT account, sum(amount) AS balance FROM ledger GROUP BY account",
+            "CREATE TABLE ledger (worker int, seq bigint, account int,"
+            " amount bigint, at timestamptz)",
+            f"CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
+            f" {self.BALANCES_DEF}",
+            # The identical relation the ALTER SINK churn cuts over to.
+            f"CREATE MATERIALIZED VIEW balances_alt IN CLUSTER compute AS"
+            f" {self.BALANCES_DEF}",
             "CREATE CONNECTION kafka_sink_conn TO KAFKA"
             " (BROKER 'toxiproxy:9192', SECURITY PROTOCOL PLAINTEXT)",
             "CREATE SINK bank_sink IN CLUSTER storage FROM balances"
             " INTO KAFKA CONNECTION kafka_sink_conn"
             f" (TOPIC '{TOPIC}', TOPIC PARTITION COUNT 1, TOPIC REPLICATION FACTOR 1)"
             " KEY (account) NOT ENFORCED FORMAT JSON ENVELOPE DEBEZIUM",
+            # GROUP BY makes (account) a provable unique key, so no NOT
+            # ENFORCED here: this also covers the documented key check.
+            "CREATE SINK bank_sink_upsert IN CLUSTER storage FROM balances"
+            " INTO KAFKA CONNECTION kafka_sink_conn"
+            f" (TOPIC '{UPSERT_TOPIC}',"
+            f" TOPIC PARTITION COUNT {UPSERT_PARTITIONS},"
+            " TOPIC REPLICATION FACTOR 1,"
+            " PARTITION BY seahash(account::text))"
+            " KEY (account) FORMAT JSON ENVELOPE UPSERT",
         ]:
             client.query(sql, timeout=120)
         client.reset()
         admin = AdminClient({"bootstrap.servers": self.bootstrap})
         wait_until(
-            lambda: TOPIC in admin.list_topics(timeout=10).topics,
+            lambda: {TOPIC, UPSERT_TOPIC} <= set(admin.list_topics(timeout=10).topics),
             CONVERGE_TIMEOUT,
             "sink topic creation",
         )
 
     def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
         client = MzClient(self.ctx, f"worker-{index}")
-        return WorkerBundle(
-            actions=[LedgerTransfer(rng, index, self.accounts, client, self.oplog)],
-            weights=[1],
-        )
+        actions: list[Action] = [
+            LedgerTransfer(rng, index, self.accounts, client, self.oplog)
+        ]
+        weights = [10]
+        if index == 0:
+            actions.append(AlterSinkFlip(rng, client))
+            weights.append(1)
+        return WorkerBundle(actions=actions, weights=weights)
 
     def checkers(self) -> list[Checker]:
-        rng = random.Random(self.ctx.rng.randrange(SEED_RANGE))
-        self.sink_checker = SinkConsumerChecker(rng, self.ctx, self.bootstrap)
-        return [self.sink_checker]
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(2)]
+        self.sink_checker = SinkConsumerChecker(rngs[0], self.ctx, self.bootstrap)
+        self.upsert_checker = UpsertSinkChecker(rngs[1], self.ctx, self.bootstrap)
+        return [self.sink_checker, self.upsert_checker]
 
     def _mz_balances(self, client: MzClient) -> dict[int, int]:
         client.query("SET cluster = quickstart")
@@ -213,29 +374,37 @@ class SinkRoundtrip(Scenario):
 
     def converge(self) -> None:
         checker = self.sink_checker
-        assert checker is not None
+        upsert = self.upsert_checker
+        assert checker is not None and upsert is not None
         if checker.consumer is None:
             checker.open()
+        if upsert.consumer is None:
+            upsert.open()
         client = MzClient(self.ctx, "converge")
 
         def caught_up() -> bool:
             checker.drain()
-            return checker.state == self._mz_balances(client)
+            upsert.drain()
+            balances = self._mz_balances(client)
+            return checker.state == balances and upsert.state == balances
 
         wait_until(caught_up, CONVERGE_TIMEOUT, "sink output catching up")
         client.reset()
 
     def final_check(self) -> None:
         checker = self.sink_checker
-        assert checker is not None
+        upsert = self.upsert_checker
+        assert checker is not None and upsert is not None
         client = MzClient(self.ctx, "final-check")
         last: dict[str, dict[int, int]] = {}
 
         def settled() -> bool:
             checker.drain()
+            upsert.drain()
             last["sink"] = dict(checker.state)
+            last["upsert"] = dict(upsert.state)
             last["mz"] = self._mz_balances(client)
-            return last["sink"] == last["mz"]
+            return last["sink"] == last["mz"] and last["upsert"] == last["mz"]
 
         try:
             # Retried, not one-shot: an UNKNOWN write whose group commit was
@@ -246,12 +415,30 @@ class SinkRoundtrip(Scenario):
         except InvariantViolation:
             raise InvariantViolation(
                 f"sink state diverged from balances MV:"
-                f" sink={last.get('sink')} mz={last.get('mz')}"
+                f" sink={last.get('sink')} upsert={last.get('upsert')}"
+                f" mz={last.get('mz')}"
             ) from None
         if sum(checker.state.values()) != 0:
             raise InvariantViolation(
                 f"final sink balances sum to {sum(checker.state.values())} != 0"
             )
+        # PARTITION BY: every key's observed partition must equal
+        # Materialize's own hash-mod assignment.
+        expected_partition = {
+            int(row[0]): int(row[1])
+            for row in client.query(
+                "SELECT account,"
+                f" (seahash(account::text) % {UPSERT_PARTITIONS})::int"
+                " FROM balances"
+            )
+        }
+        for account, partition in upsert.partition_of.items():
+            expected = expected_partition.get(account)
+            if expected is not None and expected != partition:
+                raise InvariantViolation(
+                    f"PARTITION BY put account {account} on partition"
+                    f" {partition}, seahash says {expected}"
+                )
         client.query("SET cluster = quickstart")
         broken = client.query(
             "SELECT worker, seq, count(*), sum(amount) FROM ledger"

--- a/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
+++ b/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
@@ -1,0 +1,298 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Bank balances exported through a Kafka sink, verified by a consumer.
+
+Ledger transfers (as in table-bank) feed a per-account balances MV that a
+Kafka sink exports with ENVELOPE DEBEZIUM into a single-partition topic. A
+read_committed consumer reconstructs the balances from the before/after
+pairs. Soundness of the checks relies on documented sink behavior: every
+message carries a materialize-timestamp header, updates for one timestamp
+never straddle two Kafka transactions, and within one partition timestamps
+are non-decreasing, so a header change proves the previous timestamp
+complete.
+
+Invariants: at every timestamp boundary the reconstructed balances sum to
+zero (transfers pass through the sink atomically), each message's `before`
+matches the reconstructed state (the exactly-once check: a duplicated or
+lost message breaks the chain), and after quiescing the reconstructed state
+equals the balances MV.
+"""
+
+import json
+import random
+
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.scenarios.table_bank import LedgerTransfer
+
+TOPIC = "invariants-balances"
+
+
+class SinkConsumerChecker(Checker):
+    """Tails the sink topic and replays it against a reconstructed state."""
+
+    name = "sink-consumer"
+    pause = (0.0, 0.2)
+
+    def __init__(
+        self, rng: random.Random, ctx: ScenarioContext, bootstrap: str
+    ) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.bootstrap = bootstrap
+        self.consumer = None
+        self.state: dict[int, int] = {}
+        self.current_ts: int | None = None
+
+    def open(self) -> None:
+        from confluent_kafka import OFFSET_BEGINNING, Consumer, TopicPartition
+
+        self.close()
+        # Offsets are never committed and assignment is manual, so every
+        # (re)open deterministically replays the topic from the beginning.
+        self.state = {}
+        self.current_ts = None
+        self.consumer = Consumer(
+            {
+                "bootstrap.servers": self.bootstrap,
+                "group.id": f"invariants-{self.ctx.seed}",
+                "enable.auto.commit": False,
+                # The sink writes transactionally. Aborted transactions from
+                # sink restarts must stay invisible.
+                "isolation.level": "read_committed",
+            }
+        )
+        self.consumer.assign([TopicPartition(TOPIC, 0, OFFSET_BEGINNING)])
+
+    def check_once(self) -> None:
+        self.drain(max_messages=1000)
+
+    def drain(self, max_messages: int = 100_000) -> None:
+        assert self.consumer is not None
+        for _ in range(max_messages):
+            message = self.consumer.poll(0.1)
+            if message is None:
+                return
+            if message.error() is not None:
+                raise TransientError(f"consumer error: {message.error()}")
+            self._handle(message)
+
+    def _handle(self, message) -> None:
+        headers = dict(message.headers() or [])
+        ts = int(headers["materialize-timestamp"].decode())
+        if self.current_ts is None:
+            self.current_ts = ts
+        elif ts < self.current_ts:
+            raise InvariantViolation(
+                f"sink timestamps went backwards: {ts} < {self.current_ts}"
+            )
+        elif ts > self.current_ts:
+            # The previous timestamp is complete: single partition, and one
+            # timestamp never straddles two sink transactions.
+            self.validate_boundary()
+            self.current_ts = ts
+        raw_value = message.value()
+        if raw_value is None:
+            # Compaction tombstone, carries no state.
+            return
+        account = int(json.loads(message.key())["account"])
+        value = json.loads(raw_value)
+        before, after = value["before"], value["after"]
+        expected_before = self.state.get(account)
+        actual_before = int(before["balance"]) if before is not None else None
+        if actual_before != expected_before:
+            raise InvariantViolation(
+                f"sink message chain broken for account {account} at"
+                f" {self.current_ts}: before={actual_before},"
+                f" reconstructed={expected_before} (lost or duplicated message)"
+            )
+        if after is None:
+            self.state.pop(account, None)
+        else:
+            self.state[account] = int(after["balance"])
+
+    def validate_boundary(self) -> None:
+        self.validations += 1
+        balance_sum = sum(self.state.values())
+        if balance_sum != 0:
+            raise InvariantViolation(
+                f"balances through the sink sum to {balance_sum} != 0 at"
+                f" timestamp {self.current_ts}: {self.state}"
+            )
+
+    def close(self) -> None:
+        if self.consumer is not None:
+            try:
+                self.consumer.close()
+            except Exception:
+                pass
+            self.consumer = None
+
+
+class SinkRoundtrip(Scenario):
+    name = "sink-roundtrip"
+    services = ["kafka"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "clusterd-storage",
+        "kafka-sink",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.oplog = OpLog()
+        self.sink_checker: SinkConsumerChecker | None = None
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE ledger (worker int, seq bigint, account int, amount bigint)",
+            "CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
+            " SELECT account, sum(amount) AS balance FROM ledger GROUP BY account",
+            "CREATE CONNECTION kafka_sink_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9192', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE SINK bank_sink IN CLUSTER storage FROM balances"
+            " INTO KAFKA CONNECTION kafka_sink_conn"
+            f" (TOPIC '{TOPIC}', TOPIC PARTITION COUNT 1, TOPIC REPLICATION FACTOR 1)"
+            " KEY (account) NOT ENFORCED FORMAT JSON ENVELOPE DEBEZIUM",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        wait_until(
+            lambda: TOPIC in admin.list_topics(timeout=10).topics,
+            CONVERGE_TIMEOUT,
+            "sink topic creation",
+        )
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        client = MzClient(self.ctx, f"worker-{index}")
+        return WorkerBundle(
+            actions=[LedgerTransfer(rng, index, self.accounts, client, self.oplog)],
+            weights=[1],
+        )
+
+    def checkers(self) -> list[Checker]:
+        rng = random.Random(self.ctx.rng.randrange(SEED_RANGE))
+        self.sink_checker = SinkConsumerChecker(rng, self.ctx, self.bootstrap)
+        return [self.sink_checker]
+
+    def _mz_balances(self, client: MzClient) -> dict[int, int]:
+        client.query("SET cluster = quickstart")
+        return {
+            int(row[0]): int(row[1])
+            for row in client.query("SELECT account, balance FROM balances")
+        }
+
+    def converge(self) -> None:
+        checker = self.sink_checker
+        assert checker is not None
+        if checker.consumer is None:
+            checker.open()
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            checker.drain()
+            return checker.state == self._mz_balances(client)
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "sink output catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        checker = self.sink_checker
+        assert checker is not None
+        client = MzClient(self.ctx, "final-check")
+        last: dict[str, dict[int, int]] = {}
+
+        def settled() -> bool:
+            checker.drain()
+            last["sink"] = dict(checker.state)
+            last["mz"] = self._mz_balances(client)
+            return last["sink"] == last["mz"]
+
+        try:
+            # Retried, not one-shot: an UNKNOWN write whose group commit was
+            # still in flight during the last disruption can land after
+            # converge, and the sink legitimately lags the MV by a moment. A
+            # genuine divergence persists and still fails at the timeout.
+            wait_until(settled, 60, "final sink/MV agreement")
+        except InvariantViolation:
+            raise InvariantViolation(
+                f"sink state diverged from balances MV:"
+                f" sink={last.get('sink')} mz={last.get('mz')}"
+            ) from None
+        if sum(checker.state.values()) != 0:
+            raise InvariantViolation(
+                f"final sink balances sum to {sum(checker.state.values())} != 0"
+            )
+        client.query("SET cluster = quickstart")
+        broken = client.query(
+            "SELECT worker, seq, count(*), sum(amount) FROM ledger"
+            " GROUP BY worker, seq HAVING count(*) <> 2 OR sum(amount) <> 0"
+        )
+        if broken:
+            raise InvariantViolation(f"non-atomic ledger transfers: {broken[:20]}")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM ledger WHERE worker = {worker} GROUP BY seq"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - committed - unknown
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        checker = self.sink_checker
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            mz_balances = self._mz_balances(client)
+            state = checker.state if checker else None
+            verdict = "converged" if state == mz_balances else "still diverged"
+            self.ctx.log.log(
+                "diag",
+                f"post-heal: sink boundaries={checker.validations if checker else 0},"
+                f" state {verdict}",
+            )
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal comparison failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
+++ b/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
@@ -355,9 +355,15 @@ class SinkRoundtrip(Scenario):
             LedgerTransfer(rng, index, self.accounts, client, self.oplog)
         ]
         weights = [10]
-        if index == 0:
-            actions.append(AlterSinkFlip(rng, client))
-            weights.append(1)
+        # TODO: Reenable when SS-415 is fixed. A storage replica that was
+        # unreachable while the sink was altered panics reconciling it, which
+        # under chaos is most runs, so the flip masks every other finding in
+        # this scenario. Reproducer, deterministic:
+        # bin/mzcompose --find cluster run test-ss415-alter-sink
+        #
+        # if index == 0:
+        #     actions.append(AlterSinkFlip(rng, client))
+        #     weights.append(1)
         return WorkerBundle(actions=actions, weights=weights)
 
     def checkers(self) -> list[Checker]:

--- a/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
+++ b/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
@@ -1,0 +1,492 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Bank balances exported through Kafka sinks, verified by consumers.
+
+Ledger transfers (as in table-bank) feed a per-account balances MV (only
+nonzero balances, so account rows also get deleted and re-created) that two
+Kafka sinks export: ENVELOPE DEBEZIUM into a single-partition topic, and
+ENVELOPE UPSERT into a two-partition topic routed by PARTITION BY.
+read_committed consumers reconstruct the balances. Soundness of the checks
+relies on documented sink behavior: every message carries a
+materialize-timestamp header, updates for one timestamp never straddle two
+Kafka transactions, and within one partition timestamps are non-decreasing,
+so a header change proves the previous timestamp complete.
+
+Invariants: at every timestamp boundary the reconstructed DEBEZIUM balances
+sum to zero (transfers pass through the sink atomically), each message's
+`before` matches the reconstructed state (the exactly-once check: a
+duplicated or lost message breaks the chain), the upsert sink routes every
+key to its stable PARTITION BY partition, and after quiescing both
+reconstructed states equal the balances MV. A churn action additionally
+flips the DEBEZIUM sink between two identical relations via ALTER SINK ..
+SET FROM: the documented cutover has no double emission and no gap, so the
+before/after chain must survive it unbroken.
+"""
+
+import json
+import random
+import time
+
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.scenarios.table_bank import LedgerTransfer
+
+TOPIC = "invariants-balances"
+UPSERT_TOPIC = "invariants-balances-upsert"
+UPSERT_PARTITIONS = 2
+
+# HAVING drops zero balances, so accounts also leave the relation and the
+# sinks exercise their delete paths (Debezium after: null, upsert
+# tombstones). Dropping zero terms does not change the conserved sum. Shared
+# with avro-loopback, which loops the same relation through Avro/CSR.
+BALANCES_DEF = (
+    "SELECT account, sum(amount) AS balance FROM ledger"
+    " GROUP BY account HAVING sum(amount) <> 0"
+)
+
+
+class SinkConsumerChecker(Checker):
+    """Tails the sink topic and replays it against a reconstructed state."""
+
+    name = "sink-consumer"
+    pause = (0.0, 0.2)
+
+    def __init__(
+        self, rng: random.Random, ctx: ScenarioContext, bootstrap: str
+    ) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.bootstrap = bootstrap
+        self.consumer = None
+        self.state: dict[int, int] = {}
+        self.current_ts: int | None = None
+
+    def open(self) -> None:
+        from confluent_kafka import OFFSET_BEGINNING, Consumer, TopicPartition
+
+        self.close()
+        # Offsets are never committed and assignment is manual, so every
+        # (re)open deterministically replays the topic from the beginning.
+        self.state = {}
+        self.current_ts = None
+        self.consumer = Consumer(
+            {
+                "bootstrap.servers": self.bootstrap,
+                "group.id": f"invariants-{self.ctx.seed}",
+                "enable.auto.commit": False,
+                # The sink writes transactionally. Aborted transactions from
+                # sink restarts must stay invisible.
+                "isolation.level": "read_committed",
+            }
+        )
+        self.consumer.assign([TopicPartition(TOPIC, 0, OFFSET_BEGINNING)])
+
+    def check_once(self) -> None:
+        self.drain(max_messages=1000)
+
+    def drain(self, max_messages: int = 100_000) -> None:
+        assert self.consumer is not None
+        for _ in range(max_messages):
+            message = self.consumer.poll(0.1)
+            if message is None:
+                return
+            if message.error() is not None:
+                raise TransientError(f"consumer error: {message.error()}")
+            self._handle(message)
+
+    def _handle(self, message) -> None:
+        headers = dict(message.headers() or [])
+        ts = int(headers["materialize-timestamp"].decode())
+        if self.current_ts is None:
+            self.current_ts = ts
+        elif ts < self.current_ts:
+            raise InvariantViolation(
+                f"sink timestamps went backwards: {ts} < {self.current_ts}"
+            )
+        elif ts > self.current_ts:
+            # The previous timestamp is complete: single partition, and one
+            # timestamp never straddles two sink transactions.
+            self.validate_boundary()
+            self.current_ts = ts
+        raw_value = message.value()
+        if raw_value is None:
+            # Compaction tombstone, carries no state.
+            return
+        account = int(json.loads(message.key())["account"])
+        value = json.loads(raw_value)
+        before, after = value["before"], value["after"]
+        expected_before = self.state.get(account)
+        actual_before = int(before["balance"]) if before is not None else None
+        if actual_before != expected_before:
+            raise InvariantViolation(
+                f"sink message chain broken for account {account} at"
+                f" {self.current_ts}: before={actual_before},"
+                f" reconstructed={expected_before} (lost or duplicated message)"
+            )
+        if after is None:
+            self.state.pop(account, None)
+        else:
+            self.state[account] = int(after["balance"])
+
+    def validate_boundary(self) -> None:
+        self.validations += 1
+        balance_sum = sum(self.state.values())
+        if balance_sum != 0:
+            raise InvariantViolation(
+                f"balances through the sink sum to {balance_sum} != 0 at"
+                f" timestamp {self.current_ts}: {self.state}"
+            )
+
+    def close(self) -> None:
+        if self.consumer is not None:
+            try:
+                self.consumer.close()
+            except Exception:
+                pass
+            self.consumer = None
+
+
+class UpsertSinkChecker(Checker):
+    """Tails the ENVELOPE UPSERT sink topic across its two partitions.
+
+    Per documented upsert-sink semantics: each message carries the latest
+    value for its key (or a null-value tombstone on delete), so
+    last-write-wins reconstruction per key yields the sinked relation. Per
+    partition the materialize-timestamp headers never decrease, and with
+    PARTITION BY every key maps to one stable partition, verified both as
+    constancy while tailing and against Materialize's own hash in the final
+    check.
+    """
+
+    name = "upsert-sink-consumer"
+    pause = (0.0, 0.2)
+
+    def __init__(
+        self, rng: random.Random, ctx: ScenarioContext, bootstrap: str
+    ) -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.bootstrap = bootstrap
+        self.consumer = None
+        self.state: dict[int, int] = {}
+        self.partition_of: dict[int, int] = {}
+        self.partition_ts: dict[int, int] = {}
+
+    def open(self) -> None:
+        from confluent_kafka import OFFSET_BEGINNING, Consumer, TopicPartition
+
+        self.close()
+        self.state = {}
+        self.partition_of = {}
+        self.partition_ts = {}
+        self.consumer = Consumer(
+            {
+                "bootstrap.servers": self.bootstrap,
+                "group.id": f"invariants-upsert-{self.ctx.seed}",
+                "enable.auto.commit": False,
+                "isolation.level": "read_committed",
+            }
+        )
+        self.consumer.assign(
+            [
+                TopicPartition(UPSERT_TOPIC, partition, OFFSET_BEGINNING)
+                for partition in range(UPSERT_PARTITIONS)
+            ]
+        )
+
+    def check_once(self) -> None:
+        self.drain(max_messages=1000)
+
+    def drain(self, max_messages: int = 100_000) -> None:
+        assert self.consumer is not None
+        for _ in range(max_messages):
+            message = self.consumer.poll(0.1)
+            if message is None:
+                return
+            if message.error() is not None:
+                raise TransientError(f"consumer error: {message.error()}")
+            self._handle(message)
+            self.validations += 1
+
+    def _handle(self, message) -> None:
+        headers = dict(message.headers() or [])
+        ts = int(headers["materialize-timestamp"].decode())
+        partition = message.partition()
+        if ts < self.partition_ts.get(partition, 0):
+            raise InvariantViolation(
+                f"upsert sink timestamps went backwards on partition"
+                f" {partition}: {ts} < {self.partition_ts[partition]}"
+            )
+        self.partition_ts[partition] = ts
+        account = int(json.loads(message.key())["account"])
+        known = self.partition_of.setdefault(account, partition)
+        if known != partition:
+            raise InvariantViolation(
+                f"PARTITION BY routed account {account} to partition"
+                f" {partition} after {known}"
+            )
+        raw_value = message.value()
+        if raw_value is None:
+            self.state.pop(account, None)
+        else:
+            self.state[account] = int(json.loads(raw_value)["balance"])
+
+    def close(self) -> None:
+        if self.consumer is not None:
+            try:
+                self.consumer.close()
+            except Exception:
+                pass
+            self.consumer = None
+
+
+class AlterSinkFlip(Action):
+    """Flip the DEBEZIUM sink between two identical relations.
+
+    ALTER SINK .. SET FROM cuts over at a timestamp with everything before
+    it from the old relation and everything after from the new one. The
+    relations are identical, so the consumer's before/after chain must
+    survive every cutover unbroken: a re-emission or gap breaks it. The
+    statement legitimately times out while the sink is unhealthy (UNKNOWN).
+    """
+
+    name = "alter-sink"
+
+    def __init__(self, rng: random.Random, client: MzClient) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.next_at = time.monotonic() + 15.0
+        self.flips = 0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(20.0, 40.0)
+        self.flips += 1
+        target = "balances_alt" if self.flips % 2 else "balances"
+        return self.client.write(f"ALTER SINK bank_sink SET FROM {target}")
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class SinkRoundtrip(Scenario):
+    name = "sink-roundtrip"
+    services = ["kafka"]
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "clusterd-storage",
+        "kafka-sink",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.oplog = OpLog()
+        self.sink_checker: SinkConsumerChecker | None = None
+        self.upsert_checker: UpsertSinkChecker | None = None
+        assert ctx.endpoints.kafka_bootstrap is not None
+        self.bootstrap = ctx.endpoints.kafka_bootstrap
+
+    def setup(self) -> None:
+        from confluent_kafka.admin import AdminClient
+
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE ledger (worker int, seq bigint, account int,"
+            " amount bigint, at timestamptz)",
+            "CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
+            f" {BALANCES_DEF}",
+            # The identical relation the ALTER SINK churn cuts over to.
+            "CREATE MATERIALIZED VIEW balances_alt IN CLUSTER compute AS"
+            f" {BALANCES_DEF}",
+            "CREATE CONNECTION kafka_sink_conn TO KAFKA"
+            " (BROKER 'toxiproxy:9192', SECURITY PROTOCOL PLAINTEXT)",
+            "CREATE SINK bank_sink IN CLUSTER storage FROM balances"
+            " INTO KAFKA CONNECTION kafka_sink_conn"
+            f" (TOPIC '{TOPIC}', TOPIC PARTITION COUNT 1, TOPIC REPLICATION FACTOR 1)"
+            " KEY (account) NOT ENFORCED FORMAT JSON ENVELOPE DEBEZIUM",
+            # GROUP BY makes (account) a provable unique key, so no NOT
+            # ENFORCED here: this also covers the documented key check.
+            "CREATE SINK bank_sink_upsert IN CLUSTER storage FROM balances"
+            " INTO KAFKA CONNECTION kafka_sink_conn"
+            f" (TOPIC '{UPSERT_TOPIC}',"
+            f" TOPIC PARTITION COUNT {UPSERT_PARTITIONS},"
+            " TOPIC REPLICATION FACTOR 1,"
+            " PARTITION BY seahash(account::text))"
+            " KEY (account) FORMAT JSON ENVELOPE UPSERT",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+        admin = AdminClient({"bootstrap.servers": self.bootstrap})
+        wait_until(
+            lambda: {TOPIC, UPSERT_TOPIC} <= set(admin.list_topics(timeout=10).topics),
+            CONVERGE_TIMEOUT,
+            "sink topic creation",
+        )
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        client = MzClient(self.ctx, f"worker-{index}")
+        actions: list[Action] = [
+            LedgerTransfer(rng, index, self.accounts, client, self.oplog)
+        ]
+        weights = [10]
+        # TODO: Reenable when SS-415 is fixed. A storage replica that was
+        # unreachable while the sink was altered panics reconciling it, which
+        # under chaos is most runs, so the flip masks every other finding in
+        # this scenario. Reproducer, deterministic:
+        # bin/mzcompose --find cluster run test-ss415-alter-sink
+        #
+        # if index == 0:
+        #     actions.append(AlterSinkFlip(rng, client))
+        #     weights.append(1)
+        return WorkerBundle(actions=actions, weights=weights)
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(2)]
+        self.sink_checker = SinkConsumerChecker(rngs[0], self.ctx, self.bootstrap)
+        self.upsert_checker = UpsertSinkChecker(rngs[1], self.ctx, self.bootstrap)
+        return [self.sink_checker, self.upsert_checker]
+
+    def _mz_balances(self, client: MzClient) -> dict[int, int]:
+        client.query("SET cluster = quickstart")
+        return {
+            int(row[0]): int(row[1])
+            for row in client.query("SELECT account, balance FROM balances")
+        }
+
+    def converge(self) -> None:
+        checker = self.sink_checker
+        upsert = self.upsert_checker
+        assert checker is not None and upsert is not None
+        if checker.consumer is None:
+            checker.open()
+        if upsert.consumer is None:
+            upsert.open()
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            checker.drain()
+            upsert.drain()
+            balances = self._mz_balances(client)
+            return checker.state == balances and upsert.state == balances
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "sink output catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        checker = self.sink_checker
+        upsert = self.upsert_checker
+        assert checker is not None and upsert is not None
+        client = MzClient(self.ctx, "final-check")
+        last: dict[str, dict[int, int]] = {}
+
+        def settled() -> bool:
+            checker.drain()
+            upsert.drain()
+            last["sink"] = dict(checker.state)
+            last["upsert"] = dict(upsert.state)
+            last["mz"] = self._mz_balances(client)
+            return last["sink"] == last["mz"] and last["upsert"] == last["mz"]
+
+        try:
+            # Retried, not one-shot: an UNKNOWN write whose group commit was
+            # still in flight during the last disruption can land after
+            # converge, and the sink legitimately lags the MV by a moment. A
+            # genuine divergence persists and still fails at the timeout.
+            wait_until(settled, 60, "final sink/MV agreement")
+        except InvariantViolation:
+            raise InvariantViolation(
+                f"sink state diverged from balances MV:"
+                f" sink={last.get('sink')} upsert={last.get('upsert')}"
+                f" mz={last.get('mz')}"
+            ) from None
+        if sum(checker.state.values()) != 0:
+            raise InvariantViolation(
+                f"final sink balances sum to {sum(checker.state.values())} != 0"
+            )
+        # PARTITION BY: every key's observed partition must equal
+        # Materialize's own hash-mod assignment.
+        expected_partition = {
+            int(row[0]): int(row[1])
+            for row in client.query(
+                "SELECT account,"
+                f" (seahash(account::text) % {UPSERT_PARTITIONS})::int"
+                " FROM balances"
+            )
+        }
+        for account, partition in upsert.partition_of.items():
+            expected = expected_partition.get(account)
+            if expected is not None and expected != partition:
+                raise InvariantViolation(
+                    f"PARTITION BY put account {account} on partition"
+                    f" {partition}, seahash says {expected}"
+                )
+        client.query("SET cluster = quickstart")
+        broken = client.query(
+            "SELECT worker, seq, count(*), sum(amount) FROM ledger"
+            " GROUP BY worker, seq HAVING count(*) <> 2 OR sum(amount) <> 0"
+        )
+        if broken:
+            raise InvariantViolation(f"non-atomic ledger transfers: {broken[:20]}")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM ledger WHERE worker = {worker} GROUP BY seq"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            issued = self.oplog.issued(worker)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - issued
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        checker = self.sink_checker
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            mz_balances = self._mz_balances(client)
+            state = checker.state if checker else None
+            verdict = "converged" if state == mz_balances else "still diverged"
+            self.ctx.log.log(
+                "diag",
+                f"post-heal: sink boundaries={checker.validations if checker else 0},"
+                f" state {verdict}",
+            )
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal comparison failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
+++ b/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
@@ -55,6 +55,15 @@ TOPIC = "invariants-balances"
 UPSERT_TOPIC = "invariants-balances-upsert"
 UPSERT_PARTITIONS = 2
 
+# HAVING drops zero balances, so accounts also leave the relation and the
+# sinks exercise their delete paths (Debezium after: null, upsert
+# tombstones). Dropping zero terms does not change the conserved sum. Shared
+# with avro-loopback, which loops the same relation through Avro/CSR.
+BALANCES_DEF = (
+    "SELECT account, sum(amount) AS balance FROM ledger"
+    " GROUP BY account HAVING sum(amount) <> 0"
+)
+
 
 class SinkConsumerChecker(Checker):
     """Tails the sink topic and replays it against a reconstructed state."""
@@ -303,14 +312,6 @@ class SinkRoundtrip(Scenario):
         assert ctx.endpoints.kafka_bootstrap is not None
         self.bootstrap = ctx.endpoints.kafka_bootstrap
 
-    # HAVING drops zero balances, so accounts also leave the relation and
-    # both sinks exercise their delete paths (Debezium after: null, upsert
-    # tombstones). Dropping zero terms does not change the conserved sum.
-    BALANCES_DEF = (
-        "SELECT account, sum(amount) AS balance FROM ledger"
-        " GROUP BY account HAVING sum(amount) <> 0"
-    )
-
     def setup(self) -> None:
         from confluent_kafka.admin import AdminClient
 
@@ -318,11 +319,11 @@ class SinkRoundtrip(Scenario):
         for sql in [
             "CREATE TABLE ledger (worker int, seq bigint, account int,"
             " amount bigint, at timestamptz)",
-            f"CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
-            f" {self.BALANCES_DEF}",
+            "CREATE MATERIALIZED VIEW balances IN CLUSTER compute AS"
+            f" {BALANCES_DEF}",
             # The identical relation the ALTER SINK churn cuts over to.
-            f"CREATE MATERIALIZED VIEW balances_alt IN CLUSTER compute AS"
-            f" {self.BALANCES_DEF}",
+            "CREATE MATERIALIZED VIEW balances_alt IN CLUSTER compute AS"
+            f" {BALANCES_DEF}",
             "CREATE CONNECTION kafka_sink_conn TO KAFKA"
             " (BROKER 'toxiproxy:9192', SECURITY PROTOCOL PLAINTEXT)",
             "CREATE SINK bank_sink IN CLUSTER storage FROM balances"

--- a/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
+++ b/misc/python/materialize/invariants/scenarios/sink_roundtrip.py
@@ -461,13 +461,13 @@ class SinkRoundtrip(Scenario):
                 )
             }
             committed = self.oplog.seqs(worker, Outcome.COMMITTED)
-            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            issued = self.oplog.issued(worker)
             missing = committed - present
             if missing:
                 raise InvariantViolation(
                     f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
                 )
-            phantom = present - committed - unknown
+            phantom = present - issued
             if phantom:
                 raise InvariantViolation(
                     f"worker {worker}: transfers present that never committed:"

--- a/misc/python/materialize/invariants/scenarios/table_bank.py
+++ b/misc/python/materialize/invariants/scenarios/table_bank.py
@@ -9,18 +9,27 @@
 
 """Bank transfers on Materialize tables.
 
-Two write paths, both atomic per Materialize's documented guarantees:
-single-statement read-then-write UPDATEs of an accounts table, and
-INSERT-only ledger transactions (a debit and a credit row that sum to zero,
-tagged with a unique (worker, seq) op id for exact reconciliation).
+Write paths, all atomic per Materialize's documented guarantees:
+single-statement read-then-write UPDATEs of an accounts table, INSERT-only
+ledger transactions (a debit and a credit row that sum to zero, tagged with
+a unique (worker, seq) op id for exact reconciliation), COPY FROM STDIN of
+balanced pairs, and a registry table driven through idempotent
+INSERT/UPDATE/DELETE per single-owner key.
 
 Invariant: sum(accounts.balance) + sum(ledger.amount) equals the initial
 total at every timestamp, no matter which subset of concurrent transfers
-committed, failed, or is in an unknown state.
+committed, failed, or is in an unknown state. The total is verified through
+many documented, result-equivalent read paths (maintained MV, ad-hoc query,
+join, window function, recursive CTE, LATERAL, multi-statement read-only
+transactions, COPY TO STDOUT, COPY TO S3 exports, a REFRESH EVERY view, a
+blue/green schema pair cut over via ALTER SCHEMA SWAP, and replacement
+materialized views applied in place).
 """
 
 import random
 import time
+from datetime import UTC, datetime
+from typing import Any
 
 from materialize.invariants.checkers import PeekChecker, SubscribeChecker
 from materialize.invariants.framework import (
@@ -43,6 +52,8 @@ from materialize.invariants.mz import MzClient, UnexpectedQueryError
 BALANCE_PER_ACCOUNT = 1000
 # Each ledger transfer writes one debit and one credit row.
 ROWS_PER_TRANSFER = 2
+# Registry keys per worker, each owned and driven by exactly one thread.
+REGISTRY_KEYS = 8
 
 
 class UpdateTransfer(Action):
@@ -95,8 +106,8 @@ class LedgerTransfer(Action):
         seq = self.seq
         src, dst = self.rng.sample(range(self.accounts), 2)
         amount = self.rng.randint(1, 100)
-        debit = f"({self.worker}, {seq}, {src}, {-amount})"
-        credit = f"({self.worker}, {seq}, {dst}, {amount})"
+        debit = f"({self.worker}, {seq}, {src}, {-amount}, now())"
+        credit = f"({self.worker}, {seq}, {dst}, {amount}, now())"
         # Register before sending: if this thread dies mid-call the op still
         # counts as possibly-applied.
         self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
@@ -152,11 +163,214 @@ class ReversalTransfer(Action):
         )
         self.oplog.record(self.worker, -seq, Outcome.UNKNOWN)
         outcome = self.client.write(
-            "INSERT INTO ledger SELECT worker, -seq, account, -amount"
+            "INSERT INTO ledger SELECT worker, -seq, account, -amount, now()"
             f" FROM ledger WHERE worker = {self.worker} AND seq = {seq}"
         )
         self.oplog.record(self.worker, -seq, outcome)
         return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class CopyTransfer(Action):
+    """Append a balanced (debit, credit) pair via COPY FROM STDIN.
+
+    One COPY is one atomic write statement, so conservation and the exact
+    (worker, seq) reconciliation hold for it like for INSERTs. Shares the
+    forward transfer's seq counter (both actions run on the same worker
+    thread) so op ids stay unique per worker.
+    """
+
+    name = "copy-transfer"
+
+    def __init__(
+        self,
+        rng: random.Random,
+        worker: int,
+        client: MzClient,
+        oplog: OpLog,
+        forward: "LedgerTransfer",
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.oplog = oplog
+        self.forward = forward
+
+    def run(self) -> Outcome | None:
+        self.forward.seq += 1
+        seq = self.forward.seq
+        src, dst = self.rng.sample(range(self.forward.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        # The `at` value is the host clock: COPY has no server-side defaults
+        # here, and the temporal-filter windows are wide enough to absorb
+        # clock skew between host and server.
+        at = datetime.now(UTC).isoformat()
+        data = (
+            f"{self.worker}\t{seq}\t{src}\t{-amount}\t{at}\n"
+            f"{self.worker}\t{seq}\t{dst}\t{amount}\t{at}\n"
+        )
+        self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        outcome = self.client.copy_in(
+            "COPY ledger (worker, seq, account, amount, at) FROM STDIN", data
+        )
+        self.oplog.record(self.worker, seq, outcome)
+        if outcome == Outcome.COMMITTED:
+            self.forward.reversible.append(seq)
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class RegistryOp(Action):
+    """Drive one owned registry key through INSERT/UPDATE/DELETE.
+
+    All statements are idempotent (guarded insert, absolute-value update,
+    keyed delete), so an UNKNOWN outcome never risks a duplicate row, and
+    versions written by the single owner only increase. Every op is appended
+    to the scenario's per-key log for the final admissible-state check.
+    """
+
+    name = "registry"
+
+    def __init__(
+        self, rng: random.Random, worker: int, client: MzClient, scenario: "TableBank"
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.scenario = scenario
+        self.ver = 0
+
+    def run(self) -> Outcome | None:
+        key = self.rng.randrange(REGISTRY_KEYS)
+        self.ver += 1
+        ver = self.ver
+        where = f"worker = {self.worker} AND key = {key}"
+        roll = self.rng.random()
+        if roll < 0.4:
+            op = ("insert", ver)
+            sql = (
+                f"INSERT INTO registry SELECT {self.worker}, {key}, {ver}"
+                f" WHERE NOT EXISTS (SELECT 1 FROM registry WHERE {where})"
+            )
+        elif roll < 0.8:
+            op = ("update", ver)
+            sql = f"UPDATE registry SET ver = {ver} WHERE {where}"
+        else:
+            op = ("delete", None)
+            sql = f"DELETE FROM registry WHERE {where}"
+        entry: dict[str, Any] = {"op": op, "outcome": Outcome.UNKNOWN}
+        log = self.scenario.registry_log[(self.worker, key)]
+        log.append(entry)
+        entry["outcome"] = self.client.write(sql)
+        return entry["outcome"]
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class SchemaSwap(Action):
+    """Blue/green cutover: atomically swap two schemas holding identical MVs.
+
+    Consumers resolve the checked MV through the stable name
+    blue.total_swap, so the documented atomicity of ALTER SCHEMA .. SWAP is
+    what keeps their reads exact through every cutover.
+    """
+
+    name = "schema-swap"
+
+    def __init__(self, rng: random.Random, client: MzClient) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.next_at = 0.0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(8.0, 20.0)
+        return self.client.write("ALTER SCHEMA blue SWAP WITH green")
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class ReplacementChurn(Action):
+    """Replace the checked total MV in place with an identical definition.
+
+    The documented flow: CREATE REPLACEMENT MATERIALIZED VIEW hydrates in
+    the background while the original keeps serving, then ALTER .. APPLY
+    REPLACEMENT switches the definition while preserving the name and all
+    downstream objects. Because the definition is identical, every existing
+    total checker must keep seeing the exact total through the switch.
+    """
+
+    name = "replacement"
+
+    # Must match the definition of the `total` MV exactly.
+    TOTAL_DEF = (
+        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total"
+    )
+
+    def __init__(self, rng: random.Random, client: MzClient) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.next_at = time.monotonic() + 20.0
+        self.supported = True
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if not self.supported or now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(30.0, 60.0)
+        # A leftover replacement from a cycle whose APPLY outcome was
+        # UNKNOWN. Dropping an unapplied replacement is documented as safe.
+        if (
+            self.client.write("DROP MATERIALIZED VIEW IF EXISTS total_repl")
+            != Outcome.COMMITTED
+        ):
+            return Outcome.UNKNOWN
+        try:
+            outcome = self.client.write(
+                "CREATE REPLACEMENT MATERIALIZED VIEW total_repl FOR total"
+                f" IN CLUSTER compute WITH (RETAIN HISTORY = FOR '600s')"
+                f" AS {self.TOTAL_DEF}"
+            )
+        except UnexpectedQueryError as e:
+            # Not available on this version, e.g. the pre-upgrade half of an
+            # --upgrade-from run. Disabling (instead of failing) keeps the
+            # rest of the scenario meaningful there.
+            self.supported = False
+            raise TransientError(f"replacement MVs unsupported: {e}") from e
+        if outcome != Outcome.COMMITTED:
+            return outcome
+        # Apply only once the replacement hydrated on every replica, per the
+        # documented workflow.
+        deadline = time.monotonic() + 90.0
+        while time.monotonic() < deadline:
+            try:
+                rows = self.client.query(
+                    "SELECT bool_and(h.hydrated)"
+                    " FROM mz_internal.mz_hydration_statuses h"
+                    " JOIN mz_catalog.mz_materialized_views v"
+                    " ON h.object_id = v.id WHERE v.name = 'total_repl'"
+                )
+            except TransientError:
+                return Outcome.UNKNOWN
+            if rows and rows[0][0]:
+                break
+            time.sleep(1.0)
+        else:
+            # Hydration did not finish, e.g. the compute leg is cut. Leave
+            # the replacement for the next cycle's drop.
+            return Outcome.UNKNOWN
+        return self.client.write(
+            "ALTER MATERIALIZED VIEW total APPLY REPLACEMENT total_repl"
+        )
 
     def close(self) -> None:
         self.client.reset()
@@ -228,32 +442,85 @@ class BankTotalPeek(PeekChecker):
     """The grand total must be exact on every cluster, at every time.
 
     Alternates between the maintained MV, an ad-hoc query over the base
-    tables, and a single query spanning both, so the same invariant is
-    verified through different plans and, in the combined form, as one
-    consistent snapshot across objects. The ad-hoc form also stays live on
-    quickstart while the compute cluster (which maintains the MV) is
-    disrupted.
+    tables, a single query spanning both, and result-equivalent
+    formulations through a join, a window function, a recursive CTE, and a
+    LATERAL subquery. The same invariant is verified through many
+    documented plans, and in the combined forms as one consistent snapshot
+    across objects. The ad-hoc forms also stay live on quickstart while the
+    compute cluster (which maintains the MV) is disrupted.
     """
 
     BASE_TOTAL = (
         "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
         " + (SELECT coalesce(sum(amount), 0) FROM ledger)"
     )
+    # Every ledger row references an existing account id, so the inner join
+    # keeps all ledger rows.
+    JOIN_TOTAL = (
+        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + coalesce(sum(l.amount), 0)"
+        " FROM ledger l JOIN accounts a ON l.account = a.id"
+    )
+    WINDOW_TOTAL = (
+        "SELECT DISTINCT sum(balance) OVER ()"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger) FROM accounts"
+    )
+    # Log-depth pairwise-halving sum: level k holds per-id/2^k partial sums,
+    # level 20 collapses everything to id 0 for up to 2^20 accounts.
+    RECURSIVE_TOTAL = (
+        "WITH MUTUALLY RECURSIVE lvl (l int, id int, bal numeric) AS ("
+        " SELECT 0, id, balance::numeric FROM accounts"
+        " UNION ALL"
+        " SELECT l + 1, id / 2, sum(bal) FROM lvl WHERE l < 20"
+        " GROUP BY l + 1, id / 2"
+        ") SELECT bal + (SELECT coalesce(sum(amount), 0) FROM ledger)"
+        " FROM lvl WHERE l = 20 AND id = 0"
+    )
+    LATERAL_TOTAL = (
+        "SELECT sub.total FROM (VALUES (0)) v (z), LATERAL ("
+        " SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger) + v.z AS total"
+        ") sub"
+    )
     QUERIES = [
         ("SELECT total FROM total", 1),
         (BASE_TOTAL, 1),
         (f"SELECT total FROM total UNION ALL {BASE_TOTAL}", 2),
+        (JOIN_TOTAL, 1),
+        (WINDOW_TOTAL, 1),
+        (RECURSIVE_TOTAL, 1),
+        (LATERAL_TOTAL, 1),
     ]
 
     def __init__(self, rng, ctx, scenario: "TableBank") -> None:
         super().__init__(rng, ctx, "total-peek", ["compute", "quickstart"])
         self.scenario = scenario
+        self.isolations = [
+            "strict serializable",
+            "serializable",
+            "bounded staleness 5s",
+        ]
 
     def check_once(self) -> None:
-        # Conservation is timestamp-free, so it must hold under either
-        # isolation level.
-        isolation = self.rng.choice(["strict serializable", "serializable"])
-        self.client.query(f"SET transaction_isolation = '{isolation}'")
+        # Conservation is timestamp-free, so it must hold under every
+        # isolation level: staleness changes the chosen timestamp, never the
+        # value of a timestamp-free invariant. A bounded staleness read with
+        # no readable timestamp in bound errors with SQLSTATE 40001, which
+        # the client classifies as a transient skip.
+        isolation = self.rng.choice(self.isolations)
+        try:
+            self.client.query(f"SET transaction_isolation = '{isolation}'")
+        except UnexpectedQueryError:
+            if isolation.startswith("bounded staleness"):
+                # Not available on this version, e.g. the pre-upgrade half
+                # of an --upgrade-from run.
+                self.isolations = [
+                    i for i in self.isolations if not i.startswith("bounded")
+                ]
+                raise TransientError(
+                    "bounded staleness unsupported, dropped from rotation"
+                ) from None
+            raise
         recent = self.scenario.recent_ts.get()
         if recent > 0 and self.rng.random() < 0.25:
             # Time travel into retained history: compaction must preserve
@@ -327,6 +594,327 @@ class LedgerDirectPeek(PeekChecker):
         self.validations += 1
 
 
+class SnapshotTxnPeek(PeekChecker):
+    """Multi-statement read-only transactions see one consistent snapshot.
+
+    The first SELECT picks the transaction's timestamp and every subsequent
+    statement reads at that same timestamp, so the accounts sum and the
+    ledger sum from separate statements must still add up to the conserved
+    total. Alternates the transaction form with a one-shot COPY TO STDOUT
+    read of the same invariant, and ends transactions with COMMIT or
+    ROLLBACK (equivalent for reads).
+    """
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "txn-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        if self.rng.random() < 0.3:
+            rows = self.client.copy_out(
+                "COPY (SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+                " + (SELECT coalesce(sum(amount), 0) FROM ledger)) TO STDOUT"
+            )
+            if len(rows) != 1 or int(rows[0][0]) != self.scenario.total:
+                raise InvariantViolation(
+                    f"total via COPY TO STDOUT: expected {self.scenario.total},"
+                    f" got {rows}"
+                )
+            self.validations += 1
+            return
+        oplog = self.scenario.oplog
+        # Bounds sampling order as in LedgerDirectPeek: lower bounds before
+        # the transaction picks its timestamp, upper bounds after it ends.
+        low = ROWS_PER_TRANSFER * oplog.committed_count()
+        watermark = self.scenario.ledger_rows.get()
+        cluster = self.clusters[self._round % len(self.clusters)]
+        self._round += 1
+        self.client.query(f"SET cluster = {cluster}")
+        self.client.query("SET transaction_isolation = 'strict serializable'")
+        try:
+            self.client.query("BEGIN")
+            accounts_sum = int(
+                self.client.query("SELECT coalesce(sum(balance), 0) FROM accounts")[0][
+                    0
+                ]
+            )
+            ledger_sum, count = (
+                int(v)
+                for v in self.client.query(
+                    "SELECT coalesce(sum(amount), 0), count(*) FROM ledger"
+                )[0]
+            )
+        finally:
+            # Read-only transactions end equivalently via COMMIT or
+            # ROLLBACK. Failures drop the connection, which also ends it.
+            try:
+                self.client.query("COMMIT" if self.rng.random() < 0.5 else "ROLLBACK")
+            except TransientError:
+                pass
+        high = ROWS_PER_TRANSFER * oplog.attempted_count()
+        if accounts_sum + ledger_sum != self.scenario.total:
+            raise InvariantViolation(
+                "read-only transaction saw a torn snapshot:"
+                f" accounts {accounts_sum} + ledger {ledger_sum}"
+                f" != {self.scenario.total}"
+            )
+        if count < watermark or count < low or count > high:
+            raise InvariantViolation(
+                f"ledger count {count} in transaction out of bounds"
+                f" [{max(low, watermark)}, {high}]"
+            )
+        # Shared with LedgerDirectPeek: both read under strict
+        # serializable, where the monotonic-read guarantee spans sessions.
+        self.scenario.ledger_rows.advance(count)
+        self.validations += 1
+
+
+class TemporalPeek(PeekChecker):
+    """Temporal filters keep exactly the rows inside their mz_now() window.
+
+    The wide window is larger than any run, so its count must equal the
+    full ledger count at the same timestamp. The short window is a subset
+    at every timestamp, and the final check verifies its rows are retracted
+    on schedule after the workload quiesces.
+    """
+
+    QUERY = (
+        "SELECT (SELECT count(*) FROM ledger),"
+        " (SELECT cnt FROM recent_wide), (SELECT cnt FROM recent_short)"
+    )
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "temporal-peek", ["compute", "quickstart"])
+
+    def check_once(self) -> None:
+        direct, wide, short = (int(v) for v in self.peek(self.QUERY)[0])
+        if wide != direct:
+            raise InvariantViolation(
+                f"wide temporal window dropped live rows: {wide} != {direct}"
+            )
+        if short > direct:
+            raise InvariantViolation(
+                f"short temporal window exceeds the full count:" f" {short} > {direct}"
+            )
+        self.validations += 1
+
+
+class RefreshMvPeek(PeekChecker):
+    """A REFRESH EVERY view serves some past snapshot, never a torn one.
+
+    Conservation is timestamp-free, so any data the view returns must be
+    the exact total. Reads that block around a refresh are transient skips
+    via the client watchdog.
+    """
+
+    pause = (1.0, 4.0)
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "refresh-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        isolation = self.rng.choice(["strict serializable", "serializable"])
+        self.client.query(f"SET transaction_isolation = '{isolation}'")
+        rows = self.peek("SELECT total FROM total_refresh")
+        if not rows:
+            # The documented unavailability window around a refresh.
+            raise TransientError("refresh view unavailable")
+        if len(rows) != 1 or int(rows[0][0]) != self.scenario.total:
+            raise InvariantViolation(
+                f"REFRESH EVERY view shows a torn snapshot: {rows}"
+            )
+        self.validations += 1
+
+
+class SwapTotalPeek(PeekChecker):
+    """The blue/green MV must be exact through every ALTER SCHEMA SWAP.
+
+    The stable name blue.total_swap resolves to either schema's MV, both
+    identically defined, so the documented atomicity of the swap means a
+    read either errors transiently (racing the catalog change) or returns
+    the exact total. Wrong data would mean a non-atomic cutover.
+    """
+
+    pause = (1.0, 3.0)
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "swap-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        rows = self.peek("SELECT total FROM blue.total_swap")
+        if len(rows) != 1 or int(rows[0][0]) != self.scenario.total:
+            raise InvariantViolation(
+                f"total via swapped schema: expected {self.scenario.total},"
+                f" got {rows}"
+            )
+        self.validations += 1
+
+
+class RegistryPeek(PeekChecker):
+    """Registry state machine: at most one live row per key, versions only
+    move forward, and the TopK (DISTINCT ON) read matches the plain read."""
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "registry-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+        self.high_water: dict[tuple[int, int], int] = {}
+
+    def check_once(self) -> None:
+        duplicated = self.peek(
+            "SELECT worker, key FROM registry GROUP BY worker, key"
+            " HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"registry holds multiple rows per key: {duplicated[:20]}"
+            )
+        # Sampled before the read, per the watermark rule.
+        watermarks = dict(self.high_water)
+        rows = self.peek(
+            "SELECT r.worker, r.key, r.ver, t.cnt FROM registry r,"
+            " (SELECT count(*) AS cnt FROM"
+            "  (SELECT DISTINCT ON (worker, key) worker, key FROM registry"
+            "   ORDER BY worker, key, ver DESC)) t"
+        )
+        limit = self.ctx.complexity.workers * REGISTRY_KEYS
+        if len(rows) > limit:
+            raise InvariantViolation(
+                f"registry holds {len(rows)} rows, only {limit} keys exist"
+            )
+        for row in rows:
+            worker, key, ver, topk_cnt = (int(v) for v in row)
+            if topk_cnt != len(rows):
+                raise InvariantViolation(
+                    f"DISTINCT ON read disagrees with plain read:"
+                    f" {topk_cnt} != {len(rows)}"
+                )
+            if watermarks.get((worker, key), -1) > ver:
+                raise InvariantViolation(
+                    f"registry key ({worker}, {key}) version moved backwards:"
+                    f" {ver} < {watermarks[(worker, key)]}"
+                )
+            current = self.high_water.get((worker, key), -1)
+            if ver > current:
+                self.high_water[(worker, key)] = ver
+        self.validations += 1
+
+
+class CopyExportPeek(Checker):
+    """COPY TO S3 exports are consistent snapshots of the ledger.
+
+    Each export must sum to zero and contain every transfer completely
+    (exactly two rows per op id, summing to zero), with the row count
+    bounded by the op ledger. Alternates the documented csv and parquet
+    formats and reads the files back through the S3 API.
+    """
+
+    name = "copy-export"
+    pause = (20.0, 45.0)
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.scenario = scenario
+        self.client = MzClient(ctx, "copy-export")
+        self.exports = 0
+        self._s3 = None
+
+    def _s3_client(self):
+        import boto3
+
+        if self._s3 is None:
+            self._s3 = boto3.client(
+                "s3",
+                endpoint_url=f"http://127.0.0.1:{self.ctx.endpoints.minio_port}",
+                aws_access_key_id="minioadmin",
+                aws_secret_access_key="minioadmin",
+                region_name="us-east-1",
+            )
+        return self._s3
+
+    def check_once(self) -> None:
+        self.exports += 1
+        fmt = "csv" if self.exports % 2 else "parquet"
+        prefix = f"{self.ctx.seed}/{self.exports}-{fmt}"
+        oplog = self.scenario.oplog
+        low = ROWS_PER_TRANSFER * oplog.committed_count()
+        self.client.query(
+            f"COPY (SELECT worker, seq, amount FROM ledger)"
+            f" TO 's3://copytos3/{prefix}'"
+            f" WITH (AWS CONNECTION = aws_conn, FORMAT = '{fmt}')",
+            timeout=max(120.0, self.ctx.complexity.query_timeout),
+        )
+        high = ROWS_PER_TRANSFER * oplog.attempted_count()
+        rows = self._read_back(prefix, fmt)
+        amount_sum = sum(amount for _, _, amount in rows)
+        if amount_sum != 0:
+            raise InvariantViolation(f"S3 export ({fmt}) sums to {amount_sum} != 0")
+        if not low <= len(rows) <= high:
+            raise InvariantViolation(
+                f"S3 export ({fmt}) has {len(rows)} rows, outside" f" [{low}, {high}]"
+            )
+        per_op: dict[tuple[int, int], list[int]] = {}
+        for worker, seq, amount in rows:
+            per_op.setdefault((worker, seq), []).append(amount)
+        broken = {
+            op: amounts
+            for op, amounts in per_op.items()
+            if len(amounts) != ROWS_PER_TRANSFER or sum(amounts) != 0
+        }
+        if broken:
+            raise InvariantViolation(
+                f"S3 export ({fmt}) tore transfers apart:"
+                f" {dict(list(broken.items())[:10])}"
+            )
+        self.validations += 1
+
+    def _read_back(self, prefix: str, fmt: str) -> list[tuple[int, int, int]]:
+        try:
+            s3 = self._s3_client()
+            listing = s3.list_objects_v2(Bucket="copytos3", Prefix=prefix)
+            rows: list[tuple[int, int, int]] = []
+            for entry in listing.get("Contents", []):
+                if entry["Key"].endswith("INCOMPLETE"):
+                    # The sentinel is deleted on completion, seeing it here
+                    # would mean an incomplete export. The COPY statement
+                    # already returned success, so treat it as not-yet-listed
+                    # rather than failing.
+                    raise TransientError("INCOMPLETE sentinel still present")
+                body = s3.get_object(Bucket="copytos3", Key=entry["Key"])["Body"].read()
+                if fmt == "csv":
+                    for line in body.decode().splitlines():
+                        worker, seq, amount = line.split(",")
+                        rows.append((int(worker), int(seq), int(amount)))
+                else:
+                    import pyarrow as pa
+                    import pyarrow.parquet as pq
+
+                    table = pq.read_table(pa.BufferReader(body))
+                    for worker, seq, amount in zip(
+                        table.column("worker").to_pylist(),
+                        table.column("seq").to_pylist(),
+                        table.column("amount").to_pylist(),
+                    ):
+                        if worker is None or seq is None or amount is None:
+                            raise InvariantViolation(
+                                "NULL in exported ledger row:"
+                                f" ({worker}, {seq}, {amount})"
+                            )
+                        rows.append((int(worker), int(seq), int(amount)))
+            return rows
+        except InvariantViolation:
+            raise
+        except Exception as e:
+            # The S3 read-back path is harness-side infrastructure, not the
+            # system under test.
+            raise TransientError(f"export read-back failed: {e}") from e
+
+    def close(self) -> None:
+        self.client.reset()
+
+
 class BankTotalSubscribe(SubscribeChecker):
     """The total MV must show the exact total at every progress boundary.
 
@@ -390,6 +978,20 @@ class TableBank(Scenario):
         # Recent mz timestamps observed by peeks, the AS OF history probes
         # stay within RETAIN HISTORY of this.
         self.recent_ts = Watermark()
+        # (worker, key) -> ordered op log, appended by the owning worker
+        # thread only and read after all workers stopped.
+        self.registry_log: dict[tuple[int, int], list[dict[str, Any]]] = {
+            (worker, key): []
+            for worker in range(ctx.complexity.workers)
+            for key in range(REGISTRY_KEYS)
+        }
+
+    # The same definition in both blue/green schemas: the checked object of
+    # the ALTER SCHEMA SWAP cutover.
+    SWAP_TOTAL_DEF = (
+        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total"
+    )
 
     def setup(self) -> None:
         client = MzClient(self.ctx, "setup")
@@ -397,7 +999,11 @@ class TableBank(Scenario):
             "CREATE TABLE accounts (id int, balance bigint)",
             f"INSERT INTO accounts SELECT generate_series(0, {self.accounts - 1}),"
             f" {BALANCE_PER_ACCOUNT}",
-            "CREATE TABLE ledger (worker int, seq bigint, account int, amount bigint)",
+            # RETAIN HISTORY on the base table keeps direct AS OF reads of
+            # the ledger itself possible, besides the MVs.
+            "CREATE TABLE ledger (worker int, seq bigint, account int,"
+            " amount bigint, at timestamptz) WITH (RETAIN HISTORY = FOR '600s')",
+            "CREATE TABLE registry (worker int, key int, ver bigint)",
             # RETAIN HISTORY keeps recent timestamps readable so the durable
             # subscribe checker can resume where it left off.
             "CREATE MATERIALIZED VIEW total IN CLUSTER compute"
@@ -408,6 +1014,30 @@ class TableBank(Scenario):
             "CREATE MATERIALIZED VIEW ledger_agg IN CLUSTER compute"
             " WITH (RETAIN HISTORY = FOR '600s') AS"
             " SELECT count(*) AS cnt FROM ledger",
+            # Temporal filters: the wide window outlasts any run, the short
+            # window drains after quiescing.
+            "CREATE MATERIALIZED VIEW recent_wide IN CLUSTER compute AS"
+            " SELECT count(*) AS cnt FROM ledger"
+            " WHERE mz_now() <= at + INTERVAL '4 hours'",
+            "CREATE MATERIALIZED VIEW recent_short IN CLUSTER compute AS"
+            " SELECT count(*) AS cnt FROM ledger"
+            " WHERE mz_now() <= at + INTERVAL '60 seconds'",
+            # REFRESH EVERY serves the last refresh's snapshot in between.
+            "CREATE MATERIALIZED VIEW total_refresh IN CLUSTER compute"
+            " WITH (REFRESH EVERY '10 seconds') AS SELECT total FROM total",
+            # Blue/green pair for the ALTER SCHEMA SWAP cutover.
+            "CREATE SCHEMA blue",
+            "CREATE SCHEMA green",
+            "CREATE MATERIALIZED VIEW blue.total_swap IN CLUSTER compute AS"
+            f" {self.SWAP_TOTAL_DEF}",
+            "CREATE MATERIALIZED VIEW green.total_swap IN CLUSTER compute AS"
+            f" {self.SWAP_TOTAL_DEF}",
+            # COPY TO S3 exports go to the MinIO container directly (the
+            # toxiproxied blob leg is persist's, not this connection's).
+            "CREATE SECRET miniopass AS 'minioadmin'",
+            "CREATE CONNECTION aws_conn TO AWS (ENDPOINT 'http://minio:9000/',"
+            " REGION 'us-east-1', ACCESS KEY ID 'minioadmin',"
+            " SECRET ACCESS KEY SECRET miniopass)",
         ]:
             client.query(sql, timeout=120)
         # Anchor for the end-of-run history audit.
@@ -417,18 +1047,25 @@ class TableBank(Scenario):
     def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
         client = MzClient(self.ctx, f"worker-{index}")
         forward = LedgerTransfer(rng, index, self.accounts, client, self.oplog)
-        return WorkerBundle(
-            actions=[
-                UpdateTransfer(rng, self.accounts, client),
-                forward,
-                ReversalTransfer(rng, index, client, self.oplog, forward),
-                DdlChurn(rng, index, client),
-            ],
-            weights=[10, 10, 3, 1],
-        )
+        actions: list[Action] = [
+            UpdateTransfer(rng, self.accounts, client),
+            forward,
+            ReversalTransfer(rng, index, client, self.oplog, forward),
+            CopyTransfer(rng, index, client, self.oplog, forward),
+            RegistryOp(rng, index, client, self),
+            DdlChurn(rng, index, client),
+        ]
+        weights = [10, 10, 3, 3, 6, 1]
+        if index == 0:
+            # Single-instance churns: concurrent swaps of the same schema
+            # pair or replacements of the same MV would only race each other
+            # in the catalog, without adding coverage.
+            actions += [SchemaSwap(rng, client), ReplacementChurn(rng, client)]
+            weights += [2, 2]
+        return WorkerBundle(actions=actions, weights=weights)
 
     def checkers(self) -> list[Checker]:
-        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(4)]
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(10)]
         return [
             BankTotalPeek(rngs[0], self.ctx, self),
             LedgerDirectPeek(rngs[1], self.ctx, self),
@@ -436,6 +1073,12 @@ class TableBank(Scenario):
             BankTotalSubscribe(
                 rngs[3], self.ctx, self, name="total-subscribe-durable", durable=True
             ),
+            SnapshotTxnPeek(rngs[4], self.ctx, self),
+            TemporalPeek(rngs[5], self.ctx),
+            RefreshMvPeek(rngs[6], self.ctx, self),
+            SwapTotalPeek(rngs[7], self.ctx, self),
+            RegistryPeek(rngs[8], self.ctx, self),
+            CopyExportPeek(rngs[9], self.ctx, self),
         ]
 
     def converge(self) -> None:
@@ -483,8 +1126,64 @@ class TableBank(Scenario):
                     f"worker {worker}: transfers present that never committed:"
                     f" {sorted(phantom)[:20]}"
                 )
+        swap_total = int(client.query("SELECT total FROM blue.total_swap")[0][0])
+        if swap_total != self.total:
+            raise InvariantViolation(
+                f"final swapped-schema total {swap_total} != {self.total}"
+            )
+        self._check_registry(client)
+        # Temporal filter drain: with the workload quiesced, the short
+        # window's rows must all be retracted once the window has passed.
+        # Bounded by the 60s window plus host/server clock skew slack.
+        wait_until(
+            lambda: int(client.query("SELECT cnt FROM recent_short")[0][0]) == 0,
+            180,
+            "temporal filter retracting expired rows",
+        )
         client.reset()
         self._history_audit(client_end_ts=None)
+
+    def _check_registry(self, client: MzClient) -> None:
+        """The final row per key must be admissible given its op log.
+
+        Replays each key's ops over the set of possible states: COMMITTED
+        ops apply to every possible state, UNKNOWN ops fork it. All
+        statements are idempotent, so applying an op is a function of the
+        current state only.
+        """
+        actual: dict[tuple[int, int], int] = {}
+        for row in client.query("SELECT worker, key, ver FROM registry"):
+            worker, key, ver = (int(v) for v in row)
+            if (worker, key) in actual:
+                raise InvariantViolation(
+                    f"registry key ({worker}, {key}) has multiple rows"
+                )
+            actual[(worker, key)] = ver
+
+        def apply(op: tuple, state: int | None) -> int | None:
+            kind, ver = op
+            if kind == "insert":
+                return state if state is not None else ver
+            if kind == "update":
+                return ver if state is not None else None
+            return None
+
+        for (worker, key), log in self.registry_log.items():
+            possible: set[int | None] = {None}
+            for entry in log:
+                if entry["outcome"] == Outcome.FAILED:
+                    continue
+                applied = {apply(entry["op"], s) for s in possible}
+                if entry["outcome"] == Outcome.COMMITTED:
+                    possible = applied
+                else:
+                    possible |= applied
+            got = actual.get((worker, key))
+            if got not in possible:
+                raise InvariantViolation(
+                    f"registry key ({worker}, {key}): final state {got} not"
+                    f" admissible ({sorted(str(s) for s in possible)[:20]})"
+                )
 
     def _history_audit(self, client_end_ts: int | None) -> None:
         """Replay the entire retained history, validating every boundary.
@@ -528,11 +1227,56 @@ class TableBank(Scenario):
                         f"vacuous history audit: only {audit.validations}"
                         " boundaries replayed"
                     )
+                self._up_to_replay(as_of, end_ts)
                 return
         audit.close()
         raise InvariantViolation(
             "liveness: the history audit did not reach the current timestamp"
         )
+
+    def _up_to_replay(self, as_of: int, end_ts: int) -> None:
+        """A bounded SUBSCRIBE .. UP TO terminates, stays inside the bound,
+        and folds to the state at the bound.
+
+        Executed as a direct statement, not a cursor: UP TO makes the
+        subscription finite, so the statement completing at all is the
+        termination check. NOTE: deliberately run without PROGRESS, since
+        with UP TO no progress message is ever emitted (see
+        FINDINGS-BUGS.md), the fold is validated against a direct read
+        instead. The workload is quiesced and end_ts postdates it, so the
+        folded count must equal the current one.
+        """
+        client = MzClient(self.ctx, "up-to-replay")
+        try:
+            rows = client.query(
+                f"SUBSCRIBE (SELECT cnt FROM ledger_agg)"
+                f" AS OF {as_of} UP TO {end_ts}",
+                timeout=120,
+            )
+        except TransientError as e:
+            raise InvariantViolation(
+                f"liveness: SUBSCRIBE UP TO {end_ts} did not terminate: {e}"
+            ) from e
+        if not rows:
+            raise InvariantViolation("SUBSCRIBE UP TO emitted no snapshot")
+        state: dict[int, int] = {}
+        for row in rows:
+            ts, diff, cnt = int(row[0]), int(row[1]), int(row[2])
+            if ts >= end_ts:
+                raise InvariantViolation(
+                    f"update at {ts} at or beyond the exclusive UP TO bound"
+                    f" {end_ts}"
+                )
+            state[cnt] = state.get(cnt, 0) + diff
+            if state[cnt] == 0:
+                del state[cnt]
+        current = int(client.query("SELECT cnt FROM ledger_agg")[0][0])
+        client.reset()
+        if state != {current: 1}:
+            raise InvariantViolation(
+                f"bounded replay folded to {state}, current count is {current}"
+            )
+        self.ctx.log.log("phase", f"bounded UP TO replay: {len(rows)} updates folded")
 
     def diagnostics(self) -> None:
         client = MzClient(self.ctx, "post-heal")

--- a/misc/python/materialize/invariants/scenarios/table_bank.py
+++ b/misc/python/materialize/invariants/scenarios/table_bank.py
@@ -1,0 +1,551 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Bank transfers on Materialize tables.
+
+Two write paths, both atomic per Materialize's documented guarantees:
+single-statement read-then-write UPDATEs of an accounts table, and
+INSERT-only ledger transactions (a debit and a credit row that sum to zero,
+tagged with a unique (worker, seq) op id for exact reconciliation).
+
+Invariant: sum(accounts.balance) + sum(ledger.amount) equals the initial
+total at every timestamp, no matter which subset of concurrent transfers
+committed, failed, or is in an unknown state.
+"""
+
+import random
+import time
+
+from materialize.invariants.checkers import PeekChecker, SubscribeChecker
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+
+BALANCE_PER_ACCOUNT = 1000
+# Each ledger transfer writes one debit and one credit row.
+ROWS_PER_TRANSFER = 2
+
+
+class UpdateTransfer(Action):
+    """Move money between two accounts in one atomic UPDATE statement."""
+
+    name = "update-transfer"
+
+    def __init__(self, rng: random.Random, accounts: int, client: MzClient) -> None:
+        super().__init__(rng)
+        self.accounts = accounts
+        self.client = client
+
+    def run(self) -> Outcome | None:
+        src, dst = self.rng.sample(range(self.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        return self.client.write(
+            f"UPDATE accounts SET balance = balance +"
+            f" CASE id WHEN {src} THEN {-amount} ELSE {amount} END"
+            f" WHERE id IN ({src}, {dst})"
+        )
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class LedgerTransfer(Action):
+    """Append a balanced (debit, credit) pair to the ledger table."""
+
+    name = "ledger-transfer"
+
+    def __init__(
+        self,
+        rng: random.Random,
+        worker: int,
+        accounts: int,
+        client: MzClient,
+        oplog: OpLog,
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.accounts = accounts
+        self.client = client
+        self.oplog = oplog
+        self.seq = 0
+        # Committed transfers not yet reversed, consumed by ReversalTransfer.
+        self.reversible: list[int] = []
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        seq = self.seq
+        src, dst = self.rng.sample(range(self.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        debit = f"({self.worker}, {seq}, {src}, {-amount})"
+        credit = f"({self.worker}, {seq}, {dst}, {amount})"
+        # Register before sending: if this thread dies mid-call the op still
+        # counts as possibly-applied.
+        self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        if self.rng.random() < 0.5:
+            outcome = self.client.write(f"INSERT INTO ledger VALUES {debit}, {credit}")
+        else:
+            # The same pair as an explicit INSERT-only transaction, which
+            # Materialize commits atomically at one timestamp.
+            outcome = self.client.write_txn(
+                [
+                    (f"INSERT INTO ledger VALUES {debit}", None),
+                    (f"INSERT INTO ledger VALUES {credit}", None),
+                ]
+            )
+        self.oplog.record(self.worker, seq, outcome)
+        if outcome == Outcome.COMMITTED:
+            self.reversible.append(seq)
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class ReversalTransfer(Action):
+    """Reverse one of this worker's committed transfers via INSERT..SELECT.
+
+    Exercises the read-then-write insert path. The reversal writes the
+    negated pair under op id (worker, -seq), so conservation and the exact
+    reconciliation keep holding for any outcome.
+    """
+
+    name = "reversal"
+
+    def __init__(
+        self,
+        rng: random.Random,
+        worker: int,
+        client: MzClient,
+        oplog: OpLog,
+        forward: "LedgerTransfer",
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.oplog = oplog
+        self.forward = forward
+
+    def run(self) -> Outcome | None:
+        if not self.forward.reversible:
+            return None
+        seq = self.forward.reversible.pop(
+            self.rng.randrange(len(self.forward.reversible))
+        )
+        self.oplog.record(self.worker, -seq, Outcome.UNKNOWN)
+        outcome = self.client.write(
+            "INSERT INTO ledger SELECT worker, -seq, account, -amount"
+            f" FROM ledger WHERE worker = {self.worker} AND seq = {seq}"
+        )
+        self.oplog.record(self.worker, -seq, outcome)
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class DdlChurn(Action):
+    """Catalog and dataflow churn on the compute cluster.
+
+    Creates and drops a scratch index and MV over the ledger. The checked
+    objects never reference them, so the invariant checkers stay unaffected
+    by the churn itself, but dataflow (un)installation keeps happening on
+    the same cluster and table the invariants cover, also while that
+    cluster's leg is disrupted. Every statement is idempotent, and index
+    names carry a nonce, because an UNKNOWN outcome leaves the catalog state
+    uncertain.
+    """
+
+    name = "ddl-churn"
+
+    def __init__(self, rng: random.Random, worker: int, client: MzClient) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.next_at = 0.0
+        self.present = False
+        self.nonce = 0
+        self.maybe_alive: list[str] = []
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(5.0, 15.0)
+        if self.present:
+            outcome = self.client.write(
+                f"DROP MATERIALIZED VIEW IF EXISTS churn_mv_{self.worker}"
+            )
+            for name in self.maybe_alive:
+                self.client.write(f"DROP INDEX IF EXISTS {name}")
+            self.maybe_alive = []
+            self.present = False
+        else:
+            outcome = self.client.write(
+                f"CREATE OR REPLACE MATERIALIZED VIEW churn_mv_{self.worker}"
+                " IN CLUSTER compute AS SELECT count(*) AS cnt FROM ledger"
+            )
+            self.nonce += 1
+            name = f"churn_idx_{self.worker}_{self.nonce}"
+            self.maybe_alive.append(name)
+            self.client.write(
+                f"CREATE INDEX {name} IN CLUSTER compute ON ledger (account)"
+            )
+            # Also churn an index on the checked MV itself: peeks against
+            # total race plan selection against the concurrent drops, which
+            # legitimately error ("was dropped") but must never be wrong.
+            total_idx = f"churn_total_idx_{self.worker}_{self.nonce}"
+            self.maybe_alive.append(total_idx)
+            self.client.write(
+                f"CREATE INDEX {total_idx} IN CLUSTER compute ON total (total)"
+            )
+            self.present = True
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class BankTotalPeek(PeekChecker):
+    """The grand total must be exact on every cluster, at every time.
+
+    Alternates between the maintained MV, an ad-hoc query over the base
+    tables, and a single query spanning both, so the same invariant is
+    verified through different plans and, in the combined form, as one
+    consistent snapshot across objects. The ad-hoc form also stays live on
+    quickstart while the compute cluster (which maintains the MV) is
+    disrupted.
+    """
+
+    BASE_TOTAL = (
+        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger)"
+    )
+    QUERIES = [
+        ("SELECT total FROM total", 1),
+        (BASE_TOTAL, 1),
+        (f"SELECT total FROM total UNION ALL {BASE_TOTAL}", 2),
+    ]
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "total-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        # Conservation is timestamp-free, so it must hold under either
+        # isolation level.
+        isolation = self.rng.choice(["strict serializable", "serializable"])
+        self.client.query(f"SET transaction_isolation = '{isolation}'")
+        recent = self.scenario.recent_ts.get()
+        if recent > 0 and self.rng.random() < 0.25:
+            # Time travel into retained history: compaction must preserve
+            # the invariant at already-validated timestamps.
+            as_of = self.rng.randint(max(recent - 120_000, 1), recent)
+            query, expected_rows = f"SELECT total FROM total AS OF {as_of}", 1
+        else:
+            # rng, not round-robin: the cluster rotation has the same period
+            # as the query list, round-robin would pin each form to one
+            # cluster.
+            query, expected_rows = self.rng.choice(self.QUERIES)
+        try:
+            rows = self.peek(query)
+        except UnexpectedQueryError as e:
+            # The history probe can race compaction: while checkers skip
+            # through long disruptions the recent_ts watermark goes stale,
+            # and the probed timestamp may fall behind the retained window.
+            # An unreadable timestamp is a skipped round, wrong data at a
+            # readable one stays fatal.
+            if "could not find a valid timestamp" in str(e):
+                raise TransientError(str(e)) from e
+            raise
+        if len(rows) != expected_rows or any(
+            int(row[0]) != self.scenario.total for row in rows
+        ):
+            raise InvariantViolation(
+                f"total mismatch via {query!r}: expected {expected_rows}x"
+                f" {self.scenario.total}, got {rows}"
+            )
+        mz_now = self.client.query("SELECT mz_now()::text")
+        self.scenario.recent_ts.advance(int(mz_now[0][0]))
+        self.validations += 1
+
+
+class LedgerDirectPeek(PeekChecker):
+    """Direct table reads: conservation, bounds, and monotonic row count.
+
+    Table reads stay live on quickstart even while the compute cluster's leg
+    is disrupted, so this checker provides coverage during those windows.
+    """
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "ledger-peek", ["quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        # Sampling order matters: lower bounds before the read, upper bounds
+        # after, and the read is compared against the watermark as it was
+        # before the read was issued.
+        low = ROWS_PER_TRANSFER * oplog.committed_count()
+        watermark = self.scenario.ledger_rows.get()
+        rows = self.peek("SELECT count(*), coalesce(sum(amount), 0) FROM ledger")
+        high = ROWS_PER_TRANSFER * oplog.attempted_count()
+        count, amount_sum = int(rows[0][0]), int(rows[0][1])
+        if amount_sum != 0:
+            raise InvariantViolation(f"ledger sum {amount_sum} != 0 (count {count})")
+        if count < watermark:
+            raise InvariantViolation(
+                f"ledger count went backwards: {count} < watermark {watermark}"
+            )
+        if count < low:
+            raise InvariantViolation(
+                f"ledger count {count} misses committed transfers (>= {low} expected)"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"ledger count {count} exceeds attempted transfers (<= {high} expected)"
+            )
+        self.scenario.ledger_rows.advance(count)
+        self.validations += 1
+
+
+class BankTotalSubscribe(SubscribeChecker):
+    """The total MV must show the exact total at every progress boundary.
+
+    The durable variant carries its state across reconnects by resuming
+    from the last validated timestamp, verifying the documented durable
+    subscription pattern under disruptions.
+    """
+
+    def __init__(
+        self,
+        rng,
+        ctx,
+        scenario: "TableBank",
+        name: str = "total-subscribe",
+        durable: bool = False,
+    ) -> None:
+        super().__init__(rng, ctx, name, "SELECT total FROM total", durable=durable)
+        self.scenario = scenario
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        expected = {(self.scenario.total,): 1}
+        got = {(int(k[0]),): v for k, v in state.items()}
+        if got != expected:
+            raise InvariantViolation(
+                f"total via SUBSCRIBE at {ts}: expected {expected}, got {got}"
+            )
+
+
+class LedgerCountAudit(SubscribeChecker):
+    """Replays the ledger count's dense history: it must never decrease."""
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "history-audit", "SELECT cnt FROM ledger_agg")
+        self.last_cnt = -1
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        if len(state) != 1 or list(state.values()) != [1]:
+            raise InvariantViolation(
+                f"ledger count history at {ts}: expected one row, got {state}"
+            )
+        cnt = int(list(state)[0][0])
+        if cnt < self.last_cnt:
+            raise InvariantViolation(
+                f"ledger count went backwards in history at {ts}:"
+                f" {cnt} < {self.last_cnt}"
+            )
+        self.last_cnt = cnt
+
+
+class TableBank(Scenario):
+    name = "table-bank"
+    services: list[str] = []
+    legs = ["metadata", "blob", "clusterd-compute", "clusterd-compute2"]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.total = self.accounts * BALANCE_PER_ACCOUNT
+        self.oplog = OpLog()
+        self.ledger_rows = Watermark()
+        # Recent mz timestamps observed by peeks, the AS OF history probes
+        # stay within RETAIN HISTORY of this.
+        self.recent_ts = Watermark()
+
+    def setup(self) -> None:
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE accounts (id int, balance bigint)",
+            f"INSERT INTO accounts SELECT generate_series(0, {self.accounts - 1}),"
+            f" {BALANCE_PER_ACCOUNT}",
+            "CREATE TABLE ledger (worker int, seq bigint, account int, amount bigint)",
+            # RETAIN HISTORY keeps recent timestamps readable so the durable
+            # subscribe checker can resume where it left off.
+            "CREATE MATERIALIZED VIEW total IN CLUSTER compute"
+            " WITH (RETAIN HISTORY = FOR '600s') AS"
+            " SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+            " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total",
+            "CREATE INDEX total_idx IN CLUSTER compute ON total (total)",
+            "CREATE MATERIALIZED VIEW ledger_agg IN CLUSTER compute"
+            " WITH (RETAIN HISTORY = FOR '600s') AS"
+            " SELECT count(*) AS cnt FROM ledger",
+        ]:
+            client.query(sql, timeout=120)
+        # Anchor for the end-of-run history audit.
+        self.setup_ts = int(client.query("SELECT mz_now()::text")[0][0])
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        client = MzClient(self.ctx, f"worker-{index}")
+        forward = LedgerTransfer(rng, index, self.accounts, client, self.oplog)
+        return WorkerBundle(
+            actions=[
+                UpdateTransfer(rng, self.accounts, client),
+                forward,
+                ReversalTransfer(rng, index, client, self.oplog, forward),
+                DdlChurn(rng, index, client),
+            ],
+            weights=[10, 10, 3, 1],
+        )
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(4)]
+        return [
+            BankTotalPeek(rngs[0], self.ctx, self),
+            LedgerDirectPeek(rngs[1], self.ctx, self),
+            BankTotalSubscribe(rngs[2], self.ctx, self),
+            BankTotalSubscribe(
+                rngs[3], self.ctx, self, name="total-subscribe-durable", durable=True
+            ),
+        ]
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            client.query("SET cluster = quickstart")
+            direct = int(client.query("SELECT count(*) FROM ledger")[0][0])
+            client.query("SET cluster = compute")
+            via_mv = int(client.query("SELECT cnt FROM ledger_agg")[0][0])
+            return direct == via_mv
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "compute MVs catching up to tables")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        total = int(client.query("SELECT total FROM total")[0][0])
+        if total != self.total:
+            raise InvariantViolation(f"final total {total} != {self.total}")
+        broken = client.query(
+            "SELECT worker, seq, count(*), sum(amount) FROM ledger"
+            " GROUP BY worker, seq HAVING count(*) <> 2 OR sum(amount) <> 0"
+        )
+        if broken:
+            raise InvariantViolation(f"non-atomic ledger transfers: {broken[:20]}")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM ledger WHERE worker = {worker} GROUP BY seq"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - committed - unknown
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        client.reset()
+        self._history_audit(client_end_ts=None)
+
+    def _history_audit(self, client_end_ts: int | None) -> None:
+        """Replay the entire retained history, validating every boundary.
+
+        Live checkers legitimately skip rounds during disruptions, this
+        audit retroactively closes those gaps: a subscribe from the earliest
+        retained timestamp must show the conserved total at every boundary
+        of the whole run.
+        """
+        client = MzClient(self.ctx, "history-audit-now")
+        end_ts = int(client.query("SELECT mz_now()::text")[0][0])
+        client.reset()
+        rng = random.Random(self.ctx.rng.randrange(SEED_RANGE))
+        # The ledger count has a dense history (unlike the constant total),
+        # so its replay meaningfully covers every timestamp of the run.
+        audit = LedgerCountAudit(rng, self.ctx)
+        # An exact AS OF: AS OF AT LEAST would let the server pick the
+        # current timestamp and skip the history. Clamped into the RETAIN
+        # HISTORY window for runs longer than the retention.
+        as_of = max(self.setup_ts, end_ts - 480_000)
+        audit.as_of_clause = f"AS OF {as_of}"
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline:
+            try:
+                audit.check_once()
+            except TransientError:
+                continue
+            if (
+                audit.last_validated_ts is not None
+                and audit.last_validated_ts >= end_ts
+            ):
+                audit.close()
+                self.ctx.log.log(
+                    "phase",
+                    f"history audit: {audit.validations} boundaries replayed",
+                )
+                # Far fewer boundaries than the audited window must contain
+                # means the audit did not actually start in the past.
+                if audit.validations < 50:
+                    raise InvariantViolation(
+                        f"vacuous history audit: only {audit.validations}"
+                        " boundaries replayed"
+                    )
+                return
+        audit.close()
+        raise InvariantViolation(
+            "liveness: the history audit did not reach the current timestamp"
+        )
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        for cluster in ("quickstart", "compute"):
+            try:
+                client.query(f"SET cluster = {cluster}")
+                rows = client.query("SELECT total FROM total", timeout=60)
+                verdict = (
+                    "still wrong" if int(rows[0][0]) != self.total else "converged"
+                )
+                self.ctx.log.log(
+                    "diag", f"post-heal total on {cluster}: {rows} ({verdict})"
+                )
+            except Exception as e:
+                self.ctx.log.log("diag", f"post-heal total on {cluster}: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/table_bank.py
+++ b/misc/python/materialize/invariants/scenarios/table_bank.py
@@ -1241,10 +1241,13 @@ class TableBank(Scenario):
         Executed as a direct statement, not a cursor: UP TO makes the
         subscription finite, so the statement completing at all is the
         termination check. NOTE: deliberately run without PROGRESS, since
-        with UP TO no progress message is ever emitted (see
-        FINDINGS-BUGS.md), the fold is validated against a direct read
-        instead. The workload is quiesced and end_ts postdates it, so the
-        folded count must equal the current one.
+        with UP TO no progress message is ever emitted, the fold is
+        validated against a direct read instead.
+        TODO: Reenable when SQL-528 is fixed: run the history audit's
+        per-boundary validation WITH (PROGRESS) UP TO instead of this
+        end-state fold.
+        The workload is quiesced and end_ts postdates it, so the folded
+        count must equal the current one.
         """
         client = MzClient(self.ctx, "up-to-replay")
         try:

--- a/misc/python/materialize/invariants/scenarios/table_bank.py
+++ b/misc/python/materialize/invariants/scenarios/table_bank.py
@@ -55,6 +55,14 @@ ROWS_PER_TRANSFER = 2
 # Registry keys per worker, each owned and driven by exactly one thread.
 REGISTRY_KEYS = 8
 
+# The conserved grand total. One shared definition: the checked `total` MV,
+# its in-place replacement, and both blue/green swap MVs must be identical
+# for the checkers to stay exact through every churn.
+TOTAL_DEF = (
+    "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+    " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total"
+)
+
 
 class UpdateTransfer(Action):
     """Move money between two accounts in one atomic UPDATE statement."""
@@ -310,15 +318,12 @@ class ReplacementChurn(Action):
 
     name = "replacement"
 
-    # Must match the definition of the `total` MV exactly.
-    TOTAL_DEF = (
-        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
-        " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total"
-    )
-
-    def __init__(self, rng: random.Random, client: MzClient) -> None:
+    def __init__(
+        self, rng: random.Random, client: MzClient, ctx: ScenarioContext
+    ) -> None:
         super().__init__(rng)
         self.client = client
+        self.ctx = ctx
         self.next_at = time.monotonic() + 20.0
         self.supported = True
 
@@ -337,8 +342,8 @@ class ReplacementChurn(Action):
         try:
             outcome = self.client.write(
                 "CREATE REPLACEMENT MATERIALIZED VIEW total_repl FOR total"
-                f" IN CLUSTER compute WITH (RETAIN HISTORY = FOR '600s')"
-                f" AS {self.TOTAL_DEF}"
+                " IN CLUSTER compute WITH (RETAIN HISTORY = FOR '600s')"
+                f" AS {TOTAL_DEF}"
             )
         except UnexpectedQueryError as e:
             # Not available on this version, e.g. the pre-upgrade half of an
@@ -349,9 +354,10 @@ class ReplacementChurn(Action):
         if outcome != Outcome.COMMITTED:
             return outcome
         # Apply only once the replacement hydrated on every replica, per the
-        # documented workflow.
+        # documented workflow. Also bail on stop: this poll can outlast the
+        # executor's join ladder and would read as a stuck thread.
         deadline = time.monotonic() + 90.0
-        while time.monotonic() < deadline:
+        while time.monotonic() < deadline and not self.ctx.stop.is_set():
             try:
                 rows = self.client.query(
                     "SELECT bool_and(h.hydrated)"
@@ -363,10 +369,11 @@ class ReplacementChurn(Action):
                 return Outcome.UNKNOWN
             if rows and rows[0][0]:
                 break
-            time.sleep(1.0)
+            self.ctx.stop.wait(1.0)
         else:
-            # Hydration did not finish, e.g. the compute leg is cut. Leave
-            # the replacement for the next cycle's drop.
+            # Hydration did not finish, e.g. the compute leg is cut or the
+            # run is shutting down. Leave the replacement for the next
+            # cycle's drop.
             return Outcome.UNKNOWN
         return self.client.write(
             "ALTER MATERIALIZED VIEW total APPLY REPLACEMENT total_repl"
@@ -408,9 +415,15 @@ class DdlChurn(Action):
             outcome = self.client.write(
                 f"DROP MATERIALIZED VIEW IF EXISTS churn_mv_{self.worker}"
             )
-            for name in self.maybe_alive:
-                self.client.write(f"DROP INDEX IF EXISTS {name}")
-            self.maybe_alive = []
+            # Keep names whose drop outcome is uncertain: an UNKNOWN drop may
+            # not have applied, and untracking such an index would leak its
+            # dataflow for the rest of the run.
+            self.maybe_alive = [
+                name
+                for name in self.maybe_alive
+                if self.client.write(f"DROP INDEX IF EXISTS {name}")
+                != Outcome.COMMITTED
+            ]
             self.present = False
         else:
             outcome = self.client.write(
@@ -550,8 +563,17 @@ class BankTotalPeek(PeekChecker):
                 f"total mismatch via {query!r}: expected {expected_rows}x"
                 f" {self.scenario.total}, got {rows}"
             )
-        mz_now = self.client.query("SELECT mz_now()::text")
-        self.scenario.recent_ts.advance(int(mz_now[0][0]))
+        # Sample the watermark that feeds the history probe. `SELECT mz_now()`
+        # has no inputs, and for such a constant query the coordinator answers
+        # at Timestamp::MAX under serializable and bounded staleness, so only
+        # strict serializable yields a usable time. The watermark never goes
+        # back down, so a single MAX sample would point every later probe at
+        # the end of time.
+        # TODO: Reenable for all isolation levels when CPU-197 is fixed.
+        if isolation == "strict serializable":
+            self.scenario.recent_ts.advance(
+                int(self.client.query("SELECT mz_now()::text")[0][0])
+            )
         self.validations += 1
 
 
@@ -986,13 +1008,6 @@ class TableBank(Scenario):
             for key in range(REGISTRY_KEYS)
         }
 
-    # The same definition in both blue/green schemas: the checked object of
-    # the ALTER SCHEMA SWAP cutover.
-    SWAP_TOTAL_DEF = (
-        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
-        " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total"
-    )
-
     def setup(self) -> None:
         client = MzClient(self.ctx, "setup")
         for sql in [
@@ -1007,9 +1022,7 @@ class TableBank(Scenario):
             # RETAIN HISTORY keeps recent timestamps readable so the durable
             # subscribe checker can resume where it left off.
             "CREATE MATERIALIZED VIEW total IN CLUSTER compute"
-            " WITH (RETAIN HISTORY = FOR '600s') AS"
-            " SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
-            " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total",
+            f" WITH (RETAIN HISTORY = FOR '600s') AS {TOTAL_DEF}",
             "CREATE INDEX total_idx IN CLUSTER compute ON total (total)",
             "CREATE MATERIALIZED VIEW ledger_agg IN CLUSTER compute"
             " WITH (RETAIN HISTORY = FOR '600s') AS"
@@ -1029,9 +1042,9 @@ class TableBank(Scenario):
             "CREATE SCHEMA blue",
             "CREATE SCHEMA green",
             "CREATE MATERIALIZED VIEW blue.total_swap IN CLUSTER compute AS"
-            f" {self.SWAP_TOTAL_DEF}",
+            f" {TOTAL_DEF}",
             "CREATE MATERIALIZED VIEW green.total_swap IN CLUSTER compute AS"
-            f" {self.SWAP_TOTAL_DEF}",
+            f" {TOTAL_DEF}",
             # COPY TO S3 exports go to the MinIO container directly (the
             # toxiproxied blob leg is persist's, not this connection's).
             "CREATE SECRET miniopass AS 'minioadmin'",
@@ -1060,7 +1073,10 @@ class TableBank(Scenario):
             # Single-instance churns: concurrent swaps of the same schema
             # pair or replacements of the same MV would only race each other
             # in the catalog, without adding coverage.
-            actions += [SchemaSwap(rng, client), ReplacementChurn(rng, client)]
+            actions += [
+                SchemaSwap(rng, client),
+                ReplacementChurn(rng, client, self.ctx),
+            ]
             weights += [2, 2]
         return WorkerBundle(actions=actions, weights=weights)
 

--- a/misc/python/materialize/invariants/scenarios/table_bank.py
+++ b/misc/python/materialize/invariants/scenarios/table_bank.py
@@ -1,0 +1,1949 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Bank transfers on Materialize tables.
+
+Write paths, all atomic per Materialize's documented guarantees:
+single-statement read-then-write UPDATEs of an accounts table, INSERT-only
+ledger transactions (a debit and a credit row that sum to zero, tagged with
+a unique (worker, seq) op id for exact reconciliation), COPY FROM STDIN of
+balanced pairs, and a registry table driven through idempotent
+INSERT/UPDATE/DELETE per single-owner key.
+
+Invariant: sum(accounts.balance) + sum(ledger.amount) equals the initial
+total at every timestamp, no matter which subset of concurrent transfers
+committed, failed, or is in an unknown state. The total is verified through
+many documented, result-equivalent read paths (maintained MV, ad-hoc query,
+join, window function, recursive CTE, LATERAL, multi-statement read-only
+transactions, COPY TO STDOUT, COPY TO S3 exports, a REFRESH EVERY view, a
+blue/green schema pair cut over via ALTER SCHEMA SWAP, and replacement
+materialized views applied in place).
+"""
+
+import math
+import random
+import time
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from materialize.invariants.checkers import (
+    GroupCompletenessPeek,
+    PeekChecker,
+    ReplicaDivergence,
+    SubscribeChecker,
+    TernaryPartitionPeek,
+)
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient, UnexpectedQueryError
+
+# The final check runs on a quiesced system and legitimately scans everything
+# the run wrote, which the per-query watchdog is not sized for: that watchdog
+# exists to stop a checker hanging during chaos, and cancelling a final-check
+# query instead reports a wedge that is really just a big honest query.
+FINAL_TIMEOUT = 600
+
+BALANCE_PER_ACCOUNT = 1000
+# Each ledger transfer writes one debit and one credit row.
+ROWS_PER_TRANSFER = 2
+# Registry keys per worker, each owned and driven by exactly one thread.
+REGISTRY_KEYS = 8
+
+# The conserved grand total. One shared definition: the checked `total` MV,
+# its in-place replacement, and both blue/green swap MVs must be identical
+# for the checkers to stay exact through every churn.
+TOTAL_DEF = (
+    "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+    " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total"
+)
+
+# Values a summed invariant cannot see. `tag` and `amount_dec` are derived
+# from the op id, so every row is checkable on its own, which catches a
+# corruption that keeps the count and the sum intact. `flt` carries the float
+# values whose comparison and statistics handling has been wrong before
+# (NaN, negative zero, infinities), and `day` is nullable, so predicates over
+# both pull persist's filter pushdown into the checked path.
+FLOAT_TEXTS = ["0", "-0", "1e-320", "NaN", "Infinity", "-Infinity", "0.5"]
+# Must match the literal in PredicateDifferentialPeek.PREDICATES.
+DAY_CUT = date(2024, 1, 1)
+
+
+def _derived(worker: int, seq: int, amount: int) -> tuple[str, str, str, str | None]:
+    """The derived columns of one ledger row, as text: dec, tag, flt, day."""
+    dec = f"{amount / 1_000_000:.6f}"
+    tag = f"w{worker}-s{seq}"
+    flt = FLOAT_TEXTS[abs(seq) % len(FLOAT_TEXTS)]
+    # NULL every fifth row, so IS NULL predicates have something to find.
+    day = (
+        None
+        if abs(seq) % 5 == 0
+        else (date(2020, 1, 1) + timedelta(days=abs(seq) % 3000)).isoformat()
+    )
+    return dec, tag, flt, day
+
+
+# Only table-bank's ledger has the derived columns. The other scenarios reuse
+# these actions against a plain (worker, seq, account, amount, at) table, so
+# every write path takes the shape as a flag rather than assuming the wide one.
+LEDGER_COLS = "worker, seq, account, amount, at"
+LEDGER_COLS_DERIVED = f"{LEDGER_COLS}, amount_dec, tag, flt, day"
+
+
+def ledger_values(
+    worker: int, seq: int, account: int, amount: int, derived: bool
+) -> str:
+    """One ledger row literal, with the derived columns when the table has them."""
+    base = f"{worker}, {seq}, {account}, {amount}, now()"
+    if not derived:
+        return f"({base})"
+    dec, tag, flt, day = _derived(worker, seq, amount)
+    day_sql = "NULL" if day is None else f"DATE '{day}'"
+    return f"({base}, {dec}, '{tag}', '{flt}'::double, {day_sql})"
+
+
+def ledger_copy_row(
+    worker: int, seq: int, account: int, amount: int, at: str, derived: bool
+) -> str:
+    """The same row in COPY's text format, NULL spelled the way COPY wants."""
+    base = f"{worker}\t{seq}\t{account}\t{amount}\t{at}"
+    if not derived:
+        return f"{base}\n"
+    dec, tag, flt, day = _derived(worker, seq, amount)
+    # COPY's text format spells NULL as \N. Bound outside the f-string, whose
+    # expression part may not contain a backslash before Python 3.12.
+    day_text = "\\N" if day is None else day
+    return f"{base}\t{dec}\t{tag}\t{flt}\t{day_text}\n"
+
+
+# The row-level contract of the derived columns, as SQL over `ledger`. Checked
+# per row rather than in aggregate: a swapped or rewritten row keeps both the
+# count and the sum, and only this notices.
+DERIVED_ROW_CONTRACT = (
+    "tag <> 'w' || worker::text || '-s' || seq::text"
+    " OR amount_dec <> amount * 0.000001"
+)
+
+
+class UpdateTransfer(Action):
+    """Move money between two accounts in one atomic UPDATE statement."""
+
+    name = "update-transfer"
+
+    def __init__(self, rng: random.Random, accounts: int, client: MzClient) -> None:
+        super().__init__(rng)
+        self.accounts = accounts
+        self.client = client
+
+    def run(self) -> Outcome | None:
+        src, dst = self.rng.sample(range(self.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        return self.client.write(
+            f"UPDATE accounts SET balance = balance +"
+            f" CASE id WHEN {src} THEN {-amount} ELSE {amount} END"
+            f" WHERE id IN ({src}, {dst})"
+        )
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class LedgerTransfer(Action):
+    """Append a balanced (debit, credit) pair to the ledger table."""
+
+    name = "ledger-transfer"
+
+    def __init__(
+        self,
+        rng: random.Random,
+        worker: int,
+        accounts: int,
+        client: MzClient,
+        oplog: OpLog,
+        derived: bool = False,
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.accounts = accounts
+        self.client = client
+        self.ctx = client.ctx
+        self.oplog = oplog
+        self.derived = derived
+        self.seq = 0
+        # Committed transfers not yet reversed, consumed by ReversalTransfer.
+        self.reversible: list[int] = []
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        seq = self.seq
+        src, dst = self.rng.sample(range(self.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        debit = ledger_values(self.worker, seq, src, -amount, self.derived)
+        credit = ledger_values(self.worker, seq, dst, amount, self.derived)
+        # Register before sending: if this thread dies mid-call the op still
+        # counts as possibly-applied.
+        self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        if self.rng.random() < 0.5:
+            outcome = self.client.write(f"INSERT INTO ledger VALUES {debit}, {credit}")
+        else:
+            # The same pair as an explicit INSERT-only transaction, which
+            # Materialize commits atomically at one timestamp.
+            outcome = self.client.write_txn(
+                [
+                    (f"INSERT INTO ledger VALUES {debit}", None),
+                    (f"INSERT INTO ledger VALUES {credit}", None),
+                ]
+            )
+        self.oplog.record(self.worker, seq, outcome)
+        if outcome == Outcome.COMMITTED:
+            self.reversible.append(seq)
+            self._read_back(seq)
+        return outcome
+
+    def _read_back(self, seq: int) -> None:
+        """A committed write must be visible to the session that wrote it.
+
+        Read-your-writes is a guarantee no timestamp-free invariant covers, and
+        it is the one a stale read breaks first. The read goes through this
+        action's own client, on purpose: another session may legitimately be
+        behind. A read that fails or times out under disruption raises
+        TransientError, which the worker loop treats as a skipped op.
+        """
+        if self.rng.random() >= 0.25 or not self.ctx.checking.is_set():
+            return
+        rows = self.client.query(
+            f"SELECT count(*) FROM ledger WHERE worker = {self.worker}"
+            f" AND seq = {seq}"
+        )
+        if int(rows[0][0]) != ROWS_PER_TRANSFER:
+            raise InvariantViolation(
+                f"read-your-writes: worker {self.worker} committed op {seq} and"
+                f" its own session then saw {rows[0][0]} of"
+                f" {ROWS_PER_TRANSFER} rows"
+            )
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class ReversalTransfer(Action):
+    """Reverse one of this worker's committed transfers via INSERT..SELECT.
+
+    Exercises the read-then-write insert path. The reversal writes the
+    negated pair under op id (worker, -seq), so conservation and the exact
+    reconciliation keep holding for any outcome.
+    """
+
+    name = "reversal"
+
+    def __init__(
+        self,
+        rng: random.Random,
+        worker: int,
+        client: MzClient,
+        oplog: OpLog,
+        forward: "LedgerTransfer",
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.oplog = oplog
+        self.forward = forward
+
+    def run(self) -> Outcome | None:
+        if not self.forward.reversible:
+            return None
+        seq = self.forward.reversible.pop(
+            self.rng.randrange(len(self.forward.reversible))
+        )
+        self.oplog.record(self.worker, -seq, Outcome.UNKNOWN)
+        derived_cols = (
+            ", -amount_dec, 'w' || worker::text || '-s' || (-seq)::text, flt, day"
+            if self.forward.derived
+            else ""
+        )
+        outcome = self.client.write(
+            "INSERT INTO ledger SELECT worker, -seq, account, -amount, now()"
+            f"{derived_cols}"
+            f" FROM ledger WHERE worker = {self.worker} AND seq = {seq}"
+        )
+        self.oplog.record(self.worker, -seq, outcome)
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class FarFrontierWrite(Action):
+    """INSERT..SELECT whose selection reads a far-future write frontier.
+
+    Every other read-then-write here reads the table it writes, so the
+    selection's frontier tracks the clock and a write timestamp taken from the
+    oracle is indistinguishable from one taken from that frontier. `total_far`
+    separates them: it settles until a refresh a millennium out. Committing
+    there ratchets the monotone, durable oracle into the future, which
+    `OracleSkewPeek` names directly.
+
+    `serializable` never consults the oracle, so such a write is invisible to
+    it rather than slow. The read-back is the witness and stays exact under any
+    concurrency, asking only for this session's own row. The value written is
+    the conserved total, so a wrong one is durable evidence for
+    `far-frontier-total`.
+    """
+
+    name = "far-frontier-write"
+
+    def __init__(self, rng: random.Random, worker: int, client: MzClient) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        seq = self.seq
+        outcome = self.client.write(
+            f"INSERT INTO frontier_probe SELECT {self.worker}, {seq}, total"
+            " FROM total_far"
+        )
+        if outcome != Outcome.COMMITTED:
+            return outcome
+        self.client.query("SET transaction_isolation = 'serializable'")
+        try:
+            rows = self.client.query(
+                "SELECT count(*) FROM frontier_probe"
+                f" WHERE worker = {self.worker} AND seq = {seq}"
+            )
+            self.client.query("SET transaction_isolation = 'strict serializable'")
+        except Exception:
+            # The isolation is only known again on a fresh connection.
+            self.client.reset()
+            raise
+        if int(rows[0][0]) != 1:
+            raise InvariantViolation(
+                "a serializable read does not see its own committed write"
+                f" (worker {self.worker}, seq {seq}): {rows}"
+            )
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class CopyTransfer(Action):
+    """Append a balanced (debit, credit) pair via COPY FROM STDIN.
+
+    One COPY is one atomic write statement, so conservation and the exact
+    (worker, seq) reconciliation hold for it like for INSERTs. Shares the
+    forward transfer's seq counter (both actions run on the same worker
+    thread) so op ids stay unique per worker.
+    """
+
+    name = "copy-transfer"
+
+    def __init__(
+        self,
+        rng: random.Random,
+        worker: int,
+        client: MzClient,
+        oplog: OpLog,
+        forward: "LedgerTransfer",
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.oplog = oplog
+        self.forward = forward
+
+    def run(self) -> Outcome | None:
+        self.forward.seq += 1
+        seq = self.forward.seq
+        src, dst = self.rng.sample(range(self.forward.accounts), 2)
+        amount = self.rng.randint(1, 100)
+        # The `at` value is the host clock: COPY has no server-side defaults
+        # here, and the temporal-filter windows are wide enough to absorb
+        # clock skew between host and server.
+        at = datetime.now(UTC).isoformat()
+        derived = self.forward.derived
+        data = ledger_copy_row(
+            self.worker, seq, src, -amount, at, derived
+        ) + ledger_copy_row(self.worker, seq, dst, amount, at, derived)
+        cols = LEDGER_COLS_DERIVED if derived else LEDGER_COLS
+        self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        outcome = self.client.copy_in(f"COPY ledger ({cols}) FROM STDIN", data)
+        self.oplog.record(self.worker, seq, outcome)
+        if outcome == Outcome.COMMITTED:
+            self.forward.reversible.append(seq)
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class RegistryOp(Action):
+    """Drive one owned registry key through INSERT/UPDATE/DELETE.
+
+    All statements are idempotent (guarded insert, absolute-value update,
+    keyed delete), so an UNKNOWN outcome never risks a duplicate row, and
+    versions written by the single owner only increase. Every op is appended
+    to the scenario's per-key log for the final admissible-state check.
+    """
+
+    name = "registry"
+
+    def __init__(
+        self, rng: random.Random, worker: int, client: MzClient, scenario: "TableBank"
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.scenario = scenario
+        self.ver = 0
+
+    def run(self) -> Outcome | None:
+        key = self.rng.randrange(REGISTRY_KEYS)
+        self.ver += 1
+        ver = self.ver
+        where = f"worker = {self.worker} AND key = {key}"
+        roll = self.rng.random()
+        if roll < 0.4:
+            op = ("insert", ver)
+            sql = (
+                f"INSERT INTO registry SELECT {self.worker}, {key}, {ver}"
+                f" WHERE NOT EXISTS (SELECT 1 FROM registry WHERE {where})"
+            )
+        elif roll < 0.8:
+            op = ("update", ver)
+            sql = f"UPDATE registry SET ver = {ver} WHERE {where}"
+        else:
+            op = ("delete", None)
+            sql = f"DELETE FROM registry WHERE {where}"
+        entry: dict[str, Any] = {"op": op, "outcome": Outcome.UNKNOWN}
+        log = self.scenario.registry_log[(self.worker, key)]
+        log.append(entry)
+        entry["outcome"] = self.client.write(sql)
+        return entry["outcome"]
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class SchemaSwap(Action):
+    """Blue/green cutover: atomically swap two schemas holding identical MVs.
+
+    Consumers resolve the checked MV through the stable name
+    blue.total_swap, so the documented atomicity of ALTER SCHEMA .. SWAP is
+    what keeps their reads exact through every cutover.
+    """
+
+    name = "schema-swap"
+
+    def __init__(
+        self, rng: random.Random, client: MzClient, ctx: ScenarioContext
+    ) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.ctx = ctx
+        self.next_at = 0.0
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(8.0, 20.0)
+        # The cutover is one catalog transaction, and the swap-total checker
+        # asserts that readers never see a torn one. Cutting the coordinator
+        # off while it commits is the only way to test that against a
+        # transaction that may or may not have landed.
+        self.ctx.request_disruption("schema-swap")
+        return self.client.write("ALTER SCHEMA blue SWAP WITH green")
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class ReplacementChurn(Action):
+    """Replace the checked total MV in place with an identical definition.
+
+    The documented flow: CREATE REPLACEMENT MATERIALIZED VIEW hydrates in
+    the background while the original keeps serving, then ALTER .. APPLY
+    REPLACEMENT switches the definition while preserving the name and all
+    downstream objects. Because the definition is identical, every existing
+    total checker must keep seeing the exact total through the switch.
+    """
+
+    name = "replacement"
+
+    def __init__(
+        self, rng: random.Random, client: MzClient, ctx: ScenarioContext
+    ) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.ctx = ctx
+        self.next_at = time.monotonic() + 20.0
+        self.supported = True
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if not self.supported or now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(30.0, 60.0)
+        # A leftover replacement from a cycle whose APPLY outcome was
+        # UNKNOWN. Dropping an unapplied replacement is documented as safe.
+        if (
+            self.client.write("DROP MATERIALIZED VIEW IF EXISTS total_repl")
+            != Outcome.COMMITTED
+        ):
+            return Outcome.UNKNOWN
+        try:
+            outcome = self.client.write(
+                "CREATE REPLACEMENT MATERIALIZED VIEW total_repl FOR total"
+                " IN CLUSTER compute WITH (RETAIN HISTORY = FOR '600s')"
+                f" AS {TOTAL_DEF}"
+            )
+        except UnexpectedQueryError as e:
+            # Not available on this version, e.g. the pre-upgrade half of an
+            # --upgrade-from run. Disabling (instead of failing) keeps the
+            # rest of the scenario meaningful there.
+            self.supported = False
+            raise TransientError(f"replacement MVs unsupported: {e}") from e
+        if outcome != Outcome.COMMITTED:
+            return outcome
+        # Apply only once the replacement hydrated on every replica, per the
+        # documented workflow. Also bail on stop: this poll can outlast the
+        # executor's join ladder and would read as a stuck thread.
+        deadline = time.monotonic() + 90.0
+        while time.monotonic() < deadline and not self.ctx.stop.is_set():
+            try:
+                rows = self.client.query(
+                    "SELECT bool_and(h.hydrated)"
+                    " FROM mz_internal.mz_hydration_statuses h"
+                    " JOIN mz_catalog.mz_materialized_views v"
+                    " ON h.object_id = v.id WHERE v.name = 'total_repl'"
+                )
+            except TransientError:
+                return Outcome.UNKNOWN
+            if rows and rows[0][0]:
+                break
+            self.ctx.stop.wait(1.0)
+        else:
+            # Hydration did not finish, e.g. the compute leg is cut or the
+            # run is shutting down. Leave the replacement for the next
+            # cycle's drop.
+            return Outcome.UNKNOWN
+        # An interrupted apply is the interesting case: the cutover finalizes
+        # the collection it replaces while the replacement still holds a read
+        # hold on it, and whatever that leaves behind has to survive a
+        # bootstrap. The next cycle's DROP cleans up an apply whose outcome
+        # was unknown.
+        return self.client.write(
+            "ALTER MATERIALIZED VIEW total APPLY REPLACEMENT total_repl"
+        )
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class DdlChurn(Action):
+    """Catalog and dataflow churn on the compute cluster.
+
+    Creates and drops a scratch index and MV over the ledger. The checked
+    objects never reference them, so the invariant checkers stay unaffected
+    by the churn itself, but dataflow (un)installation keeps happening on
+    the same cluster and table the invariants cover, also while that
+    cluster's leg is disrupted. Every statement is idempotent, and index
+    names carry a nonce, because an UNKNOWN outcome leaves the catalog state
+    uncertain.
+    """
+
+    name = "ddl-churn"
+
+    def __init__(self, rng: random.Random, worker: int, client: MzClient) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.next_at = 0.0
+        self.present = False
+        self.nonce = 0
+        self.maybe_alive: list[str] = []
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(5.0, 15.0)
+        if self.present:
+            outcome = self.client.write(
+                f"DROP MATERIALIZED VIEW IF EXISTS churn_mv_{self.worker}"
+            )
+            # Keep names whose drop outcome is uncertain: an UNKNOWN drop may
+            # not have applied, and untracking such an index would leak its
+            # dataflow for the rest of the run.
+            self.maybe_alive = [
+                name
+                for name in self.maybe_alive
+                if self.client.write(f"DROP INDEX IF EXISTS {name}")
+                != Outcome.COMMITTED
+            ]
+            self.present = False
+        else:
+            outcome = self.client.write(
+                f"CREATE OR REPLACE MATERIALIZED VIEW churn_mv_{self.worker}"
+                " IN CLUSTER compute AS SELECT count(*) AS cnt FROM ledger"
+            )
+            self.nonce += 1
+            name = f"churn_idx_{self.worker}_{self.nonce}"
+            self.maybe_alive.append(name)
+            self.client.write(
+                f"CREATE INDEX {name} IN CLUSTER compute ON ledger (account)"
+            )
+            # Also churn an index on the checked MV itself: peeks against
+            # total race plan selection against the concurrent drops, which
+            # legitimately error ("was dropped") but must never be wrong.
+            total_idx = f"churn_total_idx_{self.worker}_{self.nonce}"
+            self.maybe_alive.append(total_idx)
+            self.client.write(
+                f"CREATE INDEX {total_idx} IN CLUSTER compute ON total (total)"
+            )
+            self.present = True
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+def ledger_predicate(rng: random.Random) -> str:
+    """A random total predicate over the ledger, for the partition oracle.
+
+    Total is the requirement: no division, no fallible cast, nothing that can
+    raise, or the three branches of the partition fail differently instead of
+    disagreeing. Everything here is a comparison, a NULL test, or a boolean
+    combination of them.
+
+    The columns are chosen for the values that make filters and statistics
+    pushdown awkward. `flt` carries NaN, both infinities, negative zero and a
+    denormal, `day` is nullable, so predicates over it are the ones that put
+    rows in the IS NULL branch at all, and `amount` is signed.
+    """
+    atoms = [
+        f"amount > {rng.randint(-100, 100)}",
+        f"amount < {rng.randint(-100, 100)}",
+        f"amount = {rng.randint(-100, 100)}",
+        f"account >= {rng.randint(0, 32)}",
+        f"seq % {rng.randint(2, 9)} = 0",
+        "flt > 0",
+        "flt < 0",
+        "flt = 'NaN'::double precision",
+        "flt = 'Infinity'::double precision",
+        f"amount_dec > {rng.randint(-100, 100)}",
+        "tag LIKE 'w%'",
+        f"tag LIKE '%s{rng.randint(0, 9)}'",
+        "day IS NULL",
+        "day > DATE '2024-01-01'",
+        f"day < DATE '20{rng.randint(20, 30)}-06-01'",
+    ]
+    p = rng.choice(atoms)
+    # Compound predicates, since a filter can be right on each half and wrong
+    # on the combination, and NULL propagation through AND/OR is its own trap.
+    if rng.random() < 0.4:
+        p = f"({p}) {rng.choice(['AND', 'OR'])} ({rng.choice(atoms)})"
+    if rng.random() < 0.2:
+        p = f"NOT ({p})"
+    return p
+
+
+class CrossObjectTxn(Action):
+    """Read a compute-maintained MV and write a table, in one transaction.
+
+    Everything else here reads and writes within one side of the system. This
+    crosses it: the SELECT is served by the compute cluster and the INSERT
+    lands in storage, inside a single transaction, which is where write-lock
+    scope and timestamp selection have to agree with each other.
+
+    The invariant is that the value copied is the conserved total, so a read
+    that ever observes a torn or stale state records a wrong number durably.
+    Unlike a peek, which sees a transient inconsistency only if it happens to
+    look at that instant, this keeps the evidence.
+    """
+
+    name = "cross-object-txn"
+
+    def __init__(self, rng: random.Random, client: MzClient, scenario) -> None:
+        super().__init__(rng)
+        self.client = client
+        self.scenario = scenario
+
+    def run(self) -> Outcome | None:
+        self.client.query(f"SET cluster = {self.rng.choice(['quickstart', 'compute'])}")
+        # A read and a write in one transaction, which is only expressible
+        # this way: Materialize rejects both UPDATE and INSERT .. SELECT
+        # inside a transaction block, so the read has to be its own statement
+        # and the write has to carry the value the client saw.
+        try:
+            self.client.query("BEGIN")
+            rows = self.client.query("SELECT total FROM total")
+            self.client.query(f"INSERT INTO cross_probe VALUES ({int(rows[0][0])})")
+            self.client.query("COMMIT")
+        except TransientError:
+            self.client.reset()
+            raise
+        except Exception:
+            self.client.reset()
+            return Outcome.UNKNOWN
+        return Outcome.COMMITTED
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+# One transfer writes exactly two ledger rows, a debit and its credit, in one
+# transaction. Any other group size means the transaction became visible in
+# pieces, and a non-zero sum means the pieces do not belong together.
+LEDGER_TORN_SQL = (
+    "SELECT worker, seq, count(*), sum(amount) FROM ledger"
+    " GROUP BY worker, seq HAVING count(*) <> 2 OR sum(amount) <> 0"
+)
+
+
+class BankTotalPeek(PeekChecker):
+    """The grand total must be exact on every cluster, at every time.
+
+    Alternates between the maintained MV, an ad-hoc query over the base
+    tables, a single query spanning both, and result-equivalent
+    formulations through a join, a window function, a recursive CTE, and a
+    LATERAL subquery. The same invariant is verified through many
+    documented plans, and in the combined forms as one consistent snapshot
+    across objects. The ad-hoc forms also stay live on quickstart while the
+    compute cluster (which maintains the MV) is disrupted.
+    """
+
+    BASE_TOTAL = (
+        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger)"
+    )
+    # Every ledger row references an existing account id, so the inner join
+    # keeps all ledger rows.
+    JOIN_TOTAL = (
+        "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + coalesce(sum(l.amount), 0)"
+        " FROM ledger l JOIN accounts a ON l.account = a.id"
+    )
+    WINDOW_TOTAL = (
+        "SELECT DISTINCT sum(balance) OVER ()"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger) FROM accounts"
+    )
+    # Log-depth pairwise-halving sum: level k holds per-id/2^k partial sums,
+    # level 20 collapses everything to id 0 for up to 2^20 accounts.
+    RECURSIVE_TOTAL = (
+        "WITH MUTUALLY RECURSIVE lvl (l int, id int, bal numeric) AS ("
+        " SELECT 0, id, balance::numeric FROM accounts"
+        " UNION ALL"
+        " SELECT l + 1, id / 2, sum(bal) FROM lvl WHERE l < 20"
+        " GROUP BY l + 1, id / 2"
+        ") SELECT bal + (SELECT coalesce(sum(amount), 0) FROM ledger)"
+        " FROM lvl WHERE l = 20 AND id = 0"
+    )
+    LATERAL_TOTAL = (
+        "SELECT sub.total FROM (VALUES (0)) v (z), LATERAL ("
+        " SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+        " + (SELECT coalesce(sum(amount), 0) FROM ledger) + v.z AS total"
+        ") sub"
+    )
+    QUERIES = [
+        ("SELECT total FROM total", 1),
+        (BASE_TOTAL, 1),
+        (f"SELECT total FROM total UNION ALL {BASE_TOTAL}", 2),
+        (JOIN_TOTAL, 1),
+        (WINDOW_TOTAL, 1),
+        (RECURSIVE_TOTAL, 1),
+        (LATERAL_TOTAL, 1),
+    ]
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "total-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+        self.isolations = [
+            "strict serializable",
+            "serializable",
+            "bounded staleness 5s",
+        ]
+
+    def _context(self, isolation: str) -> str:
+        """What the next occurrence needs in order to classify itself.
+
+        A peek that returns the wrong rows says nothing on its own about where
+        it went wrong. Naming the cluster and the isolation the read used, and
+        reading the object again on every cluster with the timestamp each read
+        picks, separates a wrong shard from one wrong replica, and a window
+        that has passed from one that is still open.
+        """
+        parts = [f"cluster={self.last_cluster}", f"isolation={isolation}"]
+        for cluster in self.clusters:
+            try:
+                self.client.query(f"SET cluster = {cluster}")
+                # mz_now() over an input relation is the read's own timestamp,
+                # unlike the input-free form (CPU-197).
+                rows = self.client.query(
+                    "SELECT total, mz_now()::text FROM total", timeout=20
+                )
+                parts.append(f"re-read on {cluster}: {rows}")
+            except Exception as e:
+                parts.append(f"re-read on {cluster} failed: {e}")
+        return "; ".join(parts)
+
+    def check_once(self) -> None:
+        # Conservation is timestamp-free, so it must hold under every
+        # isolation level: staleness changes the chosen timestamp, never the
+        # value of a timestamp-free invariant. A bounded staleness read with
+        # no readable timestamp in bound errors with SQLSTATE 40001, which
+        # the client classifies as a transient skip.
+        isolation = self.rng.choice(self.isolations)
+        try:
+            self.client.query(f"SET transaction_isolation = '{isolation}'")
+        except UnexpectedQueryError:
+            if isolation.startswith("bounded staleness"):
+                # Not available on this version, e.g. the pre-upgrade half
+                # of an --upgrade-from run.
+                self.isolations = [
+                    i for i in self.isolations if not i.startswith("bounded")
+                ]
+                raise TransientError(
+                    "bounded staleness unsupported, dropped from rotation"
+                ) from None
+            raise
+        recent = self.scenario.recent_ts.get()
+        if recent > 0 and self.rng.random() < 0.25:
+            # Time travel into retained history: compaction must preserve
+            # the invariant at already-validated timestamps.
+            as_of = self.rng.randint(max(recent - 120_000, 1), recent)
+            query, expected_rows = f"SELECT total FROM total AS OF {as_of}", 1
+        else:
+            # rng, not round-robin: the cluster rotation has the same period
+            # as the query list, round-robin would pin each form to one
+            # cluster.
+            query, expected_rows = self.rng.choice(self.QUERIES)
+        try:
+            rows = self.peek(query)
+        except UnexpectedQueryError as e:
+            # The history probe can race compaction: while checkers skip
+            # through long disruptions the recent_ts watermark goes stale,
+            # and the probed timestamp may fall behind the retained window.
+            # An unreadable timestamp is a skipped round, wrong data at a
+            # readable one stays fatal.
+            if "could not find a valid timestamp" in str(e):
+                raise TransientError(str(e)) from e
+            raise
+        if len(rows) != expected_rows or any(
+            int(row[0]) != self.scenario.total for row in rows
+        ):
+            raise InvariantViolation(
+                f"total mismatch via {query!r}: expected {expected_rows}x"
+                f" {self.scenario.total}, got {rows} [{self._context(isolation)}]"
+            )
+        # Sample the watermark that feeds the history probe. `SELECT mz_now()`
+        # has no inputs, and for such a constant query the coordinator answers
+        # at Timestamp::MAX under serializable and bounded staleness, so only
+        # strict serializable yields a usable time. The watermark never goes
+        # back down, so a single MAX sample would point every later probe at
+        # the end of time.
+        # TODO: Reenable for all isolation levels when CPU-197 is fixed.
+        if isolation == "strict serializable":
+            self.scenario.recent_ts.advance(
+                int(self.client.query("SELECT mz_now()::text")[0][0])
+            )
+        self.validations += 1
+
+
+class LedgerDirectPeek(PeekChecker):
+    """Direct table reads: conservation, bounds, and monotonic row count.
+
+    Table reads stay live on quickstart even while the compute cluster's leg
+    is disrupted, so this checker provides coverage during those windows.
+    """
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "ledger-peek", ["quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        # Sampling order matters: lower bounds before the read, upper bounds
+        # after, and the read is compared against the watermark as it was
+        # before the read was issued.
+        low = ROWS_PER_TRANSFER * oplog.committed_count()
+        watermark = self.scenario.ledger_rows.get()
+        rows = self.peek(
+            "SELECT count(*), coalesce(sum(amount), 0),"
+            " coalesce(sum(amount_dec), 0) FROM ledger"
+        )
+        high = ROWS_PER_TRANSFER * oplog.attempted_count()
+        count, amount_sum, dec_sum = int(rows[0][0]), int(rows[0][1]), rows[0][2]
+        if amount_sum != 0:
+            raise InvariantViolation(f"ledger sum {amount_sum} != 0 (count {count})")
+        # The same conservation in numeric arithmetic, which has its own
+        # encoding and scale handling.
+        if float(dec_sum) != 0.0:
+            raise InvariantViolation(f"ledger decimal sum {dec_sum} != 0")
+        if count < watermark:
+            raise InvariantViolation(
+                f"ledger count went backwards: {count} < watermark {watermark}"
+            )
+        if count < low:
+            raise InvariantViolation(
+                f"ledger count {count} misses committed transfers (>= {low} expected)"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"ledger count {count} exceeds attempted transfers (<= {high} expected)"
+            )
+        self.scenario.ledger_rows.advance(count)
+        self.validations += 1
+
+
+class LedgerIdentityPeek(PeekChecker):
+    """Row-level reconciliation of a window of one worker's ledger rows.
+
+    The conserved sum and the counted bounds are blind to a corruption that
+    keeps both intact: a lost transfer masked by a duplicated one, a rewritten
+    account or tag, a pair that is present twice. This checks the identities
+    instead, over a bounded window so it stays cheap, and it remembers what it
+    saw: an op id that was there once must never be gone again, which no
+    aggregate can express.
+    """
+
+    # Ops per worker examined per round. The newest ones are where a write
+    # that is still settling would show up.
+    WINDOW = 200
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "ledger-identity", ["quickstart", "compute"])
+        self.scenario = scenario
+        # Op ids this checker has already observed, per worker. Nothing ever
+        # deletes ledger rows, so these may never disappear.
+        self.seen: dict[int, set[int]] = {}
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        worker = self.rng.randrange(self.ctx.complexity.workers)
+        # Sampling order as in LedgerDirectPeek: what must be present is
+        # sampled before the read, what may at most be present after it. An op
+        # issued while the read is in flight is legitimately in its result, and
+        # comparing it against a pre-read sample would report it as a phantom.
+        committed = oplog.seqs(worker, Outcome.COMMITTED)
+        issued = oplog.issued(worker)
+        if not issued:
+            return
+        # Bound the window by op id magnitude, so reversals (negative ids) of
+        # transfers in the window come along.
+        floor = max(abs(seq) for seq in issued) - self.WINDOW
+        rows = self.peek(
+            f"SELECT seq, count(*), coalesce(sum(amount), 0),"
+            f" count(*) FILTER (WHERE {DERIVED_ROW_CONTRACT})"
+            f" FROM ledger WHERE worker = {worker} AND abs(seq) > {floor}"
+            f" GROUP BY seq"
+        )
+        # Everything the read may legitimately contain, including ops issued
+        # while it was in flight.
+        issued_after = oplog.issued(worker)
+        present = set()
+        for seq, count, amount_sum, bad_rows in rows:
+            seq, count = int(seq), int(count)
+            present.add(seq)
+            if count != ROWS_PER_TRANSFER or int(amount_sum) != 0:
+                raise InvariantViolation(
+                    f"worker {worker} op {seq}: {count} rows summing to"
+                    f" {amount_sum}, expected {ROWS_PER_TRANSFER} summing to 0"
+                )
+            if int(bad_rows) != 0:
+                raise InvariantViolation(
+                    f"worker {worker} op {seq}: {bad_rows} rows whose derived"
+                    " columns do not match their op id"
+                )
+        missing = {seq for seq in committed if abs(seq) > floor} - present
+        if missing:
+            raise InvariantViolation(
+                f"worker {worker}: committed ops absent: {sorted(missing)[:20]}"
+            )
+        phantom = present - issued_after
+        if phantom:
+            raise InvariantViolation(
+                f"worker {worker}: ops never issued: {sorted(phantom)[:20]}"
+            )
+        seen = self.seen.setdefault(worker, set())
+        vanished = {seq for seq in seen if abs(seq) > floor} - present
+        if vanished:
+            raise InvariantViolation(
+                f"worker {worker}: ops disappeared after being observed:"
+                f" {sorted(vanished)[:20]}"
+            )
+        seen |= present
+        self.validations += 1
+
+
+class LedgerRowsSubscribe(SubscribeChecker):
+    """Row-level validation of the ledger's change stream.
+
+    Subscribes without a snapshot, so the cost is independent of how large the
+    table has grown, and judges the stream itself rather than an aggregate of
+    it: the ledger is append-only, so a retraction is a bug outright, and both
+    rows of a transfer are written in one statement, so every op id that
+    appears at a completed timestamp must appear exactly twice and sum to zero.
+    """
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(
+            rng,
+            ctx,
+            "ledger-rows-subscribe",
+            "SELECT worker, seq, account, amount FROM ledger",
+            snapshot=False,
+            append_only=True,
+        )
+        self.scenario = scenario
+
+    # Rows to carry before starting a fresh subscription, so the per-round
+    # validation stays cheap however long the run is.
+    STATE_LIMIT = 4000
+
+    def check_once(self) -> None:
+        super().check_once()
+        if len(self._state) > self.STATE_LIMIT:
+            self.recycle()
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        per_op: dict[tuple[int, int], tuple[int, int]] = {}
+        for row, count in state.items():
+            worker, seq, _account, amount = row
+            if count != 1:
+                raise InvariantViolation(f"row {row} present {count} times at {ts}")
+            rows, total = per_op.get((int(worker), int(seq)), (0, 0))
+            per_op[(int(worker), int(seq))] = (rows + 1, total + int(amount))
+        for (worker, seq), (rows, total) in per_op.items():
+            if rows != ROWS_PER_TRANSFER or total != 0:
+                raise InvariantViolation(
+                    f"worker {worker} op {seq} at {ts}: {rows} rows summing to"
+                    f" {total} in the change stream"
+                )
+            if not self.scenario.oplog.was_issued(worker, seq):
+                raise InvariantViolation(
+                    f"worker {worker} op {seq} at {ts} was never issued"
+                )
+
+
+class PredicateDifferentialPeek(PeekChecker):
+    """Predicates over the float and date columns, judged two ways.
+
+    An aggregate with a predicate lets persist skip parts by their statistics,
+    and getting that wrong is silent: the answer is simply too small. So the
+    same predicate is also evaluated on the client, over the rows the same
+    transaction returns, and the two must agree. The values chosen are the ones
+    whose statistics handling has been wrong before: NaN, negative zero, the
+    infinities, a denormal, and a nullable date.
+
+    Only predicates whose truth does not depend on where NaN sorts are used,
+    so this checks statistics handling and not float ordering semantics.
+    """
+
+    # Ops per worker read back per round, as in LedgerIdentityPeek.
+    WINDOW = 200
+
+    PREDICATES: list[tuple[str, Any]] = [
+        (
+            "flt < 0",
+            lambda flt, day: flt is not None and not math.isnan(flt) and flt < 0,
+        ),
+        (
+            "flt = 0",
+            lambda flt, day: flt is not None and not math.isnan(flt) and flt == 0,
+        ),
+        (
+            "flt = 'NaN'::double precision",
+            lambda flt, day: flt is not None and math.isnan(flt),
+        ),
+        ("day IS NULL", lambda flt, day: day is None),
+        (
+            "day > DATE '2024-01-01'",
+            lambda flt, day: day is not None and day > DAY_CUT,
+        ),
+    ]
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "predicate-differential", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        worker = self.rng.randrange(self.ctx.complexity.workers)
+        issued = oplog.issued(worker)
+        if not issued:
+            return
+        floor = max(abs(seq) for seq in issued) - self.WINDOW
+        predicate, on_client = self.rng.choice(self.PREDICATES)
+        window = f"FROM ledger WHERE worker = {worker} AND abs(seq) > {floor}"
+        cluster = self.clusters[self._round % len(self.clusters)]
+        self._round += 1
+        self.client.query(f"SET cluster = {cluster}")
+        # One read-only transaction, so both statements read at the same
+        # timestamp and a disagreement cannot be staleness.
+        self.client.query("BEGIN")
+        try:
+            counted = int(
+                self.client.query(f"SELECT count(*) {window} AND ({predicate})")[0][0]
+            )
+            rows = self.client.query(f"SELECT flt, day {window}")
+        finally:
+            try:
+                self.client.query("COMMIT")
+            except Exception:
+                pass
+        recomputed = sum(1 for flt, day in rows if on_client(flt, day))
+        if counted != recomputed:
+            raise InvariantViolation(
+                f"worker {worker}: `{predicate}` counted {counted} of"
+                f" {len(rows)} rows, recomputing it over the same read gives"
+                f" {recomputed}"
+            )
+        self.validations += 1
+
+
+class SnapshotTxnPeek(PeekChecker):
+    """Multi-statement read-only transactions see one consistent snapshot.
+
+    The first SELECT picks the transaction's timestamp and every subsequent
+    statement reads at that same timestamp, so the accounts sum and the
+    ledger sum from separate statements must still add up to the conserved
+    total. Alternates the transaction form with a one-shot COPY TO STDOUT
+    read of the same invariant, and ends transactions with COMMIT or
+    ROLLBACK (equivalent for reads).
+    """
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "txn-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        if self.rng.random() < 0.3:
+            rows = self.client.copy_out(
+                "COPY (SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
+                " + (SELECT coalesce(sum(amount), 0) FROM ledger)) TO STDOUT"
+            )
+            if len(rows) != 1 or int(rows[0][0]) != self.scenario.total:
+                raise InvariantViolation(
+                    f"total via COPY TO STDOUT: expected {self.scenario.total},"
+                    f" got {rows}"
+                )
+            self.validations += 1
+            return
+        oplog = self.scenario.oplog
+        # Bounds sampling order as in LedgerDirectPeek: lower bounds before
+        # the transaction picks its timestamp, upper bounds after it ends.
+        low = ROWS_PER_TRANSFER * oplog.committed_count()
+        watermark = self.scenario.ledger_rows.get()
+        cluster = self.clusters[self._round % len(self.clusters)]
+        self._round += 1
+        self.client.query(f"SET cluster = {cluster}")
+        self.client.query("SET transaction_isolation = 'strict serializable'")
+        try:
+            self.client.query("BEGIN")
+            accounts_sum = int(
+                self.client.query("SELECT coalesce(sum(balance), 0) FROM accounts")[0][
+                    0
+                ]
+            )
+            ledger_sum, count = (
+                int(v)
+                for v in self.client.query(
+                    "SELECT coalesce(sum(amount), 0), count(*) FROM ledger"
+                )[0]
+            )
+        finally:
+            # Read-only transactions end equivalently via COMMIT or
+            # ROLLBACK. Failures drop the connection, which also ends it.
+            try:
+                self.client.query("COMMIT" if self.rng.random() < 0.5 else "ROLLBACK")
+            except TransientError:
+                pass
+        high = ROWS_PER_TRANSFER * oplog.attempted_count()
+        if accounts_sum + ledger_sum != self.scenario.total:
+            raise InvariantViolation(
+                "read-only transaction saw a torn snapshot:"
+                f" accounts {accounts_sum} + ledger {ledger_sum}"
+                f" != {self.scenario.total}"
+            )
+        if count < watermark or count < low or count > high:
+            raise InvariantViolation(
+                f"ledger count {count} in transaction out of bounds"
+                f" [{max(low, watermark)}, {high}]"
+            )
+        # Shared with LedgerDirectPeek: both read under strict
+        # serializable, where the monotonic-read guarantee spans sessions.
+        self.scenario.ledger_rows.advance(count)
+        self.validations += 1
+
+
+class TemporalPeek(PeekChecker):
+    """Temporal filters keep exactly the rows inside their mz_now() window.
+
+    The wide window is larger than any run, so its count must equal the
+    full ledger count at the same timestamp. The short window is a subset
+    at every timestamp, and the final check verifies its rows are retracted
+    on schedule after the workload quiesces.
+    """
+
+    QUERY = (
+        "SELECT (SELECT count(*) FROM ledger),"
+        " (SELECT cnt FROM recent_wide), (SELECT cnt FROM recent_short)"
+    )
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "temporal-peek", ["compute", "quickstart"])
+
+    def check_once(self) -> None:
+        direct, wide, short = (int(v) for v in self.peek(self.QUERY)[0])
+        if wide != direct:
+            raise InvariantViolation(
+                f"wide temporal window dropped live rows: {wide} != {direct}"
+            )
+        if short > direct:
+            raise InvariantViolation(
+                f"short temporal window exceeds the full count:" f" {short} > {direct}"
+            )
+        self.validations += 1
+
+
+class RefreshMvPeek(PeekChecker):
+    """A REFRESH EVERY view serves some past snapshot, never a torn one.
+
+    Conservation is timestamp-free, so any data the view returns must be
+    the exact total. Reads that block around a refresh are transient skips
+    via the client watchdog.
+    """
+
+    pause = (1.0, 4.0)
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "refresh-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        isolation = self.rng.choice(["strict serializable", "serializable"])
+        self.client.query(f"SET transaction_isolation = '{isolation}'")
+        rows = self.peek("SELECT total FROM total_refresh")
+        if not rows:
+            # The documented unavailability window around a refresh.
+            raise TransientError("refresh view unavailable")
+        if len(rows) != 1 or int(rows[0][0]) != self.scenario.total:
+            raise InvariantViolation(
+                f"REFRESH EVERY view shows a torn snapshot: {rows}"
+            )
+        self.validations += 1
+
+
+# A local write timestamp is clamped to `now + 2 * timestamp_interval`, 10s
+# with our defaults, so anything past this did not come from the oracle. The
+# bound need not be tight: a frontier-derived one is a millennium out.
+ORACLE_SKEW_LIMIT_MS = 30_000
+
+
+class OracleSkewPeek(PeekChecker):
+    """The write timeline's oracle keeps tracking the wall clock.
+
+    Every write allocates from the oracle, which is clamped to the clock, so a
+    timestamp from anywhere else shows up only as the oracle carrying it. It is
+    monotone and durable, so once out there every write and strict-serializable
+    read blocks until the clock catches up, restarts included.
+
+    This query reads no collection, so it still answers in exactly that state,
+    where any table read would block. That is what makes it the attribution
+    rather than a wave of unrelated timeouts.
+    """
+
+    QUERY = "SELECT mz_now()::text::bigint - (extract(epoch FROM now()) * 1000)::bigint"
+
+    pause = (1.0, 4.0)
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "oracle-skew", ["compute", "quickstart"])
+
+    def check_once(self) -> None:
+        skew = int(self.peek(self.QUERY)[0][0])
+        if skew > ORACLE_SKEW_LIMIT_MS:
+            raise InvariantViolation(
+                f"the write timeline's oracle is {skew}ms ahead of the wall clock,"
+                " so a write took its timestamp from something other than the oracle"
+            )
+        self.validations += 1
+
+
+class SwapTotalPeek(PeekChecker):
+    """The blue/green MV must be exact through every ALTER SCHEMA SWAP.
+
+    The stable name blue.total_swap resolves to either schema's MV, both
+    identically defined, so the documented atomicity of the swap means a
+    read either errors transiently (racing the catalog change) or returns
+    the exact total. Wrong data would mean a non-atomic cutover.
+    """
+
+    pause = (1.0, 3.0)
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "swap-peek", ["compute", "quickstart"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        rows = self.peek("SELECT total FROM blue.total_swap")
+        if len(rows) != 1 or int(rows[0][0]) != self.scenario.total:
+            raise InvariantViolation(
+                f"total via swapped schema: expected {self.scenario.total},"
+                f" got {rows}"
+            )
+        self.validations += 1
+
+
+class RegistryPeek(PeekChecker):
+    """Registry state machine: at most one live row per key, versions only
+    move forward, and the TopK (DISTINCT ON) read matches the plain read."""
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "registry-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+        self.high_water: dict[tuple[int, int], int] = {}
+
+    def check_once(self) -> None:
+        duplicated = self.peek(
+            "SELECT worker, key FROM registry GROUP BY worker, key"
+            " HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"registry holds multiple rows per key: {duplicated[:20]}"
+            )
+        # Sampled before the read, per the watermark rule.
+        watermarks = dict(self.high_water)
+        rows = self.peek(
+            "SELECT r.worker, r.key, r.ver, t.cnt FROM registry r,"
+            " (SELECT count(*) AS cnt FROM"
+            "  (SELECT DISTINCT ON (worker, key) worker, key FROM registry"
+            "   ORDER BY worker, key, ver DESC)) t"
+        )
+        limit = self.ctx.complexity.workers * REGISTRY_KEYS
+        if len(rows) > limit:
+            raise InvariantViolation(
+                f"registry holds {len(rows)} rows, only {limit} keys exist"
+            )
+        for row in rows:
+            worker, key, ver, topk_cnt = (int(v) for v in row)
+            if topk_cnt != len(rows):
+                raise InvariantViolation(
+                    f"DISTINCT ON read disagrees with plain read:"
+                    f" {topk_cnt} != {len(rows)}"
+                )
+            if watermarks.get((worker, key), -1) > ver:
+                raise InvariantViolation(
+                    f"registry key ({worker}, {key}) version moved backwards:"
+                    f" {ver} < {watermarks[(worker, key)]}"
+                )
+            current = self.high_water.get((worker, key), -1)
+            if ver > current:
+                self.high_water[(worker, key)] = ver
+        self.validations += 1
+
+
+class CopyExportPeek(Checker):
+    """COPY TO S3 exports are consistent snapshots of the ledger.
+
+    Each export must sum to zero and contain every transfer completely
+    (exactly two rows per op id, summing to zero), with the row count
+    bounded by the op ledger. Alternates the documented csv and parquet
+    formats and reads the files back through the S3 API.
+    """
+
+    name = "copy-export"
+    pause = (20.0, 45.0)
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng)
+        self.ctx = ctx
+        self.scenario = scenario
+        self.client = MzClient(ctx, "copy-export")
+        self.exports = 0
+        self._s3 = None
+
+    def _s3_client(self):
+        import boto3
+
+        if self._s3 is None:
+            self._s3 = boto3.client(
+                "s3",
+                endpoint_url=f"http://127.0.0.1:{self.ctx.endpoints.minio_port}",
+                aws_access_key_id="minioadmin",
+                aws_secret_access_key="minioadmin",
+                region_name="us-east-1",
+            )
+        return self._s3
+
+    def check_once(self) -> None:
+        self.exports += 1
+        fmt = "csv" if self.exports % 2 else "parquet"
+        prefix = f"{self.ctx.seed}/{self.exports}-{fmt}"
+        oplog = self.scenario.oplog
+        low = ROWS_PER_TRANSFER * oplog.committed_count()
+        self.client.query(
+            f"COPY (SELECT worker, seq, amount FROM ledger)"
+            f" TO 's3://copytos3/{prefix}'"
+            f" WITH (AWS CONNECTION = aws_conn, FORMAT = '{fmt}')",
+            timeout=max(120.0, self.ctx.complexity.query_timeout),
+        )
+        high = ROWS_PER_TRANSFER * oplog.attempted_count()
+        rows = self._read_back(prefix, fmt)
+        amount_sum = sum(amount for _, _, amount in rows)
+        if amount_sum != 0:
+            raise InvariantViolation(f"S3 export ({fmt}) sums to {amount_sum} != 0")
+        if not low <= len(rows) <= high:
+            raise InvariantViolation(
+                f"S3 export ({fmt}) has {len(rows)} rows, outside" f" [{low}, {high}]"
+            )
+        per_op: dict[tuple[int, int], list[int]] = {}
+        for worker, seq, amount in rows:
+            per_op.setdefault((worker, seq), []).append(amount)
+        broken = {
+            op: amounts
+            for op, amounts in per_op.items()
+            if len(amounts) != ROWS_PER_TRANSFER or sum(amounts) != 0
+        }
+        if broken:
+            raise InvariantViolation(
+                f"S3 export ({fmt}) tore transfers apart:"
+                f" {dict(list(broken.items())[:10])}"
+            )
+        self.validations += 1
+
+    def _read_back(self, prefix: str, fmt: str) -> list[tuple[int, int, int]]:
+        try:
+            s3 = self._s3_client()
+            listing = s3.list_objects_v2(Bucket="copytos3", Prefix=prefix)
+            rows: list[tuple[int, int, int]] = []
+            for entry in listing.get("Contents", []):
+                if entry["Key"].endswith("INCOMPLETE"):
+                    # The sentinel is deleted on completion, seeing it here
+                    # would mean an incomplete export. The COPY statement
+                    # already returned success, so treat it as not-yet-listed
+                    # rather than failing.
+                    raise TransientError("INCOMPLETE sentinel still present")
+                body = s3.get_object(Bucket="copytos3", Key=entry["Key"])["Body"].read()
+                if fmt == "csv":
+                    for line in body.decode().splitlines():
+                        worker, seq, amount = line.split(",")
+                        rows.append((int(worker), int(seq), int(amount)))
+                else:
+                    import pyarrow as pa
+                    import pyarrow.parquet as pq
+
+                    table = pq.read_table(pa.BufferReader(body))
+                    for worker, seq, amount in zip(
+                        table.column("worker").to_pylist(),
+                        table.column("seq").to_pylist(),
+                        table.column("amount").to_pylist(),
+                    ):
+                        if worker is None or seq is None or amount is None:
+                            raise InvariantViolation(
+                                "NULL in exported ledger row:"
+                                f" ({worker}, {seq}, {amount})"
+                            )
+                        rows.append((int(worker), int(seq), int(amount)))
+            return rows
+        except InvariantViolation:
+            raise
+        except Exception as e:
+            # The S3 read-back path is harness-side infrastructure, not the
+            # system under test.
+            raise TransientError(f"export read-back failed: {e}") from e
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class BankTotalSubscribe(SubscribeChecker):
+    """The total MV must show the exact total at every progress boundary.
+
+    The durable variant carries its state across reconnects by resuming
+    from the last validated timestamp, verifying the documented durable
+    subscription pattern under disruptions.
+    """
+
+    def __init__(
+        self,
+        rng,
+        ctx,
+        scenario: "TableBank",
+        name: str = "total-subscribe",
+        durable: bool = False,
+    ) -> None:
+        super().__init__(rng, ctx, name, "SELECT total FROM total", durable=durable)
+        self.scenario = scenario
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        expected = {(self.scenario.total,): 1}
+        got = {(int(k[0]),): v for k, v in state.items()}
+        if got != expected:
+            raise InvariantViolation(
+                f"total via SUBSCRIBE at {ts}: expected {expected}, got {got}"
+            )
+
+
+class LedgerCountAudit(SubscribeChecker):
+    """Replays the ledger count's dense history: it must never decrease."""
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "history-audit", "SELECT cnt FROM ledger_agg")
+        self.last_cnt = -1
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        if len(state) != 1 or list(state.values()) != [1]:
+            raise InvariantViolation(
+                f"ledger count history at {ts}: expected one row, got {state}"
+            )
+        cnt = int(list(state)[0][0])
+        if cnt < self.last_cnt:
+            raise InvariantViolation(
+                f"ledger count went backwards in history at {ts}:"
+                f" {cnt} < {self.last_cnt}"
+            )
+        self.last_cnt = cnt
+
+
+class TableBank(Scenario):
+    name = "table-bank"
+    services: list[str] = []
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "pubsub-compute",
+        "pubsub-storage",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.accounts = ctx.complexity.accounts
+        self.total = self.accounts * BALANCE_PER_ACCOUNT
+        self.oplog = OpLog()
+        self.ledger_rows = Watermark()
+        # Recent mz timestamps observed by peeks, the AS OF history probes
+        # stay within RETAIN HISTORY of this.
+        self.recent_ts = Watermark()
+        # (worker, key) -> ordered op log, appended by the owning worker
+        # thread only and read after all workers stopped.
+        self.registry_log: dict[tuple[int, int], list[dict[str, Any]]] = {
+            (worker, key): []
+            for worker in range(ctx.complexity.workers)
+            for key in range(REGISTRY_KEYS)
+        }
+
+    def setup(self) -> None:
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE accounts (id int, balance bigint)",
+            f"INSERT INTO accounts SELECT generate_series(0, {self.accounts - 1}),"
+            f" {BALANCE_PER_ACCOUNT}",
+            # RETAIN HISTORY on the base table keeps direct AS OF reads of
+            # the ledger itself possible, besides the MVs.
+            # amount_dec, tag, flt and day are derived from the op id, see
+            # ledger_values: they make every row checkable on its own and put
+            # float and nullable-date predicates on the checked path.
+            "CREATE TABLE ledger (worker int, seq bigint, account int,"
+            " amount bigint, at timestamptz, amount_dec numeric(38, 6),"
+            " tag text, flt double precision, day date)"
+            " WITH (RETAIN HISTORY = FOR '600s')",
+            "CREATE TABLE registry (worker int, key int, ver bigint)",
+            "CREATE TABLE cross_probe (total bigint)",
+            # RETAIN HISTORY keeps recent timestamps readable so the durable
+            # subscribe checker can resume where it left off.
+            "CREATE MATERIALIZED VIEW total IN CLUSTER compute"
+            f" WITH (RETAIN HISTORY = FOR '600s') AS {TOTAL_DEF}",
+            "CREATE INDEX total_idx IN CLUSTER compute ON total (total)",
+            "CREATE MATERIALIZED VIEW ledger_agg IN CLUSTER compute"
+            " WITH (RETAIN HISTORY = FOR '600s') AS"
+            " SELECT count(*) AS cnt FROM ledger",
+            # Temporal filters: the wide window outlasts any run, the short
+            # window drains after quiescing.
+            "CREATE MATERIALIZED VIEW recent_wide IN CLUSTER compute AS"
+            " SELECT count(*) AS cnt FROM ledger"
+            " WHERE mz_now() <= at + INTERVAL '4 hours'",
+            "CREATE MATERIALIZED VIEW recent_short IN CLUSTER compute AS"
+            " SELECT count(*) AS cnt FROM ledger"
+            " WHERE mz_now() <= at + INTERVAL '60 seconds'",
+            # REFRESH EVERY serves the last refresh's snapshot in between.
+            "CREATE MATERIALIZED VIEW total_refresh IN CLUSTER compute"
+            " WITH (REFRESH EVERY '10 seconds') AS SELECT total FROM total",
+            # A write frontier that legitimately runs far ahead of the wall
+            # clock, see FarFrontierWrite: the near refresh makes the view
+            # readable, the far one parks its frontier a millennium out.
+            # Conservation keeps the frozen snapshot exactly checkable, the
+            # total never changes however stale the contents.
+            "CREATE MATERIALIZED VIEW total_far IN CLUSTER compute"
+            " WITH (REFRESH AT mz_now()::text::int8 + 5000, REFRESH AT '3000-01-01')"
+            " AS SELECT total FROM total",
+            "CREATE TABLE frontier_probe (worker int, seq bigint, total bigint)",
+            # Blue/green pair for the ALTER SCHEMA SWAP cutover.
+            "CREATE SCHEMA blue",
+            "CREATE SCHEMA green",
+            "CREATE MATERIALIZED VIEW blue.total_swap IN CLUSTER compute AS"
+            f" {TOTAL_DEF}",
+            "CREATE MATERIALIZED VIEW green.total_swap IN CLUSTER compute AS"
+            f" {TOTAL_DEF}",
+            # COPY TO S3 exports go to the MinIO container directly (the
+            # toxiproxied blob leg is persist's, not this connection's).
+            "CREATE SECRET miniopass AS 'minioadmin'",
+            "CREATE CONNECTION aws_conn TO AWS (ENDPOINT 'http://minio:9000/',"
+            " REGION 'us-east-1', ACCESS KEY ID 'minioadmin',"
+            " SECRET ACCESS KEY SECRET miniopass)",
+        ]:
+            client.query(sql, timeout=120)
+        # Anchor for the end-of-run history audit.
+        self.setup_ts = int(client.query("SELECT mz_now()::text")[0][0])
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        client = MzClient(self.ctx, f"worker-{index}")
+        forward = LedgerTransfer(
+            rng, index, self.accounts, client, self.oplog, derived=True
+        )
+        actions: list[Action] = [
+            UpdateTransfer(rng, self.accounts, client),
+            forward,
+            ReversalTransfer(rng, index, client, self.oplog, forward),
+            CopyTransfer(rng, index, client, self.oplog, forward),
+            RegistryOp(rng, index, client, self),
+            DdlChurn(rng, index, client),
+            CrossObjectTxn(rng, MzClient(self.ctx, f"cross-{index}"), self),
+            # Own client: the read-back flips the session's isolation.
+            FarFrontierWrite(rng, index, MzClient(self.ctx, f"far-frontier-{index}")),
+        ]
+        # The transfer actions carry the conservation and ledger-identity
+        # oracles, which are the strongest ones here, so they keep the bulk of
+        # the op budget. The rest only need to happen often enough to produce
+        # the states their checkers watch continuously.
+        weights = [10, 10, 3, 3, 6, 1, 1, 2]
+        if index == 0:
+            # Single-instance churns: concurrent swaps of the same schema
+            # pair or replacements of the same MV would only race each other
+            # in the catalog, without adding coverage.
+            actions += [
+                SchemaSwap(rng, client, self.ctx),
+                ReplacementChurn(rng, client, self.ctx),
+            ]
+            weights += [2, 2]
+        return WorkerBundle(actions=actions, weights=weights)
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(19)]
+        return [
+            BankTotalPeek(rngs[0], self.ctx, self),
+            LedgerDirectPeek(rngs[1], self.ctx, self),
+            LedgerIdentityPeek(rngs[2], self.ctx, self),
+            LedgerRowsSubscribe(rngs[3], self.ctx, self),
+            PredicateDifferentialPeek(rngs[4], self.ctx, self),
+            BankTotalSubscribe(rngs[5], self.ctx, self),
+            BankTotalSubscribe(
+                rngs[6], self.ctx, self, name="total-subscribe-durable", durable=True
+            ),
+            SnapshotTxnPeek(rngs[7], self.ctx, self),
+            TemporalPeek(rngs[8], self.ctx),
+            RefreshMvPeek(rngs[9], self.ctx, self),
+            SwapTotalPeek(rngs[10], self.ctx, self),
+            RegistryPeek(rngs[11], self.ctx, self),
+            CopyExportPeek(rngs[12], self.ctx, self),
+            ReplicaDivergence(
+                rngs[13],
+                self.ctx,
+                ("SELECT total FROM total", "SELECT cnt FROM ledger_agg"),
+            ),
+            TernaryPartitionPeek(
+                rngs[14],
+                self.ctx,
+                "ledger-partition",
+                "ledger",
+                ledger_predicate,
+                "amount",
+                history=self.recent_ts,
+            ),
+            GroupCompletenessPeek(
+                rngs[15],
+                self.ctx,
+                "cross-object-total",
+                f"SELECT total FROM cross_probe WHERE total <> {self.total} LIMIT 5",
+                history=self.recent_ts,
+            ),
+            GroupCompletenessPeek(
+                rngs[16],
+                self.ctx,
+                "ledger-atomicity",
+                LEDGER_TORN_SQL,
+                history=self.recent_ts,
+            ),
+            GroupCompletenessPeek(
+                rngs[17],
+                self.ctx,
+                "far-frontier-total",
+                "SELECT worker, seq, total FROM frontier_probe"
+                f" WHERE total <> {self.total} LIMIT 5",
+                history=self.recent_ts,
+            ),
+            OracleSkewPeek(rngs[18], self.ctx),
+        ]
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            client.query("SET cluster = quickstart")
+            direct = int(client.query("SELECT count(*) FROM ledger")[0][0])
+            client.query("SET cluster = compute")
+            via_mv = int(client.query("SELECT cnt FROM ledger_agg")[0][0])
+            return direct == via_mv
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "compute MVs catching up to tables")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        total = int(client.query("SELECT total FROM total")[0][0])
+        if total != self.total:
+            raise InvariantViolation(f"final total {total} != {self.total}")
+        broken = client.query(LEDGER_TORN_SQL, timeout=FINAL_TIMEOUT)
+        if broken:
+            raise InvariantViolation(f"non-atomic ledger transfers: {broken[:20]}")
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    f"SELECT seq FROM ledger WHERE worker = {worker} GROUP BY seq"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            issued = self.oplog.issued(worker)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
+                )
+            phantom = present - issued
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: transfers present that never committed:"
+                    f" {sorted(phantom)[:20]}"
+                )
+        wrong = client.query(
+            f"SELECT total FROM cross_probe WHERE total <> {self.total} LIMIT 20"
+        )
+        if wrong:
+            raise InvariantViolation(
+                f"a transaction reading the total MV recorded {wrong}, not {self.total}"
+            )
+        wrong = client.query(
+            "SELECT worker, seq, total FROM frontier_probe"
+            f" WHERE total <> {self.total} LIMIT 20"
+        )
+        if wrong:
+            raise InvariantViolation(
+                f"a read-then-write over a far-future frontier recorded {wrong},"
+                f" not {self.total}"
+            )
+        # A frontier-derived write timestamp leaves the oracle out in the
+        # future durably, so a run is only usable at the end if this holds.
+        skew = int(client.query(OracleSkewPeek.QUERY)[0][0])
+        if skew > ORACLE_SKEW_LIMIT_MS:
+            raise InvariantViolation(
+                f"the write timeline's oracle ended {skew}ms ahead of the wall clock"
+            )
+        swap_total = int(client.query("SELECT total FROM blue.total_swap")[0][0])
+        if swap_total != self.total:
+            raise InvariantViolation(
+                f"final swapped-schema total {swap_total} != {self.total}"
+            )
+        self._check_registry(client)
+        # Temporal filter drain: with the workload quiesced, the short
+        # window's rows must all be retracted once the window has passed.
+        # Bounded by the 60s window plus host/server clock skew slack.
+        wait_until(
+            lambda: int(client.query("SELECT cnt FROM recent_short")[0][0]) == 0,
+            180,
+            "temporal filter retracting expired rows",
+        )
+        client.reset()
+        self._history_audit(client_end_ts=None)
+
+    def _check_registry(self, client: MzClient) -> None:
+        """The final row per key must be admissible given its op log.
+
+        Replays each key's ops over the set of possible states: COMMITTED
+        ops apply to every possible state, UNKNOWN ops fork it. All
+        statements are idempotent, so applying an op is a function of the
+        current state only.
+        """
+        actual: dict[tuple[int, int], int] = {}
+        for row in client.query("SELECT worker, key, ver FROM registry"):
+            worker, key, ver = (int(v) for v in row)
+            if (worker, key) in actual:
+                raise InvariantViolation(
+                    f"registry key ({worker}, {key}) has multiple rows"
+                )
+            actual[(worker, key)] = ver
+
+        def apply(op: tuple, state: int | None) -> int | None:
+            kind, ver = op
+            if kind == "insert":
+                return state if state is not None else ver
+            if kind == "update":
+                return ver if state is not None else None
+            return None
+
+        for (worker, key), log in self.registry_log.items():
+            possible: set[int | None] = {None}
+            for entry in log:
+                if entry["outcome"] == Outcome.FAILED:
+                    continue
+                applied = {apply(entry["op"], s) for s in possible}
+                if entry["outcome"] == Outcome.COMMITTED:
+                    possible = applied
+                else:
+                    possible |= applied
+            got = actual.get((worker, key))
+            if got not in possible:
+                raise InvariantViolation(
+                    f"registry key ({worker}, {key}): final state {got} not"
+                    f" admissible ({sorted(str(s) for s in possible)[:20]})"
+                )
+
+    def _history_audit(self, client_end_ts: int | None) -> None:
+        """Replay the entire retained history, validating every boundary.
+
+        Live checkers legitimately skip rounds during disruptions, this
+        audit retroactively closes those gaps: a subscribe from the earliest
+        retained timestamp must show the conserved total at every boundary
+        of the whole run.
+        """
+        client = MzClient(self.ctx, "history-audit-now")
+        end_ts = int(client.query("SELECT mz_now()::text")[0][0])
+        client.reset()
+        rng = random.Random(self.ctx.rng.randrange(SEED_RANGE))
+        # The ledger count has a dense history (unlike the constant total),
+        # so its replay meaningfully covers every timestamp of the run.
+        audit = LedgerCountAudit(rng, self.ctx)
+        # An exact AS OF: AS OF AT LEAST would let the server pick the
+        # current timestamp and skip the history. Clamped into the RETAIN
+        # HISTORY window for runs longer than the retention.
+        as_of = max(self.setup_ts, end_ts - 480_000)
+        audit.as_of_clause = f"AS OF {as_of}"
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline:
+            try:
+                audit.check_once()
+            except TransientError:
+                continue
+            if (
+                audit.last_validated_ts is not None
+                and audit.last_validated_ts >= end_ts
+            ):
+                audit.close()
+                self.ctx.log.log(
+                    "phase",
+                    f"history audit: {audit.validations} boundaries replayed",
+                )
+                # Far fewer boundaries than the audited window must contain
+                # means the audit did not actually start in the past.
+                if audit.validations < 50:
+                    raise InvariantViolation(
+                        f"vacuous history audit: only {audit.validations}"
+                        " boundaries replayed"
+                    )
+                self._up_to_replay(as_of, end_ts)
+                return
+        audit.close()
+        raise InvariantViolation(
+            "liveness: the history audit did not reach the current timestamp"
+        )
+
+    def _up_to_replay(self, as_of: int, end_ts: int) -> None:
+        """A bounded SUBSCRIBE .. UP TO terminates, stays inside the bound,
+        and folds to the state at the bound.
+
+        Executed as a direct statement, not a cursor: UP TO makes the
+        subscription finite, so the statement completing at all is the
+        termination check. NOTE: deliberately run without PROGRESS, since
+        with UP TO no progress message is ever emitted, the fold is
+        validated against a direct read instead.
+        TODO: Reenable when SQL-528 is fixed: run the history audit's
+        per-boundary validation WITH (PROGRESS) UP TO instead of this
+        end-state fold.
+        The workload is quiesced and end_ts postdates it, so the folded
+        count must equal the current one.
+        """
+        client = MzClient(self.ctx, "up-to-replay")
+        try:
+            rows = client.query(
+                f"SUBSCRIBE (SELECT cnt FROM ledger_agg)"
+                f" AS OF {as_of} UP TO {end_ts}",
+                timeout=120,
+            )
+        except TransientError as e:
+            raise InvariantViolation(
+                f"liveness: SUBSCRIBE UP TO {end_ts} did not terminate: {e}"
+            ) from e
+        if not rows:
+            raise InvariantViolation("SUBSCRIBE UP TO emitted no snapshot")
+        state: dict[int, int] = {}
+        for row in rows:
+            ts, diff, cnt = int(row[0]), int(row[1]), int(row[2])
+            if ts >= end_ts:
+                raise InvariantViolation(
+                    f"update at {ts} at or beyond the exclusive UP TO bound"
+                    f" {end_ts}"
+                )
+            state[cnt] = state.get(cnt, 0) + diff
+            if state[cnt] == 0:
+                del state[cnt]
+        current = int(client.query("SELECT cnt FROM ledger_agg")[0][0])
+        client.reset()
+        if state != {current: 1}:
+            raise InvariantViolation(
+                f"bounded replay folded to {state}, current count is {current}"
+            )
+        self.ctx.log.log("phase", f"bounded UP TO replay: {len(rows)} updates folded")
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        for cluster in ("quickstart", "compute"):
+            try:
+                client.query(f"SET cluster = {cluster}")
+                rows = client.query("SELECT total FROM total", timeout=60)
+                verdict = (
+                    "still wrong" if int(rows[0][0]) != self.total else "converged"
+                )
+                self.ctx.log.log(
+                    "diag", f"post-heal total on {cluster}: {rows} ({verdict})"
+                )
+            except Exception as e:
+                self.ctx.log.log("diag", f"post-heal total on {cluster}: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/table_bank.py
+++ b/misc/python/materialize/invariants/scenarios/table_bank.py
@@ -26,9 +26,10 @@ blue/green schema pair cut over via ALTER SCHEMA SWAP, and replacement
 materialized views applied in place).
 """
 
+import math
 import random
 import time
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from materialize.invariants.checkers import PeekChecker, SubscribeChecker
@@ -61,6 +62,72 @@ REGISTRY_KEYS = 8
 TOTAL_DEF = (
     "SELECT (SELECT coalesce(sum(balance), 0) FROM accounts)"
     " + (SELECT coalesce(sum(amount), 0) FROM ledger) AS total"
+)
+
+# Values a summed invariant cannot see. `tag` and `amount_dec` are derived
+# from the op id, so every row is checkable on its own, which catches a
+# corruption that keeps the count and the sum intact. `flt` carries the float
+# values whose comparison and statistics handling has been wrong before
+# (NaN, negative zero, infinities), and `day` is nullable, so predicates over
+# both pull persist's filter pushdown into the checked path.
+FLOAT_TEXTS = ["0", "-0", "1e-320", "NaN", "Infinity", "-Infinity", "0.5"]
+# Must match the literal in PredicateDifferentialPeek.PREDICATES.
+DAY_CUT = date(2024, 1, 1)
+
+
+def _derived(worker: int, seq: int, amount: int) -> tuple[str, str, str, str | None]:
+    """The derived columns of one ledger row, as text: dec, tag, flt, day."""
+    dec = f"{amount / 1_000_000:.6f}"
+    tag = f"w{worker}-s{seq}"
+    flt = FLOAT_TEXTS[abs(seq) % len(FLOAT_TEXTS)]
+    # NULL every fifth row, so IS NULL predicates have something to find.
+    day = (
+        None
+        if abs(seq) % 5 == 0
+        else (date(2020, 1, 1) + timedelta(days=abs(seq) % 3000)).isoformat()
+    )
+    return dec, tag, flt, day
+
+
+# Only table-bank's ledger has the derived columns. The other scenarios reuse
+# these actions against a plain (worker, seq, account, amount, at) table, so
+# every write path takes the shape as a flag rather than assuming the wide one.
+LEDGER_COLS = "worker, seq, account, amount, at"
+LEDGER_COLS_DERIVED = f"{LEDGER_COLS}, amount_dec, tag, flt, day"
+
+
+def ledger_values(
+    worker: int, seq: int, account: int, amount: int, derived: bool
+) -> str:
+    """One ledger row literal, with the derived columns when the table has them."""
+    base = f"{worker}, {seq}, {account}, {amount}, now()"
+    if not derived:
+        return f"({base})"
+    dec, tag, flt, day = _derived(worker, seq, amount)
+    day_sql = "NULL" if day is None else f"DATE '{day}'"
+    return f"({base}, {dec}, '{tag}', '{flt}'::double, {day_sql})"
+
+
+def ledger_copy_row(
+    worker: int, seq: int, account: int, amount: int, at: str, derived: bool
+) -> str:
+    """The same row in COPY's text format, NULL spelled the way COPY wants."""
+    base = f"{worker}\t{seq}\t{account}\t{amount}\t{at}"
+    if not derived:
+        return f"{base}\n"
+    dec, tag, flt, day = _derived(worker, seq, amount)
+    # COPY's text format spells NULL as \N. Bound outside the f-string, whose
+    # expression part may not contain a backslash before Python 3.12.
+    day_text = "\\N" if day is None else day
+    return f"{base}\t{dec}\t{tag}\t{flt}\t{day_text}\n"
+
+
+# The row-level contract of the derived columns, as SQL over `ledger`. Checked
+# per row rather than in aggregate: a swapped or rewritten row keeps both the
+# count and the sum, and only this notices.
+DERIVED_ROW_CONTRACT = (
+    "tag <> 'w' || worker::text || '-s' || seq::text"
+    " OR amount_dec <> amount * 0.000001"
 )
 
 
@@ -99,12 +166,15 @@ class LedgerTransfer(Action):
         accounts: int,
         client: MzClient,
         oplog: OpLog,
+        derived: bool = False,
     ) -> None:
         super().__init__(rng)
         self.worker = worker
         self.accounts = accounts
         self.client = client
+        self.ctx = client.ctx
         self.oplog = oplog
+        self.derived = derived
         self.seq = 0
         # Committed transfers not yet reversed, consumed by ReversalTransfer.
         self.reversible: list[int] = []
@@ -114,8 +184,8 @@ class LedgerTransfer(Action):
         seq = self.seq
         src, dst = self.rng.sample(range(self.accounts), 2)
         amount = self.rng.randint(1, 100)
-        debit = f"({self.worker}, {seq}, {src}, {-amount}, now())"
-        credit = f"({self.worker}, {seq}, {dst}, {amount}, now())"
+        debit = ledger_values(self.worker, seq, src, -amount, self.derived)
+        credit = ledger_values(self.worker, seq, dst, amount, self.derived)
         # Register before sending: if this thread dies mid-call the op still
         # counts as possibly-applied.
         self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
@@ -133,7 +203,30 @@ class LedgerTransfer(Action):
         self.oplog.record(self.worker, seq, outcome)
         if outcome == Outcome.COMMITTED:
             self.reversible.append(seq)
+            self._read_back(seq)
         return outcome
+
+    def _read_back(self, seq: int) -> None:
+        """A committed write must be visible to the session that wrote it.
+
+        Read-your-writes is a guarantee no timestamp-free invariant covers, and
+        it is the one a stale read breaks first. The read goes through this
+        action's own client, on purpose: another session may legitimately be
+        behind. A read that fails or times out under disruption raises
+        TransientError, which the worker loop treats as a skipped op.
+        """
+        if self.rng.random() >= 0.25 or not self.ctx.checking.is_set():
+            return
+        rows = self.client.query(
+            f"SELECT count(*) FROM ledger WHERE worker = {self.worker}"
+            f" AND seq = {seq}"
+        )
+        if int(rows[0][0]) != ROWS_PER_TRANSFER:
+            raise InvariantViolation(
+                f"read-your-writes: worker {self.worker} committed op {seq} and"
+                f" its own session then saw {rows[0][0]} of"
+                f" {ROWS_PER_TRANSFER} rows"
+            )
 
     def close(self) -> None:
         self.client.reset()
@@ -170,8 +263,14 @@ class ReversalTransfer(Action):
             self.rng.randrange(len(self.forward.reversible))
         )
         self.oplog.record(self.worker, -seq, Outcome.UNKNOWN)
+        derived_cols = (
+            ", -amount_dec, 'w' || worker::text || '-s' || (-seq)::text, flt, day"
+            if self.forward.derived
+            else ""
+        )
         outcome = self.client.write(
             "INSERT INTO ledger SELECT worker, -seq, account, -amount, now()"
+            f"{derived_cols}"
             f" FROM ledger WHERE worker = {self.worker} AND seq = {seq}"
         )
         self.oplog.record(self.worker, -seq, outcome)
@@ -215,14 +314,13 @@ class CopyTransfer(Action):
         # here, and the temporal-filter windows are wide enough to absorb
         # clock skew between host and server.
         at = datetime.now(UTC).isoformat()
-        data = (
-            f"{self.worker}\t{seq}\t{src}\t{-amount}\t{at}\n"
-            f"{self.worker}\t{seq}\t{dst}\t{amount}\t{at}\n"
-        )
+        derived = self.forward.derived
+        data = ledger_copy_row(
+            self.worker, seq, src, -amount, at, derived
+        ) + ledger_copy_row(self.worker, seq, dst, amount, at, derived)
+        cols = LEDGER_COLS_DERIVED if derived else LEDGER_COLS
         self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
-        outcome = self.client.copy_in(
-            "COPY ledger (worker, seq, account, amount, at) FROM STDIN", data
-        )
+        outcome = self.client.copy_in(f"COPY ledger ({cols}) FROM STDIN", data)
         self.oplog.record(self.worker, seq, outcome)
         if outcome == Outcome.COMMITTED:
             self.forward.reversible.append(seq)
@@ -314,6 +412,8 @@ class ReplacementChurn(Action):
     REPLACEMENT switches the definition while preserving the name and all
     downstream objects. Because the definition is identical, every existing
     total checker must keep seeing the exact total through the switch.
+
+    The cutover itself is currently disabled, see the TODO on SQL-603 in run().
     """
 
     name = "replacement"
@@ -375,9 +475,20 @@ class ReplacementChurn(Action):
             # run is shutting down. Leave the replacement for the next
             # cycle's drop.
             return Outcome.UNKNOWN
-        return self.client.write(
-            "ALTER MATERIALIZED VIEW total APPLY REPLACEMENT total_repl"
-        )
+        # TODO: Reenable when SQL-603 is fixed. Applying the replacement
+        # finalizes the collection it replaces while the replacement still
+        # holds a read hold on it, and an interrupted apply leaves that state
+        # durable. The next bootstrap then halts on it ("dependency since
+        # frontier is empty while dependent upper is not empty"), and so does
+        # every restart after that, so environmentd never comes back: nightly
+        # 17740 spent 139 boots in that loop. Creating, hydrating and dropping
+        # the replacement stays in, only the cutover is out, so the read hold
+        # and its removal are still exercised. The next cycle's DROP cleans up.
+        #
+        # return self.client.write(
+        #     "ALTER MATERIALIZED VIEW total APPLY REPLACEMENT total_repl"
+        # )
+        return Outcome.COMMITTED
 
     def close(self) -> None:
         self.client.reset()
@@ -514,6 +625,29 @@ class BankTotalPeek(PeekChecker):
             "bounded staleness 5s",
         ]
 
+    def _context(self, isolation: str) -> str:
+        """What the next occurrence needs in order to classify itself.
+
+        A peek that returns the wrong rows says nothing on its own about where
+        it went wrong. Naming the cluster and the isolation the read used, and
+        reading the object again on every cluster with the timestamp each read
+        picks, separates a wrong shard from one wrong replica, and a window
+        that has passed from one that is still open.
+        """
+        parts = [f"cluster={self.last_cluster}", f"isolation={isolation}"]
+        for cluster in self.clusters:
+            try:
+                self.client.query(f"SET cluster = {cluster}")
+                # mz_now() over an input relation is the read's own timestamp,
+                # unlike the input-free form (CPU-197).
+                rows = self.client.query(
+                    "SELECT total, mz_now()::text FROM total", timeout=20
+                )
+                parts.append(f"re-read on {cluster}: {rows}")
+            except Exception as e:
+                parts.append(f"re-read on {cluster} failed: {e}")
+        return "; ".join(parts)
+
     def check_once(self) -> None:
         # Conservation is timestamp-free, so it must hold under every
         # isolation level: staleness changes the chosen timestamp, never the
@@ -561,7 +695,7 @@ class BankTotalPeek(PeekChecker):
         ):
             raise InvariantViolation(
                 f"total mismatch via {query!r}: expected {expected_rows}x"
-                f" {self.scenario.total}, got {rows}"
+                f" {self.scenario.total}, got {rows} [{self._context(isolation)}]"
             )
         # Sample the watermark that feeds the history probe. `SELECT mz_now()`
         # has no inputs, and for such a constant query the coordinator answers
@@ -595,11 +729,18 @@ class LedgerDirectPeek(PeekChecker):
         # before the read was issued.
         low = ROWS_PER_TRANSFER * oplog.committed_count()
         watermark = self.scenario.ledger_rows.get()
-        rows = self.peek("SELECT count(*), coalesce(sum(amount), 0) FROM ledger")
+        rows = self.peek(
+            "SELECT count(*), coalesce(sum(amount), 0),"
+            " coalesce(sum(amount_dec), 0) FROM ledger"
+        )
         high = ROWS_PER_TRANSFER * oplog.attempted_count()
-        count, amount_sum = int(rows[0][0]), int(rows[0][1])
+        count, amount_sum, dec_sum = int(rows[0][0]), int(rows[0][1]), rows[0][2]
         if amount_sum != 0:
             raise InvariantViolation(f"ledger sum {amount_sum} != 0 (count {count})")
+        # The same conservation in numeric arithmetic, which has its own
+        # encoding and scale handling.
+        if float(dec_sum) != 0.0:
+            raise InvariantViolation(f"ledger decimal sum {dec_sum} != 0")
         if count < watermark:
             raise InvariantViolation(
                 f"ledger count went backwards: {count} < watermark {watermark}"
@@ -613,6 +754,212 @@ class LedgerDirectPeek(PeekChecker):
                 f"ledger count {count} exceeds attempted transfers (<= {high} expected)"
             )
         self.scenario.ledger_rows.advance(count)
+        self.validations += 1
+
+
+class LedgerIdentityPeek(PeekChecker):
+    """Row-level reconciliation of a window of one worker's ledger rows.
+
+    The conserved sum and the counted bounds are blind to a corruption that
+    keeps both intact: a lost transfer masked by a duplicated one, a rewritten
+    account or tag, a pair that is present twice. This checks the identities
+    instead, over a bounded window so it stays cheap, and it remembers what it
+    saw: an op id that was there once must never be gone again, which no
+    aggregate can express.
+    """
+
+    # Ops per worker examined per round. The newest ones are where a write
+    # that is still settling would show up.
+    WINDOW = 200
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "ledger-identity", ["quickstart", "compute"])
+        self.scenario = scenario
+        # Op ids this checker has already observed, per worker. Nothing ever
+        # deletes ledger rows, so these may never disappear.
+        self.seen: dict[int, set[int]] = {}
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        worker = self.rng.randrange(self.ctx.complexity.workers)
+        # Sampling order as in LedgerDirectPeek: what must be present is
+        # sampled before the read, what may at most be present after it. An op
+        # issued while the read is in flight is legitimately in its result, and
+        # comparing it against a pre-read sample would report it as a phantom.
+        committed = oplog.seqs(worker, Outcome.COMMITTED)
+        issued = oplog.issued(worker)
+        if not issued:
+            return
+        # Bound the window by op id magnitude, so reversals (negative ids) of
+        # transfers in the window come along.
+        floor = max(abs(seq) for seq in issued) - self.WINDOW
+        rows = self.peek(
+            f"SELECT seq, count(*), coalesce(sum(amount), 0),"
+            f" count(*) FILTER (WHERE {DERIVED_ROW_CONTRACT})"
+            f" FROM ledger WHERE worker = {worker} AND abs(seq) > {floor}"
+            f" GROUP BY seq"
+        )
+        # Everything the read may legitimately contain, including ops issued
+        # while it was in flight.
+        issued_after = oplog.issued(worker)
+        present = set()
+        for seq, count, amount_sum, bad_rows in rows:
+            seq, count = int(seq), int(count)
+            present.add(seq)
+            if count != ROWS_PER_TRANSFER or int(amount_sum) != 0:
+                raise InvariantViolation(
+                    f"worker {worker} op {seq}: {count} rows summing to"
+                    f" {amount_sum}, expected {ROWS_PER_TRANSFER} summing to 0"
+                )
+            if int(bad_rows) != 0:
+                raise InvariantViolation(
+                    f"worker {worker} op {seq}: {bad_rows} rows whose derived"
+                    " columns do not match their op id"
+                )
+        missing = {seq for seq in committed if abs(seq) > floor} - present
+        if missing:
+            raise InvariantViolation(
+                f"worker {worker}: committed ops absent: {sorted(missing)[:20]}"
+            )
+        phantom = present - issued_after
+        if phantom:
+            raise InvariantViolation(
+                f"worker {worker}: ops never issued: {sorted(phantom)[:20]}"
+            )
+        seen = self.seen.setdefault(worker, set())
+        vanished = {seq for seq in seen if abs(seq) > floor} - present
+        if vanished:
+            raise InvariantViolation(
+                f"worker {worker}: ops disappeared after being observed:"
+                f" {sorted(vanished)[:20]}"
+            )
+        seen |= present
+        self.validations += 1
+
+
+class LedgerRowsSubscribe(SubscribeChecker):
+    """Row-level validation of the ledger's change stream.
+
+    Subscribes without a snapshot, so the cost is independent of how large the
+    table has grown, and judges the stream itself rather than an aggregate of
+    it: the ledger is append-only, so a retraction is a bug outright, and both
+    rows of a transfer are written in one statement, so every op id that
+    appears at a completed timestamp must appear exactly twice and sum to zero.
+    """
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(
+            rng,
+            ctx,
+            "ledger-rows-subscribe",
+            "SELECT worker, seq, account, amount FROM ledger",
+            snapshot=False,
+            append_only=True,
+        )
+        self.scenario = scenario
+
+    # Rows to carry before starting a fresh subscription, so the per-round
+    # validation stays cheap however long the run is.
+    STATE_LIMIT = 4000
+
+    def check_once(self) -> None:
+        super().check_once()
+        if len(self._state) > self.STATE_LIMIT:
+            self.recycle()
+
+    def validate_state(self, state: dict[tuple, int], ts: int) -> None:
+        per_op: dict[tuple[int, int], tuple[int, int]] = {}
+        for row, count in state.items():
+            worker, seq, _account, amount = row
+            if count != 1:
+                raise InvariantViolation(f"row {row} present {count} times at {ts}")
+            rows, total = per_op.get((int(worker), int(seq)), (0, 0))
+            per_op[(int(worker), int(seq))] = (rows + 1, total + int(amount))
+        for (worker, seq), (rows, total) in per_op.items():
+            if rows != ROWS_PER_TRANSFER or total != 0:
+                raise InvariantViolation(
+                    f"worker {worker} op {seq} at {ts}: {rows} rows summing to"
+                    f" {total} in the change stream"
+                )
+            if not self.scenario.oplog.was_issued(worker, seq):
+                raise InvariantViolation(
+                    f"worker {worker} op {seq} at {ts} was never issued"
+                )
+
+
+class PredicateDifferentialPeek(PeekChecker):
+    """Predicates over the float and date columns, judged two ways.
+
+    An aggregate with a predicate lets persist skip parts by their statistics,
+    and getting that wrong is silent: the answer is simply too small. So the
+    same predicate is also evaluated on the client, over the rows the same
+    transaction returns, and the two must agree. The values chosen are the ones
+    whose statistics handling has been wrong before: NaN, negative zero, the
+    infinities, a denormal, and a nullable date.
+
+    Only predicates whose truth does not depend on where NaN sorts are used,
+    so this checks statistics handling and not float ordering semantics.
+    """
+
+    # Ops per worker read back per round, as in LedgerIdentityPeek.
+    WINDOW = 200
+
+    PREDICATES: list[tuple[str, Any]] = [
+        (
+            "flt < 0",
+            lambda flt, day: flt is not None and not math.isnan(flt) and flt < 0,
+        ),
+        (
+            "flt = 0",
+            lambda flt, day: flt is not None and not math.isnan(flt) and flt == 0,
+        ),
+        (
+            "flt = 'NaN'::double precision",
+            lambda flt, day: flt is not None and math.isnan(flt),
+        ),
+        ("day IS NULL", lambda flt, day: day is None),
+        (
+            "day > DATE '2024-01-01'",
+            lambda flt, day: day is not None and day > DAY_CUT,
+        ),
+    ]
+
+    def __init__(self, rng, ctx, scenario: "TableBank") -> None:
+        super().__init__(rng, ctx, "predicate-differential", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        worker = self.rng.randrange(self.ctx.complexity.workers)
+        issued = oplog.issued(worker)
+        if not issued:
+            return
+        floor = max(abs(seq) for seq in issued) - self.WINDOW
+        predicate, on_client = self.rng.choice(self.PREDICATES)
+        window = f"FROM ledger WHERE worker = {worker} AND abs(seq) > {floor}"
+        cluster = self.clusters[self._round % len(self.clusters)]
+        self._round += 1
+        self.client.query(f"SET cluster = {cluster}")
+        # One read-only transaction, so both statements read at the same
+        # timestamp and a disagreement cannot be staleness.
+        self.client.query("BEGIN")
+        try:
+            counted = int(
+                self.client.query(f"SELECT count(*) {window} AND ({predicate})")[0][0]
+            )
+            rows = self.client.query(f"SELECT flt, day {window}")
+        finally:
+            try:
+                self.client.query("COMMIT")
+            except Exception:
+                pass
+        recomputed = sum(1 for flt, day in rows if on_client(flt, day))
+        if counted != recomputed:
+            raise InvariantViolation(
+                f"worker {worker}: `{predicate}` counted {counted} of"
+                f" {len(rows)} rows, recomputing it over the same read gives"
+                f" {recomputed}"
+            )
         self.validations += 1
 
 
@@ -1016,8 +1363,13 @@ class TableBank(Scenario):
             f" {BALANCE_PER_ACCOUNT}",
             # RETAIN HISTORY on the base table keeps direct AS OF reads of
             # the ledger itself possible, besides the MVs.
+            # amount_dec, tag, flt and day are derived from the op id, see
+            # ledger_values: they make every row checkable on its own and put
+            # float and nullable-date predicates on the checked path.
             "CREATE TABLE ledger (worker int, seq bigint, account int,"
-            " amount bigint, at timestamptz) WITH (RETAIN HISTORY = FOR '600s')",
+            " amount bigint, at timestamptz, amount_dec numeric(38, 6),"
+            " tag text, flt double precision, day date)"
+            " WITH (RETAIN HISTORY = FOR '600s')",
             "CREATE TABLE registry (worker int, key int, ver bigint)",
             # RETAIN HISTORY keeps recent timestamps readable so the durable
             # subscribe checker can resume where it left off.
@@ -1059,7 +1411,9 @@ class TableBank(Scenario):
 
     def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
         client = MzClient(self.ctx, f"worker-{index}")
-        forward = LedgerTransfer(rng, index, self.accounts, client, self.oplog)
+        forward = LedgerTransfer(
+            rng, index, self.accounts, client, self.oplog, derived=True
+        )
         actions: list[Action] = [
             UpdateTransfer(rng, self.accounts, client),
             forward,
@@ -1081,10 +1435,13 @@ class TableBank(Scenario):
         return WorkerBundle(actions=actions, weights=weights)
 
     def checkers(self) -> list[Checker]:
-        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(10)]
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(13)]
         return [
             BankTotalPeek(rngs[0], self.ctx, self),
             LedgerDirectPeek(rngs[1], self.ctx, self),
+            LedgerIdentityPeek(rngs[10], self.ctx, self),
+            LedgerRowsSubscribe(rngs[11], self.ctx, self),
+            PredicateDifferentialPeek(rngs[12], self.ctx, self),
             BankTotalSubscribe(rngs[2], self.ctx, self),
             BankTotalSubscribe(
                 rngs[3], self.ctx, self, name="total-subscribe-durable", durable=True
@@ -1130,13 +1487,13 @@ class TableBank(Scenario):
                 )
             }
             committed = self.oplog.seqs(worker, Outcome.COMMITTED)
-            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            issued = self.oplog.issued(worker)
             missing = committed - present
             if missing:
                 raise InvariantViolation(
                     f"worker {worker}: committed transfers lost: {sorted(missing)[:20]}"
                 )
-            phantom = present - committed - unknown
+            phantom = present - issued
             if phantom:
                 raise InvariantViolation(
                     f"worker {worker}: transfers present that never committed:"

--- a/misc/python/materialize/invariants/scenarios/txn_probe.py
+++ b/misc/python/materialize/invariants/scenarios/txn_probe.py
@@ -1,0 +1,477 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Transaction semantics under disruption, with no domain invariant at all.
+
+Four write shapes, each with an oracle that holds at every timestamp whatever
+the disruptions did:
+
+* read-modify-write on a small contended key set, where every committed op
+  adds exactly one, so the sum is pinned between the committed and the
+  attempted op counts. A lost update is invisible to a conservation check,
+  which is what every other scenario has.
+* transactions that never commit (explicit ROLLBACK, an aborting statement
+  error, and a connection dropped mid-transaction). Their rows must never be
+  visible, which is the one completely unambiguous oracle here.
+* one transaction writing the same markers into three separate tables, so
+  txn-wal's multi-shard commit has to be atomic across shards. The three
+  tables must hold the same set of markers at every timestamp.
+* create/write/drop of scratch tables, which is the busiest lifecycle persist
+  has (register with txn-wal, write batches, forget, finalize, GC the trace
+  away) and which nothing else drives while a leg is severed.
+"""
+
+import random
+import time
+
+from materialize.invariants.checkers import (
+    GroupCompletenessPeek,
+    PeekChecker,
+    ReplicaDivergence,
+)
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+
+# The final check runs on a quiesced system and legitimately scans everything
+# the run wrote, which the per-query watchdog is not sized for: that watchdog
+# exists to stop a checker hanging during chaos, and cancelling a final-check
+# query instead reports a wedge that is really just a big honest query.
+FINAL_TIMEOUT = 600
+
+# Rows contended by the read-then-write action. Few enough that concurrent
+# workers collide on the same row, which is the case that can lose an update.
+COUNTER_KEYS = 8
+
+# Three separate shards written by one transaction, see MultiShardTxn.
+TXN_TABLES = ("txn_a", "txn_b", "txn_c")
+
+# Markers present in one of the three tables but not the next, in both
+# directions around the ring, so any asymmetry shows up.
+MULTI_SHARD_DIFF_SQL = " UNION ALL ".join(
+    f"(SELECT '{left}' AS present_in, worker, seq, idx FROM {left}"
+    f" EXCEPT ALL SELECT '{left}', worker, seq, idx FROM {right})"
+    for left, right in zip(TXN_TABLES, TXN_TABLES[1:] + TXN_TABLES[:1], strict=False)
+)
+
+# The maintained sum against the same sum recomputed from the table, in one
+# statement, so both sides are answered at one timestamp and a difference
+# cannot be explained by progress in between.
+COUNTER_MV_DIFF_SQL = (
+    "(SELECT total FROM counter_total"
+    " EXCEPT ALL SELECT coalesce(sum(n), 0) FROM counters)"
+    " UNION ALL"
+    " (SELECT coalesce(sum(n), 0) FROM counters"
+    " EXCEPT ALL SELECT total FROM counter_total)"
+)
+
+
+class ReadThenWrite(Action):
+    """Increment a counter, half of the time reading it back client-side.
+
+    A lost update is invisible to a conservation oracle: nothing moved, so
+    the sum still balances. This counts instead, and each committed op must
+    add exactly one.
+
+    The increment is a server-side read-modify-write, and half the time it is
+    preceded by a read of the same row on the same session, so a peek and a
+    write on one key interleave.
+    """
+
+    name = "read-then-write"
+
+    def __init__(
+        self, rng: random.Random, worker: int, client: MzClient, oplog: OpLog
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.oplog = oplog
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        seq = self.seq
+        key = self.rng.randrange(COUNTER_KEYS)
+        # Registered before sending: a thread that dies mid-call still counts
+        # as possibly-applied, which keeps the upper bound sound.
+        self.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        if self.rng.random() < 0.5:
+            # A read of the same row immediately before writing it, on the
+            # same session. NOTE: the increment cannot be moved inside an
+            # explicit transaction to make this a client-side
+            # read-then-write, because Materialize rejects UPDATE in a
+            # transaction block: multi-statement transactions are read-only
+            # or insert-only.
+            self.client.query(f"SELECT n FROM counters WHERE id = {key}")
+        outcome = self.client.write(f"UPDATE counters SET n = n + 1 WHERE id = {key}")
+        self.oplog.record(self.worker, seq, outcome)
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class CounterSumPeek(PeekChecker):
+    """The counters must account for every increment that committed.
+
+    Bounds, not equality, because an op whose outcome is unknown may or may
+    not have applied. Sampling order is the framework's rule: lower bound
+    before the read, upper bound after.
+    """
+
+    def __init__(self, rng, ctx, oplog: OpLog) -> None:
+        super().__init__(rng, ctx, "counter-sum", ["quickstart", "compute"])
+        self.oplog = oplog
+
+    def check_once(self) -> None:
+        low = self.oplog.committed_count()
+        rows = self.peek("SELECT coalesce(sum(n), 0) FROM counters")
+        high = self.oplog.attempted_count()
+        total = int(rows[0][0])
+        if not low <= total <= high:
+            raise InvariantViolation(
+                f"counter sum {total} outside [{low}, {high}] on"
+                f" {self.last_cluster}: increments were lost or duplicated"
+            )
+        self.validations += 1
+
+
+class RollbackNoop(Action):
+    """A transaction that never commits must leave nothing behind.
+
+    Rolled back and abandoned transactions are the one write path with a
+    completely unambiguous oracle: the rows must never be visible, at any
+    timestamp, whatever the disruptions did. Every other action here has to
+    reason about unknown outcomes, this one does not.
+
+    Three ways to not commit, because they end the transaction differently:
+    an explicit ROLLBACK, a statement error that aborts it, and dropping the
+    connection mid-transaction, which is the case a disruption produces on
+    its own and the one where a server-side mistake would actually commit.
+    """
+
+    name = "rollback"
+
+    def __init__(self, rng: random.Random, worker: int, ctx: ScenarioContext) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.ctx = ctx
+        self.client = MzClient(ctx, f"rollback-{worker}")
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        marker = self.worker * 10_000_000 + self.seq
+        style = self.rng.choice(["rollback", "error", "drop"])
+        try:
+            self.client.query("BEGIN")
+            self.client.query(f"INSERT INTO rollback_probe VALUES ({marker})")
+            if style == "rollback":
+                self.client.query("ROLLBACK")
+            elif style == "error":
+                try:
+                    # Aborts the transaction server-side. The INSERT above must
+                    # go with it.
+                    self.client.query("SELECT 1 / 0")
+                except Exception:
+                    pass
+                self.client.query("ROLLBACK")
+            else:
+                # No ROLLBACK: the connection just goes away with the
+                # transaction open.
+                self.client.hard_close()
+        except TransientError:
+            # The disruption ended the transaction for us, which is the same
+            # contract: it must not have committed.
+            self.client.reset()
+            raise
+        except Exception:
+            self.client.reset()
+        return Outcome.FAILED
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class RollbackProbePeek(PeekChecker):
+    """Nothing a rolled back transaction wrote may ever be visible."""
+
+    pause = (0.5, 2.0)
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "rollback-probe", ["quickstart", "compute"])
+
+    def check_once(self) -> None:
+        rows = self.peek("SELECT id FROM rollback_probe LIMIT 5")
+        if rows:
+            raise InvariantViolation(
+                f"rows from transactions that never committed are visible on"
+                f" {self.last_cluster}: {rows}"
+            )
+        self.validations += 1
+
+
+class MultiShardTxn(Action):
+    """One transaction writing the same markers to three separate tables.
+
+    A single-table write never makes txn-wal's multi-shard commit be atomic
+    across shards. Here one transaction touches three, which txn-wal commits
+    by registering all three batches in the txns shard at one timestamp and
+    applying them to each data shard afterwards. If a lost consensus response
+    left that half-applied, a marker would exist in some tables and not
+    others.
+
+    The invariant needs no bookkeeping: the three tables must hold exactly the
+    same set of markers at every timestamp, whether a given transaction
+    committed or not.
+    """
+
+    name = "multi-shard-txn"
+
+    def __init__(self, rng: random.Random, worker: int, client: MzClient) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        self.seq += 1
+        # A one-row-per-table transaction is a small target: a reader has to
+        # land in the gap between three single-row writes. Widening it to
+        # tens of rows widens that gap proportionally, which is the only
+        # lever this action has on how often a tear is observable.
+        rows = self.rng.randint(1, 20)
+        values = ", ".join(f"({self.worker}, {self.seq}, {i})" for i in range(rows))
+        return self.client.write_txn(
+            [(f"INSERT INTO {table} VALUES {values}", None) for table in TXN_TABLES]
+        )
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class ShardChurn(Action):
+    """Create, write, and drop scratch tables to churn persist shards.
+
+    A table's lifecycle is the busiest sequence persist has: register the
+    shard with txn-wal, write batches, forget it, finalize it (tombstone,
+    then GC the whole trace away). Doing it while the metadata leg is being
+    severed is the point: each step is a consensus write whose response can
+    be lost, and the shard is gone shortly after, which is when a botched
+    state transition stops being recoverable.
+
+    No checker reads these tables, so their contents never matter. What
+    matters is that the churn happens on the same envd and clusters the
+    invariants cover.
+    """
+
+    name = "shard-churn"
+
+    def __init__(
+        self, rng: random.Random, worker: int, client: MzClient, ctx: ScenarioContext
+    ) -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.client = client
+        self.ctx = ctx
+        self.next_at = 0.0
+        self.nonce = 0
+        # Names whose DROP outcome was not COMMITTED. An UNKNOWN drop may not
+        # have applied, and forgetting the name would leak the shard for the
+        # rest of the run.
+        self.maybe_alive: list[str] = []
+
+    def run(self) -> Outcome | None:
+        now = time.monotonic()
+        if now < self.next_at:
+            return None
+        self.next_at = now + self.rng.uniform(3.0, 10.0)
+
+        self.maybe_alive = [
+            name
+            for name in self.maybe_alive
+            if self.client.write(f"DROP TABLE IF EXISTS {name}") != Outcome.COMMITTED
+        ]
+
+        self.nonce += 1
+        name = f"churn_tbl_{self.worker}_{self.nonce}"
+        # The shard is registered with txn-wal and written for the first time
+        # in the next few hundred milliseconds, which is the window where a
+        # lost consensus response leaves a half-created shard behind. A
+        # timer-driven cut lands there only by luck.
+        self.ctx.request_disruption("shard-create")
+        outcome = self.client.write(f"CREATE TABLE {name} (a int, b text)")
+        if outcome == Outcome.FAILED:
+            return outcome
+        self.maybe_alive.append(name)
+        # Several small transactions rather than one big insert: each is its
+        # own txn-wal commit and data batch, so the shard accumulates batches
+        # to compact before it is dropped again.
+        for i in range(self.rng.randint(1, 5)):
+            self.client.write(
+                f"INSERT INTO {name} SELECT g, repeat('x', 100)"
+                f" FROM generate_series({i} * 50, {i} * 50 + 49) g"
+            )
+            # TODO: Reenable when SQL-616 and PER-59 are fixed. Evolving the
+            # schema
+            # mid-shard leaves batches written under both schemas in one
+            # shard, so the compaction that merges them has to migrate, and
+            # the registration is one more consensus write that a severed leg
+            # can leave in doubt. That last part is the problem: a restart
+            # re-runs the schema evolution against a persist shard that
+            # already carries it, and the coordinator panics on the mismatch
+            # instead of treating it as done (SQL-616).
+            #
+            # PER-59 is the sticky follow-on: once that evolution has failed,
+            # the catalog holds the new table version while the shard still
+            # only knows the old schema, so the next bootstrap registers the
+            # table with txn-wal presenting a desc the shard never registered
+            # and panics with "schema should be registered". That one repeats
+            # on every boot, so the environment does not come back.
+            if False and self.rng.random() < 0.3:
+                self.client.write(f"ALTER TABLE {name} ADD COLUMN c{i} int")
+        return outcome
+
+    def close(self) -> None:
+        self.client.reset()
+
+
+class TxnProbe(Scenario):
+    name = "txn-probe"
+    services: list[str] = []
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-compute",
+        "clusterd-compute2",
+        "pubsub-compute",
+        "pubsub-storage",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.oplog = OpLog()
+
+    def setup(self) -> None:
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            "CREATE TABLE counters (id int, n bigint)",
+            f"INSERT INTO counters SELECT generate_series(0, {COUNTER_KEYS - 1}), 0",
+            "CREATE TABLE rollback_probe (id bigint)",
+            *(
+                f"CREATE TABLE {table} (worker int, seq bigint, idx int)"
+                for table in TXN_TABLES
+            ),
+            # RETAIN HISTORY covers the timestamp the replica comparison
+            # probes, which is deliberately slightly in the past.
+            "CREATE MATERIALIZED VIEW counter_total IN CLUSTER compute"
+            " WITH (RETAIN HISTORY = FOR '600s') AS"
+            " SELECT coalesce(sum(n), 0) AS total FROM counters",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        client = MzClient(self.ctx, f"worker-{index}")
+        actions: list[Action] = [
+            ReadThenWrite(rng, index, client, self.oplog),
+            MultiShardTxn(rng, index, client),
+            RollbackNoop(rng, index, self.ctx),
+            ShardChurn(rng, index, client, self.ctx),
+        ]
+        # ShardChurn rate-limits itself, so its weight only decides how often
+        # a worker offers it the chance to run.
+        weights = [8, 6, 3, 2]
+        return WorkerBundle(actions=actions, weights=weights)
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(5)]
+        return [
+            CounterSumPeek(rngs[0], self.ctx, self.oplog),
+            RollbackProbePeek(rngs[1], self.ctx),
+            GroupCompletenessPeek(
+                rngs[2], self.ctx, "multi-shard-txn", MULTI_SHARD_DIFF_SQL
+            ),
+            GroupCompletenessPeek(
+                rngs[3], self.ctx, "counter-mv-agrees", COUNTER_MV_DIFF_SQL
+            ),
+            ReplicaDivergence(rngs[4], self.ctx, ("SELECT total FROM counter_total",)),
+        ]
+
+    def converge(self) -> None:
+        client = MzClient(self.ctx, "converge")
+
+        def caught_up() -> bool:
+            client.query("SET cluster = quickstart")
+            direct = int(client.query("SELECT coalesce(sum(n), 0) FROM counters")[0][0])
+            client.query("SET cluster = compute")
+            via_mv = int(client.query("SELECT total FROM counter_total")[0][0])
+            return direct == via_mv
+
+        wait_until(caught_up, CONVERGE_TIMEOUT, "the counter MV catching up")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        low = self.oplog.committed_count()
+        total = int(client.query("SELECT coalesce(sum(n), 0) FROM counters")[0][0])
+        high = self.oplog.attempted_count()
+        if not low <= total <= high:
+            raise InvariantViolation(
+                f"final counter sum {total} outside [{low}, {high}]:"
+                " read-then-write increments were lost or duplicated"
+            )
+        # An empty upper bound means no increment ever reached the server, so
+        # the bounds above hold for the wrong reason.
+        if high == 0:
+            raise InvariantViolation("vacuous run: no increment was ever attempted")
+        # How blunt the check above actually is. A read-modify-write cannot be
+        # reconciled after the fact the way an insert can, since one increment
+        # is indistinguishable from another, so every op whose outcome stayed
+        # unknown widens the window forever. That makes this the one oracle
+        # here that gets *weaker* the harder the run is disrupted, and it does
+        # so silently, so the width is reported and a window wider than the
+        # thing it is measuring fails: at that point it cannot see a loss.
+        width = (high - low) / high
+        self.ctx.log.log(
+            "stats",
+            f"counter oracle resolution: [{low}, {high}], window is"
+            f" {width:.1%} of the upper bound",
+        )
+        leaked = client.query("SELECT id FROM rollback_probe LIMIT 20")
+        if leaked:
+            raise InvariantViolation(
+                f"rows from transactions that never committed are visible: {leaked}"
+            )
+        half_applied = client.query(MULTI_SHARD_DIFF_SQL, timeout=FINAL_TIMEOUT)
+        if half_applied:
+            raise InvariantViolation(
+                f"multi-shard transactions half applied between {TXN_TABLES}:"
+                f" {half_applied[:20]}"
+            )
+        disagrees = client.query(COUNTER_MV_DIFF_SQL, timeout=FINAL_TIMEOUT)
+        if disagrees:
+            raise InvariantViolation(
+                f"the counter MV disagrees with the table it sums: {disagrees}"
+            )
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/webhook_set.py
+++ b/misc/python/materialize/invariants/scenarios/webhook_set.py
@@ -1,0 +1,324 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Uniquely-numbered events POSTed to a webhook source.
+
+The documented webhook contract: a 2xx response is returned only after the
+event was durably recorded, CHECK-rejected requests are definitely not
+recorded, and a JSON ARRAY body appends one row per element. That maps
+directly onto the op-outcome model: 2xx means COMMITTED (visible exactly
+once, since the harness never retries a request), a validation rejection
+means FAILED (must never appear), and timeouts or 5xx are UNKNOWN. The
+chaos phase cuts the metadata and blob legs and kills envd while POSTs are
+in flight, targeting exactly the durable-write-before-ack promise.
+
+A COUNTER load generator source runs alongside: its count only grows, at
+the configured tick cadence.
+"""
+
+import json
+import random
+import secrets
+
+from materialize.invariants.checkers import PeekChecker, ProgressPeek
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.scenarios.kafka_ledger import WorkerStatsSubscribe
+
+# Statuses that prove the server did not record the request. Validation
+# failures (400/401/403) happen before append, as do 404 (the source is not
+# resolvable, e.g. envd still booting), 413 (oversized body), and 429 (the
+# documented concurrent-request limit). Only 400/401/403 for a well-formed
+# authorized request are a bug, the others are legitimate under chaos.
+REJECTED_STATUSES = {400, 401, 403, 404, 413, 429}
+VALIDATION_STATUSES = {400, 401, 403}
+
+SENTINEL_WORKER = -1
+
+
+class PostEvents(Action):
+    """POST one event or a JSON ARRAY batch, sometimes with bad credentials.
+
+    Every element is registered as its own op: a 2xx commits them all, a
+    validation rejection fails them all, anything else leaves them UNKNOWN.
+    """
+
+    name = "post"
+
+    def __init__(self, rng: random.Random, worker: int, scenario: "WebhookSet") -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.scenario = scenario
+        self.session = None
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        import requests
+
+        if self.session is None:
+            self.session = requests.Session()
+        batch = self.rng.randint(1, 5) if self.rng.random() < 0.3 else 1
+        seqs = []
+        events = []
+        for _ in range(batch):
+            self.seq += 1
+            seqs.append(self.seq)
+            events.append({"worker": self.worker, "seq": self.seq})
+        bad_auth = self.rng.random() < 0.05
+        token = "wrong-token" if bad_auth else self.scenario.token
+        payload = events[0] if batch == 1 else events
+        for seq in seqs:
+            self.scenario.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        try:
+            response = self.session.post(
+                self.scenario.url,
+                data=json.dumps(payload),
+                headers={
+                    "content-type": "application/json",
+                    "authorization": token,
+                },
+                timeout=(5, self.scenario.ctx.complexity.query_timeout),
+            )
+        except Exception as e:
+            self.session = None
+            raise TransientError(f"webhook POST failed: {e}") from e
+        if 200 <= response.status_code < 300:
+            if bad_auth:
+                raise InvariantViolation(
+                    "webhook accepted a request that must fail validation"
+                )
+            outcome = Outcome.COMMITTED
+        elif response.status_code in REJECTED_STATUSES:
+            outcome = Outcome.FAILED
+        else:
+            outcome = Outcome.UNKNOWN
+        for seq in seqs:
+            self.scenario.oplog.record(self.worker, seq, outcome)
+        if not bad_auth and response.status_code in VALIDATION_STATUSES:
+            raise InvariantViolation(
+                f"webhook rejected a well-formed authorized request:"
+                f" {response.status_code} {response.text[:200]}"
+            )
+        return outcome
+
+    def close(self) -> None:
+        if self.session is not None:
+            self.session.close()
+
+
+class EventCountPeek(PeekChecker):
+    """Event count: monotonic and bounded by the op ledger."""
+
+    def __init__(self, rng, ctx, scenario: "WebhookSet") -> None:
+        super().__init__(rng, ctx, "events-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        watermark = self.scenario.event_rows.get()
+        rows = self.peek("SELECT count(*) FROM wh WHERE (body->>'worker')::int >= 0")
+        high = oplog.attempted_count()
+        count = int(rows[0][0])
+        if count < watermark:
+            raise InvariantViolation(
+                f"event count went backwards: {count} < watermark {watermark}"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"event count {count} exceeds attempted events {high}"
+            )
+        # NOTE: no live lower bound against acknowledged events: webhook data
+        # is source data, which linearizability does not cover, so an acked
+        # append may become readable only when the collection's frontier
+        # catches up. Loss of acknowledged events is enforced by the final
+        # reconciliation instead.
+        self.scenario.event_rows.advance(count)
+        self.validations += 1
+
+
+class CounterPeek(PeekChecker):
+    """The COUNTER load generator's count only grows."""
+
+    pause = (1.0, 3.0)
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "counter-peek", ["quickstart"])
+        self.last = 0
+
+    def check_once(self) -> None:
+        count = int(self.peek("SELECT count(*) FROM counter_tbl")[0][0])
+        if count < self.last:
+            raise InvariantViolation(
+                f"counter count went backwards: {count} < {self.last}"
+            )
+        self.last = count
+        self.validations += 1
+
+
+class WebhookSet(Scenario):
+    name = "webhook-set"
+    services: list[str] = []
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.oplog = OpLog()
+        self.event_rows = Watermark()
+        self.token = secrets.token_hex(16)
+        self.url = (
+            f"http://{ctx.endpoints.mz_host}:{ctx.endpoints.mz_http_port}"
+            "/api/webhook/materialize/public/wh"
+        )
+
+    def setup(self) -> None:
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            f"CREATE SECRET wh_secret AS '{self.token}'",
+            "CREATE SOURCE wh IN CLUSTER storage FROM WEBHOOK"
+            " BODY FORMAT JSON ARRAY"
+            " CHECK (WITH (HEADERS, SECRET wh_secret)"
+            " constant_time_eq(headers->'authorization', wh_secret))",
+            "CREATE SOURCE counter IN CLUSTER storage"
+            " FROM LOAD GENERATOR COUNTER (TICK INTERVAL '100ms')",
+            # A source ingests through its table exports: without one, the
+            # source never leaves the 'created' status.
+            "CREATE TABLE counter_tbl FROM SOURCE counter",
+            "CREATE MATERIALIZED VIEW worker_stats IN CLUSTER compute AS"
+            " SELECT (body->>'worker')::int AS worker, count(*) AS cnt,"
+            " max((body->>'seq')::bigint) AS max_seq FROM wh"
+            " WHERE (body->>'worker')::int >= 0 GROUP BY 1",
+            "CREATE INDEX worker_stats_idx IN CLUSTER compute"
+            " ON worker_stats (worker)",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        return WorkerBundle(actions=[PostEvents(rng, index, self)], weights=[1])
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(4)]
+        return [
+            EventCountPeek(rngs[0], self.ctx, self),
+            WorkerStatsSubscribe(rngs[1], self.ctx),
+            CounterPeek(rngs[2], self.ctx),
+            # Webhook sources report no frontier progress observable here,
+            # the load generator source stands in for the progress contract.
+            ProgressPeek(rngs[3], self.ctx, "counter"),
+        ]
+
+    def converge(self) -> None:
+        import requests
+
+        # Webhook appends are synchronous, so there is no ingestion lag to
+        # wait out. Liveness: a fresh POST must succeed again, and the
+        # counter must keep ticking. Each attempt uses a fresh seq so the
+        # duplicate check stays meaningful for sentinels too.
+        sentinel_seq = [0]
+
+        def webhook_live() -> bool:
+            sentinel_seq[0] += 1
+            try:
+                response = requests.post(
+                    self.url,
+                    data=json.dumps(
+                        {"worker": SENTINEL_WORKER, "seq": sentinel_seq[0]}
+                    ),
+                    headers={
+                        "content-type": "application/json",
+                        "authorization": self.token,
+                    },
+                    timeout=(5, 30),
+                )
+            except Exception as e:
+                raise TransientError(f"webhook POST failed: {e}") from e
+            return 200 <= response.status_code < 300
+
+        wait_until(webhook_live, CONVERGE_TIMEOUT, "webhook accepting requests")
+        client = MzClient(self.ctx, "converge")
+        # The baseline read runs inside the retried condition too: right
+        # after healing it can block long enough for the watchdog to cancel
+        # it, which must be a retry, not a scenario failure.
+        base: list[int | None] = [None]
+
+        def counter_ticking() -> bool:
+            count = int(client.query("SELECT count(*) FROM counter_tbl")[0][0])
+            if base[0] is None:
+                base[0] = count
+                return False
+            return count > base[0]
+
+        wait_until(counter_ticking, CONVERGE_TIMEOUT, "counter source ticking")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        duplicated = client.query(
+            "SELECT body->>'worker', body->>'seq', count(*) FROM wh"
+            " GROUP BY 1, 2 HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"webhook events recorded more than once: {duplicated[:20]}"
+            )
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    "SELECT (body->>'seq')::bigint FROM wh"
+                    f" WHERE (body->>'worker')::int = {worker}"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: acknowledged events lost:"
+                    f" {sorted(missing)[:20]}"
+                )
+            phantom = present - committed - unknown
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: events present that were rejected or"
+                    f" never sent: {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            client.query("SET cluster = quickstart")
+            rows = client.query("SELECT count(*) FROM wh", timeout=60)
+            counts = self.oplog.counts()
+            self.ctx.log.log("diag", f"post-heal: events={rows[0][0]} oplog={counts}")
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal event count failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/webhook_set.py
+++ b/misc/python/materialize/invariants/scenarios/webhook_set.py
@@ -1,0 +1,324 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Uniquely-numbered events POSTed to a webhook source.
+
+The documented webhook contract: a 2xx response is returned only after the
+event was durably recorded, CHECK-rejected requests are definitely not
+recorded, and a JSON ARRAY body appends one row per element. That maps
+directly onto the op-outcome model: 2xx means COMMITTED (visible exactly
+once, since the harness never retries a request), a validation rejection
+means FAILED (must never appear), and timeouts or 5xx are UNKNOWN. The
+chaos phase cuts the metadata and blob legs and kills envd while POSTs are
+in flight, targeting exactly the durable-write-before-ack promise.
+
+A COUNTER load generator source runs alongside: its count only grows, at
+the configured tick cadence.
+"""
+
+import json
+import random
+import secrets
+
+from materialize.invariants.checkers import PeekChecker, ProgressPeek
+from materialize.invariants.framework import (
+    CONVERGE_TIMEOUT,
+    SEED_RANGE,
+    Action,
+    Checker,
+    InvariantViolation,
+    OpLog,
+    Outcome,
+    Scenario,
+    ScenarioContext,
+    TransientError,
+    Watermark,
+    WorkerBundle,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.scenarios.kafka_ledger import WorkerStatsSubscribe
+
+# Statuses that prove the server did not record the request. Validation
+# failures (400/401/403) happen before append, as do 404 (the source is not
+# resolvable, e.g. envd still booting), 413 (oversized body), and 429 (the
+# documented concurrent-request limit). Only 400/401/403 for a well-formed
+# authorized request are a bug, the others are legitimate under chaos.
+REJECTED_STATUSES = {400, 401, 403, 404, 413, 429}
+VALIDATION_STATUSES = {400, 401, 403}
+
+SENTINEL_WORKER = -1
+
+
+class PostEvents(Action):
+    """POST one event or a JSON ARRAY batch, sometimes with bad credentials.
+
+    Every element is registered as its own op: a 2xx commits them all, a
+    validation rejection fails them all, anything else leaves them UNKNOWN.
+    """
+
+    name = "post"
+
+    def __init__(self, rng: random.Random, worker: int, scenario: "WebhookSet") -> None:
+        super().__init__(rng)
+        self.worker = worker
+        self.scenario = scenario
+        self.session = None
+        self.seq = 0
+
+    def run(self) -> Outcome | None:
+        import requests
+
+        if self.session is None:
+            self.session = requests.Session()
+        batch = self.rng.randint(1, 5) if self.rng.random() < 0.3 else 1
+        seqs = []
+        events = []
+        for _ in range(batch):
+            self.seq += 1
+            seqs.append(self.seq)
+            events.append({"worker": self.worker, "seq": self.seq})
+        bad_auth = self.rng.random() < 0.05
+        token = "wrong-token" if bad_auth else self.scenario.token
+        payload = events[0] if batch == 1 else events
+        for seq in seqs:
+            self.scenario.oplog.record(self.worker, seq, Outcome.UNKNOWN)
+        try:
+            response = self.session.post(
+                self.scenario.url,
+                data=json.dumps(payload),
+                headers={
+                    "content-type": "application/json",
+                    "authorization": token,
+                },
+                timeout=(5, self.scenario.ctx.complexity.query_timeout),
+            )
+        except Exception as e:
+            self.session = None
+            raise TransientError(f"webhook POST failed: {e}") from e
+        if 200 <= response.status_code < 300:
+            if bad_auth:
+                raise InvariantViolation(
+                    "webhook accepted a request that must fail validation"
+                )
+            outcome = Outcome.COMMITTED
+        elif response.status_code in REJECTED_STATUSES:
+            outcome = Outcome.FAILED
+        else:
+            outcome = Outcome.UNKNOWN
+        for seq in seqs:
+            self.scenario.oplog.record(self.worker, seq, outcome)
+        if not bad_auth and response.status_code in VALIDATION_STATUSES:
+            raise InvariantViolation(
+                f"webhook rejected a well-formed authorized request:"
+                f" {response.status_code} {response.text[:200]}"
+            )
+        return outcome
+
+    def close(self) -> None:
+        if self.session is not None:
+            self.session.close()
+
+
+class EventCountPeek(PeekChecker):
+    """Event count: monotonic and bounded by the op ledger."""
+
+    def __init__(self, rng, ctx, scenario: "WebhookSet") -> None:
+        super().__init__(rng, ctx, "events-peek", ["quickstart", "compute"])
+        self.scenario = scenario
+
+    def check_once(self) -> None:
+        oplog = self.scenario.oplog
+        watermark = self.scenario.event_rows.get()
+        rows = self.peek("SELECT count(*) FROM wh WHERE (body->>'worker')::int >= 0")
+        high = oplog.attempted_count()
+        count = int(rows[0][0])
+        if count < watermark:
+            raise InvariantViolation(
+                f"event count went backwards: {count} < watermark {watermark}"
+            )
+        if count > high:
+            raise InvariantViolation(
+                f"event count {count} exceeds attempted events {high}"
+            )
+        # NOTE: no live lower bound against acknowledged events: webhook data
+        # is source data, which linearizability does not cover, so an acked
+        # append may become readable only when the collection's frontier
+        # catches up. Loss of acknowledged events is enforced by the final
+        # reconciliation instead.
+        self.scenario.event_rows.advance(count)
+        self.validations += 1
+
+
+class CounterPeek(PeekChecker):
+    """The COUNTER load generator's count only grows."""
+
+    pause = (1.0, 3.0)
+
+    def __init__(self, rng, ctx) -> None:
+        super().__init__(rng, ctx, "counter-peek", ["quickstart"])
+        self.last = 0
+
+    def check_once(self) -> None:
+        count = int(self.peek("SELECT count(*) FROM counter_tbl")[0][0])
+        if count < self.last:
+            raise InvariantViolation(
+                f"counter count went backwards: {count} < {self.last}"
+            )
+        self.last = count
+        self.validations += 1
+
+
+class WebhookSet(Scenario):
+    name = "webhook-set"
+    services: list[str] = []
+    legs = [
+        "metadata",
+        "blob",
+        "clusterd-storage",
+        "clusterd-compute",
+        "clusterd-compute2",
+    ]
+
+    def __init__(self, ctx: ScenarioContext) -> None:
+        super().__init__(ctx)
+        self.oplog = OpLog()
+        self.event_rows = Watermark()
+        self.token = secrets.token_hex(16)
+        self.url = (
+            f"http://{ctx.endpoints.mz_host}:{ctx.endpoints.mz_http_port}"
+            "/api/webhook/materialize/public/wh"
+        )
+
+    def setup(self) -> None:
+        client = MzClient(self.ctx, "setup")
+        for sql in [
+            f"CREATE SECRET wh_secret AS '{self.token}'",
+            "CREATE SOURCE wh IN CLUSTER storage FROM WEBHOOK"
+            " BODY FORMAT JSON ARRAY"
+            " CHECK (WITH (HEADERS, SECRET wh_secret)"
+            " constant_time_eq(headers->'authorization', wh_secret))",
+            "CREATE SOURCE counter IN CLUSTER storage"
+            " FROM LOAD GENERATOR COUNTER (TICK INTERVAL '100ms')",
+            # A source ingests through its table exports: without one, the
+            # source never leaves the 'created' status.
+            "CREATE TABLE counter_tbl FROM SOURCE counter",
+            "CREATE MATERIALIZED VIEW worker_stats IN CLUSTER compute AS"
+            " SELECT (body->>'worker')::int AS worker, count(*) AS cnt,"
+            " max((body->>'seq')::bigint) AS max_seq FROM wh"
+            " WHERE (body->>'worker')::int >= 0 GROUP BY 1",
+            "CREATE INDEX worker_stats_idx IN CLUSTER compute"
+            " ON worker_stats (worker)",
+        ]:
+            client.query(sql, timeout=120)
+        client.reset()
+
+    def make_worker(self, index: int, rng: random.Random) -> WorkerBundle:
+        return WorkerBundle(actions=[PostEvents(rng, index, self)], weights=[1])
+
+    def checkers(self) -> list[Checker]:
+        rngs = [random.Random(self.ctx.rng.randrange(SEED_RANGE)) for _ in range(4)]
+        return [
+            EventCountPeek(rngs[0], self.ctx, self),
+            WorkerStatsSubscribe(rngs[1], self.ctx),
+            CounterPeek(rngs[2], self.ctx),
+            # Webhook sources report no frontier progress observable here,
+            # the load generator source stands in for the progress contract.
+            ProgressPeek(rngs[3], self.ctx, "counter"),
+        ]
+
+    def converge(self) -> None:
+        import requests
+
+        # Webhook appends are synchronous, so there is no ingestion lag to
+        # wait out. Liveness: a fresh POST must succeed again, and the
+        # counter must keep ticking. Each attempt uses a fresh seq so the
+        # duplicate check stays meaningful for sentinels too.
+        sentinel_seq = [0]
+
+        def webhook_live() -> bool:
+            sentinel_seq[0] += 1
+            try:
+                response = requests.post(
+                    self.url,
+                    data=json.dumps(
+                        {"worker": SENTINEL_WORKER, "seq": sentinel_seq[0]}
+                    ),
+                    headers={
+                        "content-type": "application/json",
+                        "authorization": self.token,
+                    },
+                    timeout=(5, 30),
+                )
+            except Exception as e:
+                raise TransientError(f"webhook POST failed: {e}") from e
+            return 200 <= response.status_code < 300
+
+        wait_until(webhook_live, CONVERGE_TIMEOUT, "webhook accepting requests")
+        client = MzClient(self.ctx, "converge")
+        # The baseline read runs inside the retried condition too: right
+        # after healing it can block long enough for the watchdog to cancel
+        # it, which must be a retry, not a scenario failure.
+        base: list[int | None] = [None]
+
+        def counter_ticking() -> bool:
+            count = int(client.query("SELECT count(*) FROM counter_tbl")[0][0])
+            if base[0] is None:
+                base[0] = count
+                return False
+            return count > base[0]
+
+        wait_until(counter_ticking, CONVERGE_TIMEOUT, "counter source ticking")
+        client.reset()
+
+    def final_check(self) -> None:
+        client = MzClient(self.ctx, "final-check")
+        client.query("SET cluster = quickstart")
+        duplicated = client.query(
+            "SELECT body->>'worker', body->>'seq', count(*) FROM wh"
+            " GROUP BY 1, 2 HAVING count(*) > 1"
+        )
+        if duplicated:
+            raise InvariantViolation(
+                f"webhook events recorded more than once: {duplicated[:20]}"
+            )
+        for worker in range(self.ctx.complexity.workers):
+            present = {
+                int(row[0])
+                for row in client.query(
+                    "SELECT (body->>'seq')::bigint FROM wh"
+                    f" WHERE (body->>'worker')::int = {worker}"
+                )
+            }
+            committed = self.oplog.seqs(worker, Outcome.COMMITTED)
+            issued = self.oplog.issued(worker)
+            missing = committed - present
+            if missing:
+                raise InvariantViolation(
+                    f"worker {worker}: acknowledged events lost:"
+                    f" {sorted(missing)[:20]}"
+                )
+            phantom = present - issued
+            if phantom:
+                raise InvariantViolation(
+                    f"worker {worker}: events present that were rejected or"
+                    f" never sent: {sorted(phantom)[:20]}"
+                )
+        client.reset()
+
+    def diagnostics(self) -> None:
+        client = MzClient(self.ctx, "post-heal")
+        try:
+            client.query("SET cluster = quickstart")
+            rows = client.query("SELECT count(*) FROM wh", timeout=60)
+            counts = self.oplog.counts()
+            self.ctx.log.log("diag", f"post-heal: events={rows[0][0]} oplog={counts}")
+        except Exception as e:
+            self.ctx.log.log("diag", f"post-heal event count failed: {e}")
+        client.reset()

--- a/misc/python/materialize/invariants/scenarios/webhook_set.py
+++ b/misc/python/materialize/invariants/scenarios/webhook_set.py
@@ -297,14 +297,14 @@ class WebhookSet(Scenario):
                 )
             }
             committed = self.oplog.seqs(worker, Outcome.COMMITTED)
-            unknown = self.oplog.seqs(worker, Outcome.UNKNOWN)
+            issued = self.oplog.issued(worker)
             missing = committed - present
             if missing:
                 raise InvariantViolation(
                     f"worker {worker}: acknowledged events lost:"
                     f" {sorted(missing)[:20]}"
                 )
-            phantom = present - committed - unknown
+            phantom = present - issued
             if phantom:
                 raise InvariantViolation(
                     f"worker {worker}: events present that were rejected or"

--- a/misc/python/materialize/invariants/toxiproxy.py
+++ b/misc/python/materialize/invariants/toxiproxy.py
@@ -123,7 +123,10 @@ class ToxiproxyApi:
         r = self.session.delete(
             f"{self.base_url}/proxies/{proxy_name}/toxics/{name}", timeout=30
         )
-        assert r.status_code in (200, 204), f"deleting toxic {name}: {r} {r.text}"
+        # 404 means already deleted: heals must be idempotent, since a
+        # disruptor cycle that outlived the join deadline re-heals toxics
+        # that stop_and_heal's heal-everything already removed.
+        assert r.status_code in (200, 204, 404), f"deleting toxic {name}: {r} {r.text}"
 
     def reset(self) -> None:
         """Re-enable all proxies and remove all toxics."""
@@ -274,15 +277,21 @@ class Disruptor(threading.Thread):
             key = (f"process:{victim.name}", "kill")
             self.coverage[key] = self.coverage.get(key, 0) + 1
             self.stop_event.wait(duration / 2)
-            try:
-                victim.heal()
-            except Exception as e:
-                self._record(f"heal of {victim.name} failed ({e}), continuing")
         else:
             self.stop_event.wait(duration)
         self.active.clear()
         for leg, kind in applied:
             self._heal(leg, kind)
+        if victim is not None:
+            # Heal the victim only after the legs: its heal blocks until the
+            # process serves again (docker compose --wait), which can never
+            # happen while e.g. its metadata leg is still cut, and a
+            # disruptor stuck here would leave the toxics applied through
+            # the converge phase (nightly 17376).
+            try:
+                victim.heal()
+            except Exception as e:
+                self._record(f"heal of {victim.name} failed ({e}), continuing")
         self.cycles += 1
         self._record(
             "healed " + ", ".join(f"{kind} on {leg.name}" for leg, kind in applied)
@@ -402,7 +411,16 @@ class Disruptor(threading.Thread):
         self.stop_event.set()
         self.join(timeout=60)
         if self.is_alive():
-            self.log.log("disrupt", "disruptor thread failed to stop in time")
+            # The disruptor is stuck, e.g. inside a process heal that waits
+            # for a container to serve again. Its toxics may still be
+            # applied, so heal from this thread: the converge phase must
+            # start from a clean network no matter what. The stuck thread
+            # is blocked in a subprocess call, not in the admin API, so
+            # sharing the API session here is safe in practice.
+            self.log.log(
+                "disrupt", "disruptor thread failed to stop in time, healing anyway"
+            )
+            self._heal_all_with_retries()
         else:
             # run() already healed in its finally block, but verify.
             try:

--- a/misc/python/materialize/invariants/toxiproxy.py
+++ b/misc/python/materialize/invariants/toxiproxy.py
@@ -1,0 +1,411 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Toxiproxy administration and the disruptor thread.
+
+A `Leg` is one logical connection of the system under test (e.g. the
+envd<->clusterd gRPC pair, or the source's Postgres connection), backed by
+one or more toxiproxy proxies that are always disrupted and healed together.
+Every disruption is paired with its heal, and stopping the disruptor heals
+everything, so the converge phase always starts from a clean network.
+"""
+
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import requests
+
+from materialize.invariants.framework import EventLog, TransientError
+
+DISRUPTION_KINDS = ["disable", "latency", "timeout", "limit_data", "bandwidth"]
+
+# Kinds that cut the connection entirely, subject to Leg.max_outage.
+FULL_OUTAGE_KINDS = {"disable", "timeout"}
+
+
+@dataclass(frozen=True)
+class Proxy:
+    name: str
+    listen_port: int
+    upstream: str
+
+
+@dataclass(frozen=True)
+class Leg:
+    name: str
+    proxies: tuple[Proxy, ...]
+    # Cap on full-outage disruptions. The metadata leg fronts persist
+    # consensus, whose reader leases expire after 15 minutes and make
+    # clusterd halt, so its outages must stay well below that.
+    max_outage: float | None = None
+    # Allowed disruption kinds, None means all. High-volume legs (persist
+    # blob) exclude the buffering toxics: latency and bandwidth hold the
+    # leg's entire in-flight traffic in toxiproxy's memory.
+    kinds: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class ProcessTarget:
+    """A process the disruptor may SIGKILL or SIGSTOP, with paired heals.
+
+    `heal` must be idempotent and block until the process serves again (for
+    containers with a restart policy it can be a no-op up()). Pauses are
+    capped like full outages: a paused clusterd stops renewing its persist
+    leases, which expire after 15 minutes.
+    """
+
+    name: str
+    kill: Callable[[], None]
+    heal: Callable[[], None]
+    pause: Callable[[], None]
+    unpause: Callable[[], None]
+    max_outage: float = 120.0
+
+
+class ToxiproxyApi:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+        self.session = requests.Session()
+
+    def create(self, proxy: Proxy) -> None:
+        r = self.session.post(
+            f"{self.base_url}/proxies",
+            json={
+                "name": proxy.name,
+                "listen": f"0.0.0.0:{proxy.listen_port}",
+                "upstream": proxy.upstream,
+                "enabled": True,
+            },
+            timeout=30,
+        )
+        assert r.status_code == 201, f"creating proxy {proxy.name}: {r} {r.text}"
+
+    def set_enabled(self, proxy_name: str, enabled: bool) -> None:
+        r = self.session.post(
+            f"{self.base_url}/proxies/{proxy_name}",
+            json={"enabled": enabled},
+            timeout=30,
+        )
+        assert r.status_code == 200, f"toggling proxy {proxy_name}: {r} {r.text}"
+
+    def add_toxic(
+        self,
+        proxy_name: str,
+        name: str,
+        type_: str,
+        attributes: dict,
+        stream: str = "downstream",
+    ) -> None:
+        r = self.session.post(
+            f"{self.base_url}/proxies/{proxy_name}/toxics",
+            json={
+                "name": name,
+                "type": type_,
+                "stream": stream,
+                "attributes": attributes,
+            },
+            timeout=30,
+        )
+        assert (
+            r.status_code == 200
+        ), f"adding toxic {name} to {proxy_name}: {r} {r.text}"
+
+    def delete_toxic(self, proxy_name: str, name: str) -> None:
+        r = self.session.delete(
+            f"{self.base_url}/proxies/{proxy_name}/toxics/{name}", timeout=30
+        )
+        assert r.status_code in (200, 204), f"deleting toxic {name}: {r} {r.text}"
+
+    def reset(self) -> None:
+        """Re-enable all proxies and remove all toxics."""
+        r = self.session.post(f"{self.base_url}/reset", timeout=30)
+        assert r.status_code == 204, f"toxiproxy reset: {r} {r.text}"
+
+    def proxies(self) -> dict:
+        r = self.session.get(f"{self.base_url}/proxies", timeout=30)
+        assert r.status_code == 200, f"listing proxies: {r} {r.text}"
+        return r.json()
+
+    def assert_healed(self) -> None:
+        for name, proxy in self.proxies().items():
+            assert proxy["enabled"], f"proxy {name} still disabled"
+            assert not proxy[
+                "toxics"
+            ], f"proxy {name} still has toxics: {proxy['toxics']}"
+
+
+class Disruptor(threading.Thread):
+    """Applies random disruption/heal cycles to the scenario's legs."""
+
+    def __init__(
+        self,
+        api: ToxiproxyApi,
+        legs: list[Leg],
+        rng: random.Random,
+        log: EventLog,
+        interval: tuple[float, float],
+        duration: tuple[float, float],
+        concurrent: int,
+        on_error: Callable[[Exception], None],
+        processes: list[ProcessTarget] | None = None,
+    ) -> None:
+        super().__init__(name="disruptor")
+        self.api = api
+        self.legs = legs
+        self.rng = rng
+        self.log = log
+        self.interval = interval
+        self.duration = duration
+        self.concurrent = concurrent
+        self.on_error = on_error
+        self.processes = processes or []
+        self.stop_event = threading.Event()
+        self.cycles = 0
+        # Set while any disruption is applied, read by the executor to
+        # attribute checker validations to disruption windows.
+        self.active = threading.Event()
+        # (target, kind) -> count, the end-of-run coverage report.
+        self.coverage: dict[tuple[str, str], int] = {}
+        # Written only by this thread, read by others after join or for
+        # diagnostics (appends are atomic enough for that purpose).
+        self.history: list[str] = []
+
+    def _record(self, message: str) -> None:
+        self.history.append(f"{time.strftime('%H:%M:%S')} {message}")
+        self.log.log("disrupt", message)
+
+    def run(self) -> None:
+        try:
+            # A deterministic first sweep disrupts every leg once, so no leg
+            # can go uncovered by rng accident.
+            for leg in self.legs:
+                if self.stop_event.is_set():
+                    return
+                self._leg_cycle(duration_scale=0.3, only=leg)
+                if self.stop_event.wait(self.rng.uniform(1.0, 5.0)):
+                    return
+            while not self.stop_event.wait(self.rng.uniform(*self.interval)):
+                # Occasionally a storm: several short back-to-back
+                # disruptions followed by a longer calm window, verifying
+                # that the system recovers repeatedly, not just once at the
+                # end of the run.
+                if self.rng.random() < 0.2:
+                    self._record("storm starting")
+                    for _ in range(self.rng.randint(2, 4)):
+                        self._one_cycle(duration_scale=0.4)
+                        if self.stop_event.wait(self.rng.uniform(1.0, 5.0)):
+                            return
+                    self._record("storm over, calm window")
+                    if self.stop_event.wait(self.rng.uniform(*self.interval)):
+                        return
+                else:
+                    self._one_cycle()
+                    # The post-heal window is where crash-recovery bugs have
+                    # historically surfaced: deliberately follow some heals
+                    # with an immediate process kill.
+                    if self.processes and self.rng.random() < 0.3:
+                        if self.stop_event.wait(self.rng.uniform(2.0, 5.0)):
+                            return
+                        self._process_cycle(duration_scale=0.3, kind="kill")
+        except Exception as e:
+            self.on_error(e)
+        finally:
+            self._heal_all_with_retries()
+
+    def _one_cycle(self, duration_scale: float = 1.0) -> None:
+        try:
+            roll = self.rng.random()
+            if self.processes and roll < 0.15:
+                # A leg cut overlapping a process kill, the combination that
+                # produced the unbounded-buffering finding.
+                self._leg_cycle(duration_scale, overlap_kill=True)
+            elif self.processes and roll < 0.35:
+                self._process_cycle(duration_scale)
+            else:
+                self._leg_cycle(duration_scale)
+        except requests.RequestException as e:
+            # The toxiproxy admin API can stall while the host is overloaded
+            # (e.g. right after an envd restart). A lost cycle is not a
+            # failure, but nothing may stay disrupted.
+            self._record(f"cycle failed ({e}), healing everything")
+            self._heal_all_with_retries()
+
+    def _leg_cycle(
+        self,
+        duration_scale: float,
+        only: Leg | None = None,
+        overlap_kill: bool = False,
+    ) -> None:
+        if only is not None:
+            targets = [only]
+        else:
+            count = min(len(self.legs), self.rng.randint(1, self.concurrent))
+            targets = self.rng.sample(self.legs, count)
+        victim = self.rng.choice(self.processes) if overlap_kill else None
+        duration = self.rng.uniform(*self.duration) * duration_scale
+        applied: list[tuple[Leg, str]] = []
+        for leg in targets:
+            kind = self.rng.choice(list(leg.kinds or DISRUPTION_KINDS))
+            if kind in FULL_OUTAGE_KINDS and leg.max_outage is not None:
+                duration = min(duration, leg.max_outage)
+            self._apply(leg, kind)
+            applied.append((leg, kind))
+            key = (leg.name, kind)
+            self.coverage[key] = self.coverage.get(key, 0) + 1
+        self.active.set()
+        self._record(
+            "applied "
+            + ", ".join(f"{kind} on {leg.name}" for leg, kind in applied)
+            + (f" overlapping kill of {victim.name}" if victim else "")
+            + f" for {duration:.1f}s"
+        )
+        if victim is not None:
+            self.stop_event.wait(duration / 2)
+            victim.kill()
+            key = (f"process:{victim.name}", "kill")
+            self.coverage[key] = self.coverage.get(key, 0) + 1
+            self.stop_event.wait(duration / 2)
+            try:
+                victim.heal()
+            except Exception as e:
+                self._record(f"heal of {victim.name} failed ({e}), continuing")
+        else:
+            self.stop_event.wait(duration)
+        self.active.clear()
+        for leg, kind in applied:
+            self._heal(leg, kind)
+        self.cycles += 1
+        self._record(
+            "healed " + ", ".join(f"{kind} on {leg.name}" for leg, kind in applied)
+        )
+
+    def _process_cycle(self, duration_scale: float, kind: str | None = None) -> None:
+        target = self.rng.choice(self.processes)
+        kind = kind or self.rng.choice(["kill", "pause"])
+        duration = min(
+            self.rng.uniform(*self.duration) * duration_scale, target.max_outage
+        )
+        key = (f"process:{target.name}", kind)
+        self.coverage[key] = self.coverage.get(key, 0) + 1
+        self.active.set()
+        self._record(f"applied {kind} on process {target.name} for {duration:.1f}s")
+        if kind == "kill":
+            target.kill()
+            self.stop_event.wait(duration)
+            try:
+                target.heal()
+            except Exception as e:
+                # The up can race a crash-looping restart policy and observe
+                # an unhealthy moment. Whether the process actually serves
+                # again is the converge phase's assertion, not the heal's.
+                self._record(f"heal of {target.name} failed ({e}), continuing")
+        else:
+            target.pause()
+            self.stop_event.wait(duration)
+            target.unpause()
+        self.active.clear()
+        self.cycles += 1
+        self._record(f"healed {kind} on process {target.name}")
+
+    def _apply(self, leg: Leg, kind: str) -> None:
+        # Toxics attach to one direction only, so half of the disruptions
+        # are asymmetric: one side of the connection keeps hearing the other.
+        stream = self.rng.choice(["downstream", "upstream"])
+        for proxy in leg.proxies:
+            if kind == "disable":
+                self.api.set_enabled(proxy.name, False)
+            elif kind == "latency":
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "latency",
+                    {
+                        "latency": self.rng.randint(100, 3000),
+                        "jitter": self.rng.randint(0, 1000),
+                    },
+                    stream=stream,
+                )
+            elif kind == "timeout":
+                # timeout=0 holds the connection open and drops all data.
+                self.api.add_toxic(
+                    proxy.name, kind, "timeout", {"timeout": 0}, stream=stream
+                )
+            elif kind == "limit_data":
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "limit_data",
+                    {"bytes": self.rng.randint(128, 65536)},
+                    stream=stream,
+                )
+            elif kind == "bandwidth":
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "bandwidth",
+                    {"rate": self.rng.randint(1, 64)},
+                    stream=stream,
+                )
+            else:
+                raise ValueError(f"unknown disruption kind {kind}")
+
+    def _heal(self, leg: Leg, kind: str) -> None:
+        for proxy in leg.proxies:
+            if kind == "disable":
+                self.api.set_enabled(proxy.name, True)
+            else:
+                self.api.delete_toxic(proxy.name, kind)
+
+    def _heal_all_with_retries(self) -> None:
+        for target in self.processes:
+            try:
+                target.unpause()
+            except Exception:
+                pass
+            try:
+                target.heal()
+            except Exception as e:
+                self._record(f"heal of {target.name} failed ({e}), continuing")
+        deadline = time.monotonic() + 60
+        while True:
+            try:
+                self.api.reset()
+                # A crashed and restarted toxiproxy comes back empty. The
+                # legs' proxies must exist again before anything reconnects.
+                existing = self.api.proxies()
+                for leg in self.legs:
+                    for proxy in leg.proxies:
+                        if proxy.name not in existing:
+                            self._record(f"re-creating lost proxy {proxy.name}")
+                            self.api.create(proxy)
+                self.api.assert_healed()
+                self._record("all legs healed")
+                return
+            except Exception as e:
+                if time.monotonic() > deadline:
+                    self.on_error(
+                        TransientError(f"failed to heal toxiproxy state: {e}")
+                    )
+                    return
+                time.sleep(1)
+
+    def stop_and_heal(self) -> None:
+        self.stop_event.set()
+        self.join(timeout=60)
+        if self.is_alive():
+            self.log.log("disrupt", "disruptor thread failed to stop in time")
+        else:
+            # run() already healed in its finally block, but verify.
+            try:
+                self.api.assert_healed()
+            except Exception:
+                self._heal_all_with_retries()

--- a/misc/python/materialize/invariants/toxiproxy.py
+++ b/misc/python/materialize/invariants/toxiproxy.py
@@ -93,6 +93,16 @@ class ToxiproxyApi:
         self.base_url = base_url
         self.session = requests.Session()
 
+    def rebind(self, base_url: str) -> None:
+        """Point at a restarted toxiproxy and drop the old connections.
+
+        A recreated container is published on a fresh ephemeral host port, so
+        every client that cached the old mapping is stranded on it.
+        """
+        self.base_url = base_url
+        self.session.close()
+        self.session = requests.Session()
+
     @staticmethod
     def _check(r: requests.Response, ok: tuple[int, ...], what: str) -> None:
         if r.status_code >= 500:

--- a/misc/python/materialize/invariants/toxiproxy.py
+++ b/misc/python/materialize/invariants/toxiproxy.py
@@ -1,0 +1,787 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Toxiproxy administration and the disruptor thread.
+
+A `Leg` is one logical connection of the system under test (e.g. the
+envd<->clusterd gRPC pair, or the source's Postgres connection), backed by
+one or more toxiproxy proxies that are always disrupted and healed together.
+Every disruption is paired with its heal, and stopping the disruptor heals
+everything, so the converge phase always starts from a clean network.
+"""
+
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import requests
+
+from materialize.invariants.framework import EventLog, TransientError
+
+DISRUPTION_KINDS = [
+    "disable",
+    "latency",
+    "timeout",
+    "limit_data",
+    "bandwidth",
+    "reset_peer",
+    "flap",
+    "slicer",
+    "slow_close",
+]
+
+# Faults applied to a process rather than to one of its connections.
+PROCESS_KINDS = {"kill", "pause", "crash_loop", "throttle"}
+
+# Kinds that cut the connection entirely, subject to Leg.max_outage.
+FULL_OUTAGE_KINDS = {"disable", "timeout", "reset_peer", "flap"}
+
+
+# Sentinel distinguishing "the run is over" from "the timer expired" (None)
+# and from a trigger reason (a string, possibly empty).
+_STOPPED = object()
+
+
+class ApiStalled(Exception):
+    """A toxiproxy admin API call did not finish, so its outcome is unknown.
+
+    Toxiproxy answers a request whose handler overruns its deadline with Go's
+    default 503 timeout page and leaves the handler running behind it, so the
+    call may still take effect afterwards. Removing a toxic does this when the
+    toxic's goroutine is blocked writing to a socket whose peer was just
+    SIGKILLed, which is exactly what a leg cut overlapping a process kill sets
+    up. Recovery is the same as for a dropped admin connection: heal
+    everything, then verify.
+    """
+
+
+@dataclass(frozen=True)
+class Proxy:
+    name: str
+    listen_port: int
+    upstream: str
+
+
+@dataclass(frozen=True)
+class Leg:
+    name: str
+    proxies: tuple[Proxy, ...]
+    # Cap on full-outage disruptions. The metadata leg fronts persist
+    # consensus, whose reader leases expire after 15 minutes and make
+    # clusterd halt, so its outages must stay well below that.
+    max_outage: float | None = None
+    # Allowed disruption kinds, None means all. High-volume legs (persist
+    # blob) exclude the buffering toxics: latency and bandwidth hold the
+    # leg's entire in-flight traffic in toxiproxy's memory.
+    kinds: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class ProcessTarget:
+    """A process the disruptor may SIGKILL or SIGSTOP, with paired heals.
+
+    `heal` must be idempotent and block until the process serves again (for
+    containers with a restart policy it can be a no-op up()). Pauses are
+    capped like full outages: a paused clusterd stops renewing its persist
+    leases, which expire after 15 minutes.
+
+    None of the four may assume the process is still the one the previous
+    call saw. Anything else in the test can replace it, so all four are free
+    to fail and the disruptor treats that as a lost cycle.
+
+    `kill` and `heal` must also tolerate the container being paused, by
+    something else in the test or by a `pause` whose `unpause` was lost:
+    docker refuses to start a paused container and does not reliably kill
+    one, so both have to unpause first.
+    """
+
+    name: str
+    kill: Callable[[], None]
+    heal: Callable[[], None]
+    pause: Callable[[], None]
+    unpause: Callable[[], None]
+    max_outage: float = 120.0
+    # Squeeze the process's CPU allowance and restore it. Optional, and only
+    # offered as a disruption kind when both are present. Unlike everything
+    # else here this degrades the process without touching the network, which
+    # is what surfaces deadlines that are really assumptions about how fast a
+    # healthy peer answers.
+    throttle: Callable[[], None] | None = None
+    unthrottle: Callable[[], None] | None = None
+
+
+class ToxiproxyApi:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+        self.session = requests.Session()
+
+    def rebind(self, base_url: str) -> None:
+        """Point at a restarted toxiproxy and drop the old connections.
+
+        A recreated container is published on a fresh ephemeral host port, so
+        every client that cached the old mapping is stranded on it.
+        """
+        self.base_url = base_url
+        self.session.close()
+        self.session = requests.Session()
+
+    @staticmethod
+    def _check(r: requests.Response, ok: tuple[int, ...], what: str) -> None:
+        if r.status_code >= 500:
+            raise ApiStalled(f"{what}: {r} {r.text}")
+        assert r.status_code in ok, f"{what}: {r} {r.text}"
+
+    def create(self, proxy: Proxy) -> None:
+        r = self.session.post(
+            f"{self.base_url}/proxies",
+            json={
+                "name": proxy.name,
+                "listen": f"0.0.0.0:{proxy.listen_port}",
+                "upstream": proxy.upstream,
+                "enabled": True,
+            },
+            timeout=30,
+        )
+        self._check(r, (201,), f"creating proxy {proxy.name}")
+
+    def set_enabled(self, proxy_name: str, enabled: bool) -> None:
+        r = self.session.post(
+            f"{self.base_url}/proxies/{proxy_name}",
+            json={"enabled": enabled},
+            timeout=30,
+        )
+        self._check(r, (200,), f"toggling proxy {proxy_name}")
+
+    def add_toxic(
+        self,
+        proxy_name: str,
+        name: str,
+        type_: str,
+        attributes: dict,
+        stream: str = "downstream",
+    ) -> None:
+        r = self.session.post(
+            f"{self.base_url}/proxies/{proxy_name}/toxics",
+            json={
+                "name": name,
+                "type": type_,
+                "stream": stream,
+                "attributes": attributes,
+            },
+            timeout=30,
+        )
+        self._check(r, (200,), f"adding toxic {name} to {proxy_name}")
+
+    def delete_toxic(self, proxy_name: str, name: str) -> None:
+        r = self.session.delete(
+            f"{self.base_url}/proxies/{proxy_name}/toxics/{name}", timeout=30
+        )
+        # 404 means already deleted: heals must be idempotent, since a
+        # disruptor cycle that outlived the join deadline re-heals toxics
+        # that stop_and_heal's heal-everything already removed.
+        self._check(r, (200, 204, 404), f"deleting toxic {name}")
+
+    def reset(self) -> None:
+        """Re-enable all proxies and remove all toxics."""
+        r = self.session.post(f"{self.base_url}/reset", timeout=30)
+        self._check(r, (204,), "toxiproxy reset")
+
+    def proxies(self) -> dict:
+        r = self.session.get(f"{self.base_url}/proxies", timeout=30)
+        self._check(r, (200,), "listing proxies")
+        return r.json()
+
+    def assert_healed(self) -> None:
+        for name, proxy in self.proxies().items():
+            assert proxy["enabled"], f"proxy {name} still disabled"
+            assert not proxy[
+                "toxics"
+            ], f"proxy {name} still has toxics: {proxy['toxics']}"
+
+
+class Disruptor(threading.Thread):
+    """Applies random disruption/heal cycles to the scenario's legs."""
+
+    def __init__(
+        self,
+        api: ToxiproxyApi,
+        legs: list[Leg],
+        rng: random.Random,
+        log: EventLog,
+        interval: tuple[float, float],
+        duration: tuple[float, float],
+        concurrent: int,
+        on_error: Callable[[Exception], None],
+        processes: list[ProcessTarget] | None = None,
+        restore_proxies: list[Proxy] | None = None,
+        restart_toxiproxy: Callable[[], None] | None = None,
+        kind_filter: set[str] | None = None,
+    ) -> None:
+        super().__init__(name="disruptor")
+        self.api = api
+        self.legs = legs
+        self.rng = rng
+        self.log = log
+        self.interval = interval
+        self.duration = duration
+        self.concurrent = concurrent
+        self.on_error = on_error
+        self.processes = processes or []
+        # Restricts every choice below to these kinds, for verifying one kind
+        # or bisecting which one causes a failure. A leg or process left with
+        # no allowed kind is skipped rather than disrupted some other way.
+        self.kind_filter = kind_filter
+        # Last resort for an admin API that no longer answers, see
+        # _heal_network_with_retries.
+        self.restart_toxiproxy = restart_toxiproxy
+        # Re-created after a toxiproxy crash-restart. The harness may have
+        # created proxies beyond this scenario's legs (e.g. for a cluster the
+        # scenario does not disrupt), and losing those would strand their
+        # connections for the rest of the run.
+        self.restore_proxies = (
+            restore_proxies
+            if restore_proxies is not None
+            else [proxy for leg in legs for proxy in leg.proxies]
+        )
+        self.stop_event = threading.Event()
+        # Set by the workload to ask for a cut right now, see request_cycle.
+        self.trigger = threading.Event()
+        self.trigger_reason = ""
+        self.triggered = 0
+        self._last_trigger = 0.0
+        # Shortest gap between two triggered cuts. The high end of the timer
+        # interval, so triggered cuts are no more frequent than timer-driven
+        # ones and untargeted coverage survives.
+        self.trigger_min_gap = interval[1]
+        self.cycles = 0
+        # Set while any disruption is applied, read by the executor to
+        # attribute checker validations to disruption windows.
+        self.active = threading.Event()
+        # (target, kind) -> count, the end-of-run coverage report.
+        self.coverage: dict[tuple[str, str], int] = {}
+        # Written only by this thread, read by others after join or for
+        # diagnostics (appends are atomic enough for that purpose).
+        self.history: list[str] = []
+
+    def _record(self, message: str) -> None:
+        self.history.append(f"{time.strftime('%H:%M:%S')} {message}")
+        self.log.log("disrupt", message)
+
+    def request_cycle(self, reason: str) -> None:
+        """Ask for a disruption now, from the workload thread that knows why.
+
+        Timer-driven cuts land wherever they land, and the states worth
+        cutting through are brief: a catalog transaction committing, a shard
+        being registered, a schema evolving. The workload is the only thing
+        that knows when it is inside one, so it says so and the disruptor
+        cuts immediately.
+
+        Rate limited, because these fire far more often than the timer would
+        and a run made entirely of triggered cuts covers only the triggered
+        moments. Requests are dropped, never queued: a cut that arrives after
+        the moment has passed is just an untargeted cut.
+
+        NOTE: this makes the disruption sequence depend on workload timing,
+        so a `--seed` replay reproduces the same *choices* but not
+        necessarily at the same points.
+        """
+        now = time.monotonic()
+        if now - self._last_trigger < self.trigger_min_gap:
+            return
+        self._last_trigger = now
+        self.trigger_reason = reason
+        self.trigger.set()
+
+    def _attempt(self, what: str, action: Callable[[], None]) -> None:
+        """Run a process disruption or heal, tolerating a lost race.
+
+        Another part of the test may replace the process underneath the
+        disruptor: the midrun upgrade swap kills and re-creates the very
+        containers this cycle targets. A kill then finds its target already
+        dead, and an unpause a fresh container that was never paused, both
+        of which the orchestrator reports as errors. Neither is a test
+        failure: a disruption that does not land only loses coverage, and
+        whether the process serves again is the converge phase's assertion,
+        not a heal's.
+        """
+        try:
+            action()
+        except Exception as e:
+            self._record(f"{what} failed ({e}), continuing")
+
+    def run(self) -> None:
+        try:
+            # A deterministic first sweep disrupts every leg once, so no leg
+            # can go uncovered by rng accident.
+            for leg in self.legs:
+                if self.stop_event.is_set():
+                    return
+                self._one_cycle(duration_scale=0.3, only=leg)
+                if self.stop_event.wait(self.rng.uniform(1.0, 5.0)):
+                    return
+            while True:
+                reason = self._wait_for_next_cycle()
+                if reason is _STOPPED:
+                    return
+                if reason is not None:
+                    # A cut aimed at the state the workload just announced,
+                    # short so it lands inside it rather than around it.
+                    self.triggered += 1
+                    self._record(f"triggered by {reason}")
+                    self._one_cycle(duration_scale=0.25)
+                    key = ("trigger", str(reason))
+                    self.coverage[key] = self.coverage.get(key, 0) + 1
+                    continue
+                # Occasionally a storm: several short back-to-back
+                # disruptions followed by a longer calm window, verifying
+                # that the system recovers repeatedly, not just once at the
+                # end of the run.
+                if self.rng.random() < 0.2:
+                    self._record("storm starting")
+                    for _ in range(self.rng.randint(2, 4)):
+                        self._one_cycle(duration_scale=0.4)
+                        if self.stop_event.wait(self.rng.uniform(1.0, 5.0)):
+                            return
+                    self._record("storm over, calm window")
+                    if self.stop_event.wait(self.rng.uniform(*self.interval)):
+                        return
+                else:
+                    self._one_cycle()
+                    # The post-heal window is where crash-recovery bugs have
+                    # historically surfaced: deliberately follow some heals
+                    # with an immediate process kill.
+                    if self.processes and self.rng.random() < 0.3:
+                        if self.stop_event.wait(self.rng.uniform(2.0, 5.0)):
+                            return
+                        self._process_cycle(duration_scale=0.3, kind="kill")
+        except Exception as e:
+            self.on_error(e)
+        finally:
+            self._heal_all_with_retries()
+
+    def _wait_for_next_cycle(self) -> object:
+        """Block until the next cycle is due.
+
+        Returns the trigger reason if the workload asked for one, None if the
+        timer expired, and `_STOPPED` if the run is over.
+        """
+        deadline = time.monotonic() + self.rng.uniform(*self.interval)
+        while True:
+            if self.stop_event.is_set():
+                return _STOPPED
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            # Capped so a stop is noticed promptly even with no trigger.
+            if self.trigger.wait(min(remaining, 1.0)):
+                self.trigger.clear()
+                if self.stop_event.is_set():
+                    return _STOPPED
+                return self.trigger_reason
+
+    def _one_cycle(self, duration_scale: float = 1.0, only: Leg | None = None) -> None:
+        try:
+            # `only` draws no roll, so the rng stream is the one a seed
+            # replays whether or not the first sweep goes through here.
+            if only is not None:
+                self._leg_cycle(duration_scale, only=only)
+            else:
+                roll = self.rng.random()
+                if self.processes and roll < 0.15:
+                    # A leg cut overlapping a process kill, the combination
+                    # that produced the unbounded-buffering finding.
+                    self._leg_cycle(duration_scale, overlap_kill=True)
+                elif self.processes and roll < 0.35:
+                    self._process_cycle(duration_scale)
+                else:
+                    self._leg_cycle(duration_scale)
+        except (requests.RequestException, ApiStalled) as e:
+            # The toxiproxy admin API can stall or drop the connection while
+            # the host is overloaded (e.g. right after an envd restart). A lost
+            # cycle is not a failure, but nothing may stay disrupted.
+            self._record(f"cycle failed ({e}), healing everything")
+            self._heal_all_with_retries()
+
+    def _leg_cycle(
+        self,
+        duration_scale: float,
+        only: Leg | None = None,
+        overlap_kill: bool = False,
+    ) -> None:
+        if only is not None:
+            targets = [only]
+        else:
+            count = min(len(self.legs), self.rng.randint(1, self.concurrent))
+            targets = self.rng.sample(self.legs, count)
+        targets = [leg for leg in targets if self._allowed_kinds(leg)]
+        if not targets:
+            return
+        victim = self.rng.choice(self.processes) if overlap_kill else None
+        duration = self.rng.uniform(*self.duration) * duration_scale
+        applied: list[tuple[Leg, str, tuple[Proxy, ...]]] = []
+        for leg in targets:
+            kind = self.rng.choice(self._allowed_kinds(leg))
+            if kind in FULL_OUTAGE_KINDS and leg.max_outage is not None:
+                duration = min(duration, leg.max_outage)
+            proxies = self._proxy_subset(leg)
+            self._apply(leg, kind, proxies)
+            applied.append((leg, kind, proxies))
+            key = (leg.name, kind)
+            self.coverage[key] = self.coverage.get(key, 0) + 1
+        self.active.set()
+        self._record(
+            "applied "
+            + ", ".join(
+                f"{kind} on {leg.name}"
+                + ("" if len(proxies) == len(leg.proxies) else f"/{proxies[0].name}")
+                for leg, kind, proxies in applied
+            )
+            + (f" overlapping kill of {victim.name}" if victim else "")
+            + f" for {duration:.1f}s"
+        )
+        flapping = [(leg, proxies) for leg, kind, proxies in applied if kind == "flap"]
+        if victim is not None:
+            self._wait_out(duration / 2, flapping)
+            self._attempt(f"kill of {victim.name}", victim.kill)
+            key = (f"process:{victim.name}", "kill")
+            self.coverage[key] = self.coverage.get(key, 0) + 1
+            self._wait_out(duration / 2, flapping)
+        else:
+            self._wait_out(duration, flapping)
+        self.active.clear()
+        for leg, kind, proxies in applied:
+            self._heal(leg, kind, proxies)
+        if victim is not None:
+            # Heal the victim only after the legs: its heal blocks until the
+            # process serves again (docker compose --wait), which can never
+            # happen while e.g. its metadata leg is still cut, and a
+            # disruptor stuck here would leave the toxics applied through
+            # the converge phase (nightly 17376).
+            self._attempt(f"heal of {victim.name}", victim.heal)
+        self.cycles += 1
+        self._record(
+            "healed " + ", ".join(f"{kind} on {leg.name}" for leg, kind, _ in applied)
+        )
+
+    def _allowed_kinds(self, leg: Leg) -> list[str]:
+        kinds = list(leg.kinds or DISRUPTION_KINDS)
+        if self.kind_filter is not None:
+            kinds = [k for k in kinds if k in self.kind_filter]
+        return kinds
+
+    def _proxy_subset(self, leg: Leg) -> tuple[Proxy, ...]:
+        """Which of a leg's proxies to cut, sometimes not all of them.
+
+        A leg groups the connections of one logical dependency, and cutting
+        all of them models that dependency being unreachable. Cutting a
+        proper subset models something a whole-leg cut cannot: one channel to
+        a peer is gone while another to the same peer still works, so the two
+        sides disagree about whether they can talk. For the clusterd legs
+        that is the storage controller keeping its connection while the
+        compute controller loses its, to the same process.
+        """
+        if len(leg.proxies) < 2 or self.rng.random() >= 0.25:
+            return leg.proxies
+        return (self.rng.choice(leg.proxies),)
+
+    def _process_cycle(self, duration_scale: float, kind: str | None = None) -> None:
+        target = self.rng.choice(self.processes)
+        if kind is None:
+            kinds = ["kill", "pause", "crash_loop"]
+            if target.throttle is not None and target.unthrottle is not None:
+                kinds.append("throttle")
+            if self.kind_filter is not None:
+                kinds = [k for k in kinds if k in self.kind_filter]
+            if not kinds:
+                return
+            kind = self.rng.choice(kinds)
+        duration = min(
+            self.rng.uniform(*self.duration) * duration_scale, target.max_outage
+        )
+        key = (f"process:{target.name}", kind)
+        self.coverage[key] = self.coverage.get(key, 0) + 1
+        self.active.set()
+        self._record(f"applied {kind} on process {target.name} for {duration:.1f}s")
+        if kind == "kill":
+            self._attempt(f"kill of {target.name}", target.kill)
+            self.stop_event.wait(duration)
+            # The up can also race a crash-looping restart policy and observe
+            # an unhealthy moment.
+            self._attempt(f"heal of {target.name}", target.heal)
+        elif kind == "crash_loop":
+            self._crash_loop(target, duration)
+        elif kind == "throttle":
+            assert target.throttle is not None and target.unthrottle is not None
+            self._attempt(f"throttle of {target.name}", target.throttle)
+            self.stop_event.wait(duration)
+            self._attempt(f"unthrottle of {target.name}", target.unthrottle)
+        else:
+            self._attempt(f"pause of {target.name}", target.pause)
+            self.stop_event.wait(duration)
+            self._attempt(f"unpause of {target.name}", target.unpause)
+        self.active.clear()
+        self.cycles += 1
+        self._record(f"healed {kind} on process {target.name}")
+
+    def _crash_loop(self, target: ProcessTarget, duration: float) -> None:
+        """Kill repeatedly, never letting the process finish coming back.
+
+        A plain kill is followed by a heal that waits for healthy, so
+        everything the process does on the way up runs to completion every
+        time. Bootstrap is the least exercised code in the system and the
+        most consequential: it re-runs migrations, re-registers shards, and
+        re-applies whatever the last incarnation left half done. Killing
+        again a second or two in leaves those sequences interrupted at a
+        different point each time.
+
+        Relies on the container's restart policy to bring it back in
+        between, so no heal runs until the last kill. The final heal is the
+        normal one, which blocks until the process serves again.
+        """
+        deadline = time.monotonic() + duration
+        kills = 0
+        while time.monotonic() < deadline:
+            self._attempt(f"crash-loop kill of {target.name}", target.kill)
+            kills += 1
+            # Short enough that the restart policy has restarted the process
+            # but bootstrap is unlikely to have finished.
+            if self.stop_event.wait(self.rng.uniform(1.0, 4.0)):
+                break
+        self._record(f"crash loop killed {target.name} {kills} times")
+        self._attempt(f"heal of {target.name}", target.heal)
+
+    def _apply(self, leg: Leg, kind: str, proxies: tuple[Proxy, ...]) -> None:
+        # Toxics attach to one direction only, so half of the disruptions
+        # are asymmetric: one side of the connection keeps hearing the other.
+        stream = self.rng.choice(["downstream", "upstream"])
+        for proxy in proxies:
+            if kind == "disable":
+                self.api.set_enabled(proxy.name, False)
+            elif kind == "latency":
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "latency",
+                    {
+                        "latency": self.rng.randint(100, 3000),
+                        "jitter": self.rng.randint(0, 1000),
+                    },
+                    stream=stream,
+                )
+            elif kind == "timeout":
+                # timeout=0 holds the connection open and drops all data.
+                self.api.add_toxic(
+                    proxy.name, kind, "timeout", {"timeout": 0}, stream=stream
+                )
+            elif kind == "limit_data":
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "limit_data",
+                    {"bytes": self.rng.randint(128, 65536)},
+                    stream=stream,
+                )
+            elif kind == "bandwidth":
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "bandwidth",
+                    {"rate": self.rng.randint(1, 64)},
+                    stream=stream,
+                )
+            elif kind == "reset_peer":
+                # RSTs the connection after letting `timeout` ms of traffic
+                # through, so a request can reach the peer and take effect
+                # while its response never arrives. That is what turns a
+                # persist CaS into an Indeterminate error, which is the input
+                # to every "state transition retried as if it were idempotent"
+                # bug. A plain cut mostly yields determinate connection
+                # failures instead.
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "reset_peer",
+                    {"timeout": self.rng.randint(0, 1000)},
+                    stream=stream,
+                )
+            elif kind == "flap":
+                self.api.set_enabled(proxy.name, False)
+            elif kind == "slicer":
+                # Chops each write into small pieces and spaces them out, so
+                # every read on the other side returns a fraction of the
+                # message. A parser that assumes one read yields one framed
+                # message (length-prefixed gRPC, pgwire, chunked S3
+                # responses) only fails under this, never under a clean cut.
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "slicer",
+                    {
+                        # NOTE: no inter-slice delay, deliberately. Toxiproxy
+                        # sleeps that delay inside the toxic's goroutine, and
+                        # removing a toxic waits for that goroutine, so on a
+                        # busy leg the removal outlives the admin API's own
+                        # deadline and wedges the API for everything else. The
+                        # cost is not this leg: it is that no other leg can be
+                        # healed either, which silently turns a capped outage
+                        # into an uncapped one (nightly 17986 held a metadata
+                        # cut for 122s against a 45s cap that way, and a
+                        # clusterd OOMed buffering through it). The coverage
+                        # this toxic exists for is the chopping, not the
+                        # waiting.
+                        "average_size": self.rng.choice([64, 512, 4096]),
+                        "size_variation": 32,
+                        "delay": 0,
+                    },
+                    stream=stream,
+                )
+            elif kind == "slow_close":
+                # Delays the FIN, so the peer sees an established connection
+                # that will never carry data again. Distinct from `timeout`
+                # in that the close is in flight: whoever is waiting on the
+                # socket has to notice by its own deadline.
+                self.api.add_toxic(
+                    proxy.name,
+                    kind,
+                    "slow_close",
+                    {"delay": self.rng.randint(1000, 10_000)},
+                    stream=stream,
+                )
+            else:
+                raise ValueError(f"unknown disruption kind {kind}")
+
+    def _heal(self, leg: Leg, kind: str, proxies: tuple[Proxy, ...]) -> None:
+        for proxy in proxies:
+            if kind in ("disable", "flap"):
+                self.api.set_enabled(proxy.name, True)
+            else:
+                self.api.delete_toxic(proxy.name, kind)
+
+    def _wait_out(
+        self, duration: float, flapping: list[tuple[Leg, tuple[Proxy, ...]]]
+    ) -> None:
+        """Wait out a disruption window, toggling the flapping legs.
+
+        One long cut gives a request in flight one chance to be severed at
+        the moment its response is due. Flapping gives it one per toggle, so
+        an in-flight write that already committed is far more likely to be
+        reported as unknown to its caller.
+        """
+        if not flapping:
+            self.stop_event.wait(duration)
+            return
+        deadline = time.monotonic() + duration
+        enabled = False
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self.stop_event.wait(min(remaining, self.rng.uniform(0.05, 0.5))):
+                return
+            enabled = not enabled
+            for _leg, proxies in flapping:
+                for proxy in proxies:
+                    self.api.set_enabled(proxy.name, enabled)
+
+    def _heal_all_with_retries(self) -> None:
+        # Unpausing is instant, but a process heal blocks until the process
+        # serves again, which can never happen while one of its legs is still
+        # cut (see _leg_cycle), and this runs after cycles that were abandoned
+        # mid-flight, with toxics still applied. So the network is healed in
+        # between the two.
+        for target in self.processes:
+            try:
+                target.unpause()
+            except Exception:
+                pass
+            # A CPU squeeze outlives the disruptor thread: unlike a toxic it
+            # is container state, so an abandoned cycle would leave the
+            # process crippled through converge and turn a lost cycle into a
+            # liveness failure.
+            if target.unthrottle is not None:
+                try:
+                    target.unthrottle()
+                except Exception:
+                    pass
+        self._heal_network_with_retries()
+        for target in self.processes:
+            try:
+                target.heal()
+            except Exception as e:
+                self._record(f"heal of {target.name} failed ({e}), continuing")
+
+    def _heal_network_with_retries(self) -> None:
+        # A wedged admin API (see ApiStalled) does not recover on its own,
+        # because the toxic goroutine holding it up is blocked on a socket
+        # whose peer is gone, so retrying alone cannot heal the network.
+        # Restarting toxiproxy clears it, and comes back to the empty state
+        # the proxy re-creation below already handles.
+        # Two deadlines, because the two failures need opposite responses. A
+        # dropped or refused admin connection is worth retrying: toxiproxy is
+        # briefly busy and will answer. A 503 from its own handler timeout is
+        # not, since the goroutine holding it will never come back, and every
+        # second spent retrying is a second the other legs in the same cycle
+        # stay cut, past whatever max_outage was supposed to bound them to.
+        STALLED_DEADLINE = 10
+        UNREACHABLE_DEADLINE = 60
+        deadline = time.monotonic() + UNREACHABLE_DEADLINE
+        restarted = False
+        while True:
+            try:
+                self.api.reset()
+                # A crashed and restarted toxiproxy comes back empty. The
+                # proxies must exist again before anything reconnects.
+                existing = self.api.proxies()
+                for proxy in self.restore_proxies:
+                    if proxy.name not in existing:
+                        self._record(f"re-creating lost proxy {proxy.name}")
+                        self.api.create(proxy)
+                self.api.assert_healed()
+                self._record("all legs healed")
+                return
+            except Exception as e:
+                if isinstance(e, ApiStalled):
+                    deadline = min(deadline, time.monotonic() + STALLED_DEADLINE)
+                if time.monotonic() > deadline:
+                    if self.restart_toxiproxy is None or restarted:
+                        self.on_error(
+                            TransientError(f"failed to heal toxiproxy state: {e}")
+                        )
+                        return
+                    restarted = True
+                    self._record(f"admin API stuck ({e}), restarting toxiproxy")
+                    try:
+                        self.restart_toxiproxy()
+                    except Exception as restart_error:
+                        self._record(f"toxiproxy restart failed ({restart_error})")
+                    deadline = time.monotonic() + UNREACHABLE_DEADLINE
+                time.sleep(1)
+
+    def stop_and_heal(self) -> None:
+        self.stop_event.set()
+        self.join(timeout=60)
+        if self.is_alive():
+            # The disruptor is stuck, e.g. inside a process heal that waits
+            # for a container to serve again. Its toxics may still be
+            # applied, so heal from this thread: the converge phase must
+            # start from a clean network no matter what. The stuck thread
+            # is blocked in a subprocess call, not in the admin API, so
+            # sharing the API session here is safe in practice.
+            self.log.log(
+                "disrupt", "disruptor thread failed to stop in time, healing anyway"
+            )
+            self._heal_all_with_retries()
+        else:
+            # run() already healed in its finally block, but verify.
+            try:
+                self.api.assert_healed()
+            except Exception:
+                self._heal_all_with_retries()

--- a/misc/python/materialize/invariants/toxiproxy.py
+++ b/misc/python/materialize/invariants/toxiproxy.py
@@ -182,6 +182,7 @@ class Disruptor(threading.Thread):
         on_error: Callable[[Exception], None],
         processes: list[ProcessTarget] | None = None,
         restore_proxies: list[Proxy] | None = None,
+        restart_toxiproxy: Callable[[], None] | None = None,
     ) -> None:
         super().__init__(name="disruptor")
         self.api = api
@@ -193,6 +194,9 @@ class Disruptor(threading.Thread):
         self.concurrent = concurrent
         self.on_error = on_error
         self.processes = processes or []
+        # Last resort for an admin API that no longer answers, see
+        # _heal_network_with_retries.
+        self.restart_toxiproxy = restart_toxiproxy
         # Re-created after a toxiproxy crash-restart. The harness may have
         # created proxies beyond this scenario's legs (e.g. for a cluster the
         # scenario does not disrupt), and losing those would strand their
@@ -439,7 +443,13 @@ class Disruptor(threading.Thread):
                 self._record(f"heal of {target.name} failed ({e}), continuing")
 
     def _heal_network_with_retries(self) -> None:
+        # A wedged admin API (see ApiStalled) does not recover on its own,
+        # because the toxic goroutine holding it up is blocked on a socket
+        # whose peer is gone, so retrying alone cannot heal the network.
+        # Restarting toxiproxy clears it, and comes back to the empty state
+        # the proxy re-creation below already handles.
         deadline = time.monotonic() + 60
+        restarted = False
         while True:
             try:
                 self.api.reset()
@@ -455,10 +465,18 @@ class Disruptor(threading.Thread):
                 return
             except Exception as e:
                 if time.monotonic() > deadline:
-                    self.on_error(
-                        TransientError(f"failed to heal toxiproxy state: {e}")
-                    )
-                    return
+                    if self.restart_toxiproxy is None or restarted:
+                        self.on_error(
+                            TransientError(f"failed to heal toxiproxy state: {e}")
+                        )
+                        return
+                    restarted = True
+                    self._record(f"admin API stuck ({e}), restarting toxiproxy")
+                    try:
+                        self.restart_toxiproxy()
+                    except Exception as restart_error:
+                        self._record(f"toxiproxy restart failed ({restart_error})")
+                    deadline = time.monotonic() + 60
                 time.sleep(1)
 
     def stop_and_heal(self) -> None:

--- a/misc/python/materialize/invariants/toxiproxy.py
+++ b/misc/python/materialize/invariants/toxiproxy.py
@@ -32,6 +32,19 @@ DISRUPTION_KINDS = ["disable", "latency", "timeout", "limit_data", "bandwidth"]
 FULL_OUTAGE_KINDS = {"disable", "timeout"}
 
 
+class ApiStalled(Exception):
+    """A toxiproxy admin API call did not finish, so its outcome is unknown.
+
+    Toxiproxy answers a request whose handler overruns its deadline with Go's
+    default 503 timeout page and leaves the handler running behind it, so the
+    call may still take effect afterwards. Removing a toxic does this when the
+    toxic's goroutine is blocked writing to a socket whose peer was just
+    SIGKILLed, which is exactly what a leg cut overlapping a process kill sets
+    up. Recovery is the same as for a dropped admin connection: heal
+    everything, then verify.
+    """
+
+
 @dataclass(frozen=True)
 class Proxy:
     name: str
@@ -61,6 +74,10 @@ class ProcessTarget:
     containers with a restart policy it can be a no-op up()). Pauses are
     capped like full outages: a paused clusterd stops renewing its persist
     leases, which expire after 15 minutes.
+
+    None of the four may assume the process is still the one the previous
+    call saw. Anything else in the test can replace it, so all four are free
+    to fail and the disruptor treats that as a lost cycle.
     """
 
     name: str
@@ -76,6 +93,12 @@ class ToxiproxyApi:
         self.base_url = base_url
         self.session = requests.Session()
 
+    @staticmethod
+    def _check(r: requests.Response, ok: tuple[int, ...], what: str) -> None:
+        if r.status_code >= 500:
+            raise ApiStalled(f"{what}: {r} {r.text}")
+        assert r.status_code in ok, f"{what}: {r} {r.text}"
+
     def create(self, proxy: Proxy) -> None:
         r = self.session.post(
             f"{self.base_url}/proxies",
@@ -87,7 +110,7 @@ class ToxiproxyApi:
             },
             timeout=30,
         )
-        assert r.status_code == 201, f"creating proxy {proxy.name}: {r} {r.text}"
+        self._check(r, (201,), f"creating proxy {proxy.name}")
 
     def set_enabled(self, proxy_name: str, enabled: bool) -> None:
         r = self.session.post(
@@ -95,7 +118,7 @@ class ToxiproxyApi:
             json={"enabled": enabled},
             timeout=30,
         )
-        assert r.status_code == 200, f"toggling proxy {proxy_name}: {r} {r.text}"
+        self._check(r, (200,), f"toggling proxy {proxy_name}")
 
     def add_toxic(
         self,
@@ -115,9 +138,7 @@ class ToxiproxyApi:
             },
             timeout=30,
         )
-        assert (
-            r.status_code == 200
-        ), f"adding toxic {name} to {proxy_name}: {r} {r.text}"
+        self._check(r, (200,), f"adding toxic {name} to {proxy_name}")
 
     def delete_toxic(self, proxy_name: str, name: str) -> None:
         r = self.session.delete(
@@ -126,16 +147,16 @@ class ToxiproxyApi:
         # 404 means already deleted: heals must be idempotent, since a
         # disruptor cycle that outlived the join deadline re-heals toxics
         # that stop_and_heal's heal-everything already removed.
-        assert r.status_code in (200, 204, 404), f"deleting toxic {name}: {r} {r.text}"
+        self._check(r, (200, 204, 404), f"deleting toxic {name}")
 
     def reset(self) -> None:
         """Re-enable all proxies and remove all toxics."""
         r = self.session.post(f"{self.base_url}/reset", timeout=30)
-        assert r.status_code == 204, f"toxiproxy reset: {r} {r.text}"
+        self._check(r, (204,), "toxiproxy reset")
 
     def proxies(self) -> dict:
         r = self.session.get(f"{self.base_url}/proxies", timeout=30)
-        assert r.status_code == 200, f"listing proxies: {r} {r.text}"
+        self._check(r, (200,), "listing proxies")
         return r.json()
 
     def assert_healed(self) -> None:
@@ -160,6 +181,7 @@ class Disruptor(threading.Thread):
         concurrent: int,
         on_error: Callable[[Exception], None],
         processes: list[ProcessTarget] | None = None,
+        restore_proxies: list[Proxy] | None = None,
     ) -> None:
         super().__init__(name="disruptor")
         self.api = api
@@ -171,6 +193,15 @@ class Disruptor(threading.Thread):
         self.concurrent = concurrent
         self.on_error = on_error
         self.processes = processes or []
+        # Re-created after a toxiproxy crash-restart. The harness may have
+        # created proxies beyond this scenario's legs (e.g. for a cluster the
+        # scenario does not disrupt), and losing those would strand their
+        # connections for the rest of the run.
+        self.restore_proxies = (
+            restore_proxies
+            if restore_proxies is not None
+            else [proxy for leg in legs for proxy in leg.proxies]
+        )
         self.stop_event = threading.Event()
         self.cycles = 0
         # Set while any disruption is applied, read by the executor to
@@ -186,6 +217,23 @@ class Disruptor(threading.Thread):
         self.history.append(f"{time.strftime('%H:%M:%S')} {message}")
         self.log.log("disrupt", message)
 
+    def _attempt(self, what: str, action: Callable[[], None]) -> None:
+        """Run a process disruption or heal, tolerating a lost race.
+
+        Another part of the test may replace the process underneath the
+        disruptor: the midrun upgrade swap kills and re-creates the very
+        containers this cycle targets. A kill then finds its target already
+        dead, and an unpause a fresh container that was never paused, both
+        of which the orchestrator reports as errors. Neither is a test
+        failure: a disruption that does not land only loses coverage, and
+        whether the process serves again is the converge phase's assertion,
+        not a heal's.
+        """
+        try:
+            action()
+        except Exception as e:
+            self._record(f"{what} failed ({e}), continuing")
+
     def run(self) -> None:
         try:
             # A deterministic first sweep disrupts every leg once, so no leg
@@ -193,7 +241,7 @@ class Disruptor(threading.Thread):
             for leg in self.legs:
                 if self.stop_event.is_set():
                     return
-                self._leg_cycle(duration_scale=0.3, only=leg)
+                self._one_cycle(duration_scale=0.3, only=leg)
                 if self.stop_event.wait(self.rng.uniform(1.0, 5.0)):
                     return
             while not self.stop_event.wait(self.rng.uniform(*self.interval)):
@@ -224,21 +272,26 @@ class Disruptor(threading.Thread):
         finally:
             self._heal_all_with_retries()
 
-    def _one_cycle(self, duration_scale: float = 1.0) -> None:
+    def _one_cycle(self, duration_scale: float = 1.0, only: Leg | None = None) -> None:
         try:
-            roll = self.rng.random()
-            if self.processes and roll < 0.15:
-                # A leg cut overlapping a process kill, the combination that
-                # produced the unbounded-buffering finding.
-                self._leg_cycle(duration_scale, overlap_kill=True)
-            elif self.processes and roll < 0.35:
-                self._process_cycle(duration_scale)
+            # `only` draws no roll, so the rng stream is the one a seed
+            # replays whether or not the first sweep goes through here.
+            if only is not None:
+                self._leg_cycle(duration_scale, only=only)
             else:
-                self._leg_cycle(duration_scale)
-        except requests.RequestException as e:
-            # The toxiproxy admin API can stall while the host is overloaded
-            # (e.g. right after an envd restart). A lost cycle is not a
-            # failure, but nothing may stay disrupted.
+                roll = self.rng.random()
+                if self.processes and roll < 0.15:
+                    # A leg cut overlapping a process kill, the combination
+                    # that produced the unbounded-buffering finding.
+                    self._leg_cycle(duration_scale, overlap_kill=True)
+                elif self.processes and roll < 0.35:
+                    self._process_cycle(duration_scale)
+                else:
+                    self._leg_cycle(duration_scale)
+        except (requests.RequestException, ApiStalled) as e:
+            # The toxiproxy admin API can stall or drop the connection while
+            # the host is overloaded (e.g. right after an envd restart). A lost
+            # cycle is not a failure, but nothing may stay disrupted.
             self._record(f"cycle failed ({e}), healing everything")
             self._heal_all_with_retries()
 
@@ -273,7 +326,7 @@ class Disruptor(threading.Thread):
         )
         if victim is not None:
             self.stop_event.wait(duration / 2)
-            victim.kill()
+            self._attempt(f"kill of {victim.name}", victim.kill)
             key = (f"process:{victim.name}", "kill")
             self.coverage[key] = self.coverage.get(key, 0) + 1
             self.stop_event.wait(duration / 2)
@@ -288,10 +341,7 @@ class Disruptor(threading.Thread):
             # happen while e.g. its metadata leg is still cut, and a
             # disruptor stuck here would leave the toxics applied through
             # the converge phase (nightly 17376).
-            try:
-                victim.heal()
-            except Exception as e:
-                self._record(f"heal of {victim.name} failed ({e}), continuing")
+            self._attempt(f"heal of {victim.name}", victim.heal)
         self.cycles += 1
         self._record(
             "healed " + ", ".join(f"{kind} on {leg.name}" for leg, kind in applied)
@@ -308,19 +358,15 @@ class Disruptor(threading.Thread):
         self.active.set()
         self._record(f"applied {kind} on process {target.name} for {duration:.1f}s")
         if kind == "kill":
-            target.kill()
+            self._attempt(f"kill of {target.name}", target.kill)
             self.stop_event.wait(duration)
-            try:
-                target.heal()
-            except Exception as e:
-                # The up can race a crash-looping restart policy and observe
-                # an unhealthy moment. Whether the process actually serves
-                # again is the converge phase's assertion, not the heal's.
-                self._record(f"heal of {target.name} failed ({e}), continuing")
+            # The up can also race a crash-looping restart policy and observe
+            # an unhealthy moment.
+            self._attempt(f"heal of {target.name}", target.heal)
         else:
-            target.pause()
+            self._attempt(f"pause of {target.name}", target.pause)
             self.stop_event.wait(duration)
-            target.unpause()
+            self._attempt(f"unpause of {target.name}", target.unpause)
         self.active.clear()
         self.cycles += 1
         self._record(f"healed {kind} on process {target.name}")
@@ -375,27 +421,35 @@ class Disruptor(threading.Thread):
                 self.api.delete_toxic(proxy.name, kind)
 
     def _heal_all_with_retries(self) -> None:
+        # Unpausing is instant, but a process heal blocks until the process
+        # serves again, which can never happen while one of its legs is still
+        # cut (see _leg_cycle), and this runs after cycles that were abandoned
+        # mid-flight, with toxics still applied. So the network is healed in
+        # between the two.
         for target in self.processes:
             try:
                 target.unpause()
             except Exception:
                 pass
+        self._heal_network_with_retries()
+        for target in self.processes:
             try:
                 target.heal()
             except Exception as e:
                 self._record(f"heal of {target.name} failed ({e}), continuing")
+
+    def _heal_network_with_retries(self) -> None:
         deadline = time.monotonic() + 60
         while True:
             try:
                 self.api.reset()
                 # A crashed and restarted toxiproxy comes back empty. The
-                # legs' proxies must exist again before anything reconnects.
+                # proxies must exist again before anything reconnects.
                 existing = self.api.proxies()
-                for leg in self.legs:
-                    for proxy in leg.proxies:
-                        if proxy.name not in existing:
-                            self._record(f"re-creating lost proxy {proxy.name}")
-                            self.api.create(proxy)
+                for proxy in self.restore_proxies:
+                    if proxy.name not in existing:
+                        self._record(f"re-creating lost proxy {proxy.name}")
+                        self.api.create(proxy)
                 self.api.assert_healed()
                 self._record("all legs healed")
                 return

--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -39,6 +39,10 @@ class Clusterd(Service):
         workers: int = 1,
         process_names: list[str] = [],
         mz_service: str = "materialized",
+        # Where this process reaches persist's pubsub server. Defaults to
+        # the environmentd service, and is overridable so a test can front
+        # each clusterd's pubsub connection with its own proxy.
+        persist_pubsub_url: str | None = None,
     ) -> None:
         environment = [
             "CLUSTERD_LOG_FILTER",
@@ -54,7 +58,8 @@ class Clusterd(Service):
             "CLUSTERD_INTERNAL_HTTP_LISTEN_ADDR=0.0.0.0:6878",
             "CLUSTERD_SECRETS_READER=local-file",
             "CLUSTERD_SECRETS_READER_LOCAL_FILE_DIR=/mzdata/secrets",
-            f"CLUSTERD_PERSIST_PUBSUB_URL=http://{mz_service}:6879",
+            "CLUSTERD_PERSIST_PUBSUB_URL="
+            + (persist_pubsub_url or f"http://{mz_service}:6879"),
             *environment_extra,
         ]
 

--- a/misc/python/materialize/mzcompose/services/toxiproxy.py
+++ b/misc/python/materialize/mzcompose/services/toxiproxy.py
@@ -22,12 +22,14 @@ class Toxiproxy(Service):
         image: str = "jauderho/toxiproxy:v2.12.0",
         port: int = 8474,
         seed: int = random.randrange(2**63),
+        restart: str = "no",
     ) -> None:
         super().__init__(
             name=name,
             config={
                 "image": image,
                 "command": ["-host=0.0.0.0", f"-seed={seed}"],
+                "restart": restart,
                 "ports": [port],
                 "healthcheck": {
                     "test": ["CMD", "nc", "-z", "localhost", "8474"],

--- a/misc/python/stubs/confluent_kafka/__init__.pyi
+++ b/misc/python/stubs/confluent_kafka/__init__.pyi
@@ -13,6 +13,9 @@
 
 # Allow access to confluent_kafka.admin submodule
 from confluent_kafka import admin as admin
+from confluent_kafka.cimpl import OFFSET_BEGINNING as OFFSET_BEGINNING
+from confluent_kafka.cimpl import Consumer as Consumer
 from confluent_kafka.cimpl import KafkaError as KafkaError
 from confluent_kafka.cimpl import Message as Message
 from confluent_kafka.cimpl import Producer as Producer
+from confluent_kafka.cimpl import TopicPartition as TopicPartition

--- a/src/persist-client/tests/machine/regression_gc_stale_merge_res
+++ b/src/persist-client/tests/machine/regression_gc_stale_merge_res
@@ -1,0 +1,97 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# A merge res applied a second time, after another compaction already replaced
+# the same spine range, resurrects the parts of its own output. The
+# intervening diff recorded those parts as deleted, so GC finds them both in
+# its delete set and live in the state it is truncating to.
+#
+# merge_res is retried on Indeterminate consensus errors and the retry re-runs
+# against freshly fetched state, so the second application happens whenever the
+# first one committed but the response was lost.
+#
+# NOTE: which assertion catches this depends on debug assertions. With them on,
+# ReferencedBlobValidator sees the batch inserted twice and fires first, in
+# state_versions.rs. With them off, as in the profiles that build our images,
+# the only detector left is GC's part check at gc.rs:528, which is what the
+# nightly hit. To reproduce that one:
+#
+#   CARGO_PROFILE_TEST_DEBUG_ASSERTIONS=false CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false \
+#     DATADRIVEN_FILTER=regression_gc_stale_merge_res \
+#     bin/cargo-test -p mz-persist-client internal::datadriven::tests::machine
+
+dyncfg
+persist_inline_writes_single_max_bytes 0
+persist_inline_writes_total_max_bytes 0
+----
+ok
+
+write-batch output=b0 lower=0 upper=1
+k1 0 1
+----
+parts=1 len=1
+
+write-batch output=b1 lower=1 upper=2
+k2 1 1
+----
+parts=1 len=1
+
+write-batch output=b2 lower=2 upper=3
+k3 2 1
+----
+parts=1 len=1
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [1]
+
+compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v3 [2]
+
+# Merges b0 and b1 into one spine batch, which is what a merge res replaces.
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v4 [3]
+
+# Two compactions of the same range, racing. Each writes its own blobs.
+compact output=c1 inputs=(b0,b1) lower=0 upper=2 since=0
+----
+parts=1 len=2
+
+compact output=c2 inputs=(b0,b1) lower=0 upper=2 since=0
+----
+parts=1 len=2
+
+apply-merge-res input=c1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v5 true
+
+# c2 replaces c1. This diff records c1's parts as deleted.
+apply-merge-res input=c2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v6 true
+
+# c1's committer never saw its success and retries: c1's parts are live again.
+apply-merge-res input=c1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v7 true
+
+write-rollup output=v7
+----
+state=v7 diffs=[v1, v8)
+
+add-rollup input=v7
+----
+v8
+
+# Walks v0..v7: c1's parts are deleted at v6 and live again at v7.
+gc to_seqno=v8
+----
+v9 batch_parts=2 rollups=0 truncated=v7 state_rollups=v0

--- a/test/invariants/README.md
+++ b/test/invariants/README.md
@@ -93,9 +93,10 @@ Each finding has a concentrated reproducer, selectable via `--scenario`:
   memory while the blob store is cut (`repro-blob-memory`)
 - [PER-32](https://linear.app/materializeinc/issue/PER-32): writes stalled long
   after a metadata cut healed (`repro-postheal-stall`)
-- [CLU-34](https://linear.app/materializeinc/issue/CLU-34): compute halts
+- [PER-49](https://linear.app/materializeinc/issue/PER-49): compute halts
   hydrating a dataflow past its `as_of` (`repro-compute-asof`)
-- a resumed `SUBSCRIBE` loses its carried state (`repro-durable-resume`)
+- not yet filed: a resumed `SUBSCRIBE` loses its carried state
+  (`repro-durable-resume`)
 
 ## Running it
 

--- a/test/invariants/README.md
+++ b/test/invariants/README.md
@@ -1,0 +1,154 @@
+# Invariants
+
+A correctness-under-chaos test framework: multi-threaded scenarios whose
+invariants hold no matter which concurrent operations succeed, fail, or end up
+in an unknown state, checked *continuously* while toxiproxy cuts connections and
+processes are killed, and strictly again after healing.
+
+## Why another workload
+
+The trick is picking invariants that are **outcome-independent**. A bank
+transfer debits one account and credits another, so the grand total is
+conserved whether the transfer committed, was rejected, or timed out with an
+unknown outcome. That is what makes it safe to assert exact results *during* a
+disruption, rather than waiting for quiescence and comparing against an oracle
+that chaos has invalidated.
+
+| | catches | verifies results |
+|---|---|---|
+| parallel-workload | panics, unexpected errors | no result oracle |
+| zippy | wrong results, single-threaded | after quiescing |
+| **invariants** | **wrong results, lost/duplicated writes** | **continuously, under disruption** |
+
+## How a run works
+
+1. **setup**: create the objects, record the oracle's starting point.
+2. **chaos** (`--runtime`, default 600s): worker threads issue writes, checker
+   threads verify invariants, the disruptor injects/heals, the agitator flips
+   feature flags and cancels connections. Any checker failure fails the run
+   immediately.
+3. **heal**: every disruption is removed, with retries.
+4. **converge**: wait for all data paths to catch up.
+5. **final check**: strict assertions, plus a vacuity check: every checker and
+   the workers must have made progress in *both halves* of the chaos phase, and
+   the disruptor and agitator must have acted. A thread that wedges midway, or a
+   run where nothing was ever disrupted, fails instead of passing silently.
+
+Each thread draws its own seeded RNG in a fixed order, so `--seed` reproduces
+the whole action/disruption sequence.
+
+## What gets disrupted
+
+Toxiproxy fronts each *leg*: persist consensus (metadata store), persist blob,
+`envd`<->`clusterd` storagectl/computectl, and the source/sink/registry
+connections. Disruptions are `disable`, `latency`, `timeout`, `limit_data` and
+`bandwidth`, applied to one direction only so half are asymmetric. On top of
+that the disruptor SIGKILLs and SIGSTOPs `environmentd` and the `clusterd`
+processes, deliberately overlapping process kills with leg cuts and following
+some heals with an immediate kill, since the post-heal window is where recovery
+bugs live. Outages are capped per leg (a metadata cut must stay well under the
+15-minute persist lease expiry). Coverage is reported at the end, and a
+deterministic first sweep guarantees no leg goes untouched by RNG accident.
+
+`--upgrade-from=<image>` starts on an older release and swaps in the current
+build at the chaos midpoint: an upgrade under concurrent load *and* disruptions,
+with the invariants never pausing.
+
+## Scenarios
+
+| `--scenario` | invariant |
+|---|---|
+| `table-bank` | conserved total across tables, MVs, indexes, temporal filters, `REFRESH EVERY`, a far-future refresh frontier, schema swaps, replacement MVs, `COPY TO`/`FROM` |
+| `pg-cdc-bank`, `mysql-cdc-bank`, `sqlserver-cdc-bank` | the same conserved total, written upstream and replicated in, plus upstream DDL and real-time recency |
+| `kafka-ledger` | append-only Kafka ledger sums to the produced total |
+| `kafka-upsert` | last value per key wins under retractions |
+| `sink-roundtrip` | sink out, source back in, must equal the original |
+| `webhook-set` | every accepted webhook body appears exactly once |
+| `avro-loopback` | Avro/CSR encode-decode preserves every row |
+
+`--complexity=low|medium|high` scales workers, disruption frequency and
+concurrency. `--no-disruptions` runs the same workload and checkers clean, which
+is how you tell a product bug from a chaos artifact.
+
+## Read-path coverage
+
+The same invariant is verified through deliberately different plans and
+protocols, because a wrong answer usually only shows up in one of them: one-shot
+peeks (maintained MV, ad-hoc over base tables, and result-equivalent joins,
+window functions, recursive CTEs and LATERAL subqueries), `SUBSCRIBE` with
+`PROGRESS` (both fresh and resumed from a durable timestamp), read-only
+transaction snapshots, `AS OF` time travel into retained history, `COPY TO`
+export, and a post-run audit that replays the entire retained history and
+validates every progress boundary, retroactively closing the rounds live
+checkers had to skip during outages. Reads rotate over isolation levels, since a
+timestamp-free invariant must hold under all of them.
+
+## What the checkers assert
+
+A conserved total is safe to assert mid-disruption, which is what makes
+continuous checking possible, but on its own it is a one-dimensional projection:
+transfers are balanced pairs, so only a *torn* pair breaks the sum, and that is
+the one thing atomic batch commit already prevents. So the oracles go past it,
+while staying outcome-independent:
+
+- **row-level identity**, continuously. Every op id in a bounded window of the
+  newest ops must have exactly its two rows summing to zero, its derived columns
+  must match its op id, committed ops must be present, ops never issued must not
+  be, and an op observed once must never be absent again. A lost transfer masked
+  by a duplicated one, a rewritten row, or a resurrected retraction all keep the
+  count and the sum intact and are only visible here.
+- **the change stream itself**, via a snapshot-free `SUBSCRIBE` whose cost is
+  independent of table size. The ledger is append-only, so any retraction is a
+  bug outright, even the ones that cancel against their insert and leave the
+  folded state looking correct.
+- **read-your-writes**, on the writer's own session right after a commit. No
+  timestamp-free invariant covers it, and it is what a stale read breaks first.
+- **predicate results, recomputed**. An aggregate with a predicate lets persist
+  skip parts by their statistics, and getting that wrong is silent: the answer is
+  just too small. The same predicate is re-evaluated on the client over the rows
+  the same transaction returns, so the two must agree.
+- **the write timestamp a read-then-write chooses**. A selection over a
+  materialized view whose next refresh is a millennium out reports a frontier
+  that far ahead, while the table being written is near the clock. The timestamp
+  must still come from the oracle, which is clamped to the clock. Taking it from
+  that frontier ratchets the monotone, durable oracle into the future, so every
+  later write and strict-serializable read blocks until the clock catches up,
+  and under `serializable` an acknowledged write is simply invisible. A standing
+  checker compares `mz_now()` against the wall clock, and since that query reads
+  no collection it answers in exactly the state where every other read blocks.
+
+The ledger carries the values those oracles need in order to be able to fail: a
+numeric mirror of each amount (its own encoding and scale handling), a tag
+derived from the op id (so each row is checkable alone), floats covering NaN,
+negative zero, the infinities and a denormal, and a nullable date. Predicates
+over the last two are what pull filter pushdown onto the checked path.
+
+## Findings so far
+
+Each finding has a concentrated reproducer, selectable via `--scenario`:
+
+- [PER-10](https://linear.app/materializeinc/issue/PER-10): persist GC panic,
+  earliest state without rollup (`repro-per10`)
+- [PER-31](https://linear.app/materializeinc/issue/PER-31): unbounded clusterd
+  memory while the blob store is cut (`repro-blob-memory`)
+- [PER-32](https://linear.app/materializeinc/issue/PER-32): writes stalled long
+  after a metadata cut healed (`repro-postheal-stall`)
+- [PER-49](https://linear.app/materializeinc/issue/PER-49): compute halts
+  hydrating a dataflow past its `as_of` (`repro-compute-asof`)
+- [SS-428](https://linear.app/materializeinc/issue/SS-428): adding a table to a
+  running Postgres source pins the source's frontier until the replay that
+  follows has caught up, and the persist sink holds every update of that replay
+  resident because it can commit none of them (`repro-storage-memory`)
+- not yet filed: a resumed `SUBSCRIBE` loses its carried state
+  (`repro-durable-resume`)
+
+## Running it
+
+```shell
+bin/mzcompose --find invariants run default --scenario=table-bank --runtime=120
+bin/mzcompose --find invariants run default --scenario=repro-postheal-stall
+```
+
+Wired into Nightly as 11 steps (one per scenario, plus a large `table-bank` and
+the upgrade-under-load variant). Every failure annotation carries the exact
+reproducer command, and the run log opens with the random seed that replays it.

--- a/test/invariants/README.md
+++ b/test/invariants/README.md
@@ -1,0 +1,109 @@
+# Invariants
+
+A correctness-under-chaos test framework: multi-threaded scenarios whose
+invariants hold no matter which concurrent operations succeed, fail, or end up
+in an unknown state, checked *continuously* while toxiproxy cuts connections and
+processes are killed, and strictly again after healing.
+
+## Why another workload
+
+The trick is picking invariants that are **outcome-independent**. A bank
+transfer debits one account and credits another, so the grand total is
+conserved whether the transfer committed, was rejected, or timed out with an
+unknown outcome. That is what makes it safe to assert exact results *during* a
+disruption, rather than waiting for quiescence and comparing against an oracle
+that chaos has invalidated.
+
+| | catches | verifies results |
+|---|---|---|
+| parallel-workload | panics, unexpected errors | no result oracle |
+| zippy | wrong results, single-threaded | after quiescing |
+| **invariants** | **wrong results, lost/duplicated writes** | **continuously, under disruption** |
+
+## How a run works
+
+1. **setup**: create the objects, record the oracle's starting point.
+2. **chaos** (`--runtime`, default 600s): worker threads issue writes, checker
+   threads verify invariants, the disruptor injects/heals, the agitator flips
+   feature flags and cancels connections. Any checker failure fails the run
+   immediately.
+3. **heal**: every disruption is removed, with retries.
+4. **converge**: wait for all data paths to catch up.
+5. **final check**: strict assertions, plus a vacuity check: every checker and
+   the workers must have made progress in *both halves* of the chaos phase, and
+   the disruptor and agitator must have acted. A thread that wedges midway, or a
+   run where nothing was ever disrupted, fails instead of passing silently.
+
+Each thread draws its own seeded RNG in a fixed order, so `--seed` reproduces
+the whole action/disruption sequence.
+
+## What gets disrupted
+
+Toxiproxy fronts each *leg*: persist consensus (metadata store), persist blob,
+`envd`<->`clusterd` storagectl/computectl, and the source/sink/registry
+connections. Disruptions are `disable`, `latency`, `timeout`, `limit_data` and
+`bandwidth`, applied to one direction only so half are asymmetric. On top of
+that the disruptor SIGKILLs and SIGSTOPs `environmentd` and the `clusterd`
+processes, deliberately overlapping process kills with leg cuts and following
+some heals with an immediate kill, since the post-heal window is where recovery
+bugs live. Outages are capped per leg (a metadata cut must stay well under the
+15-minute persist lease expiry). Coverage is reported at the end, and a
+deterministic first sweep guarantees no leg goes untouched by RNG accident.
+
+`--upgrade-from=<image>` starts on an older release and swaps in the current
+build at the chaos midpoint: an upgrade under concurrent load *and* disruptions,
+with the invariants never pausing.
+
+## Scenarios
+
+| `--scenario` | invariant |
+|---|---|
+| `table-bank` | conserved total across tables, MVs, indexes, temporal filters, `REFRESH EVERY`, schema swaps, replacement MVs, `COPY TO`/`FROM` |
+| `pg-cdc-bank`, `mysql-cdc-bank`, `sqlserver-cdc-bank` | the same conserved total, written upstream and replicated in, plus upstream DDL and real-time recency |
+| `kafka-ledger` | append-only Kafka ledger sums to the produced total |
+| `kafka-upsert` | last value per key wins under retractions |
+| `sink-roundtrip` | sink out, source back in, must equal the original |
+| `webhook-set` | every accepted webhook body appears exactly once |
+| `avro-loopback` | Avro/CSR encode-decode preserves every row |
+
+`--complexity=low|medium|high` scales workers, disruption frequency and
+concurrency. `--no-disruptions` runs the same workload and checkers clean, which
+is how you tell a product bug from a chaos artifact.
+
+## Read-path coverage
+
+The same invariant is verified through deliberately different plans and
+protocols, because a wrong answer usually only shows up in one of them: one-shot
+peeks (maintained MV, ad-hoc over base tables, and result-equivalent joins,
+window functions, recursive CTEs and LATERAL subqueries), `SUBSCRIBE` with
+`PROGRESS` (both fresh and resumed from a durable timestamp), read-only
+transaction snapshots, `AS OF` time travel into retained history, `COPY TO`
+export, and a post-run audit that replays the entire retained history and
+validates every progress boundary, retroactively closing the rounds live
+checkers had to skip during outages. Reads rotate over isolation levels, since a
+timestamp-free invariant must hold under all of them.
+
+## Findings so far
+
+Each finding has a concentrated reproducer, selectable via `--scenario`:
+
+- [PER-10](https://linear.app/materializeinc/issue/PER-10): persist GC panic,
+  earliest state without rollup (`repro-per10`)
+- [PER-31](https://linear.app/materializeinc/issue/PER-31): unbounded clusterd
+  memory while the blob store is cut (`repro-blob-memory`)
+- [PER-32](https://linear.app/materializeinc/issue/PER-32): writes stalled long
+  after a metadata cut healed (`repro-postheal-stall`)
+- [CLU-34](https://linear.app/materializeinc/issue/CLU-34): compute halts
+  hydrating a dataflow past its `as_of` (`repro-compute-asof`)
+- a resumed `SUBSCRIBE` loses its carried state (`repro-durable-resume`)
+
+## Running it
+
+```shell
+bin/mzcompose --find invariants run default --scenario=table-bank --runtime=120
+bin/mzcompose --find invariants run default --scenario=repro-postheal-stall
+```
+
+Wired into Nightly as 11 steps (one per scenario, plus a large `table-bank` and
+the upgrade-under-load variant). Every failure annotation carries the exact
+reproducer command, and the run log opens with the random seed that replays it.

--- a/test/invariants/README.md
+++ b/test/invariants/README.md
@@ -83,6 +83,37 @@ validates every progress boundary, retroactively closing the rounds live
 checkers had to skip during outages. Reads rotate over isolation levels, since a
 timestamp-free invariant must hold under all of them.
 
+## What the checkers assert
+
+A conserved total is safe to assert mid-disruption, which is what makes
+continuous checking possible, but on its own it is a one-dimensional projection:
+transfers are balanced pairs, so only a *torn* pair breaks the sum, and that is
+the one thing atomic batch commit already prevents. So the oracles go past it,
+while staying outcome-independent:
+
+- **row-level identity**, continuously. Every op id in a bounded window of the
+  newest ops must have exactly its two rows summing to zero, its derived columns
+  must match its op id, committed ops must be present, ops never issued must not
+  be, and an op observed once must never be absent again. A lost transfer masked
+  by a duplicated one, a rewritten row, or a resurrected retraction all keep the
+  count and the sum intact and are only visible here.
+- **the change stream itself**, via a snapshot-free `SUBSCRIBE` whose cost is
+  independent of table size. The ledger is append-only, so any retraction is a
+  bug outright, even the ones that cancel against their insert and leave the
+  folded state looking correct.
+- **read-your-writes**, on the writer's own session right after a commit. No
+  timestamp-free invariant covers it, and it is what a stale read breaks first.
+- **predicate results, recomputed**. An aggregate with a predicate lets persist
+  skip parts by their statistics, and getting that wrong is silent: the answer is
+  just too small. The same predicate is re-evaluated on the client over the rows
+  the same transaction returns, so the two must agree.
+
+The ledger carries the values those oracles need in order to be able to fail: a
+numeric mirror of each amount (its own encoding and scale handling), a tag
+derived from the op id (so each row is checkable alone), floats covering NaN,
+negative zero, the infinities and a denormal, and a nullable date. Predicates
+over the last two are what pull filter pushdown onto the checked path.
+
 ## Findings so far
 
 Each finding has a concentrated reproducer, selectable via `--scenario`:

--- a/test/invariants/mzcompose.py
+++ b/test/invariants/mzcompose.py
@@ -15,6 +15,7 @@ toxiproxy disrupts the envd<->clusterd, metadata-store, source, and sink
 connections, and strictly again after healing.
 """
 
+import os
 import random
 import subprocess
 import threading
@@ -36,6 +37,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.postgres import Postgres, PostgresMetadata
+from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.sql_server import SqlServer
 from materialize.mzcompose.services.toxiproxy import Toxiproxy
 
@@ -43,10 +45,16 @@ from materialize.mzcompose.services.toxiproxy import Toxiproxy
 # It must be a fixed port because Kafka advertises it back to clients.
 KAFKA_HOST_PORT = 30993
 
+# Local iteration: run the Materialize services from this image instead of
+# building the current source. An environment variable, not a workflow
+# argument, because the image acquisition happens before workflow arguments
+# are parsed.
+INVARIANTS_IMAGE = os.environ.get("INVARIANTS_IMAGE")
+
 
 def materialized_service(image: str | None = None) -> Materialized:
     return Materialized(
-        image=image,
+        image=image or INVARIANTS_IMAGE,
         # Route the metadata store (persist consensus and the timestamp
         # oracle) and the persist blob store through toxiproxy. The proxies
         # must exist before this service starts.
@@ -67,6 +75,10 @@ def materialized_service(image: str | None = None) -> Materialized:
         additional_system_parameter_defaults={
             "unsafe_enable_unorchestrated_cluster_replicas": "true",
             "allow_real_time_recency": "true",
+            "enable_refresh_every_mvs": "true",
+            "enable_bounded_staleness_isolation": "true",
+            "enable_replacement_materialized_views": "true",
+            "enable_within_timestamp_order_by_in_subscribe": "true",
         },
         depends_on=["toxiproxy"],
     )
@@ -75,7 +87,7 @@ def materialized_service(image: str | None = None) -> Materialized:
 def clusterd_service(name: str, image: str | None = None) -> Clusterd:
     return Clusterd(
         name=name,
-        image=image,
+        image=image or INVARIANTS_IMAGE,
         # The controller connects through toxiproxy, so the host in request
         # URIs doesn't match this clusterd's hostname.
         environment_extra=["CLUSTERD_GRPC_HOST="],
@@ -93,7 +105,9 @@ CLUSTERD_NAMES = ["clusterd-compute", "clusterd-compute2", "clusterd-storage"]
 SERVICES = [
     Toxiproxy(),
     PostgresMetadata(),
-    Minio(setup_materialize=True),
+    # The extra bucket serves the COPY TO S3 checker, reachable for
+    # Materialize by container name and for the harness via the host port.
+    Minio(setup_materialize=True, additional_directories=["copytos3"]),
     materialized_service(),
     *(clusterd_service(name) for name in CLUSTERD_NAMES),
     # Second replica of the compute cluster, behind its own leg: peeks keep
@@ -122,6 +136,10 @@ SERVICES = [
             "SINK:PLAINTEXT,HOST:PLAINTEXT",
         ],
     ),
+    # The schema registry talks to Kafka directly (it is harness-side
+    # infrastructure for the broker); Materialize reaches it through the
+    # csr leg.
+    SchemaRegistry(kafka_servers=[("kafka", "9096")]),
 ]
 
 # One leg per connection of the system under test. All proxies are created
@@ -171,6 +189,7 @@ LEGS = {
     "sql-server": Leg("sql-server", (Proxy("sql_server", 1433, "sql-server:1433"),)),
     "kafka-source": Leg("kafka-source", (Proxy("kafka_source", 9092, "kafka:9092"),)),
     "kafka-sink": Leg("kafka-sink", (Proxy("kafka_sink", 9192, "kafka:9192"),)),
+    "csr": Leg("csr", (Proxy("csr", 8081, "schema-registry:8081"),)),
 }
 
 # Sources and sinks run in `storage`, MVs and indexes in `compute`, both on
@@ -302,6 +321,8 @@ def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
             mz_host="127.0.0.1",
             mz_port=c.default_port("materialized"),
             mz_system_port=c.port("materialized", 6877),
+            mz_http_port=c.port("materialized", 6876),
+            minio_port=c.default_port("minio"),
             pg_port=(
                 c.default_port("postgres")
                 if "postgres" in scenario_class.services

--- a/test/invariants/mzcompose.py
+++ b/test/invariants/mzcompose.py
@@ -1,0 +1,840 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Multi-threaded correctness test: scenarios whose invariants hold no matter
+which concurrent actions succeed, fail, or end up in an unknown state (e.g.
+bank transfers that conserve the total balance), checked continuously while
+toxiproxy disrupts the envd<->clusterd, metadata-store, source, and sink
+connections, and strictly again after healing.
+"""
+
+import random
+import subprocess
+import threading
+import time
+
+from materialize.invariants.executor import Runner
+from materialize.invariants.framework import (
+    COMPLEXITIES,
+    Endpoints,
+    EventLog,
+    ScenarioContext,
+)
+from materialize.invariants.scenarios import SCENARIOS
+from materialize.invariants.toxiproxy import Leg, ProcessTarget, Proxy, ToxiproxyApi
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.clusterd import Clusterd
+from materialize.mzcompose.services.kafka import Kafka
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.minio import Minio
+from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.postgres import Postgres, PostgresMetadata
+from materialize.mzcompose.services.sql_server import SqlServer
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
+
+# Host port for the Kafka listener the harness (producers, consumers) uses.
+# It must be a fixed port because Kafka advertises it back to clients.
+KAFKA_HOST_PORT = 30993
+
+
+def materialized_service(image: str | None = None) -> Materialized:
+    return Materialized(
+        image=image,
+        # Route the metadata store (persist consensus and the timestamp
+        # oracle) and the persist blob store through toxiproxy. The proxies
+        # must exist before this service starts.
+        external_metadata_store="toxiproxy",
+        metadata_store="postgres-metadata",
+        external_blob_store="toxiproxy",
+        support_external_clusterd=True,
+        sanity_restart=False,
+        # Fixed host ports: the disruptor kills this container and a
+        # recreation under ephemeral ports would strand every client on the
+        # old mapping.
+        ports=["16875:6875", "16876:6876", "16877:6877"],
+        # Crashes (both the disruptor's kills and genuine panics) restart
+        # envd so the invariants keep being verified afterwards. Panics
+        # still fail the job via the CI log annotator.
+        restart="on-failure",
+        default_replication_factor=1,
+        additional_system_parameter_defaults={
+            "unsafe_enable_unorchestrated_cluster_replicas": "true",
+            "allow_real_time_recency": "true",
+        },
+        depends_on=["toxiproxy"],
+    )
+
+
+def clusterd_service(name: str, image: str | None = None) -> Clusterd:
+    return Clusterd(
+        name=name,
+        image=image,
+        # The controller connects through toxiproxy, so the host in request
+        # URIs doesn't match this clusterd's hostname.
+        environment_extra=["CLUSTERD_GRPC_HOST="],
+        # halt! is a designed recovery path for clusterd.
+        restart="on-failure",
+        # Bounded so that runaway memory (e.g. buffering while the blob leg
+        # is cut) kills and restarts this container instead of taking down
+        # the whole agent.
+        memory="6GB",
+    )
+
+
+CLUSTERD_NAMES = ["clusterd-compute", "clusterd-compute2", "clusterd-storage"]
+
+SERVICES = [
+    Toxiproxy(),
+    PostgresMetadata(),
+    Minio(setup_materialize=True),
+    materialized_service(),
+    *(clusterd_service(name) for name in CLUSTERD_NAMES),
+    # Second replica of the compute cluster, behind its own leg: peeks keep
+    # being served (and verified) while one replica is disrupted, and a
+    # diverging replica shows up as wrong answers.
+    Postgres(),
+    MySql(),
+    SqlServer(),
+    # Kafka clients follow advertised listener addresses after bootstrap, so
+    # proxying the bootstrap address alone would not carry any traffic.
+    # Instead, dedicated source/sink listeners advertise the toxiproxy
+    # address, keeping all of Materialize's Kafka traffic on the proxied
+    # legs, while the harness uses the direct HOST listener.
+    Kafka(
+        ports=[f"{KAFKA_HOST_PORT}:{KAFKA_HOST_PORT}", 9092, 9192, 9096],
+        allow_host_ports=True,
+        advertised_listeners=[
+            "SOURCE://toxiproxy:9092",
+            "SINK://toxiproxy:9192",
+            f"HOST://localhost:{KAFKA_HOST_PORT}",
+            "PLAINTEXT://kafka:9096",
+        ],
+        environment_extra=[
+            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP="
+            "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SOURCE:PLAINTEXT,"
+            "SINK:PLAINTEXT,HOST:PLAINTEXT",
+        ],
+    ),
+]
+
+# One leg per connection of the system under test. All proxies are created
+# up front (unused ones are harmless), scenarios pick which legs to disrupt.
+LEGS = {
+    "metadata": Leg(
+        "metadata",
+        (Proxy("metadata", 26257, "postgres-metadata:26257"),),
+        # Full cuts freeze the coordinator loop (group commit blocks on
+        # the oracle), so nothing is served mid-outage and the interesting
+        # coverage is at the heal edges. Short cuts buy more edges per run,
+        # and stay far below the 15 minute persist lease expiry.
+        max_outage=45.0,
+    ),
+    "clusterd-compute": Leg(
+        "clusterd-compute",
+        (
+            Proxy("compute_storagectl", 2100, "clusterd-compute:2100"),
+            Proxy("compute_computectl", 2101, "clusterd-compute:2101"),
+        ),
+    ),
+    "clusterd-compute2": Leg(
+        "clusterd-compute2",
+        (
+            Proxy("compute2_storagectl", 2200, "clusterd-compute2:2100"),
+            Proxy("compute2_computectl", 2201, "clusterd-compute2:2101"),
+        ),
+    ),
+    "clusterd-storage": Leg(
+        "clusterd-storage",
+        (
+            Proxy("storage_storagectl", 3100, "clusterd-storage:2100"),
+            Proxy("storage_computectl", 3101, "clusterd-storage:2101"),
+        ),
+    ),
+    # Persist blob I/O of envd and every clusterd. Capped like the metadata
+    # leg, and restricted to non-buffering toxics: latency and bandwidth
+    # would hold the entire blob throughput in toxiproxy's memory.
+    "blob": Leg(
+        "blob",
+        (Proxy("blob", 9000, "minio:9000"),),
+        max_outage=45.0,
+        kinds=("disable", "timeout", "limit_data"),
+    ),
+    "pg": Leg("pg", (Proxy("pg", 5432, "postgres:5432"),)),
+    "mysql": Leg("mysql", (Proxy("mysql", 3306, "mysql:3306"),)),
+    "sql-server": Leg("sql-server", (Proxy("sql_server", 1433, "sql-server:1433"),)),
+    "kafka-source": Leg("kafka-source", (Proxy("kafka_source", 9092, "kafka:9092"),)),
+    "kafka-sink": Leg("kafka-sink", (Proxy("kafka_sink", 9192, "kafka:9192"),)),
+}
+
+# Sources and sinks run in `storage`, MVs and indexes in `compute`, both on
+# unorchestrated clusterd containers whose controller connections go through
+# toxiproxy. The built-in quickstart cluster stays undisrupted as an
+# independent observer path for checkers.
+CLUSTER_SETUP_SQL = """
+CREATE CLUSTER storage REPLICAS (r1 (
+    STORAGECTL ADDRESSES ['toxiproxy:3100'],
+    STORAGE ADDRESSES ['clusterd-storage:2103'],
+    COMPUTECTL ADDRESSES ['toxiproxy:3101'],
+    COMPUTE ADDRESSES ['clusterd-storage:2102'],
+    WORKERS 1
+));
+CREATE CLUSTER compute REPLICAS (
+    r1 (
+        STORAGECTL ADDRESSES ['toxiproxy:2100'],
+        STORAGE ADDRESSES ['clusterd-compute:2103'],
+        COMPUTECTL ADDRESSES ['toxiproxy:2101'],
+        COMPUTE ADDRESSES ['clusterd-compute:2102'],
+        WORKERS 1
+    ),
+    r2 (
+        STORAGECTL ADDRESSES ['toxiproxy:2200'],
+        STORAGE ADDRESSES ['clusterd-compute2:2103'],
+        COMPUTECTL ADDRESSES ['toxiproxy:2201'],
+        COMPUTE ADDRESSES ['clusterd-compute2:2102'],
+        WORKERS 1
+    )
+);
+GRANT ALL ON CLUSTER storage TO materialize;
+GRANT ALL ON CLUSTER compute TO materialize;
+"""
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument(
+        "--scenario",
+        default="all",
+        choices=["all", *SCENARIOS.keys(), *REPROS.keys()],
+    )
+    parser.add_argument(
+        "--complexity", default="medium", choices=list(COMPLEXITIES.keys())
+    )
+    parser.add_argument(
+        "--runtime",
+        default=600,
+        type=int,
+        help="chaos phase duration per scenario, seconds",
+    )
+    parser.add_argument("--seed", type=str, default=str(int(time.time())))
+    parser.add_argument(
+        "--upgrade-from",
+        type=str,
+        default=None,
+        help="start Materialize on this image and swap to the current build"
+        " mid-chaos, an upgrade under load and disruptions",
+    )
+    parser.add_argument(
+        "--no-disruptions",
+        action="store_true",
+        help="run the workload and checkers without any disruptions",
+    )
+    args = parser.parse_args()
+
+    print(f"--- Random seed is {args.seed}")
+    if args.scenario in REPROS:
+        log = EventLog("invariants-events.log")
+        try:
+            with c.test_case(args.scenario):
+                run_repro(c, args.scenario, args, log)
+        finally:
+            log.close()
+        return
+    names = list(SCENARIOS.keys()) if args.scenario == "all" else [args.scenario]
+    log = EventLog("invariants-events.log")
+    try:
+        for name in names:
+            with c.test_case(name):
+                run_scenario(c, name, args, log)
+    finally:
+        log.close()
+
+
+def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
+    scenario_class = SCENARIOS[name]
+    complexity = COMPLEXITIES[args.complexity]
+    # Deterministic per (seed, scenario) so single-scenario runs reproduce
+    # the same sequences as the same scenario within an `all` run.
+    rng = random.Random(f"{args.seed}-{name}")
+    log.log(
+        "scenario",
+        f"starting {name} complexity={complexity.name} runtime={args.runtime}s"
+        f" seed={args.seed}",
+    )
+    c.down(destroy_volumes=True)
+
+    # restart on-failure: proxies live in toxiproxy's memory, so after a
+    # crash the disruptor's heal re-creates them (it cannot resurrect the
+    # container itself).
+    version_services = []
+    if args.upgrade_from:
+        version_services = [materialized_service(image=args.upgrade_from)] + [
+            clusterd_service(name, image=args.upgrade_from) for name in CLUSTERD_NAMES
+        ]
+    with c.override(
+        Toxiproxy(seed=rng.randrange(2**63), restart="on-failure"),
+        *version_services,
+    ):
+        # The proxies must exist before materialized boots: its consensus and
+        # timestamp-oracle URLs point at toxiproxy.
+        c.up("toxiproxy")
+        toxiproxy = ToxiproxyApi(f"http://127.0.0.1:{c.default_port('toxiproxy')}")
+        for leg in LEGS.values():
+            for proxy in leg.proxies:
+                toxiproxy.create(proxy)
+
+        services = [
+            "materialized",
+            "clusterd-compute",
+            "clusterd-compute2",
+            "clusterd-storage",
+        ]
+        services += scenario_class.services
+        c.up(*services)
+        c.sql(CLUSTER_SETUP_SQL, port=6877, user="mz_system")
+
+        endpoints = Endpoints(
+            mz_host="127.0.0.1",
+            mz_port=c.default_port("materialized"),
+            mz_system_port=c.port("materialized", 6877),
+            pg_port=(
+                c.default_port("postgres")
+                if "postgres" in scenario_class.services
+                else None
+            ),
+            mysql_port=(
+                c.default_port("mysql") if "mysql" in scenario_class.services else None
+            ),
+            sqlserver_port=(
+                c.default_port("sql-server")
+                if "sql-server" in scenario_class.services
+                else None
+            ),
+            kafka_bootstrap=(
+                f"localhost:{KAFKA_HOST_PORT}"
+                if "kafka" in scenario_class.services
+                else None
+            ),
+        )
+        ctx = ScenarioContext(
+            endpoints=endpoints,
+            complexity=complexity,
+            rng=rng,
+            log=log,
+            seed=args.seed,
+        )
+        scenario = scenario_class(ctx)
+        scenario.setup()
+        legs = [] if args.no_disruptions else [LEGS[n] for n in scenario_class.legs]
+        midrun = make_upgrade_swap(c) if args.upgrade_from else None
+        try:
+            Runner(
+                scenario,
+                args.runtime,
+                toxiproxy,
+                legs,
+                process_targets(c),
+                midrun_event=midrun,
+            ).run()
+        finally:
+            scenario.teardown()
+
+
+def make_upgrade_swap(c: Composition):
+    def swap() -> None:
+        # Kill the old-version processes and bring everything back on the
+        # current build: an upgrade in the middle of load and disruptions,
+        # with the invariants never pausing.
+        names = [
+            "materialized",
+            "clusterd-compute",
+            "clusterd-compute2",
+            "clusterd-storage",
+        ]
+        c.kill(*names)
+        c.up(*names, detach=True, max_tries=3)
+
+    return swap
+
+
+def process_targets(c: Composition) -> list[ProcessTarget]:
+    """Processes the disruptor may kill or pause.
+
+    The clusterd containers restart automatically (restart on-failure), so
+    their heal is an idempotent up(). Upstream databases are deliberately
+    absent: they run with fsync disabled, so a SIGKILL could lose committed
+    data and invalidate the oracle.
+    """
+
+    def target(name: str, max_outage: float = 120.0) -> ProcessTarget:
+        return ProcessTarget(
+            name=name,
+            max_outage=max_outage,
+            kill=lambda: c.kill(name),
+            # Bounded retries: an up that cannot succeed (e.g. dead
+            # proxies) must not wedge the disruptor for minutes, but a
+            # single attempt can race a crash-looping restart policy.
+            heal=lambda: c.up(name, detach=True, max_tries=3),
+            pause=lambda: c.pause(name),
+            unpause=lambda: c.unpause(name),
+        )
+
+    return [
+        target("clusterd-compute"),
+        target("clusterd-compute2"),
+        target("clusterd-storage"),
+        # A paused envd freezes everything like a metadata cut, so its
+        # outages are short for the same edge-coverage reason.
+        target("materialized", max_outage=45.0),
+    ]
+
+
+# Concentrated reproducers for the open findings, selectable via
+# --scenario=repro-*. blob-memory and postheal-stall are deterministic
+# sequences, per10 and durable-resume are fixed-sequence loops over races.
+REPROS = {
+    "repro-blob-memory": "unbounded clusterd memory while the blob store is cut",
+    "repro-postheal-stall": "writes stalled long after a metadata cut healed",
+    "repro-per10": "persist GC panic: earliest state without rollup",
+    "repro-durable-resume": "resumed SUBSCRIBE cancels its carried state",
+    "repro-compute-asof": "compute halts hydrating a dataflow past its as_of",
+}
+
+
+def run_repro(c: Composition, name: str, args, log: EventLog) -> None:
+    from materialize.invariants.scenarios.table_bank import TableBank
+
+    c.down(destroy_volumes=True)
+    rng = random.Random(f"{args.seed}-{name}")
+    with c.override(Toxiproxy(seed=rng.randrange(2**63), restart="on-failure")):
+        c.up("toxiproxy")
+        toxiproxy = ToxiproxyApi(f"http://127.0.0.1:{c.default_port('toxiproxy')}")
+        for leg in LEGS.values():
+            for proxy in leg.proxies:
+                toxiproxy.create(proxy)
+        c.up(
+            "materialized", "clusterd-compute", "clusterd-compute2", "clusterd-storage"
+        )
+        c.sql(CLUSTER_SETUP_SQL, port=6877, user="mz_system")
+        ctx = ScenarioContext(
+            endpoints=Endpoints(
+                mz_host="127.0.0.1",
+                mz_port=c.default_port("materialized"),
+                mz_system_port=c.port("materialized", 6877),
+            ),
+            complexity=COMPLEXITIES["medium"],
+            rng=rng,
+            log=log,
+            seed=args.seed,
+        )
+        scenario = TableBank(ctx)
+        scenario.setup()
+        bundles = [
+            scenario.make_worker(i, random.Random(rng.randrange(2**31)))
+            for i in range(4)
+        ]
+        stop = threading.Event()
+
+        def drive(bundle) -> None:
+            ticks = 0
+            while not stop.is_set():
+                ticks += 1
+                # LedgerTransfer for steady writes (consensus churn), plus
+                # DdlChurn: created and dropped MVs mean shard finalization,
+                # which is what keeps persist GC busy.
+                action = bundle.actions[3] if ticks % 40 == 0 else bundle.actions[1]
+                try:
+                    action.run()
+                except Exception:
+                    pass
+                stop.wait(0.005)
+
+        threads = [
+            threading.Thread(target=drive, args=(b,), daemon=True) for b in bundles
+        ]
+        for t in threads:
+            t.start()
+        try:
+            REPRO_FUNCS[name](c, toxiproxy, ctx, log)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join(timeout=10)
+
+
+def _toxiproxy_heal(toxiproxy: ToxiproxyApi, log: EventLog) -> None:
+    """Heal everything, surviving a toxiproxy crash-restart in between.
+
+    A restarted toxiproxy comes back empty, so besides retrying the reset
+    the legs' proxies are re-created. Mirrors the disruptor's heal path.
+    """
+    deadline = time.monotonic() + 60
+    while True:
+        try:
+            toxiproxy.reset()
+            existing = toxiproxy.proxies()
+            for leg in LEGS.values():
+                for proxy in leg.proxies:
+                    if proxy.name not in existing:
+                        log.log("repro", f"re-creating lost proxy {proxy.name}")
+                        toxiproxy.create(proxy)
+            return
+        except Exception as e:
+            if time.monotonic() > deadline:
+                subprocess.run(
+                    ["docker", "logs", "--tail", "20", "invariants-toxiproxy-1"]
+                )
+                raise AssertionError(f"toxiproxy did not heal: {e}") from e
+            time.sleep(2)
+
+
+def _rss_gb(container: str) -> float:
+    out = (
+        subprocess.check_output(
+            ["docker", "stats", "--no-stream", "--format", "{{.MemUsage}}", container],
+            text=True,
+        )
+        .split("/")[0]
+        .strip()
+    )
+    for unit, mult in [("GiB", 1.0), ("MiB", 1 / 1024), ("KiB", 1 / 1048576)]:
+        if out.endswith(unit):
+            return float(out[: -len(unit)]) * mult
+    return 0.0
+
+
+def repro_blob_memory(c, toxiproxy, ctx, log) -> None:
+    """Cut the blob store under write load, watch process memory grow."""
+    containers = [
+        "invariants-materialized-1",
+        "invariants-clusterd-compute-1",
+        "invariants-clusterd-compute2-1",
+        "invariants-clusterd-storage-1",
+    ]
+    # Let hydration finish and take the settled baseline as the minimum of a
+    # few samples, memory right after startup spikes.
+    time.sleep(20)
+    base = {name: _rss_gb(name) for name in containers}
+    for _ in range(2):
+        time.sleep(5)
+        for name in containers:
+            base[name] = min(base[name], _rss_gb(name))
+    log.log(
+        "repro", "baseline: " + ", ".join(f"{n}={v:.2f}GiB" for n, v in base.items())
+    )
+    toxiproxy.set_enabled("blob", False)
+    try:
+        for _ in range(24):
+            time.sleep(10)
+            now = {name: _rss_gb(name) for name in containers}
+            log.log(
+                "repro",
+                "blob cut: " + ", ".join(f"{n}={v:.2f}GiB" for n, v in now.items()),
+            )
+            for name in containers:
+                if now[name] > base[name] + 1.5:
+                    raise AssertionError(
+                        f"REPRODUCED: {name} memory grew {base[name]:.2f} ->"
+                        f" {now[name]:.2f}GiB while the blob store was"
+                        " unavailable (unbounded buffering)"
+                    )
+    finally:
+        _toxiproxy_heal(toxiproxy, log)
+    log.log("repro", "not reproduced within 240s")
+
+
+def repro_postheal_stall(c, toxiproxy, ctx, log) -> None:
+    """Stall writes by making the metadata store slow under heavy catalog churn.
+
+    group_commit runs inline on the single-threaded coordinator loop and
+    blocks on metadata round trips: the timestamp oracle (get_local_write_ts)
+    and the catalog-shard consensus op (catalog.advance_upper). A clean
+    cut/heal recovers in seconds because a local postgres is fast, so this
+    models the overloaded CI metadata store with a latency toxic that delays
+    every round trip.
+
+    Both the latency and the load matter. Latency alone slows each write by
+    only a handful of round trips, and the coordinator loop is biased to
+    prioritize group commit over DDL, so DDL does not starve writes by
+    queuing. The DROP-heavy materialized-view churn instead grows the catalog
+    shard's persist state, so each delayed metadata op does more work and a
+    single group commit blocks the loop for tens of seconds. Measured
+    empirically: ~2.5s/direction plus this churn stalls writes ~150s while
+    envd keeps accepting connections. Time-to-first-committed-write is
+    measured while the store is slow.
+    """
+    from materialize.invariants.framework import Outcome
+    from materialize.invariants.mz import MzClient
+
+    # Per-direction delay on the metadata leg. Well below the stall threshold
+    # on its own: exceeding it is the churn-driven amplification (each catalog
+    # metadata op does many delayed round trips), not one slow round trip.
+    METADATA_LATENCY_MS = 2500
+    STALL_THRESHOLD_S = 120.0
+
+    stop = threading.Event()
+
+    def writer(idx: int) -> None:
+        client = MzClient(ctx, f"stall-writer-{idx}")
+        seq = 0
+        while not stop.is_set():
+            seq += 1
+            try:
+                client.write(
+                    f"INSERT INTO ledger VALUES ({1000 + idx}, {seq}, 0, 0)",
+                    timeout=20,
+                )
+            except Exception:
+                pass
+            stop.wait(0.002)
+
+    def churner(idx: int) -> None:
+        client = MzClient(ctx, f"stall-churn-{idx}")
+        seq = 0
+        while not stop.is_set():
+            seq += 1
+            # CREATE and DROP hammer the catalog shard, the same shard
+            # group_commit's advance_upper operates on. The churn grows that
+            # shard's persist state, so under a slow leg each catalog metadata
+            # op does more delayed round trips and group_commit blocks the
+            # coordinator loop for tens of seconds. Unique names plus IF
+            # EXISTS keep the loop idempotent across UNKNOWN outcomes.
+            name = f"stall_mv_{idx}_{seq}"
+            try:
+                client.write(
+                    f"CREATE MATERIALIZED VIEW {name} IN CLUSTER compute"
+                    " AS SELECT count(*) AS cnt FROM ledger",
+                    timeout=20,
+                )
+                client.write(f"DROP MATERIALIZED VIEW IF EXISTS {name}", timeout=20)
+            except Exception:
+                pass
+            stop.wait(0.02)
+
+    threads = [
+        threading.Thread(target=writer, args=(i,), daemon=True) for i in range(8)
+    ] + [threading.Thread(target=churner, args=(i,), daemon=True) for i in range(12)]
+    for t in threads:
+        t.start()
+    try:
+        # Let the load reach steady state and the catalog shard get hot
+        # before the store slows down.
+        time.sleep(20)
+        # Model the overloaded metadata store: delay both directions so every
+        # oracle and consensus round trip costs seconds.
+        for proxy in LEGS["metadata"].proxies:
+            for stream in ("downstream", "upstream"):
+                toxiproxy.add_toxic(
+                    proxy.name,
+                    f"latency-{stream}",
+                    "latency",
+                    {
+                        "latency": METADATA_LATENCY_MS,
+                        "jitter": METADATA_LATENCY_MS // 2,
+                    },
+                    stream=stream,
+                )
+        log.log(
+            "repro",
+            f"metadata slowed (~{METADATA_LATENCY_MS}ms/direction), probing"
+            " write liveness",
+        )
+        # A per-attempt timeout above the threshold so one attempt can observe
+        # a commit anywhere up to the threshold and report its true latency.
+        probe_timeout = STALL_THRESHOLD_S + 10
+        client = MzClient(ctx, "stall-probe")
+        start = time.monotonic()
+        while time.monotonic() - start < 300:
+            if (
+                client.write(
+                    "INSERT INTO ledger VALUES (-3, 0, 0, 0)", timeout=probe_timeout
+                )
+                == Outcome.COMMITTED
+            ):
+                took = time.monotonic() - start
+                log.log("repro", f"first write committed {took:.1f}s into slowdown")
+                if took > STALL_THRESHOLD_S:
+                    raise AssertionError(
+                        f"REPRODUCED: writes stalled {took:.1f}s while the"
+                        " metadata store was slow"
+                    )
+                return
+        raise AssertionError(
+            "REPRODUCED: no write committed within 300s of the metadata store"
+            " slowing down"
+        )
+    finally:
+        _toxiproxy_heal(toxiproxy, log)
+        stop.set()
+        for t in threads:
+            t.join(timeout=10)
+
+
+def repro_per10(c, toxiproxy, ctx, log) -> None:
+    """Blob cut, heal, immediate kill: the PER-10 panic window.
+
+    A ~1%-per-cycle race in CI, so this loops tightly: short cuts, kills
+    alternating between envd and the clusterds, DDL churn in the load for
+    shard-finalization GC pressure, and the panic grepped in all processes.
+    """
+    targets = ["materialized", "clusterd-compute", "clusterd-storage"]
+    for iteration in range(30):
+        toxiproxy.set_enabled("blob", False)
+        time.sleep(5)
+        _toxiproxy_heal(toxiproxy, log)
+        time.sleep(2)
+        victim = targets[iteration % len(targets)]
+        c.kill(victim)
+        c.up(victim, detach=True, max_tries=3)
+        time.sleep(5)
+        for name in targets + ["clusterd-compute2"]:
+            logs = c.invoke("logs", name, capture=True).stdout or ""
+            if "did not have corresponding rollup" in logs:
+                raise AssertionError(
+                    f"REPRODUCED PER-10 in {name}, iteration {iteration}"
+                )
+        log.log("repro", f"iteration {iteration} (killed {victim}): no panic yet")
+    log.log("repro", "not reproduced in 30 iterations")
+
+
+def repro_durable_resume(c, toxiproxy, ctx, log) -> None:
+    """Blob cut + envd kill, then a durable resume must keep its state."""
+    from materialize.invariants.checkers import SubscribeChecker
+    from materialize.invariants.framework import InvariantViolation
+
+    total = ctx.complexity.accounts * 1000
+
+    class ResumeChecker(SubscribeChecker):
+        def __init__(self, rng: random.Random) -> None:
+            super().__init__(
+                rng, ctx, "resume-repro", "SELECT total FROM total", durable=True
+            )
+
+        def validate_state(self, state: dict, ts: int) -> None:
+            got = {(int(k[0]),): v for k, v in state.items()}
+            if got != {(total,): 1}:
+                raise InvariantViolation(f"state {got} at {ts}")
+
+    for iteration in range(5):
+        rng = random.Random(f"resume-{iteration}")
+        checker = ResumeChecker(rng)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            try:
+                checker.check_once()
+            except Exception:
+                pass
+        assert checker.last_validated_ts is not None
+        toxiproxy.set_enabled("blob", False)
+        time.sleep(15)
+        _toxiproxy_heal(toxiproxy, log)
+        time.sleep(2)
+        c.kill("materialized")
+        c.up("materialized", detach=True, max_tries=3)
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            try:
+                checker.check_once()  # raises InvariantViolation if reproduced
+            except AssertionError:
+                raise AssertionError(
+                    f"REPRODUCED durable-resume anomaly, iteration {iteration}"
+                )
+            except Exception:
+                pass
+        checker.close()
+        log.log("repro", f"iteration {iteration}: resume stayed consistent")
+    log.log("repro", "not reproduced in 5 iterations")
+
+
+def repro_compute_asof(c, toxiproxy, ctx, log) -> None:
+    """Compute halts hydrating a dataflow whose input compacted past its as_of.
+
+    incidents-and-escalations #39 / CLU-34. When the controller loses a
+    replica it drops that replica's per-replica read holds, and for a dataflow
+    it no longer wants (a canceled peek) it does not reinstall them, while the
+    replica still has the dataflow pending. The inputs then compact, and when
+    the replica renders the dataflow its as_of is below the input's since, so
+    compute_import halts with "cannot serve requested as_of".
+
+    Concentrates that window against the compute cluster's second replica
+    (clusterd-compute2, its own control-plane leg): a burst of slow-path peeks
+    over the base ledger builds one-off dataflows on both replicas, the leg is
+    cut so the controller drops r2's holds while r2 keeps the pending
+    dataflows, the peeks are canceled so their global holds drop too, and the
+    base ledger has no RETAIN HISTORY, so with nothing holding it its since
+    advances to ~now while the leg stays cut. r2 then renders a pending peek at
+    a since-passed as_of and halts. The disruption is a leg cut, not a kill: a
+    killed replica loses the pending dataflow and would just get fresh as_ofs
+    on restart. A race, so it loops and greps r2's log for the halt.
+    """
+    from materialize.invariants.mz import MzClient
+
+    def set_compute2(enabled: bool) -> None:
+        for proxy in LEGS["clusterd-compute2"].proxies:
+            toxiproxy.set_enabled(proxy.name, enabled)
+
+    def halted() -> str | None:
+        for name in ("clusterd-compute2", "clusterd-compute"):
+            logs = c.invoke("logs", name, capture=True).stdout or ""
+            if "cannot serve requested as_of" in logs:
+                return name
+        return None
+
+    def peek(tag: str) -> None:
+        cl = MzClient(ctx, f"asof-peek-{tag}")
+        try:
+            cl.query("SET cluster = compute")
+            # A predicate no index serves forces the slow path, a one-off peek
+            # dataflow importing the base ledger. The short timeout cancels it,
+            # dropping its global read hold.
+            cl.query(
+                f"SELECT count(*) FROM ledger WHERE amount > {tag} AND account >= 0",
+                timeout=3,
+            )
+        except Exception:
+            pass
+        cl.reset()
+
+    for iteration in range(15):
+        set_compute2(True)
+        # Fire the peeks, then cut r2's control plane ~1s in, while the peek
+        # dataflows are still installing/rendering on r2.
+        threads = [
+            threading.Thread(target=peek, args=(f"{iteration}-{i}",), daemon=True)
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(1.0)
+        set_compute2(False)
+        # The peeks cancel at their 3s timeout, dropping the global holds. With
+        # r2's per-replica holds already dropped by the disconnect, nothing
+        # pins the ledger, so its since advances past the pending as_ofs while
+        # the leg stays cut.
+        for t in threads:
+            t.join(timeout=10)
+        time.sleep(40)
+        set_compute2(True)
+        time.sleep(8)
+        name = halted()
+        if name is not None:
+            raise AssertionError(
+                f"REPRODUCED incident #39: {name} halted with 'cannot serve"
+                f" requested as_of', iteration {iteration}"
+            )
+        log.log("repro", f"iteration {iteration}: no as_of halt yet")
+    log.log("repro", "not reproduced in 15 iterations")
+
+
+REPRO_FUNCS = {
+    "repro-blob-memory": repro_blob_memory,
+    "repro-postheal-stall": repro_postheal_stall,
+    "repro-per10": repro_per10,
+    "repro-durable-resume": repro_durable_resume,
+    "repro-compute-asof": repro_compute_asof,
+}

--- a/test/invariants/mzcompose.py
+++ b/test/invariants/mzcompose.py
@@ -171,6 +171,13 @@ LEGS = {
             Proxy("compute2_storagectl", 2200, "clusterd-compute2:2100"),
             Proxy("compute2_computectl", 2201, "clusterd-compute2:2101"),
         ),
+        # TODO: Reenable the cutting kinds when PER-49 is fixed. Losing this
+        # replica drops its per-replica read holds while it keeps a pending
+        # dataflow, whose inputs then compact past the dataflow's as_of, and
+        # rendering it halts the process. Degrading the leg still covers the
+        # controller's slow-replica paths. Reproducer:
+        # bin/mzcompose --find invariants run default --scenario=repro-compute-asof
+        kinds=("latency", "limit_data", "bandwidth"),
     ),
     "clusterd-storage": Leg(
         "clusterd-storage",
@@ -182,10 +189,16 @@ LEGS = {
     # Persist blob I/O of envd and every clusterd. Capped like the metadata
     # leg, and restricted to non-buffering toxics: latency and bandwidth
     # would hold the entire blob throughput in toxiproxy's memory.
+    # TODO: Shorten to 45s again when PER-31 is fixed. Every process buffers
+    # unboundedly for as long as blob writes cannot land, and at high
+    # complexity one 45s cut already grows clusterd by GiBs, so repeated cuts
+    # OOM-kill it before the run finishes. 15s still exercises the heal edges,
+    # which is where the recovery bugs are. Reproducer:
+    # bin/mzcompose --find invariants run default --scenario=repro-blob-memory
     "blob": Leg(
         "blob",
         (Proxy("blob", 9000, "minio:9000"),),
-        max_outage=45.0,
+        max_outage=15.0,
         kinds=("disable", "timeout", "limit_data"),
     ),
     "pg": Leg("pg", (Proxy("pg", 5432, "postgres:5432"),)),
@@ -380,6 +393,7 @@ def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
                 restore_proxies=[
                     proxy for leg in LEGS.values() for proxy in leg.proxies
                 ],
+                restart_toxiproxy=lambda: _restart_toxiproxy(c),
             ).run()
         finally:
             scenario.teardown()
@@ -469,7 +483,8 @@ REPROS = {
     " healed",
     "repro-per10": "PER-10: persist GC panic, earliest state without rollup",
     "repro-durable-resume": "resumed SUBSCRIBE cancels its carried state",
-    "repro-compute-asof": "CLU-34: compute halts hydrating a dataflow past its as_of",
+    "repro-compute-asof": "PER-49: compute halts hydrating a dataflow past its"
+    " as_of",
 }
 
 
@@ -537,6 +552,18 @@ def run_repro(c: Composition, name: str, args, log: EventLog) -> None:
             stop.set()
             for t in threads:
                 t.join(timeout=10)
+
+
+def _restart_toxiproxy(c: Composition) -> None:
+    """Replace a toxiproxy whose admin API no longer answers.
+
+    Every leg runs through this container, so the restart cuts them all for a
+    moment. That is the same event as a toxiproxy crash, which the disruptor
+    recovers from by re-creating the proxies, and it is the only way out of a
+    wedged admin API.
+    """
+    c.kill("toxiproxy")
+    c.up("toxiproxy", detach=True, max_tries=3)
 
 
 def _toxiproxy_heal(toxiproxy: ToxiproxyApi, log: EventLog) -> None:
@@ -775,9 +802,29 @@ def repro_per10(c, toxiproxy, ctx, log) -> None:
 
 
 def repro_durable_resume(c, toxiproxy, ctx, log) -> None:
-    """Blob cut + envd kill, then a durable resume must keep its state."""
+    """Blob cut that freezes writes, envd death, then a durable resume.
+
+    The observed occurrence had two ingredients: a blob cut that froze every
+    write for 89s, so the subscriber's resume timestamp fell far behind the
+    shard, and envd dying seconds after the heal from the PER-10 GC panic. A
+    scripted clean kill and restart on its own was ruled out as a trigger, so
+    each cycle first gives that panic a window to fire (envd's restart policy
+    brings it back) and kills only when it does not, recording which trigger
+    the cycle actually got. Cut lengths alternate between the incident's long
+    write freeze and repro-per10's short cut, whose heal is where the panic
+    fires.
+    """
     from materialize.invariants.checkers import SubscribeChecker
     from materialize.invariants.framework import InvariantViolation
+
+    # Long cuts match the incident's write freeze, short ones repro-per10.
+    CUT_LENGTHS = [90.0, 5.0, 90.0, 5.0, 90.0]
+    # Grace period for the GC panic to kill envd on its own after a heal.
+    PANIC_WINDOW_S = 15.0
+
+    def rollup_panics() -> int:
+        logs = c.invoke("logs", "materialized", capture=True).stdout or ""
+        return logs.count("did not have corresponding rollup")
 
     total = ctx.complexity.accounts * 1000
 
@@ -792,7 +839,7 @@ def repro_durable_resume(c, toxiproxy, ctx, log) -> None:
             if got != {(total,): 1}:
                 raise InvariantViolation(f"state {got} at {ts}")
 
-    for iteration in range(5):
+    for iteration, cut_s in enumerate(CUT_LENGTHS):
         rng = random.Random(f"resume-{iteration}")
         checker = ResumeChecker(rng)
         deadline = time.monotonic() + 15
@@ -804,32 +851,54 @@ def repro_durable_resume(c, toxiproxy, ctx, log) -> None:
                 raise
             except Exception:
                 pass
-        assert checker.last_validated_ts is not None
+        assert (
+            checker.last_validated_ts is not None
+        ), "warmup validated no timestamp, so there is no state to carry"
+        resume_from = checker.last_validated_ts
+        panics_before = rollup_panics()
         toxiproxy.set_enabled("blob", False)
-        time.sleep(15)
+        time.sleep(cut_s)
         _toxiproxy_heal(toxiproxy, log)
-        time.sleep(2)
-        c.kill("materialized")
+        trigger = "clean kill (ruled out on its own)"
+        panic_deadline = time.monotonic() + PANIC_WINDOW_S
+        while time.monotonic() < panic_deadline:
+            if rollup_panics() > panics_before:
+                trigger = "PER-10 panic"
+                break
+            time.sleep(1)
+        if trigger != "PER-10 panic":
+            c.kill("materialized")
         c.up("materialized", detach=True, max_tries=3)
         deadline = time.monotonic() + 60
         while time.monotonic() < deadline:
             try:
                 checker.check_once()  # raises InvariantViolation if reproduced
-            except AssertionError:
+            except AssertionError as e:
+                # Carry the violation through: it holds the shard-vs-stream
+                # probe and the session context that classify the occurrence.
                 raise AssertionError(
-                    f"REPRODUCED durable-resume anomaly, iteration {iteration}"
-                )
+                    f"REPRODUCED durable-resume anomaly, iteration"
+                    f" {iteration} ({trigger}): {e}"
+                ) from e
             except Exception:
                 pass
+        # resumes==0 means the resume never ran, which is not evidence of
+        # consistency, so the count is part of the result.
+        log.log(
+            "repro",
+            f"iteration {iteration}: {cut_s:.0f}s cut, {trigger}, resumed"
+            f" {checker.resumes}x from {resume_from}, stayed consistent",
+        )
         checker.close()
-        log.log("repro", f"iteration {iteration}: resume stayed consistent")
-    log.log("repro", "not reproduced in 5 iterations")
+    log.log("repro", f"not reproduced in {len(CUT_LENGTHS)} iterations")
 
 
 def repro_compute_asof(c, toxiproxy, ctx, log) -> None:
     """Compute halts hydrating a dataflow whose input compacted past its as_of.
 
-    incidents-and-escalations #39 / CLU-34. When the controller loses a
+    The halt is tracked as PER-49, the retry mechanism that would absorb it as
+    CPU-34, and it was seen in incidents-and-escalations #39. When the
+    controller loses a
     replica it drops that replica's per-replica read holds, and for a dataflow
     it no longer wants (a canceled peek) it does not reinstall them, while the
     replica still has the dataflow pending. The inputs then compact, and when

--- a/test/invariants/mzcompose.py
+++ b/test/invariants/mzcompose.py
@@ -20,14 +20,18 @@ import random
 import subprocess
 import threading
 import time
+from contextlib import ExitStack
 
 from materialize.invariants.executor import Runner
 from materialize.invariants.framework import (
     COMPLEXITIES,
     Endpoints,
     EventLog,
+    InvariantViolation,
     ScenarioContext,
+    wait_until,
 )
+from materialize.invariants.mz import MzClient
 from materialize.invariants.scenarios import SCENARIOS
 from materialize.invariants.toxiproxy import Leg, ProcessTarget, Proxy, ToxiproxyApi
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -109,10 +113,10 @@ SERVICES = [
     # Materialize by container name and for the harness via the host port.
     Minio(setup_materialize=True, additional_directories=["copytos3"]),
     materialized_service(),
+    # clusterd-compute2 is the compute cluster's second replica, behind its
+    # own leg: peeks keep being served (and verified) while one replica is
+    # disrupted, and a diverging replica shows up as wrong answers.
     *(clusterd_service(name) for name in CLUSTERD_NAMES),
-    # Second replica of the compute cluster, behind its own leg: peeks keep
-    # being served (and verified) while one replica is disrupted, and a
-    # diverging replica shows up as wrong answers.
     Postgres(),
     MySql(),
     SqlServer(),
@@ -287,18 +291,28 @@ def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
     )
     c.down(destroy_volumes=True)
 
-    # restart on-failure: proxies live in toxiproxy's memory, so after a
-    # crash the disruptor's heal re-creates them (it cannot resurrect the
-    # container itself).
-    version_services = []
-    if args.upgrade_from:
-        version_services = [materialized_service(image=args.upgrade_from)] + [
-            clusterd_service(name, image=args.upgrade_from) for name in CLUSTERD_NAMES
-        ]
-    with c.override(
-        Toxiproxy(seed=rng.randrange(2**63), restart="on-failure"),
-        *version_services,
-    ):
+    with ExitStack() as stack:
+        # restart on-failure: proxies live in toxiproxy's memory, so after a
+        # crash the disruptor's heal re-creates them (it cannot resurrect the
+        # container itself).
+        stack.enter_context(
+            c.override(Toxiproxy(seed=rng.randrange(2**63), restart="on-failure"))
+        )
+        # The old-version services of an --upgrade-from run live in their own
+        # stack: up() renders the current composition, so the mid-run upgrade
+        # swap must be able to close this override (restoring the
+        # current-build definitions) without disturbing the toxiproxy one.
+        version_override = stack.enter_context(ExitStack())
+        if args.upgrade_from:
+            version_override.enter_context(
+                c.override(
+                    materialized_service(image=args.upgrade_from),
+                    *(
+                        clusterd_service(name, image=args.upgrade_from)
+                        for name in CLUSTERD_NAMES
+                    ),
+                )
+            )
         # The proxies must exist before materialized boots: its consensus and
         # timestamp-oracle URLs point at toxiproxy.
         c.up("toxiproxy")
@@ -352,7 +366,9 @@ def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
         scenario = scenario_class(ctx)
         scenario.setup()
         legs = [] if args.no_disruptions else [LEGS[n] for n in scenario_class.legs]
-        midrun = make_upgrade_swap(c) if args.upgrade_from else None
+        midrun = (
+            make_upgrade_swap(c, ctx, version_override) if args.upgrade_from else None
+        )
         try:
             Runner(
                 scenario,
@@ -361,12 +377,24 @@ def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
                 legs,
                 process_targets(c),
                 midrun_event=midrun,
+                restore_proxies=[
+                    proxy for leg in LEGS.values() for proxy in leg.proxies
+                ],
             ).run()
         finally:
             scenario.teardown()
 
 
-def make_upgrade_swap(c: Composition):
+def make_upgrade_swap(
+    c: Composition, ctx: ScenarioContext, version_override: ExitStack
+):
+    # Captured now, while the old version is still healthy: mid-chaos it may
+    # not answer, and the post-swap probe needs it to prove the version
+    # actually changed.
+    client = MzClient(ctx, "upgrade-swap")
+    old_version = str(client.query("SELECT mz_version()")[0][0])
+    client.reset()
+
     def swap() -> None:
         # Kill the old-version processes and bring everything back on the
         # current build: an upgrade in the middle of load and disruptions,
@@ -378,7 +406,23 @@ def make_upgrade_swap(c: Composition):
             "clusterd-storage",
         ]
         c.kill(*names)
+        # up() renders the composition, which the version override pins to
+        # the old image, so the override must be closed first.
+        version_override.close()
         c.up(*names, detach=True, max_tries=3)
+
+        def upgraded() -> bool:
+            version = str(client.query("SELECT mz_version()", timeout=30)[0][0])
+            if version == old_version:
+                raise InvariantViolation(
+                    f"upgrade swap brought back the old version {version}"
+                )
+            return True
+
+        # Bounded probe rather than one-shot: legs may still be disrupted
+        # when the swap fires, but a full metadata cut is capped at 45s and
+        # the new build must serve after healing.
+        wait_until(upgraded, 180, "swapped-in build serving its new version")
 
     return swap
 
@@ -419,11 +463,13 @@ def process_targets(c: Composition) -> list[ProcessTarget]:
 # --scenario=repro-*. blob-memory and postheal-stall are deterministic
 # sequences, per10 and durable-resume are fixed-sequence loops over races.
 REPROS = {
-    "repro-blob-memory": "unbounded clusterd memory while the blob store is cut",
-    "repro-postheal-stall": "writes stalled long after a metadata cut healed",
-    "repro-per10": "persist GC panic: earliest state without rollup",
+    "repro-blob-memory": "PER-31: unbounded clusterd memory while the blob"
+    " store is cut",
+    "repro-postheal-stall": "PER-32: writes stalled long after a metadata cut"
+    " healed",
+    "repro-per10": "PER-10: persist GC panic, earliest state without rollup",
     "repro-durable-resume": "resumed SUBSCRIBE cancels its carried state",
-    "repro-compute-asof": "compute halts hydrating a dataflow past its as_of",
+    "repro-compute-asof": "CLU-34: compute halts hydrating a dataflow past its as_of",
 }
 
 
@@ -462,13 +508,18 @@ def run_repro(c: Composition, name: str, args, log: EventLog) -> None:
         stop = threading.Event()
 
         def drive(bundle) -> None:
+            actions = {action.name: action for action in bundle.actions}
             ticks = 0
             while not stop.is_set():
                 ticks += 1
                 # LedgerTransfer for steady writes (consensus churn), plus
                 # DdlChurn: created and dropped MVs mean shard finalization,
                 # which is what keeps persist GC busy.
-                action = bundle.actions[3] if ticks % 40 == 0 else bundle.actions[1]
+                action = (
+                    actions["ddl-churn"]
+                    if ticks % 40 == 0
+                    else actions["ledger-transfer"]
+                )
                 try:
                     action.run()
                 except Exception:
@@ -748,6 +799,9 @@ def repro_durable_resume(c, toxiproxy, ctx, log) -> None:
         while time.monotonic() < deadline:
             try:
                 checker.check_once()
+            except InvariantViolation:
+                # No disruption is active yet, a violation here is real.
+                raise
             except Exception:
                 pass
         assert checker.last_validated_ts is not None

--- a/test/invariants/mzcompose.py
+++ b/test/invariants/mzcompose.py
@@ -1,0 +1,2049 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Multi-threaded correctness test: scenarios whose invariants hold no matter
+which concurrent actions succeed, fail, or end up in an unknown state (e.g.
+bank transfers that conserve the total balance), checked continuously while
+toxiproxy disrupts the envd<->clusterd, metadata-store, source, and sink
+connections, and strictly again after healing.
+"""
+
+import json
+import os
+import random
+import re
+import subprocess
+import threading
+import time
+from contextlib import ExitStack
+from typing import Any
+
+from materialize.invariants.executor import Runner
+from materialize.invariants.framework import (
+    COMPLEXITIES,
+    Endpoints,
+    EventLog,
+    InvariantViolation,
+    ScenarioContext,
+    wait_until,
+)
+from materialize.invariants.mz import MzClient
+from materialize.invariants.scenarios import SCENARIOS
+from materialize.invariants.toxiproxy import (
+    DISRUPTION_KINDS,
+    PROCESS_KINDS,
+    Leg,
+    ProcessTarget,
+    Proxy,
+    ToxiproxyApi,
+)
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.clusterd import Clusterd
+from materialize.mzcompose.services.kafka import Kafka
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.minio import Minio, minio_blob_uri
+from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.persistcli import Persistcli
+from materialize.mzcompose.services.postgres import Postgres, PostgresMetadata
+from materialize.mzcompose.services.schema_registry import SchemaRegistry
+from materialize.mzcompose.services.sql_server import SqlServer
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
+from materialize.version_list import get_latest_published_version
+
+# Host port for the Kafka listener the harness (producers, consumers) uses.
+# It must be a fixed port because Kafka advertises it back to clients.
+KAFKA_HOST_PORT = 30993
+
+# Local iteration: run the Materialize services from this image instead of
+# building the current source. An environment variable, not a workflow
+# argument, because the image acquisition happens before workflow arguments
+# are parsed.
+INVARIANTS_IMAGE = os.environ.get("INVARIANTS_IMAGE")
+
+# Whether a soft assertion panics, which the CI log annotator reports, or only
+# logs. `MZ_SOFT_ASSERTIONS` decides at runtime, not compile time, so the
+# optimized profile our images build with keeps them live, and `Materialized`
+# and `Clusterd` both already set it to 1. Set INVARIANTS_SOFT_ASSERTIONS=0 once
+# a known soft assertion fires often enough to mask everything behind it. An
+# environment variable for the same reason as INVARIANTS_IMAGE: the services are
+# constructed before workflow arguments are parsed.
+SOFT_ASSERTIONS = os.environ.get("INVARIANTS_SOFT_ASSERTIONS", "1")
+
+# Applied in order, so appending this overrides the service's own setting.
+SOFT_ASSERTION_ENV = [f"MZ_SOFT_ASSERTIONS={SOFT_ASSERTIONS}"]
+
+
+def materialized_service(image: str | None = None) -> Materialized:
+    return Materialized(
+        image=image or INVARIANTS_IMAGE,
+        environment_extra=SOFT_ASSERTION_ENV,
+        # Route the metadata store (persist consensus and the timestamp
+        # oracle) and the persist blob store through toxiproxy. The proxies
+        # must exist before this service starts.
+        external_metadata_store="toxiproxy",
+        metadata_store="postgres-metadata",
+        external_blob_store="toxiproxy",
+        support_external_clusterd=True,
+        sanity_restart=False,
+        # Fixed host ports: the disruptor kills this container and a
+        # recreation under ephemeral ports would strand every client on the
+        # old mapping.
+        ports=["16875:6875", "16876:6876", "16877:6877"],
+        # Crashes (both the disruptor's kills and genuine panics) restart
+        # envd so the invariants keep being verified afterwards. Panics
+        # still fail the job via the CI log annotator.
+        restart="on-failure",
+        default_replication_factor=1,
+        additional_system_parameter_defaults={
+            "unsafe_enable_unorchestrated_cluster_replicas": "true",
+            "allow_real_time_recency": "true",
+            "enable_refresh_every_mvs": "true",
+            "enable_bounded_staleness_isolation": "true",
+            "enable_replacement_materialized_views": "true",
+            "enable_within_timestamp_order_by_in_subscribe": "true",
+            # ShardChurn evolves the schema of its scratch tables, so
+            # compaction has to migrate batches written under both.
+            "enable_alter_table_add_column": "true",
+        },
+        depends_on=["toxiproxy"],
+    )
+
+
+# Persist pubsub, one toxiproxy listener per clusterd. Persist's blob and
+# consensus URLs are chosen by envd and handed to every clusterd verbatim, so
+# those legs can only be cut for all processes at once. Pubsub is the one
+# persist connection each clusterd is configured with individually, which
+# makes it the only place a *partial* partition is expressible: one process
+# stops hearing about other processes' writes while the rest keep hearing
+# them, so it falls back to polling and lags behind a system that thinks it
+# is fine. Nothing else here produces two peers with different views.
+# CPU squeeze for the `throttle` disruption, as a cgroup quota per period.
+CPU_PERIOD = 100_000
+CPU_THROTTLED = 50_000
+
+PUBSUB_PORTS = {
+    "clusterd-compute": 6879,
+    "clusterd-compute2": 6880,
+    "clusterd-storage": 6881,
+}
+
+
+def clusterd_service(name: str, image: str | None = None) -> Clusterd:
+    return Clusterd(
+        name=name,
+        image=image or INVARIANTS_IMAGE,
+        # The controller connects through toxiproxy, so the host in request
+        # URIs doesn't match this clusterd's hostname.
+        environment_extra=["CLUSTERD_GRPC_HOST=", *SOFT_ASSERTION_ENV],
+        persist_pubsub_url=f"http://toxiproxy:{PUBSUB_PORTS[name]}",
+        # halt! is a designed recovery path for clusterd.
+        restart="on-failure",
+        # Bounded so that runaway memory (e.g. buffering while the blob leg
+        # is cut) kills and restarts this container instead of taking down
+        # the whole agent.
+        memory="6GB",
+    )
+
+
+CLUSTERD_NAMES = ["clusterd-compute", "clusterd-compute2", "clusterd-storage"]
+
+SERVICES = [
+    Toxiproxy(),
+    PostgresMetadata(),
+    # The extra bucket serves the COPY TO S3 checker, reachable for
+    # Materialize by container name and for the harness via the host port.
+    Minio(setup_materialize=True, additional_directories=["copytos3"]),
+    materialized_service(),
+    # clusterd-compute2 is the compute cluster's second replica, behind its
+    # own leg: peeks keep being served (and verified) while one replica is
+    # disrupted, and a diverging replica shows up as wrong answers.
+    *(clusterd_service(name) for name in CLUSTERD_NAMES),
+    Postgres(),
+    MySql(),
+    SqlServer(),
+    # Kafka clients follow advertised listener addresses after bootstrap, so
+    # proxying the bootstrap address alone would not carry any traffic.
+    # Instead, dedicated source/sink listeners advertise the toxiproxy
+    # address, keeping all of Materialize's Kafka traffic on the proxied
+    # legs, while the harness uses the direct HOST listener.
+    Kafka(
+        ports=[f"{KAFKA_HOST_PORT}:{KAFKA_HOST_PORT}", 9092, 9192, 9096],
+        allow_host_ports=True,
+        advertised_listeners=[
+            "SOURCE://toxiproxy:9092",
+            "SINK://toxiproxy:9192",
+            f"HOST://localhost:{KAFKA_HOST_PORT}",
+            "PLAINTEXT://kafka:9096",
+        ],
+        environment_extra=[
+            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP="
+            "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SOURCE:PLAINTEXT,"
+            "SINK:PLAINTEXT,HOST:PLAINTEXT",
+        ],
+    ),
+    # The schema registry talks to Kafka directly (it is harness-side
+    # infrastructure for the broker); Materialize reaches it through the
+    # csr leg.
+    SchemaRegistry(kafka_servers=[("kafka", "9096")]),
+    # Idle sidecar, started only for the post-run persist state audit.
+    Persistcli(),
+]
+
+# One leg per connection of the system under test. All proxies are created
+# up front (unused ones are harmless), scenarios pick which legs to disrupt.
+LEGS = {
+    "metadata": Leg(
+        "metadata",
+        (Proxy("metadata", 26257, "postgres-metadata:26257"),),
+        # Full cuts freeze the coordinator loop (group commit blocks on
+        # the oracle), so nothing is served mid-outage and the interesting
+        # coverage is at the heal edges. Short cuts buy more edges per run,
+        # and stay far below the 15 minute persist lease expiry.
+        max_outage=45.0,
+    ),
+    "clusterd-compute": Leg(
+        "clusterd-compute",
+        (
+            Proxy("compute_storagectl", 2100, "clusterd-compute:2100"),
+            Proxy("compute_computectl", 2101, "clusterd-compute:2101"),
+        ),
+        # TODO: Reenable the cutting kinds when PER-49 is fixed, as for
+        # clusterd-compute2 below. NOTE: this does not remove the trigger.
+        # Losing the replica is what drops its per-replica read holds, and the
+        # disruptor's SIGKILLs of this process do that just as well as a leg
+        # cut, so the halt keeps occurring until PER-49 is fixed. Reproducer:
+        # bin/mzcompose --find invariants run default --scenario=repro-compute-asof
+        kinds=("latency", "limit_data", "bandwidth"),
+    ),
+    "clusterd-compute2": Leg(
+        "clusterd-compute2",
+        (
+            Proxy("compute2_storagectl", 2200, "clusterd-compute2:2100"),
+            Proxy("compute2_computectl", 2201, "clusterd-compute2:2101"),
+        ),
+        # TODO: Reenable the cutting kinds when PER-49 is fixed. Losing this
+        # replica drops its per-replica read holds while it keeps a pending
+        # dataflow, whose inputs then compact past the dataflow's as_of, and
+        # rendering it halts the process. Degrading the leg still covers the
+        # controller's slow-replica paths. Reproducer:
+        # bin/mzcompose --find invariants run default --scenario=repro-compute-asof
+        kinds=("latency", "limit_data", "bandwidth"),
+    ),
+    "clusterd-storage": Leg(
+        "clusterd-storage",
+        (
+            Proxy("storage_storagectl", 3100, "clusterd-storage:2100"),
+            Proxy("storage_computectl", 3101, "clusterd-storage:2101"),
+        ),
+    ),
+    # Persist blob I/O of envd and every clusterd. Capped like the metadata
+    # leg, and restricted to non-buffering toxics: latency and bandwidth
+    # would hold the entire blob throughput in toxiproxy's memory.
+    # TODO: Shorten to 45s again when PER-31 is fixed. Every process buffers
+    # unboundedly for as long as blob writes cannot land, and at high
+    # complexity one 45s cut already grows clusterd by GiBs, so repeated cuts
+    # OOM-kill it before the run finishes. 15s still exercises the heal edges,
+    # which is where the recovery bugs are. Reproducer:
+    # bin/mzcompose --find invariants run default --scenario=repro-blob-memory
+    "blob": Leg(
+        "blob",
+        (Proxy("blob", 9000, "minio:9000"),),
+        max_outage=15.0,
+        # NOTE: limit_data is dropped here, not for the buffering reason above
+        # but because max_outage only caps the full-outage kinds. A limit_data
+        # on this leg kills every connection past its byte budget, so it stalls
+        # blob writes for its whole uncapped duration, which is all PER-31
+        # needs: nightly 17743 OOM-killed clusterd at 6.2GiB during a 29s one.
+        kinds=("disable", "timeout", "reset_peer", "flap"),
+    ),
+    # One per clusterd, see PUBSUB_PORTS. Losing pubsub must cost latency and
+    # nothing else: it is a notification channel, and every reader that stops
+    # hearing from it falls back to polling. A correctness failure here is a
+    # real one, and a partial cut is the only way to reach the state where one
+    # process is behind and the others are not.
+    **{
+        f"pubsub-{name.removeprefix('clusterd-')}": Leg(
+            f"pubsub-{name.removeprefix('clusterd-')}",
+            (Proxy(f"pubsub_{name.replace('-', '_')}", port, "materialized:6879"),),
+        )
+        for name, port in PUBSUB_PORTS.items()
+    },
+    "pg": Leg("pg", (Proxy("pg", 5432, "postgres:5432"),)),
+    "mysql": Leg("mysql", (Proxy("mysql", 3306, "mysql:3306"),)),
+    "sql-server": Leg("sql-server", (Proxy("sql_server", 1433, "sql-server:1433"),)),
+    "kafka-source": Leg("kafka-source", (Proxy("kafka_source", 9092, "kafka:9092"),)),
+    "kafka-sink": Leg("kafka-sink", (Proxy("kafka_sink", 9192, "kafka:9192"),)),
+    "csr": Leg("csr", (Proxy("csr", 8081, "schema-registry:8081"),)),
+}
+
+# Sources and sinks run in `storage`, MVs and indexes in `compute`, both on
+# unorchestrated clusterd containers whose controller connections go through
+# toxiproxy. The built-in quickstart cluster stays undisrupted as an
+# independent observer path for checkers.
+CLUSTER_SETUP_SQL = """
+CREATE CLUSTER storage REPLICAS (r1 (
+    STORAGECTL ADDRESSES ['toxiproxy:3100'],
+    STORAGE ADDRESSES ['clusterd-storage:2103'],
+    COMPUTECTL ADDRESSES ['toxiproxy:3101'],
+    COMPUTE ADDRESSES ['clusterd-storage:2102'],
+    WORKERS 1
+));
+CREATE CLUSTER compute REPLICAS (
+    r1 (
+        STORAGECTL ADDRESSES ['toxiproxy:2100'],
+        STORAGE ADDRESSES ['clusterd-compute:2103'],
+        COMPUTECTL ADDRESSES ['toxiproxy:2101'],
+        COMPUTE ADDRESSES ['clusterd-compute:2102'],
+        WORKERS 1
+    ),
+    r2 (
+        STORAGECTL ADDRESSES ['toxiproxy:2200'],
+        STORAGE ADDRESSES ['clusterd-compute2:2103'],
+        COMPUTECTL ADDRESSES ['toxiproxy:2201'],
+        COMPUTE ADDRESSES ['clusterd-compute2:2102'],
+        WORKERS 1
+    )
+);
+GRANT ALL ON CLUSTER storage TO materialize;
+GRANT ALL ON CLUSTER compute TO materialize;
+"""
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument(
+        "--scenario",
+        default="all",
+        choices=["all", *SCENARIOS.keys(), *REPROS.keys()],
+    )
+    parser.add_argument(
+        "--complexity", default="medium", choices=list(COMPLEXITIES.keys())
+    )
+    parser.add_argument(
+        "--runtime",
+        default=600,
+        type=int,
+        help="chaos phase duration per scenario, seconds",
+    )
+    parser.add_argument("--seed", type=str, default=str(int(time.time())))
+    parser.add_argument(
+        "--upgrade-from",
+        type=str,
+        nargs="?",
+        const="latest",
+        default=None,
+        metavar="IMAGE",
+        help="start Materialize on this image and swap to the current build"
+        " mid-chaos, an upgrade under load and disruptions. Bare or 'latest'"
+        " resolves to the most recent published release",
+    )
+    parser.add_argument(
+        "--no-disruptions",
+        action="store_true",
+        help="run the workload and checkers without any disruptions",
+    )
+    parser.add_argument(
+        "--legs",
+        type=str,
+        default=None,
+        metavar="NAME,...",
+        help="disrupt only these legs of the scenario's set, for bisecting"
+        " which dependency a symptom depends on",
+    )
+    parser.add_argument(
+        "--kinds",
+        type=str,
+        default=None,
+        metavar="KIND,...",
+        help="use only these disruption kinds, both toxics and process"
+        " faults, for exercising one kind or bisecting which one a symptom"
+        " depends on. A leg or process left with no allowed kind is skipped",
+    )
+    parser.add_argument(
+        "--persist-churn",
+        action="store_true",
+        help="drive persist compaction, rollups, and GC as hard as the"
+        " workload allows, see PERSIST_CHURN_SQL",
+    )
+    args = parser.parse_args()
+
+    if args.upgrade_from == "latest":
+        args.upgrade_from = f"materialize/materialized:{get_latest_published_version()}"
+        print(f"--- Upgrading from {args.upgrade_from}")
+    print(f"--- Random seed is {args.seed}")
+    if args.scenario in REPROS:
+        log = EventLog("invariants-events.log")
+        try:
+            with c.test_case(args.scenario):
+                run_repro(c, args.scenario, args, log)
+        finally:
+            log.close()
+        return
+    names = list(SCENARIOS.keys()) if args.scenario == "all" else [args.scenario]
+    log = EventLog("invariants-events.log")
+    try:
+        for name in names:
+            with c.test_case(name):
+                run_scenario(c, name, args, log)
+    finally:
+        log.close()
+
+
+class MemorySampler(threading.Thread):
+    """Records each container's resident memory into the event log.
+
+    A process that grows without bound is only visible here as a kernel OOM
+    line in a log nobody reads, after the fact, with no way to tell which
+    disruption drove the growth or how fast it went. The disruptor writes its
+    history to the same log, so sampling into it makes the two line up.
+
+    Growth past a fraction of the container's limit is echoed as well, so it
+    shows up in the job output while the process is still alive rather than
+    only in the artifact afterwards, and a clusterd that gets there has a heap
+    profile taken. A kernel OOM kill leaves no panic, no core, and no trace of
+    where the memory went, so the profile has to be taken while the process is
+    still alive or the evidence is gone for good.
+    """
+
+    ECHO_FRACTION = 0.7
+    # Far enough below ECHO_FRACTION that the profile is taken while the
+    # process still has room to answer the request, and above any settled
+    # working set we have measured.
+    PROFILE_FRACTION = 0.5
+    INTERVAL = 15.0
+
+    def __init__(self, c: Composition, log: EventLog) -> None:
+        super().__init__(name="memory-sampler", daemon=True)
+        self.c = c
+        self.log = log
+        self.stop_event = threading.Event()
+        self.peak: dict[str, float] = {}
+        self.profiled: set[str] = set()
+
+    def run(self) -> None:
+        while not self.stop_event.wait(self.INTERVAL):
+            try:
+                out = subprocess.run(
+                    [
+                        "docker",
+                        "stats",
+                        "--no-stream",
+                        "--format",
+                        "{{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                ).stdout
+            except Exception:
+                # Sampling is diagnostics. Docker being briefly unavailable
+                # (a container mid-restart, the daemon busy) must never
+                # disturb the run.
+                continue
+            rows = []
+            for line in out.splitlines():
+                parts = line.split("\t")
+                if len(parts) != 3 or "invariants-" not in parts[0]:
+                    continue
+                short = parts[0].removeprefix("invariants-").removesuffix("-1")
+                rows.append(f"{short}={parts[1].split(' / ')[0]}")
+                try:
+                    pct = float(parts[2].rstrip("%"))
+                except ValueError:
+                    continue
+                if (
+                    pct >= self.PROFILE_FRACTION * 100
+                    and short.startswith("clusterd-")
+                    and short not in self.profiled
+                ):
+                    self.profiled.add(short)
+                    _heap_profile(self.c, short, f"{pct:.0f}pct", self.log)
+                if pct >= self.ECHO_FRACTION * 100 and pct > self.peak.get(short, 0.0):
+                    self.peak[short] = pct
+                    self.log.log("mem", f"{short} at {pct:.0f}% of its memory limit")
+            if rows:
+                self.log.log("mem", " ".join(rows), echo=False)
+
+
+def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
+    scenario_class = SCENARIOS[name]
+    complexity = COMPLEXITIES[args.complexity]
+    # Deterministic per (seed, scenario) so single-scenario runs reproduce
+    # the same sequences as the same scenario within an `all` run.
+    rng = random.Random(f"{args.seed}-{name}")
+    log.log(
+        "scenario",
+        f"starting {name} complexity={complexity.name} runtime={args.runtime}s"
+        f" seed={args.seed}",
+    )
+    c.down(destroy_volumes=True)
+
+    with ExitStack() as stack:
+        # restart on-failure: proxies live in toxiproxy's memory, so after a
+        # crash the disruptor's heal re-creates them (it cannot resurrect the
+        # container itself).
+        stack.enter_context(
+            c.override(Toxiproxy(seed=rng.randrange(2**63), restart="on-failure"))
+        )
+        # The old-version services of an --upgrade-from run live in their own
+        # stack: up() renders the current composition, so the mid-run upgrade
+        # swap must be able to close this override (restoring the
+        # current-build definitions) without disturbing the toxiproxy one.
+        version_override = stack.enter_context(ExitStack())
+        if args.upgrade_from:
+            version_override.enter_context(
+                c.override(
+                    materialized_service(image=args.upgrade_from),
+                    *(
+                        clusterd_service(name, image=args.upgrade_from)
+                        for name in CLUSTERD_NAMES
+                    ),
+                )
+            )
+        # The proxies must exist before materialized boots: its consensus and
+        # timestamp-oracle URLs point at toxiproxy.
+        c.up("toxiproxy")
+        toxiproxy = ToxiproxyApi(f"http://127.0.0.1:{c.default_port('toxiproxy')}")
+        for leg in LEGS.values():
+            for proxy in leg.proxies:
+                toxiproxy.create(proxy)
+
+        services = [
+            "materialized",
+            "clusterd-compute",
+            "clusterd-compute2",
+            "clusterd-storage",
+        ]
+        services += scenario_class.services
+        c.up(*services)
+        c.sql(CLUSTER_SETUP_SQL, port=6877, user="mz_system")
+        if args.persist_churn:
+            c.sql(PERSIST_CHURN_SQL, port=6877, user="mz_system")
+
+        endpoints = Endpoints(
+            mz_host="127.0.0.1",
+            mz_port=c.default_port("materialized"),
+            mz_system_port=c.port("materialized", 6877),
+            mz_http_port=c.port("materialized", 6876),
+            minio_port=c.default_port("minio"),
+            pg_port=(
+                c.default_port("postgres")
+                if "postgres" in scenario_class.services
+                else None
+            ),
+            mysql_port=(
+                c.default_port("mysql") if "mysql" in scenario_class.services else None
+            ),
+            sqlserver_port=(
+                c.default_port("sql-server")
+                if "sql-server" in scenario_class.services
+                else None
+            ),
+            kafka_bootstrap=(
+                f"localhost:{KAFKA_HOST_PORT}"
+                if "kafka" in scenario_class.services
+                else None
+            ),
+        )
+        ctx = ScenarioContext(
+            endpoints=endpoints,
+            complexity=complexity,
+            rng=rng,
+            log=log,
+            seed=args.seed,
+        )
+        scenario = scenario_class(ctx)
+        scenario.setup()
+        legs = [] if args.no_disruptions else [LEGS[n] for n in scenario_class.legs]
+        kind_filter = None
+        if args.kinds:
+            kind_filter = {k.strip() for k in args.kinds.split(",") if k.strip()}
+            unknown = kind_filter - set(DISRUPTION_KINDS) - PROCESS_KINDS
+            assert not unknown, f"--kinds: unknown: {sorted(unknown)}"
+        if args.legs:
+            selected = set(args.legs.split(","))
+            unknown = selected - {leg.name for leg in legs}
+            assert not unknown, f"--legs: not in this scenario: {sorted(unknown)}"
+            legs = [leg for leg in legs if leg.name in selected]
+        midrun = (
+            make_upgrade_swap(c, ctx, version_override) if args.upgrade_from else None
+        )
+        sampler = MemorySampler(c, log)
+        sampler.start()
+        try:
+            runner = Runner(
+                scenario,
+                args.runtime,
+                toxiproxy,
+                legs,
+                process_targets(c),
+                midrun_event=midrun,
+                restore_proxies=[
+                    proxy for leg in LEGS.values() for proxy in leg.proxies
+                ],
+                restart_toxiproxy=lambda: _restart_toxiproxy(c, toxiproxy),
+                kind_filter=kind_filter,
+            )
+            try:
+                runner.run()
+            except BaseException:
+                # A failure is when the shard history is most worth having,
+                # not least: what a run reports is often a symptom (a wedged
+                # checker, a cancelled query) of a persist event that left no
+                # other trace, and the state history is the only place that
+                # event is still visible. Diagnostics only here, so nothing
+                # can mask or replace the failure being raised.
+                try:
+                    audit_persist_history(c, ctx, log)
+                except Exception as e:
+                    log.log("audit", f"post-failure state audit did not run: {e}")
+                raise
+            # After the run, so it sees the whole history the run produced.
+            try:
+                audit_persist_history(c, ctx, log)
+            except InvariantViolation:
+                raise
+            except Exception as e:
+                # The audit is a second opinion on a run whose own invariants
+                # already held. Its plumbing (a sidecar container, a CLI, a
+                # catalog query) failing is not a verdict on the run.
+                log.log("audit", f"persist state audit did not run: {e}")
+        finally:
+            sampler.stop_event.set()
+            scenario.teardown()
+
+
+def make_upgrade_swap(
+    c: Composition, ctx: ScenarioContext, version_override: ExitStack
+):
+    # Captured now, while the old version is still healthy: mid-chaos it may
+    # not answer, and the post-swap probe needs it to prove the version
+    # actually changed.
+    client = MzClient(ctx, "upgrade-swap")
+    old_version = str(client.query("SELECT mz_version()")[0][0])
+    client.reset()
+
+    def swap() -> None:
+        # Kill the old-version processes and bring everything back on the
+        # current build: an upgrade in the middle of load and disruptions,
+        # with the invariants never pausing.
+        names = [
+            "materialized",
+            "clusterd-compute",
+            "clusterd-compute2",
+            "clusterd-storage",
+        ]
+
+        unpause_quietly(c, *names)
+        # The disruptor may kill one of these at any moment, and a
+        # `docker compose kill` naming a container that is not running fails
+        # the whole invocation. Kill what is running, and retry once the set
+        # has been re-observed if the disruptor won the race in between. A
+        # container the disruptor killed is already in the state the swap
+        # needs, and up() recreates it on the new image either way, so the
+        # guarantee that no process survives on the old image still holds.
+        for attempt in range(3):
+            running = [name for name in names if c.is_running(name)]
+            if not running:
+                break
+            try:
+                c.kill(*running)
+                break
+            except Exception:
+                if attempt == 2:
+                    raise
+        # up() renders the composition, which the version override pins to
+        # the old image, so the override must be closed first.
+        version_override.close()
+        # A pause can also land between the kill and the up, so retry around
+        # unpausing rather than relying on up()'s own retries, which would
+        # hit the same paused container three times.
+        for attempt in range(3):
+            try:
+                c.up(*names, detach=True)
+                break
+            except Exception:
+                if attempt == 2:
+                    raise
+                unpause_quietly(c, *names)
+
+        def upgraded() -> bool:
+            version = str(client.query("SELECT mz_version()", timeout=30)[0][0])
+            if version == old_version:
+                raise InvariantViolation(
+                    f"upgrade swap brought back the old version {version}"
+                )
+            return True
+
+        # Bounded probe rather than one-shot: legs may still be disrupted
+        # when the swap fires, but a full metadata cut is capped at 45s and
+        # the new build must serve after healing.
+        wait_until(upgraded, 180, "swapped-in build serving its new version")
+
+    return swap
+
+
+# Caps on the post-run persist audit: overall, per shard, per shard's output,
+# and on the size of shard it looks at in the first place.
+AUDIT_BUDGET_S = 240.0
+AUDIT_SHARD_TIMEOUT_S = 20
+AUDIT_MAX_BYTES = 50_000_000
+AUDIT_MAX_PARTS = 500
+
+
+def audit_persist_history(c: Composition, ctx: ScenarioContext, log: EventLog) -> None:
+    """Fails the run if a shard's live state history resurrects a blob.
+
+    Every blob key a shard references must be live over one contiguous run of
+    seqnos: it enters state when a batch referencing it is added and leaves
+    when the last one is removed, and nothing may bring it back. A key that is
+    live, gone, and live again means a state transition was applied to a state
+    it was not computed from, which is how a stale merge res or a replayed
+    rollup insert corrupts a shard.
+
+    Persist notices this itself only in narrow circumstances: GC's part check
+    (`gc.rs`) needs the key to land in the same delete batch it is walking, and
+    `ReferencedBlobValidator` is compiled out of the profiles that build our
+    images. This audit sees every resurrection in the live window regardless
+    of whether GC happened to run, so it is worth the one pass per shard.
+    """
+    from materialize.mzcompose.composition import Service as ServiceName
+
+    c.up(ServiceName("persistcli", idle=True))
+
+    def inspect(*args: str) -> str:
+        return c.exec(
+            "persistcli",
+            "persistcli",
+            "inspect",
+            *args,
+            f"--blob-uri={minio_blob_uri()}",
+            capture=True,
+            silent=True,
+        ).stdout
+
+    # Enumerated from blob rather than from mz_storage_shards, which knows
+    # only about storage objects, so this also covers the catalog and txn-wal
+    # shards. Big shards are skipped: `state-diff` prints the whole state
+    # twice per transition, which for the bank tables is gigabytes. Those are
+    # also the shards GC walks constantly under --persist-churn, so its own
+    # part check covers them. What it does not cover is a shard that is
+    # dropped before GC ever gets to it, which is exactly what is left here.
+    counts = json.loads(inspect("blob-count"))
+    shards = sorted(
+        (
+            shard
+            for shard, count in counts.items()
+            if count["batch_part_count"] <= AUDIT_MAX_PARTS
+        ),
+        key=lambda shard: -counts[shard]["batch_part_count"],
+    )
+    # Keys are "<writer>/<part>", and only their identity matters here.
+    key_re = re.compile(r'"([a-z0-9]+/[a-z][0-9a-f-]{36})"')
+    findings = []
+    audited = 0
+    truncated = 0
+    # An environment has more shards than a post-run check should spend
+    # minutes on, and the ones a run churned are as good a sample as any.
+    deadline = time.monotonic() + AUDIT_BUDGET_S
+    for shard in shards:
+        if time.monotonic() > deadline:
+            break
+        try:
+            # Bounded in both time and bytes: state size times version count
+            # has no useful upper bound, and this runs inside a test.
+            out = c.exec(
+                "persistcli",
+                "bash",
+                "-c",
+                f"timeout {AUDIT_SHARD_TIMEOUT_S} persistcli inspect state-diff"
+                f" --shard-id={shard}"
+                " --consensus-uri=postgres://root@postgres-metadata:26257"
+                "?options=--search_path=consensus"
+                f" --blob-uri='{minio_blob_uri()}' 2>/dev/null"
+                f" | head -c {AUDIT_MAX_BYTES}",
+                capture=True,
+                silent=True,
+            ).stdout
+        except Exception as e:
+            # A shard finalized between the query and here, or a persistcli
+            # that cannot reach its stores. Neither says anything about the
+            # invariant, and the audit is not the run's purpose.
+            log.log("audit", f"{shard}: inspect failed ({e})", echo=False)
+            continue
+        # One JSON object per line, each holding the states before and after
+        # one transition, oldest first.
+        states = []
+        for line in out.splitlines():
+            if not line.strip():
+                continue
+            try:
+                transition = json.loads(line)
+            except json.JSONDecodeError:
+                # The byte cap cuts the last line in half. Everything before
+                # it is still a valid prefix of the history, so the shard is
+                # audited, just not to its end.
+                truncated += 1
+                break
+            if not states:
+                states.append(transition["previous"])
+            states.append(transition["new"])
+        live_at: dict[str, list[int]] = {}
+        for index, state in enumerate(states):
+            for key in set(key_re.findall(json.dumps(state))):
+                live_at.setdefault(key, []).append(index)
+        for key, indexes in live_at.items():
+            if indexes != list(range(indexes[0], indexes[-1] + 1)):
+                seqnos = [states[i].get("seqno") for i in indexes]
+                findings.append(f"{shard} resurrects {key}, live at seqnos {seqnos}")
+        audited += 1
+    if findings:
+        raise InvariantViolation("persist state history: " + "; ".join(findings[:5]))
+    log.log(
+        "audit",
+        f"no resurrected blobs across {audited}/{len(shards)} shards"
+        f" ({truncated} truncated at the byte cap)",
+    )
+
+
+# Makes persist take as many state transitions per second as it can: small
+# batches so every write compacts, compaction claimable by any process so two
+# of them race on the same spine range, and rollups often enough that GC has
+# something to truncate on every pass. The disruptions then have something to
+# interleave with, which is what turns a lost consensus response into a
+# retried non-idempotent state transition.
+PERSIST_CHURN_SQL = """
+ALTER SYSTEM SET persist_inline_writes_single_max_bytes = 0;
+ALTER SYSTEM SET persist_inline_writes_total_max_bytes = 0;
+ALTER SYSTEM SET persist_blob_target_size = 4096;
+ALTER SYSTEM SET persist_compaction_heuristic_min_inputs = 2;
+ALTER SYSTEM SET persist_compaction_heuristic_min_parts = 1;
+ALTER SYSTEM SET persist_compaction_heuristic_min_updates = 1;
+ALTER SYSTEM SET persist_claim_unclaimed_compactions = true;
+ALTER SYSTEM SET persist_claim_compaction_percent = 100;
+-- A partial replacement keeps the spine id of the batch it rewrites, which is
+-- the one state change that leaves a previously applied merge res still
+-- matching the range it was computed for. Short runs make partial
+-- replacements the common case. (The agitator flips both back and forth, so
+-- these are starting points, not pins.)
+ALTER SYSTEM SET persist_enable_incremental_compaction = true;
+ALTER SYSTEM SET persist_batch_max_run_len = 2;
+ALTER SYSTEM SET persist_rollup_threshold = 8;
+ALTER SYSTEM SET persist_gc_min_versions = 8;
+"""
+
+
+def unpause_quietly(c: Composition, *names: str) -> None:
+    """Unpause containers, ignoring those that were not paused.
+
+    A paused container can be neither killed nor started: docker refuses a
+    start with "cannot start a paused container", and a kill of a paused
+    container is not reliable either. Everything in the harness that kills or
+    starts a container races the disruptor's pause of the same container, so
+    they all unpause first. Unpausing a running container is an error rather
+    than a no-op, which is why the result is discarded.
+    """
+    for name in names:
+        try:
+            c.unpause(name)
+        except Exception:
+            pass
+
+
+def process_targets(c: Composition) -> list[ProcessTarget]:
+    """Processes the disruptor may kill or pause.
+
+    The clusterd containers restart automatically (restart on-failure), so
+    their heal is an idempotent up(). Upstream databases are deliberately
+    absent: they run with fsync disabled, so a SIGKILL could lose committed
+    data and invalidate the oracle.
+    """
+
+    def target(name: str, max_outage: float = 120.0) -> ProcessTarget:
+        def kill() -> None:
+            unpause_quietly(c, name)
+            c.kill(name)
+
+        def heal() -> None:
+            unpause_quietly(c, name)
+            # Bounded retries: an up that cannot succeed (e.g. dead
+            # proxies) must not wedge the disruptor for minutes, but a
+            # single attempt can race a crash-looping restart policy.
+            c.up(name, detach=True, max_tries=3)
+
+        def update_cpu(*args: str) -> str:
+            # `docker update`, not compose: changing the CPU allowance of a
+            # running container in place is the only way to degrade a process
+            # without restarting it, and compose has no equivalent. A
+            # container the disruptor killed moments ago is simply gone, and
+            # the caller treats a failed disruption as a lost cycle.
+            #
+            # The quota/period pair rather than `--cpus`, because only the
+            # quota can be cleared again: `--cpus=0` is read as "leave the
+            # limit alone", so a heal written that way silently does nothing
+            # and the process stays crippled for the rest of the run. The
+            # two also disagree in `docker inspect`, since setting `--cpus`
+            # reports through NanoCpus and leaves CpuQuota at 0.
+            container = f"{c.project_name}-{name}-1"
+            subprocess.run(
+                ["docker", "update", *args, container],
+                check=True,
+                capture_output=True,
+            )
+            quota = subprocess.run(
+                ["docker", "inspect", "-f", "{{.HostConfig.CpuQuota}}", container],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return quota.stdout.strip()
+
+        def throttle() -> None:
+            update_cpu(f"--cpu-period={CPU_PERIOD}", f"--cpu-quota={CPU_THROTTLED}")
+
+        def unthrottle() -> None:
+            # Verified and retried, not assumed. A heal that quietly fails to
+            # restore the allowance turns one disruption into a permanent one,
+            # which is invisible except as everything downstream slowly
+            # falling apart. Retried because a container killed by another
+            # disruption cannot be updated while it is down, and a restart
+            # policy brings back the same container with the same limit.
+            last = ""
+            for attempt in range(3):
+                try:
+                    last = update_cpu("--cpu-quota=-1")
+                    if last == "-1":
+                        return
+                except Exception as e:
+                    last = str(e)
+                if attempt < 2:
+                    time.sleep(2.0)
+            raise RuntimeError(f"{name} still CPU limited after heal: {last}")
+
+        return ProcessTarget(
+            name=name,
+            max_outage=max_outage,
+            kill=kill,
+            heal=heal,
+            pause=lambda: c.pause(name),
+            unpause=lambda: c.unpause(name),
+            # Half a core: a process that is merely slow is the case every
+            # timeout in the system is implicitly betting against, and unlike
+            # a pause it keeps answering, so peers see a live but lagging peer
+            # rather than an absent one. Squeezing harder than this makes the
+            # coordinator unable to drain its backlog at all, which is a plain
+            # outage with extra steps and is what `pause` is for.
+            throttle=throttle,
+            unthrottle=unthrottle,
+        )
+
+    return [
+        target("clusterd-compute"),
+        target("clusterd-compute2"),
+        target("clusterd-storage"),
+        # A paused envd freezes everything like a metadata cut, so its
+        # outages are short for the same edge-coverage reason.
+        target("materialized", max_outage=45.0),
+    ]
+
+
+# Concentrated reproducers for the open findings, selectable via
+# --scenario=repro-*. blob-memory and postheal-stall are deterministic
+# sequences, per10 and durable-resume are fixed-sequence loops over races.
+REPROS = {
+    "repro-blob-memory": "PER-31: unbounded clusterd memory while the blob"
+    " store is cut",
+    "repro-storage-memory": "SS-428: unbounded clusterd-storage memory"
+    " replaying a source backlog while a new table's rewind pins the frontier",
+    "repro-postheal-stall": "PER-32: writes stalled long after a metadata cut"
+    " healed",
+    "repro-per10": "PER-10: persist GC panic, earliest state without rollup",
+    "repro-durable-resume": "resumed SUBSCRIBE cancels its carried state",
+    "repro-compute-asof": "PER-49: compute halts hydrating a dataflow past its"
+    " as_of",
+    "repro-replacement-brick": "SQL-603: bootstrap halts forever on an"
+    " interrupted replacement apply",
+    "repro-stale-merge-res": "a merge res retried after a lost consensus"
+    " response overwrites a newer compaction",
+    "repro-alter-table-schema": "SQL-616 / PER-59: a kill inside ALTER TABLE"
+    " ADD COLUMN leaves the catalog and the shard's schema out of step",
+}
+
+
+# Background load for a repro, as (scenario, actions). The first action runs
+# every tick for steady write pressure, the rest rotate slowly because they are
+# DDL. TableBank's ledger transfers keep consensus busy and its created and
+# dropped views mean shard finalization, which keeps persist GC busy, so a
+# finding only needs its own entry when it lives in another scenario's shape.
+DEFAULT_REPRO_LOAD = ("table-bank", ("ledger-transfer", "ddl-churn"))
+REPRO_LOAD = {
+    # The source-table churn is driven by the repro itself, at the moment in
+    # the sequence that matters, not at random.
+    "repro-storage-memory": ("pg-cdc-bank", ("cdc-transfer", "wide-txn")),
+}
+
+
+def run_repro(c: Composition, name: str, args, log: EventLog) -> None:
+    scenario_name, load_actions = REPRO_LOAD.get(name, DEFAULT_REPRO_LOAD)
+    scenario_class = SCENARIOS[scenario_name]
+
+    c.down(destroy_volumes=True)
+    rng = random.Random(f"{args.seed}-{name}")
+    with c.override(Toxiproxy(seed=rng.randrange(2**63), restart="on-failure")):
+        c.up("toxiproxy")
+        toxiproxy = ToxiproxyApi(f"http://127.0.0.1:{c.default_port('toxiproxy')}")
+        for leg in LEGS.values():
+            for proxy in leg.proxies:
+                toxiproxy.create(proxy)
+        c.up(
+            "materialized",
+            "clusterd-compute",
+            "clusterd-compute2",
+            "clusterd-storage",
+            *scenario_class.services,
+        )
+        c.sql(CLUSTER_SETUP_SQL, port=6877, user="mz_system")
+        ctx = ScenarioContext(
+            endpoints=Endpoints(
+                mz_host="127.0.0.1",
+                mz_port=c.default_port("materialized"),
+                mz_system_port=c.port("materialized", 6877),
+                pg_port=(
+                    c.default_port("postgres")
+                    if "postgres" in scenario_class.services
+                    else None
+                ),
+            ),
+            complexity=COMPLEXITIES[args.complexity],
+            rng=rng,
+            log=log,
+            seed=args.seed,
+        )
+        scenario = scenario_class(ctx)
+        scenario.setup()
+        bundles = [
+            scenario.make_worker(i, random.Random(rng.randrange(2**31)))
+            for i in range(4)
+        ]
+        stop = threading.Event()
+
+        def drive(bundle) -> None:
+            actions = {action.name: action for action in bundle.actions}
+            steady, *periodic = load_actions
+            ticks = 0
+            while not stop.is_set():
+                ticks += 1
+                if periodic and ticks % 40 == 0:
+                    action = actions[periodic[(ticks // 40) % len(periodic)]]
+                else:
+                    action = actions[steady]
+                try:
+                    action.run()
+                except Exception:
+                    pass
+                stop.wait(0.005)
+
+        threads = [
+            threading.Thread(target=drive, args=(b,), daemon=True) for b in bundles
+        ]
+        for t in threads:
+            t.start()
+        try:
+            REPRO_FUNCS[name](c, toxiproxy, ctx, log)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join(timeout=10)
+
+
+def _restart_toxiproxy(c: Composition, api: ToxiproxyApi) -> None:
+    """Replace a toxiproxy whose admin API no longer answers.
+
+    Every leg runs through this container, so the restart cuts them all for a
+    moment. That is the same event as a toxiproxy crash, which the disruptor
+    recovers from by re-creating the proxies, and it is the only way out of a
+    wedged admin API.
+
+    The admin port is published on an ephemeral host port, which a recreated
+    container does not keep, so the API is re-pointed at the new mapping.
+    """
+    c.kill("toxiproxy")
+    c.up("toxiproxy", detach=True, max_tries=3)
+    api.rebind(f"http://127.0.0.1:{c.default_port('toxiproxy')}")
+
+
+def _toxiproxy_heal(toxiproxy: ToxiproxyApi, log: EventLog) -> None:
+    """Heal everything, surviving a toxiproxy crash-restart in between.
+
+    A restarted toxiproxy comes back empty, so besides retrying the reset
+    the legs' proxies are re-created. Mirrors the disruptor's heal path.
+    """
+    deadline = time.monotonic() + 60
+    while True:
+        try:
+            toxiproxy.reset()
+            existing = toxiproxy.proxies()
+            for leg in LEGS.values():
+                for proxy in leg.proxies:
+                    if proxy.name not in existing:
+                        log.log("repro", f"re-creating lost proxy {proxy.name}")
+                        toxiproxy.create(proxy)
+            return
+        except Exception as e:
+            if time.monotonic() > deadline:
+                subprocess.run(
+                    ["docker", "logs", "--tail", "20", "invariants-toxiproxy-1"]
+                )
+                raise AssertionError(f"toxiproxy did not heal: {e}") from e
+            time.sleep(2)
+
+
+def _rss_gb(container: str) -> float:
+    out = (
+        subprocess.check_output(
+            ["docker", "stats", "--no-stream", "--format", "{{.MemUsage}}", container],
+            text=True,
+        )
+        .split("/")[0]
+        .strip()
+    )
+    for unit, mult in [("GiB", 1.0), ("MiB", 1 / 1024), ("KiB", 1 / 1048576)]:
+        if out.endswith(unit):
+            return float(out[: -len(unit)]) * mult
+    return 0.0
+
+
+def repro_blob_memory(c, toxiproxy, ctx, log) -> None:
+    """Cut the blob store under write load, watch process memory grow."""
+    containers = [
+        "invariants-materialized-1",
+        "invariants-clusterd-compute-1",
+        "invariants-clusterd-compute2-1",
+        "invariants-clusterd-storage-1",
+    ]
+    # Let hydration finish and take the settled baseline as the minimum of a
+    # few samples, memory right after startup spikes.
+    time.sleep(20)
+    base = {name: _rss_gb(name) for name in containers}
+    for _ in range(2):
+        time.sleep(5)
+        for name in containers:
+            base[name] = min(base[name], _rss_gb(name))
+    log.log(
+        "repro", "baseline: " + ", ".join(f"{n}={v:.2f}GiB" for n, v in base.items())
+    )
+    toxiproxy.set_enabled("blob", False)
+    try:
+        for _ in range(24):
+            time.sleep(10)
+            now = {name: _rss_gb(name) for name in containers}
+            log.log(
+                "repro",
+                "blob cut: " + ", ".join(f"{n}={v:.2f}GiB" for n, v in now.items()),
+            )
+            for name in containers:
+                if now[name] > base[name] + 1.5:
+                    raise AssertionError(
+                        f"REPRODUCED: {name} memory grew {base[name]:.2f} ->"
+                        f" {now[name]:.2f}GiB while the blob store was"
+                        " unavailable (unbounded buffering)"
+                    )
+    finally:
+        _toxiproxy_heal(toxiproxy, log)
+    log.log("repro", "not reproduced within 240s")
+
+
+def _heap_profile(c: Composition, service: str, label: str, log: EventLog) -> None:
+    """Save a symbolized heap profile of `service` next to the event log.
+
+    Our images build jemalloc with profiling active, and clusterd's internal
+    HTTP server serves the dump, so nothing has to be arranged in advance. The
+    result is a folded-stack `.mzfg`, which both the flamegraph viewer and
+    `sort`/`grep` can read, so a run that grew can be attributed from the
+    artifacts alone.
+    """
+    path = f"heap-{service}-{label}.mzfg"
+    try:
+        port = c.port(service, 6878)
+        with open(path, "wb") as f:
+            subprocess.run(
+                [
+                    "curl",
+                    "-sS",
+                    "--max-time",
+                    "120",
+                    "-X",
+                    "POST",
+                    "-d",
+                    "action=dump_sym_mzfg",
+                    f"http://127.0.0.1:{port}/",
+                ],
+                check=True,
+                stdout=f,
+                timeout=180,
+            )
+        log.log("repro", f"heap profile of {service} written to {path}")
+    except Exception as e:
+        log.log("repro", f"heap profile of {service} ({label}) failed: {e}")
+
+
+def repro_storage_memory(c, toxiproxy, ctx, log) -> None:
+    """SS-428: add a table to a Postgres source that has a replication backlog.
+
+    Adding a table to a running source makes the snapshot operator emit a
+    rewind request for the new export, and the replication reader then holds
+    its data capability at offset zero until it has replayed past the new
+    table's snapshot LSN, because that is where the rewind's negated updates
+    go. The source's frontier therefore does not move for the whole replay.
+
+    A snapshot on its own survives that: all of its rows carry offset zero, so
+    they land in one persist batch builder, which spills parts to blob once it
+    passes `persist_blob_target_size`. The replay does not. Its rows carry
+    real timestamps, one per remap binding, so they land in one open builder
+    per second of replay, and none of them can be finished while the frontier
+    is pinned. Everything replayed stays resident until the rewind clears.
+
+    So the growth is the size of the backlog, and it does not stop until the
+    replay has caught up. This builds the backlog with a source-leg outage and
+    bulk upstream writes, then adds the table the moment the leg is whole
+    again. The comparison is the same sequence without the added table: that
+    replay commits as it goes and stays flat.
+
+    While it grows, `SELECT` on any of the source's tables blocks, which is
+    the same pinned frontier seen from the outside.
+    """
+    container = "invariants-clusterd-storage-1"
+    # The upstream keeps committing through this, so it sets the size of the
+    # replay. Also stops the slot's confirmed_flush_lsn from advancing, which
+    # is where the replay starts from.
+    OUTAGE_S = 150.0
+    # Rows per bulk statement. Server-side generate_series, so the harness is
+    # not the bottleneck and the outage is worth GiBs of WAL.
+    BULK_ROWS = 100_000
+    # Growth this far above the settled baseline is staged replay, not a
+    # replay working through: the same outage without the added table peaks
+    # 0.15GiB above its baseline and drains within a minute. Measured growth
+    # once the rewind is pending is 30-60MiB/min and does not stop, so the
+    # watch has to be long enough for the slow end of that to clear the
+    # threshold on a loaded agent.
+    GROWTH_GIB = 0.75
+    WATCH_S = 2400.0
+
+    import psycopg
+
+    client = MzClient(ctx, "repro-source-table")
+    stop_bulk = threading.Event()
+
+    def connect_upstream():
+        # Direct, not through the proxy: the upstream has to keep committing
+        # while the source's leg is cut.
+        return psycopg.connect(
+            host=ctx.endpoints.mz_host,
+            port=ctx.endpoints.pg_port,
+            user="postgres",
+            password="postgres",
+            dbname="postgres",
+            connect_timeout=10,
+        )
+
+    def bulk_writer(idx: int) -> None:
+        conn: Any = None
+        seq = 0
+        while not stop_bulk.is_set():
+            seq += 1
+            try:
+                if conn is None:
+                    conn = connect_upstream()
+                # Self-consistent rows, so the wide-transaction invariant
+                # still holds if this scenario is ever checked here.
+                conn.cursor().execute(
+                    "INSERT INTO wide_txn (txn_id, txn_rows, idx) SELECT"
+                    f" {900_000_000 + idx * 1_000_000 + seq}, {BULK_ROWS}, g"
+                    f" FROM generate_series(1, {BULK_ROWS}) g"
+                )
+                conn.commit()
+            except Exception:
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    conn = None
+                stop_bulk.wait(1.0)
+
+    writers = [
+        threading.Thread(target=bulk_writer, args=(i,), daemon=True) for i in range(4)
+    ]
+    try:
+        time.sleep(30)
+        base = min(_rss_gb(container) for _ in range(3))
+        log.log("repro", f"baseline {base:.2f}GiB")
+        _heap_profile(c, "clusterd-storage", "baseline", log)
+
+        # Only while the leg is cut: the backlog should be this window's
+        # writes and nothing more, and the upstream should stop growing once
+        # the replay it feeds has started.
+        toxiproxy.set_enabled("pg", False)
+        log.log("repro", f"source leg cut for {OUTAGE_S:.0f}s, building a backlog")
+        for t in writers:
+            t.start()
+        try:
+            time.sleep(OUTAGE_S)
+        finally:
+            stop_bulk.set()
+            for t in writers:
+                t.join(timeout=30)
+            _toxiproxy_heal(toxiproxy, log)
+
+        # Immediately, while the backlog is still unreplayed: the rewind has
+        # to be pending for the replay, not after it.
+        deadline = time.monotonic() + 60
+        while True:
+            try:
+                client.write(
+                    "CREATE TABLE accounts_stuck FROM SOURCE bank_source"
+                    " (REFERENCE accounts)"
+                )
+                break
+            except Exception as e:
+                if time.monotonic() > deadline:
+                    raise AssertionError(
+                        f"could not add a table to the source: {e}"
+                    ) from e
+                time.sleep(0.5)
+        log.log("repro", "table added while the backlog replays, watching memory")
+
+        peak = base
+        started = time.monotonic()
+        deadline = started + WATCH_S
+        # The replay takes tens of minutes to clear the threshold, so the
+        # watch reports as it goes. A loop this long that prints only its
+        # verdict is indistinguishable from a hang.
+        next_report = started
+        while time.monotonic() < deadline:
+            time.sleep(5)
+            now = _rss_gb(container)
+            peak = max(peak, now)
+            if time.monotonic() >= next_report:
+                next_report = time.monotonic() + 30
+                log.log(
+                    "repro",
+                    f"{time.monotonic() - started:.0f}s into the replay:"
+                    f" clusterd-storage {now:.2f}GiB, {now - base:+.2f}GiB from"
+                    f" baseline, threshold {base + GROWTH_GIB:.2f}GiB",
+                )
+            if now > base + GROWTH_GIB:
+                _heap_profile(c, "clusterd-storage", "grown", log)
+                raise AssertionError(
+                    f"REPRODUCED: clusterd-storage grew {base:.2f} ->"
+                    f" {now:.2f}GiB staging a replay it cannot commit while a"
+                    " newly added table's rewind pins the source frontier"
+                )
+        log.log(
+            "repro", f"not reproduced, peaked at {peak:.2f}GiB (base {base:.2f}GiB)"
+        )
+    finally:
+        stop_bulk.set()
+        for t in writers:
+            if t.is_alive():
+                t.join(timeout=10)
+
+
+def repro_postheal_stall(c, toxiproxy, ctx, log) -> None:
+    """Stall writes by making the metadata store slow under heavy catalog churn.
+
+    group_commit runs inline on the single-threaded coordinator loop and
+    blocks on metadata round trips: the timestamp oracle (get_local_write_ts)
+    and the catalog-shard consensus op (catalog.advance_upper). A clean
+    cut/heal recovers in seconds because a local postgres is fast, so this
+    models the overloaded CI metadata store with a latency toxic that delays
+    every round trip.
+
+    Both the latency and the load matter. Latency alone slows each write by
+    only a handful of round trips, and the coordinator loop is biased to
+    prioritize group commit over DDL, so DDL does not starve writes by
+    queuing. The DROP-heavy materialized-view churn instead grows the catalog
+    shard's persist state, so each delayed metadata op does more work and a
+    single group commit blocks the loop for tens of seconds. Measured
+    empirically: ~2.5s/direction plus this churn stalls writes ~150s while
+    envd keeps accepting connections. Time-to-first-committed-write is
+    measured while the store is slow.
+    """
+    from materialize.invariants.framework import Outcome
+    from materialize.invariants.mz import MzClient
+
+    # Per-direction delay on the metadata leg. Well below the stall threshold
+    # on its own: exceeding it is the churn-driven amplification (each catalog
+    # metadata op does many delayed round trips), not one slow round trip.
+    METADATA_LATENCY_MS = 2500
+    STALL_THRESHOLD_S = 120.0
+
+    stop = threading.Event()
+
+    def writer(idx: int) -> None:
+        client = MzClient(ctx, f"stall-writer-{idx}")
+        seq = 0
+        while not stop.is_set():
+            seq += 1
+            try:
+                client.write(
+                    f"INSERT INTO ledger (worker, seq, account, amount)"
+                    f" VALUES ({1000 + idx}, {seq}, 0, 0)",
+                    timeout=20,
+                )
+            except Exception:
+                pass
+            stop.wait(0.002)
+
+    def churner(idx: int) -> None:
+        client = MzClient(ctx, f"stall-churn-{idx}")
+        seq = 0
+        while not stop.is_set():
+            seq += 1
+            # CREATE and DROP hammer the catalog shard, the same shard
+            # group_commit's advance_upper operates on. The churn grows that
+            # shard's persist state, so under a slow leg each catalog metadata
+            # op does more delayed round trips and group_commit blocks the
+            # coordinator loop for tens of seconds. Unique names plus IF
+            # EXISTS keep the loop idempotent across UNKNOWN outcomes.
+            name = f"stall_mv_{idx}_{seq}"
+            try:
+                client.write(
+                    f"CREATE MATERIALIZED VIEW {name} IN CLUSTER compute"
+                    " AS SELECT count(*) AS cnt FROM ledger",
+                    timeout=20,
+                )
+                client.write(f"DROP MATERIALIZED VIEW IF EXISTS {name}", timeout=20)
+            except Exception:
+                pass
+            stop.wait(0.02)
+
+    threads = [
+        threading.Thread(target=writer, args=(i,), daemon=True) for i in range(8)
+    ] + [threading.Thread(target=churner, args=(i,), daemon=True) for i in range(12)]
+    for t in threads:
+        t.start()
+    try:
+        # Let the load reach steady state and the catalog shard get hot
+        # before the store slows down.
+        time.sleep(20)
+        # Model the overloaded metadata store: delay both directions so every
+        # oracle and consensus round trip costs seconds.
+        for proxy in LEGS["metadata"].proxies:
+            for stream in ("downstream", "upstream"):
+                toxiproxy.add_toxic(
+                    proxy.name,
+                    f"latency-{stream}",
+                    "latency",
+                    {
+                        "latency": METADATA_LATENCY_MS,
+                        "jitter": METADATA_LATENCY_MS // 2,
+                    },
+                    stream=stream,
+                )
+        log.log(
+            "repro",
+            f"metadata slowed (~{METADATA_LATENCY_MS}ms/direction), probing"
+            " write liveness",
+        )
+        # A per-attempt timeout above the threshold so one attempt can observe
+        # a commit anywhere up to the threshold and report its true latency.
+        probe_timeout = STALL_THRESHOLD_S + 10
+        client = MzClient(ctx, "stall-probe")
+        start = time.monotonic()
+        while time.monotonic() - start < 300:
+            if (
+                client.write(
+                    "INSERT INTO ledger VALUES (-3, 0, 0, 0)", timeout=probe_timeout
+                )
+                == Outcome.COMMITTED
+            ):
+                took = time.monotonic() - start
+                log.log("repro", f"first write committed {took:.1f}s into slowdown")
+                if took > STALL_THRESHOLD_S:
+                    raise AssertionError(
+                        f"REPRODUCED: writes stalled {took:.1f}s while the"
+                        " metadata store was slow"
+                    )
+                return
+        raise AssertionError(
+            "REPRODUCED: no write committed within 300s of the metadata store"
+            " slowing down"
+        )
+    finally:
+        _toxiproxy_heal(toxiproxy, log)
+        stop.set()
+        for t in threads:
+            t.join(timeout=10)
+
+
+def repro_per10(c, toxiproxy, ctx, log) -> None:
+    """Blob cut, heal, immediate kill: the PER-10 panic window.
+
+    A ~1%-per-cycle race in CI, so this loops tightly: short cuts, kills
+    alternating between envd and the clusterds, DDL churn in the load for
+    shard-finalization GC pressure, and the panic grepped in all processes.
+    """
+    targets = ["materialized", "clusterd-compute", "clusterd-storage"]
+    for iteration in range(30):
+        toxiproxy.set_enabled("blob", False)
+        time.sleep(5)
+        _toxiproxy_heal(toxiproxy, log)
+        time.sleep(2)
+        victim = targets[iteration % len(targets)]
+        c.kill(victim)
+        c.up(victim, detach=True, max_tries=3)
+        time.sleep(5)
+        for name in targets + ["clusterd-compute2"]:
+            logs = c.invoke("logs", name, capture=True).stdout or ""
+            if "did not have corresponding rollup" in logs:
+                raise AssertionError(
+                    f"REPRODUCED PER-10 in {name}, iteration {iteration}"
+                )
+        log.log("repro", f"iteration {iteration} (killed {victim}): no panic yet")
+    log.log("repro", "not reproduced in 30 iterations")
+
+
+def repro_durable_resume(c, toxiproxy, ctx, log) -> None:
+    """Durable-subscribe resumes across a disruption, many at a time.
+
+    The one occurrence had a blob cut that froze every write for 89s, so the
+    subscriber's resume timestamp fell far behind the shard, and envd dying
+    seconds after the heal from the PER-10 GC panic. Neither a clean kill on
+    its own nor the `SNAPSHOT = false` semantics reproduce it, so the trigger
+    is not known and this samples around the occurrence rather than replaying
+    it: the cut leg, its length, the lag each subscriber carries, and how envd
+    dies are all drawn per cycle.
+
+    The cost of a run is dominated by bringing the composition up, and the
+    cost of an attempt is one resume, so the two things that matter are riding
+    each disruption with many independent subscribers and doing many cycles
+    per invocation. Every subscriber carries its own state across the same
+    event, and any one of them folding to the wrong state fails the run.
+    """
+    from materialize.invariants.checkers import SubscribeChecker
+    from materialize.invariants.framework import InvariantViolation
+
+    # Independent subscribers riding each cycle, i.e. resume attempts per
+    # disruption.
+    SUBSCRIBERS = 12
+    CYCLES = 30
+    # Enough for every subscriber to validate a timestamp it can carry.
+    WARMUP_S = 15.0
+    # After the trigger, long enough for a resume to land and be validated
+    # even while envd is still coming back.
+    RESUME_S = 60.0
+
+    # Drawn from the run's seed, so looping this workflow explores rather than
+    # repeating one fixed sequence.
+    rng = random.Random(ctx.rng.randrange(2**63))
+    total = ctx.complexity.accounts * 1000
+
+    class ResumeChecker(SubscribeChecker):
+        def __init__(self, index: int, rng: random.Random) -> None:
+            super().__init__(
+                rng,
+                ctx,
+                f"resume-{index}",
+                "SELECT total FROM total",
+                # Both read paths, since a resume is served through whichever
+                # cluster the session is on.
+                cluster="compute" if index % 2 else "quickstart",
+                durable=True,
+            )
+
+        def validate_state(self, state: dict, ts: int) -> None:
+            got = {(int(k[0]),): v for k, v in state.items()}
+            if got != {(total,): 1}:
+                raise InvariantViolation(f"state {got} at {ts}")
+
+    def pump(checkers: list, seconds: float) -> None:
+        """Fetch on each subscriber for `seconds`.
+
+        A violation is always fatal, including mid-disruption: these are exact
+        results at a timestamp the server agreed to serve. Everything else is
+        the disruption and is skipped.
+        """
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            for checker in checkers:
+                try:
+                    checker.check_once()
+                except AssertionError:
+                    raise
+                except Exception:
+                    pass
+            time.sleep(0.1)
+
+    def rollup_panics() -> int:
+        logs = c.invoke("logs", "materialized", capture=True).stdout or ""
+        return logs.count("did not have corresponding rollup")
+
+    for cycle in range(CYCLES):
+        checkers = [
+            ResumeChecker(i, random.Random(rng.randrange(2**31)))
+            for i in range(SUBSCRIBERS)
+        ]
+        try:
+            pump(checkers, WARMUP_S)
+            warm = [ch for ch in checkers if ch.last_validated_ts is not None]
+            assert warm, "no subscriber validated a timestamp, nothing to carry"
+
+            # Staleness of the carried state is the one quantity the
+            # occurrence pins down (~90s), so half the subscribers stop
+            # fetching early and fall further behind than the cut alone.
+            parked = set(rng.sample(range(len(checkers)), len(checkers) // 2))
+            active = [ch for i, ch in enumerate(checkers) if i not in parked]
+            pump(active, rng.uniform(0.0, 45.0))
+
+            leg = rng.choice(["blob", "metadata"])
+            # Blob cuts freeze writes, which is what strands a resume point.
+            # Metadata cuts stall the coordinator instead, and both stay under
+            # the 15 minute persist lease.
+            cut_s = rng.uniform(5.0, 120.0) if leg == "blob" else rng.uniform(5.0, 40.0)
+            panics_before = rollup_panics()
+            toxiproxy.set_enabled(leg, False)
+            time.sleep(cut_s)
+            _toxiproxy_heal(toxiproxy, log)
+
+            # How envd goes away, if it does. "resume" kills it with the
+            # resumes already in flight, which no other variant covers.
+            fault = rng.choice(["kill", "pause", "resume", "none"])
+            if fault == "kill":
+                c.kill("materialized")
+                c.up("materialized", detach=True, max_tries=3)
+            elif fault == "pause":
+                c.pause("materialized")
+                time.sleep(rng.uniform(5.0, 20.0))
+                unpause_quietly(c, "materialized")
+            elif fault == "resume":
+                pump(checkers, rng.uniform(1.0, 4.0))
+                c.kill("materialized")
+                c.up("materialized", detach=True, max_tries=3)
+
+            # Every subscriber takes the resume path, whether or not the
+            # fault happened to break its own session. The resume is the
+            # operation under test, and a cycle where half the sessions
+            # survived is a cycle with half the attempts.
+            for checker in checkers:
+                checker.drop_session()
+            pump(checkers, RESUME_S)
+
+            panicked = rollup_panics() > panics_before
+            resumes = sum(ch.resumes for ch in checkers)
+            # resumes==0 means no resume ran, which is not evidence of
+            # consistency, so the count is part of the result.
+            log.log(
+                "repro",
+                f"cycle {cycle}: {cut_s:.0f}s cut on {leg}, envd {fault}"
+                f"{', PER-10 panic' if panicked else ''}, {resumes} resumes"
+                f" across {len(checkers)} subscribers, all consistent",
+            )
+        except AssertionError as e:
+            # Carry the violation through: it holds the shard-vs-stream probe
+            # and the session context that classify the occurrence.
+            raise AssertionError(
+                f"REPRODUCED durable-resume anomaly in cycle {cycle}: {e}"
+            ) from e
+        finally:
+            for checker in checkers:
+                checker.close()
+    log.log("repro", f"not reproduced in {CYCLES} cycles")
+
+
+def repro_compute_asof(c, toxiproxy, ctx, log) -> None:
+    """Compute halts hydrating a dataflow whose input compacted past its as_of.
+
+    The halt is tracked as PER-49, the retry mechanism that would absorb it as
+    CPU-34, and it was seen in incidents-and-escalations #39. When the
+    controller loses a
+    replica it drops that replica's per-replica read holds, and for a dataflow
+    it no longer wants (a canceled peek) it does not reinstall them, while the
+    replica still has the dataflow pending. The inputs then compact, and when
+    the replica renders the dataflow its as_of is below the input's since, so
+    compute_import halts with "cannot serve requested as_of".
+
+    Concentrates that window against the compute cluster's second replica
+    (clusterd-compute2, its own control-plane leg): a burst of slow-path peeks
+    over the base ledger builds one-off dataflows on both replicas, the leg is
+    cut so the controller drops r2's holds while r2 keeps the pending
+    dataflows, the peeks are canceled so their global holds drop too, and the
+    base ledger has no RETAIN HISTORY, so with nothing holding it its since
+    advances to ~now while the leg stays cut. r2 then renders a pending peek at
+    a since-passed as_of and halts. The disruption is a leg cut, not a kill: a
+    killed replica loses the pending dataflow and would just get fresh as_ofs
+    on restart. A race, so it loops and greps r2's log for the halt.
+    """
+    from materialize.invariants.mz import MzClient
+
+    def set_compute2(enabled: bool) -> None:
+        for proxy in LEGS["clusterd-compute2"].proxies:
+            toxiproxy.set_enabled(proxy.name, enabled)
+
+    def halted() -> str | None:
+        for name in ("clusterd-compute2", "clusterd-compute"):
+            logs = c.invoke("logs", name, capture=True).stdout or ""
+            if "cannot serve requested as_of" in logs:
+                return name
+        return None
+
+    def peek(tag: str) -> None:
+        cl = MzClient(ctx, f"asof-peek-{tag}")
+        try:
+            cl.query("SET cluster = compute")
+            # A predicate no index serves forces the slow path, a one-off peek
+            # dataflow importing the base ledger. The short timeout cancels it,
+            # dropping its global read hold.
+            cl.query(
+                f"SELECT count(*) FROM ledger WHERE amount > {tag} AND account >= 0",
+                timeout=3,
+            )
+        except Exception:
+            pass
+        cl.reset()
+
+    for iteration in range(15):
+        set_compute2(True)
+        # Fire the peeks, then cut r2's control plane ~1s in, while the peek
+        # dataflows are still installing/rendering on r2.
+        threads = [
+            threading.Thread(target=peek, args=(f"{iteration}-{i}",), daemon=True)
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(1.0)
+        set_compute2(False)
+        # The peeks cancel at their 3s timeout, dropping the global holds. With
+        # r2's per-replica holds already dropped by the disconnect, nothing
+        # pins the ledger, so its since advances past the pending as_ofs while
+        # the leg stays cut.
+        for t in threads:
+            t.join(timeout=10)
+        time.sleep(40)
+        set_compute2(True)
+        time.sleep(8)
+        name = halted()
+        if name is not None:
+            raise AssertionError(
+                f"REPRODUCED incident #39: {name} halted with 'cannot serve"
+                f" requested as_of', iteration {iteration}"
+            )
+        log.log("repro", f"iteration {iteration}: no as_of halt yet")
+    log.log("repro", "not reproduced in 15 iterations")
+
+
+def repro_replacement_brick(c, toxiproxy, ctx, log) -> None:
+    """Kill environmentd while a replacement is applied, then fail to boot.
+
+    The storage controller's bootstrap halts whenever a dependency read hold
+    has an empty since, calling it a concurrent deletion. The condition it
+    tests is narrower than the one its message claims: it does not check the
+    dependent's own write frontier, and the check right below it documents why
+    that matters ("We don't care about the dependency since when the write
+    frontier is empty. In that case, no-one can write down any more updates.").
+
+    A replacement MV holds a read hold on the collection it replaces, so an
+    apply that is interrupted can leave the replacement registered while the
+    replaced collection is already finalized. Both frontiers are then empty,
+    which is benign, and bootstrap halts on it anyway. The state is durable, so
+    every restart halts again and environmentd never comes back:
+    src/storage-controller/src/lib.rs:992, nightly 17740 spent 139 boots there.
+
+    SQL-603. NOTE: this presses the sequence but has not reproduced it, in 30
+    kill-during-apply cycles across two variants (the second delays the
+    metadata leg to widen the window between the storage finalize and the
+    catalog commit). The nightly hit it in 6 of 8 upgrade runs, so an
+    ingredient here is still missing, most likely the concurrent load and the
+    other dependents of `total` that a full scenario has.
+    """
+    from materialize.invariants.mz import MzClient
+    from materialize.invariants.scenarios.table_bank import TOTAL_DEF
+
+    MARKER = "dependency since frontier is empty"
+
+    def bricked() -> bool:
+        logs = c.invoke("logs", "materialized", capture=True).stdout or ""
+        return logs.count(MARKER) > 0
+
+    applier = MzClient(ctx, "brick-applier")
+    driver = MzClient(ctx, "brick-driver")
+    for iteration in range(15):
+        driver.write("DROP MATERIALIZED VIEW IF EXISTS total_repl")
+        driver.write(
+            "CREATE REPLACEMENT MATERIALIZED VIEW total_repl FOR total"
+            " IN CLUSTER compute WITH (RETAIN HISTORY = FOR '600s')"
+            f" AS {TOTAL_DEF}"
+        )
+        # Applying an unhydrated replacement is rejected, so wait for it as the
+        # documented workflow does.
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            rows = driver.query(
+                "SELECT bool_and(h.hydrated)"
+                " FROM mz_internal.mz_hydration_statuses h"
+                " JOIN mz_catalog.mz_materialized_views v ON h.object_id = v.id"
+                " WHERE v.name = 'total_repl'"
+            )
+            if rows and rows[0][0]:
+                break
+            time.sleep(1)
+
+        # The kill has to land inside the apply, which finalizes the replaced
+        # collection and retires the replacement in one go.
+        def apply() -> None:
+            try:
+                applier.write(
+                    "ALTER MATERIALIZED VIEW total APPLY REPLACEMENT total_repl"
+                )
+            except Exception:
+                pass
+
+        # The apply finalizes the replaced collection and retires the
+        # replacement, then commits the catalog transaction, and the state that
+        # bricks the next boot is the window in between. Both halves are
+        # consensus writes, so delaying the metadata leg stretches that window
+        # from microseconds to something a kill can land in.
+        for stream in ("upstream", "downstream"):
+            toxiproxy.add_toxic(
+                "metadata",
+                f"apply-delay-{stream}",
+                "latency",
+                {"latency": 1500, "jitter": 500},
+                stream=stream,
+            )
+        thread = threading.Thread(target=apply, daemon=True)
+        thread.start()
+        time.sleep(0.5 + 0.5 * (iteration % 12))
+        c.kill("materialized")
+        for stream in ("upstream", "downstream"):
+            toxiproxy.delete_toxic("metadata", f"apply-delay-{stream}")
+        try:
+            c.up("materialized", detach=True, max_tries=2)
+        except Exception as e:
+            # A bricked environmentd never becomes healthy, which is the
+            # symptom, so the log decides rather than this call.
+            log.log(
+                "repro", f"iteration {iteration}: environmentd did not come up ({e})"
+            )
+        thread.join(timeout=30)
+        if bricked():
+            raise AssertionError(
+                "REPRODUCED: environmentd halts at bootstrap and cannot come"
+                f" back, iteration {iteration}"
+            )
+        applier.reset()
+        driver.reset()
+        log.log("repro", f"iteration {iteration}: booted again")
+    log.log("repro", "not reproduced in 15 iterations")
+
+
+def repro_stale_merge_res(c, toxiproxy, ctx, log) -> None:
+    """Race a forced compaction against a merge res whose response is lost.
+
+    The organic version of this needs two compactions of the *same* spine id
+    to be applied around one indeterminate retry, and nothing in a short run
+    produces the second one reliably: claiming an unclaimed compaction needs
+    the previous one to be older than the writer lease, which is a hardcoded
+    60 minutes. `persistcli admin force-compaction` has no such rule, it
+    ignores active compactions entirely, and its own writes go straight to the
+    metadata store rather than through toxiproxy. So it can land a competing
+    res for the same range while envd's merge res is stuck retrying.
+
+    Each iteration: start a forced compaction, flap the metadata leg so envd's
+    own merge res CaS comes back indeterminate and retries against a state the
+    forced compaction has moved, heal, then force a GC to walk the diffs.
+    Reproduced means envd panicking in gc.rs, or GC deleting a part current
+    state still references, which the post-run audit would catch.
+    """
+    from materialize.invariants.mz import MzClient
+
+    system = MzClient(
+        ctx, "stale-merge-res", user="mz_system", port=ctx.endpoints.mz_system_port
+    )
+    # envd force-compacts the catalog shard in a background task whose fuel and
+    # period are dyncfgs ("we're going to gradually turn this on via dyncfgs").
+    # Turned up, it produces a merge res for the same spine ids regular
+    # compaction is working on, from the same process, over the same proxied
+    # consensus connection. That is the racing pair the bug needs, and unlike
+    # `persistcli admin force-compaction` it runs with the real codecs.
+    system.query("ALTER SYSTEM SET persist_catalog_force_compaction_wait = '1s'")
+    system.query("ALTER SYSTEM SET persist_catalog_force_compaction_fuel = 1000000")
+    system.query("ALTER SYSTEM SET persist_rollup_threshold = 8")
+    system.query("ALTER SYSTEM SET persist_inline_writes_single_max_bytes = 0")
+    system.query("ALTER SYSTEM SET persist_inline_writes_total_max_bytes = 0")
+    system.query("ALTER SYSTEM SET persist_blob_target_size = 4096")
+    log.log("repro", "catalog forced compaction turned up")
+
+    def panicked() -> bool:
+        logs = c.invoke("logs", "materialized", capture=True, silent=True).stdout or ""
+        return "batch_parts_to_delete" in logs or "should only be appended once" in logs
+
+    for iteration in range(40):
+        # Short cuts, so a CaS that already reached consensus loses only its
+        # response. A long outage would just fail the call outright.
+        for _ in range(24):
+            try:
+                toxiproxy.set_enabled("metadata", False)
+                time.sleep(0.15)
+                toxiproxy.set_enabled("metadata", True)
+                time.sleep(0.25)
+            except Exception:
+                break
+        _toxiproxy_heal(toxiproxy, log)
+        # Let the retries land and GC walk what they produced.
+        time.sleep(8)
+        if panicked():
+            raise AssertionError(
+                f"REPRODUCED: stale merge res corrupted a shard, iteration {iteration}"
+            )
+        retries = (
+            c.invoke("logs", "materialized", capture=True, silent=True).stdout or ""
+        ).count("merge_res received an indeterminate")
+        log.log(
+            "repro",
+            f"iteration {iteration}: no corruption yet, {retries} merge_res retries",
+        )
+    log.log("repro", "not reproduced in 40 iterations")
+
+
+def repro_alter_table_schema(c, toxiproxy, ctx, log) -> None:
+    """Kill environmentd between ALTER TABLE's two halves, then fail to boot.
+
+    The catalog transaction commits first and the persist schema evolution
+    runs afterwards, as a catalog implication. A crash in between leaves the
+    catalog holding a table version whose schema the data shard never
+    registered.
+
+    Two panics come out of that state. Re-running the evolution finds persist
+    already past the version it expects and soft-panics instead of treating it
+    as done (SQL-616). Once it has failed, bootstrap registers the table with
+    txn-wal presenting a desc the shard never registered and dies with "schema
+    should be registered" (PER-59), on every boot.
+
+    Hitting that gap needs the offset to be measured rather than guessed. A
+    latency toxic on the metadata leg stretches every round trip the ALTER
+    makes, not only the evolution, so the pre-commit half alone runs for tens
+    of seconds. This calibrates the whole window, bisects it for the moment
+    the catalog commit lands, and then kills just after it.
+    """
+    from materialize.invariants.mz import MzClient
+
+    MARKERS = ("schema should be registered", "schema expectation mismatch")
+
+    def panicked() -> str | None:
+        logs = c.invoke("logs", "materialized", capture=True, silent=True).stdout or ""
+        return next((m for m in MARKERS if m in logs), None)
+
+    driver = MzClient(ctx, "alter-driver")
+    system = MzClient(
+        ctx, "alter-system", user="mz_system", port=ctx.endpoints.mz_system_port
+    )
+    system.query("ALTER SYSTEM SET enable_alter_table_add_column = true")
+
+    def with_delay(add: bool) -> None:
+        for stream in ("upstream", "downstream"):
+            if add:
+                toxiproxy.add_toxic(
+                    "metadata",
+                    f"alter-delay-{stream}",
+                    "latency",
+                    {"latency": 1500, "jitter": 500},
+                    stream=stream,
+                )
+            else:
+                toxiproxy.delete_toxic("metadata", f"alter-delay-{stream}")
+
+    def attempt(table: str, offset: float) -> tuple[bool, str | None]:
+        """ALTER, kill at `offset`, restart. Returns (committed, panic)."""
+        driver.write(f"CREATE TABLE {table} (a int, b text)")
+        driver.write(f"INSERT INTO {table} VALUES (1, 'x')")
+
+        def alter() -> None:
+            try:
+                MzClient(ctx, f"alter-{table}").write(
+                    f"ALTER TABLE {table} ADD COLUMN c int", timeout=300
+                )
+            except Exception:
+                pass
+
+        with_delay(True)
+        thread = threading.Thread(target=alter, daemon=True)
+        thread.start()
+        time.sleep(offset)
+        c.kill("materialized")
+        with_delay(False)
+        try:
+            c.up("materialized", detach=True, max_tries=2)
+        except Exception as e:
+            log.log("repro", f"{table}: did not come up ({e})")
+        thread.join(timeout=60)
+        marker = panicked()
+        driver.reset()
+        try:
+            committed = bool(
+                driver.query(
+                    "SELECT 1 FROM mz_catalog.mz_columns c"
+                    " JOIN mz_catalog.mz_tables t ON c.id = t.id"
+                    f" WHERE t.name = '{table}' AND c.name = 'c'"
+                )
+            )
+        except Exception:
+            committed = False
+        return committed, marker
+
+    # 1. How long is one uninterrupted ALTER under the delay?
+    driver.write("CREATE TABLE alter_calibrate (a int, b text)")
+    with_delay(True)
+    started = time.monotonic()
+    driver.write("ALTER TABLE alter_calibrate ADD COLUMN c int", timeout=300)
+    window = time.monotonic() - started
+    with_delay(False)
+    log.log("repro", f"one ALTER takes {window:.1f}s under the metadata delay")
+
+    # 2. Bisect for the earliest offset whose kill still leaves the catalog
+    #    change committed. That is the moment the transaction lands, and the
+    #    implication runs in the seconds right after it.
+    low, high = 0.0, window
+    for step in range(6):
+        mid = (low + high) / 2
+        committed, marker = attempt(f"alter_bisect_{step}", mid)
+        if marker is not None:
+            raise AssertionError(f"REPRODUCED {marker!r} while bisecting at {mid:.1f}s")
+        log.log("repro", f"bisect {mid:.1f}s: committed={committed}")
+        if committed:
+            high = mid
+        else:
+            low = mid
+    log.log("repro", f"catalog commit lands at ~{high:.1f}s of {window:.1f}s")
+
+    # 3. Kill just after the commit, walking outwards until the implication
+    #    has certainly finished.
+    for step, delta in enumerate([0.2, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]):
+        committed, marker = attempt(f"alter_exploit_{step}", high + delta)
+        if marker is not None:
+            raise AssertionError(
+                f"REPRODUCED {marker!r} killing {delta:.1f}s after the commit"
+            )
+        log.log("repro", f"commit+{delta:.1f}s: committed={committed}, booted again")
+    log.log("repro", "not reproduced")
+
+
+REPRO_FUNCS = {
+    "repro-blob-memory": repro_blob_memory,
+    "repro-storage-memory": repro_storage_memory,
+    "repro-postheal-stall": repro_postheal_stall,
+    "repro-per10": repro_per10,
+    "repro-durable-resume": repro_durable_resume,
+    "repro-compute-asof": repro_compute_asof,
+    "repro-replacement-brick": repro_replacement_brick,
+    "repro-alter-table-schema": repro_alter_table_schema,
+    "repro-stale-merge-res": repro_stale_merge_res,
+}

--- a/test/invariants/mzcompose.py
+++ b/test/invariants/mzcompose.py
@@ -44,6 +44,7 @@ from materialize.mzcompose.services.postgres import Postgres, PostgresMetadata
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.sql_server import SqlServer
 from materialize.mzcompose.services.toxiproxy import Toxiproxy
+from materialize.version_list import get_latest_published_version
 
 # Host port for the Kafka listener the harness (producers, consumers) uses.
 # It must be a fixed port because Kafka advertises it back to clients.
@@ -164,6 +165,13 @@ LEGS = {
             Proxy("compute_storagectl", 2100, "clusterd-compute:2100"),
             Proxy("compute_computectl", 2101, "clusterd-compute:2101"),
         ),
+        # TODO: Reenable the cutting kinds when PER-49 is fixed, as for
+        # clusterd-compute2 below. NOTE: this does not remove the trigger.
+        # Losing the replica is what drops its per-replica read holds, and the
+        # disruptor's SIGKILLs of this process do that just as well as a leg
+        # cut, so the halt keeps occurring until PER-49 is fixed. Reproducer:
+        # bin/mzcompose --find invariants run default --scenario=repro-compute-asof
+        kinds=("latency", "limit_data", "bandwidth"),
     ),
     "clusterd-compute2": Leg(
         "clusterd-compute2",
@@ -199,7 +207,12 @@ LEGS = {
         "blob",
         (Proxy("blob", 9000, "minio:9000"),),
         max_outage=15.0,
-        kinds=("disable", "timeout", "limit_data"),
+        # NOTE: limit_data is dropped here, not for the buffering reason above
+        # but because max_outage only caps the full-outage kinds. A limit_data
+        # on this leg kills every connection past its byte budget, so it stalls
+        # blob writes for its whole uncapped duration, which is all PER-31
+        # needs: nightly 17743 OOM-killed clusterd at 6.2GiB during a 29s one.
+        kinds=("disable", "timeout"),
     ),
     "pg": Leg("pg", (Proxy("pg", 5432, "postgres:5432"),)),
     "mysql": Leg("mysql", (Proxy("mysql", 3306, "mysql:3306"),)),
@@ -261,9 +274,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "--upgrade-from",
         type=str,
+        nargs="?",
+        const="latest",
         default=None,
+        metavar="IMAGE",
         help="start Materialize on this image and swap to the current build"
-        " mid-chaos, an upgrade under load and disruptions",
+        " mid-chaos, an upgrade under load and disruptions. Bare or 'latest'"
+        " resolves to the most recent published release",
     )
     parser.add_argument(
         "--no-disruptions",
@@ -272,6 +289,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
+    if args.upgrade_from == "latest":
+        args.upgrade_from = f"materialize/materialized:{get_latest_published_version()}"
+        print(f"--- Upgrading from {args.upgrade_from}")
     print(f"--- Random seed is {args.seed}")
     if args.scenario in REPROS:
         log = EventLog("invariants-events.log")
@@ -393,7 +413,7 @@ def run_scenario(c: Composition, name: str, args, log: EventLog) -> None:
                 restore_proxies=[
                     proxy for leg in LEGS.values() for proxy in leg.proxies
                 ],
-                restart_toxiproxy=lambda: _restart_toxiproxy(c),
+                restart_toxiproxy=lambda: _restart_toxiproxy(c, toxiproxy),
             ).run()
         finally:
             scenario.teardown()
@@ -485,6 +505,8 @@ REPROS = {
     "repro-durable-resume": "resumed SUBSCRIBE cancels its carried state",
     "repro-compute-asof": "PER-49: compute halts hydrating a dataflow past its"
     " as_of",
+    "repro-replacement-brick": "SQL-603: bootstrap halts forever on an"
+    " interrupted replacement apply",
 }
 
 
@@ -554,16 +576,20 @@ def run_repro(c: Composition, name: str, args, log: EventLog) -> None:
                 t.join(timeout=10)
 
 
-def _restart_toxiproxy(c: Composition) -> None:
+def _restart_toxiproxy(c: Composition, api: ToxiproxyApi) -> None:
     """Replace a toxiproxy whose admin API no longer answers.
 
     Every leg runs through this container, so the restart cuts them all for a
     moment. That is the same event as a toxiproxy crash, which the disruptor
     recovers from by re-creating the proxies, and it is the only way out of a
     wedged admin API.
+
+    The admin port is published on an ephemeral host port, which a recreated
+    container does not keep, so the API is re-pointed at the new mapping.
     """
     c.kill("toxiproxy")
     c.up("toxiproxy", detach=True, max_tries=3)
+    api.rebind(f"http://127.0.0.1:{c.default_port('toxiproxy')}")
 
 
 def _toxiproxy_heal(toxiproxy: ToxiproxyApi, log: EventLog) -> None:
@@ -685,7 +711,8 @@ def repro_postheal_stall(c, toxiproxy, ctx, log) -> None:
             seq += 1
             try:
                 client.write(
-                    f"INSERT INTO ledger VALUES ({1000 + idx}, {seq}, 0, 0)",
+                    f"INSERT INTO ledger (worker, seq, account, amount)"
+                    f" VALUES ({1000 + idx}, {seq}, 0, 0)",
                     timeout=20,
                 )
             except Exception:
@@ -975,10 +1002,116 @@ def repro_compute_asof(c, toxiproxy, ctx, log) -> None:
     log.log("repro", "not reproduced in 15 iterations")
 
 
+def repro_replacement_brick(c, toxiproxy, ctx, log) -> None:
+    """Kill environmentd while a replacement is applied, then fail to boot.
+
+    The storage controller's bootstrap halts whenever a dependency read hold
+    has an empty since, calling it a concurrent deletion. The condition it
+    tests is narrower than the one its message claims: it does not check the
+    dependent's own write frontier, and the check right below it documents why
+    that matters ("We don't care about the dependency since when the write
+    frontier is empty. In that case, no-one can write down any more updates.").
+
+    A replacement MV holds a read hold on the collection it replaces, so an
+    apply that is interrupted can leave the replacement registered while the
+    replaced collection is already finalized. Both frontiers are then empty,
+    which is benign, and bootstrap halts on it anyway. The state is durable, so
+    every restart halts again and environmentd never comes back:
+    src/storage-controller/src/lib.rs:992, nightly 17740 spent 139 boots there.
+
+    SQL-603. NOTE: this presses the sequence but has not reproduced it, in 30
+    kill-during-apply cycles across two variants (the second delays the
+    metadata leg to widen the window between the storage finalize and the
+    catalog commit). The nightly hit it in 6 of 8 upgrade runs, so an
+    ingredient here is still missing, most likely the concurrent load and the
+    other dependents of `total` that a full scenario has.
+    """
+    from materialize.invariants.mz import MzClient
+    from materialize.invariants.scenarios.table_bank import TOTAL_DEF
+
+    MARKER = "dependency since frontier is empty"
+
+    def bricked() -> bool:
+        logs = c.invoke("logs", "materialized", capture=True).stdout or ""
+        return logs.count(MARKER) > 0
+
+    applier = MzClient(ctx, "brick-applier")
+    driver = MzClient(ctx, "brick-driver")
+    for iteration in range(15):
+        driver.write("DROP MATERIALIZED VIEW IF EXISTS total_repl")
+        driver.write(
+            "CREATE REPLACEMENT MATERIALIZED VIEW total_repl FOR total"
+            " IN CLUSTER compute WITH (RETAIN HISTORY = FOR '600s')"
+            f" AS {TOTAL_DEF}"
+        )
+        # Applying an unhydrated replacement is rejected, so wait for it as the
+        # documented workflow does.
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            rows = driver.query(
+                "SELECT bool_and(h.hydrated)"
+                " FROM mz_internal.mz_hydration_statuses h"
+                " JOIN mz_catalog.mz_materialized_views v ON h.object_id = v.id"
+                " WHERE v.name = 'total_repl'"
+            )
+            if rows and rows[0][0]:
+                break
+            time.sleep(1)
+
+        # The kill has to land inside the apply, which finalizes the replaced
+        # collection and retires the replacement in one go.
+        def apply() -> None:
+            try:
+                applier.write(
+                    "ALTER MATERIALIZED VIEW total APPLY REPLACEMENT total_repl"
+                )
+            except Exception:
+                pass
+
+        # The apply finalizes the replaced collection and retires the
+        # replacement, then commits the catalog transaction, and the state that
+        # bricks the next boot is the window in between. Both halves are
+        # consensus writes, so delaying the metadata leg stretches that window
+        # from microseconds to something a kill can land in.
+        for stream in ("upstream", "downstream"):
+            toxiproxy.add_toxic(
+                "metadata",
+                f"apply-delay-{stream}",
+                "latency",
+                {"latency": 1500, "jitter": 500},
+                stream=stream,
+            )
+        thread = threading.Thread(target=apply, daemon=True)
+        thread.start()
+        time.sleep(0.5 + 0.5 * (iteration % 12))
+        c.kill("materialized")
+        for stream in ("upstream", "downstream"):
+            toxiproxy.delete_toxic("metadata", f"apply-delay-{stream}")
+        try:
+            c.up("materialized", detach=True, max_tries=2)
+        except Exception as e:
+            # A bricked environmentd never becomes healthy, which is the
+            # symptom, so the log decides rather than this call.
+            log.log(
+                "repro", f"iteration {iteration}: environmentd did not come up ({e})"
+            )
+        thread.join(timeout=30)
+        if bricked():
+            raise AssertionError(
+                "REPRODUCED: environmentd halts at bootstrap and cannot come"
+                f" back, iteration {iteration}"
+            )
+        applier.reset()
+        driver.reset()
+        log.log("repro", f"iteration {iteration}: booted again")
+    log.log("repro", "not reproduced in 15 iterations")
+
+
 REPRO_FUNCS = {
     "repro-blob-memory": repro_blob_memory,
     "repro-postheal-stall": repro_postheal_stall,
     "repro-per10": repro_per10,
     "repro-durable-resume": repro_durable_resume,
     "repro-compute-asof": repro_compute_asof,
+    "repro-replacement-brick": repro_replacement_brick,
 }


### PR DESCRIPTION
A correctness-under-chaos test framework: multi-threaded scenarios whose
invariants hold no matter which concurrent operations succeed, fail, or end up
in an unknown state, checked *continuously* while toxiproxy cuts connections and
processes are killed, and strictly again after healing.

### Why another workload

The trick is picking invariants that are **outcome-independent**. A bank
transfer debits one account and credits another, so the grand total is
conserved whether the transfer committed, was rejected, or timed out with an
unknown outcome. That is what makes it safe to assert exact results *during* a
disruption, rather than waiting for quiescence and comparing against an oracle
that chaos has invalidated.

| | catches | verifies results |
|---|---|---|
| parallel-workload | panics, unexpected errors | no result oracle |
| zippy | wrong results, single-threaded | after quiescing |
| **invariants** | **wrong results, lost/duplicated writes** | **continuously, under disruption** |

### How a run works

1. **setup**: create the objects, record the oracle's starting point.
2. **chaos** (`--runtime`, default 600s): worker threads issue writes, checker
   threads verify invariants, the disruptor injects/heals, the agitator flips
   feature flags and cancels connections. Any checker failure fails the run
   immediately.
3. **heal**: every disruption is removed, with retries.
4. **converge**: wait for all data paths to catch up.
5. **final check**: strict assertions, plus a vacuity check: every checker and
   the workers must have made progress in *both halves* of the chaos phase, and
   the disruptor and agitator must have acted. A thread that wedges midway, or a
   run where nothing was ever disrupted, fails instead of passing silently.

Each thread draws its own seeded RNG in a fixed order, so `--seed` reproduces
the whole action/disruption sequence.

### What gets disrupted

Toxiproxy fronts each *leg*: persist consensus (metadata store), persist blob,
`envd`<->`clusterd` storagectl/computectl, and the source/sink/registry
connections. Disruptions are `disable`, `latency`, `timeout`, `limit_data`,
`bandwidth`, `reset_peer`, `flap`, `slicer` and `slow_close`, applied to one
direction only so half are asymmetric, and to a proper subset of a leg's
proxies a quarter of the time, so one channel to a process dies while another
to the same process lives. The last two exist because a dependency that is simply *down*
mostly produces determinate failures, and the interesting bugs live in
*partial* failure: `reset_peer` RSTs a connection after letting some traffic
through, so a request can land and take effect while its response is lost, and
`flap` toggles the leg every 50-500ms instead of cutting once, so an in-flight
write gets a severed response on every toggle rather than once per cycle. Both
manufacture the "did my write commit?" ambiguity that retry logic has to
survive. `slicer` chops each write into small pieces and spaces them out, so
no read returns a whole framed message, which is the shape that breaks a parser
assuming otherwise and which no clean cut produces.

On top of
that the disruptor SIGKILLs and SIGSTOPs `environmentd` and the `clusterd`
processes, deliberately overlapping process kills with leg cuts and following
some heals with an immediate kill, since the post-heal window is where recovery
bugs live. It also crash-loops a process, killing it every 1-4s so the restart
policy keeps bringing it partway up and bootstrap never completes, and squeezes
one to 0.15 CPU, which is the only fault here that leaves a process answering
but far too slowly, so peers see a live but lagging peer rather than an absent
one.

Cuts are not only timer-driven: the workload can ask for one, naming the state
it is entering (`shard-create`, `schema-swap`), and the disruptor cuts
immediately. The states worth cutting through are brief, and only the workload
knows when it is inside one. Outages are capped per leg (a metadata cut must stay well under the
15-minute persist lease expiry). Coverage is reported at the end, and a
deterministic first sweep guarantees no leg goes untouched by RNG accident.

`--upgrade-from=<image>` starts on an older release and swaps in the current
build at the chaos midpoint: an upgrade under concurrent load *and* disruptions,
with the invariants never pausing.

### Scenarios

| `--scenario` | invariant |
|---|---|
| `table-bank` | conserved total across tables, MVs, indexes, temporal filters, `REFRESH EVERY`, schema swaps, replacement MVs, `COPY TO`/`FROM` |
| `txn-probe` | transaction semantics with no domain invariant: lost updates on a contended counter, transactions that never commit, one transaction across three shards, table create/write/drop churn |
| `graph` | the transitive closure of a churning DAG, maintained by a recursive (`WITH MUTUALLY RECURSIVE`) view, must stay closed and must equal a from-scratch recomputation at the same timestamp |
| `pg-cdc-bank`, `mysql-cdc-bank`, `sqlserver-cdc-bank` | the same conserved total, written upstream and replicated in, plus upstream DDL and real-time recency |
| `kafka-ledger` | append-only Kafka ledger sums to the produced total |
| `kafka-upsert` | last value per key wins under retractions |
| `sink-roundtrip` | sink out, source back in, must equal the original |
| `webhook-set` | every accepted webhook body appears exactly once |
| `avro-loopback` | Avro/CSR encode-decode preserves every row |

`--complexity=low|medium|high|large` scales workers, disruption frequency and
concurrency. `--no-disruptions` runs the same workload and checkers clean, which
is how you tell a product bug from a chaos artifact. `--legs=a,b` and `--kinds=x,y` restrict the
disruptor to a subset of connections or of fault kinds, turning "something in
the mix causes this" into a two-run bisection. `--persist-churn` drives persist to take as many state
transitions per second as it can (no inline writes, tiny blob target, minimum
compaction heuristics, frequent rollups), so the disruptions have something to
interleave with. `INVARIANTS_SOFT_ASSERTIONS=1` turns every soft assertion in
the processes under test into a panic, which our images otherwise compile out.

### Read-path coverage

The same invariant is verified through deliberately different plans and
protocols, because a wrong answer usually only shows up in one of them: one-shot
peeks (maintained MV, ad-hoc over base tables, and result-equivalent joins,
window functions, recursive CTEs and LATERAL subqueries), `SUBSCRIBE` with
`PROGRESS` (both fresh and resumed from a durable timestamp), read-only
transaction snapshots, `AS OF` time travel into retained history, `COPY TO`
export, and a post-run audit that replays the entire retained history and
validates every progress boundary, retroactively closing the rounds live
checkers had to skip during outages. Reads rotate over isolation levels, since a
timestamp-free invariant must hold under all of them.

### What the checkers assert

A conserved total is safe to assert mid-disruption, which is what makes
continuous checking possible, but on its own it is a one-dimensional projection:
transfers are balanced pairs, so only a *torn* pair breaks the sum, and that is
the one thing atomic batch commit already prevents. So the oracles go past it,
while staying outcome-independent:

- **row-level identity**, continuously. Every op id in a bounded window of the
  newest ops must have exactly its two rows summing to zero, its derived columns
  must match its op id, committed ops must be present, ops never issued must not
  be, and an op observed once must never be absent again. A lost transfer masked
  by a duplicated one, a rewritten row, or a resurrected retraction all keep the
  count and the sum intact and are only visible here.
- **the change stream itself**, via a snapshot-free `SUBSCRIBE` whose cost is
  independent of table size. The ledger is append-only, so any retraction is a
  bug outright, even the ones that cancel against their insert and leave the
  folded state looking correct.
- **read-your-writes**, on the writer's own session right after a commit. No
  timestamp-free invariant covers it, and it is what a stale read breaks first.
- **predicate results, recomputed**. An aggregate with a predicate lets persist
  skip parts by their statistics, and getting that wrong is silent: the answer is
  just too small. The same predicate is re-evaluated on the client over the rows
  the same transaction returns, so the two must agree.

- **transaction atomicity, by construction**. Rows carry the identity and the
  size of the transaction that wrote them, so a torn transaction is one
  statement that must return nothing at every timestamp: group by the
  transaction, require every group to be whole. Nothing on the checker side
  has to know which transactions ran or committed, which is what makes it
  usable when most outcomes are unknown, and it is strictly stronger than a
  conserved sum, which cannot see a tear that happens to preserve it. It runs
  over one transaction spanning three shards (txn-wal's cross-shard commit),
  over the ledger's balanced pairs, and upstream over transactions tens of
  rows wide, since a two-row transaction is a small target for an interrupted
  snapshot to fall inside.
- **the past, not just the present**. A quarter of the conservation and
  atomicity rounds re-ask the same question `AS OF` a timestamp in retained
  history. A tear is durable in the shard's history even after the live state
  has converged, so probing the past turns a race that reproduces once a week
  into an artifact that can still be found afterwards.
- **lost updates**. Conservation survives a write vanishing outright, because
  nothing moved. A contended counter incremented once per op, bounded below by
  the committed count and above by the attempted count, is what fails when a
  read-then-write is lost or applied twice. Half the increments are preceded
  by a read of the same row on the same session, so a peek and a write on one
  key interleave.
- **transactions that never commit**. The only completely unambiguous oracle
  here: their rows must not be visible at any timestamp, whatever the
  disruptions did, so nothing has to reason about unknown outcomes. Three ways
  of not committing, because they end the transaction differently: an explicit
  `ROLLBACK`, a statement error that aborts it, and a connection dropped with
  the transaction still open, which is the case a disruption produces on its
  own and the one where a server-side mistake would actually commit.
- **a maintained view against a recomputation, in one statement**. Both sides
  of the difference are answered at one timestamp, so a disagreement cannot be
  explained away as progress in between. Run over a sum, and over the
  transitive closure of a churning DAG, where deletions are the point: an
  insert only grows the closure, which an iterative dataflow can get right by
  accumulating, while a delete has to retract every path that went through the
  removed edge, including paths discovered several iterations deep.
- **replica agreement, directly**. Other checkers read through the cluster, so
  a replica that computes the wrong answer is only caught if the coordinator
  happens to pick it. Both replicas are asked the same query at the same
  explicit timestamp, so any difference is a determinism bug rather than a
  race.

The ledger carries the values those oracles need in order to be able to fail: a
numeric mirror of each amount (its own encoding and scale handling), a tag
derived from the op id (so each row is checkable alone), floats covering NaN,
negative zero, the infinities and a denormal, and a nullable date. Predicates
over the last two are what pull filter pushdown onto the checked path.

### What the harness watches, beyond the scenarios

- **Panics** are left to CI's log annotator, which already fails the job on
  one and attributes it. The harness kills processes constantly, so it cannot
  tell a panic apart from its own disruption without duplicating that logic,
  and a second panic check would only compete with the one that already works.
  Every disruption is logged with its timing, so an annotated panic can be
  lined up against what was severed when.
- **Persist state history.** After a run passes, shards' live states are
  walked and every blob key must be live over one contiguous run of seqnos. A
  key that is live, gone, then live again means a state transition was applied
  to a state it was not computed from. GC notices that only if it happens to
  walk the right range, and the debug-only validator that would catch it is
  compiled out of our images, so this sees corruption that would otherwise
  surface days later as a missing blob.

### Findings so far

Each finding has a concentrated reproducer, selectable via `--scenario`:

- [PER-10](https://linear.app/materializeinc/issue/PER-10): persist GC panic, earliest state without rollup (`repro-per10`)
- [PER-31](https://linear.app/materializeinc/issue/PER-31): unbounded clusterd memory while the blob store is cut (`repro-blob-memory`)
- [PER-32](https://linear.app/materializeinc/issue/PER-32): writes stalled long after a metadata cut healed (`repro-postheal-stall`)
- [PER-49](https://linear.app/materializeinc/issue/PER-49): compute halts hydrating a dataflow past its `as_of` (`repro-compute-asof`)
- [SQL-603](https://linear.app/materializeinc/issue/SQL-603): halting process, dependency since frontier is empty while dependent upper is not empty. Fixed, and the `ALTER .. APPLY REPLACEMENT` cutover it forced out of `table-bank` is back in (`repro-replacement-brick` keeps the sequence as a regression check)
- [SS-427](https://linear.app/materializeinc/issue/SS-427): a MySQL snapshot taken while the upstream connection is truncated mid-response exposes half of an upstream transaction. The conservation check on a newly added table read 32034 instead of 32000, which is the full table with one transfer's credit visible and its debit missing. Transient, and durable in history.
- [SQL-616](https://linear.app/materializeinc/issue/SQL-616): `ALTER TABLE .. ADD COLUMN` commits its catalog transaction first and evolves the persist schema afterwards, as an implication. Re-running the evolution finds persist already past the version it expects and soft-panics instead of treating it as done (`repro-alter-table-schema`)
- [PER-59](https://linear.app/materializeinc/issue/PER-59): the sticky follow-on. Once that evolution has failed, the catalog holds a table version whose schema the shard never registered, and bootstrap dies with "schema should be registered" on every boot
- [PER-58](https://linear.app/materializeinc/issue/PER-58): a merge res retried after a lost consensus response overwrites a newer compaction, resurrecting blob parts an earlier diff recorded as deleted. Depending on where the retry lands relative to the seqno GC truncates to, this either panics GC or silently deletes blobs that live state still references. Deterministic reproducers for both faces live in `src/persist-client/tests/machine/` (`repro-stale-merge-res` end to end)
- [SS-428](https://linear.app/materializeinc/issue/SS-428): adding a table to a running Postgres source makes the replication reader hold its data capability at offset zero until the replay that follows has caught up, because that is where the new table's rewind retractions go. The source's frontier does not move for that whole replay, so the persist sink can finish no batch and holds every update it receives resident, spread over one open batch builder per timestamp. Every persist limit that would bound this is per builder, so opening more builders raises the ceiling instead of sharing it. `clusterd-storage` reached its 6GB limit and 6GB of swap on top of it in under four minutes, while the leg it was reading was passing a few KB/s (`repro-storage-memory`)
- not yet filed: a resumed `SUBSCRIBE` loses its carried state (`repro-durable-resume`)

### Coverage currently switched off

Each open bug above is loud enough that leaving its trigger enabled would mask
everything behind it, so the trigger is disabled with a `TODO: Reenable when
<TICKET> is fixed`. The price is a hole in the coverage, and they are worth
reading as a list rather than as scattered comments:

- both compute legs run without their cutting kinds (`disable`, `timeout`,
  `reset_peer`, `flap`), leaving only degradation, because losing a replica
  trips [PER-49](https://linear.app/materializeinc/issue/PER-49)
- the blob leg is capped at 15s and drops `limit_data`, because of [PER-31](https://linear.app/materializeinc/issue/PER-31)
- `ALTER TABLE .. ADD COLUMN` on the churned shards is off, because of [SQL-616](https://linear.app/materializeinc/issue/SQL-616)
  and [PER-59](https://linear.app/materializeinc/issue/PER-59)
- soft assertions are off by default (`INVARIANTS_SOFT_ASSERTIONS=1` turns them
  on), because the ones that fire today are known and would drown the rest

### What it cannot find yet

Where the next round of work is, in rough order of what would change the
suite's reach the most:

- **partial partitions of blob and consensus.** Each is fronted by a single
  shared proxy, so a cut takes envd and every clusterd at once. Per-consumer
  proxies are not expressible: envd chooses those URLs and hands the identical
  string to every clusterd, and there is no clusterd-side override. Persist
  pubsub *is* configured per process, so that is where the partial partition
  lives today, but the case persist's CaS and epoch logic actually exists
  for, one process fenced out of consensus while the others proceed, needs a
  clusterd-side persist URL flag first.
- **a full disk.** The blob store's data directory sits on the host disk, so
  exhausting it means exhausting the agent. Reaching `ENOSPC` safely needs a
  bounded mount, which no run can then share with a normal workload.
- **clock skew.** Lease expiry, `RETAIN HISTORY`, temporal filters and
  timestamp selection all key off wall clock, which never moves in a run.
- **failing on memory growth.** Per-container RSS is sampled into the event
  log, and a clusterd that crosses half its limit now has a heap profile taken
  while it is still alive, which is what attributed [SS-428](https://linear.app/materializeinc/issue/SS-428). Missing is a
  threshold that fails the run: a process that OOMs, restarts and lets the run
  pass is still only visible because CI's annotator greps the kernel log.
- **a real zero-downtime upgrade.** `--upgrade-from` kills the old processes
  and starts the new ones. The production path has both running at once, and
  the handoff is the interesting part.

### Running it

```shell
bin/mzcompose --find invariants run default --scenario=table-bank --runtime=120
bin/mzcompose --find invariants run default --scenario=repro-postheal-stall
```

Wired into Nightly as 14 steps (one per scenario, plus a large `table-bank`,
the upgrade-under-load variant, and a 40-minute soak that crosses persist's
15-minute reader lease several times, which a 20-minute run barely reaches).
Every failure annotation carries the exact reproducer command, and the run log
opens with the random seed that replays it.








