### PR TITLE
docs: remove dictionary compression mention from v26.31.0 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -34,7 +34,6 @@ For more information, see [MCP Server for Agents](/integrations/mcp-server/mcp-a
 
 ### Improvements {#v26.31-improvements}
 - **Faster `count(*)` over `generate_series`**: Queries like `SELECT count(*) FROM generate_series(1, N)` now evaluate in constant time instead of materializing all rows.
-- **Faster arrangement hydration**: Improved dictionary compression build performance and extended compression coverage to additional arrangement paths, reducing hydration time and memory usage.
 - **System parameter override introspection**: Added `mz_internal.mz_overridden_system_parameters`, a catalog view that lists environment-wide system parameter overrides set via `ALTER SYSTEM`, readable by all users.
 - **Kubernetes resource labels for Self-Managed**: Standard `app.kubernetes.io/*` labels are now applied to all Kubernetes resources (pods, services, statefulsets, deployments) managed by the operator.
 


### PR DESCRIPTION
### Motivation

The "Faster arrangement hydration" Improvements bullet in the v26.31.0 release
notes called out the alpha "dictionary compression" feature. That feature is
still very much alpha and shouldn't be highlighted in release notes yet.

Slack thread: https://materializeinc.slack.com/archives/CPNFV9CVB/p1783079567845049?thread_ts=1783049778.720069&cid=CPNFV9CVB

### Description

Removes the single "Faster arrangement hydration" Improvements bullet
(mentioning dictionary compression) from the v26.31.0 release notes in
`doc/user/content/releases/_index.md`. This is a one-line deletion with no
other changes.

### Verification

Documentation-only change. Reviewed the rendered release notes section to
confirm the alpha dictionary compression bullet is no longer present and the
surrounding Improvements list remains intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GznGmrKzia5ePiZ6jGDiSX)_