### PR TITLE
edu-55: noindex,nofollow for preview pages

### DIFF
--- a/ci/test/preview-docs.sh
+++ b/ci/test/preview-docs.sh
@@ -21,7 +21,7 @@ fi
 cd doc/user
 
 # Build main docs to public/
-hugo --gc --baseURL "/materialize/$BUILDKITE_PULL_REQUEST"
+hugo --gc --environment preview --baseURL "/materialize/$BUILDKITE_PULL_REQUEST"
 
 # Build skill docs to public/markdown-docs/
 hugo --config config.toml,config.skill.toml --gc --baseURL "/materialize/$BUILDKITE_PULL_REQUEST" --disableKinds sitemap,robotsTXT,taxonomy

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -7,7 +7,9 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <meta name="description" content="{{ $description }}" />
 
-{{ if .Params.robots }}
+{{ if eq hugo.Environment "preview" }}
+  <meta name="robots" content="noindex, nofollow">
+{{ else if .Params.robots }}
   <meta name="robots" content="{{ .Params.robots }}">
 {{ end }}
 


### PR DESCRIPTION
Alternatively, if we use cloudfront for previews, I think we can add custom response header policy to noindex,nofollow.  But not sure what we do.
