### PR TITLE
orchestratord tests: Retry installing metrics server

### DIFF
--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -348,7 +348,7 @@ def recreate_kind_cluster() -> None:
         ]
     )
 
-    install_metrics_server()
+    retry(install_metrics_server, 20)
 
 
 @contextmanager


### PR DESCRIPTION
Download was seen flaking: https://buildkite.com/materialize/nightly/builds/17039#019f3d18-581e-4276-955f-09f5a4c2c4b4

Test run: https://buildkite.com/materialize/nightly/builds/17041