### PR TITLE
[envd/metrics]: don't panic on NULL label in `/metrics/mz_usage`

### DIFF
--- a/src/environmentd/src/http/prometheus.rs
+++ b/src/environmentd/src/http/prometheus.rs
@@ -145,7 +145,9 @@ pub(crate) static USAGE_METRIC_QUERIES: &[PrometheusSqlQuery] = &[
     PrometheusSqlQuery {
         metric_name: "mz_cluster_reps_count",
         help: "Number of active cluster replicas in the instance, by replica size.",
-        query: "select size
+        // `mz_cluster_replicas.size` is NULL for unmanaged replicas. Coalesce
+        // to an empty string so the resulting Prometheus label is a string.
+        query: "select COALESCE(size, '') as size
                 , count(id) as replicas
             from mz_cluster_replicas
             where cluster_id like 'u%'
@@ -173,7 +175,7 @@ pub(crate) static USAGE_METRIC_QUERIES: &[PrometheusSqlQuery] = &[
         query: "SELECT
                 type,
                 COALESCE(envelope_type, '<none>') AS envelope_type,
-                mz_cluster_replicas.size AS size,
+                COALESCE(mz_cluster_replicas.size, '') AS size,
                 count(mz_sources.id) AS sources
             FROM
                 mz_sources, mz_cluster_replicas
@@ -212,7 +214,7 @@ pub(crate) static USAGE_METRIC_QUERIES: &[PrometheusSqlQuery] = &[
         query: "SELECT
                 type,
                 COALESCE(envelope_type, '<none>') AS envelope_type,
-                mz_cluster_replicas.size AS size,
+                COALESCE(mz_cluster_replicas.size, '') AS size,
                 count(mz_sinks.id) AS sinks
             FROM
                 mz_sinks, mz_cluster_replicas

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -180,12 +180,17 @@ async fn execute_promsql_query(
         });
 
     for row in rows {
+        // Non-value columns become Prometheus label values. A SQL `NULL`
+        // arrives as JSON `null` and yields `None` from `as_str()`; fall back
+        // to an empty label rather than panicking. The query author is
+        // responsible for `COALESCE`ing nullable columns to a meaningful
+        // value; this is a defensive backstop.
         let mut label_values = desc
             .columns
             .iter()
             .zip_eq(row)
             .filter(|(col, _)| col.name != query.value_column_name)
-            .map(|(_, val)| val.as_str().expect("must be string"))
+            .map(|(_, val)| val.as_str().unwrap_or(""))
             .collect::<Vec<_>>();
 
         let value = desc

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7126,3 +7126,39 @@ def workflow_test_prometheus_metrics(c: Composition) -> None:
                   FROM mz_introspection.mz_cluster_prometheus_metrics
                 true
                 """))
+
+
+def workflow_test_metrics_null_label(c: Composition) -> None:
+    """SQL-198: `/metrics/mz_usage` must not abort environmentd when a
+    Prometheus label column is SQL NULL. An unorchestrated cluster replica has
+    `mz_cluster_replicas.size = NULL`, which used to reach an `.expect("must be
+    string")` in the label-values assembly."""
+    c.up("materialized")
+
+    # The default `Materialized()` in this composition already enables
+    # unorchestrated cluster replicas.
+    c.sql(
+        """CREATE CLUSTER sql198_unmgd REPLICAS (
+               r1 (STORAGECTL ADDRESSES ['s:1234'],
+                   COMPUTECTL ADDRESSES ['c:1234']))""",
+        port=6877,
+        user="mz_system",
+    )
+
+    try:
+        result = c.exec(
+            "materialized",
+            "curl",
+            "-sf",
+            "http://localhost:6878/metrics/mz_usage",
+            capture=True,
+        )
+        assert (
+            result.returncode == 0
+        ), f"metrics endpoint failed (rc={result.returncode})"
+        assert len(result.stdout) > 0, "metrics response was empty"
+
+        # Server is still alive.
+        assert c.sql_query("SELECT 1", reuse_connection=False)[0][0] == 1
+    finally:
+        c.sql("DROP CLUSTER sql198_unmgd CASCADE", port=6877, user="mz_system")


### PR DESCRIPTION
Problem:
Scraping `/metrics/mz_usage` while an unorchestrated cluster replica is present aborts environmentd. The reason is Prometheus label values are expected to be a string, but SQL NULL triggered a panic, when `mz_cluster_reps_count` grouped by `mz_cluster_replicas.size`, which is NULL for unmanaged replicas.

Solution:
- fall back to an empty label instead of panicking
- make the queries deliberate about NULL by `COALESCE`ing the nullable `size` column in `mz_cluster_reps_count`, `mz_sources_count`, and `mz_sinks_count` (matching what `mz_compute_cluster_status` already does).

Testing:
- `workflow_test_metrics_null_label` in `test/cluster/mzcompose.py`:

Fixes SQL-198.
