### PR TITLE
sql: reject array-of-list/map from polymorphic array functions

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1627,6 +1627,17 @@ fn coerce_args_to_types(
                         // polymorphic type.
                         PlanError::UnsolvablePolymorphicFunctionInput
                     })?;
+                if let SqlScalarType::Array(elem) = &target {
+                    if matches!(
+                        **elem,
+                        SqlScalarType::List { .. } | SqlScalarType::Map { .. }
+                    ) {
+                        bail_unsupported!(format!(
+                            "{}[]",
+                            ecx.humanize_sql_scalar_type(elem, false)
+                        ));
+                    }
+                }
                 do_convert(cexpr, &target)?
             }
         };

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -585,6 +585,21 @@ SELECT array_remove(ARRAY[1,1,1], 1)
 query error removing elements from multidimensional arrays is not supported
 SELECT array_remove(ARRAY[[1]], 1)
 
+query error integer list\[\] not yet supported
+SELECT array_remove(NULL, LIST[1])
+
+query error map\[text=>integer\]\[\] not yet supported
+SELECT array_remove(NULL, '{a=>1}'::map[text=>int4])
+
+statement ok
+CREATE TABLE t0 (c3 int4 list)
+
+query error integer list\[\] not yet supported
+SELECT array_remove('[2020-01-01,2021-01-01)', t0.c3) AS col0 FROM t0
+
+statement ok
+DROP TABLE t0
+
 # array_cat
 
 query T


### PR DESCRIPTION
array_remove (and other polymorphic array functions) could resolve their result to `array of list`/`array of map`, which has no pg type OID and crashed the pgwire connection when the row description was encoded. Reject it at plan time, like the ARRAY[] constructor and array_fill already do.

Closes SQL-458