### PR TITLE
adapter: reject INSERT ... SELECT and COPY TO <url> reads of user objects on mz_catalog_server

### DIFF
--- a/src/adapter/src/coord/catalog_serving.rs
+++ b/src/adapter/src/coord/catalog_serving.rs
@@ -247,6 +247,10 @@ pub fn check_cluster_restrictions(
             SubscribeFrom::Query { ref expr, .. } => Box::new(expr.depends_on().into_iter()),
         },
         Plan::Select(plan) => Box::new(plan.source.depends_on().into_iter()),
+        // COPY ... TO <url> runs its select as a dataflow on the active
+        // cluster. COPY ... TO STDOUT is planned as `Plan::Select` and is
+        // covered above.
+        Plan::CopyTo(plan) => Box::new(plan.select_plan.source.depends_on().into_iter()),
         _ => return Ok(()),
     };
 

--- a/src/adapter/src/coord/catalog_serving.rs
+++ b/src/adapter/src/coord/catalog_serving.rs
@@ -235,6 +235,13 @@ pub fn check_cluster_restrictions(
     // 'mz_catalog_server' cluster to be "read-only", which restricts these actions.
     let depends_on: Box<dyn Iterator<Item = GlobalId>> = match plan {
         Plan::ReadThenWrite(plan) => Box::new(plan.selection.depends_on().into_iter()),
+        // A non-constant INSERT runs its selection as a peek on the active
+        // cluster. The `ReadThenWrite` arm above does not cover it, because
+        // the INSERT is rewritten into a read-then-write only later, during
+        // sequencing, without passing through this check again. A constant
+        // INSERT has no dependencies and passes the check below, which is
+        // fine because it never runs computation on the cluster.
+        Plan::Insert(plan) => Box::new(plan.values.depends_on().into_iter()),
         Plan::Subscribe(plan) => match plan.from {
             SubscribeFrom::Id(id) => Box::new(std::iter::once(id)),
             SubscribeFrom::Query { ref expr, .. } => Box::new(expr.depends_on().into_iter()),

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -532,6 +532,23 @@ SET CLUSTER TO mz_catalog_server;
 statement error querying the following items "materialize\.public\.bar" is not allowed from the "mz_catalog_server" cluster
 SELECT key FROM bar;
 
+# INSERT ... SELECT with a non-constant body is internally a read-then-write
+# whose SELECT half peeks on the active cluster, so reading a user object this
+# way from mz_catalog_server must be rejected like the bare SELECT above.
+
+statement ok
+CREATE TABLE sink_tbl ( key text, val bigint );
+
+statement error querying the following items "materialize\.public\.bar" is not allowed from the "mz_catalog_server" cluster
+INSERT INTO sink_tbl SELECT key, val FROM bar;
+
+# A constant INSERT runs no computation on the cluster and stays allowed.
+statement ok
+INSERT INTO sink_tbl VALUES ('a', 1);
+
+statement ok
+DROP TABLE sink_tbl;
+
 # But inspecting those objects, e.g. checking what indexes exist, should be allowed.
 statement ok
 SHOW INDEXES on bar;

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -549,6 +549,24 @@ INSERT INTO sink_tbl VALUES ('a', 1);
 statement ok
 DROP TABLE sink_tbl;
 
+# COPY ... TO <url> runs its select as a dataflow on the active cluster, so
+# reading a user object this way from mz_catalog_server must be rejected too.
+
+statement ok
+CREATE SECRET aws_secret AS 'secret_key';
+
+statement ok
+CREATE CONNECTION aws_conn TO AWS (ACCESS KEY ID = 'access_key', SECRET ACCESS KEY = SECRET aws_secret) WITH (VALIDATE = false);
+
+statement error querying the following items "materialize\.public\.bar" is not allowed from the "mz_catalog_server" cluster
+COPY (SELECT key FROM bar) TO 's3://path/to/dir' WITH (AWS CONNECTION = aws_conn, FORMAT = 'csv');
+
+statement ok
+DROP CONNECTION aws_conn;
+
+statement ok
+DROP SECRET aws_secret;
+
 # But inspecting those objects, e.g. checking what indexes exist, should be allowed.
 statement ok
 SHOW INDEXES on bar;


### PR DESCRIPTION
### Motivation

Fixes SQL-433 (https://linear.app/materializeinc/issue/SQL-433/resource-isolation-bypass-on-mz-catalog-server)

`check_cluster_restrictions` prevents reading user objects on the reserved `mz_catalog_server` cluster, but only inspected `Select`, `Subscribe`, and `ReadThenWrite` plans. Two other plan types run reads on the active cluster and slipped through, letting any role run arbitrarily expensive dataflows on the shared catalog cluster.

### Description

* `Plan::Insert`: a non-constant `INSERT ... SELECT` is rewritten into a read-then-write only later, during sequencing, without passing through the check again, so the existing `ReadThenWrite` arm never sees it. The new arm checks the insert's selection. Constant inserts have no dependencies and stay allowed, they run no computation on the cluster.
* `Plan::CopyTo`: `COPY ... TO <url>` runs its select as a dataflow on the target cluster and was not inspected at all. `COPY ... TO STDOUT` was already covered, it plans as `Plan::Select`.

### Verification

Extended `test/sqllogictest/system-cluster.slt` with rejected `INSERT ... SELECT` and `COPY ... TO 's3://...'` cases on `mz_catalog_server`, plus a constant `INSERT` that must remain allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)