### PR TITLE
adapter: move arrangement size snapshotting off the coordinator loop

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -165,17 +165,17 @@ metrics:
   tags:
   - compute
 - name: mz_arrangement_sizes_collection_time_seconds_bucket
-  help: Seconds to read mz_object_arrangement_sizes and prepare history-table updates for one snapshot.
+  help: Seconds to read mz_object_arrangement_sizes and prepare history records for one snapshot.
   labels:
   - le
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_arrangement_sizes_collection_time_seconds_count
-  help: Seconds to read mz_object_arrangement_sizes and prepare history-table updates for one snapshot.
+  help: Seconds to read mz_object_arrangement_sizes and prepare history records for one snapshot.
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_arrangement_sizes_collection_time_seconds_sum
-  help: Seconds to read mz_object_arrangement_sizes and prepare history-table updates for one snapshot.
+  help: Seconds to read mz_object_arrangement_sizes and prepare history records for one snapshot.
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_arrangement_sizes_rows_written_total

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -316,6 +316,17 @@ impl IdPool {
     }
 }
 
+/// A row for `mz_object_arrangement_size_history`, prepared off-thread by the
+/// arrangement sizes snapshot task and stamped with a collection timestamp at
+/// write time.
+#[derive(Debug)]
+pub struct ArrangementSizeRecord {
+    pub replica_id: String,
+    pub object_id: String,
+    pub size: i64,
+    pub hydration_complete: bool,
+}
+
 #[derive(Debug)]
 pub enum Message {
     Command(OpenTelemetryContext, Command),
@@ -359,6 +370,7 @@ pub enum Message {
     StorageUsagePrune(Vec<BuiltinTableUpdate>),
     ArrangementSizesSchedule,
     ArrangementSizesSnapshot,
+    ArrangementSizesWrite(Vec<ArrangementSizeRecord>),
     ArrangementSizesPrune(Vec<BuiltinTableUpdate>),
     /// Performs any cleanup and logging actions necessary for
     /// finalizing a statement execution.
@@ -510,6 +522,7 @@ impl Message {
             Message::StorageUsagePrune(_) => "storage_usage_prune",
             Message::ArrangementSizesSchedule => "arrangement_sizes_schedule",
             Message::ArrangementSizesSnapshot => "arrangement_sizes_snapshot",
+            Message::ArrangementSizesWrite(_) => "arrangement_sizes_write",
             Message::ArrangementSizesPrune(_) => "arrangement_sizes_prune",
             Message::RetireExecute { .. } => "retire_execute",
             Message::ExecuteSingleStatementTransaction { .. } => {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -97,7 +97,9 @@ use mz_adapter_types::dyncfgs::{
 };
 use mz_auth::password::Password;
 use mz_build_info::BuildInfo;
-use mz_catalog::builtin::{BUILTINS, BUILTINS_STATIC, MZ_STORAGE_USAGE_BY_SHARD};
+use mz_catalog::builtin::{
+    BUILTINS, BUILTINS_STATIC, MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY, MZ_STORAGE_USAGE_BY_SHARD,
+};
 use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, ClusterReplicaSizeMap};
 use mz_catalog::durable::OpenableDurableCatalogState;
 use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions};
@@ -3022,21 +3024,29 @@ impl Coordinator {
         debug!("coordinator init: resetting system tables");
         let read_ts = self.get_local_read_ts().await;
 
-        // Filter out the 'mz_storage_usage_by_shard' table since we need to retain that info for
-        // billing purposes.
+        // Filter out tables whose contents must survive restarts:
+        // 'mz_storage_usage_by_shard' for billing, and
+        // 'mz_object_arrangement_size_history', which accumulates history that
+        // is pruned by its own retention period instead.
         let mz_storage_usage_by_shard_schema: SchemaSpecifier = self
             .catalog()
             .resolve_system_schema(MZ_STORAGE_USAGE_BY_SHARD.schema)
             .into();
-        let is_storage_usage_by_shard = |meta: &TableMetadata| -> bool {
-            meta.name.item == MZ_STORAGE_USAGE_BY_SHARD.name
-                && meta.name.qualifiers.schema_spec == mz_storage_usage_by_shard_schema
+        let arrangement_size_history_schema: SchemaSpecifier = self
+            .catalog()
+            .resolve_system_schema(MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY.schema)
+            .into();
+        let is_retained_across_restarts = |meta: &TableMetadata| -> bool {
+            (meta.name.item == MZ_STORAGE_USAGE_BY_SHARD.name
+                && meta.name.qualifiers.schema_spec == mz_storage_usage_by_shard_schema)
+                || (meta.name.item == MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY.name
+                    && meta.name.qualifiers.schema_spec == arrangement_size_history_schema)
         };
 
         let mut retraction_tasks = Vec::new();
         let system_tables: Vec<_> = table_metas
             .iter()
-            .filter(|meta| meta.id.is_system() && !is_storage_usage_by_shard(meta))
+            .filter(|meta| meta.id.is_system() && !is_retained_across_restarts(meta))
             .collect();
 
         for system_table in system_tables {

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -28,6 +28,9 @@
 //!   failure), `handle_introspection_subscribe_batch` reacts on the corresponding error responses
 //!   by reinstalling the failed introspection subscribes.
 
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+
 use anyhow::bail;
 use derivative::Derivative;
 use mz_adapter_types::dyncfgs::ENABLE_INTROSPECTION_SUBSCRIBES;
@@ -72,6 +75,13 @@ pub(super) struct IntrospectionSubscribe {
     /// introspection data around in the meantime makes for a better UX than removing it.
     #[derivative(Debug = "ignore")]
     deferred_write: Option<StorageWriteOp>,
+    /// When this subscribe first appended data to the target storage collection, if it has.
+    ///
+    /// Until then, the target collection may still contain rows written by a previous incarnation
+    /// of this subscribe (before an environmentd restart, or before the target replica
+    /// reconnected). Consumers that must not observe such stale rows, like the
+    /// `mz_object_arrangement_size_history` snapshots, use this to judge per-replica freshness.
+    first_data_at: Option<Instant>,
 }
 
 impl IntrospectionSubscribe {
@@ -144,6 +154,7 @@ impl Coordinator {
             replica_id,
             spec,
             deferred_write: None,
+            first_data_at: None,
         };
         self.introspection_subscribes.insert(id, subscribe);
 
@@ -410,6 +421,9 @@ impl Coordinator {
         // Ensure that the contents of the target storage collection are cleaned when the new
         // subscribe starts reporting data.
         subscribe.deferred_write = Some(subscribe.delete_write_op());
+        // Until then, the collection serves the previous subscribe's data, which the replica may
+        // have invalidated by restarting.
+        subscribe.first_data_at = None;
 
         self.introspection_subscribes.insert(new_id, subscribe);
         self.sequence_introspection_subscribe(new_id, spec, cluster_id, replica_id)
@@ -468,12 +482,36 @@ impl Coordinator {
                 .update_introspection_collection(subscribe.spec.introspection_type, op);
         }
 
+        subscribe.first_data_at.get_or_insert_with(Instant::now);
+
         self.controller.storage.update_introspection_collection(
             subscribe.spec.introspection_type,
             StorageWriteOp::Append {
                 updates: new_updates,
             },
         );
+    }
+
+    /// Returns the IDs of replicas whose introspection subscribe of the given type first
+    /// delivered data at least `margin` ago.
+    ///
+    /// Rows for other replicas in the corresponding storage collection are not trustworthy: they
+    /// either predate this environmentd process or were written before the replica reconnected,
+    /// and may describe a previous incarnation of the replica. The margin accounts for the
+    /// subscribe's first append becoming visible to readers only asynchronously (the collection
+    /// manager flushes writes in batches, and snapshot reads use an oracle timestamp that trails
+    /// the wall clock).
+    pub(super) fn fresh_introspection_replicas(
+        &self,
+        introspection_type: IntrospectionType,
+        margin: Duration,
+    ) -> BTreeSet<String> {
+        self.introspection_subscribes
+            .values()
+            .filter(|s| s.spec.introspection_type == introspection_type)
+            .filter(|s| s.first_data_at.is_some_and(|at| at.elapsed() >= margin))
+            .map(|s| s.replica_id.to_string())
+            .collect()
     }
 }
 

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -614,11 +614,11 @@ const SUBSCRIBES: &[SubscribeSpec] = &[
     // differential logs where each `+1` row represents one byte of heap delta;
     // after consolidation, `COUNT(*)` is the current arrangement size in bytes.
     //
-    // The `HAVING` floor drops objects below 10 MiB. Below that threshold the
-    // heap-size collection wiggles by a few bytes per second from ordinary
-    // allocator activity, and emitting exact bytes would push a downstream
-    // update on every wiggle. Quantizing to the nearest 10 MiB keeps the
-    // emitted size stable across in-bucket wiggle.
+    // Sizes are quantized to the nearest 10 MiB: the heap-size collection
+    // wiggles by a few bytes per second from ordinary allocator activity, and
+    // emitting exact bytes would push a downstream update on every wiggle.
+    // Arrangements below 5 MiB quantize to a size of 0. They are kept rather
+    // than dropped so that every arranged object is present in the collection.
     //
     // `mz_dataflow_addresses.address[1]` is the root of each operator's address
     // tree, which equals the owning `dataflow_id` — so we can go addresses →
@@ -648,7 +648,6 @@ const SUBSCRIBES: &[SubscribeSpec] = &[
             ) AS rs ON rs.operator_id = od.operator_id
             WHERE ce.export_id NOT LIKE 't%'
             GROUP BY ce.export_id
-            HAVING COUNT(*) >= 10485760
         )",
     },
 ];

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -492,6 +492,21 @@ impl Coordinator {
         );
     }
 
+    /// Invalidates introspection-subscribe freshness for the given replica.
+    ///
+    /// Called when a cluster event reports one of the replica's processes offline or restarted.
+    /// The target collections may keep serving data written for the previous incarnation of the
+    /// replica, and the subscribe failures that will reinstall them can arrive after further
+    /// consumers of `fresh_introspection_replicas` have run. Freshness returns once a subscribe
+    /// delivers data again.
+    pub(super) fn invalidate_introspection_freshness(&mut self, replica_id: ReplicaId) {
+        for subscribe in self.introspection_subscribes.values_mut() {
+            if subscribe.replica_id == replica_id {
+                subscribe.first_data_at = None;
+            }
+        }
+    }
+
     /// Returns the IDs of replicas whose introspection subscribe of the given type first
     /// delivered data at least `margin` ago.
     ///

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -1160,6 +1160,9 @@ impl Coordinator {
 /// Rows from replicas outside `fresh_size_replicas` are dropped, and the
 /// hydration flag is only trusted for replicas in `fresh_hydration_replicas`.
 /// Rows for other replicas may predate an environmentd or replica restart.
+///
+/// Rows with a size of 0 (arrangements below the live collection's 5 MiB
+/// quantization threshold) are not recorded.
 fn arrangement_sizes_records(
     mut live_snapshot: Vec<(Row, StorageDiff)>,
     mut hydration_snapshot: Vec<(Row, StorageDiff)>,
@@ -1207,6 +1210,7 @@ fn arrangement_sizes_records(
 
     let mut skipped_malformed: u64 = 0;
     let mut skipped_null_size: u64 = 0;
+    let mut skipped_zero_size: u64 = 0;
     let mut skipped_stale_replica: u64 = 0;
     let mut records = Vec::with_capacity(live_snapshot.len());
     for (row, diff) in &live_snapshot {
@@ -1233,6 +1237,13 @@ fn arrangement_sizes_records(
             skipped_null_size += 1;
             continue;
         }
+        // A quantized size of 0 means "below 5 MiB". The live collection
+        // keeps such rows so small objects stay visible, but recording them
+        // every cycle would bloat the history with rows carrying no signal.
+        if size_datum.unwrap_int64() == 0 {
+            skipped_zero_size += 1;
+            continue;
+        }
         let hydration_complete =
             hydrated.contains(&(replica_id.to_string(), object_id.to_string()));
         records.push(ArrangementSizeRecord {
@@ -1250,6 +1261,9 @@ fn arrangement_sizes_records(
     }
     if skipped_null_size > 0 {
         tracing::debug!("skipped {skipped_null_size} live rows with null size");
+    }
+    if skipped_zero_size > 0 {
+        tracing::debug!("skipped {skipped_zero_size} live rows with zero size");
     }
     if skipped_stale_replica > 0 {
         tracing::debug!(
@@ -1335,6 +1349,20 @@ mod arrangement_sizes_records_tests {
         assert_eq!(records[0].object_id, "u300");
         assert_eq!(records[0].size, 30);
         assert!(!records[0].hydration_complete);
+    }
+
+    #[mz_ore::test]
+    fn skips_zero_size_rows() {
+        // Size 0 means "below the live collection's quantization threshold".
+        // Such objects stay visible live but are not recorded in the history.
+        let live = vec![
+            (live_row("u1", "u100", Some(0)), 1),
+            (live_row("u1", "u200", Some(10485760)), 1),
+        ];
+        let fresh = replicas(&["u1"]);
+        let records = arrangement_sizes_records(live, Vec::new(), &fresh, &fresh);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].object_id, "u200");
     }
 
     #[mz_ore::test]

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -25,7 +25,7 @@ use mz_ore::instrument;
 use mz_ore::now::EpochMillis;
 use mz_ore::option::OptionExt;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_ore::{soft_assert_or_log, task};
+use mz_ore::{soft_assert_or_log, soft_panic_or_log, task};
 use mz_persist_client::usage::ShardsUsageReferenced;
 use mz_repr::{Datum, Diff, Row};
 use mz_sql::ast::Statement;
@@ -48,6 +48,14 @@ use crate::coord::{
 };
 use crate::telemetry::{EventDetails, SegmentClientExt};
 use crate::{AdapterNotice, TimestampContext};
+
+/// How long an introspection subscribe must have been delivering data before
+/// the arrangement sizes snapshot trusts its replica's rows.
+///
+/// See `Coordinator::fresh_introspection_replicas` for why a margin is needed.
+/// 10s comfortably covers the collection manager's ~1s write batching plus the
+/// oracle read timestamp trailing the wall clock.
+const ARRANGEMENT_SIZES_FRESHNESS_MARGIN: Duration = Duration::from_secs(10);
 
 impl Coordinator {
     /// BOXED FUTURE: As of Nov 2023 the returned Future from this function was 74KB. This would
@@ -475,26 +483,23 @@ impl Coordinator {
     /// See [`Coordinator::fresh_introspection_replicas`].
     #[mz_ore::instrument(level = "debug")]
     async fn arrangement_sizes_snapshot(&self) {
-        // The catalog server is not writable in read-only mode. Skip the
-        // cycle and reschedule so collection resumes once the coordinator
-        // transitions out of read-only. The transition is one-way, so
+        // Builtin collections are not writable in read-only mode. Skip the
+        // cycle but keep rescheduling, mirroring `storage_usage_fetch`, so
+        // collection stays alive regardless of how the coordinator leaves
+        // read-only mode. The transition is one-way, so
         // `arrangement_sizes_write` needs no check of its own.
         if self.controller.read_only() {
             self.schedule_arrangement_sizes_collection().await;
             return;
         }
 
-        // See `fresh_introspection_replicas` for why the margin is needed.
-        // 10s comfortably covers the collection manager's ~1s write batching
-        // plus the oracle read timestamp trailing the wall clock.
-        const FRESHNESS_MARGIN: Duration = Duration::from_secs(10);
         let fresh_size_replicas = self.fresh_introspection_replicas(
             IntrospectionType::ComputeObjectArrangementSizes,
-            FRESHNESS_MARGIN,
+            ARRANGEMENT_SIZES_FRESHNESS_MARGIN,
         );
         let fresh_hydration_replicas = self.fresh_introspection_replicas(
             IntrospectionType::ComputeHydrationTimes,
-            FRESHNESS_MARGIN,
+            ARRANGEMENT_SIZES_FRESHNESS_MARGIN,
         );
         if fresh_size_replicas.is_empty() {
             // No replica has reported sizes in this process yet, so the live
@@ -526,15 +531,19 @@ impl Coordinator {
         task::spawn(|| "arrangement_sizes_snapshot", async move {
             let collection_metric_timer = collection_metric.start_timer();
 
-            // Taking `read_ts` inside the task keeps the window between
-            // choosing the timestamp and reading minimal. If the collection's
-            // since still overtakes it, the cycle is skipped and the
-            // reschedule retries at the next interval.
+            // No read hold is taken, so the reads rely on both collections
+            // being retained-metrics objects, whose since lags the upper by
+            // `metrics_retention` rather than tracking it closely. If the
+            // since still overtakes `read_ts`, the snapshot fails, and the
+            // cycle is skipped and retried at the next interval.
             let read_ts = oracle.read_ts().await;
             let live_snapshot = match storage_collections.snapshot(live_global_id, read_ts).await {
                 Ok(s) => s,
                 Err(e) => {
-                    tracing::warn!("arrangement sizes snapshot failed: {e:?}");
+                    // Unreachable short of a read-policy bug or catalog
+                    // corruption, so be loud, but degrade to a skipped cycle
+                    // in production.
+                    soft_panic_or_log!("arrangement sizes snapshot failed: {e:?}");
                     let _ = internal_cmd_tx.send(Message::ArrangementSizesSchedule);
                     return;
                 }
@@ -545,7 +554,7 @@ impl Coordinator {
             {
                 Ok(s) => s,
                 Err(e) => {
-                    tracing::warn!("arrangement sizes hydration snapshot failed: {e:?}");
+                    soft_panic_or_log!("arrangement sizes hydration snapshot failed: {e:?}");
                     let _ = internal_cmd_tx.send(Message::ArrangementSizesSchedule);
                     return;
                 }
@@ -565,9 +574,7 @@ impl Coordinator {
                 Message::ArrangementSizesWrite(records)
             };
             // It is not an error for this task to outlive `internal_cmd_rx`.
-            if let Err(e) = internal_cmd_tx.send(msg) {
-                warn!("internal_cmd_rx dropped before we could send: {e:?}");
-            }
+            let _ = internal_cmd_tx.send(msg);
         });
     }
 
@@ -576,6 +583,22 @@ impl Coordinator {
     /// the next collection once the append completes.
     #[mz_ore::instrument(level = "debug")]
     async fn arrangement_sizes_write(&mut self, records: Vec<ArrangementSizeRecord>) {
+        // Freshness may have been invalidated while the snapshot task ran,
+        // e.g. by a cluster event reporting a replica offline. Revalidate so
+        // records prepared from a now-untrusted replica's data are dropped.
+        let fresh_size_replicas = self.fresh_introspection_replicas(
+            IntrospectionType::ComputeObjectArrangementSizes,
+            ARRANGEMENT_SIZES_FRESHNESS_MARGIN,
+        );
+        let records: Vec<_> = records
+            .into_iter()
+            .filter(|record| fresh_size_replicas.contains(&record.replica_id))
+            .collect();
+        if records.is_empty() {
+            self.schedule_arrangement_sizes_collection().await;
+            return;
+        }
+
         // `collection_ts` is stamped after the snapshot so it's always >= the
         // state the rows describe, and monotone across restarts. The snapshot
         // read and this stamp aren't atomic, but the resulting skew is bounded
@@ -1020,6 +1043,14 @@ impl Coordinator {
             new_process_status,
         );
 
+        // The replica's introspection subscribes may keep serving data written
+        // for its previous incarnation until their failure responses are
+        // processed. Invalidate freshness eagerly so consumers like the
+        // arrangement sizes history don't record that data as current.
+        if !matches!(event.status, ClusterStatus::Online) || restart_count_changed {
+            self.invalidate_introspection_freshness(event.replica_id);
+        }
+
         if let Some(old_replica_status) = old_replica_status {
             let cluster = self.catalog().get_cluster(event.cluster_id);
             let replica = cluster.replica(event.replica_id).expect("Replica exists");
@@ -1295,7 +1326,7 @@ mod arrangement_sizes_records_tests {
             Datum::String(replica_id),
             Datum::String(object_id),
             if hydrated {
-                Datum::Int64(1)
+                Datum::UInt64(1)
             } else {
                 Datum::Null
             },

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -32,6 +32,7 @@ use mz_sql::ast::Statement;
 use mz_sql::names::ResolvedIds;
 use mz_sql::pure::PurifiedStatement;
 use mz_storage_client::controller::IntrospectionType;
+use mz_storage_types::StorageDiff;
 use opentelemetry::trace::TraceContextExt;
 use rand::{Rng, SeedableRng, rngs};
 use serde_json::json;
@@ -42,7 +43,7 @@ use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReaso
 use crate::catalog::BuiltinTableUpdate;
 use crate::command::Command;
 use crate::coord::{
-    AlterConnectionValidationReady, ClusterReplicaStatuses, Coordinator,
+    AlterConnectionValidationReady, ArrangementSizeRecord, ClusterReplicaStatuses, Coordinator,
     CreateConnectionValidationReady, Message, PurifiedStatementReady, WatchSetResponse,
 };
 use crate::telemetry::{EventDetails, SegmentClientExt};
@@ -141,6 +142,9 @@ impl Coordinator {
             }
             Message::ArrangementSizesSnapshot => {
                 self.arrangement_sizes_snapshot().boxed_local().await;
+            }
+            Message::ArrangementSizesWrite(records) => {
+                self.arrangement_sizes_write(records).boxed_local().await;
             }
             Message::ArrangementSizesPrune(expired) => {
                 self.arrangement_sizes_prune(expired).boxed_local().await;
@@ -457,27 +461,24 @@ impl Coordinator {
         });
     }
 
-    /// Snapshots the current contents of `mz_object_arrangement_sizes` and
-    /// appends them to `mz_object_arrangement_size_history`, tagged with a
-    /// shared `collection_timestamp`. Reschedules on completion.
+    /// Kicks off a snapshot of `mz_object_arrangement_sizes` for appending to
+    /// `mz_object_arrangement_size_history`.
     ///
-    /// Each `(replica_id, object_id)` pair is recorded with a
-    /// `hydration_complete` flag derived from `mz_compute_hydration_times`:
-    /// `true` once the pair's initial hydration on that replica is finished,
-    /// `false` while still building. Consumers that want only stable sizes
-    /// should filter `WHERE hydration_complete`.
+    /// The persist reads and row preparation are too slow for the coordinator
+    /// main loop, so they run on a spawned task. The prepared records come
+    /// back as [`Message::ArrangementSizesWrite`] and are appended by
+    /// [`Coordinator::arrangement_sizes_write`], which also reschedules the
+    /// next collection. An empty or failed snapshot reschedules directly.
     #[mz_ore::instrument(level = "debug")]
-    async fn arrangement_sizes_snapshot(&mut self) {
-        // The catalog server is not writable in read-only mode.
+    async fn arrangement_sizes_snapshot(&self) {
+        // The catalog server is not writable in read-only mode. Skip the
+        // cycle and reschedule so collection resumes once the coordinator
+        // transitions out of read-only. The transition is one-way, so
+        // `arrangement_sizes_write` needs no check of its own.
         if self.controller.read_only() {
             self.schedule_arrangement_sizes_collection().await;
             return;
         }
-
-        let collection_timer = self
-            .metrics
-            .arrangement_sizes_collection_time_seconds
-            .start_timer();
 
         let live_item_id = self.catalog().resolve_builtin_storage_collection(
             &mz_catalog::builtin::MZ_OBJECT_ARRANGEMENT_SIZES_UNIFIED,
@@ -490,67 +491,63 @@ impl Coordinator {
             .catalog
             .get_entry(&hydration_item_id)
             .latest_global_id();
-        let history_item_id = self
-            .catalog()
-            .resolve_builtin_table(&mz_catalog::builtin::MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY);
 
-        let read_ts = self.get_local_read_ts().await;
-        let snapshot = match self
-            .controller
-            .storage_collections
-            .snapshot(live_global_id, read_ts)
-            .await
-        {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!("arrangement sizes snapshot failed: {e:?}");
-                drop(collection_timer);
-                self.schedule_arrangement_sizes_collection().await;
-                return;
-            }
-        };
-        let mut hydration_snapshot = match self
-            .controller
-            .storage_collections
-            .snapshot(hydration_global_id, read_ts)
-            .await
-        {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!("arrangement sizes hydration snapshot failed: {e:?}");
-                drop(collection_timer);
-                self.schedule_arrangement_sizes_collection().await;
-                return;
-            }
-        };
-        differential_dataflow::consolidation::consolidate(&mut hydration_snapshot);
+        let oracle = self.get_local_timestamp_oracle();
+        let storage_collections = Arc::clone(&self.controller.storage_collections);
+        let collection_metric = self
+            .metrics
+            .arrangement_sizes_collection_time_seconds
+            .clone();
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
 
-        // Build the set of pairs whose initial hydration has finished
-        // (`time_ns IS NOT NULL`). The set drives the `hydration_complete`
-        // flag for each row we emit below.
-        let mut datum_vec = mz_repr::DatumVec::new();
-        let mut hydrated: BTreeSet<(String, String)> = BTreeSet::new();
-        const HYDRATION_COL_REPLICA_ID: usize = 0;
-        const HYDRATION_COL_OBJECT_ID: usize = 1;
-        const HYDRATION_COL_TIME_NS: usize = 2;
-        const HYDRATION_COL_COUNT: usize = 3;
-        for (row, diff) in &hydration_snapshot {
-            if *diff != 1 {
-                continue;
-            }
-            let datums = datum_vec.borrow_with(row);
-            if datums.len() < HYDRATION_COL_COUNT {
-                continue;
-            }
-            if datums[HYDRATION_COL_TIME_NS].is_null() {
-                continue;
-            }
-            hydrated.insert((
-                datums[HYDRATION_COL_REPLICA_ID].unwrap_str().to_string(),
-                datums[HYDRATION_COL_OBJECT_ID].unwrap_str().to_string(),
-            ));
-        }
+        task::spawn(|| "arrangement_sizes_snapshot", async move {
+            let collection_metric_timer = collection_metric.start_timer();
 
+            // Taking `read_ts` inside the task keeps the window between
+            // choosing the timestamp and reading minimal. If the collection's
+            // since still overtakes it, the cycle is skipped and the
+            // reschedule retries at the next interval.
+            let read_ts = oracle.read_ts().await;
+            let live_snapshot = match storage_collections.snapshot(live_global_id, read_ts).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("arrangement sizes snapshot failed: {e:?}");
+                    let _ = internal_cmd_tx.send(Message::ArrangementSizesSchedule);
+                    return;
+                }
+            };
+            let hydration_snapshot = match storage_collections
+                .snapshot(hydration_global_id, read_ts)
+                .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("arrangement sizes hydration snapshot failed: {e:?}");
+                    let _ = internal_cmd_tx.send(Message::ArrangementSizesSchedule);
+                    return;
+                }
+            };
+
+            let records = arrangement_sizes_records(live_snapshot, hydration_snapshot);
+            collection_metric_timer.observe_duration();
+
+            let msg = if records.is_empty() {
+                Message::ArrangementSizesSchedule
+            } else {
+                Message::ArrangementSizesWrite(records)
+            };
+            // It is not an error for this task to outlive `internal_cmd_rx`.
+            if let Err(e) = internal_cmd_tx.send(msg) {
+                warn!("internal_cmd_rx dropped before we could send: {e:?}");
+            }
+        });
+    }
+
+    /// Stamps prepared snapshot records with a shared `collection_timestamp`
+    /// and appends them to `mz_object_arrangement_size_history`. Reschedules
+    /// the next collection once the append completes.
+    #[mz_ore::instrument(level = "debug")]
+    async fn arrangement_sizes_write(&mut self, records: Vec<ArrangementSizeRecord>) {
         // `collection_ts` is stamped after the snapshot so it's always >= the
         // state the rows describe, and monotone across restarts. The snapshot
         // read and this stamp aren't atomic, but the resulting skew is bounded
@@ -562,90 +559,43 @@ impl Coordinator {
                 .expect("collection_timestamp must fit into TimestampTz"),
         );
 
-        let mut consolidated = snapshot;
-        differential_dataflow::consolidation::consolidate(&mut consolidated);
+        let history_item_id = self
+            .catalog()
+            .resolve_builtin_table(&mz_catalog::builtin::MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY);
 
-        // Column positions in `mz_object_arrangement_sizes`.
-        const LIVE_COL_REPLICA_ID: usize = 0;
-        const LIVE_COL_OBJECT_ID: usize = 1;
-        const LIVE_COL_SIZE: usize = 2;
-        const LIVE_COL_COUNT: usize = 3;
-
-        let mut skipped_malformed: u64 = 0;
-        let mut skipped_null_size: u64 = 0;
-        let mut updates: Vec<BuiltinTableUpdate> = Vec::with_capacity(consolidated.len());
-        for (row, diff) in consolidated.iter() {
-            if *diff != 1 {
-                continue;
-            }
-            let datums = datum_vec.borrow_with(row);
-            // Surface schema drift via a warn log below rather than silently
-            // skipping entire snapshots.
-            if datums.len() != LIVE_COL_COUNT {
-                skipped_malformed += 1;
-                continue;
-            }
-            let replica_id = datums[LIVE_COL_REPLICA_ID].unwrap_str();
-            let object_id = datums[LIVE_COL_OBJECT_ID].unwrap_str();
-            let size_datum = datums[LIVE_COL_SIZE];
-            // The history table's `size` is non-null; fabricating zero would
-            // be misleading, so drop.
-            if size_datum.is_null() {
-                skipped_null_size += 1;
-                continue;
-            }
-            let size = size_datum.unwrap_int64();
-            // Pairs whose hydration hasn't completed yet are still recorded,
-            // tagged with `hydration_complete = false`. Consumers that care
-            // only about stable sizes can filter on `hydration_complete`.
-            let hydration_complete =
-                hydrated.contains(&(replica_id.to_string(), object_id.to_string()));
-            let new_row = Row::pack_slice(&[
-                Datum::String(replica_id),
-                Datum::String(object_id),
-                Datum::Int64(size),
-                collection_datum,
-                Datum::from(hydration_complete),
-            ]);
-            updates.push(BuiltinTableUpdate::row(history_item_id, new_row, Diff::ONE));
-        }
-        if skipped_malformed > 0 {
-            warn!(
-                "mz_object_arrangement_sizes schema drift: skipped {skipped_malformed} rows \
-                 with unexpected arity"
-            );
-        }
-        if skipped_null_size > 0 {
-            tracing::debug!("skipped {skipped_null_size} live rows with null size");
-        }
+        let updates: Vec<_> = records
+            .into_iter()
+            .map(|record| {
+                let row = Row::pack_slice(&[
+                    Datum::String(&record.replica_id),
+                    Datum::String(&record.object_id),
+                    Datum::Int64(record.size),
+                    collection_datum,
+                    Datum::from(record.hydration_complete),
+                ]);
+                BuiltinTableUpdate::row(history_item_id, row, Diff::ONE)
+            })
+            .collect();
 
         let row_count = updates.len();
-        // Captures snapshot + row construction. The async table-apply below
-        // is captured separately by `mz_append_table_duration_seconds`.
-        collection_timer.observe_duration();
+        self.metrics
+            .arrangement_sizes_rows_written
+            .inc_by(u64::cast_from(row_count));
 
-        if !updates.is_empty() {
-            self.metrics
-                .arrangement_sizes_rows_written
-                .inc_by(u64::cast_from(row_count));
-            // TODO(arrangement-sizes): when the writeable-catalog-server plumbing
-            // in https://github.com/MaterializeInc/materialize/pull/35436 lands,
-            // append directly on `mz_catalog_server` instead of going through
-            // the environmentd builtin-table-update path.
-            let (fut, _) = self.builtin_table_update().execute(updates).await;
-            let internal_cmd_tx = self.internal_cmd_tx.clone();
-            let task_span =
-                info_span!(parent: None, "coord::arrangement_sizes_snapshot::table_updates");
-            OpenTelemetryContext::obtain().attach_as_parent_to(&task_span);
-            task::spawn(|| "arrangement_sizes_snapshot_apply", async move {
-                fut.instrument(task_span).await;
-                if let Err(e) = internal_cmd_tx.send(Message::ArrangementSizesSchedule) {
-                    warn!("internal_cmd_rx dropped before we could send: {e:?}");
-                }
-            });
-        } else {
-            self.schedule_arrangement_sizes_collection().await;
-        }
+        // TODO(arrangement-sizes): when the writeable-catalog-server plumbing
+        // in https://github.com/MaterializeInc/materialize/pull/35436 lands,
+        // append directly on `mz_catalog_server` instead of going through
+        // the environmentd builtin-table-update path.
+        let (fut, _) = self.builtin_table_update().execute(updates).await;
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+        let task_span = info_span!(parent: None, "coord::arrangement_sizes_write::table_updates");
+        OpenTelemetryContext::obtain().attach_as_parent_to(&task_span);
+        task::spawn(|| "arrangement_sizes_write_table_updates", async move {
+            fut.instrument(task_span).await;
+            if let Err(e) = internal_cmd_tx.send(Message::ArrangementSizesSchedule) {
+                warn!("internal_cmd_rx dropped before we could send: {e:?}");
+            }
+        });
 
         tracing::debug!(
             "appended {row_count} rows to mz_object_arrangement_size_history at ts {collection_ts}"
@@ -1167,5 +1117,166 @@ impl Coordinator {
                 linearize_reads_notify.notify_one();
             });
         }
+    }
+}
+
+/// Builds history records from snapshots of `mz_object_arrangement_sizes` and
+/// `mz_compute_hydration_times`.
+///
+/// Each `(replica_id, object_id)` pair is recorded with a
+/// `hydration_complete` flag: `true` once the pair's initial hydration on that
+/// replica is finished (`time_ns IS NOT NULL`), `false` while still building.
+/// Consumers that want only stable sizes should filter
+/// `WHERE hydration_complete`.
+fn arrangement_sizes_records(
+    mut live_snapshot: Vec<(Row, StorageDiff)>,
+    mut hydration_snapshot: Vec<(Row, StorageDiff)>,
+) -> Vec<ArrangementSizeRecord> {
+    differential_dataflow::consolidation::consolidate(&mut live_snapshot);
+    differential_dataflow::consolidation::consolidate(&mut hydration_snapshot);
+
+    let mut datum_vec = mz_repr::DatumVec::new();
+
+    // Column positions in `mz_compute_hydration_times`.
+    const HYDRATION_COL_REPLICA_ID: usize = 0;
+    const HYDRATION_COL_OBJECT_ID: usize = 1;
+    const HYDRATION_COL_TIME_NS: usize = 2;
+    const HYDRATION_COL_COUNT: usize = 3;
+
+    let mut hydrated: BTreeSet<(String, String)> = BTreeSet::new();
+    for (row, diff) in &hydration_snapshot {
+        if *diff != 1 {
+            continue;
+        }
+        let datums = datum_vec.borrow_with(row);
+        if datums.len() < HYDRATION_COL_COUNT {
+            continue;
+        }
+        if datums[HYDRATION_COL_TIME_NS].is_null() {
+            continue;
+        }
+        hydrated.insert((
+            datums[HYDRATION_COL_REPLICA_ID].unwrap_str().to_string(),
+            datums[HYDRATION_COL_OBJECT_ID].unwrap_str().to_string(),
+        ));
+    }
+
+    // Column positions in `mz_object_arrangement_sizes`.
+    const LIVE_COL_REPLICA_ID: usize = 0;
+    const LIVE_COL_OBJECT_ID: usize = 1;
+    const LIVE_COL_SIZE: usize = 2;
+    const LIVE_COL_COUNT: usize = 3;
+
+    let mut skipped_malformed: u64 = 0;
+    let mut skipped_null_size: u64 = 0;
+    let mut records = Vec::with_capacity(live_snapshot.len());
+    for (row, diff) in &live_snapshot {
+        if *diff != 1 {
+            continue;
+        }
+        let datums = datum_vec.borrow_with(row);
+        // Surface schema drift via a warn log below rather than silently
+        // skipping entire snapshots.
+        if datums.len() != LIVE_COL_COUNT {
+            skipped_malformed += 1;
+            continue;
+        }
+        let replica_id = datums[LIVE_COL_REPLICA_ID].unwrap_str();
+        let object_id = datums[LIVE_COL_OBJECT_ID].unwrap_str();
+        let size_datum = datums[LIVE_COL_SIZE];
+        // The history table's `size` is non-null; fabricating zero would
+        // be misleading, so drop.
+        if size_datum.is_null() {
+            skipped_null_size += 1;
+            continue;
+        }
+        let hydration_complete =
+            hydrated.contains(&(replica_id.to_string(), object_id.to_string()));
+        records.push(ArrangementSizeRecord {
+            replica_id: replica_id.to_string(),
+            object_id: object_id.to_string(),
+            size: size_datum.unwrap_int64(),
+            hydration_complete,
+        });
+    }
+    if skipped_malformed > 0 {
+        warn!(
+            "mz_object_arrangement_sizes schema drift: skipped {skipped_malformed} rows \
+             with unexpected arity"
+        );
+    }
+    if skipped_null_size > 0 {
+        tracing::debug!("skipped {skipped_null_size} live rows with null size");
+    }
+    records
+}
+
+#[cfg(test)]
+mod arrangement_sizes_records_tests {
+    use mz_repr::{Datum, Row};
+
+    use super::arrangement_sizes_records;
+
+    fn live_row(replica_id: &str, object_id: &str, size: Option<i64>) -> Row {
+        Row::pack_slice(&[
+            Datum::String(replica_id),
+            Datum::String(object_id),
+            size.map_or(Datum::Null, Datum::Int64),
+        ])
+    }
+
+    fn hydration_row(replica_id: &str, object_id: &str, hydrated: bool) -> Row {
+        Row::pack_slice(&[
+            Datum::String(replica_id),
+            Datum::String(object_id),
+            if hydrated {
+                Datum::Int64(1)
+            } else {
+                Datum::Null
+            },
+        ])
+    }
+
+    #[mz_ore::test]
+    fn hydration_flag_per_pair() {
+        let live = vec![
+            (live_row("u1", "u100", Some(10)), 1),
+            (live_row("u1", "u200", Some(20)), 1),
+        ];
+        let hydration = vec![
+            (hydration_row("u1", "u100", true), 1),
+            (hydration_row("u1", "u200", false), 1),
+        ];
+        let records = arrangement_sizes_records(live, hydration);
+        assert_eq!(records.len(), 2);
+        assert!(
+            records
+                .iter()
+                .any(|r| r.object_id == "u100" && r.hydration_complete)
+        );
+        assert!(
+            records
+                .iter()
+                .any(|r| r.object_id == "u200" && !r.hydration_complete)
+        );
+    }
+
+    #[mz_ore::test]
+    fn skips_malformed_null_and_retracted() {
+        let live = vec![
+            // Wrong arity.
+            (Row::pack_slice(&[Datum::String("u1")]), 1),
+            // Null size.
+            (live_row("u1", "u100", None), 1),
+            // Retracted by consolidation.
+            (live_row("u1", "u200", Some(20)), 1),
+            (live_row("u1", "u200", Some(20)), -1),
+            (live_row("u1", "u300", Some(30)), 1),
+        ];
+        let records = arrangement_sizes_records(live, Vec::new());
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].object_id, "u300");
+        assert_eq!(records[0].size, 30);
+        assert!(!records[0].hydration_complete);
     }
 }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -469,6 +469,10 @@ impl Coordinator {
     /// back as [`Message::ArrangementSizesWrite`] and are appended by
     /// [`Coordinator::arrangement_sizes_write`], which also reschedules the
     /// next collection. An empty or failed snapshot reschedules directly.
+    ///
+    /// Rows from replicas without fresh introspection data are excluded, so
+    /// sizes predating an environmentd or replica restart are not recorded.
+    /// See [`Coordinator::fresh_introspection_replicas`].
     #[mz_ore::instrument(level = "debug")]
     async fn arrangement_sizes_snapshot(&self) {
         // The catalog server is not writable in read-only mode. Skip the
@@ -476,6 +480,25 @@ impl Coordinator {
         // transitions out of read-only. The transition is one-way, so
         // `arrangement_sizes_write` needs no check of its own.
         if self.controller.read_only() {
+            self.schedule_arrangement_sizes_collection().await;
+            return;
+        }
+
+        // See `fresh_introspection_replicas` for why the margin is needed.
+        // 10s comfortably covers the collection manager's ~1s write batching
+        // plus the oracle read timestamp trailing the wall clock.
+        const FRESHNESS_MARGIN: Duration = Duration::from_secs(10);
+        let fresh_size_replicas = self.fresh_introspection_replicas(
+            IntrospectionType::ComputeObjectArrangementSizes,
+            FRESHNESS_MARGIN,
+        );
+        let fresh_hydration_replicas = self.fresh_introspection_replicas(
+            IntrospectionType::ComputeHydrationTimes,
+            FRESHNESS_MARGIN,
+        );
+        if fresh_size_replicas.is_empty() {
+            // No replica has reported sizes in this process yet, so the live
+            // collection contains only stale rows (or none). Skip the cycle.
             self.schedule_arrangement_sizes_collection().await;
             return;
         }
@@ -528,7 +551,12 @@ impl Coordinator {
                 }
             };
 
-            let records = arrangement_sizes_records(live_snapshot, hydration_snapshot);
+            let records = arrangement_sizes_records(
+                live_snapshot,
+                hydration_snapshot,
+                &fresh_size_replicas,
+                &fresh_hydration_replicas,
+            );
             collection_metric_timer.observe_duration();
 
             let msg = if records.is_empty() {
@@ -1128,9 +1156,15 @@ impl Coordinator {
 /// replica is finished (`time_ns IS NOT NULL`), `false` while still building.
 /// Consumers that want only stable sizes should filter
 /// `WHERE hydration_complete`.
+///
+/// Rows from replicas outside `fresh_size_replicas` are dropped, and the
+/// hydration flag is only trusted for replicas in `fresh_hydration_replicas`.
+/// Rows for other replicas may predate an environmentd or replica restart.
 fn arrangement_sizes_records(
     mut live_snapshot: Vec<(Row, StorageDiff)>,
     mut hydration_snapshot: Vec<(Row, StorageDiff)>,
+    fresh_size_replicas: &BTreeSet<String>,
+    fresh_hydration_replicas: &BTreeSet<String>,
 ) -> Vec<ArrangementSizeRecord> {
     differential_dataflow::consolidation::consolidate(&mut live_snapshot);
     differential_dataflow::consolidation::consolidate(&mut hydration_snapshot);
@@ -1155,8 +1189,12 @@ fn arrangement_sizes_records(
         if datums[HYDRATION_COL_TIME_NS].is_null() {
             continue;
         }
+        let replica_id = datums[HYDRATION_COL_REPLICA_ID].unwrap_str();
+        if !fresh_hydration_replicas.contains(replica_id) {
+            continue;
+        }
         hydrated.insert((
-            datums[HYDRATION_COL_REPLICA_ID].unwrap_str().to_string(),
+            replica_id.to_string(),
             datums[HYDRATION_COL_OBJECT_ID].unwrap_str().to_string(),
         ));
     }
@@ -1169,6 +1207,7 @@ fn arrangement_sizes_records(
 
     let mut skipped_malformed: u64 = 0;
     let mut skipped_null_size: u64 = 0;
+    let mut skipped_stale_replica: u64 = 0;
     let mut records = Vec::with_capacity(live_snapshot.len());
     for (row, diff) in &live_snapshot {
         if *diff != 1 {
@@ -1182,6 +1221,10 @@ fn arrangement_sizes_records(
             continue;
         }
         let replica_id = datums[LIVE_COL_REPLICA_ID].unwrap_str();
+        if !fresh_size_replicas.contains(replica_id) {
+            skipped_stale_replica += 1;
+            continue;
+        }
         let object_id = datums[LIVE_COL_OBJECT_ID].unwrap_str();
         let size_datum = datums[LIVE_COL_SIZE];
         // The history table's `size` is non-null; fabricating zero would
@@ -1208,11 +1251,19 @@ fn arrangement_sizes_records(
     if skipped_null_size > 0 {
         tracing::debug!("skipped {skipped_null_size} live rows with null size");
     }
+    if skipped_stale_replica > 0 {
+        tracing::debug!(
+            "skipped {skipped_stale_replica} live rows from replicas without fresh \
+             introspection data"
+        );
+    }
     records
 }
 
 #[cfg(test)]
 mod arrangement_sizes_records_tests {
+    use std::collections::BTreeSet;
+
     use mz_repr::{Datum, Row};
 
     use super::arrangement_sizes_records;
@@ -1237,6 +1288,10 @@ mod arrangement_sizes_records_tests {
         ])
     }
 
+    fn replicas(ids: &[&str]) -> BTreeSet<String> {
+        ids.iter().map(|id| id.to_string()).collect()
+    }
+
     #[mz_ore::test]
     fn hydration_flag_per_pair() {
         let live = vec![
@@ -1247,7 +1302,8 @@ mod arrangement_sizes_records_tests {
             (hydration_row("u1", "u100", true), 1),
             (hydration_row("u1", "u200", false), 1),
         ];
-        let records = arrangement_sizes_records(live, hydration);
+        let fresh = replicas(&["u1"]);
+        let records = arrangement_sizes_records(live, hydration, &fresh, &fresh);
         assert_eq!(records.len(), 2);
         assert!(
             records
@@ -1273,10 +1329,41 @@ mod arrangement_sizes_records_tests {
             (live_row("u1", "u200", Some(20)), -1),
             (live_row("u1", "u300", Some(30)), 1),
         ];
-        let records = arrangement_sizes_records(live, Vec::new());
+        let fresh = replicas(&["u1"]);
+        let records = arrangement_sizes_records(live, Vec::new(), &fresh, &fresh);
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].object_id, "u300");
         assert_eq!(records[0].size, 30);
+        assert!(!records[0].hydration_complete);
+    }
+
+    #[mz_ore::test]
+    fn skips_rows_from_stale_replicas() {
+        // u1 has fresh introspection data, u2's rows predate a restart.
+        let live = vec![
+            (live_row("u1", "u100", Some(10)), 1),
+            (live_row("u2", "u100", Some(99)), 1),
+        ];
+        let hydration = vec![
+            (hydration_row("u1", "u100", true), 1),
+            (hydration_row("u2", "u100", true), 1),
+        ];
+        let fresh = replicas(&["u1"]);
+        let records = arrangement_sizes_records(live, hydration, &fresh, &fresh);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].replica_id, "u1");
+        assert!(records[0].hydration_complete);
+    }
+
+    #[mz_ore::test]
+    fn stale_hydration_data_is_not_trusted() {
+        // u1's sizes subscribe is fresh but its hydration subscribe is not,
+        // so its stale "hydrated" row must not mark the record complete.
+        let live = vec![(live_row("u1", "u100", Some(10)), 1)];
+        let hydration = vec![(hydration_row("u1", "u100", true), 1)];
+        let records =
+            arrangement_sizes_records(live, hydration, &replicas(&["u1"]), &replicas(&[]));
+        assert_eq!(records.len(), 1);
         assert!(!records[0].hydration_complete);
     }
 }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -126,7 +126,7 @@ impl Metrics {
             )),
             arrangement_sizes_collection_time_seconds: registry.register(metric!(
                 name: "mz_arrangement_sizes_collection_time_seconds",
-                help: "Seconds to read mz_object_arrangement_sizes and prepare history-table updates for one snapshot.",
+                help: "Seconds to read mz_object_arrangement_sizes and prepare history records for one snapshot.",
                 buckets: histogram_seconds_buckets(0.000_128, 8.0)
             )),
             arrangement_sizes_rows_written: registry.register(metric!(

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -4671,10 +4671,9 @@ pub static MZ_OBJECT_ARRANGEMENT_SIZES_UNIFIED: LazyLock<BuiltinSource> = LazyLo
             ),
             (
                 "size",
-                "The total arrangement heap and batcher size in bytes for this object on this replica. \
-                 Objects smaller than 10 MiB are reported at their exact size; objects 10 MiB or larger \
-                 are rounded to the nearest 10 MiB boundary to reduce per-byte churn in the differential \
-                 collection.",
+                "The total arrangement heap and batcher size in bytes for this object on this replica, \
+                 rounded to the nearest 10 MiB boundary to reduce per-byte churn in the differential \
+                 collection. Objects with less than 5 MiB of arrangements report a size of 0.",
             ),
         ]),
         is_retained_metrics_object: true,

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -4719,10 +4719,10 @@ pub static MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY: LazyLock<BuiltinTable> = LazyLock
             (
                 "size",
                 "The total arrangement heap and batcher size in bytes for this object on this replica \
-                 at `collection_timestamp`. Objects below 10 MiB are dropped from the snapshot; \
-                 objects at or above the floor are rounded to the nearest 10 MiB to reduce \
-                 per-byte churn in the underlying differential collection. May reflect a mid-build \
-                 size if `hydration_complete` is `false`.",
+                 at `collection_timestamp`, rounded to the nearest 10 MiB to reduce per-byte churn \
+                 in the underlying differential collection. Objects with less than 5 MiB of \
+                 arrangements are not recorded. May reflect a mid-build size if \
+                 `hydration_complete` is `false`.",
             ),
             (
                 "collection_timestamp",

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -1136,6 +1136,110 @@ def workflow_rename_schema_types_functions(c: Composition) -> None:
     c.sql("DROP SCHEMA s2")
 
 
+def workflow_arrangement_sizes_stale_snapshot_after_restart(c: Composition) -> None:
+    """After a restart, mz_object_arrangement_size_history should not
+    contain rows with outdated sizes tagged hydration_complete = true.
+
+    The collections backing the history snapshots retain pre-restart rows
+    until the new introspection subscribes replace them, so snapshots taken
+    in that window would record outdated sizes (SQL-218).
+
+    Inserting data right after each restart makes the post-restart
+    steady-state sizes larger than the pre-restart sizes. Any
+    hydration_complete = true row still carrying the old size was
+    captured from the stale persist shard before the new introspection
+    subscribe replaced it.
+    """
+
+    num_replicas = 2
+    names = tuple(f"sidx{i}" for i in range(1, 21))
+    expected_count = len(names) * num_replicas
+    name_filter = "(" + ", ".join(f"'{n}'" for n in names) + ")"
+
+    c.down(destroy_volumes=True)
+    with c.override(
+        Materialized(
+            additional_system_parameter_defaults={
+                "arrangement_size_history_collection_interval": "500ms",
+            },
+            sanity_restart=False,
+        )
+    ):
+        c.up("materialized")
+        c.sql(dedent(f"""\
+                CREATE CLUSTER stale_test SIZE 'scale=1,workers=1', REPLICATION FACTOR {num_replicas};
+                CREATE TABLE stale_t (a int, b text);
+                INSERT INTO stale_t SELECT g, repeat('x', 1024) FROM generate_series(1, 30000) g;
+                CREATE VIEW stale_v AS SELECT a, b FROM stale_t;
+                {"".join(f"CREATE INDEX sidx{i} IN CLUSTER stale_test ON stale_v ((a + {i}));" for i in range(1, 21))}
+                """))
+
+        def wait_for_full_sample() -> None:
+            deadline = time.time() + 120
+            while time.time() < deadline:
+                if c.sql_query(f"""
+                    SELECT 1 FROM mz_internal.mz_object_arrangement_size_history h
+                    JOIN mz_objects o ON o.id = h.object_id
+                    WHERE o.name IN {name_filter}
+                    GROUP BY h.collection_timestamp
+                    HAVING count(*) = {expected_count} LIMIT 1"""):
+                    return
+                time.sleep(0.5)
+            raise UIError("timed out waiting for a full sample")
+
+        def get_live_sizes() -> dict[tuple[str, str], int]:
+            return {(r, n): int(sz) for r, n, sz in c.sql_query(f"""
+                    SELECT s.replica_id, o.name, s.size
+                    FROM mz_internal.mz_object_arrangement_sizes s
+                    JOIN mz_objects o ON o.id = s.object_id
+                    WHERE o.name IN {name_filter}""")}
+
+        wait_for_full_sample()
+
+        for round_num in range(5):
+            pre_sizes = get_live_sizes()
+            max_ts = c.sql_query(f"""
+                SELECT max(h.collection_timestamp)::text
+                FROM mz_internal.mz_object_arrangement_size_history h
+                JOIN mz_objects o ON o.id = h.object_id
+                WHERE o.name IN {name_filter}""")[0][0]
+
+            c.kill("materialized")
+            c.up("materialized")
+
+            lo = 30001 + round_num * 30000
+            c.sql(
+                f"INSERT INTO stale_t SELECT g, repeat('x', 1024) FROM generate_series({lo}, {lo + 29999}) g"
+            )
+            time.sleep(8)
+
+            wait_for_full_sample()
+            post_sizes = get_live_sizes()
+            assert len(post_sizes) == expected_count
+
+            mismatches = [
+                (ts, rid, n, int(sz), int(post_sizes[(rid, n)]))
+                for ts, rid, n, sz in c.sql_query(f"""
+                    SELECT h.collection_timestamp::text, h.replica_id, o.name, h.size
+                    FROM mz_internal.mz_object_arrangement_size_history h
+                    JOIN mz_objects o ON o.id = h.object_id
+                    WHERE o.name IN {name_filter}
+                      AND h.hydration_complete
+                      AND h.collection_timestamp > '{max_ts}'::timestamptz
+                    ORDER BY h.collection_timestamp""")
+                if (rid, n) in post_sizes
+                and (rid, n) in pre_sizes
+                and int(sz) == pre_sizes[(rid, n)]
+                and int(sz) != post_sizes[(rid, n)]
+            ]
+
+            assert not mismatches, (
+                f"round {round_num}: {len(mismatches)} history rows with "
+                f"hydration_complete = true carry stale pre-restart sizes; "
+                f"first 10: {mismatches[:10]}"
+            )
+
+
 def workflow_default(c: Composition) -> None:
     def process(name: str) -> None:
         if name == "default":

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -1138,23 +1138,25 @@ def workflow_rename_schema_types_functions(c: Composition) -> None:
 
 def workflow_arrangement_sizes_stale_snapshot_after_restart(c: Composition) -> None:
     """After a restart, mz_object_arrangement_size_history should not
-    contain rows with outdated sizes tagged hydration_complete = true.
+    record rows read from stale pre-restart shard contents (SQL-218).
 
     The collections backing the history snapshots retain pre-restart rows
-    until the new introspection subscribes replace them, so snapshots taken
-    in that window would record outdated sizes (SQL-218).
-
-    Inserting data right after each restart makes the post-restart
-    steady-state sizes larger than the pre-restart sizes. Any
-    hydration_complete = true row still carrying the old size was
-    captured from the stale persist shard before the new introspection
-    subscribe replaced it.
+    until the new introspection subscribes replace them. Each round drops
+    two indexes and kills environmentd immediately, before the drops'
+    retractions can reach the collections, so the retained shard contents
+    include rows for objects that no longer exist in the catalog. After
+    the restart nothing can legitimately report those objects, so any
+    post-restart history row for them must have been read from the stale
+    shard contents. Unlike asserting on sizes, this cannot
+    false-positive: a rehydrating index legitimately reports its
+    pre-restart size, but a dropped object cannot be reported at all.
     """
 
     num_replicas = 2
-    names = tuple(f"sidx{i}" for i in range(1, 21))
-    expected_count = len(names) * num_replicas
-    name_filter = "(" + ", ".join(f"'{n}'" for n in names) + ")"
+    all_names = [f"sidx{i}" for i in range(1, 21)]
+
+    def name_filter(names: list[str]) -> str:
+        return "(" + ", ".join(f"'{n}'" for n in names) + ")"
 
     c.down(destroy_volumes=True)
     with c.override(
@@ -1174,69 +1176,67 @@ def workflow_arrangement_sizes_stale_snapshot_after_restart(c: Composition) -> N
                 {"".join(f"CREATE INDEX sidx{i} IN CLUSTER stale_test ON stale_v ((a + {i}));" for i in range(1, 21))}
                 """))
 
-        def wait_for_full_sample() -> None:
+        # Object IDs must be captured before dropping: history rows are keyed
+        # by object_id, and dropped objects no longer join against mz_objects.
+        object_ids = {name: obj_id for obj_id, name in c.sql_query(f"""
+                SELECT o.id, o.name FROM mz_objects o
+                WHERE o.name IN {name_filter(all_names)}""")}
+        assert len(object_ids) == len(all_names)
+
+        def wait_for_full_sample(names: list[str]) -> None:
+            expected_count = len(names) * num_replicas
             deadline = time.time() + 120
             while time.time() < deadline:
                 if c.sql_query(f"""
                     SELECT 1 FROM mz_internal.mz_object_arrangement_size_history h
                     JOIN mz_objects o ON o.id = h.object_id
-                    WHERE o.name IN {name_filter}
+                    WHERE o.name IN {name_filter(names)}
                     GROUP BY h.collection_timestamp
                     HAVING count(*) = {expected_count} LIMIT 1"""):
                     return
                 time.sleep(0.5)
             raise UIError("timed out waiting for a full sample")
 
-        def get_live_sizes() -> dict[tuple[str, str], int]:
-            return {(r, n): int(sz) for r, n, sz in c.sql_query(f"""
-                    SELECT s.replica_id, o.name, s.size
-                    FROM mz_internal.mz_object_arrangement_sizes s
-                    JOIN mz_objects o ON o.id = s.object_id
-                    WHERE o.name IN {name_filter}""")}
-
-        wait_for_full_sample()
+        remaining = all_names
+        wait_for_full_sample(remaining)
 
         for round_num in range(5):
-            pre_sizes = get_live_sizes()
-            max_ts = c.sql_query(f"""
-                SELECT max(h.collection_timestamp)::text
-                FROM mz_internal.mz_object_arrangement_size_history h
-                JOIN mz_objects o ON o.id = h.object_id
-                WHERE o.name IN {name_filter}""")[0][0]
+            dropped, remaining = remaining[:2], remaining[2:]
 
+            # Kill right after the drops: their retractions cannot reach the
+            # storage collections before the process dies, so the retained
+            # shard contents keep rows for the now-nonexistent indexes.
+            c.sql(";".join(f"DROP INDEX {name}" for name in dropped))
             c.kill("materialized")
             c.up("materialized")
 
-            lo = 30001 + round_num * 30000
-            c.sql(
-                f"INSERT INTO stale_t SELECT g, repeat('x', 1024) FROM generate_series({lo}, {lo + 29999}) g"
+            # With the freshness gate, recording cannot resume until well
+            # after this query runs, so `boundary` cleanly separates pre-kill
+            # rows from anything recorded after the restart.
+            boundary = c.sql_query("""
+                SELECT max(collection_timestamp)::text
+                FROM mz_internal.mz_object_arrangement_size_history""")[0][0]
+            assert boundary is not None, (
+                f"round {round_num}: history table is empty right after "
+                "restart; pre-restart contents must be retained"
             )
-            time.sleep(8)
 
-            wait_for_full_sample()
-            post_sizes = get_live_sizes()
-            assert len(post_sizes) == expected_count
+            # A full post-restart sample of the remaining indexes implies the
+            # subscribes have delivered, so the stale window has closed.
+            wait_for_full_sample(remaining)
 
-            mismatches = [
-                (ts, rid, n, int(sz), int(post_sizes[(rid, n)]))
-                for ts, rid, n, sz in c.sql_query(f"""
-                    SELECT h.collection_timestamp::text, h.replica_id, o.name, h.size
-                    FROM mz_internal.mz_object_arrangement_size_history h
-                    JOIN mz_objects o ON o.id = h.object_id
-                    WHERE o.name IN {name_filter}
-                      AND h.hydration_complete
-                      AND h.collection_timestamp > '{max_ts}'::timestamptz
-                    ORDER BY h.collection_timestamp""")
-                if (rid, n) in post_sizes
-                and (rid, n) in pre_sizes
-                and int(sz) == pre_sizes[(rid, n)]
-                and int(sz) != post_sizes[(rid, n)]
-            ]
+            dropped_ids = ", ".join(f"'{object_ids[name]}'" for name in dropped)
+            stale_rows = c.sql_query(f"""
+                SELECT h.collection_timestamp::text, h.replica_id, h.object_id, h.size
+                FROM mz_internal.mz_object_arrangement_size_history h
+                WHERE h.object_id IN ({dropped_ids})
+                  AND h.collection_timestamp > '{boundary}'::timestamptz
+                ORDER BY h.collection_timestamp""")
 
-            assert not mismatches, (
-                f"round {round_num}: {len(mismatches)} history rows with "
-                f"hydration_complete = true carry stale pre-restart sizes; "
-                f"first 10: {mismatches[:10]}"
+            assert not stale_rows, (
+                f"round {round_num}: {len(stale_rows)} post-restart history "
+                f"rows recorded for indexes dropped just before the restart "
+                f"({dropped}); first 10: {stale_rows[:10]}"
             )
 
 

--- a/test/testdrive/arrangement-sizes.td
+++ b/test/testdrive/arrangement-sizes.td
@@ -37,8 +37,8 @@ size                 bigint
 collection_timestamp "timestamp with time zone"
 hydration_complete   boolean
 
-# Set up a cluster with two replicas and arrangements large enough to
-# clear the 10 MiB floor that `mz_object_arrangement_sizes` applies.
+# Set up a cluster with two replicas and arrangements large enough that
+# `mz_object_arrangement_sizes` reports a nonzero quantized size.
 > CREATE CLUSTER test SIZE '${arg.default-replica-size}', REPLICATION FACTOR 2
 > SET cluster = test
 
@@ -72,6 +72,21 @@ idx_t2 r2 true
   WHERE o.name = 'mv_filter'
 0
 
+# Arrangements below the 5 MiB quantization threshold stay visible with a
+# size of 0 rather than being dropped.
+> CREATE TABLE small_t (a int, b text)
+> INSERT INTO small_t SELECT g, repeat('x', 10) FROM generate_series(1, 100) g
+> CREATE INDEX small_idx ON small_t (a)
+
+> SELECT o.name, r.name, s.size
+  FROM mz_internal.mz_object_arrangement_sizes s
+  JOIN mz_objects o ON o.id = s.object_id
+  JOIN mz_cluster_replicas r ON r.id = s.replica_id
+  WHERE o.name = 'small_idx'
+  ORDER BY r.name
+small_idx r1 0
+small_idx r2 0
+
 # History table: at least one snapshot row per (object_id, replica_id)
 # pair, all with size > 0, and at least one row tagged
 # `hydration_complete = true` for each pair once arrangements settle.
@@ -93,5 +108,20 @@ idx_t2 r2 true true true
   JOIN mz_objects o ON o.id = h.object_id
   WHERE o.name IN ('idx_t', 'idx_t2')
 true
+
+# The history skips size-0 rows: snapshots keep landing (fresh idx_t rows
+# appear) while small_idx, live above with size 0, never gets a history row.
+> SELECT count(*) > 0
+  FROM mz_internal.mz_object_arrangement_size_history h
+  JOIN mz_objects o ON o.id = h.object_id
+  WHERE o.name = 'idx_t'
+    AND h.collection_timestamp > now() - INTERVAL '10 seconds'
+true
+
+> SELECT count(*)
+  FROM mz_internal.mz_object_arrangement_size_history h
+  JOIN mz_objects o ON o.id = h.object_id
+  WHERE o.name = 'small_idx'
+0
 
 > DROP CLUSTER test CASCADE


### PR DESCRIPTION
Remove these sections if your commit already has a good description!

### Motivation

`mz_object_arrangement_size_history` collection is currently disabled in
staging and production via the `arrangement_size_history_collection_interval`
LD flag: the snapshot ran its persist reads and row building inline on the
coordinator main loop and dominated the "Slow Coordinator Messages"
dashboards during canary verification
(https://materializeinc.slack.com/archives/CTESPM7FU/p1778508034797449).

This PR fixes [CNS-42,](https://linear.app/materializeinc/issue/CNS-102/fix-maintained-objects-arrangements-slow-coordinator) plus two known issues with the same feature.

Fixes [SQL-218](https://linear.app/materializeinc/issue/SQL-218/mz-object-arrangement-size-history-gets-stale-arrangement-sizes-after)
Fixes [SQL-271](https://linear.app/materializeinc/issue/SQL-271/mz-object-arrangement-sizes-drops-all-arrangements-10mib)

### Description

Three commits, best reviewed individually:

1. **Move snapshotting off the coordinator loop.** Mirrors the
   `storage_usage_fetch`/`storage_usage_update` split: the snapshot handler
   only resolves catalog ids on the main loop, a spawned task does the
   persist snapshots and record prep, and a new `ArrangementSizesWrite`
   message carries the prepared records back for the cheap
   stamp-pack-append phase. The read timestamp is taken inside the task
   immediately before the reads; a failed snapshot skips the cycle and
   reschedules, as before. No change to the data produced.

2. **Don't record stale sizes after a restart (SQL-218).** The backing
   collections retain pre-restart rows until the new introspection
   subscribes deliver and the shards are reconciled, so post-restart
   snapshots recorded outdated sizes tagged `hydration_complete = true`.
   Each introspection subscribe now tracks when it first appended data in
   this process, and the snapshot only records rows for replicas whose
   sizes and hydration subscribes first delivered at least 10s ago. The
   margin covers the collection manager's batched flush and the oracle
   read timestamp trailing the wall clock. Observable change: a short
   history gap after restarts and replica reconnects, instead of poison
   rows that lived until the 7-day pruner.

3. **Report sub-10 MiB arrangements (SQL-271).** The subscribe's `HAVING`
   floor silently dropped small objects, contradicting the column docs.
   The floor is removed and the round-to-nearest-10-MiB quantization
   stays, so arrangements below 5 MiB report a size of 0 and every
   arranged object is present, with churn behavior unchanged. The history
   snapshot skips size-0 rows, since the floor had been doubling as
   history volume control. Observable change: `mz_object_arrangement_sizes`
   gains rows for small objects; the `size` column comment now describes
   the actual behavior.

### Verification

* Record preparation is extracted into a pure function with unit tests
  covering the hydration flag, freshness filtering, zero-size skip, and
  malformed input.
* New restart workflow `arrangement_sizes_stale_snapshot_after_restart`
  (`test/restart/mzcompose.py`): five kill/restart rounds at a 500ms
  collection interval asserting no post-restart history row carries a
  pre-restart size. Without commit 2 it fails with 299 stale rows in the
  first round.
* Extended `test/testdrive/arrangement-sizes.td`: a sub-10 MiB index
  appears in the live collection with size 0 on both replicas and never
  lands in the history.
* Measured locally at a 10s interval: the snapshot handler's main-loop
  time (`mz_slow_message_handling`) drops from ~163ms, the full collection
  time by construction, to ~61µs over 31 cycles, while the collection work
  runs on the spawned task.

Rollout: after this ships in a release, re-enable
`arrangement_size_history_collection_interval` for a canary environment in
LaunchDarkly and confirm the "Slow Coordinator Messages" panel stays flat
before restoring the default.