### PR TITLE
SS-124: SQL Server: Improve handling of CHAR(N) type when dealing with multi-byte encoding

### DIFF
--- a/doc/user/content/headless/sql-server-supported-types.md
+++ b/doc/user/content/headless/sql-server-supported-types.md
@@ -34,3 +34,10 @@ Materialize natively supports the following SQL Server types:
 - `datetimeoffset`
 - `uniqueidentifier`
 {{</ multicolumn-list >}}
+
+#### `char` and `nchar` columns
+
+To preserve values exactly as SQL Server returns them, `char` and `nchar` columns
+are replicated as `text` rather than fixed-length. SQL Server and Materialize
+measure fixed-length character types differently, so replicating as text avoids
+truncation and padding mismatches.

--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -27,7 +27,6 @@ use chrono::{NaiveDateTime, SubsecRound};
 use dec::OrderedDecimal;
 use mz_ore::cast::CastFrom;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType};
-use mz_repr::adt::char::CharLength;
 use mz_repr::adt::numeric::{Numeric, NumericMaxScale};
 use mz_repr::adt::timestamp::{CheckedTimestamp, TimestampPrecision};
 use mz_repr::adt::varchar::VarCharMaxLength;
@@ -411,233 +410,216 @@ fn parse_data_type(
         });
     }
 
-    let scalar =
-        match raw.data_type.to_lowercase().as_str() {
-            "tinyint" => (SqlScalarType::Int16, SqlServerColumnDecodeType::U8),
-            "smallint" => (SqlScalarType::Int16, SqlServerColumnDecodeType::I16),
-            "int" => (SqlScalarType::Int32, SqlServerColumnDecodeType::I32),
-            "bigint" => (SqlScalarType::Int64, SqlServerColumnDecodeType::I64),
-            "bit" => (SqlScalarType::Bool, SqlServerColumnDecodeType::Bool),
-            "decimal" | "numeric" | "money" | "smallmoney" => {
-                // SQL Server supports a precision in the range of [1, 38] and then
-                // the scale is 0 <= scale <= precision.
-                //
-                // Materialize numerics are floating point with a fixed precision of 39.
-                //
-                // See: <https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver16#arguments>
-                if raw.precision > 38 || raw.scale > raw.precision {
-                    tracing::warn!(
-                        "unexpected value from SQL Server, precision of {} and scale of {}",
-                        raw.precision,
-                        raw.scale,
-                    );
-                }
-                if raw.precision > 39 {
-                    let reason = format!(
-                        "precision of {} is greater than our maximum of 39",
-                        raw.precision
-                    );
-                    return Err(UnsupportedDataType {
-                        column_name: raw.name.to_string(),
-                        column_type: raw.data_type.to_string(),
-                        reason,
-                    });
-                }
-
-                let raw_scale = usize::cast_from(raw.scale);
-                let max_scale =
-                    NumericMaxScale::try_from(raw_scale).map_err(|_| UnsupportedDataType {
-                        column_type: raw.data_type.to_string(),
-                        column_name: raw.name.to_string(),
-                        reason: format!("scale of {} is too large", raw.scale),
-                    })?;
-                let column_type = SqlScalarType::Numeric {
-                    max_scale: Some(max_scale),
-                };
-
-                (column_type, SqlServerColumnDecodeType::Numeric)
-            }
-            // SQL Server has a few IEEE 754 floating point type names. The underlying type is float(n),
-            // where n is the number of bits used. SQL Server still ends up with only 2 distinct types
-            // as it treats 1 <= n <= 24 as n=24, and 25 <= n <= 53 as n=53.
+    let scalar = match raw.data_type.to_lowercase().as_str() {
+        "tinyint" => (SqlScalarType::Int16, SqlServerColumnDecodeType::U8),
+        "smallint" => (SqlScalarType::Int16, SqlServerColumnDecodeType::I16),
+        "int" => (SqlScalarType::Int32, SqlServerColumnDecodeType::I32),
+        "bigint" => (SqlScalarType::Int64, SqlServerColumnDecodeType::I64),
+        "bit" => (SqlScalarType::Bool, SqlServerColumnDecodeType::Bool),
+        "decimal" | "numeric" | "money" | "smallmoney" => {
+            // SQL Server supports a precision in the range of [1, 38] and then
+            // the scale is 0 <= scale <= precision.
             //
-            // Additionally, `real` and `double precision` exist as synonyms of float(24) and float(53),
-            // respectively.  What doesn't appear to be documented is how these appear in `sys.types`.
-            // See <https://learn.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=sql-server-ver17>
-            "real" | "float" | "double precision" => match raw.max_length {
-                // Decide the MZ type based on the number of bytes rather than the name, just in case
-                // there is inconsistency among versions.
-                4 => (SqlScalarType::Float32, SqlServerColumnDecodeType::F32),
-                8 => (SqlScalarType::Float64, SqlServerColumnDecodeType::F64),
-                _ => {
-                    return Err(UnsupportedDataType {
-                        column_name: raw.name.to_string(),
-                        column_type: raw.data_type.to_string(),
-                        reason: format!("unsupported length {}", raw.max_length),
-                    });
-                }
-            },
-            dt @ ("char" | "nchar" | "sysname") => {
-                // There isn't a char(max) or nchar(max), so it isn't clear if this condition
-                // is possible.
-                if raw.max_length == -1 {
-                    return Err(UnsupportedDataType {
-                        column_name: raw.name.to_string(),
-                        column_type: raw.data_type.to_string(),
-                        reason: "columns with unlimited size do not support CDC".to_string(),
-                    });
-                }
-
-                let column_type = match dt {
-                    "char" => {
-                        let length =
-                            if raw.max_length != -1 {
-                                let length = CharLength::try_from(i64::from(raw.max_length))
-                                    .map_err(|e| UnsupportedDataType {
-                                        column_name: raw.name.to_string(),
-                                        column_type: raw.data_type.to_string(),
-                                        reason: e.to_string(),
-                                    })?;
-                                Some(length)
-                            } else {
-                                None
-                            };
-                        SqlScalarType::Char { length }
-                    }
-                    // Determining the max character count for these types is difficult
-                    // because of different character encodings, so we fallback to just
-                    // representing them as "text".
-                    "nchar" | "sysname" => SqlScalarType::String,
-                    other => unreachable!("'{other}' checked above"),
-                };
-
-                (column_type, SqlServerColumnDecodeType::String)
+            // Materialize numerics are floating point with a fixed precision of 39.
+            //
+            // See: <https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver16#arguments>
+            if raw.precision > 38 || raw.scale > raw.precision {
+                tracing::warn!(
+                    "unexpected value from SQL Server, precision of {} and scale of {}",
+                    raw.precision,
+                    raw.scale,
+                );
             }
-            "varchar" | "nvarchar" => {
-                // `max text repl size` is 64KB by default.  If a user attempts to insert a value
-                // that exceeds this limit, SQL Server will return an error and the insert fails
-                // with error `7139`.  This is also true for updates that increase the field length
-                // beyond the limit.
-                //
-                // See <https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-7000-to-7999?view=sql-server-ver17>
-                //
-                // If the `max text repl size` changes, it does not affect events already written to
-                // the CDC table, nor does it change the behavior of what CDC captures for updates
-                // to non-LOD columns (based on testing).
-                let max_length =
-                    if raw.max_length != -1 {
-                        let length = VarCharMaxLength::try_from(i64::from(raw.max_length))
-                            .map_err(|e| UnsupportedDataType {
-                                column_name: raw.name.to_string(),
-                                column_type: raw.data_type.to_string(),
-                                reason: e.to_string(),
-                            })?;
-                        Some(length)
-                    } else {
-                        None
-                    };
-                let column_type = SqlScalarType::VarChar { max_length };
-                (column_type, SqlServerColumnDecodeType::String)
+            if raw.precision > 39 {
+                let reason = format!(
+                    "precision of {} is greater than our maximum of 39",
+                    raw.precision
+                );
+                return Err(UnsupportedDataType {
+                    column_name: raw.name.to_string(),
+                    column_type: raw.data_type.to_string(),
+                    reason,
+                });
             }
-            "text" | "ntext" | "image" => {
-                // SQL Server docs indicate this should always be 16. There's no
-                // issue if it's not, but it's good to track.
-                mz_ore::soft_assert_eq_no_log!(raw.max_length, 16);
 
-                // TODO(sql_server3): Support UPSERT semantics for SQL Server.
+            let raw_scale = usize::cast_from(raw.scale);
+            let max_scale =
+                NumericMaxScale::try_from(raw_scale).map_err(|_| UnsupportedDataType {
+                    column_type: raw.data_type.to_string(),
+                    column_name: raw.name.to_string(),
+                    reason: format!("scale of {} is too large", raw.scale),
+                })?;
+            let column_type = SqlScalarType::Numeric {
+                max_scale: Some(max_scale),
+            };
+
+            (column_type, SqlServerColumnDecodeType::Numeric)
+        }
+        // SQL Server has a few IEEE 754 floating point type names. The underlying type is float(n),
+        // where n is the number of bits used. SQL Server still ends up with only 2 distinct types
+        // as it treats 1 <= n <= 24 as n=24, and 25 <= n <= 53 as n=53.
+        //
+        // Additionally, `real` and `double precision` exist as synonyms of float(24) and float(53),
+        // respectively.  What doesn't appear to be documented is how these appear in `sys.types`.
+        // See <https://learn.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=sql-server-ver17>
+        "real" | "float" | "double precision" => match raw.max_length {
+            // Decide the MZ type based on the number of bytes rather than the name, just in case
+            // there is inconsistency among versions.
+            4 => (SqlScalarType::Float32, SqlServerColumnDecodeType::F32),
+            8 => (SqlScalarType::Float64, SqlServerColumnDecodeType::F64),
+            _ => {
+                return Err(UnsupportedDataType {
+                    column_name: raw.name.to_string(),
+                    column_type: raw.data_type.to_string(),
+                    reason: format!("unsupported length {}", raw.max_length),
+                });
+            }
+        },
+        "char" | "nchar" | "sysname" => {
+            // There isn't a char(max) or nchar(max), so it isn't clear if this condition
+            // is possible.
+            if raw.max_length == -1 {
                 return Err(UnsupportedDataType {
                     column_name: raw.name.to_string(),
                     column_type: raw.data_type.to_string(),
                     reason: "columns with unlimited size do not support CDC".to_string(),
                 });
             }
-            "xml" => {
-                // When the `max_length` is -1 SQL Server will not present us with the "before" value
-                // for updated columns.
-                //
-                // TODO(sql_server3): Support UPSERT semantics for SQL Server.
-                if raw.max_length == -1 {
-                    return Err(UnsupportedDataType {
-                        column_name: raw.name.to_string(),
-                        column_type: raw.data_type.to_string(),
-                        reason: "columns with unlimited size do not support CDC".to_string(),
-                    });
-                }
-                (SqlScalarType::String, SqlServerColumnDecodeType::Xml)
-            }
-            "binary" | "varbinary" => {
-                // [`SqlScalarType`] does not support tracking max_length for binary data. To ensure
-                // columns of type varbinary(max) (Large Object Data) are decoded properly, it is
-                // necessary to know that the length is `max`. `varchar` and `nvarchar` track this
-                // using [`SqlScalarType::VarChar`] max_length field.
-                if raw.max_length == -1 {
-                    return Err(UnsupportedDataType {
-                        column_name: raw.name.to_string(),
-                        column_type: raw.data_type.to_string(),
-                        reason: "columns with unlimited size do not support CDC".to_string(),
-                    });
-                }
-                (SqlScalarType::Bytes, SqlServerColumnDecodeType::Bytes)
-            }
-            "json" => (SqlScalarType::Jsonb, SqlServerColumnDecodeType::String),
-            "date" => (SqlScalarType::Date, SqlServerColumnDecodeType::NaiveDate),
-            // SQL Server supports a scale of (and defaults to) 7 digits (aka 100 nanoseconds)
-            // for time related types.
-            //
-            // Internally Materialize supports a scale of 9 (aka nanoseconds), but for Postgres
-            // compatibility we constraint ourselves to a scale of 6 (aka microseconds). By
-            // default we will round values we get from  SQL Server to fit in Materialize.
-            //
-            // TODO(sql_server3): Support a "strict" mode where we're fail the creation of the
-            // source if the scale is too large.
-            // TODO(sql_server3): Support specifying a precision for SqlScalarType::Time.
-            //
-            // See: <https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=sql-server-ver16>.
-            "time" => (SqlScalarType::Time, SqlServerColumnDecodeType::NaiveTime),
-            dt @ ("smalldatetime" | "datetime" | "datetime2" | "datetimeoffset") => {
-                if raw.scale > 7 {
-                    tracing::warn!("unexpected scale '{}' from SQL Server", raw.scale);
-                }
-                if raw.scale > mz_repr::adt::timestamp::MAX_PRECISION {
-                    tracing::warn!("truncating scale of '{}' for '{}'", raw.scale, dt);
-                }
-                let precision = std::cmp::min(raw.scale, mz_repr::adt::timestamp::MAX_PRECISION);
-                let precision =
-                    Some(TimestampPrecision::try_from(i64::from(precision)).expect("known to fit"));
 
-                match dt {
-                    "smalldatetime" | "datetime" | "datetime2" => (
-                        SqlScalarType::Timestamp { precision },
-                        SqlServerColumnDecodeType::NaiveDateTime,
-                    ),
-                    "datetimeoffset" => (
-                        SqlScalarType::TimestampTz { precision },
-                        SqlServerColumnDecodeType::DateTime,
-                    ),
-                    other => unreachable!("'{other}' checked above"),
-                }
-            }
-            "uniqueidentifier" => (SqlScalarType::Uuid, SqlServerColumnDecodeType::Uuid),
-            // TODO(sql_server3): Support reading the following types, at least as text:
+            // We represent these as "text" rather than a fixed-length
+            // `character(n)`. SQL Server sizes them in bytes, while
+            // Materialize's `Char` length is a character count. Under a
+            // multi-byte collation a single character can span several
+            // bytes, so `sys.columns.max_length` is not a usable character
+            // count. Rather than guess, we pass the value through as-is.
+            (SqlScalarType::String, SqlServerColumnDecodeType::String)
+        }
+        "varchar" | "nvarchar" => {
+            // `max text repl size` is 64KB by default.  If a user attempts to insert a value
+            // that exceeds this limit, SQL Server will return an error and the insert fails
+            // with error `7139`.  This is also true for updates that increase the field length
+            // beyond the limit.
             //
-            // * geography
-            // * geometry
-            // * json (preview)
-            // * vector (preview)
+            // See <https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-7000-to-7999?view=sql-server-ver17>
             //
-            // None of these types are implemented in `tiberius`, the crate that
-            // provides our SQL Server client, so we'll need to implement support
-            // for decoding them.
+            // If the `max text repl size` changes, it does not affect events already written to
+            // the CDC table, nor does it change the behavior of what CDC captures for updates
+            // to non-LOD columns (based on testing).
+            let max_length = if raw.max_length != -1 {
+                let length =
+                    VarCharMaxLength::try_from(i64::from(raw.max_length)).map_err(|e| {
+                        UnsupportedDataType {
+                            column_name: raw.name.to_string(),
+                            column_type: raw.data_type.to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+                Some(length)
+            } else {
+                None
+            };
+            let column_type = SqlScalarType::VarChar { max_length };
+            (column_type, SqlServerColumnDecodeType::String)
+        }
+        "text" | "ntext" | "image" => {
+            // SQL Server docs indicate this should always be 16. There's no
+            // issue if it's not, but it's good to track.
+            mz_ore::soft_assert_eq_no_log!(raw.max_length, 16);
+
+            // TODO(sql_server3): Support UPSERT semantics for SQL Server.
+            return Err(UnsupportedDataType {
+                column_name: raw.name.to_string(),
+                column_type: raw.data_type.to_string(),
+                reason: "columns with unlimited size do not support CDC".to_string(),
+            });
+        }
+        "xml" => {
+            // When the `max_length` is -1 SQL Server will not present us with the "before" value
+            // for updated columns.
             //
-            // See <https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/355f7890-6e91-4978-ab76-2ded17ee09bc>.
-            other => {
+            // TODO(sql_server3): Support UPSERT semantics for SQL Server.
+            if raw.max_length == -1 {
                 return Err(UnsupportedDataType {
-                    column_type: other.to_string(),
                     column_name: raw.name.to_string(),
-                    reason: format!("'{other}' is unimplemented"),
+                    column_type: raw.data_type.to_string(),
+                    reason: "columns with unlimited size do not support CDC".to_string(),
                 });
             }
-        };
+            (SqlScalarType::String, SqlServerColumnDecodeType::Xml)
+        }
+        "binary" | "varbinary" => {
+            // [`SqlScalarType`] does not support tracking max_length for binary data. To ensure
+            // columns of type varbinary(max) (Large Object Data) are decoded properly, it is
+            // necessary to know that the length is `max`. `varchar` and `nvarchar` track this
+            // using [`SqlScalarType::VarChar`] max_length field.
+            if raw.max_length == -1 {
+                return Err(UnsupportedDataType {
+                    column_name: raw.name.to_string(),
+                    column_type: raw.data_type.to_string(),
+                    reason: "columns with unlimited size do not support CDC".to_string(),
+                });
+            }
+            (SqlScalarType::Bytes, SqlServerColumnDecodeType::Bytes)
+        }
+        "json" => (SqlScalarType::Jsonb, SqlServerColumnDecodeType::String),
+        "date" => (SqlScalarType::Date, SqlServerColumnDecodeType::NaiveDate),
+        // SQL Server supports a scale of (and defaults to) 7 digits (aka 100 nanoseconds)
+        // for time related types.
+        //
+        // Internally Materialize supports a scale of 9 (aka nanoseconds), but for Postgres
+        // compatibility we constraint ourselves to a scale of 6 (aka microseconds). By
+        // default we will round values we get from  SQL Server to fit in Materialize.
+        //
+        // TODO(sql_server3): Support a "strict" mode where we're fail the creation of the
+        // source if the scale is too large.
+        // TODO(sql_server3): Support specifying a precision for SqlScalarType::Time.
+        //
+        // See: <https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=sql-server-ver16>.
+        "time" => (SqlScalarType::Time, SqlServerColumnDecodeType::NaiveTime),
+        dt @ ("smalldatetime" | "datetime" | "datetime2" | "datetimeoffset") => {
+            if raw.scale > 7 {
+                tracing::warn!("unexpected scale '{}' from SQL Server", raw.scale);
+            }
+            if raw.scale > mz_repr::adt::timestamp::MAX_PRECISION {
+                tracing::warn!("truncating scale of '{}' for '{}'", raw.scale, dt);
+            }
+            let precision = std::cmp::min(raw.scale, mz_repr::adt::timestamp::MAX_PRECISION);
+            let precision =
+                Some(TimestampPrecision::try_from(i64::from(precision)).expect("known to fit"));
+
+            match dt {
+                "smalldatetime" | "datetime" | "datetime2" => (
+                    SqlScalarType::Timestamp { precision },
+                    SqlServerColumnDecodeType::NaiveDateTime,
+                ),
+                "datetimeoffset" => (
+                    SqlScalarType::TimestampTz { precision },
+                    SqlServerColumnDecodeType::DateTime,
+                ),
+                other => unreachable!("'{other}' checked above"),
+            }
+        }
+        "uniqueidentifier" => (SqlScalarType::Uuid, SqlServerColumnDecodeType::Uuid),
+        // TODO(sql_server3): Support reading the following types, at least as text:
+        //
+        // * geography
+        // * geometry
+        // * json (preview)
+        // * vector (preview)
+        //
+        // None of these types are implemented in `tiberius`, the crate that
+        // provides our SQL Server client, so we'll need to implement support
+        // for decoding them.
+        //
+        // See <https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/355f7890-6e91-4978-ab76-2ded17ee09bc>.
+        other => {
+            return Err(UnsupportedDataType {
+                column_type: other.to_string(),
+                column_name: raw.name.to_string(),
+                reason: format!("'{other}' is unimplemented"),
+            });
+        }
+    };
     Ok(scalar)
 }
 
@@ -754,17 +736,34 @@ impl SqlServerColumnDecodeType {
                 .try_get(name)
                 .map_err(|_| SqlServerDecodeError::invalid_column(name, "string"))?
                 .map(Datum::String),
+            // `char`, `nchar`, and `sysname` columns now map to `String`, so
+            // new sources never produce this type. It remains to decode sources
+            // created before that change, whose persisted desc still carries
+            // `Char { length }`.
             (SqlScalarType::Char { length }, SqlServerColumnDecodeType::String) => data
                 .try_get(name)
                 .map_err(|_| SqlServerDecodeError::invalid_column(name, "char"))?
                 .map(|val: &str| match length {
-                    Some(expected) => {
+                    // SQL Server sizes `char(n)` in bytes, and `length` (from
+                    // `sys.columns.max_length`) is that byte count, while
+                    // Materialize's `Char` length is a character count. SQL
+                    // Server blank-pads the value to fill the byte length, so a
+                    // multi-byte collation yields fewer characters than bytes.
+                    // The character count can therefore be at most `length`,
+                    // never more, so we only reject when it exceeds `length`.
+                    //
+                    // This encodes at a different length in Materialize vs.
+                    // the upstream, which is why it is deprecated. An
+                    // upstream CHAR(10) column with the string "café" would
+                    // have 5 trailing spaces. In Materialize, this would
+                    // have 6 trailing spaces.
+                    Some(max) => {
                         let found_chars = val.chars().count();
-                        let expct_chars = usize::cast_from(expected.into_u32());
-                        if found_chars != expct_chars {
+                        let max_chars = usize::cast_from(max.into_u32());
+                        if found_chars > max_chars {
                             Err(SqlServerDecodeError::invalid_char(
                                 name,
-                                expct_chars,
+                                max_chars,
                                 found_chars,
                             ))
                         } else {
@@ -1263,6 +1262,7 @@ mod tests {
     use itertools::Itertools;
     use mz_ore::assert_contains;
     use mz_ore::collections::CollectionExt;
+    use mz_repr::adt::char::CharLength;
     use mz_repr::adt::numeric::NumericMaxScale;
     use mz_repr::adt::varchar::VarCharMaxLength;
     use mz_repr::{Datum, RelationDesc, Row, RowArena, SqlScalarType};
@@ -1439,6 +1439,61 @@ mod tests {
             &rnd_row,
             &Row::pack_slice(&[Datum::String("foo bar"), Datum::False, Datum::Null])
         );
+    }
+
+    #[mz_ore::test]
+    fn decode_legacy_char_column() {
+        // Sources created when `char` columns mapped to `Char { length }`
+        // carry that type in their persisted desc. `length` is the upstream
+        // byte count, so under a multi-byte collation the blank-padded value
+        // holds fewer characters than `length` and must still decode.
+        let length = Some(CharLength::try_from(10i64).expect("known valid"));
+        let column_type = SqlScalarType::Char { length }.nullable(false);
+        let columns = [SqlServerColumnDesc {
+            name: "a".into(),
+            column_type: Some(column_type.clone()),
+            primary_key_constraint: None,
+            decode_type: SqlServerColumnDecodeType::String,
+            raw_type: "char".into(),
+        }];
+        let table_desc = SqlServerTableDesc {
+            schema_name: "my_schema".into(),
+            name: "my_table".into(),
+            columns: columns.into(),
+            constraints: vec![],
+        };
+        let relation_desc = RelationDesc::builder()
+            .with_column("a", column_type)
+            .finish();
+        let decoder = table_desc.decoder(&relation_desc).expect("known valid");
+
+        let char_row = |val: &'static str| {
+            tiberius::Row::build([(
+                tiberius::Column::new("a".to_string(), tiberius::ColumnType::BigChar),
+                tiberius::ColumnData::String(Some(val.into())),
+            )])
+        };
+        let mut mz_row = Row::default();
+        let arena = RowArena::default();
+
+        // 'café' in a char(10) column under a UTF-8 collation: 10 bytes but
+        // only 9 characters.
+        decoder
+            .decode(&char_row("café     "), &mut mz_row, &arena, None)
+            .unwrap();
+        assert_eq!(&mz_row, &Row::pack_slice(&[Datum::String("café     ")]));
+
+        // A single-byte collation pads to exactly `length` characters.
+        decoder
+            .decode(&char_row("0123456789"), &mut mz_row, &arena, None)
+            .unwrap();
+        assert_eq!(&mz_row, &Row::pack_slice(&[Datum::String("0123456789")]));
+
+        // More characters than the upstream byte count is impossible, reject.
+        let err = decoder
+            .decode(&char_row("0123456789!"), &mut mz_row, &arena, None)
+            .unwrap_err();
+        assert_contains!(err.to_string(), "expected 10 chars found 11");
     }
 
     #[mz_ore::test]

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -936,10 +936,14 @@ impl SqlServerDecodeError {
         }
     }
 
-    fn invalid_char(name: &str, expected_chars: usize, found_chars: usize) -> Self {
+    fn invalid_char(name: &str, max_chars: usize, found_chars: usize) -> Self {
+        // NOTE: This text is persisted verbatim in a row-level `DecodeError`.
+        // Retractions re-decode the before-image, so the string must stay
+        // byte-identical to what older sources persisted, else the `-1` fails
+        // to cancel the stored `+1` on the next UPDATE/DELETE.
         SqlServerDecodeError::InvalidData {
             column_name: name.to_string(),
-            error: format!("expected {expected_chars} chars found {found_chars}"),
+            error: format!("expected {max_chars} chars found {found_chars}"),
         }
     }
 

--- a/test/sql-server-cdc/40-data-types.td
+++ b/test/sql-server-cdc/40-data-types.td
@@ -78,6 +78,10 @@ CREATE TABLE table_char(val char(17));
 INSERT INTO table_char VALUES ('i need to be 17 c'), ('so do i !!!!!!!!!'), (NULL);
 EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_char', @role_name = 'SA', @supports_net_changes = 0;
 
+CREATE TABLE table_char_utf8(val char(10));
+INSERT INTO table_char_utf8 VALUES (N'café'), (N'naïve'), (NULL);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_char_utf8', @role_name = 'SA', @supports_net_changes = 0;
+
 CREATE TABLE table_varchar(val varchar(999));
 INSERT INTO table_varchar VALUES ('I dont need to be 999 characters'), ('because we are variable length'), (NULL);
 EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_varchar', @role_name = 'SA', @supports_net_changes = 0;
@@ -252,6 +256,11 @@ true
 > SELECT * FROM table_char ORDER BY val ASC;
 "i need to be 17 c"
 "so do i !!!!!!!!!"
+<null>
+
+> SELECT * FROM table_char_utf8 ORDER BY val ASC;
+"café     "
+"naïve    "
 <null>
 
 > SELECT * FROM table_varchar ORDER BY val ASC;


### PR DESCRIPTION
SQL Server `CHAR(N)` type limits the number of bytes, not characters. Under different collations, this column has variable character length. Materialize expects this to contain a consistent character length.

This PR adds the test from the bug report, fix, and a minor doc addition about the encoding.

The fix has 2 parts:
- sources created *__after__* this fix will encode `CHAR(N)` as `STRING`, so there is no character length validation, and Materialize displays the string consistently with the upstream DB.
- sources created *__before__* this fix will continue to decode as `CHARACTER` with padding, but the check is relaxed to only error if the character length is greater than the byte length. This is a deprecated code path, so I didn't modify the error.


Fixes https://linear.app/materializeinc/issue/SS-124/sql-server-charn-with-utf-8-expected-n-chars-found-less-than-n



There are some formatting changes in the PR, so view with ignore white space