### PR TITLE
sql: reject SET TRANSACTION access modes at plan time

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -846,6 +846,12 @@ impl AdapterError {
             AdapterError::PlanError(PlanError::ParameterNotAllowed(_)) => {
                 SqlState::UNDEFINED_PARAMETER
             }
+            // `PlanError::Unsupported` is raised (via `bail_unsupported!`) only for
+            // genuinely unsupported features, so it maps to PostgreSQL's
+            // feature-not-supported code rather than internal-error. See SQL-326.
+            AdapterError::PlanError(PlanError::Unsupported { .. }) => {
+                SqlState::FEATURE_NOT_SUPPORTED
+            }
             AdapterError::PlanError(_) => SqlState::INTERNAL_ERROR,
             AdapterError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
@@ -875,6 +881,9 @@ impl AdapterError {
                 }
                 OptimizerError::PlanError(PlanError::ParameterNotAllowed(_)) => {
                     SqlState::UNDEFINED_PARAMETER
+                }
+                OptimizerError::PlanError(PlanError::Unsupported { .. }) => {
+                    SqlState::FEATURE_NOT_SUPPORTED
                 }
                 OptimizerError::PlanError(_) => SqlState::INTERNAL_ERROR,
                 OptimizerError::RecursionLimitError(_) => RECURSION_LIMIT_ERROR_CODE,

--- a/src/sql/src/plan/statement/tcl.rs
+++ b/src/sql/src/plan/statement/tcl.rs
@@ -53,6 +53,17 @@ pub fn plan_set_transaction(
     _: &StatementContext,
     SetTransactionStatement { local, modes }: SetTransactionStatement,
 ) -> Result<Plan, PlanError> {
+    // The sequencer applies each mode's side effect in order and rejects access
+    // modes outright. Reject them here, before any plan is produced, so a
+    // statement that cannot fully succeed leaves no partially-applied state
+    // behind (e.g. a silently changed isolation level). This mirrors
+    // `plan_start_transaction`, which validates all modes at plan time.
+    if modes
+        .iter()
+        .any(|m| matches!(m, TransactionMode::AccessMode(_)))
+    {
+        bail_unsupported!("SET TRANSACTION <access-mode>");
+    }
     Ok(Plan::SetTransaction(SetTransactionPlan { local, modes }))
 }
 

--- a/test/pgtest/vars.pt
+++ b/test/pgtest/vars.pt
@@ -70,3 +70,15 @@ ReadyForQuery
 ----
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22023"},{"typ":"M","value":"invalid value for parameter \"TimeZone\": \"bad\""}]}
 ReadyForQuery {"status":"I"}
+
+# SET TRANSACTION <access-mode> is unsupported and must map to 0A000
+# (feature_not_supported), not XX000 (internal_error). See SQL-326.
+send
+Query {"query": "SET TRANSACTION READ ONLY"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"SET TRANSACTION <access-mode> not yet supported"}]}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -818,6 +818,39 @@ RESET TRANSACTION_ISOLATION
 statement ok
 ROLLBACK
 
+# Regression: a `SET TRANSACTION` / `SET SESSION CHARACTERISTICS` whose mode
+# list mixes a (supported) isolation level with an (unsupported) access mode
+# must be rejected atomically. Previously the sequencer applied each mode in
+# order, so an isolation level listed before an access mode was applied to the
+# session before the statement then errored on the access mode, leaving the
+# session silently pinned to a different isolation level despite the error.
+
+statement ok
+RESET transaction_isolation
+
+query T
+SHOW transaction_isolation
+----
+strict serializable
+
+statement error SET TRANSACTION <access-mode>
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE READ WRITE
+
+# The failed statement must not have changed the isolation level.
+query T
+SHOW transaction_isolation
+----
+strict serializable
+
+# Access mode alone is likewise rejected, with no isolation change.
+statement error SET TRANSACTION <access-mode>
+SET TRANSACTION READ ONLY
+
+query T
+SHOW transaction_isolation
+----
+strict serializable
+
 # Test explicit single statement transactions.
 
 reset-server

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -216,7 +216,7 @@ strict serializable
 statement error Expected transaction mode, found EOF
 SET TRANSACTION
 
-statement error SET TRANSACTION <access-mode> are not supported
+statement error SET TRANSACTION <access-mode> not yet supported
 SET TRANSACTION READ ONLY
 
 # Test that a failed transaction will not commit var changes.


### PR DESCRIPTION
The sequencer applied each transaction mode's side effect in order before rejecting access modes, so `SET ... ISOLATION LEVEL x READ WRITE` changed the session isolation level and then errored, leaving it silently changed. Reject access modes in the planner (like `plan_start_transaction`) so no partial state is applied. Adds an SLT regression test.