### PR TITLE
sql: fix NULL semantics for ANY/ALL over array and array_position

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3022,6 +3022,9 @@ class FlipFlagsAction(Action):
         )
         self.flags_with_values["enable_upsert_v2"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_coalesce_case_transform"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_any_all_null_array_semantics"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_compute_sync_mv_sink"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_column_paged_batcher"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_columnar_merge_batcher"] = BOOLEAN_FLAG_VALUES

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -407,10 +407,9 @@ fn array_position<'a>(
         return Err(EvalError::MultiDimensionalArraySearch);
     }
 
-    if search == Datum::Null {
-        return Ok(None);
-    }
-
+    // Comparisons use IS NOT DISTINCT FROM semantics, so a NULL search term
+    // matches a NULL element rather than yielding NULL. `Datum` equality already
+    // treats `Null == Null` as true, so the search loop below handles it.
     let skip = match initial_pos.0 {
         None => 0,
         Some(None) => return Err(EvalError::MustNotBeNull("initial position".into())),

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -430,6 +430,14 @@ fn array_position<'a>(
     // Comparisons use IS NOT DISTINCT FROM semantics, so a NULL search term
     // matches a NULL element rather than yielding NULL. `Datum` equality already
     // treats `Null == Null` as true, so the search loop below handles it.
+    //
+    // NOTE: rejecting a NULL initial position before the search is a deliberate
+    // divergence from PostgreSQL. PostgreSQL validates the initial position only
+    // after a fast path that returns NULL when the search term is NULL and the
+    // array holds no NULL element, so it errors for
+    // `array_position(ARRAY['sun', NULL], NULL, NULL)` but not for
+    // `array_position(ARRAY['sun'], NULL, NULL)`. Making the error depend on the
+    // array contents is not worth reproducing.
     let skip = match initial_pos.0 {
         None => 0,
         Some(None) => return Err(EvalError::MustNotBeNull("initial position".into())),

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -427,10 +427,9 @@ fn array_position<'a>(
         return Err(EvalError::MultiDimensionalArraySearch);
     }
 
-    if search == Datum::Null {
-        return Ok(None);
-    }
-
+    // Comparisons use IS NOT DISTINCT FROM semantics, so a NULL search term
+    // matches a NULL element rather than yielding NULL. `Datum` equality already
+    // treats `Null == Null` as true, so the search loop below handles it.
     let skip = match initial_pos.0 {
         None => 0,
         Some(None) => return Err(EvalError::MustNotBeNull("initial position".into())),

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -672,11 +672,25 @@ impl<'a> Desugarer<'a> {
 
         // `$expr = ALL ($array_expr)`
         // =>
-        // `$expr = ALL (SELECT elem FROM unnest($array_expr) _ (elem))`
+        // `CASE WHEN $array_expr IS NULL THEN NULL
+        //       ELSE $expr = ALL (SELECT elem FROM unnest($array_expr) _ (elem)) END`
         //
         // and analogously for other operators and ANY.
+        //
+        // The `IS NULL` guard is required because a NULL array is distinct from
+        // an empty array. PG yields NULL for the former but the empty-set answer
+        // (false for ANY, true for ALL) for the latter, whereas `unnest` maps
+        // both to zero rows and so cannot tell them apart.
         if let Expr::AnyExpr { left, op, right } | Expr::AllExpr { left, op, right } = expr {
             let binding = ident!("elem");
+
+            // Clone the array expression for the null guard before it is consumed
+            // into the `unnest` call below.
+            let array_is_null = Expr::IsExpr {
+                expr: Box::new((**right).clone()),
+                construct: IsExprConstruct::Null,
+                negated: false,
+            };
 
             let subquery = Query::select(
                 Select::default()
@@ -710,7 +724,7 @@ impl<'a> Desugarer<'a> {
 
             let op = op.clone();
 
-            *expr = match expr {
+            let any_all = match expr {
                 Expr::AnyExpr { .. } => Expr::AnySubquery {
                     left,
                     op,
@@ -722,6 +736,13 @@ impl<'a> Desugarer<'a> {
                     right: Box::new(subquery),
                 },
                 _ => unreachable!(),
+            };
+
+            *expr = Expr::Case {
+                operand: None,
+                conditions: vec![array_is_null],
+                results: vec![Expr::null()],
+                else_result: Some(Box::new(any_all)),
             };
         }
 

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -720,11 +720,25 @@ impl<'a> Desugarer<'a> {
 
         // `$expr = ALL ($array_expr)`
         // =>
-        // `$expr = ALL (SELECT elem FROM unnest($array_expr) _ (elem))`
+        // `CASE WHEN $array_expr IS NULL THEN NULL
+        //       ELSE $expr = ALL (SELECT elem FROM unnest($array_expr) _ (elem)) END`
         //
         // and analogously for other operators and ANY.
+        //
+        // The `IS NULL` guard is required because a NULL array is distinct from
+        // an empty array. PG yields NULL for the former but the empty-set answer
+        // (false for ANY, true for ALL) for the latter, whereas `unnest` maps
+        // both to zero rows and so cannot tell them apart.
         if let Expr::AnyExpr { left, op, right } | Expr::AllExpr { left, op, right } = expr {
             let binding = ident!("elem");
+
+            // Clone the array expression for the null guard before it is consumed
+            // into the `unnest` call below.
+            let array_is_null = Expr::IsExpr {
+                expr: Box::new((**right).clone()),
+                construct: IsExprConstruct::Null,
+                negated: false,
+            };
 
             let subquery = Query::select(
                 Select::default()
@@ -758,7 +772,7 @@ impl<'a> Desugarer<'a> {
 
             let op = op.clone();
 
-            *expr = match expr {
+            let any_all = match expr {
                 Expr::AnyExpr { .. } => Expr::AnySubquery {
                     left,
                     op,
@@ -770,6 +784,13 @@ impl<'a> Desugarer<'a> {
                     right: Box::new(subquery),
                 },
                 _ => unreachable!(),
+            };
+
+            *expr = Expr::Case {
+                operand: None,
+                conditions: vec![array_is_null],
+                results: vec![Expr::null()],
+                else_result: Some(Box::new(any_all)),
             };
         }
 

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -26,6 +26,7 @@ use mz_sql_parser::ident;
 
 use crate::names::{Aug, PartialItemName, ResolvedDataType, ResolvedItemName};
 use crate::plan::{PlanError, StatementContext};
+use crate::session::vars::ENABLE_ANY_ALL_NULL_ARRAY_SEMANTICS;
 use crate::{ORDINALITY_COL_NAME, normalize};
 
 pub(crate) fn transform<N>(scx: &StatementContext, node: &mut N) -> Result<(), PlanError>
@@ -729,16 +730,25 @@ impl<'a> Desugarer<'a> {
         // an empty array. PG yields NULL for the former but the empty-set answer
         // (false for ANY, true for ALL) for the latter, whereas `unnest` maps
         // both to zero rows and so cannot tell them apart.
+        //
+        // The guard is gated because it costs plan quality in value context over a
+        // non-constant array. Several `ANY`/`ALL` operands in one clause used to be
+        // lowered together over a shared `distinct_inner`, but HIR lowering defers a
+        // subquery that sits under an `If`, so each guarded operand now lowers on its
+        // own and duplicates the `unnest`. In filter context, and whenever the array
+        // is constant, the guard folds away and plans are unchanged.
         if let Expr::AnyExpr { left, op, right } | Expr::AllExpr { left, op, right } = expr {
             let binding = ident!("elem");
 
-            // Clone the array expression for the null guard before it is consumed
-            // into the `unnest` call below.
-            let array_is_null = Expr::IsExpr {
-                expr: Box::new((**right).clone()),
-                construct: IsExprConstruct::Null,
-                negated: false,
-            };
+            // Cloned here because `right` is consumed into the `unnest` call below.
+            let array_is_null = self
+                .scx
+                .is_feature_flag_enabled(&ENABLE_ANY_ALL_NULL_ARRAY_SEMANTICS)
+                .then(|| Expr::IsExpr {
+                    expr: Box::new((**right).clone()),
+                    construct: IsExprConstruct::Null,
+                    negated: false,
+                });
 
             let subquery = Query::select(
                 Select::default()
@@ -786,11 +796,14 @@ impl<'a> Desugarer<'a> {
                 _ => unreachable!(),
             };
 
-            *expr = Expr::Case {
-                operand: None,
-                conditions: vec![array_is_null],
-                results: vec![Expr::null()],
-                else_result: Some(Box::new(any_all)),
+            *expr = match array_is_null {
+                Some(array_is_null) => Expr::Case {
+                    operand: None,
+                    conditions: vec![array_is_null],
+                    results: vec![Expr::null()],
+                    else_result: Some(Box::new(any_all)),
+                },
+                None => any_all,
             };
         }
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2380,6 +2380,16 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        // An escape hatch: the `CASE` guard defeats the batched lowering that shares one
+        // `unnest` across several `ANY`/`ALL` operands, so a query with multiple `ANY`/`ALL`
+        // over a non-constant array plans into more arrangements than before. Turning the flag
+        // off restores the old plans at the cost of the wrong answer for a NULL array.
+        name: enable_any_all_null_array_semantics,
+        desc: "PostgreSQL-compatible NULL semantics for `ANY`/`ALL` over a NULL array or list.",
+        default: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -235,6 +235,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_0dt_deployment_panic_after_timeout
     enable_adapter_frontend_occ_read_then_write
     enable_alter_table_add_column
+    enable_any_all_null_array_semantics
     enable_auto_scaling_strategy
     enable_background_alter_cluster
     enable_statement_arrival_logging

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -115,6 +115,49 @@ SELECT 'hi'::text = ANY(ARRAY[]::text[])
 ----
 false
 
+# A NULL array yields NULL, distinct from the empty-array case above.
+query B
+SELECT 33 = ANY(NULL::int[])
+----
+NULL
+
+query B
+SELECT 33 = ALL(NULL::int[])
+----
+NULL
+
+# An empty array yields the empty-set answer, not NULL.
+query B
+SELECT 33 = ALL(ARRAY[]::int[])
+----
+true
+
+# NULL elements propagate through the comparison per three-valued logic.
+query B
+SELECT 33 = ANY(ARRAY[NULL]::int[])
+----
+NULL
+
+query B
+SELECT 33 = ANY(ARRAY[33, NULL])
+----
+true
+
+query B
+SELECT 33 = ANY(ARRAY[1, NULL])
+----
+NULL
+
+query B
+SELECT 33 = ALL(ARRAY[33, NULL])
+----
+NULL
+
+query B
+SELECT 33 = ALL(ARRAY[1, NULL])
+----
+false
+
 query error ARRAY types integer and boolean cannot be matched
 SELECT 123.4 = ANY(ARRAY[1, true, 'hi'::text])
 
@@ -1076,6 +1119,22 @@ SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], nu
 ----
 NULL
 
+# Searching for NULL finds the first NULL element (IS NOT DISTINCT FROM semantics).
+query I
+SELECT array_position(ARRAY['sun','mon',NULL,'fri'], NULL)
+----
+3
+
+query I
+SELECT array_position(ARRAY[NULL, 'sun', NULL]::text[], NULL)
+----
+1
+
+query I
+SELECT array_position(ARRAY['sun', NULL, 'mon']::text[], NULL, 3)
+----
+NULL
+
 query I
 SELECT array_position(null::text[], 'abc')
 ----
@@ -1086,10 +1145,8 @@ SELECT array_position(null::text[], 'abc', null)
 ----
 NULL
 
-query I
+query error initial position must not be null
 SELECT array_position(ARRAY['sun'], null, null)
-----
-NULL
 
 query error initial position must not be null
 SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'mon', null)

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -115,6 +115,49 @@ SELECT 'hi'::text = ANY(ARRAY[]::text[])
 ----
 false
 
+# A NULL array yields NULL, distinct from the empty-array case above.
+query B
+SELECT 33 = ANY(NULL::int[])
+----
+NULL
+
+query B
+SELECT 33 = ALL(NULL::int[])
+----
+NULL
+
+# An empty array yields the empty-set answer, not NULL.
+query B
+SELECT 33 = ALL(ARRAY[]::int[])
+----
+true
+
+# NULL elements propagate through the comparison per three-valued logic.
+query B
+SELECT 33 = ANY(ARRAY[NULL]::int[])
+----
+NULL
+
+query B
+SELECT 33 = ANY(ARRAY[33, NULL])
+----
+true
+
+query B
+SELECT 33 = ANY(ARRAY[1, NULL])
+----
+NULL
+
+query B
+SELECT 33 = ALL(ARRAY[33, NULL])
+----
+NULL
+
+query B
+SELECT 33 = ALL(ARRAY[1, NULL])
+----
+false
+
 query error ARRAY types integer and boolean cannot be matched
 SELECT 123.4 = ANY(ARRAY[1, true, 'hi'::text])
 
@@ -1061,6 +1104,22 @@ SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], nu
 ----
 NULL
 
+# Searching for NULL finds the first NULL element (IS NOT DISTINCT FROM semantics).
+query I
+SELECT array_position(ARRAY['sun','mon',NULL,'fri'], NULL)
+----
+3
+
+query I
+SELECT array_position(ARRAY[NULL, 'sun', NULL]::text[], NULL)
+----
+1
+
+query I
+SELECT array_position(ARRAY['sun', NULL, 'mon']::text[], NULL, 3)
+----
+NULL
+
 query I
 SELECT array_position(null::text[], 'abc')
 ----
@@ -1071,10 +1130,8 @@ SELECT array_position(null::text[], 'abc', null)
 ----
 NULL
 
-query I
+query error initial position must not be null
 SELECT array_position(ARRAY['sun'], null, null)
-----
-NULL
 
 query error initial position must not be null
 SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'mon', null)

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -158,6 +158,30 @@ SELECT 33 = ALL(ARRAY[1, NULL])
 ----
 false
 
+# The NULL-array rule is a property of the quantifier, not of `=`.
+query B
+SELECT 33 < ANY(NULL::int[])
+----
+NULL
+
+query B
+SELECT 33 < ALL(NULL::int[])
+----
+NULL
+
+# The cases above all use a constant array, where the NULL guard folds away
+# before execution. Reading the array from a relation instead keeps the guard
+# in the plan, so this exercises the lowered form.
+query IBB
+SELECT i, 1 = ANY(a), 1 = ALL(a)
+FROM (VALUES (1, NULL::int[]), (2, ARRAY[]::int[]), (3, ARRAY[1]), (4, ARRAY[NULL::int])) v (i, a)
+ORDER BY i
+----
+1  NULL  NULL
+2  false  true
+3  true  true
+4  NULL  NULL
+
 query error ARRAY types integer and boolean cannot be matched
 SELECT 123.4 = ANY(ARRAY[1, true, 'hi'::text])
 
@@ -1145,6 +1169,12 @@ SELECT array_position(null::text[], 'abc', null)
 ----
 NULL
 
+# Deliberately different from PostgreSQL, which returns NULL here: it validates
+# the initial position only after a fast path that fires when the search term is
+# NULL and the array holds no NULL element. PostgreSQL therefore errors for
+# `array_position(ARRAY['sun', NULL], null, null)` but not for the query below.
+# Rejecting a NULL initial position regardless of the array contents is the more
+# defensible behavior.
 query error initial position must not be null
 SELECT array_position(ARRAY['sun'], null, null)
 

--- a/test/sqllogictest/cockroach/suboperators.slt
+++ b/test/sqllogictest/cockroach/suboperators.slt
@@ -526,14 +526,14 @@ NULL
 query B
 SELECT NULL = ANY(NULL::INTEGER[]);
 ----
-false
+NULL
 
 query B
 SELECT NULL = SOME(NULL::INTEGER[]);
 ----
-false
+NULL
 
 query B
 SELECT NULL = ALL(NULL::INTEGER[]);
 ----
-true
+NULL

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -3059,3 +3059,27 @@ statement ok
 CREATE MATERIALIZED VIEW json_mv AS (
     SELECT * FROM jsons WHERE random_id = CAST(payload->>'my_field' AS uuid list)[random_index]
 )
+
+# ANY/ALL over a list desugars through the same `unnest` subquery as ANY/ALL over
+# an array, so a NULL list yields NULL while an empty list yields the empty-set
+# answer.
+
+query B
+SELECT 1 = ANY(NULL::int list)
+----
+NULL
+
+query B
+SELECT 1 = ALL(NULL::int list)
+----
+NULL
+
+query B
+SELECT 1 = ANY(LIST[]::int list)
+----
+false
+
+query B
+SELECT 1 = ALL(LIST[]::int list)
+----
+true

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -690,68 +690,78 @@ With
           Get l1 // { arity: 2 }
           Get materialize.left_joins_raw.dim01 // { arity: 6 }
   cte l4 =
-    Distinct project=[#12{dim01_d01}] // { arity: 1 }
+    Filter (((strtoarray("{24, 42}")) IS NULL = false) OR ((strtoarray("{24, 42}")) IS NULL) IS NULL) // { arity: 17 }
       Get l3 // { arity: 17 }
   cte l5 =
+    Distinct project=[#12{dim01_d01}] // { arity: 1 }
+      Get l4 // { arity: 17 }
+  cte l6 =
     Reduce group_by=[#0{dim01_d01}] aggregates=[any((#0{dim01_d01} = #1{right_col0_0}))] // { arity: 2 }
       FlatMap unnest_array(strtoarray("{24, 42}")) // { arity: 2 }
-        Get l4 // { arity: 1 }
-  cte l6 =
+        Get l5 // { arity: 1 }
+  cte l7 =
     Union // { arity: 2 }
-      Get l5 // { arity: 2 }
+      Get l6 // { arity: 2 }
       CrossJoin // { arity: 2 }
         Project (#0{dim01_d01}) // { arity: 1 }
           Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Distinct project=[#0{dim01_d01}] // { arity: 1 }
-                  Get l5 // { arity: 2 }
+                  Get l6 // { arity: 2 }
               Distinct project=[#0{dim01_d01}] // { arity: 1 }
-                Get l4 // { arity: 1 }
-            Get l4 // { arity: 1 }
+                Get l5 // { arity: 1 }
+            Get l5 // { arity: 1 }
         Constant // { arity: 1 }
           - (false)
-  cte l7 =
+  cte l8 =
     Union // { arity: 2 }
-      Get l6 // { arity: 2 }
+      Get l7 // { arity: 2 }
       Project (#0{dim01_d01}, #2) // { arity: 2 }
         FlatMap guard_subquery_size(#1{count}) // { arity: 3 }
           Reduce group_by=[#0{dim01_d01}] aggregates=[count(*)] // { arity: 2 }
-            Get l6 // { arity: 2 }
-  cte l8 =
+            Get l7 // { arity: 2 }
+  cte l9 =
     Project (#0{x}..=#16{dim01_d05}) // { arity: 17 }
       Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND #17{any}) // { arity: 18 }
-        Project (#0{x}..=#16{dim01_d05}, #18{any}) // { arity: 18 }
-          Join on=(#12{dim01_d01} = #17{dim01_d01}) // { arity: 19 }
-            Get l3 // { arity: 17 }
-            Union // { arity: 2 }
-              Get l7 // { arity: 2 }
-              CrossJoin // { arity: 2 }
-                Project (#0{dim01_d01}) // { arity: 1 }
-                  Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
-                    Union // { arity: 1 }
-                      Negate // { arity: 1 }
-                        Distinct project=[#0{dim01_d01}] // { arity: 1 }
-                          Get l7 // { arity: 2 }
-                      Distinct project=[#0{dim01_d01}] // { arity: 1 }
-                        Get l4 // { arity: 1 }
-                    Get l4 // { arity: 1 }
-                Constant // { arity: 1 }
-                  - (null)
+        Union // { arity: 18 }
+          Project (#0{x}..=#17) // { arity: 18 }
+            Map (null) // { arity: 18 }
+              Filter (strtoarray("{24, 42}")) IS NULL // { arity: 17 }
+                Get l3 // { arity: 17 }
+          Project (#0{x}..=#16{dim01_d05}, #18{any}) // { arity: 18 }
+            Map (#17{any}) // { arity: 19 }
+              Project (#0{x}..=#16{dim01_d05}, #18{any}) // { arity: 18 }
+                Join on=(#12{dim01_d01} = #17{dim01_d01}) // { arity: 19 }
+                  Get l4 // { arity: 17 }
+                  Union // { arity: 2 }
+                    Get l8 // { arity: 2 }
+                    CrossJoin // { arity: 2 }
+                      Project (#0{dim01_d01}) // { arity: 1 }
+                        Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
+                          Union // { arity: 1 }
+                            Negate // { arity: 1 }
+                              Distinct project=[#0{dim01_d01}] // { arity: 1 }
+                                Get l8 // { arity: 2 }
+                            Distinct project=[#0{dim01_d01}] // { arity: 1 }
+                              Get l5 // { arity: 1 }
+                          Get l5 // { arity: 1 }
+                      Constant // { arity: 1 }
+                        - (null)
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
       Project (#0{x}..=#2{facts_k01}, #6{facts_d01}, #3{dim01_k01}, #12{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
-          Get l8 // { arity: 17 }
+          Get l9 // { arity: 17 }
           CrossJoin // { arity: 17 }
             Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
               Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                 Union // { arity: 11 }
                   Negate // { arity: 11 }
                     Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                      Get l8 // { arity: 17 }
+                      Get l9 // { arity: 17 }
                   Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
                     Get l2 // { arity: 11 }
                 Get l2 // { arity: 11 }


### PR DESCRIPTION
`x = ANY (NULL::int[])` and `x = ALL (NULL::int[])` desugar to a subquery over `unnest(array)`, which returns zero rows for both a NULL array and an empty array. That collapsed the NULL case into the empty-set answer (false for ANY, true for ALL) instead of NULL, diverging from PostgreSQL. Fixed by guarding the desugared form with `CASE WHEN array IS NULL THEN NULL ELSE ... END`. Lists reach the same desugaring and get the same fix.

The guard is gated behind `enable_any_all_null_array_semantics`, which defaults on. In value context over a non-constant array the `CASE` costs plan quality: HIR lowering defers a subquery that sits under an `If`, so several `ANY`/`ALL` operands in one clause no longer share a single lowered `unnest`. The flag is an escape hatch for a user who hits that, not a rollout mechanism. `enable_for_item_parsing` stays off, because forcing the flag on during catalog rehydration would re-plan items with semantics they were not created under. In filter context, and whenever the array is constant, the guard folds away and plans are unchanged.

`array_position(array, NULL)` short-circuited to NULL instead of searching for a NULL element using IS NOT DISTINCT FROM semantics, which is what PostgreSQL does. Fixed by removing the short-circuit; `Datum` equality already treats `Null == Null` as true. One corner deliberately diverges from PostgreSQL, which validates the initial position only after a fast path for a NULL search term over a NULL-free array, making its error depend on the array contents. We reject a NULL initial position unconditionally.

Fixes [CPU-154](https://linear.app/materializeinc/issue/CPU-154).

### Tests

`test/sqllogictest/arrays.slt` covers the ANY/ALL NULL-array and NULL-element cases, a non-`=` operator, a non-constant array read from a relation so the guard survives into the plan, and the `array_position` NULL-search cases. `test/sqllogictest/list.slt` covers the list spelling. `FlipFlagsAction` in parallel workload flips the new flag.

### Release note

This release will fix `ANY`/`ALL` over a NULL array or list to return NULL rather than the empty-set answer, and `array_position` to find NULL elements, both matching PostgreSQL.