### PR TITLE
pgwire: make startup parameters the session's reset defaults

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -433,6 +433,88 @@ async fn test_conn_startup() {
     }
 }
 
+// Startup-packet parameters must become the session defaults, like in
+// PostgreSQL, so that RESET and DISCARD ALL restore them rather than the
+// server defaults. Connection poolers rely on this. For example, pgbouncer's
+// default server_reset_query is DISCARD ALL, which must not rebind a pooled
+// connection to the default database.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[allow(clippy::disallowed_methods)]
+async fn test_startup_params_survive_reset() {
+    let server = test_util::TestHarness::default().start().await;
+
+    async fn show(client: &tokio_postgres::Client, name: &str) -> String {
+        client
+            .query_one(&format!("SHOW {name}"), &[])
+            .await
+            .unwrap()
+            .get(0)
+    }
+
+    // Parameters passed directly in the startup packet.
+    {
+        let client = server
+            .connect()
+            .dbname("startup_db")
+            .application_name("startup_app")
+            .await
+            .unwrap();
+
+        client
+            .batch_execute("SET application_name = 'changed_app'")
+            .await
+            .unwrap();
+        assert_eq!(show(&client, "application_name").await, "changed_app");
+        client
+            .batch_execute("RESET application_name")
+            .await
+            .unwrap();
+        assert_eq!(show(&client, "application_name").await, "startup_app");
+
+        client
+            .batch_execute("SET database = other_db")
+            .await
+            .unwrap();
+        client.batch_execute("DISCARD ALL").await.unwrap();
+        assert_eq!(show(&client, "database").await, "startup_db");
+        assert_eq!(show(&client, "application_name").await, "startup_app");
+
+        client.batch_execute("RESET database").await.unwrap();
+        assert_eq!(show(&client, "database").await, "startup_db");
+    }
+
+    // Parameters passed via the `options` startup parameter.
+    {
+        let client = server
+            .connect()
+            .options("--search_path=custom_schema")
+            .await
+            .unwrap();
+
+        client.batch_execute("DISCARD ALL").await.unwrap();
+        assert_eq!(show(&client, "search_path").await, "custom_schema");
+    }
+
+    // Client-supplied startup parameters take precedence over role defaults,
+    // also as the reset value.
+    {
+        let client = server.connect().await.unwrap();
+        client
+            .batch_execute("ALTER ROLE materialize SET database = role_db")
+            .await
+            .unwrap();
+
+        let client = server.connect().dbname("client_db").await.unwrap();
+        assert_eq!(show(&client, "database").await, "client_db");
+        client.batch_execute("DISCARD ALL").await.unwrap();
+        assert_eq!(show(&client, "database").await, "client_db");
+
+        // Without a client-supplied database, the role default applies.
+        let client = server.connect().await.unwrap();
+        assert_eq!(show(&client, "database").await, "role_db");
+    }
+}
+
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
 fn test_conn_user() {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -540,6 +540,10 @@ where
     };
 
     let system_vars = adapter_client.get_system_vars().await;
+    // Startup parameters that were successfully applied. They additionally
+    // become the session's default values below, once role defaults have been
+    // applied too.
+    let mut applied_params = vec![];
     for (name, value) in params {
         let settings = match name.as_str() {
             "options" => match &options {
@@ -560,14 +564,17 @@ where
             // (silently ignore errors on set), but erroring the connection
             // might be the better behavior. We maybe need to support more
             // options sent by psql and drivers before we can safely do this.
-            if let Err(err) = session
+            match session
                 .vars_mut()
                 .set(&system_vars, key, VarInput::Flat(val), LOCAL)
             {
-                session.add_notice(AdapterNotice::BadStartupSetting {
-                    name: key.clone(),
-                    reason: err.to_string(),
-                });
+                Ok(()) => applied_params.push((key.clone(), val.clone())),
+                Err(err) => {
+                    session.add_notice(AdapterNotice::BadStartupSetting {
+                        name: key.clone(),
+                        reason: err.to_string(),
+                    });
+                }
             }
         }
     }
@@ -588,6 +595,24 @@ where
         Ok(adapter_client) => adapter_client,
         Err(e) => return conn.send(e.into_response(Severity::Fatal)).await,
     };
+
+    // Make the startup parameters the session's default values, so that RESET
+    // and DISCARD ALL restore them rather than the server defaults. This
+    // matches PostgreSQL, where client-supplied startup parameters take
+    // precedence over role defaults (which startup registration applied) both
+    // as the current value and as the reset value. Connection poolers rely on
+    // this. For example, pgbouncer's default server_reset_query is DISCARD
+    // ALL, which must not rebind a pooled connection to the default database.
+    for (key, val) in applied_params {
+        if let Err(err) = adapter_client
+            .session()
+            .vars_mut()
+            .set_default(&key, VarInput::Flat(&val))
+        {
+            // Unexpected, since the same value was accepted by set() above.
+            mz_ore::soft_panic_or_log!("failed to apply startup parameter as default: {err:?}");
+        }
+    }
 
     let mut buf = vec![BackendMessage::AuthenticationOk];
     for var in adapter_client.session().vars().notify_set() {


### PR DESCRIPTION
Fixes SQL-471.

Apply successfully-set startup-packet parameters (including those in "options") as session variable defaults, so that RESET and DISCARD ALL restore them instead of the server defaults. This matches PostgreSQL, where client-supplied startup parameters are the reset value and take precedence over role defaults. In particular, pgbouncer's default server_reset_query (DISCARD ALL) no longer rebinds a pooled connection to the wrong database.