### PR TITLE
adapter: don't panic on non-UTF-8 char params in statement logging

### DIFF
--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
@@ -787,15 +788,32 @@ pub(crate) fn should_sample_statement(
     }
 }
 
-/// Helper function to serialize statement parameters for logging.
+/// Serializes statement parameters for logging as UTF-8 strings.
+///
+/// Non-UTF-8 wire bytes are lossily replaced with `U+FFFD`.
 fn serialize_params(params: &Params) -> Vec<Option<String>> {
     std::iter::zip(params.execute_types.iter(), params.datums.iter())
-        .map(|(r#type, datum)| {
+        .enumerate()
+        .map(|(index, (r#type, datum))| {
             mz_pgrepr::Value::from_datum(datum, r#type).map(|val| {
                 let mut buf = BytesMut::new();
                 val.encode_text(&mut buf);
-                String::from_utf8(Into::<Vec<u8>>::into(buf))
-                    .expect("Serialization shouldn't produce non-UTF-8 strings.")
+                // NOTE: `encode_text` can emit non-UTF-8 bytes for `"char"`
+                // (`PgLegacyChar`) params, which write their byte verbatim.
+                // Log the raw bytes so operators can recover what came in.
+                match String::from_utf8_lossy(&buf) {
+                    Cow::Borrowed(s) => s.to_owned(),
+                    Cow::Owned(s) => {
+                        let bytes_hex: String = buf.iter().map(|b| format!("{:02x}", b)).collect();
+                        tracing::warn!(
+                            index,
+                            ty = ?r#type,
+                            bytes_hex = %bytes_hex,
+                            "non-UTF-8 bytes in statement-logging param, replaced with U+FFFD"
+                        );
+                        s
+                    }
+                }
             })
         })
         .collect()
@@ -1051,5 +1069,41 @@ impl WatchSetCreation {
             storage_ids,
             compute_ids,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_repr::{Datum, Row, SqlScalarType};
+    use mz_sql::plan::Params;
+
+    use super::serialize_params;
+
+    /// A `"char"` param whose byte is `>= 0x80` used to panic
+    /// `String::from_utf8` on the statement-logging path. It should now
+    /// round-trip through `from_utf8_lossy` and emit the replacement
+    /// character instead.
+    #[mz_ore::test]
+    fn serialize_params_replaces_non_utf8_char() {
+        let params = Params {
+            datums: Row::pack_slice(&[Datum::UInt8(0xFF)]),
+            execute_types: vec![SqlScalarType::PgLegacyChar],
+            expected_types: vec![SqlScalarType::PgLegacyChar],
+        };
+        let out = serialize_params(&params);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].as_deref(), Some("\u{FFFD}"));
+    }
+
+    /// An ASCII `"char"` param must render as its ASCII character, unchanged.
+    #[mz_ore::test]
+    fn serialize_params_ascii_char_unchanged() {
+        let params = Params {
+            datums: Row::pack_slice(&[Datum::UInt8(b'A')]),
+            execute_types: vec![SqlScalarType::PgLegacyChar],
+            expected_types: vec![SqlScalarType::PgLegacyChar],
+        };
+        let out = serialize_params(&params);
+        assert_eq!(out[0].as_deref(), Some("A"));
     }
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -15,6 +15,8 @@ usual clusterd included in the materialized container).
 import json
 import random
 import re
+import socket
+import struct
 import time
 from collections.abc import Callable
 from copy import copy
@@ -3945,6 +3947,65 @@ def workflow_test_github_7000(c: Composition, parser: WorkflowArgumentParser) ->
         c.up("materialized")
 
 
+def _char_param_survives(host: str, port: int) -> bool:
+    """Whether environmentd survives an untyped binary ``"char"`` param
+    whose byte is >= 0x80 (SQL-371 regression).
+
+    The param stays untyped (0 OIDs in Parse) so the server infers
+    ``PgLegacyChar`` from the query's cast. Binary format avoids the
+    text-param UTF-8 decode that would reject the byte first. This
+    routes an invalid UTF-8 byte through statement-logging's param
+    serialization, which used to panic and abort the process.
+
+    Returns False if the connection drops before ReadyForQuery, True
+    otherwise.
+    """
+
+    def frame(tag: bytes, body: bytes) -> bytes:
+        return tag + struct.pack(">I", len(body) + 4) + body
+
+    def drain_to_ready(s: socket.socket) -> bool:
+        buf = b""
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                # Connection dropped: server aborted.
+                return False
+            buf += chunk
+            while len(buf) >= 5:
+                end = struct.unpack(">I", buf[1:5])[0] + 1
+                if len(buf) < end:
+                    break
+                ready = buf[0:1] == b"Z"  # ReadyForQuery
+                buf = buf[end:]
+                if ready:
+                    return True
+
+    with socket.create_connection((host, port), timeout=30) as s:
+        # Startup; the `materialize` user has no password in mzcompose.
+        s.sendall(
+            frame(
+                b"",
+                struct.pack(">I", 196608)
+                + b"user\x00materialize\x00database\x00materialize\x00\x00",
+            )
+        )
+        assert drain_to_ready(s), "startup failed"
+        s.sendall(
+            frame(b"P", b'\x00SELECT $1::"char"\x00' + struct.pack(">H", 0))
+            + frame(
+                b"B",
+                b"\x00\x00"
+                + struct.pack(">HHHi", 1, 1, 1, 1)
+                + b"\xff"
+                + struct.pack(">H", 0),
+            )
+            + frame(b"E", b"\x00" + struct.pack(">I", 0))
+            + frame(b"S", b"")
+        )
+        return drain_to_ready(s)
+
+
 def workflow_statement_logging(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Statement logging test needs to run with 100% logging of tests (as opposed to the default 1% )"""
 
@@ -3964,6 +4025,16 @@ def workflow_statement_logging(c: Composition, parser: WorkflowArgumentParser) -
         )
 
         c.run_testdrive_files("statement-logging/statement-logging.td")
+
+        # SQL-371: a `"char"` binary param with byte >= 0x80 must not
+        # abort environmentd via statement logging. Sampling is forced
+        # to 100% above, so this deterministically exercises the path.
+        assert _char_param_survives(
+            "127.0.0.1", c.port("materialized", 6875)
+        ), "environmentd aborted on non-UTF-8 char param"
+        assert (
+            c.sql_query("SELECT 1", reuse_connection=False)[0][0] == 1
+        ), "environmentd unreachable after char-param test"
 
 
 def workflow_blue_green_deployment(


### PR DESCRIPTION
Problem:

Binding a `char` (`PgLegacyChar`) param over the extended binary protocol with a byte `>= 0x80` aborted `environmentd`.

`0xFF` isn't valid UTF-8, so the `.expect` panicked the process. Any authenticated user could trigger it whenever the statement was sampled by statement logging.

Solution:
Statement logging is diagnostic, not correctness-critical, so replace the panic with `String::from_utf8_lossy`: invalid bytes become `U+FFFD` and the logged row keeps its structure and position.

Testing:
- Two unit tests in statement_logging.rs
- MZCompose test from the bug

Fixes SQL-371
