### PR TITLE
[SS-80] ALTER COMMIT INTERVAL for Iceberg sinks

### DIFF
--- a/misc/python/materialize/checks/all_checks/iceberg_sink.py
+++ b/misc/python/materialize/checks/all_checks/iceberg_sink.py
@@ -451,6 +451,182 @@ class AlterIcebergSinkWebhook(Check):
 
 
 @externally_idempotent(False)
+class AlterIcebergSinkCommitInterval(Check):
+    """Check ALTER SINK ... SET (COMMIT INTERVAL ...) on an Iceberg sink"""
+
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse_mz("v26.33.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > CREATE TABLE iceberg_table_alter_ci (x int, y string)
+                > CREATE SINK iceberg_sink_alter_ci FROM iceberg_table_alter_ci
+                  INTO ICEBERG CATALOG CONNECTION polaris_conn (
+                    NAMESPACE 'default_namespace',
+                    TABLE 'iceberg_sink_alter_ci'
+                  )
+                  USING AWS CONNECTION aws_conn
+                  KEY (x, y) NOT ENFORCED
+                  MODE UPSERT
+                  WITH (COMMIT INTERVAL '1s');
+                > INSERT INTO iceberg_table_alter_ci VALUES (0, 'a')
+                """))
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > ALTER SINK iceberg_sink_alter_ci SET (COMMIT INTERVAL = '2s');
+
+                > SELECT create_sql LIKE '%COMMIT INTERVAL = ''2s''%' FROM (SHOW CREATE SINK iceberg_sink_alter_ci);
+                true
+
+                > INSERT INTO iceberg_table_alter_ci VALUES (1, 'b')
+                """,
+                """
+                > ALTER SINK iceberg_sink_alter_ci SET (COMMIT INTERVAL = '3s');
+
+                > SELECT create_sql LIKE '%COMMIT INTERVAL = ''3s''%' FROM (SHOW CREATE SINK iceberg_sink_alter_ci);
+                true
+
+                > INSERT INTO iceberg_table_alter_ci VALUES (2, 'c')
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > SELECT create_sql LIKE '%COMMIT INTERVAL = ''3s''%' FROM (SHOW CREATE SINK iceberg_sink_alter_ci);
+                true
+
+                $ set-from-sql var=iceberg_user
+                SELECT user FROM iceberg_credentials
+
+                $ set-from-sql var=iceberg_key
+                SELECT key FROM iceberg_credentials
+
+                $ duckdb-execute name=iceberg
+                CREATE SECRET s3_secret (TYPE S3, KEY_ID '${iceberg_user}', SECRET '${iceberg_key}', ENDPOINT 'minio:9000', URL_STYLE 'path', USE_SSL false, REGION 'minio');
+                SET unsafe_enable_version_guessing = true;
+
+                $ duckdb-query name=iceberg
+                SELECT * FROM iceberg_scan('s3://test-bucket/default_namespace/iceberg_sink_alter_ci') ORDER BY 1
+                0 a
+                1 b
+                2 c
+            """))
+
+
+@externally_idempotent(False)
+class IcebergSinkCommitIntervalMigration(Check):
+    """Regression test for the COMMIT INTERVAL migration (SS-80, #37493).
+
+    Since v26.33, planning rejects `COMMIT INTERVAL < 1s` for Iceberg sinks.
+    Because catalog bootstrap re-plans every object's persisted `create_sql`,
+    an environment that already has such a sink -- created on an older version
+    that accepted it -- panics environmentd on upgrade ("invalid persisted
+    SQL") and crash-loops the whole environment unless the migration rewrites
+    the value to '1s'. We create the sinks on the old base version and assert
+    the environment still boots, the values are rewritten, and the sinks keep
+    committing.
+
+    The interval is covered in both AST shapes a user can persist it as: a
+    single-quoted string ('999ms', stored as WithOptionValue::Value) and a
+    double-quoted value ("998ms", lexed as an identifier and stored as
+    WithOptionValue::UnresolvedItemName). The migration must rewrite both.
+    """
+
+    def _can_run(self, e: Executor) -> bool:
+        # The < 1s rejection landed in v26.33. Only reproducible when the base
+        # version still accepts the value; otherwise the CREATEs in
+        # initialize() fail up-front. Also makes this a no-op in non-upgrade
+        # scenarios (base == current, rejecting build).
+        return (
+            MzVersion.parse_mz("v26.10.0-dev")
+            <= self.base_version
+            < MzVersion.parse_mz("v26.33.0-dev")
+        )
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > CREATE TABLE iceberg_ci_migration_table (x int, y string)
+                > CREATE SINK iceberg_ci_migration_sink1 FROM iceberg_ci_migration_table
+                  INTO ICEBERG CATALOG CONNECTION polaris_conn (
+                    NAMESPACE 'default_namespace',
+                    TABLE 'iceberg_ci_migration_sink1'
+                  )
+                  USING AWS CONNECTION aws_conn
+                  KEY (x, y) NOT ENFORCED
+                  MODE UPSERT
+                  WITH (COMMIT INTERVAL '999ms');
+                > CREATE SINK iceberg_ci_migration_sink2 FROM iceberg_ci_migration_table
+                  INTO ICEBERG CATALOG CONNECTION polaris_conn (
+                    NAMESPACE 'default_namespace',
+                    TABLE 'iceberg_ci_migration_sink2'
+                  )
+                  USING AWS CONNECTION aws_conn
+                  KEY (x, y) NOT ENFORCED
+                  MODE UPSERT
+                  WITH (COMMIT INTERVAL = "998ms");
+                > INSERT INTO iceberg_ci_migration_table VALUES (0, 'a')
+                """))
+
+    def manipulate(self) -> list[Testdrive]:
+        # Only flow data; the manipulate phases run on newer (rejecting)
+        # builds, so no sub-second-interval DDL here.
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > INSERT INTO iceberg_ci_migration_table VALUES (1, 'b')
+                """,
+                """
+                > INSERT INTO iceberg_ci_migration_table VALUES (2, 'c')
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        # Reaching validate() means bootstrap survived the upgrade. Also
+        # assert that the migration rewrote both intervals to '1s' and that
+        # the sinks are still healthy and committing.
+        return Testdrive(dedent("""
+                > SELECT create_sql LIKE '%COMMIT INTERVAL = ''1s''%' FROM (SHOW CREATE SINK iceberg_ci_migration_sink1);
+                true
+
+                > SELECT create_sql LIKE '%COMMIT INTERVAL = ''1s''%' FROM (SHOW CREATE SINK iceberg_ci_migration_sink2);
+                true
+
+                > SELECT status FROM mz_internal.mz_sink_statuses WHERE name LIKE 'iceberg_ci_migration_sink%';
+                running
+                running
+
+                $ set-from-sql var=iceberg_user
+                SELECT user FROM iceberg_credentials
+
+                $ set-from-sql var=iceberg_key
+                SELECT key FROM iceberg_credentials
+
+                $ duckdb-execute name=iceberg
+                CREATE SECRET s3_secret (TYPE S3, KEY_ID '${iceberg_user}', SECRET '${iceberg_key}', ENDPOINT 'minio:9000', URL_STYLE 'path', USE_SSL false, REGION 'minio');
+                SET unsafe_enable_version_guessing = true;
+
+                $ duckdb-query name=iceberg
+                SELECT * FROM iceberg_scan('s3://test-bucket/default_namespace/iceberg_ci_migration_sink1') ORDER BY 1
+                0 a
+                1 b
+                2 c
+
+                $ duckdb-query name=iceberg
+                SELECT * FROM iceberg_scan('s3://test-bucket/default_namespace/iceberg_ci_migration_sink2') ORDER BY 1
+                0 a
+                1 b
+                2 c
+            """))
+
+
+@externally_idempotent(False)
 class AlterIcebergSinkOrder(Check):
     """Check ALTER SINK with a table created after the sink, see incident 131"""
 

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -155,6 +155,7 @@ pub(crate) async fn migrate(
         ast_rewrite_sql_server_constraints(stmt)?;
         ast_rewrite_add_missing_index_ids(tx, stmt)?;
         ast_rewrite_kafka_metadata_refresh_intervals(stmt)?;
+        ast_rewrite_small_commit_intervals(stmt)?;
         Ok(())
     })?;
 
@@ -1047,9 +1048,8 @@ fn ast_rewrite_kafka_metadata_refresh_intervals(
 ) -> Result<(), anyhow::Error> {
     use mz_sql::ast::{
         CreateSinkConnection, CreateSourceConnection, KafkaSinkConfigOptionName,
-        KafkaSourceConfigOptionName, Value, WithOptionValue,
+        KafkaSourceConfigOptionName, WithOptionValue,
     };
-    use mz_sql::plan::TryFromValue;
     // A user can persist the interval either as a string literal
     // (`WithOptionValue::Value`) or, if they wrote it as a double-quoted
     // value, as a lexed identifier (`WithOptionValue::UnresolvedItemName`).
@@ -1094,12 +1094,52 @@ fn ast_rewrite_kafka_metadata_refresh_intervals(
         return Ok(());
     };
 
-    let interval_dur = Duration::try_from_value(interval.clone()).map_err(|e| {
-        anyhow::anyhow!("invalid value for kafka metadata refresh interval: {interval:?}: {e}")
-    })?;
+    rewrite_interval_option_floor_1s(interval, "kafka metadata refresh interval")
+}
 
-    if interval_dur < Duration::from_secs(1) {
-        *interval = WithOptionValue::Value(Value::String("1s".to_string()));
+/// Planning enforces a 1 second minimum `COMMIT INTERVAL`, but smaller
+/// intervals used to be accepted (and a sub-millisecond one left the sink
+/// unable to ever commit). Rewrite any persisted smaller interval to 1s so
+/// the sink still plans after an upgrade.
+///
+/// `COMMIT INTERVAL` is a generic `CREATE SINK` option in the grammar, but only
+/// Iceberg sinks accept it and only Iceberg planning enforces the 1s floor.
+fn ast_rewrite_small_commit_intervals(stmt: &mut Statement<Raw>) -> Result<(), anyhow::Error> {
+    use mz_sql::ast::{CreateSinkConnection, CreateSinkOptionName};
+
+    let Statement::CreateSink(stmt) = stmt else {
+        return Ok(());
+    };
+    if !matches!(stmt.connection, CreateSinkConnection::Iceberg { .. }) {
+        return Ok(());
+    }
+    let interval = stmt.with_options.iter_mut().find_map(|o| {
+        if matches!(o.name, CreateSinkOptionName::CommitInterval) {
+            o.value.as_mut()
+        } else {
+            None
+        }
+    });
+    let Some(interval) = interval else {
+        return Ok(());
+    };
+
+    rewrite_interval_option_floor_1s(interval, "commit interval")
+}
+
+/// Rewrites an interval option value to `'1s'` if it is below 1 second.
+fn rewrite_interval_option_floor_1s(
+    value: &mut mz_sql::ast::WithOptionValue<Raw>,
+    label: &str,
+) -> Result<(), anyhow::Error> {
+    use mz_sql::ast::{Value, WithOptionValue};
+    use mz_sql::plan::TryFromValue;
+
+    let dur = Duration::try_from_value(value.clone())
+        .map_err(|e| anyhow::anyhow!("invalid value for {label}: {value:?}: {e}"))?;
+
+    if dur < Duration::from_secs(1) {
+        *value = WithOptionValue::Value(Value::String("1s".to_string()));
     }
 
     Ok(())

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -35,9 +35,9 @@ use mz_ore::{instrument, soft_panic_or_log};
 use mz_repr::role_id::RoleId;
 use mz_repr::{Diff, GlobalId, SqlScalarType, Timestamp};
 use mz_sql::ast::{
-    AlterConnectionAction, AlterConnectionStatement, AlterSinkAction, AlterSourceAction, AstInfo,
-    ConstantVisitor, CopyRelation, CopyStatement, CreateSourceOptionName, Raw, Statement,
-    StatementKind, SubscribeStatement,
+    AlterConnectionAction, AlterConnectionStatement, AlterSourceAction, AstInfo, ConstantVisitor,
+    CopyRelation, CopyStatement, CreateSourceOptionName, Raw, Statement, StatementKind,
+    SubscribeStatement,
 };
 use mz_sql::catalog::RoleAttributesRaw;
 use mz_sql::names::{Aug, PartialItemName, ResolvedIds};
@@ -1716,17 +1716,13 @@ impl Coordinator {
             // users.
             Statement::AlterCluster(_) => false,
 
-            // `ALTER SINK SET FROM` waits for the old relation to make enough progress for a clean
-            // cutover. If the old collection is stalled, it may block forever. Checks in
+            // `ALTER SINK` waits for the sink to make enough progress for a clean cutover to the
+            // new configuration. If the sink is stalled, it may block forever. Checks in
             // sequencing ensure that the operation fails if any one of these happens concurrently:
             //   * the sink is dropped
-            //   * the new source relation is dropped
+            //   * the source relation is dropped
             //   * another `ALTER SINK` for the same sink is applied first
-            Statement::AlterSink(stmt)
-                if matches!(stmt.action, AlterSinkAction::ChangeRelation(_)) =>
-            {
-                false
-            }
+            Statement::AlterSink(_) => false,
 
             // `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` waits for the target MV to make
             // enough progress for a clean cutover. If the target MV is stalled, it may block

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3435,9 +3435,11 @@ impl Coordinator {
             sink: sink_plan,
             with_snapshot,
             in_cluster,
+            set_options,
+            reset_options,
         } = ctx.plan.clone();
 
-        // We avoid taking the DDL lock for `ALTER SINK SET FROM` commands, see
+        // We avoid taking the DDL lock for `ALTER SINK` commands, see
         // `Coordinator::must_serialize_ddl`. We therefore must assume that the world has
         // arbitrarily changed since we performed planning, and we must re-assert that it still
         // matches our requirements.
@@ -3501,18 +3503,23 @@ impl Coordinator {
         };
 
         // Update the sink version.
-        stmt.with_options
-            .retain(|o| o.name != CreateSinkOptionName::Version);
-        stmt.with_options.push(CreateSinkOption {
-            name: CreateSinkOptionName::Version,
-            value: Some(WithOptionValue::Value(mz_sql::ast::Value::Number(
-                sink_plan.version.to_string(),
-            ))),
-        });
+        plan::apply_sink_option_edits(
+            &mut stmt.with_options,
+            &[CreateSinkOption {
+                name: CreateSinkOptionName::Version,
+                value: Some(WithOptionValue::Value(mz_sql::ast::Value::Number(
+                    sink_plan.version.to_string(),
+                ))),
+            }],
+            &[],
+        );
 
         let conn_catalog = self.catalog().for_system_session();
         let (mut stmt, resolved_ids) =
             mz_sql::names::resolve(&conn_catalog, stmt).expect("resolvable create_sql");
+
+        // Re-apply the option edits requested by the `ALTER SINK`.
+        plan::apply_sink_option_edits(&mut stmt.with_options, &set_options, &reset_options);
 
         // Update the `from` relation.
         let from_entry = self.catalog().get_entry_by_global_id(&sink_plan.from);

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -51,9 +51,9 @@ use mz_repr::{
     SqlColumnType, SqlRelationType, SqlScalarType, Timestamp, VersionedRelationDesc,
 };
 use mz_sql_parser::ast::{
-    AlterSourceAddSubsourceOption, ClusterAlterOptionValue, ConnectionOptionName, QualifiedReplica,
-    RawDataType, SelectStatement, TransactionIsolationLevel, TransactionMode, UnresolvedItemName,
-    Value, WithOptionValue,
+    AlterSourceAddSubsourceOption, ClusterAlterOptionValue, ConnectionOptionName, CreateSinkOption,
+    CreateSinkOptionName, QualifiedReplica, RawDataType, SelectStatement,
+    TransactionIsolationLevel, TransactionMode, UnresolvedItemName, Value, WithOptionValue,
 };
 use mz_ssh_util::keys::SshKeyPair;
 use mz_storage_types::connections::aws::AwsConnection;
@@ -1282,6 +1282,27 @@ pub struct AlterSinkPlan {
     pub sink: Sink,
     pub with_snapshot: bool,
     pub in_cluster: ClusterId,
+    /// The with-option edit requested by the `ALTER SINK`. Sequencing must
+    /// re-apply it to the catalog's `create_sql` (via
+    /// [`apply_sink_option_edits`]) because the `create_sql` may have changed
+    /// since planning, for example due to a schema swap.
+    pub set_options: Vec<CreateSinkOption<Aug>>,
+    pub reset_options: Vec<CreateSinkOptionName>,
+}
+
+/// Applies the option edits of an `ALTER SINK ... SET/RESET (...)` to the
+/// with-options of a `CREATE SINK` statement.
+pub fn apply_sink_option_edits<T: mz_sql_parser::ast::AstInfo>(
+    with_options: &mut Vec<CreateSinkOption<T>>,
+    set_options: &[CreateSinkOption<T>],
+    reset_options: &[CreateSinkOptionName],
+) where
+    CreateSinkOption<T>: Clone,
+{
+    with_options.retain(|o| {
+        set_options.iter().all(|s| s.name != o.name) && !reset_options.contains(&o.name)
+    });
+    with_options.extend(set_options.iter().cloned());
 }
 
 #[derive(Debug, Clone)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3758,8 +3758,17 @@ fn iceberg_sink_builder(
     let Some(namespace) = namespace else {
         sql_bail!("Iceberg sink must specify NAMESPACE");
     };
-    if commit_interval.is_none() {
-        sql_bail!("Iceberg sink must specify COMMIT INTERVAL");
+    match commit_interval {
+        None => sql_bail!("Iceberg sink must specify COMMIT INTERVAL"),
+        // The sink truncates the interval to whole milliseconds, and a
+        // truncated interval of zero would make it mint zero-width batches in
+        // a busy loop, never committing any data. Require a full second so
+        // truncation is irrelevant, matching the TOPIC METADATA REFRESH
+        // INTERVAL minimum.
+        Some(interval) if interval < Duration::from_secs(1) => {
+            sql_bail!("COMMIT INTERVAL must be at least 1 second")
+        }
+        Some(_) => {}
     }
 
     Ok(StorageSinkConnection::Iceberg(IcebergSinkConnection {
@@ -7318,40 +7327,93 @@ pub fn plan_alter_sink(
     // Always ALTER objects from their latest version.
     let item = item.at_version(RelationVersionSelector::Latest);
 
+    // First we reconstruct the original CREATE SINK statement
+    let create_sql = item.create_sql();
+    let stmts = mz_sql_parser::parser::parse_statements(create_sql)?;
+    let [stmt]: [StatementParseResult; 1] = stmts
+        .try_into()
+        .map_err(|_| internal_err!("create SQL of sink was not exactly one statement"))?;
+    let Statement::CreateSink(stmt) = stmt.ast else {
+        bail_internal!("create SQL of sink is not a CREATE SINK statement");
+    };
+    let (mut stmt, _) = crate::names::resolve(scx.catalog, stmt)?;
+
+    // Then apply the requested change to the statement
+    let mut set_options = vec![];
+    let mut reset_options = vec![];
     match action {
         AlterSinkAction::ChangeRelation(new_from) => {
-            // First we reconstruct the original CREATE SINK statement
-            let create_sql = item.create_sql();
-            let stmts = mz_sql_parser::parser::parse_statements(create_sql)?;
-            let [stmt]: [StatementParseResult; 1] = stmts
-                .try_into()
-                .map_err(|_| internal_err!("create SQL of sink was not exactly one statement"))?;
-            let Statement::CreateSink(stmt) = stmt.ast else {
-                bail_internal!("create SQL of sink is not a CREATE SINK statement");
-            };
-
-            // Then resolve and swap the resolved from relation to the new one
-            let (mut stmt, _) = crate::names::resolve(scx.catalog, stmt)?;
             stmt.from = new_from;
-
-            // Finally re-plan the modified create sink statement to verify the new configuration is valid
-            let Plan::CreateSink(mut plan) = plan_sink(scx, stmt)? else {
-                bail_internal!("plan_sink did not produce a CreateSink plan");
-            };
-
-            plan.sink.version += 1;
-
-            Ok(Plan::AlterSink(AlterSinkPlan {
-                item_id: item.id(),
-                global_id: item.global_id(),
-                sink: plan.sink,
-                with_snapshot: plan.with_snapshot,
-                in_cluster: plan.in_cluster,
-            }))
         }
-        AlterSinkAction::SetOptions(_) => bail_unsupported!("ALTER SINK SET options"),
-        AlterSinkAction::ResetOptions(_) => bail_unsupported!("ALTER SINK RESET option"),
+        AlterSinkAction::SetOptions(options) => {
+            for option in &options {
+                match &option.name {
+                    CreateSinkOptionName::CommitInterval => {}
+                    name => bail_unsupported!(format!(
+                        "ALTER SINK ... SET ({})",
+                        name.to_ast_string_simple()
+                    )),
+                }
+            }
+            // Setting every option to its current value would restart the
+            // sink dataflow without changing its behavior, so make it a
+            // no-op instead. The values are compared as ASTs, so spelling
+            // the same value differently (`'60s'` vs `'1m'`) still counts
+            // as a change.
+            //
+            // NOTE: This check races with other `ALTER SINK` statements,
+            // because `ALTER SINK` does not take the DDL lock. Example: the
+            // interval is '1s', we plan `SET (COMMIT INTERVAL = '1s')` as a
+            // no-op, and before we respond a concurrent `ALTER SINK` changes
+            // the interval to '2s'. We then report success even though the
+            // interval is now '2s', not the '1s' we were asked for. An alter
+            // that is not a no-op detects this in sequencing by checking the
+            // sink's version, but a no-op is never re-checked. We accept this
+            // because alters are last-writer-wins anyway.
+            if options.iter().all(|o| stmt.with_options.contains(o)) {
+                return Ok(Plan::AlterNoop(AlterNoopPlan { object_type }));
+            }
+            set_options = options;
+        }
+        AlterSinkAction::ResetOptions(names) => {
+            for name in &names {
+                match name {
+                    CreateSinkOptionName::CommitInterval => {}
+                    name => bail_unsupported!(format!(
+                        "ALTER SINK ... RESET ({})",
+                        name.to_ast_string_simple()
+                    )),
+                }
+                // Resetting an option that is not set would still restart the
+                // sink dataflow, so reject it instead of silently no-oping.
+                if !stmt.with_options.iter().any(|o| o.name == *name) {
+                    sql_bail!(
+                        "cannot RESET {}: option is not set",
+                        name.to_ast_string_simple()
+                    );
+                }
+            }
+            reset_options = names;
+        }
     }
+    crate::plan::apply_sink_option_edits(&mut stmt.with_options, &set_options, &reset_options);
+
+    // Finally re-plan the modified create sink statement to verify the new configuration is valid
+    let Plan::CreateSink(mut plan) = plan_sink(scx, stmt)? else {
+        bail_internal!("plan_sink did not produce a CreateSink plan");
+    };
+
+    plan.sink.version += 1;
+
+    Ok(Plan::AlterSink(AlterSinkPlan {
+        item_id: item.id(),
+        global_id: item.global_id(),
+        sink: plan.sink,
+        with_snapshot: plan.with_snapshot,
+        in_cluster: plan.in_cluster,
+        set_options,
+        reset_options,
+    }))
 }
 
 pub fn describe_alter_source(

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -1137,6 +1137,8 @@ fn generate_rbac_requirements(
             sink,
             with_snapshot: _,
             in_cluster,
+            set_options: _,
+            reset_options: _,
         }) => {
             let items = iter::once(sink.from).map(|gid| catalog.resolve_item_id(&gid));
             let mut privileges = generate_read_privileges(catalog, items, role_id);

--- a/test/iceberg/alter-commit-interval.td
+++ b/test/iceberg/alter-commit-interval.td
@@ -1,0 +1,135 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# ALTER SINK ... SET (COMMIT INTERVAL ...) changes the commit interval of a
+# running Iceberg sink. The sink dataflow restarts with the new interval and
+# subsequent batches follow the new cadence.
+
+> CREATE CONNECTION polaris TO ICEBERG CATALOG (
+    CATALOG TYPE = 'REST',
+    URL = 'http://polaris:8181/api/catalog',
+    CREDENTIAL = 'root:root',
+    WAREHOUSE = 'default_catalog',
+    SCOPE = 'PRINCIPAL_ROLE:ALL'
+  );
+
+> CREATE TABLE t (a int, b text);
+
+> INSERT INTO t VALUES (1, 'one'), (2, 'two');
+
+> CREATE SINK alter_demo
+    FROM t
+    INTO ICEBERG CATALOG CONNECTION polaris (
+        NAMESPACE 'default_namespace',
+        TABLE 'alter_ci_table'
+    )
+    KEY (a) NOT ENFORCED
+    MODE UPSERT
+    WITH (COMMIT INTERVAL '1s');
+
+# Only COMMIT INTERVAL is alterable.
+! ALTER SINK alter_demo SET (SNAPSHOT = false)
+contains: ALTER SINK ... SET (SNAPSHOT) not yet supported
+
+! ALTER SINK alter_demo RESET (SNAPSHOT)
+contains: ALTER SINK ... RESET (SNAPSHOT) not yet supported
+
+# Iceberg sinks require a commit interval, so it cannot be reset.
+! ALTER SINK alter_demo RESET (COMMIT INTERVAL)
+contains: Iceberg sink must specify COMMIT INTERVAL
+
+# A sub-second interval would truncate to milliseconds (and possibly to a
+# zero-width batch that never commits anything).
+! ALTER SINK alter_demo SET (COMMIT INTERVAL = '500ms')
+contains: COMMIT INTERVAL must be at least 1 second
+
+! ALTER SINK alter_demo SET (COMMIT INTERVAL = '0s')
+contains: COMMIT INTERVAL must be at least 1 second
+
+# Iceberg sinks commit data asynchronously, need to wait for at least one
+# commit interval.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
+
+$ duckdb-execute name=iceberg
+CREATE SECRET s3_secret (TYPE S3, KEY_ID 'tduser', SECRET '${arg.s3-access-key}', ENDPOINT '${arg.aws-endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'minio');
+SET unsafe_enable_version_guessing = true;
+
+$ duckdb-query name=iceberg
+SELECT a, b FROM iceberg_scan('s3://test-bucket/default_namespace/alter_ci_table') ORDER BY a
+1 one
+2 two
+
+# Stretch the commit interval to an hour.
+$ set-from-sql var=status_count
+SELECT COUNT(*)::text FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON mz_internal.mz_sink_status_history.sink_id = mz_sinks.id WHERE name = 'alter_demo' AND status = 'running'
+
+> ALTER SINK alter_demo SET (COMMIT INTERVAL = '1h')
+
+> SELECT create_sql LIKE '%COMMIT INTERVAL = ''1h''%' FROM (SHOW CREATE SINK alter_demo)
+true
+
+# Wait for the restarted sink dataflow to reach running.
+> SELECT COUNT(*) > ${status_count} FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON mz_internal.mz_sink_status_history.sink_id = mz_sinks.id WHERE name = 'alter_demo' AND status = 'running'
+true
+
+# The restarted sink picks a cutoff time: rows older than the cutoff are
+# committed immediately (ignoring the interval), rows newer than it wait for
+# the next hourly commit. We want row 3 to wait, so it must be inserted after
+# the cutoff is picked.
+#
+# The problem: the sink picks the cutoff only after loading the Iceberg table
+# from the catalog, which takes a few network round trips, and nothing
+# queryable tells us when that has happened. The 'running' status above
+# appears before it. So we sleep and assume 5 seconds is enough.
+#
+# If row 3 ever shows up in the "1 one / 2 two" check below, the table load
+# took longer than the sleep. Bump the duration.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=5s
+
+# Data inserted from now on sits in an open one-hour batch and must not show
+# up in the Iceberg table.
+> INSERT INTO t VALUES (3, 'three')
+
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
+
+$ duckdb-query name=iceberg
+SELECT a, b FROM iceberg_scan('s3://test-bucket/default_namespace/alter_ci_table') ORDER BY a
+1 one
+2 two
+
+# Shrink the interval back down. This also re-plans the create_sql that the
+# previous ALTER rewrote. The pending row must now commit promptly.
+> ALTER SINK alter_demo SET (COMMIT INTERVAL = '1s')
+
+> SELECT create_sql LIKE '%COMMIT INTERVAL = ''1s''%' FROM (SHOW CREATE SINK alter_demo)
+true
+
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
+
+$ duckdb-query name=iceberg
+SELECT a, b FROM iceberg_scan('s3://test-bucket/default_namespace/alter_ci_table') ORDER BY a
+1 one
+2 two
+3 three
+
+# The sink is healthy after all the alters.
+> SELECT status FROM mz_internal.mz_sink_statuses WHERE name = 'alter_demo'
+running
+
+# Setting the commit interval to its current value is a no-op and does not
+# restart the sink dataflow, so no new status history entries appear.
+$ set-from-sql var=noop_status_count
+SELECT COUNT(*)::text FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON mz_internal.mz_sink_status_history.sink_id = mz_sinks.id WHERE name = 'alter_demo'
+
+> ALTER SINK alter_demo SET (COMMIT INTERVAL = '1s')
+
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=5s
+
+> SELECT COUNT(*) = ${noop_status_count} FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON mz_internal.mz_sink_status_history.sink_id = mz_sinks.id WHERE name = 'alter_demo'
+true

--- a/test/iceberg/mzcompose.py
+++ b/test/iceberg/mzcompose.py
@@ -105,6 +105,18 @@ def workflow_mode_append(c: Composition) -> None:
     )
 
 
+def workflow_alter_commit_interval(c: Composition) -> None:
+    """ALTER SINK ... SET (COMMIT INTERVAL ...) restarts the sink dataflow
+    with the new interval and subsequent batches follow the new cadence."""
+    key = _setup(c)
+
+    c.run_testdrive_files(
+        f"--var=s3-access-key={key}",
+        "--var=aws-endpoint=minio:9000",
+        "alter-commit-interval.td",
+    )
+
+
 def workflow_empty_source(c: Composition) -> None:
     """A fresh Iceberg sink whose input closes after producing zero rows
     commits one empty snapshot instead of stalling or erroring."""

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -124,3 +124,17 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
 
 $ kafka-verify-data format=json sink=materialize.public.sink key=false
 {"before": null, "after": {"created_post_name": "hundred", "created_post_value": 99}}
+
+# COMMIT INTERVAL only applies to Iceberg sinks.
+! ALTER SINK sink SET (COMMIT INTERVAL = '1s');
+contains: COMMIT INTERVAL option is not supported with KAFKA sinks
+
+! ALTER SINK sink RESET (COMMIT INTERVAL);
+contains: cannot RESET COMMIT INTERVAL: option is not set
+
+# Other sink options are not alterable.
+! ALTER SINK sink SET (SNAPSHOT = false);
+contains: ALTER SINK ... SET (SNAPSHOT) not yet supported
+
+! ALTER SINK sink RESET (SNAPSHOT);
+contains: ALTER SINK ... RESET (SNAPSHOT) not yet supported


### PR DESCRIPTION
In this PR:
- Allow users to alter an Iceberg sink's commit interval.
- Set 1s as the minimum commit interval for Iceberg sinks.