### PR TITLE
Reject `\0` bytes in text

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -745,6 +745,11 @@ fn test_pgtest_notice() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_nul() {
+    pg_test_inner(Path::new("../../test/pgtest/nul.pt"), false);
+}
+
+#[mz_ore::test]
 fn test_pgtest_params() {
     pg_test_inner(Path::new("../../test/pgtest/params.pt"), false);
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -354,6 +354,12 @@ fn convert_from<'a>(a: &'a [u8], b: &str) -> Result<&'a str, EvalError> {
     }
 
     match str::from_utf8(a) {
+        // Match PostgreSQL, which rejects NUL bytes because text values must
+        // never contain them.
+        Ok(from) if from.contains('\0') => Err(EvalError::InvalidByteSequence {
+            byte_sequence: "0x00".into(),
+            encoding_name,
+        }),
         Ok(from) => Ok(from),
         Err(e) => Err(EvalError::InvalidByteSequence {
             byte_sequence: e.to_string().into(),

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -27,7 +27,7 @@ pub mod oid;
 pub use types::{
     ANYCOMPATIBLELIST, ANYCOMPATIBLEMAP, LIST, MAP, Type, TypeConversionError, TypeFromOidError,
 };
-pub use value::error::IntoDatumError;
+pub use value::error::{IntoDatumError, NulCharacterError};
 pub use value::interval::Interval;
 pub use value::jsonb::Jsonb;
 pub use value::numeric::Numeric;

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -33,7 +33,7 @@ use postgres_types::{FromSql, IsNull, ToSql, Type as PgType};
 use uuid::Uuid;
 
 use crate::types::{NumericConstraints, UINT2, UINT4, UINT8};
-use crate::value::error::IntoDatumError;
+use crate::value::error::{IntoDatumError, NulCharacterError};
 use crate::{Interval, Jsonb, Numeric, Type, UInt2, UInt4, UInt8};
 
 pub mod error;
@@ -670,6 +670,9 @@ impl Value {
         raw: &'a [u8],
     ) -> Result<Value, Box<dyn Error + Sync + Send>> {
         let s = str::from_utf8(raw)?;
+        // Match PostgreSQL, which rejects NUL bytes in text-format values of
+        // any type as part of client encoding verification.
+        reject_nul(s)?;
         Ok(match ty {
             Type::Array(elem_type) => {
                 let (elements, dims) = strconv::parse_array(
@@ -746,6 +749,9 @@ impl Value {
         s: &'a str,
         packer: &mut RowPacker,
     ) -> Result<(), Box<dyn Error + Sync + Send>> {
+        // Match PostgreSQL, which rejects NUL bytes in text-format values of
+        // any type as part of client encoding verification.
+        reject_nul(s)?;
         Ok(match ty {
             Type::Array(elem_type) => {
                 let (elements, dims) =
@@ -890,6 +896,7 @@ impl Value {
             Type::Map { .. } => Err("binary decoding of map types is not implemented".into()),
             Type::Name => {
                 let s = String::from_sql(ty.inner(), raw)?;
+                reject_nul(&s)?;
                 if s.len() > NAME_MAX_BYTES {
                     return Err("identifier too long".into());
                 }
@@ -906,9 +913,9 @@ impl Value {
                 u32::from_sql(ty.inner(), raw).map(Value::Oid)
             }
             Type::Record(_) => Err("input of anonymous composite types is not implemented".into()),
-            Type::Text => String::from_sql(ty.inner(), raw).map(Value::Text),
-            Type::BpChar { .. } => String::from_sql(ty.inner(), raw).map(Value::BpChar),
-            Type::VarChar { .. } => String::from_sql(ty.inner(), raw).map(Value::VarChar),
+            Type::Text => decode_binary_string(ty, raw).map(Value::Text),
+            Type::BpChar { .. } => decode_binary_string(ty, raw).map(Value::BpChar),
+            Type::VarChar { .. } => decode_binary_string(ty, raw).map(Value::VarChar),
             Type::Time { .. } => NaiveTime::from_sql(ty.inner(), raw).map(Value::Time),
             Type::TimeTz { .. } => Err("input of timetz types is not implemented".into()),
             Type::Timestamp { .. } => {
@@ -935,6 +942,23 @@ impl Value {
             Type::AclItem => Err("aclitem has no binary encoding".into()),
         }
     }
+}
+
+/// Returns an error if `s` contains a NUL character, which PostgreSQL rejects
+/// in text values.
+fn reject_nul(s: &str) -> Result<(), Box<dyn Error + Sync + Send>> {
+    if s.contains('\0') {
+        Err(Box::new(NulCharacterError))
+    } else {
+        Ok(())
+    }
+}
+
+/// Decodes a binary-format string value, rejecting embedded NUL characters.
+fn decode_binary_string(ty: &Type, raw: &[u8]) -> Result<String, Box<dyn Error + Sync + Send>> {
+    let s = String::from_sql(ty.inner(), raw)?;
+    reject_nul(&s)?;
+    Ok(s)
 }
 
 /// Rescales `n` to the scale required by `constraints`, if any.
@@ -1080,5 +1104,41 @@ mod tests {
             panic!("decode_text of a numeric must yield Value::Numeric");
         };
         assert_eq!(text, expected, "text decode did not rescale to scale 2");
+    }
+
+    /// Text values must never contain NUL characters, in either wire format.
+    #[mz_ore::test]
+    fn decode_rejects_nul_in_strings() {
+        const NUL_ERR: &str = "invalid byte sequence for encoding \"UTF8\": 0x00";
+        let raw = b"foo\x00bar";
+
+        for ty in [
+            Type::Text,
+            Type::BpChar { length: None },
+            Type::VarChar { max_length: None },
+            Type::Name,
+        ] {
+            for format in [Format::Text, Format::Binary] {
+                let res = Value::decode(format, &ty, raw);
+                assert_eq!(
+                    res.map(|_| ()).map_err(|e| e.to_string()).unwrap_err(),
+                    NUL_ERR,
+                    "{ty:?} in {format:?} format must reject NUL",
+                );
+            }
+        }
+
+        // The text format rejects NUL bytes regardless of the target type.
+        let res = Value::decode_text(&Type::Bytea, b"\\x00\x00");
+        assert_eq!(
+            res.map(|_| ()).map_err(|e| e.to_string()).unwrap_err(),
+            NUL_ERR,
+        );
+
+        // NUL-free values still decode.
+        let Value::Text(s) = Value::decode(Format::Binary, &Type::Text, b"foobar").unwrap() else {
+            panic!("decoding a text value must yield Value::Text");
+        };
+        assert_eq!(s, "foobar");
     }
 }

--- a/src/pgrepr/src/value/error.rs
+++ b/src/pgrepr/src/value/error.rs
@@ -7,13 +7,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Error type for fallible conversion from [`super::Value`] to [`mz_repr::Datum`].
+//! Error types for decoding wire-format values and for fallible conversion
+//! from [`super::Value`] to [`mz_repr::Datum`].
 
 use std::error::Error;
 use std::fmt;
 
 use mz_repr::adt::array::InvalidArrayError;
 use mz_repr::adt::range::InvalidRangeError;
+
+/// Error returned when a decoded text value contains a NUL character, which
+/// PostgreSQL-compatible text values must never contain.
+#[derive(Debug)]
+pub struct NulCharacterError;
+
+impl fmt::Display for NulCharacterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // This matches PostgreSQL's message for NUL bytes in text values.
+        f.write_str("invalid byte sequence for encoding \"UTF8\": 0x00")
+    }
+}
+
+impl Error for NulCharacterError {}
 
 /// Errors that can occur when converting a [`super::Value`] into a [`mz_repr::Datum`].
 #[derive(Debug)]

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1406,12 +1406,18 @@ where
                         }
                     },
                     Err(err) => {
-                        let msg = format!("unable to decode parameter: {}", err);
-                        return self
-                            .send_error_and_get_state(ErrorResponse::error(
+                        // NUL characters get the same SQLSTATE that PostgreSQL
+                        // reports for them.
+                        let (code, msg) = if err.is::<mz_pgrepr::NulCharacterError>() {
+                            (SqlState::CHARACTER_NOT_IN_REPERTOIRE, err.to_string())
+                        } else {
+                            (
                                 SqlState::INVALID_PARAMETER_VALUE,
-                                msg,
-                            ))
+                                format!("unable to decode parameter: {}", err),
+                            )
+                        };
+                        return self
+                            .send_error_and_get_state(ErrorResponse::error(code, msg))
                             .await;
                     }
                 },

--- a/src/sql-lexer/src/lexer.rs
+++ b/src/sql-lexer/src/lexer.rs
@@ -268,6 +268,7 @@ fn lex_string(buf: &mut LexBuf) -> Result<String, LexerError> {
             match buf.next() {
                 Some('\'') if buf.consume('\'') => s.push('\''),
                 Some('\'') => break,
+                Some('\0') => bail!(pos, "null character in string literal"),
                 Some(c) => s.push(c),
                 None => bail!(pos, "unterminated quoted string"),
             }
@@ -281,10 +282,15 @@ fn lex_string(buf: &mut LexBuf) -> Result<String, LexerError> {
 fn lex_extended_string(buf: &mut LexBuf) -> Result<Token, LexerError> {
     fn lex_unicode_escape(buf: &mut LexBuf, n: usize) -> Result<char, LexerError> {
         let pos = buf.pos() - 2;
-        buf.next_n(n)
+        let ch = buf
+            .next_n(n)
             .and_then(|s| u32::from_str_radix(s, 16).ok())
             .and_then(|codepoint| char::try_from(codepoint).ok())
-            .ok_or_else(|| LexerError::new(pos, "invalid unicode escape"))
+            .ok_or_else(|| LexerError::new(pos, "invalid unicode escape"))?;
+        if ch == '\0' {
+            return Err(LexerError::new(pos, "null character in string literal"));
+        }
+        Ok(ch)
     }
 
     // We do not support octal (\o) or hexadecimal (\x) escapes, since it is
@@ -322,9 +328,11 @@ fn lex_extended_string(buf: &mut LexBuf) -> Result<Token, LexerError> {
                     Some('U') => s.push(lex_unicode_escape(buf, 8)?),
                     Some('0'..='7') => return Err(lex_octal_escape(buf)),
                     Some('x') => return Err(lex_hexadecimal_escape(buf)),
+                    Some('\0') => bail!(pos, "null character in string literal"),
                     Some(c) => s.push(c),
                     None => bail!(pos, "unterminated quoted string"),
                 },
+                Some('\0') => bail!(pos, "null character in string literal"),
                 Some(c) => s.push(c),
                 None => bail!(pos, "unterminated quoted string"),
             }
@@ -348,6 +356,9 @@ fn lex_dollar_string(buf: &mut LexBuf) -> Result<Token, LexerError> {
     let tag = format!("${}$", buf.take_while(|ch| ch != '$'));
     let _ = buf.next();
     if let Some(s) = buf.take_to_delimiter(&tag) {
+        if s.contains('\0') {
+            return Err(LexerError::new(pos, "null character in string literal"));
+        }
         Ok(Token::String(s.into()))
     } else {
         Err(LexerError::new(pos, "unterminated dollar-quoted string"))

--- a/src/sql-lexer/tests/lexer.rs
+++ b/src/sql-lexer/tests/lexer.rs
@@ -21,6 +21,32 @@
 use datadriven::walk;
 use mz_sql_lexer::lexer::lex;
 
+/// Raw NUL characters in string literals must be rejected. They cannot appear
+/// in datadriven testdata files, which hold text, so they are exercised here.
+#[mz_ore::test]
+fn test_nul_characters_rejected() {
+    for query in [
+        "SELECT 'foo\0bar'",
+        "SELECT E'foo\0bar'",
+        "SELECT E'foo\\\0bar'",
+        "SELECT $$foo\0bar$$",
+        "SELECT $tag$foo\0bar$tag$",
+        "SELECT x'\0'",
+        "SELECT E'\\u0000'",
+        "SELECT E'\\U00000000'",
+    ] {
+        let err = match lex(query) {
+            Ok(_) => panic!("lexing {query:?} must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err.to_string(),
+            "null character in string literal",
+            "query: {query:?}"
+        );
+    }
+}
+
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn test_datadriven() {
@@ -33,7 +59,7 @@ fn test_datadriven() {
                         .map(|t| format!("{}: {:?}\n", t.offset, t.kind))
                         .collect::<Vec<_>>()
                         .join(""),
-                    Err(err) => err.to_string(),
+                    Err(err) => format!("{}\n", err),
                 },
                 _ => unreachable!("unknown directive"),
             }

--- a/src/sql-lexer/tests/testdata/strings
+++ b/src/sql-lexer/tests/testdata/strings
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+lex
+SELECT E'A'
+----
+0: Keyword(Select)
+7: String("A")
+
+lex
+SELECT E'\u0000'
+----
+null character in string literal
+
+lex
+SELECT E'\U00000000'
+----
+null character in string literal

--- a/src/sql-parser/tests/testdata/lexer
+++ b/src/sql-parser/tests/testdata/lexer
@@ -98,6 +98,20 @@ error: hexadecimal escapes are not supported
 e'\x1fg'
   ^
 
+parse-scalar
+e'\u0000'
+----
+error: null character in string literal
+e'\u0000'
+  ^
+
+parse-scalar
+e'\U00000000'
+----
+error: null character in string literal
+e'\U00000000'
+  ^
+
 # Dollar string literals.
 
 parse-statement roundtrip

--- a/test/pgtest/nul.pt
+++ b/test/pgtest/nul.pt
@@ -1,0 +1,107 @@
+# Test that parameter values containing NUL characters are rejected,
+# like PostgreSQL does.
+
+# Binary-format text parameter containing "foo\0bar".
+send
+Parse {"query": "SELECT $1::text"}
+Bind {"binary_values": [[102, 111, 111, 0, 98, 97, 114]], "param_formats": [1]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22021"},{"typ":"M","value":"invalid byte sequence for encoding \"UTF8\": 0x00"}]}
+ReadyForQuery {"status":"I"}
+
+# Text-format text parameter containing "foo\0bar".
+send
+Parse {"query": "SELECT $1::text"}
+Bind {"values": ["foo\u0000bar"]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22021"},{"typ":"M","value":"invalid byte sequence for encoding \"UTF8\": 0x00"}]}
+ReadyForQuery {"status":"I"}
+
+# Text-format parameters of non-string types also reject NUL bytes.
+send
+Parse {"query": "SELECT $1::int4"}
+Bind {"values": ["1\u00002"]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22021"},{"typ":"M","value":"invalid byte sequence for encoding \"UTF8\": 0x00"}]}
+ReadyForQuery {"status":"I"}
+
+# NUL-free parameters still work.
+send
+Parse {"query": "SELECT $1::text"}
+Bind {"binary_values": [[102, 111, 111]], "param_formats": [1]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["foo"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# COPY FROM rejects NUL bytes produced by hex escapes in the text format.
+# PostgreSQL reports 22021 here. Materialize wraps all COPY decode errors
+# in a bad-copy-format error, so the code is 22P04.
+send
+Query {"query": "CREATE TABLE nul_copy (v text)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY nul_copy FROM STDIN"}
+----
+
+until
+CopyIn
+----
+CopyIn {"format":"text","column_formats":["text"]}
+
+send
+CopyData "foo\\x00bar"
+CopyDone
+----
+
+until err_field_typs=C
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"22P04"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "DROP TABLE nul_copy"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/bytea.slt
+++ b/test/sqllogictest/bytea.slt
@@ -215,6 +215,14 @@ SELECT convert_from(b, 'invalid encoding') FROM test
 query error invalid utf-8 sequence of 1 bytes
 SELECT convert_from('\x00ff', 'utf-8')
 
+# NUL bytes are valid UTF-8 but are rejected because text values must never
+# contain them.
+query error invalid byte sequence '0x00' for encoding 'utf-8'
+SELECT convert_from('\x00', 'utf-8')
+
+query error invalid byte sequence '0x00' for encoding 'utf-8'
+SELECT convert_from('\x666f6f00626172', 'utf-8')
+
 # get_byte
 
 statement ok

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1969,3 +1969,17 @@ select string_to_array('abc', '|', 'abc') from string_to_array_words;
 {NULL}
 
 # string_to_array - end.
+
+### NUL characters ###
+
+# Text values must never contain NUL characters, so string literals that
+# would produce one are rejected at lexing.
+
+query error null character in string literal
+SELECT E'\u0000'
+
+query error null character in string literal
+SELECT E'\U00000000'
+
+query error null character in string literal
+SELECT E'foo\u0000bar'


### PR DESCRIPTION
### Motivation

Fixes SQL-472.

Text values must never contain NUL characters, but Materialize accepted them
through several ingress paths that PostgreSQL rejects, most notably
binary-format bind parameters, which round-tripped `foo\0bar` into `text`
columns.

### Description

One commit per ingress path, see the individual commit messages:

* `pgrepr`: reject NUL when decoding values in both wire formats. This is the
  chokepoint shared by pgwire parameters, the HTTP SQL API, COPY FROM, and the
  oneshot CSV source.
* `sql-lexer`: reject `\u0000` escapes and raw NUL characters in string
  literals. Raw NUL cannot arrive via pgwire, but can via the HTTP SQL API,
  which carries SQL as JSON.
* `expr`: reject NUL bytes in `convert_from`.
* `pgwire`: report SQLSTATE 22021 (`character_not_in_repertoire`) with
  PostgreSQL's exact message for NUL in parameters, instead of the generic
  22023.

Known gaps left for follow-ups: jsonb `\u0000` escapes can still produce NUL
via `->>` (the jsonb parser is shared with source ingestion, so rejecting
there is a bigger decision), NUL can still enter text columns through sources
(MySQL/SQL Server CDC, webhooks, Avro), and COPY FROM reports the rejection
under 22P04 rather than PG's 22021.

### Verification

New wire-level pgtest (`test/pgtest/nul.pt`) covering binary and text
parameters and COPY FROM against a real environmentd, unit tests in
`mz-pgrepr` and `mz-sql-lexer`, new lexer/parser datadriven cases, and new SLT
cases in `string.slt` and `bytea.slt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)