### PR TITLE
mcp: enforce 1 MB parser size limit on MCP HTTP endpoint DEX-64

### DIFF
--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -1558,8 +1558,10 @@ mod tests {
     /// emits.
     #[mz_ore::test]
     fn test_validate_readonly_query_enforces_size_limit() {
-        // ~1.2 MB of valid statements: exceeds MAX_STATEMENT_BATCH_SIZE (1 MB).
-        let oversized: String = "SELECT 1;".repeat(1_200_000 / "SELECT 1;".len());
+        use mz_sql_parser::parser::MAX_STATEMENT_BATCH_SIZE;
+        // Just over the limit so the guard is the *only* thing that rejects.
+        let oversized: String =
+            "SELECT 1;".repeat((MAX_STATEMENT_BATCH_SIZE / "SELECT 1;".len()) + 1);
         let err = validate_readonly_query(&oversized).expect_err("should be rejected");
         let msg = err.to_string();
         assert!(
@@ -1570,8 +1572,9 @@ mod tests {
 
     #[mz_ore::test]
     fn test_validate_system_catalog_query_enforces_size_limit() {
-        let oversized: String =
-            "SELECT * FROM mz_tables;".repeat(1_200_000 / "SELECT * FROM mz_tables;".len());
+        use mz_sql_parser::parser::MAX_STATEMENT_BATCH_SIZE;
+        let stmt = "SELECT * FROM mz_tables;";
+        let oversized: String = stmt.repeat((MAX_STATEMENT_BATCH_SIZE / stmt.len()) + 1);
         let err = validate_system_catalog_query(&oversized).expect_err("should be rejected");
         let msg = err.to_string();
         assert!(
@@ -2126,7 +2129,8 @@ mod tests {
     /// millions of `(` characters) is rejected before lexing.
     #[mz_ore::test]
     fn test_safe_data_product_name_enforces_size_limit() {
-        let oversized: String = "(".repeat(1_200_000);
+        use mz_sql_parser::parser::MAX_STATEMENT_BATCH_SIZE;
+        let oversized: String = "(".repeat(MAX_STATEMENT_BATCH_SIZE + 1);
         let err = safe_data_product_name(&oversized).expect_err("should be rejected");
         let msg = err.to_string();
         assert!(

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -36,13 +36,12 @@ use mz_adapter_types::dyncfgs::{
     ENABLE_MCP_DEVELOPER, ENABLE_MCP_DEVELOPER_QUERY_TOOL, MCP_MAX_RESPONSE_SIZE,
 };
 use mz_repr::namespaces::{self, SYSTEM_SCHEMAS};
-use mz_sql::parse::parse;
+use mz_sql::parse::{parse_item_name_with_limit, parse_with_limit};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::{APPLICATION_NAME, Var, VarInput};
 use mz_sql_parser::ast::display::{AstDisplay, escaped_string_literal};
 use mz_sql_parser::ast::visit::{self, Visit};
 use mz_sql_parser::ast::{Raw, RawItemName};
-use mz_sql_parser::parser::parse_item_name;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
@@ -1093,13 +1092,17 @@ fn safe_data_product_name(name: &str) -> Result<String, McpRequestError> {
         ));
     }
 
-    let parsed = parse_item_name(name).map_err(|_| {
-        McpRequestError::QueryValidationFailed(format!(
-            "Invalid data product name: {}. Expected a valid object name, \
-             e.g. '\"database\".\"schema\".\"name\"' or 'my_view'",
-            name
-        ))
-    })?;
+    // `parse_item_name_with_limit` enforces the 1 MB guard on the raw input
+    // (DEX-64) before lexing.
+    let parsed = parse_item_name_with_limit(name)
+        .map_err(McpRequestError::QueryValidationFailed)?
+        .map_err(|_| {
+            McpRequestError::QueryValidationFailed(format!(
+                "Invalid data product name: {}. Expected a valid object name, \
+                 e.g. '\"database\".\"schema\".\"name\"' or 'my_view'",
+                name
+            ))
+        })?;
 
     // Stable formatting forces all identifiers to be double-quoted,
     // so SQL keywords and special characters cannot escape.
@@ -1235,10 +1238,14 @@ fn validate_readonly_query(sql: &str) -> Result<(), McpRequestError> {
         ));
     }
 
-    // Parse the SQL to get AST
-    let stmts = parse(sql).map_err(|e| {
-        McpRequestError::QueryValidationFailed(format!("Failed to parse SQL: {}", e))
-    })?;
+    // Parse the SQL to get AST. `parse_with_limit` rejects inputs larger
+    // than `MAX_STATEMENT_BATCH_SIZE` before lexing so the MCP endpoint
+    // enforces the same 1 MB guard as the SQL HTTP path (DEX-64).
+    let stmts = parse_with_limit(sql)
+        .map_err(McpRequestError::QueryValidationFailed)?
+        .map_err(|e| {
+            McpRequestError::QueryValidationFailed(format!("Failed to parse SQL: {}", e))
+        })?;
 
     // Only allow a single statement
     if stmts.len() != 1 {
@@ -1385,10 +1392,13 @@ impl<'ast> Visit<'ast, Raw> for TableReferenceCollector {
 /// to prevent misuse of the developer endpoint for arbitrary computation).
 /// SHOW and EXPLAIN statements are allowed without table references.
 fn validate_system_catalog_query(sql: &str) -> Result<(), McpRequestError> {
-    // Parse the SQL to validate it
-    let stmts = parse(sql).map_err(|e| {
-        McpRequestError::QueryValidationFailed(format!("Failed to parse SQL: {}", e))
-    })?;
+    // Parse the SQL to validate it. `parse_with_limit` enforces the 1 MB
+    // guard shared with the SQL HTTP path (DEX-64).
+    let stmts = parse_with_limit(sql)
+        .map_err(McpRequestError::QueryValidationFailed)?
+        .map_err(|e| {
+            McpRequestError::QueryValidationFailed(format!("Failed to parse SQL: {}", e))
+        })?;
 
     if stmts.is_empty() {
         return Err(McpRequestError::QueryValidationFailed(
@@ -1538,6 +1548,36 @@ mod tests {
     fn test_validate_readonly_query_rejects_empty() {
         assert!(validate_readonly_query("").is_err());
         assert!(validate_readonly_query("   ").is_err());
+    }
+
+    /// Regression test for DEX-64: without the 1 MB parser guard, the MCP
+    /// validators would happily lex and parse multi-megabyte input. Both
+    /// `validate_readonly_query` and `validate_system_catalog_query` now go
+    /// through `parse_with_limit`, so an oversized batch is rejected with the
+    /// same "statement batch size cannot exceed" message the SQL HTTP path
+    /// emits.
+    #[mz_ore::test]
+    fn test_validate_readonly_query_enforces_size_limit() {
+        // ~1.2 MB of valid statements: exceeds MAX_STATEMENT_BATCH_SIZE (1 MB).
+        let oversized: String = "SELECT 1;".repeat(1_200_000 / "SELECT 1;".len());
+        let err = validate_readonly_query(&oversized).expect_err("should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("statement batch size cannot exceed"),
+            "expected size-guard error, got: {msg}"
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_validate_system_catalog_query_enforces_size_limit() {
+        let oversized: String =
+            "SELECT * FROM mz_tables;".repeat(1_200_000 / "SELECT * FROM mz_tables;".len());
+        let err = validate_system_catalog_query(&oversized).expect_err("should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("statement batch size cannot exceed"),
+            "expected size-guard error, got: {msg}"
+        );
     }
 
     #[mz_ore::test]
@@ -2079,6 +2119,20 @@ mod tests {
     fn test_safe_data_product_name_rejects_empty() {
         assert!(safe_data_product_name("").is_err());
         assert!(safe_data_product_name("   ").is_err());
+    }
+
+    /// DEX-64: `parse_item_name` is unbounded on its own; the MCP path
+    /// switches to `parse_item_name_with_limit` so a pathological name (e.g.
+    /// millions of `(` characters) is rejected before lexing.
+    #[mz_ore::test]
+    fn test_safe_data_product_name_enforces_size_limit() {
+        let oversized: String = "(".repeat(1_200_000);
+        let err = safe_data_product_name(&oversized).expect_err("should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("statement batch size cannot exceed"),
+            "expected size-guard error, got: {msg}"
+        );
     }
 
     #[mz_ore::test]

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -206,6 +206,24 @@ pub fn parse_item_name(sql: &str) -> Result<UnresolvedItemName, ParserError> {
     }
 }
 
+/// Parses a SQL item name, rejecting inputs larger than
+/// [`MAX_STATEMENT_BATCH_SIZE`] before lexing.
+///
+/// The outer `Result` is for the size guard; the inner `Result` is for the
+/// parser. Mirrors [`parse_statements_with_limit`] so untrusted-input paths
+/// (e.g. the MCP HTTP handlers) can bound work before allocating.
+pub fn parse_item_name_with_limit(
+    sql: &str,
+) -> Result<Result<UnresolvedItemName, ParserError>, String> {
+    if sql.bytes().count() > MAX_STATEMENT_BATCH_SIZE {
+        return Err(format!(
+            "statement batch size cannot exceed {}",
+            ByteSize::b(u64::cast_from(MAX_STATEMENT_BATCH_SIZE))
+        ));
+    }
+    Ok(parse_item_name(sql))
+}
+
 /// Parses a string containing a comma-separated list of identifiers and
 /// returns their underlying string values.
 ///

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -126,7 +126,7 @@ impl<T> ParserStatementErrorMapper<T> for Result<T, ParserError> {
 pub fn parse_statements_with_limit(
     sql: &str,
 ) -> Result<Result<Vec<StatementParseResult<'_>>, ParserStatementError>, String> {
-    if sql.bytes().count() > MAX_STATEMENT_BATCH_SIZE {
+    if sql.len() > MAX_STATEMENT_BATCH_SIZE {
         return Err(format!(
             "statement batch size cannot exceed {}",
             ByteSize::b(u64::cast_from(MAX_STATEMENT_BATCH_SIZE))
@@ -215,7 +215,7 @@ pub fn parse_item_name(sql: &str) -> Result<UnresolvedItemName, ParserError> {
 pub fn parse_item_name_with_limit(
     sql: &str,
 ) -> Result<Result<UnresolvedItemName, ParserError>, String> {
-    if sql.bytes().count() > MAX_STATEMENT_BATCH_SIZE {
+    if sql.len() > MAX_STATEMENT_BATCH_SIZE {
         return Err(format!(
             "statement batch size cannot exceed {}",
             ByteSize::b(u64::cast_from(MAX_STATEMENT_BATCH_SIZE))

--- a/src/sql/src/parse.rs
+++ b/src/sql/src/parse.rs
@@ -10,6 +10,6 @@
 //! SQL parsing.
 
 pub use mz_sql_parser::parser::{
-    StatementParseResult, parse_statements as parse,
+    StatementParseResult, parse_item_name_with_limit, parse_statements as parse,
     parse_statements_with_limit as parse_with_limit,
 };

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -1137,3 +1137,57 @@ def workflow_oauth_metadata_extras(c: Composition) -> None:
                 port=6877,
                 print_statement=False,
             )
+
+
+# Error emitted by the 1 MB parser guard (MAX_STATEMENT_BATCH_SIZE in
+# src/sql-parser/src/parser.rs) before any lexing happens.
+SIZE_LIMIT_ERROR = "statement batch size cannot exceed"
+
+
+def workflow_parser_statement_size_limit_bypass(c: Composition) -> None:
+    """Regression test for DEX-64: the 1 MB parser guard lives in
+    `parse_with_limit` / `parse_item_name_with_limit`. Before the fix the MCP
+    handlers called the unbounded `parse()` and `parse_item_name()` directly,
+    so they lexed and parsed multi-megabyte input the guard should reject
+    (HTTP bodies go up to 5 MiB). These cases pin that MCP enforces the same
+    limit; the "statement batch size cannot exceed ..." message is the
+    fingerprint that the guard fired.
+    """
+    c.up("materialized")
+
+    # A >1 MB batch of valid statements. The guard rejects it before lexing;
+    # the unbounded parser instead parses all of them, so a "Found N
+    # statements" rejection would be the fingerprint that the guard was
+    # skipped.
+    batch = "SELECT 1;" * (1_200_000 // len("SELECT 1;"))
+
+    def tool_error(endpoint: str, tool: str, arguments: dict) -> str:
+        r = post_mcp(
+            c, endpoint, jsonrpc("tools/call", {"name": tool, "arguments": arguments})
+        )
+        assert r.status_code == 200, f"{r.status_code}: {r.text}"
+        err = r.json().get("error")
+        assert err is not None, f"oversized input should be rejected: {r.text[:500]}"
+        return err["message"]
+
+    with c.test_case("sql_http_endpoint_enforces_size_limit"):
+        # Control: the reference SQL path rejects it with the guard, on any build.
+        port = c.port("materialized", 6876)
+        r = requests.post(f"http://localhost:{port}/api/sql", json={"query": batch})
+        assert SIZE_LIMIT_ERROR in r.text, r.text[:500]
+
+    # `parse()` bypass, reached through `validate_readonly_query` in both tools.
+    for endpoint, tool, args in [
+        ("agent", "query", {"cluster": "quickstart", "sql_query": batch}),
+        ("developer", "query_system_catalog", {"sql_query": batch}),
+    ]:
+        with c.test_case(f"{endpoint}_{tool}_enforces_size_limit"):
+            msg = tool_error(endpoint, tool, args)
+            assert SIZE_LIMIT_ERROR in msg, f"{tool} parsed the oversized batch: {msg}"
+
+    # `parse_item_name()` bypass: an oversized, non-parseable data product name.
+    with c.test_case("agent_read_data_product_name_enforces_size_limit"):
+        msg = tool_error("agent", "read_data_product", {"name": "(" * 1_200_000})
+        assert (
+            SIZE_LIMIT_ERROR in msg
+        ), f"parse_item_name processed oversized name: {msg[:200]}"


### PR DESCRIPTION
The 1 MB `MAX_STATEMENT_BATCH_SIZE` guard only fires in `parse_with_limit`, but the MCP validators were calling the unbounded `parse()` and `parse_item_name()` directly, letting multi-megabyte input reach the lexer and parser. Switches the three MCP call sites (`validate_readonly_query`, `validate_system_catalog_query`, `safe_data_product_name`) to the bounded variants (adding `parse_item_name_with_limit`) and pins the behavior with three unit tests plus the mzcompose workflow from [DEX-64](https://linear.app/materializeinc/issue/DEX-64/mcp-1-mb-sql-parser-size-guard-is-not-active-for-mcp-http-endpoint).