### PR TITLE
pgwire: ignore stray COPY subprotocol messages outside COPY mode

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -855,6 +855,11 @@ fn test_pgtest_mz_startup() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_stray_copy() {
+    pg_test_inner(Path::new("../../test/pgtest-mz/stray-copy.pt"), true);
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_transactions() {
     pg_test_inner(Path::new("../../test/pgtest-mz/transactions.pt"), true);
 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1005,10 +1005,17 @@ where
             Some(FrontendMessage::Sync) => self.sync().await?,
             Some(FrontendMessage::Terminate) => State::Done,
 
+            // Accept but ignore stray COPY subprotocol messages, mirroring
+            // PostgreSQL. Clients stream COPY data optimistically, so when a
+            // COPY statement fails before COPY mode is entered, its pipelined
+            // CopyData/CopyDone/CopyFail arrive here. Draining instead would
+            // discard unrelated messages until the next Sync, hanging simple
+            // protocol clients that never send one.
             Some(FrontendMessage::CopyData(_))
             | Some(FrontendMessage::CopyDone)
-            | Some(FrontendMessage::CopyFail(_))
-            | Some(FrontendMessage::Password { .. })
+            | Some(FrontendMessage::CopyFail(_)) => State::Ready,
+
+            Some(FrontendMessage::Password { .. })
             | Some(FrontendMessage::RawAuthentication(_))
             | Some(FrontendMessage::SASLInitialResponse { .. })
             | Some(FrontendMessage::SASLResponse(_)) => State::Drain,

--- a/test/pgtest-mz/stray-copy.pt
+++ b/test/pgtest-mz/stray-copy.pt
@@ -1,0 +1,74 @@
+# Stray COPY subprotocol messages received outside COPY mode are accepted but
+# ignored, matching PostgreSQL (SQL-469). Clients like pgx stream COPY data
+# optimistically without waiting for CopyInResponse, so a COPY statement that
+# fails before COPY mode is entered leaves pipelined CopyData/CopyDone in the
+# stream after the ErrorResponse. This lives in pgtest-mz because the trigger
+# relies on Materialize rejecting binary COPY FROM at planning, which
+# PostgreSQL supports.
+
+send
+Query {"query": "CREATE TABLE strayt (i INT8)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+# Simple protocol after the stray messages: the Query must be answered.
+send
+Query {"query": "COPY strayt FROM STDIN (FORMAT binary)"}
+CopyData "ignored"
+CopyDone
+Query {"query": "SELECT 1"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"?column?"}]}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Extended protocol after the stray messages: nothing may be swallowed, the
+# Parse must produce a ParseComplete.
+send
+Query {"query": "COPY strayt FROM STDIN (FORMAT binary)"}
+CopyData "ignored"
+CopyDone
+Parse {"query": "SELECT 2"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# A stray CopyFail in the idle state is ignored as well.
+send
+CopyFail "stray failure"
+Query {"query": "SELECT 3"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"?column?"}]}
+DataRow {"fields":["3"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
### Motivation

Fixes SQL-469.

PostgreSQL accepts but ignores `CopyData`/`CopyDone`/`CopyFail` messages received outside COPY mode, because clients like pgx and libpq stream COPY data optimistically without waiting for `CopyInResponse`. When a COPY statement fails before COPY mode is entered (e.g. `COPY ... FROM STDIN (FORMAT binary)`, which Materialize rejects at planning), the pipelined COPY messages arrive after the `ErrorResponse`, while the session is back in the ready state.

Previously these stray messages sent the session into the drain state, which silently discards everything until the next `Sync`, corrupting the session:

* Extended protocol next: everything until the next `Sync` was silently discarded. A `Parse` was swallowed (no error, no `ParseComplete`), and a later `Bind` failed with `26000 prepared statement does not exist`.
* Simple protocol next: no response at all, a permanent hang until client timeout, because simple protocol clients never send `Sync`.

Since pgx `CopyFrom` always uses binary COPY (unsupported, DRV-12), any Go application attempting a COPY ended up with a corrupted connection.

This change accepts but ignores the three COPY subprotocol messages in the ready state, matching PostgreSQL (`postgres.c` handles this identically, with a comment noting the same client race). Stray authentication messages keep the drain behavior.

### Tips for reviewer

The pre-existing drain loop in `copy_from_inner` covers the related case where the COPY fails *after* `CopyInResponse` was sent. This bug was the same race for statements that fail *before* COPY mode is entered.

### Testing

Adds `test/pgtest-mz/stray-copy.pt`, which exercises a failed binary COPY with pipelined `CopyData`/`CopyDone` followed by simple protocol traffic (previously hung forever) and extended protocol traffic (previously swallowed until `Sync`), plus a stray `CopyFail` in the idle state. Verified the test fails (hangs until the pgtest timeout) without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)