### PR TITLE
adapter: fix coordinator panic when a SUBSCRIBE races a dependency drop

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -581,7 +581,23 @@ impl Coordinator {
         // subscribing session.
         let write_notify =
             self.add_active_compute_sink(sink_id, ActiveComputeSink::Subscribe(active_subscribe));
-        self.ship_dataflow(df_desc, cluster_id, replica_id).await;
+
+        // Ship the dataflow, handling errors gracefully. With the frontend subscribe
+        // sequencing, a dependency can be dropped between sequencing (on the session
+        // task) and here. The read holds acquired during sequencing don't prevent that:
+        // they hold back compaction, not drops.
+        if let Err(e) = self
+            .try_ship_dataflow(df_desc, cluster_id, replica_id)
+            .await
+        {
+            // Clean up the active compute sink that was added above, since the dataflow
+            // was never created. If we don't do this, the sink_id remains in
+            // `drop_sinks` but no collection exists in the compute controller, causing
+            // a panic when the connection terminates. This also retracts the deferred
+            // `mz_subscriptions` write, so `write_notify` can be dropped.
+            self.remove_active_compute_sink(sink_id).await;
+            return Err(AdapterError::concurrent_dependency_drop_from_dataflow_creation_error(e));
+        }
 
         // Explicitly drop read holds, just to make it obvious what's happening.
         drop(read_holds);

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -1403,6 +1403,12 @@ impl PeekClient {
                     &df_meta.optimizer_notices,
                 );
 
+                // Test-only synchronization point: parks a subscribe between
+                // sequencing and dispatch, so a test can land a concurrent DROP
+                // of a dependency in this window. Used by
+                // workflow_test_drop_index_during_subscribe_sequencing.
+                fail::fail_point!("subscribe_before_dispatch");
+
                 let response = self
                     .call_coordinator(|tx| Command::ExecuteSubscribe {
                         df_desc,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4528,6 +4528,111 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
         ), "statement execution was ended twice; end-of-execution ownership handoff regressed"
 
 
+def workflow_test_drop_index_during_subscribe_sequencing(c: Composition) -> None:
+    """Deterministically exercise a dependency drop racing a SUBSCRIBE (SQL-456).
+
+    The frontend subscribe sequencing runs on the session task: it optimizes
+    the plan (binding the indexes to read through) and acquires read holds,
+    then dispatches `Command::ExecuteSubscribe` to the coordinator. A `DROP
+    INDEX` that lands in this window removes the index's compute collection
+    (read holds hold back compaction, not drops), so shipping the subscribe
+    dataflow fails with `CollectionMissing`. Historically the coordinator
+    treated dataflow creation as infallible and panicked, aborting
+    environmentd; it must instead return a "was dropped" error to the client.
+
+    The window is a sub-millisecond cross-thread gap, so we make it
+    deterministic with the `subscribe_before_dispatch` failpoint: pause a
+    subscribe right after sequencing, drop the index it reads through while
+    it's parked, then resume so the dataflow ships against the dropped index.
+    Assert that the client gets a clean error, that environmentd survives, and
+    that no duplicate statement-logging end was logged.
+    """
+
+    failpoint = "subscribe_before_dispatch"
+
+    with c.override(Materialized()):
+        c.up("materialized")
+
+        c.sql(
+            """
+            ALTER SYSTEM SET statement_logging_max_sample_rate = 1.0;
+            ALTER SYSTEM SET statement_logging_default_sample_rate = 1.0;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        c.sql("CREATE TABLE t (a int); INSERT INTO t SELECT generate_series(1, 10);")
+        # The subscribe reads through this index, so its dataflow imports it.
+        c.sql("CREATE DEFAULT INDEX t_idx ON t")
+
+        subscriber_ready = Event()
+        failpoint_armed = Event()
+        subscribe_outcome: list[str] = []
+
+        def subscriber() -> None:
+            try:
+                with c.sql_cursor() as cur:
+                    # We connect *before* the failpoint is armed. The failpoint
+                    # only parks subscribes, but keeping the same structure as
+                    # the registered-peek tests makes the ordering obvious.
+                    subscriber_ready.set()
+                    failpoint_armed.wait()
+                    cur.execute("BEGIN")
+                    cur.execute("DECLARE sub CURSOR FOR SUBSCRIBE (SELECT * FROM t)")
+                    # The FETCH executes the subscribe: it sequences on the
+                    # session task and parks at the failpoint before
+                    # dispatching to the coordinator. It fails once t_idx is
+                    # dropped.
+                    cur.execute("FETCH ALL sub WITH (timeout = '30s')")
+                    cur.fetchall()
+                    subscribe_outcome.append("ok")
+            except Exception as e:
+                subscribe_outcome.append(f"error: {e}")
+
+        subscribe_thread = PropagatingThread(target=subscriber, name="subscriber")
+        subscribe_thread.start()
+
+        with c.sql_cursor() as control:
+            assert subscriber_ready.wait(timeout=30), "subscriber failed to connect"
+            # Arm: every subscribe now parks right after sequencing.
+            control.execute(f"SET failpoints = '{failpoint}=pause'")
+            failpoint_armed.set()
+            # Give the subscriber time to sequence its SUBSCRIBE and park. It
+            # stays parked until we turn the failpoint off, so this only has to
+            # outlast planning and optimization, not race a narrow window.
+            time.sleep(5)
+            # Drop the index while the subscribe is parked: the coordinator
+            # removes the index's compute collection.
+            control.execute("DROP INDEX t_idx")
+            # Resume the subscribe: shipping its dataflow now fails on the
+            # missing index collection, which must surface as an error on the
+            # subscribing session, not a coordinator panic.
+            control.execute(f"SET failpoints = '{failpoint}=off'")
+
+        subscribe_thread.join(timeout=30)
+
+        # The parked subscribe must actually have failed on the dropped index;
+        # otherwise the race didn't happen and the test is silently vacuous.
+        assert subscribe_outcome, "subscriber thread did not finish"
+        assert subscribe_outcome[0].startswith("error") and "was dropped" in (
+            subscribe_outcome[0]
+        ), f"expected the subscribe to fail on the dropped index, got: {subscribe_outcome[0]}"
+
+        # A panic on the coordinator thread aborts the entire environmentd
+        # process (src/ore/src/panic.rs); with no restart policy the container
+        # stays down and this fresh connection raises.
+        with c.sql_cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone() == (1,)
+
+        # Statement logging must have ended the failed subscribe exactly once
+        # (the frontend logs the error end; the coordinator defuses its guard).
+        logs = c.invoke("logs", "materialized", capture=True)
+        assert (
+            "duplicate end_statement_execution" not in logs.stdout
+        ), "statement execution was ended twice; end-of-execution ownership handoff regressed"
+
+
 def workflow_test_refresh_mv_warmup(
     c: Composition, parser: WorkflowArgumentParser
 ) -> None:


### PR DESCRIPTION
### Motivation

Fixes [SQL-456](https://linear.app/materializeinc/issue/SQL-456/thread-coordinator-panicked-at-srcadaptersrcutilrs26323-dataflow): a `SUBSCRIBE` racing a concurrent `DROP INDEX` aborted environmentd with

```
thread 'coordinator' panicked at src/adapter/src/util.rs:263:23:
dataflow creation cannot fail: CollectionMissing(User(628))
```

### Description

With the frontend subscribe sequencing (on by default), a SUBSCRIBE is sequenced on the session task and then dispatched to the coordinator via `Command::ExecuteSubscribe`. A `DROP INDEX` processed in this window removes the index's compute collection (read holds hold back compaction, not drops), so shipping the dataflow fails with `CollectionMissing`, which `ship_dataflow` treated as impossible. The old staged path cannot hit this, since its `PlanValidity` check runs in the same coordinator message as `ship_dataflow`.

The fix mirrors how slow-path peeks and COPY TO handle the same race: `implement_subscribe` ships via `try_ship_dataflow`, and on failure removes the just-registered active compute sink (leaving it registered would panic later on connection termination) and returns a `ConcurrentDependencyDrop` error. Statement logging ends exactly once on the new error path: the `ExecuteSubscribe` handler defuses its coordinator-side guard (from #36956) and the frontend logs the error end.

### Verification

New deterministic regression test `workflow_test_drop_index_during_subscribe_sequencing` in `test/cluster/mzcompose.py`, using a new `subscribe_before_dispatch` failpoint: park a SUBSCRIBE between sequencing and dispatch, drop the index it reads through, resume. It asserts a clean "was dropped" error on the client, environmentd survival, and no duplicate statement-logging end. On the unfixed code it reproduces the exact SQL-456 panic. Also verified against the stochastic reproducer from SQL-456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)