### PR TITLE
sql: allocate globally unique LocalIds for CTEs

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -18,7 +18,6 @@ use std::sync::LazyLock;
 use anyhow::anyhow;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::LocalId;
-use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_repr::network_policy_id::NetworkPolicyId;
 use mz_repr::role_id::RoleId;
@@ -1327,6 +1326,11 @@ struct ItemResolutionConfig {
 pub struct NameResolver<'a> {
     catalog: &'a dyn SessionCatalog,
     ctes: BTreeMap<String, LocalId>,
+    /// The next `LocalId` to allocate for a CTE. Never decremented, so every
+    /// CTE in the statement gets a unique id, even when CTE names shadow each
+    /// other. Later phases (e.g., HIR lowering's `CteMap`) key CTEs by
+    /// `LocalId` and rely on this uniqueness.
+    next_cte_id: u64,
     status: Result<(), PlanError>,
     ids: BTreeMap<CatalogItemId, BTreeSet<GlobalId>>,
 }
@@ -1336,9 +1340,16 @@ impl<'a> NameResolver<'a> {
         NameResolver {
             catalog,
             ctes: BTreeMap::new(),
+            next_cte_id: 0,
             status: Ok(()),
             ids: BTreeMap::new(),
         }
+    }
+
+    fn allocate_cte_id(&mut self) -> LocalId {
+        let id = LocalId::new(self.next_cte_id);
+        self.next_cte_id += 1;
+        id
     }
 
     fn resolve_data_type(&mut self, data_type: RawDataType) -> Result<ResolvedDataType, PlanError> {
@@ -1665,11 +1676,9 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             CteBlock::Simple(ctes) => {
                 let mut result_ctes = Vec::<Cte<Aug>>::new();
 
-                let initial_id = self.ctes.len();
-
-                for (offset, cte) in ctes.into_iter().enumerate() {
+                for cte in ctes.into_iter() {
                     let cte_name = normalize::ident(cte.alias.name.clone());
-                    let local_id = LocalId::new(u64::cast_from(initial_id + offset));
+                    let local_id = self.allocate_cte_id();
 
                     result_ctes.push(Cte {
                         alias: cte.alias,
@@ -1685,19 +1694,18 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             CteBlock::MutuallyRecursive(MutRecBlock { options, ctes }) => {
                 let mut result_ctes = Vec::<CteMutRec<Aug>>::new();
 
-                let initial_id = self.ctes.len();
-
-                // The identifiers for each CTE will be `initial_id` plus their offset in `q.ctes`.
-                for (offset, cte) in ctes.iter().enumerate() {
+                // All bindings go into scope before any definition is walked,
+                // so that the definitions can refer to each other.
+                let mut local_ids = Vec::with_capacity(ctes.len());
+                for cte in ctes.iter() {
                     let cte_name = normalize::ident(cte.name.clone());
-                    let local_id = LocalId::new(u64::cast_from(initial_id + offset));
+                    let local_id = self.allocate_cte_id();
                     let shadowed_id = self.ctes.insert(cte_name.clone(), local_id);
                     shadowed_cte_ids.push((cte_name, shadowed_id));
+                    local_ids.push(local_id);
                 }
 
-                for (offset, cte) in ctes.into_iter().enumerate() {
-                    let local_id = LocalId::new(u64::cast_from(initial_id + offset));
-
+                for (cte, local_id) in ctes.into_iter().zip_eq(local_ids) {
                     let columns = cte
                         .columns
                         .into_iter()

--- a/test/sqllogictest/cte.slt
+++ b/test/sqllogictest/cte.slt
@@ -249,3 +249,100 @@ WITH count AS (VALUES (9)) SELECT count(*) FROM count;
 ----
 count
 1
+
+# Regression tests for SQL-355: CTE `LocalId` allocation must be unique across
+# the whole statement. Ids used to be derived from the number of CTE names
+# currently in scope, so a shadowing CTE (which doesn't grow that count) could
+# collide with a CTE in a nested scope, and references would silently bind to
+# the wrong CTE.
+
+# `a` here used to resolve to `b`, returning 30.
+query I
+WITH a AS (SELECT 10 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 20 AS v)
+  SELECT * FROM (
+    WITH b AS (SELECT 30 AS v)
+    SELECT v FROM a
+  ) t2
+) t1;
+----
+20
+
+# Both the shadowing CTE and the colliding one referenced side by side.
+query II
+WITH a AS (SELECT 10 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 20 AS v)
+  SELECT * FROM (
+    WITH b AS (SELECT 30 AS v)
+    SELECT a.v, b.v FROM a, b
+  ) t2
+) t1;
+----
+20  30
+
+# Deeper shadowing chain: `a` is shadowed twice, so two ids collide with the
+# innermost WITH block's ids.
+query I
+WITH a AS (SELECT 1 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 2 AS v)
+  SELECT * FROM (
+    WITH a AS (SELECT 3 AS v)
+    SELECT * FROM (
+      WITH b AS (SELECT 4 AS v), c AS (SELECT 5 AS v)
+      SELECT a.v + b.v + c.v FROM a, b, c
+    ) t3
+  ) t2
+) t1;
+----
+12
+
+# WITH MUTUALLY RECURSIVE allocates ids the same way. The reference to `a`
+# inside the definition of `b` used to bind to `b` itself.
+query I
+WITH a AS (SELECT 1 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 2 AS v)
+  SELECT * FROM (
+    WITH MUTUALLY RECURSIVE b (v int) AS (SELECT v FROM a)
+    SELECT v FROM b
+  ) t2
+) t1;
+----
+2
+
+# Same, but with more than one binding in the WMR block. The bindings are
+# allocated ids in a separate pre-pass, so this exercises that both of them,
+# and the sibling reference between them, stay clear of the shadowed outer
+# `a`. `b` references the outer `a` (= 2), `c` references its sibling `b`.
+query I
+WITH a AS (SELECT 1 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 2 AS v)
+  SELECT * FROM (
+    WITH MUTUALLY RECURSIVE
+      b (v int) AS (SELECT v FROM a),
+      c (v int) AS (SELECT v + 10 FROM b)
+    SELECT v FROM c
+  ) t2
+) t1;
+----
+12
+
+# A colliding `Let` inside a correlated subquery used to trip an id-uniqueness
+# assertion in HIR-to-MIR lowering.
+query II rowsort
+WITH a AS (SELECT 10 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 20 AS v)
+  SELECT x.a, l.w FROM x, LATERAL(
+    WITH b AS (SELECT x.a + (SELECT v FROM a) AS w)
+    SELECT w FROM b
+  ) l
+) t;
+----
+1  21
+2  22
+3  23

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -531,11 +531,11 @@ Project (#1)
       Get materialize.public.y
     cte [l2 as x] =
       Get l1
-    cte [l8 as subquery-8] =
+    cte [l10 as subquery-10] =
       With
         cte [l3 as c] =
           Get materialize.public.y
-        cte [l5 as subquery-5] =
+        cte [l7 as subquery-7] =
           With
             cte [l4 as d] =
               Get l3
@@ -543,26 +543,26 @@ Project (#1)
             Reduce aggregates=[max(#0{d})]
               Get l4
       Return
-        Filter (select(Get l5) > 1)
+        Filter (select(Get l7) > 1)
           Get l3
   Return
-    Map (select(Get l8))
+    Map (select(Get l10))
       With
-        cte [l3 as e] =
+        cte [l5 as e] =
           Get l1
-        cte [l7 as subquery-7] =
+        cte [l9 as subquery-9] =
           Reduce aggregates=[max(#0{x})]
             Get l2
-        cte [l6 as subquery-6] =
+        cte [l8 as subquery-8] =
           With
-            cte [l4 as f] =
-              Get l3
+            cte [l6 as f] =
+              Get l5
           Return
             Reduce aggregates=[min(#0{f})]
-              Get l4
+              Get l6
       Return
-        Filter (select(Get l6) < select(Get l7))
-          Get l3
+        Filter (select(Get l8) < select(Get l9))
+          Get l5
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -367,12 +367,12 @@ CrossJoin
       Filter (#0{m} != #^0{a})
         Get l0
   With
-    cte [l0 as r4] =
+    cte [l1 as r4] =
       Reduce aggregates=[max((#^0{a} * #0{a}))]
         Get materialize.public.t
   Return
     Filter ((#0{m} != #^0{a}) OR ((#0{m}) IS NOT NULL AND (#^0{a}) IS NULL))
-      Get l0
+      Get l1
 
 Target cluster: quickstart
 


### PR DESCRIPTION
### Motivation

Fixes SQL-349's sibling bug, SQL-355.

CTE `LocalId`s were allocated in name resolution as `self.ctes.len() + offset`, where `self.ctes` is the map of CTE names *currently in scope*. A shadowing CTE does not grow that map, so a CTE in a nested scope could be assigned the same `LocalId` as an outer, shadowed CTE. Later phases key CTEs by `LocalId` (`qcx.ctes` during planning, `CteMap` during lowering), so a reference to the shadowed name silently bound to the wrong CTE and returned wrong results.

Example (correct in PostgreSQL, wrong before this change in Materialize):

```sql
WITH a AS (SELECT 10 AS v)
SELECT * FROM (
  WITH a AS (SELECT 20 AS v)
  SELECT * FROM (
    WITH b AS (SELECT 30 AS v)
    SELECT v FROM a            -- resolves to the middle `a`, i.e. 20
  ) t2
) t1;
```

Materialize returned `30`; the correct answer is `20`. A colliding `Let` inside a correlated subquery could also trip the id-uniqueness assertion in lowering's `branch()`.

### Description

Allocate CTE ids from a monotonic per-statement counter on `NameResolver` instead of from the size of the in-scope name map. This is the only allocation site for planner CTE `LocalId`s.

For queries that were already correct, only the id *labels* in `EXPLAIN RAW PLAN` output change, because MIR ids are allocated independently during lowering. Hence the re-blessed plans in `cte_lowering.slt` and `explain/raw_plan_as_text.slt`. Query results change only for queries that were previously getting wrong answers, which is the intended fix.

### Verification

Regression tests added to `test/sqllogictest/cte.slt`, covering the shadowing repro, a deeper shadowing chain, a `WITH MUTUALLY RECURSIVE` variant, and a colliding `Let` inside a correlated subquery. Expected results for the non-recursive cases were verified against PostgreSQL 16. PostgreSQL does not support `WITH MUTUALLY RECURSIVE`, so that case's expected result was derived by hand; it follows the same shadowing resolution as the non-recursive cases.
