### PR TITLE
sql: avoid LocalId collisions in EXPLAIN RAW PLAN

### DIFF
--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -158,6 +158,11 @@ fn id_gen(expr: &HirRelationExpr) -> impl Iterator<Item = LocalId> + use<> {
     expr.visit_pre(&mut |expr| {
         match expr {
             HirRelationExpr::Let { id, .. } => max_id = std::cmp::max(max_id, id.into()),
+            HirRelationExpr::LetRec { bindings, .. } => {
+                for (_, id, _, _) in bindings {
+                    max_id = std::cmp::max(max_id, id.into());
+                }
+            }
             _ => (),
         };
     });

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -662,6 +662,36 @@ Target cluster: mz_catalog_server
 
 EOF
 
+# Regression test for CLU-149: hoisted subquery bindings must not collide with
+# the LocalIds bound by WITH MUTUALLY RECURSIVE.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+WITH MUTUALLY RECURSIVE
+    a (x int4) AS (SELECT 1),
+    b (x int4) AS (SELECT x FROM a WHERE EXISTS (SELECT 1 FROM a))
+SELECT * FROM b;
+----
+With Mutually Recursive
+  cte [l0 as a] =
+    Map (1)
+      Constant
+        - ()
+  cte [l1 as b] =
+    With
+      cte [l2 as subquery-2] =
+        Project (#1)
+          Map (1)
+            Get l0
+    Return
+      Filter exists(Get l2)
+        Get l0
+Return
+  Get l1
+
+Target cluster: mz_catalog_server
+
+EOF
+
 statement ok
 CREATE TABLE accounts(id int, balance int);
 


### PR DESCRIPTION
### Motivation

Fixes https://linear.app/materializeinc/issue/CLU-149/explain-raw-plan-has-colliding-localids

### Description

`EXPLAIN RAW PLAN` hoists subqueries into `Let` bindings for rendering.
The id generator picked fresh LocalIds by scanning existing `Let` nodes only.
`WITH MUTUALLY RECURSIVE` binds LocalIds via `LetRec`, so a hoisted subquery could reuse an id already bound by a recursive CTE, producing colliding names in the rendered plan.
The generator now also scans `LetRec` binding ids.

### Verification

Regression test in `test/sqllogictest/explain/raw_plan_as_text.slt` with the query from the issue.
It reproduces the collision without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)