### PR TITLE
adapter: fix builtin cluster replication factor drift across restarts

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1127,63 +1127,85 @@ fn add_new_remove_old_builtin_cluster_replicas_migration(
             acc
         });
 
-    // Add new replicas.
+    // Reconcile builtin replicas against the durable cluster row.
+    //
+    // The target replication factor comes from `cluster.config.variant`,
+    // which is the durable source of truth: seeded from the bootstrap flag
+    // on first boot, updated by `ALTER CLUSTER` after that. Reading from
+    // the cluster row here (instead of the bootstrap flag) means an ALTER
+    // survives a restart, and keeps the invariant
+    // `count(system replicas of cluster C) == C.replication_factor`.
+    //
+    // Also handles the rf > 0 -> rf = 0 direction: a replica that should
+    // no longer exist stays in `durable_replicas` and gets removed by the
+    // orphan-cleanup loop at the bottom of this function.
+    //
+    // The bootstrap map is still consulted for the Unmanaged fallback,
+    // matching prior behavior for legacy on-disk configs.
     for builtin_replica in BUILTIN_CLUSTER_REPLICAS {
         let cluster = cluster_lookup
             .get(builtin_replica.cluster_name)
             .expect("builtin cluster replica references non-existent cluster");
-        // `empty_map` is a hack to simplify the if statement below.
+
+        let (target_rf, replica_size) = match &cluster.config.variant {
+            ClusterVariant::Managed(m) => (m.replication_factor, m.size.clone()),
+            ClusterVariant::Unmanaged => {
+                let bootstrap =
+                    builtin_cluster_config_map.get_config(builtin_replica.cluster_name)?;
+                (bootstrap.replication_factor, bootstrap.size.clone())
+            }
+        };
+
+        // Stand-in empty map for clusters with no stored replicas, so the
+        // branches below can treat `replica_names` uniformly.
         let mut empty_map: BTreeMap<String, ClusterReplica> = BTreeMap::new();
         let replica_names = durable_replicas
             .get_mut(&cluster.id)
             .unwrap_or(&mut empty_map);
 
-        let builtin_cluster_bootstrap_config =
-            builtin_cluster_config_map.get_config(builtin_replica.cluster_name)?;
-        if replica_names.remove(builtin_replica.name).is_none()
-            // NOTE(SangJunBak): We need to explicitly check the replication factor because
-            // BUILT_IN_CLUSTER_REPLICAS is constant throughout all deployments but the replication
-            // factor is configurable on bootstrap.
-            && builtin_cluster_bootstrap_config.replication_factor > 0
-        {
-            let replica_size = match cluster.config.variant {
-                ClusterVariant::Managed(ClusterVariantManaged { ref size, .. }) => size.clone(),
-                ClusterVariant::Unmanaged => builtin_cluster_bootstrap_config.size.clone(),
-            };
-
-            let config = builtin_cluster_replica_config(replica_size.clone());
-            // Builtin replicas live on system clusters. This runs inside the
-            // catalog-open transaction with no coordinator, so allocating from
-            // the same transaction is single-source and safe.
-            let replica_id = txn.allocate_system_replica_id()?;
-            txn.insert_cluster_replica_with_id(
-                cluster.id,
-                replica_id,
-                builtin_replica.name,
-                config,
-                MZ_SYSTEM_ROLE_ID,
-            )?;
-
-            let audit_id = txn.allocate_audit_log_id()?;
-            txn.insert_audit_log_event(VersionedEvent::new(
-                audit_id,
-                EventType::Create,
-                ObjectType::ClusterReplica,
-                EventDetails::CreateClusterReplicaV4(mz_audit_log::CreateClusterReplicaV4 {
-                    cluster_id: cluster.id.to_string(),
-                    cluster_name: cluster.name.clone(),
-                    replica_id: Some(replica_id.to_string()),
-                    replica_name: builtin_replica.name.to_string(),
-                    logical_size: replica_size,
-                    billed_as: None,
-                    internal: false,
-                    reason: CreateOrDropClusterReplicaReasonV1::System,
-                    scheduling_policies: None,
-                }),
-                None,
-                boot_ts.into(),
-            ));
+        if target_rf == 0 {
+            // Leave any existing replica in `durable_replicas` so the
+            // cleanup loop below removes it.
+            continue;
         }
+
+        if replica_names.remove(builtin_replica.name).is_some() {
+            // Replica already exists. Nothing to do.
+            continue;
+        }
+
+        let config = builtin_cluster_replica_config(replica_size.clone());
+        // Builtin replicas live on system clusters. This runs inside the
+        // catalog-open transaction with no coordinator, so allocating from
+        // the same transaction is single-source and safe.
+        let replica_id = txn.allocate_system_replica_id()?;
+        txn.insert_cluster_replica_with_id(
+            cluster.id,
+            replica_id,
+            builtin_replica.name,
+            config,
+            MZ_SYSTEM_ROLE_ID,
+        )?;
+
+        let audit_id = txn.allocate_audit_log_id()?;
+        txn.insert_audit_log_event(VersionedEvent::new(
+            audit_id,
+            EventType::Create,
+            ObjectType::ClusterReplica,
+            EventDetails::CreateClusterReplicaV4(mz_audit_log::CreateClusterReplicaV4 {
+                cluster_id: cluster.id.to_string(),
+                cluster_name: cluster.name.clone(),
+                replica_id: Some(replica_id.to_string()),
+                replica_name: builtin_replica.name.to_string(),
+                logical_size: replica_size,
+                billed_as: None,
+                internal: false,
+                reason: CreateOrDropClusterReplicaReasonV1::System,
+                scheduling_policies: None,
+            }),
+            None,
+            boot_ts.into(),
+        ));
     }
 
     // Remove old replicas.

--- a/src/environmentd/tests/bootstrap_builtin_clusters.rs
+++ b/src/environmentd/tests/bootstrap_builtin_clusters.rs
@@ -36,3 +36,129 @@ fn test_zero_replication_factor_no_replicas() {
     assert_eq!(replication_factor, 0);
     assert_eq!(replica_count, 0);
 }
+
+/// Fetch `(mz_clusters.replication_factor, count(mz_cluster_replicas))` for a
+/// builtin cluster name.
+fn fetch_rf_and_replica_count(
+    server: &test_util::TestServerWithRuntime,
+    cluster_name: &str,
+) -> (i32, i32) {
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    let row = client
+        .query_one(
+            "SELECT c.replication_factor::integer, \
+                    COUNT(cr.id)::integer AS replica_count \
+             FROM mz_clusters c \
+             LEFT JOIN mz_cluster_replicas cr ON c.id = cr.cluster_id \
+             WHERE c.name = $1 \
+             GROUP BY c.id, c.replication_factor",
+            &[&cluster_name],
+        )
+        .unwrap();
+    (row.get(0), row.get(1))
+}
+
+// Regression test for SQL-207. The bootstrap flag seeds the durable
+// `mz_clusters.replication_factor` on first boot and is not consulted
+// again on subsequent boots. Whatever the flag is set to on later boots,
+// the stored `replication_factor` and the actual replica count must stay
+// in sync.
+//
+// NOTE: `TestHarness::default()` generates a fresh `environment_id` per
+// call, which points each boot at a different durable catalog. Clone the
+// harness and swap the flag with `with_builtin_system_cluster_replication_factor`
+// so both boots share one durable catalog.
+#[mz_ore::test]
+fn test_builtin_system_cluster_replication_factor_zero_across_restart() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let base = test_util::TestHarness::default().data_directory(data_dir.path());
+
+    // First boot at rf=0 seeds the durable value.
+    {
+        let server = base
+            .clone()
+            .with_builtin_system_cluster_replication_factor(0)
+            .start_blocking();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (0, 0));
+    }
+
+    // Second boot at rf=1: bootstrap flag is ignored, durable value stays
+    // at 0, no replica is created.
+    {
+        let server = base
+            .clone()
+            .with_builtin_system_cluster_replication_factor(1)
+            .start_blocking();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (0, 0));
+    }
+}
+
+#[mz_ore::test]
+fn test_builtin_system_cluster_replication_factor_one_across_restart() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let base = test_util::TestHarness::default().data_directory(data_dir.path());
+
+    // First boot at rf=1 seeds the durable value and creates the replica.
+    {
+        let server = base
+            .clone()
+            .with_builtin_system_cluster_replication_factor(1)
+            .start_blocking();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (1, 1));
+    }
+
+    // Second boot at rf=0: bootstrap flag is ignored, durable value stays
+    // at 1, replica is preserved.
+    {
+        let server = base
+            .clone()
+            .with_builtin_system_cluster_replication_factor(0)
+            .start_blocking();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (1, 1));
+    }
+}
+
+// `ALTER CLUSTER mz_system SET (REPLICATION FACTOR N)` must survive a
+// restart. The replica migration reconciles `mz_cluster_replicas` to the
+// stored `replication_factor` on boot, in both directions.
+#[mz_ore::test]
+fn test_builtin_system_cluster_alter_survives_restart() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let base = test_util::TestHarness::default().data_directory(data_dir.path());
+
+    {
+        let server = base
+            .clone()
+            .with_builtin_system_cluster_replication_factor(1)
+            .start_blocking();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (1, 1));
+
+        let mut client = server.connect_internal(postgres::NoTls).unwrap();
+        client
+            .execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 0)", &[])
+            .unwrap();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (0, 0));
+    }
+
+    {
+        let server = base
+            .clone()
+            .with_builtin_system_cluster_replication_factor(1)
+            .start_blocking();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (0, 0));
+
+        let mut client = server.connect_internal(postgres::NoTls).unwrap();
+        client
+            .execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)", &[])
+            .unwrap();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (1, 1));
+    }
+
+    {
+        let server = base
+            .clone()
+            .with_builtin_system_cluster_replication_factor(0)
+            .start_blocking();
+        assert_eq!(fetch_rf_and_replica_count(&server, "mz_system"), (1, 1));
+    }
+}

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -993,6 +993,122 @@ def workflow_user_id_no_reuse_after_restart(c: Composition) -> None:
     c.sql("DROP TABLE idreuse_t1")
 
 
+def _assert_builtin_cluster_consistent(
+    c: Composition, cluster_name: str, expected_rf: int | None = None
+) -> None:
+    """Assert the count invariant for a builtin cluster.
+
+    `mz_clusters.replication_factor` must equal the number of rows in
+    `mz_cluster_replicas` for that cluster. If `expected_rf` is given, also
+    assert the stored value matches it.
+    """
+    stored_rf = int(
+        c.sql_query(
+            f"SELECT replication_factor FROM mz_clusters WHERE name = '{cluster_name}'"
+        )[0][0]
+    )
+    actual_replicas = int(
+        c.sql_query(
+            "SELECT count(*) FROM mz_cluster_replicas r "
+            "JOIN mz_clusters c ON c.id = r.cluster_id "
+            f"WHERE c.name = '{cluster_name}'"
+        )[0][0]
+    )
+    assert stored_rf == actual_replicas, (
+        f"{cluster_name} has replication_factor={stored_rf} "
+        f"but {actual_replicas} actual replica(s)"
+    )
+    if expected_rf is not None:
+        assert (
+            stored_rf == expected_rf
+        ), f"{cluster_name} has replication_factor={stored_rf}, expected {expected_rf}"
+
+
+def workflow_builtin_cluster_replication_factor_drift_zero_to_one(
+    c: Composition,
+) -> None:
+    """Regression test for SQL-207.
+
+    Boot `mz_system` with `--bootstrap-builtin-system-cluster-replication-factor=0`,
+    then restart with `=1`. The bootstrap flag is one-time, so
+    `mz_clusters.replication_factor` should stay at 0 after the restart, and
+    the invariant `stored rf == replica count` must hold on both boots.
+    """
+    c.down(destroy_volumes=True)
+
+    with c.override(Materialized(builtin_system_cluster_replication_factor=0)):
+        c.up("materialized")
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=0)
+        c.kill("materialized")
+
+    with c.override(Materialized(builtin_system_cluster_replication_factor=1)):
+        c.up("materialized")
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=0)
+        c.kill("materialized")
+
+    c.down(destroy_volumes=True)
+
+
+def workflow_builtin_cluster_replication_factor_drift_one_to_zero(
+    c: Composition,
+) -> None:
+    """Regression test for SQL-207, mirror direction.
+
+    Boot `mz_system` with rf=1, then restart with rf=0. Same reasoning: the
+    bootstrap flag is one-time, so `mz_clusters.replication_factor` stays at
+    1 after the restart, and the invariant must hold.
+    """
+    c.down(destroy_volumes=True)
+
+    with c.override(Materialized(builtin_system_cluster_replication_factor=1)):
+        c.up("materialized")
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=1)
+        c.kill("materialized")
+
+    with c.override(Materialized(builtin_system_cluster_replication_factor=0)):
+        c.up("materialized")
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=1)
+        c.kill("materialized")
+
+    c.down(destroy_volumes=True)
+
+
+def workflow_builtin_cluster_alter_survives_restart(c: Composition) -> None:
+    """`ALTER CLUSTER mz_system SET (REPLICATION FACTOR N)` must survive a
+    restart, and `mz_cluster_replicas` must reconcile to the new value.
+    """
+    c.down(destroy_volumes=True)
+
+    with c.override(Materialized(builtin_system_cluster_replication_factor=1)):
+        c.up("materialized")
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=1)
+
+        c.sql(
+            "ALTER CLUSTER mz_system SET (REPLICATION FACTOR 0)",
+            port=6877,
+            user="mz_system",
+        )
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=0)
+        c.kill("materialized")
+
+        c.up("materialized")
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=0)
+
+        c.sql(
+            "ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)",
+            port=6877,
+            user="mz_system",
+        )
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=1)
+        c.kill("materialized")
+
+        c.up("materialized")
+        _assert_builtin_cluster_consistent(c, "mz_system", expected_rf=1)
+        c.kill("materialized")
+
+    c.down(destroy_volumes=True)
+
+
 def workflow_rename_schema_types_functions(c: Composition) -> None:
     """Verify that ALTER SCHEMA RENAME updates references to a renamed schema's types.
 


### PR DESCRIPTION
Problem:
Booting environmentd with
`--bootstrap-builtin-<name>-cluster-replication-factor=X`, then restarting with a different value, leaves `mz_clusters.replication_factor` out of sync with the actual replica count for the affected builtin cluster (mz_system`, `mz_catalog_server`, `mz_probe). Two directions are broken:
- 0 -> 1: the replica migration creates a replica because it re-reads the bootstrap flag on every boot, but the cluster migration doesn't touch the existing cluster row, so `mz_clusters.replication_factor` stays at 0.
- 1 -> 0: symmetric drift because the replica migration only handles the "create if missing" direction, never removes an existing replica when the flag drops.

`ALTER CLUSTER mz_system SET (REPLICATION FACTOR N)` also silently loses on the next restart in some interleavings, since the two writes (user ALTER, boot-time replica migration) read different sources of truth for the target rf.

Solution:
Treat the bootstrap flag as one-time initialization only, as its name suggests, and make the durable `mz_clusters.replication_factor` the sole authority after that.

`ALTER CLUSTER` is the ongoing dial and survives restarts, and the invariant `count(system replicas of cluster C) == C.replication_factor` holds.

Testing:
- Rust integration tests in bootstrap_builtin_clusters.rs
- MZCompose workflows in test/restart/mzcompose.py

Fixes SQL-207.