### PR TITLE
SS-322: prune keys referencing excluded columns during PG purification

### DIFF
--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -451,7 +451,20 @@ pub(super) async fn purify_source_exports(
             let exclude_columns = exclude_column_map.remove(&desc.oid);
 
             if let Some(exclude_cols) = &exclude_columns {
+                let excluded_col_nums: BTreeSet<u16> = desc
+                    .columns
+                    .iter()
+                    .filter(|c| exclude_cols.contains(&c.name))
+                    .map(|c| c.col_num)
+                    .collect();
                 desc.columns.retain(|c| !exclude_cols.contains(&c.name));
+                // A key naming an excluded column can never be re-verified against
+                // upstream, since the column (and any constraint on it) can be
+                // dropped independently of the columns we still track. Drop such
+                // keys now rather than carrying a stale key that will look like an
+                // incompatible schema change once the excluded column disappears.
+                desc.keys
+                    .retain(|k| k.cols.iter().all(|c| !excluded_col_nums.contains(c)));
             }
 
             if let (Some(text_cols), Some(exclude_cols)) = (&text_columns, &exclude_columns) {

--- a/test/pg-cdc/exclude-columns-key.td
+++ b/test/pg-cdc/exclude-columns-key.td
@@ -40,6 +40,18 @@ CREATE TABLE uniq_table (id int NOT NULL, u int NOT NULL, val text NOT NULL, UNI
 INSERT INTO uniq_table VALUES (1, 10, 'a'), (2, 20, 'b');
 ALTER TABLE uniq_table REPLICA IDENTITY FULL;
 
+# A table with a composite PRIMARY KEY: `(id, sub_id)`. Excluding just one of the
+# two columns must drop the whole key, not leave a partial one behind.
+CREATE TABLE composite_pk_table (id int NOT NULL, sub_id int NOT NULL, val text NOT NULL, PRIMARY KEY (id, sub_id));
+INSERT INTO composite_pk_table VALUES (1, 10, 'a'), (2, 20, 'b');
+ALTER TABLE composite_pk_table REPLICA IDENTITY FULL;
+
+# A table with two independent keys: `PRIMARY KEY (id)` and `UNIQUE (u)`. Excluding
+# `id` must drop only the key that names it, leaving `UNIQUE (u)` intact.
+CREATE TABLE multi_key_table (id int NOT NULL, u int NOT NULL, val text NOT NULL, PRIMARY KEY (id), UNIQUE (u));
+INSERT INTO multi_key_table VALUES (1, 10, 'a'), (2, 20, 'b');
+ALTER TABLE multi_key_table REPLICA IDENTITY FULL;
+
 ANALYZE;
 
 > CREATE SOURCE mz_source
@@ -55,6 +67,17 @@ ANALYZE;
 > CREATE TABLE uniq_table
   FROM SOURCE mz_source (REFERENCE public.uniq_table)
   WITH (EXCLUDE COLUMNS (u));
+
+# Excluding one column of a composite PRIMARY KEY drops the whole key
+> CREATE TABLE composite_pk_table
+  FROM SOURCE mz_source (REFERENCE public.composite_pk_table)
+  WITH (EXCLUDE COLUMNS (id));
+
+# Excluding the PRIMARY KEY's column drops that key, but the unrelated
+# UNIQUE (u) constraint is unaffected
+> CREATE TABLE multi_key_table
+  FROM SOURCE mz_source (REFERENCE public.multi_key_table)
+  WITH (EXCLUDE COLUMNS (id));
 
 # Verify that the constraint is ignored on uniq_table
 > CREATE DEFAULT INDEX ON uniq_table;
@@ -72,6 +95,20 @@ Used Indexes:
   - materialize.public.uniq_table_primary_idx (*** full scan ***)
 
 Target cluster: quickstart
+
+# Verify that excluding one column of a composite key drops the whole key: no
+# unique key remains, so the default index is a full scan over every column.
+> CREATE DEFAULT INDEX ON composite_pk_table;
+
+> SELECT key FROM (SHOW INDEXES ON composite_pk_table);
+{sub_id,val}
+
+# Verify that excluding the PRIMARY KEY's column only drops that key; the
+# unrelated UNIQUE (u) constraint still makes `u` a valid index key.
+> CREATE DEFAULT INDEX ON multi_key_table;
+
+> SELECT key FROM (SHOW INDEXES ON multi_key_table);
+{u}
 
 # Sanity: excluding a non-key column on a keyed table still works, and the key
 # constraint is preserved on the resulting table.

--- a/test/pg-cdc/exclude-columns-key.td
+++ b/test/pg-cdc/exclude-columns-key.td
@@ -82,3 +82,58 @@ Target cluster: quickstart
 > SELECT * FROM pk_table_2;
 1
 2
+
+#
+# Regression: excluding a key column then dropping it upstream must not halt the
+# source. Purification prunes the excluded column from the stored descriptor but
+# not the key referencing it, so determine_compatibility's keys check fails once
+# the upstream key is gone. PG/keys analog of MySQL's SS-129. Covers both
+# verify_schema call sites: replication (pk_drop) and snapshot (pk_drop_snapshot).
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE pk_drop (id int PRIMARY KEY, val text);
+INSERT INTO pk_drop VALUES (1, 'a'), (2, 'b');
+# REPLICA IDENTITY FULL so dropping the PK column leaves the keys check as the
+# sole reason compatibility could fail.
+ALTER TABLE pk_drop REPLICA IDENTITY FULL;
+
+> CREATE TABLE pk_drop
+  FROM SOURCE mz_source (REFERENCE public.pk_drop)
+  WITH (EXCLUDE COLUMNS (id));
+
+> SELECT * FROM pk_drop;
+a
+b
+
+# Drop replicas so the second table snapshots against the post-drop schema.
+> ALTER CLUSTER storage SET (REPLICATION FACTOR 0)
+
+> CREATE TABLE pk_drop_snapshot
+  FROM SOURCE mz_source (REFERENCE public.pk_drop)
+  WITH (EXCLUDE COLUMNS (id));
+
+# Drop the excluded PK column upstream. Postgres drops the PK constraint with it.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE pk_drop DROP COLUMN id;
+
+> ALTER CLUSTER storage SET (REPLICATION FACTOR 1)
+
+# Snapshot path: the second table must snapshot against the post-drop schema.
+> SELECT * FROM pk_drop_snapshot;
+a
+b
+
+# Replication path: a write forces a Relation message; both tables must ingest it.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO pk_drop VALUES ('c');
+
+> SELECT * FROM pk_drop;
+a
+b
+c
+
+> SELECT * FROM pk_drop_snapshot;
+a
+b
+c


### PR DESCRIPTION
## Summary
- Postgres source purification pruned an excluded column from the stored table descriptor but left any key/constraint naming that column untouched.
- If the excluded column (and its constraint) was later dropped upstream, `determine_compatibility`'s keys check saw the stale key vanish from the upstream key set and halted the source with "incompatible schema change", even though the column was never ingested.
- Fix: when pruning excluded columns in `purify_source_exports`, also drop any key whose columns reference an excluded column, so the descriptor doesn't carry a key that can never be re-verified once the excluded column disappears upstream.

## Test plan
- [x] Added a regression test to `test/pg-cdc/exclude-columns-key.td` covering both `verify_schema` call sites (replication and snapshot) for a table that excludes its primary key column and later has that column dropped upstream.
- [x] `bin/mzcompose --find pg-cdc run cdc exclude-columns-key.td` passes, including the post-fix Materialize restart sanity check.
- [x] `cargo check -p mz-sql` and `bin/fmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)