### PR TITLE
sql: Fix GRANT/REVOKE ON ALL POLICIES to include network policies

### DIFF
--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -125,6 +125,28 @@ TO <role_name> [, ... ];
 
 {{</ tab >}}
 
+<!-- ================== Network policy syntax ==================  -->
+
+{{< tab "Network policy">}}
+
+For specific network policies:
+
+```mzsql
+GRANT <USAGE | ALL [PRIVILEGES]>
+ON NETWORK POLICY <name> [, ...]
+TO <role_name> [, ... ];
+```
+
+For all network policies:
+
+```mzsql
+GRANT <USAGE | ALL [PRIVILEGES]>
+ON ALL POLICIES
+TO <role_name> [, ... ];
+```
+
+{{</ tab >}}
+
 <!-- ==================== Schema syntax =====================  -->
 
 {{< tab "Schema">}}

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -128,6 +128,28 @@ FROM <role_name> [, ... ];
 
 {{</ tab >}}
 
+<!-- ================== Network policy syntax ==================  -->
+
+{{< tab "Network policy">}}
+
+For specific network policies:
+
+```mzsql
+REVOKE <USAGE | ALL [PRIVILEGES]>
+ON NETWORK POLICY <name> [, ...]
+FROM <role_name> [, ... ];
+```
+
+For all network policies:
+
+```mzsql
+REVOKE <USAGE | ALL [PRIVILEGES]>
+ON ALL POLICIES
+FROM <role_name> [, ... ];
+```
+
+{{</ tab >}}
+
 <!-- ==================== Schema syntax =====================  -->
 
 {{< tab "Schema">}}

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -9825,6 +9825,7 @@ impl<'a> Parser<'a> {
                 DATABASE,
                 SCHEMA,
                 FUNCTION,
+                NETWORK,
             ])? {
                 TABLE => ObjectType::Table,
                 VIEW => ObjectType::View,
@@ -9853,6 +9854,14 @@ impl<'a> Parser<'a> {
                 DATABASE => ObjectType::Database,
                 SCHEMA => ObjectType::Schema,
                 FUNCTION => ObjectType::Func,
+                NETWORK => {
+                    if self.parse_keyword(POLICY) {
+                        ObjectType::NetworkPolicy
+                    } else {
+                        self.prev_token();
+                        return None;
+                    }
+                }
                 _ => unreachable!(),
             },
         )

--- a/src/sql-parser/tests/testdata/acl
+++ b/src/sql-parser/tests/testdata/acl
@@ -390,6 +390,20 @@ GRANT USAGE ON CONNECTION foo TO joe
 GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: Object { object_type: Connection, object_spec_inner: Objects { names: [Item(UnresolvedItemName([Ident("foo")]))] } }, roles: [Ident("joe")] })
 
 parse-statement
+GRANT USAGE ON NETWORK POLICY foo TO joe
+----
+GRANT USAGE ON NETWORK POLICY foo TO joe
+=>
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: Object { object_type: NetworkPolicy, object_spec_inner: Objects { names: [NetworkPolicy(Ident("foo"))] } }, roles: [Ident("joe")] })
+
+parse-statement
+REVOKE USAGE ON NETWORK POLICY foo FROM joe
+----
+REVOKE USAGE ON NETWORK POLICY foo FROM joe
+=>
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: Object { object_type: NetworkPolicy, object_spec_inner: Objects { names: [NetworkPolicy(Ident("foo"))] } }, roles: [Ident("joe")] })
+
+parse-statement
 GRANT SELECT ON VIEW foo TO joe
 ----
 error: For object type VIEW, you must specify 'TABLE' or omit the object type

--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -465,10 +465,16 @@ fn plan_update_privilege(
                         .get_items()
                         .into_iter()
                         .map(|item| item.id().into());
+                    let network_policy_ids = scx
+                        .catalog
+                        .get_network_policies()
+                        .into_iter()
+                        .map(|network_policy| ObjectId::NetworkPolicy(network_policy.id()));
                     cluster_ids
                         .chain(database_ids)
                         .chain(schema_ids)
                         .chain(item_ids)
+                        .chain(network_policy_ids)
                         .filter(|object_id| object_type_filter(object_id, &object_type, scx))
                         .filter(|object_id| object_id.is_user())
                         .collect()

--- a/test/sqllogictest/network_policy.slt
+++ b/test/sqllogictest/network_policy.slt
@@ -107,3 +107,167 @@ select * from (SHOW NETWORK POLICIES)
 default
 open_ingress
 (empty)
+
+# Regression test: `GRANT/REVOKE USAGE ON ALL POLICIES` must apply to existing
+# network policies. The `All` target chain in plan_update_privilege
+# built its id set from clusters, databases, schemas, and items only. None of
+# those iterators produce an `ObjectId::NetworkPolicy`, so the object-type
+# filter dropped every candidate and the statement planned zero updates. The
+# result was a silent no-op: `GRANT`/`REVOKE` reported success while changing
+# nothing. This mirrors the omission fixed earlier for DROP OWNED BY / REASSIGN
+# OWNED BY.
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE np_grantee
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE NETWORK POLICY np_grant (RULES (r1 (address='0.0.0.0/32', action='allow', direction='ingress')))
+----
+COMPLETE 0
+
+# np_grantee starts without any network policy privileges.
+query TT rowsort
+SELECT np.name, mz_internal.mz_aclitem_privileges(priv)
+FROM mz_internal.mz_network_policies np,
+     unnest(np.privileges) AS priv,
+     mz_roles r
+WHERE mz_internal.mz_aclitem_grantee(priv) = r.id AND r.name = 'np_grantee'
+----
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON ALL POLICIES TO np_grantee
+----
+COMPLETE 0
+
+# The grant must land on every user network policy: the built-in `default`
+# policy and the freshly created `np_grant`.
+query TT rowsort
+SELECT np.name, mz_internal.mz_aclitem_privileges(priv)
+FROM mz_internal.mz_network_policies np,
+     unnest(np.privileges) AS priv,
+     mz_roles r
+WHERE mz_internal.mz_aclitem_grantee(priv) = r.id AND r.name = 'np_grantee'
+----
+default
+U
+np_grant
+U
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON ALL POLICIES FROM np_grantee
+----
+COMPLETE 0
+
+# The revoke must clear USAGE from every user network policy.
+query TT rowsort
+SELECT np.name, mz_internal.mz_aclitem_privileges(priv)
+FROM mz_internal.mz_network_policies np,
+     unnest(np.privileges) AS priv,
+     mz_roles r
+WHERE mz_internal.mz_aclitem_grantee(priv) = r.id AND r.name = 'np_grantee'
+----
+
+simple conn=mz_system,user=mz_system
+DROP NETWORK POLICY np_grant
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP ROLE np_grantee
+----
+COMPLETE 0
+
+# Regression test: a non-system role that owns a network policy can grant and
+# revoke USAGE on it through the singular `GRANT/REVOKE ... ON NETWORK POLICY
+# <name>` form. The bulk `ALL POLICIES` form always includes the built-in
+# `default` policy owned by mz_system, so the GRANT/REVOKE ownership check in
+# generate_rbac_requirements rejects the whole statement for a non-system
+# owner. The singular target is the escape hatch owners need to manage USAGE on
+# their own policies.
+
+# RBAC enforcement is the premise of this test. It is on by default, but set it
+# explicitly so the test stays meaningful if that default ever changes.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks = true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE np_owner
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE np_owner_grantee
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATENETWORKPOLICY ON SYSTEM TO np_owner
+----
+COMPLETE 0
+
+# np_owner creates and therefore owns this policy.
+simple conn=np_owner,user=np_owner
+CREATE NETWORK POLICY np_owner_np (RULES (r1 (address='0.0.0.0/32', action='allow', direction='ingress')))
+----
+COMPLETE 0
+
+# The bulk form is unusable for np_owner: it also targets the built-in `default`
+# policy, which np_owner does not own.
+simple conn=np_owner,user=np_owner
+GRANT USAGE ON ALL POLICIES TO np_owner_grantee
+----
+db error: ERROR: must be owner of NETWORK POLICY default
+
+# The singular form lets np_owner grant USAGE on the policy it owns.
+simple conn=np_owner,user=np_owner
+GRANT USAGE ON NETWORK POLICY np_owner_np TO np_owner_grantee
+----
+COMPLETE 0
+
+query TT rowsort
+SELECT np.name, mz_internal.mz_aclitem_privileges(priv)
+FROM mz_internal.mz_network_policies np,
+     unnest(np.privileges) AS priv,
+     mz_roles r
+WHERE mz_internal.mz_aclitem_grantee(priv) = r.id AND r.name = 'np_owner_grantee'
+----
+np_owner_np
+U
+
+# And the singular form revokes it again.
+simple conn=np_owner,user=np_owner
+REVOKE USAGE ON NETWORK POLICY np_owner_np FROM np_owner_grantee
+----
+COMPLETE 0
+
+query TT rowsort
+SELECT np.name, mz_internal.mz_aclitem_privileges(priv)
+FROM mz_internal.mz_network_policies np,
+     unnest(np.privileges) AS priv,
+     mz_roles r
+WHERE mz_internal.mz_aclitem_grantee(priv) = r.id AND r.name = 'np_owner_grantee'
+----
+
+simple conn=mz_system,user=mz_system
+DROP NETWORK POLICY np_owner_np
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP ROLE np_owner_grantee
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATENETWORKPOLICY ON SYSTEM FROM np_owner
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP ROLE np_owner
+----
+COMPLETE 0


### PR DESCRIPTION
plan_update_privilege built its `ON ALL <type>` target set from clusters, databases, schemas, and items only, none of which produce an ObjectId::NetworkPolicy. So `GRANT/REVOKE USAGE ON ALL POLICIES` planned zero updates and silently succeeded as a no-op. Since `ALL POLICIES` is the only reachable grammar for network-policy USAGE, there was no way to grant or revoke it at all.

Add network policies to the `All` chain, mirroring the DROP OWNED BY / REASSIGN OWNED BY fix in daff501451. Broken since network-policy SQL landed in #30172.