### PR TITLE
ci: re-enable the Kafka auth test suite (fixes for Confluent Platform 8.x)

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -444,7 +444,6 @@ steps:
               composition: kafka-auth
         agents:
           queue: hetzner-aarch64-8cpu-16gb
-        skip: "https://linear.app/materializeinc/issue/SS-115"
 
       - id: kafka-exactly-once
         label: Kafka exactly-once

--- a/test/kafka-auth/schema-registry.jaas.config
+++ b/test/kafka-auth/schema-registry.jaas.config
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// NOTE: Jetty 12 (Confluent Platform 8.x) moved the JAAS login modules from
+// org.eclipse.jetty.jaas.spi to org.eclipse.jetty.security.jaas.spi.
 SchemaRegistry {
-    org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required file="/etc/schema-registry/user.properties";
+    org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule required file="/etc/schema-registry/user.properties";
 };

--- a/test/kafka-auth/test-kafka-mssl.td
+++ b/test/kafka-auth/test-kafka-mssl.td
@@ -29,7 +29,11 @@ banana
     BROKER 'kafka:9094',
     SSL CERTIFICATE AUTHORITY = '${ca-crt}'
   )
-contains:ssl/tls alert bad certificate
+# NOTE: the exact alert text varies with the negotiated TLS version and
+# OpenSSL build (TLS 1.2: "ssl/tls alert bad certificate", TLS 1.3:
+# "tlsv13 alert certificate required"), so assert only that the broker
+# rejected the connection with a TLS alert.
+contains:alert
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9094',
@@ -37,7 +41,7 @@ contains:ssl/tls alert bad certificate
     SSL KEY SECRET kafka1_key,
     SSL CERTIFICATE AUTHORITY '${ca-crt}'
   )
-contains:ssl/tls alert certificate unknown
+contains:alert
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9094',

--- a/test/kafka-auth/test-kafka-sasl-mssl.td
+++ b/test/kafka-auth/test-kafka-sasl-mssl.td
@@ -33,7 +33,11 @@ banana
     SASL PASSWORD SECRET password,
     SSL CERTIFICATE AUTHORITY = '${ca-crt}'
   )
-contains:ssl/tls alert bad certificate
+# NOTE: the exact alert text varies with the negotiated TLS version and
+# OpenSSL build (TLS 1.2: "ssl/tls alert bad certificate", TLS 1.3:
+# "tlsv13 alert certificate required"), so assert only that the broker
+# rejected the connection with a TLS alert.
+contains:alert
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9097',
@@ -44,7 +48,7 @@ contains:ssl/tls alert bad certificate
     SSL KEY SECRET kafka1_key,
     SSL CERTIFICATE AUTHORITY '${ca-crt}'
   )
-contains:ssl/tls alert certificate unknown
+contains:alert
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9097',


### PR DESCRIPTION
## Summary

Re-enables the Kafka auth test suite, disabled since #36405 (SS-115), and fixes the two breakages that accumulated while it was dark.

## What broke while the suite was disabled

The Confluent Platform 7.9.4 → 8.2.0 bump (#36683) landed three weeks after the suite was skipped, and broke its setup in two ways nothing could catch:

1. **Schema registry basic auth returned 401 for everyone.** CP 8.x ships Jetty 12, which moved the JAAS login modules from `org.eclipse.jetty.jaas.spi` to `org.eclipse.jetty.security.jaas.spi`. Our `schema-registry.jaas.config` referenced the old class, so the login module never loaded and every request, correct credentials included, got 401. Verified directly: `curl -u materialize:sekurity` against the container → 401 before, 200 after the one-line class-path fix (wrong/missing creds still 401).
2. **Kafka mssl negative tests asserted TLS 1.2 alert text.** CP 8.x brokers negotiate TLS 1.3, where a missing/untrusted client certificate fails with `tlsv13 alert certificate required` (alert 116) instead of `ssl/tls alert bad certificate` (alert 42). The assertions now check only that the broker rejected the connection with a TLS alert. The exact wording is a function of TLS version and OpenSSL build that we do not control. This is the third exact-text loosening in this suite's history (#30501, #36232), so the loosening deliberately goes all the way rather than chasing the new strings.

## On the original SS-115 flake

The `PEM routines:get_name:no start line` flake that got the suite disabled did not reproduce in local full-suite runs against current main images (reqwest 0.12) or against the reqwest 0.13.4 branch (#37469). Timeline evidence from SS-115 itself shows the flake continued after the reqwest 0.13 revert (#36241), so reqwest was likely misattributed. If it resurfaces, the `ci-regexp` in SS-115 will link it; the suite being enabled is what gives us the data to root-cause it.

## Why now

Two in-flight workstreams change exactly the surface this suite covers: the reqwest 0.13 re-application (#37469) and the rdkafka → AWS-LC switch (#35941). Landing those with this suite dark is how auth/TLS regressions reach production unobserved.

## Test plan

- [x] Full suite green locally against main images (all fixes applied)
- [x] Repeated local runs to probe for the SS-115 flake: 8 consecutive local full-suite passes (5-run loop + 3 individual), plus 2 clean runs on the reqwest-0.12 main baseline. The PEM flake did not reproduce.
- [ ] Kafka auth 1–3 green in this PR's CI (the un-skip makes them run here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

