### PR TITLE
sql: honor zero and runtime changes for optimizer warning threshold

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -335,6 +335,7 @@ impl Coordinator {
         let mut update_cluster_scheduling_config = false;
         let mut update_http_config = false;
         let mut update_advance_timelines_interval = false;
+        let mut update_optimizer_e2e_latency_warning_threshold = false;
 
         for op in &ops {
             match op {
@@ -389,6 +390,8 @@ impl Coordinator {
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
                     update_http_config |= vars::is_http_config_var(name);
                     update_advance_timelines_interval |= name == DEFAULT_TIMESTAMP_INTERVAL.name();
+                    update_optimizer_e2e_latency_warning_threshold |=
+                        name == vars::OPTIMIZER_E2E_LATENCY_WARNING_THRESHOLD.name();
                 }
                 catalog::Op::ResetAllSystemConfiguration => {
                     // Assume they all need to be updated.
@@ -405,6 +408,7 @@ impl Coordinator {
                     update_metrics_config = true;
                     update_http_config = true;
                     update_advance_timelines_interval = true;
+                    update_optimizer_e2e_latency_warning_threshold = true;
                 }
                 catalog::Op::RenameItem { id, .. } => {
                     let item = self.catalog().get_entry(id);
@@ -560,6 +564,14 @@ impl Coordinator {
                 if new_interval != self.advance_timelines_interval.period() {
                     self.advance_timelines_interval = tokio::time::interval(new_interval);
                 }
+            }
+            if update_optimizer_e2e_latency_warning_threshold {
+                let threshold = self
+                    .catalog()
+                    .system_config()
+                    .optimizer_e2e_latency_warning_threshold();
+                self.optimizer_metrics
+                    .set_e2e_optimization_time_log_threshold(threshold);
             }
         }
         .instrument(info_span!("coord::catalog_transact_with::finalize"))

--- a/src/sql/src/optimizer_metrics.rs
+++ b/src/sql/src/optimizer_metrics.rs
@@ -9,6 +9,8 @@
 
 //! Metrics collected by the optimizer.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use mz_ore::metric;
@@ -20,7 +22,11 @@ use prometheus::{HistogramVec, IntCounterVec};
 #[derive(Debug, Clone)]
 pub struct OptimizerMetrics {
     e2e_optimization_time_seconds: HistogramVec,
-    e2e_optimization_time_seconds_log_threshold: Duration,
+    /// Threshold in nanoseconds above which optimization emits a "slow
+    /// optimization" `warn!`. Zero disables the warning. Shared via `Arc` so a
+    /// runtime threshold change reaches every clone, including the long-lived
+    /// copies held by the coordinator and `PeekClient`.
+    e2e_optimization_time_seconds_log_threshold: Arc<AtomicU64>,
     outer_join_lowering_cases: IntCounterVec,
     transform_hits: IntCounterVec,
     transform_total: IntCounterVec,
@@ -41,7 +47,9 @@ impl OptimizerMetrics {
                  var_labels: ["object_type"],
                  buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
-            e2e_optimization_time_seconds_log_threshold,
+            e2e_optimization_time_seconds_log_threshold: Arc::new(AtomicU64::new(
+                duration_to_nanos(e2e_optimization_time_seconds_log_threshold),
+            )),
             outer_join_lowering_cases: registry.register(metric!(
                 name: "outer_join_lowering_cases",
                 help: "How many times the different outer join lowering cases happened.",
@@ -61,11 +69,26 @@ impl OptimizerMetrics {
         }
     }
 
+    /// Updates the "slow optimization" warning threshold. Shared via `Arc`, so
+    /// the change reaches every existing clone.
+    pub fn set_e2e_optimization_time_log_threshold(&self, threshold: Duration) {
+        self.e2e_optimization_time_seconds_log_threshold
+            .store(duration_to_nanos(threshold), Ordering::Relaxed);
+    }
+
     pub fn observe_e2e_optimization_time(&self, object_type: &str, duration: Duration) {
         self.e2e_optimization_time_seconds
             .with_label_values(&[object_type])
             .observe(duration.as_secs_f64());
-        // Also log it when it's big.
+        // Log it when it's big. Zero disables the warning, matching the
+        // `optimizer_e2e_latency_warning_threshold` var contract.
+        let configured = Duration::from_nanos(
+            self.e2e_optimization_time_seconds_log_threshold
+                .load(Ordering::Relaxed),
+        );
+        if configured.is_zero() {
+            return;
+        }
         let debug_threshold = cfg!(debug_assertions);
         let threshold = if debug_threshold {
             // Debug builds are much slower to optimize (despite mz-transform being built
@@ -73,9 +96,9 @@ impl OptimizerMetrics {
             // (A big part of the slowness comes from not optimizing mz-expr, but turning on
             // optimizations for that in debug builds would slow down the build
             // considerably.)
-            self.e2e_optimization_time_seconds_log_threshold * 6
+            configured * 6
         } else {
-            self.e2e_optimization_time_seconds_log_threshold
+            configured
         };
         if duration > threshold {
             let transform_times = self
@@ -127,4 +150,9 @@ impl OptimizerMetrics {
             transform_time_seconds.insert(transform.to_string(), vec![duration]);
         }
     }
+}
+
+/// Saturates at `u64::MAX` nanoseconds (~584 years), beyond any real threshold.
+fn duration_to_nanos(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }


### PR DESCRIPTION
The `optimizer_e2e_latency_warning_threshold` var is documented as "zero disables" and is ALTER SYSTEM settable, but neither held:

- Zero produced a "slow optimization" warn! on every optimization (duration > 0 is always true) plus a per-query JSON dump, instead of disabling the warning.
- The threshold was snapshotted once at coordinator boot, so ALTER SYSTEM SET had no effect until restart.

Store the threshold in a shared Arc<AtomicU64>, skip the warning when it is zero, and refresh it from the coordinator's system-var-change handler so updates reach every clone, including the long-lived copies held by the coordinator and PeekClient.