### PR TITLE
sqllogictest: harden bounded_staleness.slt against fresh-table race

### DIFF
--- a/test/sqllogictest/bounded_staleness.slt
+++ b/test/sqllogictest/bounded_staleness.slt
@@ -172,6 +172,19 @@ RESET transaction_isolation
 statement ok
 CREATE TABLE bs_as_of (a int)
 
+# A freshly created table has no readable timestamp until its upper advances
+# past its registration timestamp, and the write frontier the coordinator
+# consults catches up asynchronously. Bump the upper with a write and block on
+# a read before switching isolation levels, so that the bounded staleness
+# freshness check below does not race the frontier reporting.
+statement ok
+INSERT INTO bs_as_of (a) VALUES (1)
+
+query I
+SELECT * FROM bs_as_of
+----
+1
+
 statement ok
 SET transaction_isolation TO 'bounded staleness 5s'
 


### PR DESCRIPTION
Fixes MaterializeInc/materialize CLU-151 flake.

A freshly created table has no readable timestamp until its upper advances past its registration timestamp, and the write frontier the coordinator consults for timestamp selection catches up asynchronously.
The bounded staleness freshness check right after `CREATE TABLE` could observe a stale frontier and fail with `BoundedStalenessExceeded`.
Bump the table's upper with a write and block on a read before switching to bounded staleness isolation.

The underlying controller inconsistency (fresh tables reporting a write frontier of `[min]`) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)