### PR TITLE
sql: fix decorrelation of correlated CTEs referenced from nested correlated scopes

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -84,6 +84,7 @@ def get_minimal_system_parameters(
         "enable_eager_delta_joins": "true",
         "enable_envelope_debezium_in_subscribe": "true",
         "enable_expressions_in_limit_syntax": "true",
+        "enable_fixed_correlated_cte_lowering": "true",
         "enable_introspection_subscribes": "true",
         "enable_kafka_sink_partition_by": "true",
         "enable_lgalloc": "false",
@@ -211,6 +212,11 @@ def get_variable_system_parameters(
         ),
         VariableSystemParameter(
             "enable_cast_elimination",
+            "true",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
+            "enable_fixed_correlated_cte_lowering",
             "true",
             ["true", "false"],
         ),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1680,6 +1680,9 @@ class FlipFlagsAction(Action):
         ]
         self.flags_with_values["enable_case_literal_transform"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_cast_elimination"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_fixed_correlated_cte_lowering"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_upsert_v2"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_coalesce_case_transform"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_compute_sync_mv_sink"] = BOOLEAN_FLAG_VALUES

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -347,6 +347,9 @@ impl From<&OptimizerConfig> for mz_sql::plan::HirToMirConfig {
             enable_simplify_quantified_comparisons: config
                 .features
                 .enable_simplify_quantified_comparisons,
+            enable_fixed_correlated_cte_lowering: config
+                .features
+                .enable_fixed_correlated_cte_lowering,
         }
     }
 }

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -137,6 +137,8 @@ optimizer_feature_flags!({
     enable_coalesce_case_transform: bool,
     // See the feature flag of the same name.
     enable_will_distinct_propagation: bool,
+    // See the feature flag of the same name.
+    enable_fixed_correlated_cte_lowering: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -110,6 +110,7 @@ Connection
 Connections
 Constraint
 Copy
+Correlated
 Count
 Counter
 Cpu
@@ -123,6 +124,7 @@ Credential
 Cross
 Cse
 Csv
+Cte
 Current
 Cursor
 Database
@@ -189,6 +191,7 @@ File
 Files
 Filter
 First
+Fixed
 Fixpoint
 Float
 Following

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -4090,6 +4090,7 @@ pub enum ExplainPlanOptionName {
     EnableLetrecFixpointAnalysis,
     EnableJoinPrioritizeArranged,
     EnableProjectionPushdownAfterRelationCse,
+    EnableFixedCorrelatedCteLowering,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -4126,7 +4127,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableJoinPrioritizeArranged
-            | Self::EnableProjectionPushdownAfterRelationCse => false,
+            | Self::EnableProjectionPushdownAfterRelationCse
+            | Self::EnableFixedCorrelatedCteLowering => false,
         }
     }
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -18,7 +18,6 @@ use std::sync::LazyLock;
 use anyhow::anyhow;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::LocalId;
-use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_repr::network_policy_id::NetworkPolicyId;
 use mz_repr::role_id::RoleId;
@@ -1327,6 +1326,11 @@ struct ItemResolutionConfig {
 pub struct NameResolver<'a> {
     catalog: &'a dyn SessionCatalog,
     ctes: BTreeMap<String, LocalId>,
+    /// The next `LocalId` to allocate for a CTE. Never decremented, so every
+    /// CTE in the statement gets a unique id, even when CTE names shadow each
+    /// other. Later phases (e.g., HIR lowering's `CteMap`) key CTEs by
+    /// `LocalId` and rely on this uniqueness.
+    next_cte_id: u64,
     status: Result<(), PlanError>,
     ids: BTreeMap<CatalogItemId, BTreeSet<GlobalId>>,
 }
@@ -1336,9 +1340,16 @@ impl<'a> NameResolver<'a> {
         NameResolver {
             catalog,
             ctes: BTreeMap::new(),
+            next_cte_id: 0,
             status: Ok(()),
             ids: BTreeMap::new(),
         }
+    }
+
+    fn allocate_cte_id(&mut self) -> LocalId {
+        let id = LocalId::new(self.next_cte_id);
+        self.next_cte_id += 1;
+        id
     }
 
     fn resolve_data_type(&mut self, data_type: RawDataType) -> Result<ResolvedDataType, PlanError> {
@@ -1665,11 +1676,9 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             CteBlock::Simple(ctes) => {
                 let mut result_ctes = Vec::<Cte<Aug>>::new();
 
-                let initial_id = self.ctes.len();
-
-                for (offset, cte) in ctes.into_iter().enumerate() {
+                for cte in ctes.into_iter() {
                     let cte_name = normalize::ident(cte.alias.name.clone());
-                    let local_id = LocalId::new(u64::cast_from(initial_id + offset));
+                    let local_id = self.allocate_cte_id();
 
                     result_ctes.push(Cte {
                         alias: cte.alias,
@@ -1685,19 +1694,18 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             CteBlock::MutuallyRecursive(MutRecBlock { options, ctes }) => {
                 let mut result_ctes = Vec::<CteMutRec<Aug>>::new();
 
-                let initial_id = self.ctes.len();
-
-                // The identifiers for each CTE will be `initial_id` plus their offset in `q.ctes`.
-                for (offset, cte) in ctes.iter().enumerate() {
+                // All bindings go into scope before any definition is walked,
+                // so that the definitions can refer to each other.
+                let mut local_ids = Vec::with_capacity(ctes.len());
+                for cte in ctes.iter() {
                     let cte_name = normalize::ident(cte.name.clone());
-                    let local_id = LocalId::new(u64::cast_from(initial_id + offset));
+                    let local_id = self.allocate_cte_id();
                     let shadowed_id = self.ctes.insert(cte_name.clone(), local_id);
                     shadowed_cte_ids.push((cte_name, shadowed_id));
+                    local_ids.push(local_id);
                 }
 
-                for (offset, cte) in ctes.into_iter().enumerate() {
-                    let local_id = LocalId::new(u64::cast_from(initial_id + offset));
-
+                for (cte, local_id) in ctes.into_iter().zip_eq(local_ids) {
                     let columns = cte
                         .columns
                         .into_iter()

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -141,6 +141,8 @@ pub struct Config {
     pub enable_variadic_left_join_lowering: bool,
     pub enable_cast_elimination: bool,
     pub enable_simplify_quantified_comparisons: bool,
+    /// See the feature flag of the same name.
+    pub enable_fixed_correlated_cte_lowering: bool,
 }
 
 impl Default for Config {
@@ -150,6 +152,7 @@ impl Default for Config {
             enable_variadic_left_join_lowering: false,
             enable_cast_elimination: false,
             enable_simplify_quantified_comparisons: false,
+            enable_fixed_correlated_cte_lowering: false,
         }
     }
 }
@@ -161,6 +164,7 @@ impl From<&SystemVars> for Config {
             enable_variadic_left_join_lowering: vars.enable_variadic_left_join_lowering(),
             enable_cast_elimination: vars.enable_cast_elimination(),
             enable_simplify_quantified_comparisons: vars.enable_simplify_quantified_comparisons(),
+            enable_fixed_correlated_cte_lowering: vars.enable_fixed_correlated_cte_lowering(),
         }
     }
 }
@@ -1869,56 +1873,149 @@ where
         }
     });
     // Collect all the outer columns referenced by any CTE referenced by
-    // the inner relation.
-    #[allow(deprecated)]
-    inner.visit(0, &mut |e, _| match e {
-        HirRelationExpr::Get {
-            id: mz_expr::Id::Local(id),
-            ..
-        } => {
-            if let Some(cte_desc) = cte_map.get(id) {
-                let cte_outer_arity = cte_desc.outer_relation.arity();
-                outer_cols.extend(
-                    col_map
-                        .inner
-                        .iter()
-                        .filter(|(_, position)| **position < cte_outer_arity)
-                        .map(|(c, _)| {
-                            // `col_map` maps column references to column positions in
-                            // `outer`'s projection.
-                            // `outer_cols` is meant to contain the external column
-                            // references in `inner`.
-                            // Since `inner` defines a new scope, any column reference
-                            // in `col_map` is one level deeper when seen from within
-                            // `inner`, hence the +1.
-                            ColumnRef {
-                                level: c.level + 1,
-                                column: c.column,
-                            }
-                        }),
-                );
+    // the inner relation. The `Get` arm of `applied_to` reconciles a CTE
+    // reference with the relation the CTE was applied to by equating the
+    // first `cte_outer_arity` columns of both sides, so it relies on the
+    // outer columns of every referenced CTE sitting at the beginning of the
+    // branch key, in order. We track the maximum such arity to arrange for
+    // that below.
+    let mut max_cte_outer_arity = 0;
+    {
+        let mut visit = |e: &HirRelationExpr| match e {
+            HirRelationExpr::Get {
+                id: mz_expr::Id::Local(id),
+                ..
+            } => {
+                if let Some(cte_desc) = cte_map.get(id) {
+                    let cte_outer_arity = cte_desc.outer_relation.arity();
+                    max_cte_outer_arity = max_cte_outer_arity.max(cte_outer_arity);
+                    outer_cols.extend(
+                        col_map
+                            .inner
+                            .iter()
+                            .filter(|(_, position)| **position < cte_outer_arity)
+                            .map(|(c, _)| {
+                                // `col_map` maps column references to column positions in
+                                // `outer`'s projection.
+                                // `outer_cols` is meant to contain the external column
+                                // references in `inner`.
+                                // Since `inner` defines a new scope, any column reference
+                                // in `col_map` is one level deeper when seen from within
+                                // `inner`, hence the +1.
+                                ColumnRef {
+                                    level: c.level + 1,
+                                    column: c.column,
+                                }
+                            }),
+                    );
+                }
             }
+            HirRelationExpr::Let { id, .. } => {
+                // Note: if ID uniqueness is not guaranteed, we can't use `visit` since
+                // we would need to remove the old CTE with the same ID temporarily while
+                // traversing the definition of the new CTE under the same ID.
+                assert!(!cte_map.contains_key(id));
+            }
+            _ => {}
+        };
+        if context.config.enable_fixed_correlated_cte_lowering {
+            // `visit_post` descends into scalar subqueries, so this finds CTE
+            // references at any depth inside `inner`. Full depth matters: a
+            // nested `branch()` inside `inner` relies on the key computed
+            // here already carrying its referenced CTEs' outer columns as a
+            // prefix.
+            inner.visit_post(&mut visit);
+        } else {
+            // The deprecated `visit` does not descend into scalar subqueries,
+            // so CTE references inside them are missed and the branch key can
+            // lack outer columns that the CTE reference's reconciliation join
+            // needs, producing wrong correlations (SQL-349).
+            #[allow(deprecated)]
+            inner.visit(0, &mut |e, _| visit(e));
         }
-        HirRelationExpr::Let { id, .. } => {
-            // Note: if ID uniqueness is not guaranteed, we can't use `visit` since
-            // we would need to remove the old CTE with the same ID temporarily while
-            // traversing the definition of the new CTE under the same ID.
-            assert!(!cte_map.contains_key(id));
-        }
-        _ => {}
-    });
+    }
     let mut new_col_map = BTreeMap::new();
     let mut key = vec![];
-    for col in outer_cols {
-        new_col_map.insert(col, key.len());
-        key.push(col_map.get(&ColumnRef {
-            // Note: `outer_cols` contains the external column references within `inner`.
-            // We must compensate for `inner`'s scope when translating column references
-            // as seen within `inner` to column references as seen from `outer`'s context,
-            // hence the -1.
-            level: col.level - 1,
-            column: col.column,
-        }));
+    if context.config.enable_fixed_correlated_cte_lowering {
+        // The `Get` arm reconciles a CTE reference by equating key slots
+        // `0..cte_outer_arity` with the CTE's outer columns, positionally, so
+        // it needs every referenced CTE's outer columns at the head of the
+        // key, in their original `outer` order. Those columns are exactly the
+        // ones at `outer` positions `0..max_cte_outer_arity` (see the discovery
+        // above), so we split the discovered columns into that prefix and the
+        // rest, and emit the prefix first, sorted by position. That makes
+        // `key[i] == i` over the prefix, which is what the `Get` arm assumes.
+        //
+        // A single prefix covers all referenced CTEs because their outer
+        // relations are nested prefixes of one another (nested scopes only ever
+        // append columns). The `rest`'s order is free: the final join in
+        // `branch` compensates for any key order, and only the `Get` arm cares
+        // about absolute slot positions (we keep `outer_cols`'s order).
+        let mut prefix = Vec::new();
+        let mut rest = Vec::new();
+        for col in outer_cols {
+            // `position` is `col`'s index in `outer`'s projection.
+            let position = col_map.get(&ColumnRef {
+                // `outer_cols` holds references as seen from within `inner`,
+                // one level deeper than `outer`'s scope (the discovery walk and
+                // `visit_columns` both record them that way), so undo that with
+                // `-1` before looking `col` up in `outer`'s `col_map`.
+                level: col.level - 1,
+                column: col.column,
+            });
+            if position < max_cte_outer_arity {
+                prefix.push((position, col));
+            } else {
+                rest.push((position, col));
+            }
+        }
+        prefix.sort_unstable_by_key(|(position, _)| *position);
+        // The discovery inserts every position `0..cte_outer_arity` of each
+        // referenced CTE, and `col_map` is a bijection onto `0..col_map.len()`,
+        // so the prefix positions are exactly `0..max_cte_outer_arity`, each
+        // once, reading `0, 1, ..., max-1` after the sort. If they don't, the
+        // `Get` arm's reconciliation would join on the wrong columns and
+        // silently produce wrong results, so fail the query instead. There is
+        // no safe fallback: the unpartitioned key order is the bug this is
+        // fixing.
+        if !prefix
+            .iter()
+            .map(|(position, _)| *position)
+            .eq(0..max_cte_outer_arity)
+        {
+            return Err(PlanError::Internal(format!(
+                "CTE outer columns are not a contiguous prefix of the branch key: \
+                 prefix positions {:?}, max_cte_outer_arity {}",
+                prefix
+                    .iter()
+                    .map(|(position, _)| *position)
+                    .collect::<Vec<_>>(),
+                max_cte_outer_arity,
+            )));
+        }
+        // Give each chosen outer column its key slot: `new_col_map` records the
+        // slot, `key` records which `outer` position feeds it. Over the prefix
+        // the slot (`key.len()`) equals `position`, so `key[i] == i`; over the
+        // rest they may differ, which is fine.
+        for (position, col) in prefix.into_iter().chain(rest) {
+            new_col_map.insert(col, key.len());
+            key.push(position);
+        }
+    } else {
+        // Note: this order can break the `Get` arm's prefix assumption when a
+        // level-1 column sorts before a referenced CTE's outer column
+        // (SQL-349).
+        for col in outer_cols {
+            new_col_map.insert(col, key.len());
+            key.push(col_map.get(&ColumnRef {
+                // Note: `outer_cols` contains the external column references within `inner`.
+                // We must compensate for `inner`'s scope when translating column references
+                // as seen within `inner` to column references as seen from `outer`'s context,
+                // hence the -1.
+                level: col.level - 1,
+                column: col.column,
+            }));
+        }
     }
     let new_col_map = ColumnMap::new(new_col_map);
     outer.let_in(id_gen, |id_gen, get_outer| {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4957,6 +4957,7 @@ pub fn unplan_create_cluster(
                 enable_simplify_quantified_comparisons: _,
                 enable_coalesce_case_transform: _,
                 enable_will_distinct_propagation: _,
+                enable_fixed_correlated_cte_lowering: _,
             } = optimizer_feature_overrides;
             // The ones from above that don't occur below are not wired up to cluster features.
             let features_extracted = ClusterFeatureExtracted {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -577,6 +577,11 @@ generate_extracted_config!(
         EnableProjectionPushdownAfterRelationCse,
         Option<bool>,
         Default(None)
+    ),
+    (
+        EnableFixedCorrelatedCteLowering,
+        Option<bool>,
+        Default(None)
     )
 );
 
@@ -638,6 +643,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_simplify_quantified_comparisons: Default::default(),
                 enable_coalesce_case_transform: Default::default(),
                 enable_will_distinct_propagation: Default::default(),
+                enable_fixed_correlated_cte_lowering: v.enable_fixed_correlated_cte_lowering,
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2040,6 +2040,13 @@ feature_flags!(
         scope: ParameterScope::Cluster,
     },
     {
+        name: enable_fixed_correlated_cte_lowering,
+        desc: "CTE-aware branch keys in HIR-to-MIR lowering, fixing references to \
+               correlated CTEs from nested correlated scopes",
+        default: true,
+        enable_for_item_parsing: false,
+    },
+    {
         name: enable_time_at_time_zone,
         desc: "use of AT TIME ZONE or timezone() with time type",
         default: false,
@@ -2320,6 +2327,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_simplify_quantified_comparisons: vars.enable_simplify_quantified_comparisons(),
             enable_coalesce_case_transform: vars.enable_coalesce_case_transform(),
             enable_will_distinct_propagation: vars.enable_will_distinct_propagation(),
+            enable_fixed_correlated_cte_lowering: vars.enable_fixed_correlated_cte_lowering(),
         }
     }
 }
@@ -2362,6 +2370,7 @@ mod tests {
             enable_simplify_quantified_comparisons,
             enable_coalesce_case_transform,
             enable_will_distinct_propagation,
+            enable_fixed_correlated_cte_lowering,
         } = false_features;
 
         let mut vars = SystemVars::new();
@@ -2392,6 +2401,7 @@ mod tests {
         set_var!(enable_simplify_quantified_comparisons);
         set_var!(enable_coalesce_case_transform);
         set_var!(enable_will_distinct_propagation);
+        set_var!(enable_fixed_correlated_cte_lowering);
 
         // Enable for item parsing, then ensure we still get the same optimizer features.
         vars.enable_for_item_parsing();

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -244,6 +244,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_dequadratic_eqprop_map
     enable_envelope_materialize
     enable_eq_classes_withholding_errors
+    enable_fixed_correlated_cte_lowering
     enable_frontend_subscribes
     enable_introspection_subscribes
     enable_less_reduce_in_eqprop

--- a/test/sqllogictest/cte.slt
+++ b/test/sqllogictest/cte.slt
@@ -249,3 +249,100 @@ WITH count AS (VALUES (9)) SELECT count(*) FROM count;
 ----
 count
 1
+
+# Regression tests for SQL-355: CTE `LocalId` allocation must be unique across
+# the whole statement. Ids used to be derived from the number of CTE names
+# currently in scope, so a shadowing CTE (which doesn't grow that count) could
+# collide with a CTE in a nested scope, and references would silently bind to
+# the wrong CTE.
+
+# `a` here used to resolve to `b`, returning 30.
+query I
+WITH a AS (SELECT 10 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 20 AS v)
+  SELECT * FROM (
+    WITH b AS (SELECT 30 AS v)
+    SELECT v FROM a
+  ) t2
+) t1;
+----
+20
+
+# Both the shadowing CTE and the colliding one referenced side by side.
+query II
+WITH a AS (SELECT 10 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 20 AS v)
+  SELECT * FROM (
+    WITH b AS (SELECT 30 AS v)
+    SELECT a.v, b.v FROM a, b
+  ) t2
+) t1;
+----
+20  30
+
+# Deeper shadowing chain: `a` is shadowed twice, so two ids collide with the
+# innermost WITH block's ids.
+query I
+WITH a AS (SELECT 1 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 2 AS v)
+  SELECT * FROM (
+    WITH a AS (SELECT 3 AS v)
+    SELECT * FROM (
+      WITH b AS (SELECT 4 AS v), c AS (SELECT 5 AS v)
+      SELECT a.v + b.v + c.v FROM a, b, c
+    ) t3
+  ) t2
+) t1;
+----
+12
+
+# WITH MUTUALLY RECURSIVE allocates ids the same way. The reference to `a`
+# inside the definition of `b` used to bind to `b` itself.
+query I
+WITH a AS (SELECT 1 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 2 AS v)
+  SELECT * FROM (
+    WITH MUTUALLY RECURSIVE b (v int) AS (SELECT v FROM a)
+    SELECT v FROM b
+  ) t2
+) t1;
+----
+2
+
+# Same, but with more than one binding in the WMR block. The bindings are
+# allocated ids in a separate pre-pass, so this exercises that both of them,
+# and the sibling reference between them, stay clear of the shadowed outer
+# `a`. `b` references the outer `a` (= 2), `c` references its sibling `b`.
+query I
+WITH a AS (SELECT 1 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 2 AS v)
+  SELECT * FROM (
+    WITH MUTUALLY RECURSIVE
+      b (v int) AS (SELECT v FROM a),
+      c (v int) AS (SELECT v + 10 FROM b)
+    SELECT v FROM c
+  ) t2
+) t1;
+----
+12
+
+# A colliding `Let` inside a correlated subquery used to trip an id-uniqueness
+# assertion in HIR-to-MIR lowering.
+query II rowsort
+WITH a AS (SELECT 10 AS v)
+SELECT * FROM (
+  WITH a AS (SELECT 20 AS v)
+  SELECT x.a, l.w FROM x, LATERAL(
+    WITH b AS (SELECT x.a + (SELECT v FROM a) AS w)
+    SELECT w FROM b
+  ) l
+) t;
+----
+1  21
+2  22
+3  23

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -531,11 +531,11 @@ Project (#1)
       Get materialize.public.y
     cte [l2 as x] =
       Get l1
-    cte [l8 as subquery-8] =
+    cte [l10 as subquery-10] =
       With
         cte [l3 as c] =
           Get materialize.public.y
-        cte [l5 as subquery-5] =
+        cte [l7 as subquery-7] =
           With
             cte [l4 as d] =
               Get l3
@@ -543,26 +543,26 @@ Project (#1)
             Reduce aggregates=[max(#0{d})]
               Get l4
       Return
-        Filter (select(Get l5) > 1)
+        Filter (select(Get l7) > 1)
           Get l3
   Return
-    Map (select(Get l8))
+    Map (select(Get l10))
       With
-        cte [l3 as e] =
+        cte [l5 as e] =
           Get l1
-        cte [l7 as subquery-7] =
+        cte [l9 as subquery-9] =
           Reduce aggregates=[max(#0{x})]
             Get l2
-        cte [l6 as subquery-6] =
+        cte [l8 as subquery-8] =
           With
-            cte [l4 as f] =
-              Get l3
+            cte [l6 as f] =
+              Get l5
           Return
             Reduce aggregates=[min(#0{f})]
-              Get l4
+              Get l6
       Return
-        Filter (select(Get l6) < select(Get l7))
-          Get l3
+        Filter (select(Get l8) < select(Get l9))
+          Get l5
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -444,6 +444,104 @@ With
       Get l1 // { arity: 1 }
       Get materialize.public.y // { arity: 1 }
   cte l4 =
+    CrossJoin // { arity: 3 }
+      Distinct project=[#0, #1] // { arity: 2 }
+        Get l3 // { arity: 2 }
+      Get materialize.public.x // { arity: 1 }
+  cte l5 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l4 // { arity: 3 }
+  cte l6 =
+    Project (#0, #2) // { arity: 2 }
+      Join on=(#0 = #1) // { arity: 3 }
+        Get l5 // { arity: 1 }
+        Union // { arity: 2 }
+          Get l2 // { arity: 2 }
+          CrossJoin // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Join on=(#0 = #1) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Get l2 // { arity: 2 }
+                  Distinct project=[#0] // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Constant // { arity: 1 }
+              - (null)
+  cte l7 =
+    Union // { arity: 2 }
+      Get l6 // { arity: 2 }
+      Project (#0, #2) // { arity: 2 }
+        FlatMap guard_subquery_size(#1) // { arity: 3 }
+          Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+            Get l6 // { arity: 2 }
+Return // { arity: 3 }
+  Project (#0, #2, #3) // { arity: 3 }
+    Join on=(#0 = #1) // { arity: 4 }
+      Get l0 // { arity: 1 }
+      Project (#0, #1, #4) // { arity: 3 }
+        Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
+          Get l3 // { arity: 2 }
+          Project (#0, #1, #3) // { arity: 3 }
+            Map (#1{a}) // { arity: 4 }
+              Project (#0..=#2) // { arity: 3 }
+                Filter (#3 > 0) // { arity: 4 }
+                  Project (#0..=#2, #4) // { arity: 4 }
+                    Join on=(#0 = #3) // { arity: 5 }
+                      Get l4 // { arity: 3 }
+                      Union // { arity: 2 }
+                        Get l7 // { arity: 2 }
+                        CrossJoin // { arity: 2 }
+                          Project (#0) // { arity: 1 }
+                            Join on=(#0 = #1) // { arity: 2 }
+                              Union // { arity: 1 }
+                                Negate // { arity: 1 }
+                                  Distinct project=[#0] // { arity: 1 }
+                                    Get l7 // { arity: 2 }
+                                Distinct project=[#0] // { arity: 1 }
+                                  Get l5 // { arity: 1 }
+                              Get l5 // { arity: 1 }
+                          Constant // { arity: 1 }
+                            - (null)
+
+Target cluster: quickstart
+
+EOF
+
+# The same query with `enable_fixed_correlated_cte_lowering = false`, i.e.,
+# the plan that turning the flag off reverts to. The branch key of the nested
+# LATERAL scope misses the CTE's outer column `x.a` (the CTE reference sits
+# inside a scalar subquery, which the old CTE discovery does not descend
+# into), so the CTE lookup join in l4 reconciles on `y.a` instead of `x.a`,
+# producing wrong correlations (SQL-349).
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(arity, enable fixed correlated cte lowering = false) FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM y INNER JOIN LATERAL(SELECT y.a FROM x WHERE (SELECT m FROM a) > 0) ON true);
+----
+With
+  cte l0 =
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
+  cte l1 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
+  cte l2 =
+    Reduce group_by=[#0] aggregates=[max(#1{a})] // { arity: 2 }
+      Filter (#1{a} < #0{a}) // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Get l1 // { arity: 1 }
+          Get materialize.public.y // { arity: 1 }
+  cte l3 =
+    CrossJoin // { arity: 2 }
+      Get l1 // { arity: 1 }
+      Get materialize.public.y // { arity: 1 }
+  cte l4 =
     CrossJoin // { arity: 2 }
       Distinct project=[#1] // { arity: 1 }
         Get l3 // { arity: 2 }
@@ -508,6 +606,48 @@ Return // { arity: 3 }
 Target cluster: quickstart
 
 EOF
+
+# Regression tests for SQL-349: references to a correlated CTE from a nested
+# correlated scope. Expected results verified against PostgreSQL.
+
+# The CTE reference sits inside a scalar subquery of a nested LATERAL scope,
+# so the CTE discovery in `branch()` must descend into scalar subqueries for
+# the branch key to retain the CTE's outer column `x.a`.
+query III rowsort
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM y INNER JOIN LATERAL(SELECT y.a FROM x WHERE (SELECT m FROM a) > 0) ON true);
+----
+3  2  2
+3  2  2
+3  2  2
+3  3  3
+3  3  3
+3  3  3
+3  4  4
+3  4  4
+3  4  4
+
+# The scalar subquery references both the CTE and the level-1 column `y.a`,
+# which sorts before the CTE's outer column `x.a` in `BTreeSet<ColumnRef>`
+# order (level ascending). The branch key must nevertheless keep `x.a` at its
+# prefix.
+query II rowsort
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT (SELECT m + 0*y.a FROM a) FROM y);
+----
+1  NULL
+1  NULL
+1  NULL
+2  NULL
+2  NULL
+2  NULL
+3  2
+3  2
+3  2
 
 # Check that CTEs are annotated with their names
 query T multiline

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -367,12 +367,12 @@ CrossJoin
       Filter (#0{m} != #^0{a})
         Get l0
   With
-    cte [l0 as r4] =
+    cte [l1 as r4] =
       Reduce aggregates=[max((#^0{a} * #0{a}))]
         Get materialize.public.t
   Return
     Filter ((#0{m} != #^0{a}) OR ((#0{m}) IS NOT NULL AND (#^0{a}) IS NULL))
-      Get l0
+      Get l1
 
 Target cluster: quickstart
 


### PR DESCRIPTION
Stacked on top of https://github.com/MaterializeInc/materialize/pull/37505, the first commit should be reviewed there.

### Motivation

Fixes SQL-349.

When a correlated CTE is referenced from a nested correlated scope, HIR-to-MIR lowering could decorrelate it with the wrong correlation, producing wrong results. Example (results verified against PostgreSQL):

```sql
SELECT *
FROM x,
     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
             SELECT * FROM y INNER JOIN LATERAL(SELECT y.a FROM x WHERE (SELECT m FROM a) > 0) ON true);
```

> [!NOTE]
> Stacked on #37505 and should be merged after it. That PR makes CTE `LocalId`s unique, which this PR's deeper CTE-discovery walk relies on (the `Let` id-uniqueness assertion in `branch()` would otherwise fire). Until #37505 merges, this PR's diff includes its commit (`sql: allocate globally unique LocalIds for CTEs`); review only the second commit here. I'll rebase onto `main` once #37505 lands.

### Description

Two interacting causes in lowering's `branch()`:

1. The walk that collects the outer columns of referenced CTEs used the deprecated `visit`, which does not descend into scalar subqueries. A CTE referenced only from inside a scalar subquery was therefore missed, so its outer columns were dropped from the branch key.
2. The branch key followed `BTreeSet<ColumnRef>` order (level ascending). The `Get` arm reconciles a CTE reference with the relation the CTE was applied to by equating the first `cte_outer_arity` columns of both sides, which assumes the CTE's outer columns sit at the key's prefix, in order. A level-1 column sorting before the CTE's outer column broke that assumption.

The fix addresses both: discover CTE references with `visit_post` (descends into subqueries at any depth) and partition the branch key so the CTE outer columns form its prefix, ordered by position. Referenced CTEs' outer relations are nested prefixes of one another (nested scopes only ever append columns), so a single prefix covers them all.

Both changes are gated behind the new `enable_fixed_correlated_cte_lowering` optimizer feature flag, default on. With the flag off, lowering is byte-identical to before, which gives a rollback lever for upgrade safety: the plan change only lands for objects that reference a correlated CTE from a correlated scope, and flipping the flag off and restarting re-optimizes back to the old plans.

Follow-up outside this PR: the `enable_fixed_correlated_cte_lowering` flag must be created in LaunchDarkly to be controllable in production. It is temporarily added to `KNOWN_MISSING_FROM_LD` so the nightly LD-consistency check does not fail meanwhile.

### Verification

Regression tests added to `test/sqllogictest/cte_lowering.slt`, along with a flag-off `EXPLAIN DECORRELATED PLAN WITH(enable fixed correlated cte lowering = false)` that documents the old (broken) plan next to the fixed one. Expected query results verified against PostgreSQL 16. Ran the CTE, subquery, and decorrelated/optimized/raw plan-as-text sqllogictest files with no fallout beyond the intended `cte_lowering.slt` re-bless.

Nightly subset run: https://buildkite.com/materialize/nightly/builds/17069