### PR TITLE
sql: reject non-boolean arguments to mz_any and mz_all

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -5282,11 +5282,17 @@ pub static MZ_UNSAFE_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLock
     use ParamType::*;
     use SqlScalarBaseType::*;
     builtins! {
+        // `mz_all`/`mz_any` back the `ALL`/`ANY` subquery operators, whose
+        // rewrite in `transform_ast` always feeds them a boolean comparison.
+        // The parameter must stay `Bool`: `AggregateFunc::All`/`Any` render as
+        // accumulable reduces whose accumulator only accepts boolean datums, so
+        // a non-boolean argument would crash a compute worker at runtime rather
+        // than being rejected here at plan time (database-issues#9298).
         "mz_all" => Aggregate {
-            params!(Any) => AggregateFunc::All => Bool, oid::FUNC_MZ_ALL_OID;
+            params!(Bool) => AggregateFunc::All => Bool, oid::FUNC_MZ_ALL_OID;
         },
         "mz_any" => Aggregate {
-            params!(Any) => AggregateFunc::Any => Bool, oid::FUNC_MZ_ANY_OID;
+            params!(Bool) => AggregateFunc::Any => Bool, oid::FUNC_MZ_ANY_OID;
         },
         "mz_avg_promotion_internal_v1" => Scalar {
             // Promotes a numeric type to the smallest fractional type that

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1696,6 +1696,32 @@ SELECT mz_unsafe.mz_sleep('inf'::float8)
 statement error cannot sleep for 1e\+300 seconds
 SELECT mz_unsafe.mz_sleep('1e300'::float8)
 
+# mz_all/mz_any back the ALL/ANY subquery operators, whose rewrite always feeds
+# them a boolean comparison. They render as accumulable reduces whose accumulator
+# only accepts boolean datums, so a non-boolean argument used to crash a compute
+# worker with "Invalid argument to AggregateFunc::Any" (database-issues#9298).
+# The Bool parameter turns this into a clean plan-time error instead, for the
+# plain aggregate, the windowed aggregate, and the grouped forms alike.
+statement error function mz_unsafe\.mz_any\(integer\) does not exist
+SELECT mz_unsafe.mz_any(a) FROM (VALUES (1), (2)) AS t (a)
+
+statement error function mz_unsafe\.mz_all\(integer\) does not exist
+SELECT mz_unsafe.mz_all(a) FROM (VALUES (1), (2)) AS t (a)
+
+statement error function mz_unsafe\.mz_any\(integer\) does not exist
+SELECT mz_unsafe.mz_any(a) OVER (ORDER BY a) FROM (VALUES (1), (2)) AS t (a)
+
+# The boolean form that the ALL/ANY subquery rewrite depends on still works.
+query B
+SELECT mz_unsafe.mz_any(a) FROM (VALUES (false), (true)) AS t (a)
+----
+true
+
+query B
+SELECT mz_unsafe.mz_all(a) FROM (VALUES (false), (true)) AS t (a)
+----
+false
+
 # mz_unsafe functions can't be executed with the enable_unsafe_functions flag turned off
 
 simple conn=mz_system,user=mz_system
@@ -1719,7 +1745,7 @@ statement ok
 INSERT INTO dangerous_table (a) VALUES (1)
 
 statement error executing potentially dangerous functions is not supported
-SELECT mz_unsafe.mz_any(a) FROM dangerous_table
+SELECT mz_unsafe.mz_any(a > 0) FROM dangerous_table
 
 statement error executing potentially dangerous functions is not supported
 INSERT INTO dangerous_table (b) VALUES (mz_unsafe.mz_panic('hello'))


### PR DESCRIPTION
mz_all and mz_any back the ALL and ANY subquery operators. They were declared with a params!(Any) signature that accepts an argument of any type, but AggregateFunc::All and AggregateFunc::Any render as accumulable reduces whose accumulator only accepts boolean datums. A direct call such as mz_unsafe.mz_any(1) therefore passed planning and then crashed a compute worker at runtime with "Invalid argument to AggregateFunc::Any". The plain, grouped, and windowed aggregate forms were all affected.

The ANY and ALL subquery rewrites in transform_ast always feed these functions a boolean comparison, so tightening the signature to params!(Bool) leaves internal usage untouched while turning a direct non-boolean call into a clean plan-time error ("function mz_unsafe.mz_any(integer) does not exist").

Fixes https://github.com/MaterializeInc/database-issues/issues/9298