### PR TITLE
adapter: Give ImpossibleTimestampConstraints a dedicated SQLSTATE (MZ012)

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -941,8 +941,11 @@ impl AdapterError {
             AdapterError::ReplaceMaterializedViewSealed { .. } => {
                 SqlState::OBJECT_NOT_IN_PREREQUISITE_STATE
             }
-            // similar to AbsurdSubscribeBounds
-            AdapterError::ImpossibleTimestampConstraints { .. } => SqlState::DATA_EXCEPTION,
+            // A dedicated code so clients can detect a timestamp-constraint
+            // failure without matching the error message text. For a SUBSCRIBE
+            // with an explicit AS OF this is the compaction horizon: the
+            // requested time is older than the inputs' since frontier.
+            AdapterError::ImpossibleTimestampConstraints { .. } => SqlState::from_code("MZ012"),
             AdapterError::OidcGroupSyncFailed(_) => SqlState::INTERNAL_ERROR,
             AdapterError::BoundedStalenessExceeded { .. } => SqlState::T_R_SERIALIZATION_FAILURE,
             // Matches ReadOnlyTransaction/ReadOnly: a write was rejected


### PR DESCRIPTION
Maps the 'could not find a valid timestamp' error to a dedicated MZ012 SQLSTATE instead of the generic DATA_EXCEPTION, so clients (notably the Subscribe SDK) can detect the compaction-horizon case on resume by code instead of matching error message text (which has already changed once, in #34712). Draft/proposal: this error is broader than just the compaction horizon and is currently grouped with AbsurdSubscribeBounds, so reviewers should weigh a dedicated code on this error versus a more specific compaction-horizon error variant; an integration test that triggers the horizon should be added before merge.