### PR TITLE
persist: remove unused MINIMUM_CONSOLIDATED_VERSION

### DIFF
--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -34,7 +34,6 @@ use mz_persist_types::arrow::{ArrayBound, ArrayIdx, ArrayOrd};
 use mz_persist_types::columnar::data_type;
 use mz_persist_types::part::Part;
 use mz_persist_types::{Codec, Codec64};
-use semver::Version;
 use timely::progress::Timestamp;
 use tracing::{Instrument, debug_span};
 
@@ -44,11 +43,6 @@ use crate::internal::encoding::Schemas;
 use crate::internal::metrics::{ReadMetrics, ShardMetrics};
 use crate::internal::state::{HollowRun, RunMeta, RunOrder, RunPart};
 use crate::metrics::Metrics;
-
-/// Versions prior to this had bugs in consolidation, or used a different sort. However,
-/// we can assume that consolidated parts at this version or higher were consolidated
-/// according to the current definition.
-pub const MINIMUM_CONSOLIDATED_VERSION: Version = Version::new(0, 67, 0);
 
 /// The data needed to fetch a batch part, bundled up to make it easy
 /// to send between threads.

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -2180,9 +2180,10 @@ mod tests {
         // and the two versions would not consolidate out.
         // This can impact correctness!
         //
-        // If you need to change how SourceDatas are encoded, that's still fine...
-        // but we'll also need to increase
-        // the MINIMUM_CONSOLIDATED_VERSION as part of the same release.
+        // If you need to change how SourceDatas are encoded, that can be
+        // okay, but think through the consequences: a record whose old and
+        // new encodings differ never consolidates away inside existing
+        // persist shards. Loop in the persist team.
         assert_eq!(
             encoded,
             reencoded.as_str(),


### PR DESCRIPTION
`MINIMUM_CONSOLIDATED_VERSION` gated assumptions about codec-order consolidation: parts written before it could not be assumed to be consolidated/sorted according to the current definition. Its last consumers were removed in f02f202c7e ("Remove codec-order consolidation") when consolidation moved entirely to structured (Arrow) ordering with per-run `RunOrder` metadata, leaving the constant unreferenced.

Removing it avoids sending future readers down a dead path: the comment on the `source_proto_serialization_stability` test in `mz-storage-types` still instructed encoding changes to "increase the MINIMUM_CONSOLIDATED_VERSION as part of the same release", an instruction that has had no effect since then. This PR updates that comment as well. (#37482 corrects the same comment in more detail and will be rebased on top of this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(https://github.com/MaterializeInc/materialize/pull/37482 is on top of this PR.)