### PR TITLE
test(aws): allow sts:SetSourceIdentity on testdrive connection roles

### DIFF
--- a/test/aws/mzcompose.py
+++ b/test/aws/mzcompose.py
@@ -240,7 +240,7 @@ def test_assume_role(c: Composition, ctx: TestContext):
         )[0][0]
         ctx.iam.update_assume_role_policy(
             RoleName=customer_role,
-            PolicyDocument=json.dumps(trust_policy),
+            PolicyDocument=json.dumps(_allow_set_source_identity(trust_policy)),
         )
 
         # Wait for IAM to propagate.
@@ -298,7 +298,7 @@ def test_s3tablesrest_connection(c: Composition, ctx: TestContext):
         )[0][0]
         ctx.iam.update_assume_role_policy(
             RoleName=customer_role,
-            PolicyDocument=json.dumps(trust_policy),
+            PolicyDocument=json.dumps(_allow_set_source_identity(trust_policy)),
         )
 
         c.sql(
@@ -377,7 +377,7 @@ def test_s3tablesrest_region_mismatch(c: Composition, ctx: TestContext):
         )[0][0]
         ctx.iam.update_assume_role_policy(
             RoleName=customer_role,
-            PolicyDocument=json.dumps(trust_policy),
+            PolicyDocument=json.dumps(_allow_set_source_identity(trust_policy)),
         )
 
         c.sleep(ctx.iam_propagation_seconds)
@@ -491,7 +491,7 @@ def test_iceberg_e2e(c: Composition, ctx: TestContext):
 
         ctx.iam.update_assume_role_policy(
             RoleName=customer_role,
-            PolicyDocument=json.dumps(trust_policy),
+            PolicyDocument=json.dumps(_allow_set_source_identity(trust_policy)),
         )
         c.sleep(ctx.iam_propagation_seconds)
 
@@ -537,22 +537,50 @@ def test_iceberg_e2e(c: Composition, ctx: TestContext):
             _delete_role(ctx, customer_role)
 
 
+def _allow_set_source_identity(trust_policy: dict) -> dict:
+    # CI sessions carry a source identity (scratch-aws-access hook, #36639),
+    # which propagates through the AssumeRole chain and makes STS require
+    # sts:SetSourceIdentity on each role's trust policy. Add it as its own
+    # statement per AssumeRole principal rather than folding it into the
+    # existing statement: Materialize's example_trust_policy conditions
+    # AssumeRole on sts:ExternalId, and that key is absent from the request
+    # context when SetSourceIdentity is authorized, so a shared condition would
+    # always deny it. The customer-facing example_trust_policy itself is left
+    # untouched (see SEC-617).
+    extra = []
+    for statement in trust_policy["Statement"]:
+        actions = statement["Action"]
+        actions = [actions] if isinstance(actions, str) else actions
+        if "sts:AssumeRole" in actions:
+            extra.append(
+                {
+                    "Effect": "Allow",
+                    "Principal": statement["Principal"],
+                    "Action": "sts:SetSourceIdentity",
+                }
+            )
+    trust_policy["Statement"].extend(extra)
+    return trust_policy
+
+
 def _create_role(ctx: TestContext, customer_role: str, principal: str) -> None:
     ctx.iam.create_role(
         RoleName=customer_role,
         AssumeRolePolicyDocument=json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {
-                            "AWS": principal,
-                        },
-                        "Action": "sts:AssumeRole",
-                    }
-                ],
-            }
+            _allow_set_source_identity(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": principal,
+                            },
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            )
         ),
     )
 


### PR DESCRIPTION
## Summary

Fixes the `AccessDenied` breakage in the nightly `test/aws` pipeline introduced by #36639.

#36639 changed the `scratch-aws-access` Buildkite hook to mint the CI `ci` session with `--source-identity "$BUILDKITE_JOB_ID"`. A source identity is **sticky** — it propagates through every subsequent `AssumeRole` in the chain, and STS then requires the target role's trust policy to allow `sts:SetSourceIdentity`, not just `sts:AssumeRole`.

The AWS connection test creates throwaway roles whose trust policies only allowed `sts:AssumeRole`, so the hops that run under the source-identity-bearing session failed:

- environmentd's jump-role → customer-role hop during `VALIDATE CONNECTION`, e.g.:

```
User: .../testdrive-<seed>-MaterializeConnection/... is not authorized to perform:
sts:SetSourceIdentity on resource: arn:aws:iam::400121260767:role/testdrive-<seed>-Customer
```

- the test runner's direct `assume_role` for duckdb credentials (caller `ci/ci`).

## Change

Route every **test-created** trust policy through a small `_allow_set_source_identity` helper, applied at:

- `_create_role` (the `MaterializeConnection` jump role + initially-created customer roles)
- the four sites that apply a fetched `example_trust_policy` to a customer role (including the e2e path that also adds the test runner's own principal for duckdb)

The helper adds `sts:SetSourceIdentity` as its **own condition-free statement** for each `AssumeRole` principal, rather than appending the action to the existing statement. This is the crux: `example_trust_policy` conditions `AssumeRole` on `sts:ExternalId`, and that condition key is **absent from the request context when STS authorizes `sts:SetSourceIdentity`** — so folding the action into that statement makes its condition unsatisfiable and the action is denied. (Only the `example_trust_policy` hop failed this way; the condition-free `_create_role` hop already worked, which is what isolated the cause.) Propagation needs only the trust (resource) side — the caller's identity policy is not additionally required for role chaining.

This is deliberately confined to the test harness. The customer-facing `AwsConnection::example_trust_policy` is **left untouched** — real Materialize environments do not assume connection roles from a source-identity-bearing session, so customers must not be told to grant `sts:SetSourceIdentity`.

## Test plan

- [x] Nightly `test/aws` **AWS (Real)** is green on this branch — Nightly [#16960](https://buildkite.com/materialize/nightly/builds/16960) (`VALIDATE CONNECTION` and the s3tables/iceberg e2e duckdb paths succeed, no `AccessDenied`).
- [x] `test_assume_role`'s "role trust policy does not require an external ID" assertion still fires (the `SetSourceIdentity` grant lets STS reach the external-ID check instead of failing earlier).

## Notes

The companion CI-infra fix (granting the *scratch `ci` role* identity policy `sts:SetSourceIdentity` for the cross-account agent→ci hop) landed separately in i2 (MaterializeInc/i2#3478). This PR covers the *downstream* testdrive role-chaining hops that #36639 also affected.

The customer-facing decision this raised (whether to carry source identity across the AWS-connection customer boundary, and the account-wide breaking-change risk of doing so) is tracked in **SEC-617**. This PR deliberately does *not* touch the customer-facing `example_trust_policy`; note that the `sts:ExternalId` condition trap above is exactly what any customer-migration guidance would have to account for.
