### PR TITLE
SS-336: GSR client: Add write and additional lookup APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6049,6 +6049,7 @@ dependencies = [
  "aws-sdk-glue",
  "aws-smithy-runtime-api",
  "aws-types",
+ "mz-ore",
  "thiserror 2.0.18",
  "tracing",
  "uuid",

--- a/src/aws-glue-schema-registry/Cargo.toml
+++ b/src/aws-glue-schema-registry/Cargo.toml
@@ -16,3 +16,6 @@ aws-types.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }

--- a/src/aws-glue-schema-registry/src/client.rs
+++ b/src/aws-glue-schema-registry/src/client.rs
@@ -10,12 +10,20 @@
 //! The Glue Schema Registry client.
 
 use aws_sdk_glue::error::{DisplayErrorContext, SdkError};
+use aws_sdk_glue::operation::create_schema::CreateSchemaError as SdkCreateSchemaError;
 use aws_sdk_glue::operation::get_registry::GetRegistryError as SdkGetRegistryError;
+use aws_sdk_glue::operation::get_schema::GetSchemaError as SdkGetSchemaError;
 use aws_sdk_glue::operation::get_schema_version::{
     GetSchemaVersionError as SdkGetSchemaVersionError, GetSchemaVersionOutput,
 };
+// Module aliases: these two operation error types share names with this crate's
+// own error enums, so they must be qualified, and their fully-aliased `use`
+// lines overflow the format width. A short module alias sidesteps both.
+use aws_sdk_glue::operation::get_schema_by_definition as sdk_get_by_def;
+use aws_sdk_glue::operation::register_schema_version as sdk_register;
 use aws_sdk_glue::types::{
-    DataFormat as SdkDataFormat, RegistryId, RegistryStatus as SdkRegistryStatus, SchemaId,
+    Compatibility as SdkCompatibility, DataFormat as SdkDataFormat, RegistryId,
+    RegistryStatus as SdkRegistryStatus, SchemaId, SchemaStatus as SdkSchemaStatus,
     SchemaVersionNumber, SchemaVersionStatus as SdkSchemaVersionStatus,
 };
 use aws_types::SdkConfig;
@@ -120,6 +128,133 @@ impl Client {
             .map_err(classify_get_schema_version_error)?;
         Ok(SchemaVersion::from_sdk(output))
     }
+
+    /// Look up the schema version whose definition byte-for-byte matches
+    /// `definition`, returning its UUID.
+    ///
+    /// This is the sink reuse path: before registering a new version, callers
+    /// check whether the exact definition is already registered so that a sink
+    /// restart does not create a duplicate version. Returns
+    /// [`GetSchemaByDefinitionError::NotFound`] if the schema does not exist or
+    /// has no version matching `definition`.
+    pub async fn get_schema_by_definition(
+        &self,
+        registry_name: &str,
+        schema_name: &str,
+        definition: &str,
+    ) -> Result<Uuid, GetSchemaByDefinitionError> {
+        let schema_id = SchemaId::builder()
+            .registry_name(registry_name)
+            .schema_name(schema_name)
+            .build();
+        let output = self
+            .inner
+            .get_schema_by_definition()
+            .schema_id(schema_id)
+            .schema_definition(definition)
+            .send()
+            .await
+            .map_err(classify_get_schema_by_definition_error)?;
+        parse_schema_version_id(output.schema_version_id).map_err(GetSchemaByDefinitionError::Other)
+    }
+
+    /// Register `definition` as a new version of an existing schema, returning
+    /// the new version's UUID.
+    ///
+    /// The schema `(registry_name, schema_name)` must already exist. Returns
+    /// [`RegisterSchemaVersionError::SchemaNotFound`] if it does not, in which
+    /// case the caller should create it with [`Client::create_schema`].
+    /// Registering a definition identical to an existing version is idempotent
+    /// on Glue's side and returns that version's UUID.
+    pub async fn register_schema_version(
+        &self,
+        registry_name: &str,
+        schema_name: &str,
+        definition: &str,
+    ) -> Result<Uuid, RegisterSchemaVersionError> {
+        let schema_id = SchemaId::builder()
+            .registry_name(registry_name)
+            .schema_name(schema_name)
+            .build();
+        let output = self
+            .inner
+            .register_schema_version()
+            .schema_id(schema_id)
+            .schema_definition(definition)
+            .send()
+            .await
+            .map_err(classify_register_schema_version_error)?;
+        parse_schema_version_id(output.schema_version_id).map_err(RegisterSchemaVersionError::Other)
+    }
+
+    /// Create a schema in `registry_name` with `definition` as its first version
+    /// and `compatibility` as its evolution policy, returning the first
+    /// version's UUID.
+    ///
+    /// Glue sets a schema's compatibility only at creation. This crate exposes
+    /// no way to change it afterward, matching the sink's set-if-unset policy:
+    /// an existing schema's compatibility is read (via [`Client::get_schema`])
+    /// and warned on, never overwritten.
+    ///
+    /// Returns [`CreateSchemaError::AlreadyExists`] if the schema already exists
+    /// and [`CreateSchemaError::RegistryNotFound`] if the registry does not.
+    pub async fn create_schema(
+        &self,
+        registry_name: &str,
+        schema_name: &str,
+        data_format: DataFormat,
+        compatibility: Compatibility,
+        definition: &str,
+    ) -> Result<Uuid, CreateSchemaError> {
+        let registry_id = RegistryId::builder().registry_name(registry_name).build();
+        let output = self
+            .inner
+            .create_schema()
+            .registry_id(registry_id)
+            .schema_name(schema_name)
+            .data_format(data_format.to_sdk())
+            .compatibility(compatibility.to_sdk())
+            .schema_definition(definition)
+            .send()
+            .await
+            .map_err(classify_create_schema_error)?;
+        parse_schema_version_id(output.schema_version_id).map_err(CreateSchemaError::Other)
+    }
+
+    /// Fetch a schema's metadata by `(registry_name, schema_name)`.
+    ///
+    /// The sink uses this to read the current compatibility policy so it can
+    /// warn on a mismatch without overwriting it, and to detect whether the
+    /// schema already exists. Returns [`GetSchemaError::NotFound`] if the schema
+    /// does not exist.
+    pub async fn get_schema(
+        &self,
+        registry_name: &str,
+        schema_name: &str,
+    ) -> Result<Schema, GetSchemaError> {
+        let schema_id = SchemaId::builder()
+            .registry_name(registry_name)
+            .schema_name(schema_name)
+            .build();
+        let output = self
+            .inner
+            .get_schema()
+            .schema_id(schema_id)
+            .send()
+            .await
+            .map_err(classify_get_schema_error)?;
+        Ok(Schema {
+            compatibility: output.compatibility.map(Compatibility::from_sdk),
+            lifecycle_status: output.schema_status.map(SchemaLifecycleStatus::from_sdk),
+        })
+    }
+}
+
+/// Parse a schema-version UUID from a Glue response, mapping a missing or
+/// malformed id to a diagnostic string for the caller to wrap.
+fn parse_schema_version_id(id: Option<String>) -> Result<Uuid, String> {
+    let id = id.ok_or_else(|| "Glue response missing schema version id".to_string())?;
+    Uuid::parse_str(&id).map_err(|e| format!("invalid Glue schema version id {id:?}: {e}"))
 }
 
 /// A Glue Schema Registry, as returned by [`Client::get_registry`].
@@ -240,6 +375,15 @@ impl DataFormat {
         }
     }
 
+    fn to_sdk(&self) -> SdkDataFormat {
+        match self {
+            DataFormat::Avro => SdkDataFormat::Avro,
+            DataFormat::Json => SdkDataFormat::Json,
+            DataFormat::Protobuf => SdkDataFormat::Protobuf,
+            DataFormat::Unknown(s) => SdkDataFormat::from(s.as_str()),
+        }
+    }
+
     /// Returns the canonical Glue data-format string (`AVRO`, `JSON`,
     /// `PROTOBUF`), or the raw SDK-reported value for `Unknown`.
     pub fn as_str(&self) -> &str {
@@ -248,6 +392,94 @@ impl DataFormat {
             DataFormat::Json => "JSON",
             DataFormat::Protobuf => "PROTOBUF",
             DataFormat::Unknown(s) => s,
+        }
+    }
+}
+
+/// A schema's evolution policy, as accepted by [`Client::create_schema`] and
+/// returned by [`Client::get_schema`].
+///
+/// Mirrors `aws_sdk_glue::types::Compatibility`, with `Unknown(String)` as the
+/// forward-compat escape hatch. The `*All` variants are Glue's transitive
+/// modes (a new schema must be compatible with every prior version, not just
+/// the latest). `Disabled` turns off enforcement entirely and has no Confluent
+/// analogue. See [`RegistryLifecycleStatus`] for the mirroring rationale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Compatibility {
+    None,
+    Disabled,
+    Backward,
+    BackwardAll,
+    Forward,
+    ForwardAll,
+    Full,
+    FullAll,
+    /// A value the SDK reported that this crate does not yet know about.
+    Unknown(String),
+}
+
+impl Compatibility {
+    fn from_sdk(compatibility: SdkCompatibility) -> Self {
+        match &compatibility {
+            SdkCompatibility::None => Compatibility::None,
+            SdkCompatibility::Disabled => Compatibility::Disabled,
+            SdkCompatibility::Backward => Compatibility::Backward,
+            SdkCompatibility::BackwardAll => Compatibility::BackwardAll,
+            SdkCompatibility::Forward => Compatibility::Forward,
+            SdkCompatibility::ForwardAll => Compatibility::ForwardAll,
+            SdkCompatibility::Full => Compatibility::Full,
+            SdkCompatibility::FullAll => Compatibility::FullAll,
+            _ => Compatibility::Unknown(compatibility.as_str().to_string()),
+        }
+    }
+
+    fn to_sdk(&self) -> SdkCompatibility {
+        match self {
+            Compatibility::None => SdkCompatibility::None,
+            Compatibility::Disabled => SdkCompatibility::Disabled,
+            Compatibility::Backward => SdkCompatibility::Backward,
+            Compatibility::BackwardAll => SdkCompatibility::BackwardAll,
+            Compatibility::Forward => SdkCompatibility::Forward,
+            Compatibility::ForwardAll => SdkCompatibility::ForwardAll,
+            Compatibility::Full => SdkCompatibility::Full,
+            Compatibility::FullAll => SdkCompatibility::FullAll,
+            Compatibility::Unknown(s) => SdkCompatibility::from(s.as_str()),
+        }
+    }
+}
+
+/// A Glue schema's metadata, as returned by [`Client::get_schema`].
+///
+/// Only the fields the sink needs are surfaced. `compatibility` drives the
+/// warn-on-mismatch check; `lifecycle_status` distinguishes a live schema from
+/// one mid-deletion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Schema {
+    pub compatibility: Option<Compatibility>,
+    pub lifecycle_status: Option<SchemaLifecycleStatus>,
+}
+
+/// Lifecycle status of a Glue schema.
+///
+/// Mirrors `aws_sdk_glue::types::SchemaStatus`. Distinct from
+/// [`SchemaVersionLifecycleStatus`], which tracks an individual version. See
+/// [`RegistryLifecycleStatus`] for the mirroring rationale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaLifecycleStatus {
+    Available,
+    Pending,
+    Deleting,
+    /// A value the SDK reported that this crate does not yet know about.
+    Unknown(String),
+}
+
+impl SchemaLifecycleStatus {
+    fn from_sdk(status: SdkSchemaStatus) -> Self {
+        match &status {
+            SdkSchemaStatus::Available => SchemaLifecycleStatus::Available,
+            SdkSchemaStatus::Pending => SchemaLifecycleStatus::Pending,
+            SdkSchemaStatus::Deleting => SchemaLifecycleStatus::Deleting,
+            _ => SchemaLifecycleStatus::Unknown(status.as_str().to_string()),
         }
     }
 }
@@ -303,4 +535,165 @@ fn classify_get_schema_version_error(
         return GetSchemaVersionError::NotFound;
     }
     GetSchemaVersionError::Other(DisplayErrorContext(&err).to_string())
+}
+
+/// Errors returned by [`Client::get_schema_by_definition`].
+#[derive(Debug, Error)]
+pub enum GetSchemaByDefinitionError {
+    /// No schema version with the given definition exists (either the schema is
+    /// absent or none of its versions match). Maps from Glue's
+    /// `EntityNotFoundException`.
+    #[error("schema version for definition not found")]
+    NotFound,
+    /// Anything else: auth failure, throttling, transport error, or a malformed
+    /// version id in the response.
+    #[error("AWS Glue error: {0}")]
+    Other(String),
+}
+
+fn classify_get_schema_by_definition_error(
+    err: SdkError<sdk_get_by_def::GetSchemaByDefinitionError>,
+) -> GetSchemaByDefinitionError {
+    if let SdkError::ServiceError(service_err) = &err
+        && matches!(
+            service_err.err(),
+            sdk_get_by_def::GetSchemaByDefinitionError::EntityNotFoundException(_)
+        )
+    {
+        return GetSchemaByDefinitionError::NotFound;
+    }
+    GetSchemaByDefinitionError::Other(DisplayErrorContext(&err).to_string())
+}
+
+/// Errors returned by [`Client::register_schema_version`].
+#[derive(Debug, Error)]
+pub enum RegisterSchemaVersionError {
+    /// The target schema does not exist, so there is nothing to add a version
+    /// to. The caller should create it with [`Client::create_schema`]. Maps
+    /// from Glue's `EntityNotFoundException`.
+    #[error("schema not found")]
+    SchemaNotFound,
+    /// Anything else: auth failure, throttling, transport error, or a malformed
+    /// version id in the response.
+    #[error("AWS Glue error: {0}")]
+    Other(String),
+}
+
+fn classify_register_schema_version_error(
+    err: SdkError<sdk_register::RegisterSchemaVersionError>,
+) -> RegisterSchemaVersionError {
+    if let SdkError::ServiceError(service_err) = &err
+        && matches!(
+            service_err.err(),
+            sdk_register::RegisterSchemaVersionError::EntityNotFoundException(_)
+        )
+    {
+        return RegisterSchemaVersionError::SchemaNotFound;
+    }
+    RegisterSchemaVersionError::Other(DisplayErrorContext(&err).to_string())
+}
+
+/// Errors returned by [`Client::create_schema`].
+#[derive(Debug, Error)]
+pub enum CreateSchemaError {
+    /// A schema with this name already exists in the registry. The caller
+    /// should reuse it via [`Client::get_schema_by_definition`] and
+    /// [`Client::register_schema_version`]. Maps from Glue's
+    /// `AlreadyExistsException`.
+    #[error("schema already exists")]
+    AlreadyExists,
+    /// The target registry does not exist. Maps from Glue's
+    /// `EntityNotFoundException`.
+    #[error("registry not found")]
+    RegistryNotFound,
+    /// Anything else: auth failure, throttling, transport error, or a malformed
+    /// version id in the response.
+    #[error("AWS Glue error: {0}")]
+    Other(String),
+}
+
+fn classify_create_schema_error(err: SdkError<SdkCreateSchemaError>) -> CreateSchemaError {
+    if let SdkError::ServiceError(service_err) = &err {
+        match service_err.err() {
+            SdkCreateSchemaError::AlreadyExistsException(_) => {
+                return CreateSchemaError::AlreadyExists;
+            }
+            SdkCreateSchemaError::EntityNotFoundException(_) => {
+                return CreateSchemaError::RegistryNotFound;
+            }
+            _ => {}
+        }
+    }
+    CreateSchemaError::Other(DisplayErrorContext(&err).to_string())
+}
+
+/// Errors returned by [`Client::get_schema`].
+#[derive(Debug, Error)]
+pub enum GetSchemaError {
+    /// The schema does not exist. Maps from Glue's `EntityNotFoundException`.
+    #[error("schema not found")]
+    NotFound,
+    /// Anything else: auth failure, throttling, transport error, etc.
+    #[error("AWS Glue error: {0}")]
+    Other(String),
+}
+
+fn classify_get_schema_error(err: SdkError<SdkGetSchemaError>) -> GetSchemaError {
+    if let SdkError::ServiceError(service_err) = &err
+        && matches!(
+            service_err.err(),
+            SdkGetSchemaError::EntityNotFoundException(_)
+        )
+    {
+        return GetSchemaError::NotFound;
+    }
+    GetSchemaError::Other(DisplayErrorContext(&err).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn parse_schema_version_id_valid() {
+        let uuid = Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap();
+        assert_eq!(parse_schema_version_id(Some(uuid.to_string())), Ok(uuid));
+    }
+
+    #[mz_ore::test]
+    fn parse_schema_version_id_missing() {
+        let err = parse_schema_version_id(None).unwrap_err();
+        assert!(err.contains("missing schema version id"), "{err}");
+    }
+
+    #[mz_ore::test]
+    fn parse_schema_version_id_malformed() {
+        let err = parse_schema_version_id(Some("not-a-uuid".to_string())).unwrap_err();
+        assert!(err.contains("invalid Glue schema version id"), "{err}");
+    }
+
+    #[mz_ore::test]
+    fn compatibility_sdk_round_trip() {
+        // Every known variant must survive to_sdk -> from_sdk unchanged, so the
+        // CSR-to-Glue mapping in the sink can rely on stable identities.
+        for c in [
+            Compatibility::None,
+            Compatibility::Disabled,
+            Compatibility::Backward,
+            Compatibility::BackwardAll,
+            Compatibility::Forward,
+            Compatibility::ForwardAll,
+            Compatibility::Full,
+            Compatibility::FullAll,
+        ] {
+            assert_eq!(Compatibility::from_sdk(c.to_sdk()), c);
+        }
+    }
+
+    #[mz_ore::test]
+    fn data_format_sdk_round_trip() {
+        for f in [DataFormat::Avro, DataFormat::Json, DataFormat::Protobuf] {
+            assert_eq!(DataFormat::from_sdk(f.to_sdk()), f);
+        }
+    }
 }

--- a/src/aws-glue-schema-registry/src/lib.rs
+++ b/src/aws-glue-schema-registry/src/lib.rs
@@ -15,7 +15,7 @@
 //! Registry client. It is intentionally narrow: only the surface needed by
 //! the current Materialize integration is implemented.
 //!
-//! Currently implemented:
+//! Read path (source decode, DDL planning, connection validation):
 //!
 //! * [`Client::get_registry`] — used by `GlueSchemaRegistryConnection::validate`
 //!   to verify a registry exists at `CREATE CONNECTION` time.
@@ -24,10 +24,21 @@
 //! * [`Client::get_schema_version_latest_by_name`] — DDL planning: pin a
 //!   reader schema to the registry's current "latest" version.
 //!
-//! Future work will add:
+//! Write path (sink encode):
 //!
-//! * `register_schema_version`, `get_schema_version_by_definition`,
-//!   `get_compatibility`, `update_compatibility` — sink encode.
+//! * [`Client::get_schema_by_definition`] — reuse an already-registered
+//!   definition so a sink restart does not create a duplicate version.
+//! * [`Client::register_schema_version`] — add a new version to an existing
+//!   schema.
+//! * [`Client::create_schema`] — create a schema on first publish, setting its
+//!   compatibility policy.
+//! * [`Client::get_schema`] — read a schema's compatibility to warn on a
+//!   mismatch without overwriting it.
+//!
+//! Glue has no separate get/update-compatibility API: a schema's compatibility
+//! is set once at [`Client::create_schema`] and read back via
+//! [`Client::get_schema`]. This crate deliberately exposes no way to change it,
+//! matching the sink's set-if-unset policy.
 //!
 //! ## Example usage
 //!
@@ -51,7 +62,9 @@ mod client;
 mod config;
 
 pub use client::{
-    Client, DataFormat, GetRegistryError, GetSchemaVersionError, Registry, RegistryLifecycleStatus,
-    SchemaVersion, SchemaVersionLifecycleStatus,
+    Client, Compatibility, CreateSchemaError, DataFormat, GetRegistryError,
+    GetSchemaByDefinitionError, GetSchemaError, GetSchemaVersionError, RegisterSchemaVersionError,
+    Registry, RegistryLifecycleStatus, Schema, SchemaLifecycleStatus, SchemaVersion,
+    SchemaVersionLifecycleStatus,
 };
 pub use config::ClientConfig;


### PR DESCRIPTION
In preparation for using Glue schema registry with Kafka sinks, this PR adds new APIs to the Glue schema registry client.

- *create_schema* - create new schema
- *register_schema_version* - create a new version of an existing schema
- *get_schema* - get a schema by name
- *get_schema_by_definition* - get a schema by definition

E2E tests running under https://github.com/MaterializeInc/materialize/pull/37496: https://buildkite.com/materialize/test/builds/127658