### PR TITLE
adapter: don't let a stale cancellation cancel the next statement

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1072,6 +1072,19 @@ impl Coordinator {
         // outer execute should be considered finished once the inner one is.
         outer_context: Option<ExecuteContextGuard>,
     ) {
+        // A new statement is starting, so discard any cancellation that was signaled while no
+        // statement was running. Such a cancellation targeted an earlier statement and must not
+        // cancel the new one. (Like in PostgreSQL, a cancel request that arrives when nothing is
+        // running has no effect.) The watch would otherwise retain a stale `true` within an
+        // explicit transaction, because it is removed only when the transaction is cleared, not
+        // at statement end.
+        //
+        // Don't do this for nested executes (e.g., FETCH executing its cursor's statement): the
+        // outer statement is still running and a pending cancellation may target it.
+        if outer_context.is_none() {
+            self.connection_cancel_watches.remove(session.conn_id());
+        }
+
         if session.vars().emit_trace_id_notice() {
             let span_context = tracing::Span::current()
                 .context()

--- a/test/testdrive/cancel-stale-staged-cancellation.td
+++ b/test/testdrive/cancel-stale-staged-cancellation.td
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# A cancellation that arrives while no statement is running must not cancel
+# the next statement on that connection. Regression test for SQL-275: within
+# an explicit transaction, the per-connection cancel watch of a finished
+# staged statement (e.g. EXPLAIN TIMESTAMP) lingered until transaction end,
+# so a late cancellation was misattributed to the transaction's next
+# statement.
+
+> CREATE TABLE cancel_stale_t (a int)
+
+$ postgres-connect name=main url=postgres://materialize@${testdrive.materialize-sql-addr}
+$ postgres-connect name=canceler url=postgres://materialize@${testdrive.materialize-sql-addr}
+
+> CREATE TABLE _cancel_pid (pid int4)
+
+$ postgres-execute connection=main
+INSERT INTO _cancel_pid SELECT pg_backend_pid();
+
+$ set-from-sql var=main-pid
+SELECT CAST(pid AS text) FROM _cancel_pid;
+
+$ postgres-execute connection=main
+BEGIN;
+
+$ postgres-execute connection=main
+EXPLAIN TIMESTAMP FOR SELECT * FROM cancel_stale_t;
+
+$ postgres-execute connection=canceler
+SELECT pg_cancel_backend(CAST(${main-pid} AS int4));
+
+$ postgres-execute connection=main
+EXPLAIN TIMESTAMP FOR SELECT * FROM cancel_stale_t;
+
+$ postgres-execute connection=main
+COMMIT;
+
+> DROP TABLE _cancel_pid
+> DROP TABLE cancel_stale_t


### PR DESCRIPTION
### Motivation

Fixes SQL-275: within an explicit transaction, canceling a request while no statement was running caused the *next* statement in the transaction to be canceled.

### Description

The staged-execution machinery keeps a per-connection watch channel (`connection_cancel_watches`) that stages use to observe cancellation. The watch of a finished statement is only removed when the transaction is cleared, not at statement end. So inside `BEGIN ... COMMIT`, a `pg_cancel_backend` (or pgwire cancel request) that arrives while the connection is idle sets the finished statement's stale watch to `true`, and the next staged statement's start-of-stage check misreads that as a cancellation of itself.

The fix clears the connection's watch when a new statement begins in `handle_execute`, so a cancellation that arrives while nothing is running has no effect, like in PostgreSQL. Cancellation of a running statement is unaffected: stage continuations re-enter via internal messages, not via `handle_execute`, so the watch stays in place for the statement's whole execution. Nested executes (e.g. `FETCH` executing its cursor's statement) skip the removal, because the outer statement is still running and a pending cancellation may target it.

### Verification

* Added `test/testdrive/cancel-stale-staged-cancellation.td` (the reproducer from the issue). It deterministically fails on `main` and passes with this fix.
* Verified that in-flight cancellation still works: `cancel-subscribe.td` and `divergent-dataflow-cancellation.td` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)