### PR TITLE
tests: Print environment ID for tests connecting to Cloud

### DIFF
--- a/misc/python/materialize/mz_env_util.py
+++ b/misc/python/materialize/mz_env_util.py
@@ -9,6 +9,8 @@
 
 """mz env util"""
 
+import psycopg
+
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.mz import Mz
 
@@ -24,3 +26,35 @@ def get_cloud_hostname(
         Mz(region=region, environment=environment, app_password=app_password)
     ):
         return c.cloud_hostname(quiet=quiet)
+
+
+def print_environment_id(conn: psycopg.Connection, indent: str = "") -> None:
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT mz_environment_id()")
+            row = cur.fetchone()
+        env_id = row[0] if row else "<unknown>"
+        print(f"{indent}mz_environment_id() = {env_id}")
+    except Exception as e:
+        print(f"{indent}WARNING: failed to read mz_environment_id(): {e}")
+
+
+def connect_and_print_environment_id(
+    host: str,
+    user: str | None,
+    password: str | None,
+    port: int = 6875,
+    dbname: str = "materialize",
+) -> None:
+    try:
+        with psycopg.connect(
+            host=host,
+            user=user,
+            password=password,
+            port=port,
+            dbname=dbname,
+            sslmode="require",
+        ) as conn:
+            print_environment_id(conn)
+    except Exception as e:
+        print(f"WARNING: failed to connect to {host}: {e}")

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -40,6 +40,7 @@ import psycopg
 from psycopg import sql
 
 from materialize.biglake import bootstrap_namespace
+from materialize.mz_env_util import connect_and_print_environment_id
 from materialize.mzcompose import loader
 from materialize.mzcompose.composition import (
     Composition,
@@ -659,6 +660,13 @@ def workflow_test(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="Seconds to watch each object's write frontier; it must advance within this window.",
     )
     args = parser.parse_args()
+
+    assert MATERIALIZE_PROD_SANDBOX_HOSTNAME is not None
+    connect_and_print_environment_id(
+        MATERIALIZE_PROD_SANDBOX_HOSTNAME,
+        MATERIALIZE_PROD_SANDBOX_USERNAME,
+        MATERIALIZE_PROD_SANDBOX_APP_PASSWORD,
+    )
 
     # `stop` lets the frontier checks bail out promptly on Ctrl-C: signals go to
     # the main thread, so the workers can't see the KeyboardInterrupt — they poll

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -24,7 +24,10 @@ from psycopg.errors import IdleInTransactionSessionTimeout, OperationalError
 from requests.exceptions import ConnectionError, ReadTimeout
 
 from materialize.cloudtest.util.jwt_key import fetch_jwt
-from materialize.mz_env_util import get_cloud_hostname
+from materialize.mz_env_util import (
+    connect_and_print_environment_id,
+    get_cloud_hostname,
+)
 from materialize.mzcompose.composition import (
     Composition,
     Service,
@@ -126,6 +129,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     host = get_cloud_hostname(
         c, region=REGION, environment=ENVIRONMENT, app_password=APP_PASSWORD
     )
+
+    connect_and_print_environment_id(host, USERNAME, APP_PASSWORD)
 
     with c.override(
         Testdrive(

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -25,6 +25,7 @@ import urllib.parse
 import psycopg
 
 from materialize import MZ_ROOT
+from materialize.mz_env_util import connect_and_print_environment_id
 from materialize.mz_version import MzVersion
 from materialize.mzcompose import (
     _wait_for_pg,
@@ -275,6 +276,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         assert "materialize.cloud" in c.cloud_hostname()
         wait_for_cloud(c)
+
+        connect_and_print_environment_id(c.cloud_hostname(), USERNAME, APP_PASSWORD)
 
         if args.version_check:
             version_check(c)

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -32,6 +32,7 @@ from psycopg import InterfaceError, OperationalError
 from psycopg import sql as psycopg_sql
 
 from materialize import MZ_ROOT, buildkite
+from materialize.mz_env_util import print_environment_id
 from materialize.mz_version import MzVersion
 from materialize.mzcompose import _wait_for_pg
 from materialize.mzcompose.composition import (
@@ -3561,14 +3562,8 @@ def log_environment_info(target: "BenchTarget") -> None:
         print(f"  WARNING: could not open connection to log environment info: {e}")
         return
     try:
+        print_environment_id(conn, indent="  ")
         with conn.cursor() as cur:
-            try:
-                cur.execute("SELECT mz_environment_id()")
-                row = cur.fetchone()
-                env_id = row[0] if row else "<unknown>"
-                print(f"  mz_environment_id() = {env_id}")
-            except Exception as e:
-                print(f"  WARNING: failed to read mz_environment_id(): {e}")
             for param in SYSTEM_PARAMETERS_TO_LOG:
                 try:
                     cur.execute(

--- a/test/mz-e2e/mzcompose.py
+++ b/test/mz-e2e/mzcompose.py
@@ -19,6 +19,7 @@ import time
 
 import psycopg
 
+from materialize.mz_env_util import connect_and_print_environment_id
 from materialize.mzcompose import (
     _wait_for_pg,
 )
@@ -79,6 +80,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         assert "materialize.cloud" in c.cloud_hostname()
         wait_for_cloud(c)
+
+        connect_and_print_environment_id(c.cloud_hostname(), USERNAME, APP_PASSWORD)
 
         # Test - `mz app-password`
         # Assert `mz app-password create`

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -23,7 +23,10 @@ from matplotlib.markers import MarkerStyle
 
 from materialize import MZ_ROOT, buildkite
 from materialize.docker import image_registry
-from materialize.mz_env_util import get_cloud_hostname
+from materialize.mz_env_util import (
+    connect_and_print_environment_id,
+    get_cloud_hostname,
+)
 from materialize.mzcompose import ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS
 from materialize.mzcompose.composition import (
     Composition,
@@ -408,6 +411,7 @@ def run_once(
             port=6875,
             ssl=True,
         )
+        connect_and_print_environment_id(target.host, target.user, target.password)
     elif args.canary_env:
         assert not args.mz_url
         assert not args.benchmarking_env
@@ -427,6 +431,7 @@ def run_once(
             port=6875,
             ssl=True,
         )
+        connect_and_print_environment_id(target.host, target.user, target.password)
     elif args.mz_url:
         overrides = [
             Testdrive(


### PR DESCRIPTION
Noticed in https://materializeinc.slack.com/archives/CTESPM7FU/p1783065572694669 that it's a good idea to have.

Test run: https://buildkite.com/materialize/nightly/builds/16988