### PR TITLE
SS-336: interchange: generalize AvroEncoder over Confluent and Glue framing

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -15,7 +15,7 @@ mod schema;
 
 pub use crate::avro::decode::{Decoder, DiffPair};
 pub use crate::avro::encode::{
-    AvroEncoder, AvroSchemaGenerator, DocTarget, encode_datums_as_avro,
+    AvroEncoder, AvroSchemaGenerator, AvroSchemaId, DocTarget, encode_datums_as_avro,
     encode_debezium_transaction_unchecked, get_debezium_transaction_schema,
 };
 pub use crate::avro::schema::{

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -22,6 +22,7 @@ use mz_repr::adt::jsonb::JsonbRef;
 use mz_repr::adt::numeric::{self, NUMERIC_AGG_MAX_PRECISION, NUMERIC_DATUM_MAX_PRECISION};
 use mz_repr::{CatalogItemId, ColumnName, Datum, RelationDesc, Row, SqlColumnType, SqlScalarType};
 use serde_json::json;
+use uuid::Uuid;
 
 use crate::encode::{Encode, TypedDatum, column_names_and_types};
 use crate::envelopes::{self, DBZ_ROW_TYPE_ID, ENVELOPE_CUSTOM_NAMES};
@@ -82,7 +83,23 @@ static DEBEZIUM_TRANSACTION_SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
     .expect("valid schema constructed")
 });
 
-fn encode_avro_header(buf: &mut Vec<u8>, schema_id: i32) {
+/// Identifies the schema-registry wire framing an [`AvroEncoder`] prepends to
+/// each record, carrying the registry-specific schema id.
+///
+/// The variant is fixed when the encoder is built and determines both the
+/// header written by [`Encode::encode_unchecked`] and the header stripped by
+/// [`Encode::hash`]. The two must always agree: hashing with the wrong stripper
+/// would hash a byte-shifted payload and scramble stable partitioning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AvroSchemaId {
+    /// Confluent wire format: magic byte `0x00` then a 4-byte big-endian id.
+    Confluent(i32),
+    /// AWS Glue wire format: an 18-byte header carrying a schema-version UUID.
+    /// See [`crate::glue`].
+    Glue(Uuid),
+}
+
+fn encode_confluent_header(buf: &mut Vec<u8>, schema_id: i32) {
     // The first byte is a magic byte (0) that indicates the Confluent
     // serialization format version, and the next four bytes are a
     // 32-bit schema ID.
@@ -94,16 +111,26 @@ fn encode_avro_header(buf: &mut Vec<u8>, schema_id: i32) {
 }
 
 fn encode_message_unchecked(
-    schema_id: i32,
+    schema_id: AvroSchemaId,
     row: Row,
     schema: &Schema,
     columns: &[(ColumnName, SqlColumnType)],
 ) -> Vec<u8> {
-    let mut buf = vec![];
-    encode_avro_header(&mut buf, schema_id);
     let value = encode_datums_as_avro(row.iter(), columns);
-    mz_avro::encode_unchecked(&value, schema, &mut buf);
-    buf
+    match schema_id {
+        AvroSchemaId::Confluent(id) => {
+            let mut buf = vec![];
+            encode_confluent_header(&mut buf, id);
+            mz_avro::encode_unchecked(&value, schema, &mut buf);
+            buf
+        }
+        AvroSchemaId::Glue(id) => {
+            let mut buf = vec![];
+            crate::glue::write_avro_header(&mut buf, id);
+            mz_avro::encode_unchecked(&value, schema, &mut buf);
+            buf
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -210,7 +237,7 @@ impl AvroSchemaGenerator {
 pub struct AvroEncoder {
     columns: Vec<(ColumnName, SqlColumnType)>,
     schema: Schema,
-    schema_id: i32,
+    schema_id: AvroSchemaId,
 }
 
 impl fmt::Debug for AvroEncoder {
@@ -222,7 +249,7 @@ impl fmt::Debug for AvroEncoder {
 }
 
 impl AvroEncoder {
-    pub fn new(desc: RelationDesc, debezium: bool, schema: &str, schema_id: i32) -> Self {
+    pub fn new(desc: RelationDesc, debezium: bool, schema: &str, schema_id: AvroSchemaId) -> Self {
         let mut columns = column_names_and_types(desc);
         if debezium {
             columns = envelopes::dbz_envelope(columns);
@@ -242,9 +269,22 @@ impl Encode for AvroEncoder {
     }
 
     fn hash(&self, buf: &[u8]) -> u64 {
-        // Compute a stable hash by ignoring the avro header which might contain a
-        // non-deterministic schema id.
-        let (_schema_id, payload) = crate::confluent::extract_avro_header(buf).unwrap();
+        // Compute a stable hash by ignoring the avro header, which carries a
+        // schema id that may vary run-to-run. Strip whichever framing this
+        // encoder wrote: hashing with the wrong stripper would hash a
+        // byte-shifted payload and scramble stable partitioning.
+        let payload = match self.schema_id {
+            AvroSchemaId::Confluent(_) => {
+                crate::confluent::extract_avro_header(buf)
+                    .expect("encode_unchecked wrote a Confluent header")
+                    .1
+            }
+            AvroSchemaId::Glue(_) => {
+                crate::glue::extract_avro_header(buf)
+                    .expect("encode_unchecked wrote a Glue header")
+                    .1
+            }
+        };
         seahash::hash(payload)
     }
 }
@@ -454,7 +494,7 @@ pub fn encode_debezium_transaction_unchecked(
     message_count: Option<i64>,
 ) -> Vec<u8> {
     let mut buf = Vec::new();
-    encode_avro_header(&mut buf, schema_id);
+    encode_confluent_header(&mut buf, schema_id);
 
     let transaction_id = Value::String(id.to_owned());
     let status = Value::String(status.to_owned());
@@ -503,4 +543,57 @@ pub fn encode_debezium_transaction_unchecked(
     debug_assert!(avro.validate(DEBEZIUM_TRANSACTION_SCHEMA.top_node()));
     mz_avro::encode_unchecked(&avro, &DEBEZIUM_TRANSACTION_SCHEMA, &mut buf);
     buf
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_repr::{Datum, RelationDesc, Row, SqlScalarType};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::encode::Encode;
+
+    const SCHEMA: &str = r#"{"type":"record","name":"row","fields":[{"name":"a","type":"long"}]}"#;
+
+    fn encoder(schema_id: AvroSchemaId) -> AvroEncoder {
+        let desc = RelationDesc::builder()
+            .with_column("a", SqlScalarType::Int64.nullable(false))
+            .finish();
+        AvroEncoder::new(desc, false, SCHEMA, schema_id)
+    }
+
+    fn row() -> Row {
+        Row::pack_slice(&[Datum::Int64(42)])
+    }
+
+    #[mz_ore::test]
+    fn confluent_framing() {
+        let bytes = encoder(AvroSchemaId::Confluent(7)).encode_unchecked(row());
+        let (id, payload) = crate::confluent::extract_avro_header(&bytes).unwrap();
+        assert_eq!(bytes[0], 0x00, "confluent magic byte");
+        assert_eq!(id, 7);
+        assert!(!payload.is_empty());
+    }
+
+    #[mz_ore::test]
+    fn glue_framing() {
+        let uuid = Uuid::from_u128(0x1234_5678);
+        let bytes = encoder(AvroSchemaId::Glue(uuid)).encode_unchecked(row());
+        let (parsed, payload) = crate::glue::extract_avro_header(&bytes).unwrap();
+        assert_eq!(bytes[0], 0x03, "glue header version");
+        assert_eq!(parsed, uuid);
+        assert!(!payload.is_empty());
+    }
+
+    #[mz_ore::test]
+    fn hash_ignores_framing() {
+        // The same row under different framings must hash identically: `hash`
+        // strips the schema-id-bearing header before hashing, so framing (and
+        // the run-to-run-varying id it carries) cannot perturb partitioning.
+        let confluent = encoder(AvroSchemaId::Confluent(7));
+        let glue = encoder(AvroSchemaId::Glue(Uuid::from_u128(0x1234_5678)));
+        let cb = confluent.encode_unchecked(row());
+        let gb = glue.encode_unchecked(row());
+        assert_eq!(confluent.hash(&cb), glue.hash(&gb));
+    }
 }

--- a/src/interchange/src/glue.rs
+++ b/src/interchange/src/glue.rs
@@ -76,16 +76,15 @@ pub fn extract_avro_header(buf: &[u8]) -> Result<(Uuid, &[u8])> {
     Ok((uuid, &buf[HEADER_LEN..]))
 }
 
-/// Frame `payload` with the Glue Avro header, producing a buffer suitable
-/// to publish to Kafka. The header is laid down using the uncompressed
-/// framing (`compression = 0x00`).
-pub fn prepend_avro_header(schema_version_id: Uuid, payload: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(HEADER_LEN + payload.len());
-    out.push(HEADER_VERSION);
-    out.push(COMPRESSION_NONE);
-    out.extend_from_slice(schema_version_id.as_bytes());
-    out.extend_from_slice(payload);
-    out
+/// Write the Glue Avro header to `buf`, using the uncompressed framing
+/// (`compression = 0x00`). Callers append the serialized record payload
+/// directly after the header, so the framed record needs only a single
+/// allocation.
+pub fn write_avro_header(buf: &mut Vec<u8>, schema_version_id: Uuid) {
+    buf.reserve(HEADER_LEN);
+    buf.push(HEADER_VERSION);
+    buf.push(COMPRESSION_NONE);
+    buf.extend_from_slice(schema_version_id.as_bytes());
 }
 
 #[cfg(test)]
@@ -97,11 +96,18 @@ mod tests {
         Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap()
     }
 
+    fn framed(uuid: Uuid, payload: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        write_avro_header(&mut buf, uuid);
+        buf.extend_from_slice(payload);
+        buf
+    }
+
     #[mz_ore::test]
     fn roundtrip() {
         let uuid = fixture_uuid();
         let payload = b"avro-bytes-here";
-        let framed = prepend_avro_header(uuid, payload);
+        let framed = framed(uuid, payload);
         assert_eq!(framed.len(), HEADER_LEN + payload.len());
         let (parsed_uuid, rest) = extract_avro_header(&framed).unwrap();
         assert_eq!(parsed_uuid, uuid);
@@ -111,7 +117,7 @@ mod tests {
     #[mz_ore::test]
     fn header_byte_layout() {
         let uuid = fixture_uuid();
-        let framed = prepend_avro_header(uuid, &[]);
+        let framed = framed(uuid, &[]);
         assert_eq!(framed[0], HEADER_VERSION);
         assert_eq!(framed[1], COMPRESSION_NONE);
         assert_eq!(&framed[2..HEADER_LEN], uuid.as_bytes());
@@ -127,7 +133,7 @@ mod tests {
 
     #[mz_ore::test]
     fn rejects_wrong_header_version() {
-        let mut buf = prepend_avro_header(fixture_uuid(), b"payload");
+        let mut buf = framed(fixture_uuid(), b"payload");
         buf[0] = 0x02;
         let err = extract_avro_header(&buf).unwrap_err();
         assert!(
@@ -139,7 +145,7 @@ mod tests {
 
     #[mz_ore::test]
     fn rejects_compressed_payload() {
-        let mut buf = prepend_avro_header(fixture_uuid(), b"payload");
+        let mut buf = framed(fixture_uuid(), b"payload");
         buf[1] = 0x05; // zlib
         let err = extract_avro_header(&buf).unwrap_err();
         assert!(
@@ -152,7 +158,7 @@ mod tests {
     #[mz_ore::test]
     fn empty_payload_is_legal() {
         let uuid = fixture_uuid();
-        let framed = prepend_avro_header(uuid, &[]);
+        let framed = framed(uuid, &[]);
         let (parsed_uuid, rest) = extract_avro_header(&framed).unwrap();
         assert_eq!(parsed_uuid, uuid);
         assert!(rest.is_empty());

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -90,7 +90,7 @@ use differential_dataflow::{AsCollection, Hashable, VecCollection};
 use futures::StreamExt;
 use maplit::btreemap;
 use mz_expr::{Eval, MirScalarExpr};
-use mz_interchange::avro::AvroEncoder;
+use mz_interchange::avro::{AvroEncoder, AvroSchemaId};
 use mz_interchange::encode::Encode;
 use mz_interchange::envelopes::{dbz_format, for_each_diff_pair};
 use mz_interchange::json::JsonEncoder;
@@ -1477,7 +1477,12 @@ fn encode_collection<'scope>(
                         .await
                         .context("error publishing kafka schemas for sink")?;
 
-                        Some(Box::new(AvroEncoder::new(desc, false, &schema, schema_id)))
+                        Some(Box::new(AvroEncoder::new(
+                            desc,
+                            false,
+                            &schema,
+                            AvroSchemaId::Confluent(schema_id),
+                        )))
                     }
                     (None, None) => None,
                     (desc, format) => {
@@ -1528,7 +1533,12 @@ fn encode_collection<'scope>(
                     .await
                     .context("error publishing kafka schemas for sink")?;
 
-                    Box::new(AvroEncoder::new(value_desc, debezium, &schema, schema_id))
+                    Box::new(AvroEncoder::new(
+                        value_desc,
+                        debezium,
+                        &schema,
+                        AvroSchemaId::Confluent(schema_id),
+                    ))
                 }
             };
 


### PR DESCRIPTION
Generalizes AvroEncoder so the upcoming Glue sink work can reuse it, leaving the Confluent path behavior-identical.


- Replace AvroEncoder's schema_id: i32 with an `AvroSchemaId` enum. The variant selects both the header written on encode and the one stripped on hash.
- small refactor: turn `glue::prepend_avro_header` into `write_avro_header`, which writes into the caller's buffer so a framed record needs a single allocation instead of two.
- Kafka sink call sites pass `AvroSchemaId::Confluent(...)`, so no observable behavior changes.
- New avro::encode unit tests cover Confluent and Glue framing and confirm hash ignores the header (the same row hashes identically under both framings). The existing `glue.rs` header tests are ported to the new API.