### PR TITLE
catalog: keep replica-drop 'paused' in source/sink status views

### DIFF
--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -1824,9 +1824,10 @@ pub static MZ_SOURCE_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
     -- We ignore per-replica events from replicas that no longer exist. A dropped
     -- replica's last reported status is stale: without this filter a defunct
     -- replica's lingering 'running' can outrank (see precedence below) a live
-    -- replica's 'stalled', hiding a genuinely broken source. '<source>' is the
-    -- sentinel for source-global events (replica_id was NULL), which are always
-    -- relevant and so are always retained.
+    -- replica's 'stalled', hiding a genuinely broken source. We always retain
+    -- source-global events ('<source>' is the sentinel for replica_id NULL)
+    -- and 'paused' events. A per-replica 'paused' is only written when the
+    -- replica is dropped, so it is a terminal drop marker, not a stale report.
     latest_per_replica_events AS
     (
         SELECT DISTINCT ON (source_id, replica_id)
@@ -1834,13 +1835,15 @@ pub static MZ_SOURCE_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
         FROM uniform_status_history
         WHERE replica_id = '<source>'
             OR replica_id IN (SELECT id FROM mz_catalog.mz_cluster_replicas)
+            OR status = 'paused'
         ORDER BY source_id, replica_id, occurred_at DESC
     ),
     -- We have a precedence list that determines the overall status in case
     -- there is differing per-replica (including source-global) statuses. If
     -- there is no 'dropped' status, and any replica reports 'running', the
     -- overall status is 'running' even if there might be some replica that has
-    -- errors or is paused.
+    -- errors or is paused. Precedence ties are broken by recency, so a dropped
+    -- replica's 'paused' wins over an older source-global 'paused'.
     latest_events AS
     (
        SELECT DISTINCT ON (source_id)
@@ -1858,7 +1861,7 @@ pub static MZ_SOURCE_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
                     WHEN 'paused' THEN 5
                     WHEN 'ceased' THEN 6
                     ELSE 7  -- For any other status values
-                END
+                END, occurred_at DESC
     ),
     -- Determine which sources are subsources and which are parent sources
     subsources AS
@@ -2103,9 +2106,10 @@ uniform_status_history AS
 -- We ignore per-replica events from replicas that no longer exist. A dropped
 -- replica's last reported status is stale: without this filter a defunct
 -- replica's lingering 'running' can outrank (see precedence below) a live
--- replica's 'stalled', hiding a genuinely broken sink. '<sink>' is the
--- sentinel for sink-global events (replica_id was NULL), which are always
--- relevant and so are always retained.
+-- replica's 'stalled', hiding a genuinely broken sink. We always retain
+-- sink-global events ('<sink>' is the sentinel for replica_id NULL)
+-- and 'paused' events. A per-replica 'paused' is only written when the
+-- replica is dropped, so it is a terminal drop marker, not a stale report.
 latest_per_replica_events AS
 (
     SELECT DISTINCT ON (sink_id, replica_id)
@@ -2113,13 +2117,15 @@ latest_per_replica_events AS
     FROM uniform_status_history
     WHERE replica_id = '<sink>'
         OR replica_id IN (SELECT id FROM mz_catalog.mz_cluster_replicas)
+        OR status = 'paused'
     ORDER BY sink_id, replica_id, occurred_at DESC
 ),
 -- We have a precedence list that determines the overall status in case
 -- there is differing per-replica (including sink-global) statuses. If
 -- there is no 'dropped' status, and any replica reports 'running', the
 -- overall status is 'running' even if there might be some replica that has
--- errors or is paused.
+-- errors or is paused. Precedence ties are broken by recency, so a dropped
+-- replica's 'paused' wins over an older sink-global 'paused'.
 latest_events AS
 (
     SELECT DISTINCT ON (sink_id)
@@ -2137,7 +2143,7 @@ latest_events AS
                 WHEN 'paused' THEN 5
                 WHEN 'ceased' THEN 6
                 ELSE 7  -- For any other status values
-            END
+            END, occurred_at DESC
 )
 SELECT
     mz_sinks.id,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -576,6 +576,8 @@ impl StorageController for Controller {
         let mut source_status_updates = vec![];
         let mut sink_status_updates = vec![];
 
+        // NOTE: mz_source_statuses and mz_sink_statuses rely on per-replica `paused` meaning
+        // "replica dropped"
         let make_update = |id, object_type| StatusUpdate {
             id,
             status: Status::Paused,

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -2872,7 +2872,7 @@ mz_internal.mz_sink_statuses:
             Project: #0..=#4
               →Non-monotonic TopK
                 Group By #1
-                Order By #5 asc nulls_last
+                Order By #5 asc nulls_last, #0 desc nulls_first
                 Limit 1
                 →Map/Filter/Project
                   Project: #0..=#4, #6
@@ -2882,21 +2882,27 @@ mz_internal.mz_sink_statuses:
                       Order By #0 desc nulls_first
                       Limit 1
                       →Differential Join %0:l0[#5] » %1[#0]
+                        after %1:
+                          Project: #1..=#5, #0
+                          Filter: (#6 OR (#3{status} = "paused") OR (#0{replica_id} = "<sink>"))
                         →Arrange (#5)
                           →Fused with Child Map/Filter/Project
                             Filter: NOT(like["s%"](#1{sink_id}))
                               →Read l0
                         →Arrange (#0)
-                          →Consolidating Union
-                            →Stream l2
-                            →Negate Diffs
-                              →Fused with Child Map/Filter/Project
-                                Filter: (#0 = "<sink>")
-                                  →Read l2
+                          →Union
                             →Fused with Child Map/Filter/Project
-                              Filter: (#0 = "<sink>")
-                                →Index Lookup on l1
-                                  Key: (#0) Value: ("<sink>")
+                              Project: #0, #1
+                              Map: true
+                                →Read l2
+                            →Map/Filter/Project
+                              Project: #0, #1
+                              Map: false
+                                →Consolidating Union
+                                  →Negate Diffs
+                                    →Stream l2
+                                  →Unarranged Raw Stream
+                                    →Arranged l1
   →Return
     →Map/Filter/Project
       Project: #0..=#3, #7, #5, #6
@@ -3064,7 +3070,7 @@ mz_internal.mz_source_statuses:
         Project: #0..=#4
           →Non-monotonic TopK
             Group By #1
-            Order By #5 asc nulls_last
+            Order By #5 asc nulls_last, #0 desc nulls_first
             Limit 1
             →Map/Filter/Project
               Project: #0..=#4, #6
@@ -3074,19 +3080,25 @@ mz_internal.mz_source_statuses:
                   Order By #0 desc nulls_first
                   Limit 1
                   →Differential Join %0:l0[#5] » %1[#0]
+                    after %1:
+                      Project: #1..=#5, #0
+                      Filter: (#6 OR (#3{status} = "paused") OR (#0{replica_id} = "<source>"))
                     →Arrange (#5)
                       →Stream l0
                     →Arrange (#0)
-                      →Consolidating Union
-                        →Stream l2
-                        →Negate Diffs
-                          →Fused with Child Map/Filter/Project
-                            Filter: (#0 = "<source>")
-                              →Read l2
+                      →Union
                         →Fused with Child Map/Filter/Project
-                          Filter: (#0 = "<source>")
-                            →Index Lookup on l1
-                              Key: (#0) Value: ("<source>")
+                          Project: #0, #1
+                          Map: true
+                            →Read l2
+                        →Map/Filter/Project
+                          Project: #0, #1
+                          Map: false
+                            →Consolidating Union
+                              →Negate Diffs
+                                →Stream l2
+                              →Unarranged Raw Stream
+                                →Arranged l1
     cte l4 =
       →Arranged mz_catalog.mz_sources
     cte l5 =

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -225,19 +225,20 @@ pg_tbl         paused    "{\"hints\":[\"The replica running this source has been
 mysql          paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
 mysql_tbl      paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
 
-> SELECT o.name, s.status FROM mz_internal.mz_source_statuses s JOIN mz_objects o USING (id)
-accounts       paused
-auction        paused
-auctions       paused
-bids           paused
-organizations  paused
-users          paused
-kafka          paused
-kafka_tbl      paused
-pg             paused
-pg_tbl         paused
-mysql          paused
-mysql_tbl      paused
+# The dropped replica's 'paused' must win over the older source-global 'paused'.
+> SELECT o.name, s.status, s.details FROM mz_internal.mz_source_statuses s JOIN mz_objects o USING (id)
+accounts       paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+auction        paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+auctions       paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+bids           paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+organizations  paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+users          paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+kafka          paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+kafka_tbl      paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+pg             paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+pg_tbl         paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+mysql          paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
+mysql_tbl      paused  "{\"hints\":[\"The replica running this source has been dropped\"]}"
 
 > ALTER CLUSTER sources SET (REPLICATION FACTOR 1)
 
@@ -426,9 +427,10 @@ kafka1  paused    "{\"hints\":[\"The replica running this sink has been dropped\
   LIMIT 1
 kafka2  paused    "{\"hints\":[\"The replica running this sink has been dropped\"]}"   ${replica_id_1}
 
-> SELECT o.name, s.status FROM mz_internal.mz_sink_statuses s JOIN mz_objects o USING (id)
-kafka1  paused
-kafka2  paused
+# The dropped replica's 'paused' must win over the older sink-global 'paused'.
+> SELECT o.name, s.status, s.details FROM mz_internal.mz_sink_statuses s JOIN mz_objects o USING (id)
+kafka1  paused  "{\"hints\":[\"The replica running this sink has been dropped\"]}"
+kafka2  paused  "{\"hints\":[\"The replica running this sink has been dropped\"]}"
 
 > ALTER CLUSTER sinks SET (REPLICATION FACTOR 1)
 


### PR DESCRIPTION
The dead-replica filter in mz_source_statuses and mz_sink_statuses (#37453) also discarded the terminal per-replica 'paused' that the storage controller writes when a replica is dropped. That row is the only fresh diagnostic after repeated REPLICATION FACTOR 0 cycles, since the status-history dedup suppresses repeated object-global 'paused' rows. Retain 'paused' rows from dropped replicas and break precedence ties by recency so the drop marker wins over an older global 'paused'.