### PR TITLE
misc: Deprecate the standalone Python MCP servers

### DIFF
--- a/misc/mcp-materialize-agents/README.md
+++ b/misc/mcp-materialize-agents/README.md
@@ -1,5 +1,12 @@
 # Materialize MCP Server
 
+> [!WARNING]
+> **Deprecated.** The Materialize MCP server is now built into Materialize and
+> served directly by `environmentd` (the `/api/mcp/agent` and
+> `/api/mcp/developer` endpoints). This standalone package is no longer the
+> recommended way to use MCP with Materialize and is not actively maintained.
+> See the [MCP server documentation](https://materialize.com/docs/integrations/mcp-server/).
+
 **The live data layer for apps and agents**
 
 Agents succeed when they can act in a loop with confidence.

--- a/misc/mcp-materialize-agents/mcp_materialize_agents/mcp_materialize_agents/__init__.py
+++ b/misc/mcp-materialize-agents/mcp_materialize_agents/mcp_materialize_agents/__init__.py
@@ -299,6 +299,11 @@ def json_serial(obj):
 def main():
     """Synchronous wrapper for the async main function."""
     try:
+        logger.warning(
+            "DEPRECATED: this standalone MCP server is superseded by the MCP "
+            "server built into Materialize (the /api/mcp endpoints). See "
+            "https://materialize.com/docs/integrations/mcp-server/"
+        )
         logger.info("Starting Materialize MCP Server...")
         asyncio.run(run())
     except KeyboardInterrupt:

--- a/misc/mcp-materialize-agents/pyproject.toml
+++ b/misc/mcp-materialize-agents/pyproject.toml
@@ -24,6 +24,8 @@ authors = [
 ]
 
 keywords = ["materialize", "mcp", "database", "api"]
+# Deprecated: superseded by the MCP server built into Materialize.
+classifiers = ["Development Status :: 7 - Inactive"]
 dependencies = [
     "mcp>=1.10.1",
     "psycopg-pool>=3.2.6",

--- a/misc/mcp-materialize/README.md
+++ b/misc/mcp-materialize/README.md
@@ -1,5 +1,12 @@
 # Materialize MCP Server
 
+> [!WARNING]
+> **Deprecated.** The Materialize MCP server is now built into Materialize and
+> served directly by `environmentd` (the `/api/mcp/agent` and
+> `/api/mcp/developer` endpoints). This standalone package is no longer the
+> recommended way to use MCP with Materialize and is not actively maintained.
+> See the [MCP server documentation](https://materialize.com/docs/integrations/mcp-server/).
+
 **Instantly turn indexed views in Materialize into real-time context tools for LLM-powered applications.**
 
 Materialize MCP Server exposes your Materialize views—when indexed and documented—as live, typed, callable tools. These tools behave like stable APIs for structured data, enabling models to act on fresh, consistent, and trustworthy information.

--- a/misc/mcp-materialize/mcp_materialize/__init__.py
+++ b/misc/mcp-materialize/mcp_materialize/__init__.py
@@ -159,6 +159,11 @@ async def run():
 def main():
     """Synchronous wrapper for the async main function."""
     try:
+        logger.warning(
+            "DEPRECATED: this standalone MCP server is superseded by the MCP "
+            "server built into Materialize (the /api/mcp endpoints). See "
+            "https://materialize.com/docs/integrations/mcp-server/"
+        )
         logger.info("Starting Materialize MCP Server...")
         asyncio.run(run())
     except KeyboardInterrupt:

--- a/misc/mcp-materialize/pyproject.toml
+++ b/misc/mcp-materialize/pyproject.toml
@@ -24,6 +24,8 @@ authors = [
 ]
 
 keywords = ["materialize", "mcp", "database", "api"]
+# Deprecated: superseded by the MCP server built into Materialize.
+classifiers = ["Development Status :: 7 - Inactive"]
 dependencies = [
     "aiohttp>=3.11.18",
     "aiorwlock>=1.5.0",


### PR DESCRIPTION
Marks misc/mcp-materialize and misc/mcp-materialize-agents as deprecated (README banner, a startup log warning, and a PyPI 'Inactive' classifier), pointing users to the MCP server now built into environmentd and documented at materialize.com/docs/integrations/mcp-server/. Draft/proposal: this is a product/comms call on messaging and timing, and it intentionally keeps publishing the packages (so existing users see the notice) rather than removing them from ci/deploy/pypi.py — end-of-life is a possible follow-up.