### PR TITLE
sql-parser: redact `COMMENT` bodies and `PARTITION BY` option values

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -58,9 +58,11 @@ impl WithOptionName for MaterializedViewOptionName {
     fn redact_value(&self) -> bool {
         match self {
             MaterializedViewOptionName::AssertNotNull
-            | MaterializedViewOptionName::PartitionBy
             | MaterializedViewOptionName::RetainHistory
             | MaterializedViewOptionName::Refresh => false,
+            // The value is an arbitrary user expression/literal that may embed
+            // sensitive data, so redact it (mirrors `KafkaSinkConfigOptionName`).
+            MaterializedViewOptionName::PartitionBy => true,
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1676,7 +1676,9 @@ impl WithOptionName for TableOptionName {
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
         match self {
-            TableOptionName::PartitionBy => false,
+            // The value is an arbitrary user expression/literal that may embed
+            // sensitive data, so redact it (mirrors `KafkaSinkConfigOptionName`).
+            TableOptionName::PartitionBy => true,
             TableOptionName::RetainHistory => false,
             TableOptionName::RedactedTest => true,
         }
@@ -1730,8 +1732,10 @@ impl WithOptionName for TableFromSourceOptionName {
             TableFromSourceOptionName::Details
             | TableFromSourceOptionName::TextColumns
             | TableFromSourceOptionName::ExcludeColumns
-            | TableFromSourceOptionName::RetainHistory
-            | TableFromSourceOptionName::PartitionBy => false,
+            | TableFromSourceOptionName::RetainHistory => false,
+            // The value is an arbitrary user expression/literal that may embed
+            // sensitive data, so redact it (mirrors `KafkaSinkConfigOptionName`).
+            TableFromSourceOptionName::PartitionBy => true,
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -5772,9 +5772,15 @@ impl<T: AstInfo> AstDisplay for CommentStatement<T> {
         f.write_str(" IS ");
         match &self.comment {
             Some(s) => {
-                f.write_str("'");
-                f.write_node(&display::escape_single_quote_string(s));
-                f.write_str("'");
+                if f.redacted() {
+                    // The comment body is arbitrary free text and may contain PII,
+                    // so redact it like every other user-supplied value.
+                    f.write_str("'<REDACTED>'");
+                } else {
+                    f.write_str("'");
+                    f.write_node(&display::escape_single_quote_string(s));
+                    f.write_str("'");
+                }
             }
             None => f.write_str("NULL"),
         }

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -209,7 +209,11 @@ pub trait WithOptionName {
     /// # WARNING
     ///
     /// Whenever implementing this trait consider very carefully whether or not
-    /// this value could contain sensitive user data.
+    /// this value could contain sensitive user data. Returning `false` disables
+    /// redaction for the value AND all of its descendants: the macro fully
+    /// un-redacts the formatter before rendering the value, so every nested
+    /// literal, sub-option, and expression underneath it prints verbatim too,
+    /// not just an immediate scalar.
     ///
     /// # Context
     /// Many statements in MZ use the format `WITH (<options>...)` to modify the

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -601,6 +601,50 @@ fn test_comment_body_redacted() {
 
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+fn test_partition_by_value_redacted() {
+    // A `PARTITION BY` value can be an arbitrary user literal. It flows into
+    // redacted_sql / trace spans, so it must not render verbatim in redacted
+    // mode. A column-list `PARTITION BY (a, b)` carries only identifiers, which
+    // stay verbatim (they are schema, not data).
+    for sql in [
+        "CREATE TABLE t (a int4) WITH (PARTITION BY = 'sensitive_literal')",
+        "CREATE MATERIALIZED VIEW mv WITH (PARTITION BY = 'sensitive_literal') AS SELECT 1",
+    ] {
+        let ast = parse_statements(sql)
+            .unwrap_or_else(|e| panic!("{sql:?} should parse: {e}"))
+            .into_iter()
+            .next()
+            .expect("one statement")
+            .ast;
+        let redacted = ast.to_ast_string_redacted();
+        assert!(
+            redacted.contains("<REDACTED>") && !redacted.contains("sensitive_literal"),
+            "PARTITION BY literal leaked into redacted output {redacted:?}"
+        );
+        assert!(
+            ast.to_ast_string_simple().contains("sensitive_literal"),
+            "PARTITION BY literal should be preserved in non-redacted output"
+        );
+    }
+
+    // Column-list partitioning must not be over-redacted: the identifiers are
+    // part of the schema and appear verbatim elsewhere in the statement.
+    let cols =
+        parse_statements("CREATE MATERIALIZED VIEW mv WITH (PARTITION BY (a, b)) AS SELECT a, b")
+            .expect("should parse")
+            .into_iter()
+            .next()
+            .expect("one statement")
+            .ast;
+    let redacted = cols.to_ast_string_redacted();
+    assert!(
+        redacted.contains("(a, b)") && !redacted.contains("<REDACTED>"),
+        "PARTITION BY column list should stay verbatim when redacted, got {redacted:?}"
+    );
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn test_collate_low_precedence_display_roundtrip() {
     // `COLLATE` binds very tightly (`PostfixCollateAt`), so a low-precedence
     // operand must print parenthesized — `(a + b) COLLATE c` would otherwise

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -563,6 +563,44 @@ fn test_role_password_display_roundtrip() {
 
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+fn test_comment_body_redacted() {
+    // `COMMENT ON ... IS '<text>'` carries arbitrary user free text that flows
+    // into `redacted_sql` and trace spans, so the redacted rendering must not
+    // leak the body. `NULL` carries no data and prints verbatim.
+    let ast = parse_statements("COMMENT ON TABLE customers IS 'ssn 123-45-6789'")
+        .expect("should parse")
+        .into_iter()
+        .next()
+        .expect("one statement")
+        .ast;
+    let redacted = ast.to_ast_string_redacted();
+    assert!(
+        redacted.contains("<REDACTED>"),
+        "comment body should be redacted, got {redacted:?}"
+    );
+    assert!(
+        !redacted.contains("ssn 123-45-6789"),
+        "comment body leaked into redacted output {redacted:?}"
+    );
+    assert!(
+        ast.to_ast_string_simple().contains("ssn 123-45-6789"),
+        "comment body should be preserved in non-redacted output"
+    );
+
+    let null_ast = parse_statements("COMMENT ON TABLE customers IS NULL")
+        .expect("should parse")
+        .into_iter()
+        .next()
+        .expect("one statement")
+        .ast;
+    assert!(
+        null_ast.to_ast_string_redacted().ends_with("IS NULL"),
+        "NULL comment should print verbatim when redacted"
+    );
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn test_collate_low_precedence_display_roundtrip() {
     // `COLLATE` binds very tightly (`PostfixCollateAt`), so a low-precedence
     // operand must print parenthesized — `(a + b) COLLATE c` would otherwise


### PR DESCRIPTION
Two redaction gaps in `AstDisplay` where user free-text leaks into `to_ast_string_redacted()`. That rendering is the canonical PII-free form: it feeds `redacted_sql` (`mz_internal.mz_sql_text_redacted`, readable by `mz_monitor_redacted`/`mz_support`/`mz_analytics`), the redacted catalog `create_sql`, and the OpenTelemetry span evaluated on every execute. Both defeat a documented redaction guarantee across a privilege boundary.

### `COMMENT ON ... IS '<text>'`

`CommentStatement::fmt` rendered the comment body verbatim in every mode, with no `f.redacted()` guard, unlike every other free-text field (`Value::String`, `SECRET`). The body is arbitrary user text and the field most likely to hold inadvertent PII. Now redacted like `Value::String`; `NULL` stays verbatim.

### `PARTITION BY` option values

`PARTITION BY` on tables, table-from-source, and materialized views had `redact_value()` return `false`. The `impl_display_for_with_option!` macro reads that as "safe" and fully un-redacts the formatter for the whole value subtree, so `PARTITION BY = 'literal'` printed verbatim under redaction. Returning `true` delegates to `WithOptionValue`'s per-type logic, which redacts scalar literals while leaving column-list identifiers (`PARTITION BY (a, b)`) verbatim, since those are schema, not data. Mirrors the existing `KafkaSinkConfigOptionName::PartitionBy => true`.

Also documented on `WithOptionName::redact_value` that opting out disables redaction for the value and all of its descendants, not just an immediate scalar.

### Tests

`test_comment_body_redacted` and `test_partition_by_value_redacted` in `sqlparser_common.rs` assert the redacted output contains `<REDACTED>` and not the literal, that non-redacted output is preserved, and that a `PARTITION BY` column list is not over-redacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)