### PR TITLE
mcp: Introduce McpCallStatus enum for MCP metric labels

### DIFF
--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -49,7 +49,7 @@ use thiserror::Error;
 use tracing::{debug, warn};
 
 use crate::http::AuthedClient;
-use crate::http::mcp_metrics::{McpMetrics, ToolCallGuard};
+use crate::http::mcp_metrics::{McpCallStatus, McpMetrics, ToolCallGuard};
 use crate::http::sql::{SqlRequest, SqlResponse, SqlResult, execute_request};
 
 // To add a new tool: add entry to tools/list, add handler function, add dispatch case.
@@ -469,12 +469,8 @@ async fn handle_mcp_request(
 ) -> impl IntoResponse {
     let endpoint_label = endpoint_type.as_label();
     let method_label = request.method.to_string();
-    let record_request = |status: &str| {
-        metrics
-            .requests
-            .with_label_values(&[endpoint_label, &method_label, status])
-            .inc();
-    };
+    let record_request =
+        |status: McpCallStatus| metrics.record_request(endpoint_label, &method_label, status);
 
     // Check the per-endpoint feature flag via a catalog snapshot, similar to frontend_peek.rs.
     let catalog = client.client.catalog_snapshot("mcp").await;
@@ -485,7 +481,7 @@ async fn handle_mcp_request(
     };
     if !enabled {
         debug!(endpoint = %endpoint_type, "MCP endpoint disabled by feature flag");
-        record_request("endpoint_disabled");
+        record_request(McpCallStatus::EndpointDisabled);
         return StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
 
@@ -532,7 +528,7 @@ async fn handle_mcp_request(
     // Handle notifications (no response needed)
     if is_notification {
         debug!(method = %request.method, "Received notification (no response will be sent)");
-        record_request("ok");
+        record_request(McpCallStatus::Ok);
         return StatusCode::OK.into_response();
     }
 
@@ -561,7 +557,7 @@ async fn handle_mcp_request(
     )
     .await;
 
-    let (response, status_label): (McpResponse, &'static str) = match result {
+    let (response, status_label): (McpResponse, McpCallStatus) = match result {
         Ok(inner) => inner,
         Err(_elapsed) => {
             warn!(
@@ -577,7 +573,7 @@ async fn handle_mcp_request(
                 ))
                 .into(),
             );
-            (response, "timeout")
+            (response, McpCallStatus::Timeout)
         }
     };
 
@@ -593,7 +589,7 @@ async fn handle_mcp_request_inner(
     read_data_product_tool_enabled: bool,
     max_response_size: usize,
     metrics: McpMetrics,
-) -> (McpResponse, &'static str) {
+) -> (McpResponse, McpCallStatus) {
     // Extract request ID (guaranteed to be Some since notifications are filtered earlier)
     let request_id = request.id.clone().unwrap_or(serde_json::Value::Null);
 
@@ -608,10 +604,7 @@ async fn handle_mcp_request_inner(
     )
     .await;
 
-    let status_label = match &result {
-        Ok(_) => "ok",
-        Err(e) => e.error_type(),
-    };
+    let status_label = call_status(&result);
 
     let response = match result {
         Ok(result_value) => McpResponse::success(request_id, result_value),
@@ -1005,12 +998,18 @@ async fn handle_tools_call(
         ))),
     };
 
-    guard.set_status(match &result {
-        Ok(_) => "ok",
-        Err(e) => e.error_type(),
-    });
+    guard.set_status(call_status(&result));
 
     result
+}
+
+/// Maps a handler result to its metric [`McpCallStatus`]. Errors carry the
+/// closed `error_type()` label; anything else is `Ok`.
+fn call_status<T>(result: &Result<T, McpRequestError>) -> McpCallStatus {
+    match result {
+        Ok(_) => McpCallStatus::Ok,
+        Err(e) => McpCallStatus::Error(e.error_type()),
+    }
 }
 
 /// Execute SQL via `execute_request` from sql.rs.

--- a/src/environmentd/src/http/mcp_metrics.rs
+++ b/src/environmentd/src/http/mcp_metrics.rs
@@ -11,14 +11,47 @@
 //!
 //! Tracks request counts, tool call counts, and tool call durations,
 //! labeled by endpoint type (`agent` / `developer`) and either the
-//! JSON-RPC method name or the MCP tool name. The status label is `ok`
-//! for successful calls and the `McpRequestError` error type
-//! (e.g. `ToolNotFound`, `DataProductNotFound`) for failures.
+//! JSON-RPC method name or the MCP tool name. The status label is one of
+//! the [`McpCallStatus`] variants: `ok`, a lifecycle outcome, or the
+//! `McpRequestError` error type (e.g. `ToolNotFound`) for failures.
 
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::stats::histogram_seconds_buckets;
 use prometheus::{HistogramTimer, HistogramVec, IntCounterVec};
+
+/// Closed set of outcomes recorded in the MCP `status` label. Keeping these
+/// as an enum (rather than free-form strings at the call sites) pins the
+/// metric's label cardinality and stops typos from silently creating new
+/// label values. Mirrors `oauth_metadata::MetricStatus`.
+#[derive(Debug, Clone, Copy)]
+pub enum McpCallStatus {
+    /// The request or tool call succeeded.
+    Ok,
+    /// The surrounding future was dropped before the outcome was recorded
+    /// (e.g. by the request timeout). This is the [`ToolCallGuard`] default,
+    /// so a dropped call records as cancelled rather than being lost.
+    Cancelled,
+    /// The request exceeded the configured timeout.
+    Timeout,
+    /// The endpoint is disabled by its feature flag.
+    EndpointDisabled,
+    /// The request failed with the given `McpRequestError::error_type()`. The
+    /// wrapped value comes from a closed match, so cardinality stays bounded.
+    Error(&'static str),
+}
+
+impl McpCallStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Cancelled => "cancelled",
+            Self::Timeout => "timeout",
+            Self::EndpointDisabled => "endpoint_disabled",
+            Self::Error(e) => e,
+        }
+    }
+}
 
 /// Metrics emitted by the MCP HTTP handlers.
 ///
@@ -44,7 +77,7 @@ pub struct ToolCallGuard<'a> {
     metrics: &'a McpMetrics,
     endpoint_label: &'static str,
     tool_label: String,
-    status: &'static str,
+    status: McpCallStatus,
     /// `HistogramTimer::drop` observes the duration into the histogram, so
     /// holding the timer here means we get the duration recorded for both
     /// normal completion and early drop.
@@ -63,14 +96,14 @@ impl<'a> ToolCallGuard<'a> {
             metrics,
             endpoint_label,
             tool_label,
-            status: "cancelled",
+            status: McpCallStatus::Cancelled,
             _timer: timer,
         }
     }
 
     /// Records the outcome of the call. Callers should set this on the
     /// normal completion path right before the guard is dropped.
-    pub fn set_status(&mut self, status: &'static str) {
+    pub fn set_status(&mut self, status: McpCallStatus) {
         self.status = status;
     }
 }
@@ -79,7 +112,7 @@ impl Drop for ToolCallGuard<'_> {
     fn drop(&mut self) {
         self.metrics
             .tool_calls
-            .with_label_values(&[self.endpoint_label, &self.tool_label, self.status])
+            .with_label_values(&[self.endpoint_label, &self.tool_label, self.status.as_str()])
             .inc();
     }
 }
@@ -105,12 +138,38 @@ impl McpMetrics {
             )),
         }
     }
+
+    /// Records a request in `mz_mcp_requests_total`. Encapsulates the label
+    /// ordering and the [`McpCallStatus`] to `&str` conversion so call sites
+    /// never touch raw label strings.
+    pub fn record_request(&self, endpoint_label: &str, method_label: &str, status: McpCallStatus) {
+        self.requests
+            .with_label_values(&[endpoint_label, method_label, status.as_str()])
+            .inc();
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::McpMetrics;
+    use super::{McpCallStatus, McpMetrics};
     use mz_ore::metrics::MetricsRegistry;
+
+    /// The status label strings are a wire/dashboard contract; pin them so a
+    /// rename is a deliberate, visible change.
+    #[mz_ore::test]
+    fn test_call_status_labels() {
+        assert_eq!(McpCallStatus::Ok.as_str(), "ok");
+        assert_eq!(McpCallStatus::Cancelled.as_str(), "cancelled");
+        assert_eq!(McpCallStatus::Timeout.as_str(), "timeout");
+        assert_eq!(
+            McpCallStatus::EndpointDisabled.as_str(),
+            "endpoint_disabled"
+        );
+        assert_eq!(
+            McpCallStatus::Error("ToolNotFound").as_str(),
+            "ToolNotFound"
+        );
+    }
 
     /// All three metrics register cleanly and show up in the gathered output
     /// with the expected names. `IntCounterVec` / `HistogramVec` families


### PR DESCRIPTION
Replaces the free-form status label strings threaded through the MCP metrics with a closed McpCallStatus enum (mirroring oauth_metadata::MetricStatus), pinning label cardinality and centralizing the label plumbing in a record_request helper.