### PR TITLE
optimizer: Correct the comment on zero counts in the subquery-size guard

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3784,11 +3784,17 @@ impl TableFunc {
                 generate_subscripts_array(datums[0], datums[1].unwrap_int32())
             }
             TableFunc::GuardSubquerySize { column_type: _ } => {
-                // A subquery used as an expression may return at most one row;
-                // for 0 or 1 we emit no rows and let the subquery's own output
-                // flow through. Zero is benign, not "can't happen": constant
-                // folding can prove the body empty and fold its count to a
-                // literal `0`, which decorrelates to NULL via the outer lookup.
+                // A subquery used as an expression may return at most one row.
+                // For 0 or 1 we emit no rows and let the subquery's own output
+                // flow through. Zero can't come directly from the count that
+                // lowering plants (an MIR `count(true)`, at least 1 per group),
+                // but over a provably empty subquery body the optimizer may
+                // vacuously rewrite the counted expression to `null`, and a
+                // count of `null` over a group is 0. Later simplifications can
+                // surface that 0 as a literal argument that is evaluated
+                // during optimization. Emitting no rows is also the correct
+                // semantics: the empty subquery decorrelates to NULL via the
+                // outer lookup.
                 let count = datums[0].unwrap_int64();
                 if count > 1 {
                     Err(EvalError::MultipleRowsFromSubquery)
@@ -4171,8 +4177,10 @@ mod tests {
 
     /// 0 and 1 are valid (no guard rows), >1 errors with
     /// `MultipleRowsFromSubquery`, <0 with `NegativeRowsFromSubquery`. Zero is
-    /// legitimate, not "can't happen": constant folding can fold an empty
-    /// subquery's count to `0`, which must not panic (regression for #37049).
+    /// legitimate, not "can't happen": the optimizer can turn an empty
+    /// subquery's count into a literal `0` that is evaluated during
+    /// optimization (see the comment in `eval`), so it must not panic (exposed
+    /// by #37049).
     #[mz_ore::test]
     fn guard_subquery_size_accepts_zero_and_one() {
         let func = TableFunc::GuardSubquerySize {


### PR DESCRIPTION
Comment-only change. Followup to https://github.com/MaterializeInc/materialize/pull/37155

The previous comment said constant folding folds an empty subquery's count to a literal 0, but folding an MIR count over an empty collection yields an empty collection, not a 0. The actual mechanism (verified by tracing the original failure from #37155 on the commit where it occurred): over a provably empty subquery body, EquivalencePropagation vacuously rewrites the guard's count(true) to count(null), ReduceElision then elides the Reduce into a literal 0 via on_unique, LiteralLifting substitutes that literal into the guard's argument, and FlatMapElimination eagerly evaluates table functions with all-literal arguments during optimization.
