### PR TITLE
compute: plan the sink source arrangement key

### DIFF
--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -282,6 +282,8 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
             non_null_assertions: Vec::new(),
             // No `REFRESH` for copy_to.
             refresh_schedule: None,
+            // Populated during LIR lowering.
+            from_key: None,
         };
         df_desc.export_sink(self.select_id, sink_description);
 

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -259,6 +259,8 @@ impl Optimize<LocalMirPlan> for Optimizer {
             up_to: Antichain::default(),
             non_null_assertions: self.non_null_assertions.clone(),
             refresh_schedule: self.refresh_schedule.clone(),
+            // Populated during LIR lowering.
+            from_key: None,
         };
         df_desc.export_sink(self.sink_id, sink_description);
 

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -206,6 +206,8 @@ impl Optimize<SubscribePlan> for Optimizer {
                     non_null_assertions: vec![],
                     // No `REFRESH` for subscribes
                     refresh_schedule: None,
+                    // Populated during LIR lowering.
+                    from_key: None,
                 };
                 df_desc.export_sink(self.sink_id, sink_description);
             }
@@ -250,6 +252,8 @@ impl Optimize<SubscribePlan> for Optimizer {
                     non_null_assertions: vec![],
                     // No `REFRESH` for subscribes
                     refresh_schedule: None,
+                    // Populated during LIR lowering.
+                    from_key: None,
                 };
                 df_desc.export_sink(self.sink_id, sink_description);
             }

--- a/src/clusterd-test-driver/src/dataflow.rs
+++ b/src/clusterd-test-driver/src/dataflow.rs
@@ -347,6 +347,7 @@ impl DataflowBuilder {
             up_to: Antichain::new(),
             non_null_assertions: vec![],
             refresh_schedule: None,
+            from_key: None,
         };
         self.mir.export_sink(sink_id, desc);
         self
@@ -377,6 +378,7 @@ impl DataflowBuilder {
             up_to,
             non_null_assertions: vec![],
             refresh_schedule: None,
+            from_key: None,
         };
         self.mir.export_sink(sink_id, desc);
         self
@@ -614,6 +616,7 @@ fn augment(
                 up_to: sink.up_to,
                 non_null_assertions: sink.non_null_assertions,
                 refresh_schedule: sink.refresh_schedule,
+                from_key: sink.from_key,
             },
         );
     }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -1130,6 +1130,7 @@ mod tests {
                     up_to: Default::default(),
                     non_null_assertions: Default::default(),
                     refresh_schedule: Default::default(),
+                    from_key: None,
                 };
                 (id, desc)
             })

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1554,6 +1554,7 @@ impl Instance {
                 up_to: se.up_to,
                 non_null_assertions: se.non_null_assertions,
                 refresh_schedule: se.refresh_schedule,
+                from_key: se.from_key,
             };
             sink_exports.insert(id, desc);
         }

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -146,12 +146,32 @@ impl Context {
             objects_to_build.push(BuildDesc { id: build.id, plan });
         }
 
+        // Choose, for each sink, which form of its `from` collection the renderer consumes.
+        // `None` means the unarranged collection. Otherwise we name an arrangement key, so the
+        // renderer no longer has to pick one arbitrarily at runtime. The choice is possible here
+        // because the loop above registered the arrangements of every built object.
+        let mut sink_exports = desc.sink_exports;
+        for sink in sink_exports.values_mut() {
+            let available = self
+                .arrangements
+                .get(&Id::Global(sink.from))
+                .cloned()
+                .unwrap_or_else(AvailableCollections::new_raw);
+            sink.from_key = if available.raw {
+                None
+            } else {
+                available
+                    .arbitrary_arrangement()
+                    .map(|(key, _permutation, _thinning)| key.clone())
+            };
+        }
+
         Ok(DataflowDescription {
             source_imports: desc.source_imports,
             index_imports: desc.index_imports,
             objects_to_build,
             index_exports: desc.index_exports,
-            sink_exports: desc.sink_exports,
+            sink_exports,
             as_of: desc.as_of,
             until: desc.until,
             initial_storage_as_of: desc.initial_storage_as_of,

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -17,6 +17,8 @@ use mz_storage_types::sinks::S3UploadInfo;
 use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
 
+use crate::plan::scalar::LirScalarExpr;
+
 /// A sink for updates to a relational collection.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ComputeSinkDesc<S: 'static = ()> {
@@ -34,6 +36,15 @@ pub struct ComputeSinkDesc<S: 'static = ()> {
     pub non_null_assertions: Vec<usize>,
     /// TODO(database-issues#7533): Add documentation.
     pub refresh_schedule: Option<RefreshSchedule>,
+    /// The arrangement key by which the renderer should consume the `from` collection.
+    ///
+    /// `None` means consume the unarranged collection. `Some(key)` names an arrangement of
+    /// `from` from which the renderer reconstructs full rows before feeding the sink. The
+    /// permutation and thinning are a pure function of `key` and are derived at render time.
+    ///
+    /// Chosen during LIR lowering, where the available arrangements of `from` are known. It is
+    /// `None` before lowering runs.
+    pub from_key: Option<Vec<LirScalarExpr>>,
 }
 
 /// TODO(database-issues#7533): Add documentation.

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -60,32 +60,36 @@ impl<'g, T: RenderTimestamp> Context<'g, T> {
             }
         }
 
-        // TODO[btv] - We should determine the key and permutation to use during planning,
-        // rather than at runtime.
-        //
-        // This is basically an inlined version of the old `as_collection`.
+        // Which arrangement of the `from` collection to consume was decided during LIR lowering
+        // and recorded in `sink.from_key`. An unarranged form takes precedence when the bundle
+        // provides one. Lowering promises one exactly when `from_key` is `None`, but the renderer
+        // can produce one where lowering promised only an arrangement: a snapshot-excluded
+        // subscribe imports an index as a filtered collection instead (see `import_index`).
+        // When we do consume the arrangement named by `from_key`, we reconstruct full rows via an
+        // MFP. The permutation and thinning are a pure function of `key`, so we derive them here
+        // rather than carrying them in the plan.
         let bundle = self
             .lookup_id(mz_expr::Id::Global(sink.from))
             .expect("Sink source collection not loaded");
-        let (ok_collection, mut err_collection) = if let Some(collection) = &bundle.collection {
-            collection.clone()
-        } else {
-            let (key, _arrangement) = bundle
-                .arranged
-                .iter()
-                .next()
-                .expect("Invariant violated: at least one collection must be present.");
-            let unthinned_arity = sink.from_desc.arity();
-            let (permutation, thinning) = permutation_for_arrangement(key, unthinned_arity);
-            let mut mfp = MapFilterProject::<LirScalarExpr>::new(unthinned_arity);
-            mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
-            let mfp_plan = mfp.into_plan().expect("MFP planning failed");
-            bundle.as_collection_core(
-                mfp_plan,
-                Some((key.clone(), None)),
-                self.until.clone(),
-                &self.config_set,
-            )
+        let (ok_collection, mut err_collection) = match (&bundle.collection, &sink.from_key) {
+            (Some(collection), _) => collection.clone(),
+            (None, Some(key)) => {
+                let unthinned_arity = sink.from_desc.arity();
+                let (permutation, thinning) = permutation_for_arrangement(key, unthinned_arity);
+                let mut mfp = MapFilterProject::<LirScalarExpr>::new(unthinned_arity);
+                mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
+                let mfp_plan = mfp.into_plan().expect("MFP planning failed");
+                bundle.as_collection_core(
+                    mfp_plan,
+                    Some((key.clone(), None)),
+                    self.until.clone(),
+                    &self.config_set,
+                )
+            }
+            (None, None) => panic!(
+                "sink source {} has neither a collection nor a planned arrangement key",
+                sink.from
+            ),
         };
 
         // Attach logging of dataflow errors.


### PR DESCRIPTION
When a sink consumes an arranged `from` collection, the renderer previously picked an arrangement key arbitrarily (`bundle.arranged.iter().next()`) at runtime and derived the unthinning permutation there. That key choice is a planning decision, so this moves it to LIR lowering.

`ComputeSinkDesc` gains `from_key: Option<Vec<LirScalarExpr>>`. Lowering sets it from the available arrangements of `from`: `None` selects the unarranged collection, `Some(key)` names an arrangement the renderer reconstructs full rows from. The permutation and thinning stay derived at render time, since they are a pure function of the key.

Behavior is unchanged: when `raw` is available lowering picks `None`, matching the old collection-preference; otherwise it names the same key set the renderer builds. The former arbitrary-pick fallback becomes a planned lookup.

Retires the `TODO[btv]` in `render/sinks.rs`.

Draft: not yet exercised end-to-end against subscribe/MV/copy-to sink dataflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)