### PR TITLE
adapter: retire linearize reads from AdvanceTimelines to fix residual starvation

### DIFF
--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -224,6 +224,41 @@ If you need conflict detection, evaluate the precondition atomically with the
 commit, a real compare-and-append against the durable store. A check that merely
 precedes the write on the loop is not that, even when it reads the right state.
 
+### Coordinator work that depends on a signal must ride that signal, not a lower select branch
+
+The coordinator's main loop is a `biased` `select!`. Bias means every branch
+below the highest one can be starved: whenever a higher branch is runnable on a
+poll, the lower branches never run. A branch that a client can keep runnable
+indefinitely (user command intake on `cmd_rx`, group commit under a write flood)
+will pin the loop and starve everything beneath it for as long as the load
+lasts.
+
+Work whose progress depends on some event is therefore only safe to place below
+that event's branch if it can also be *driven* from that event, not merely
+polled for on its own low-priority branch. The concrete case: strict
+serializable reads that pick a timestamp ahead of the oracle become pending and
+retire only once the oracle advances. The oracle advances only via group commit.
+Placing the retirement re-check on its own branch below `cmd_rx` means a
+sustained write flood advances the oracle on the group commit branch while
+starving the re-check, so the reads never retire until the flood drains. This is
+a self-sustaining priority inversion, not a transient hiccup.
+
+Reordering the select does not fix this. A biased select always has a lowest
+branch, so moving the re-check up only chooses a different victim (lifting
+retirement above `cmd_rx` would let a read flood starve user commands instead).
+The fix is to couple the work to the causal signal: retire pending reads from
+the `Message::AdvanceTimelines` handler, which group commit emits on the
+top-priority internal channel after advancing the oracle. Retirement then runs
+exactly when progress is possible, on a branch load cannot starve.
+
+Repositioning a branch is only safe when it is *causally downstream* of the
+branch it moves above and does trivial work. Enqueuing a pending read can move
+above `cmd_rx` because a read must first be sequenced off `cmd_rx` before it can
+be enqueued, so the enqueue branch cannot outrun `cmd_rx` and the move
+introduces no new starvation victim. When adding or moving a branch, ask which
+branch can keep the loop busy, what sits below it, and whether anything down
+there depends on a signal it cannot also be driven by.
+
 ## Rejected Optimizations
 
 This section records specific optimizations that have been attempted and found

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -258,6 +258,126 @@ class PgReadReplicaRTR(Scenario):
         )
 
 
+class LinearizeReadStarvation(Scenario):
+    """
+    Guards against a coordinator priority inversion that pins strict
+    serializable reads behind sustained write traffic.
+
+    A real-time-recency strict serializable read can pick a timestamp ahead of
+    the oracle, becoming a pending linearize read that retires only once the
+    oracle advances past its chosen timestamp. The oracle advances via group
+    commit, which the coordinator's biased select polls above user command
+    intake (`cmd_rx`). Both the branch that moves a read into the pending set
+    and the branch that re-checks pending reads sit below `cmd_rx`. A sustained
+    write flood keeps `cmd_rx` runnable on every poll, so those lower branches
+    starve: the read never enters the pending set or never gets re-checked, even
+    though the same flood keeps advancing the oracle past the read's timestamp
+    on the higher-priority group commit branch. The read stays pending until the
+    flood drains.
+
+    The scenario drives both halves at once:
+
+    * A heavy closed-loop `INSERT` flood into a native table. Its group commits
+      advance the EpochMilliseconds oracle on the high-priority branch, and the
+      insert commands keep `cmd_rx` non-empty well past the command batch size.
+    * Real-time-recency strict serializable reads over a Postgres-source
+      materialized view. Real-time recency pushes them ahead of the oracle, so
+      they become pending linearize reads that the flood then starves.
+
+    When retirement is starved, the reads only retire once the flood stops at
+    the end of the load phase, so their p99 latency approaches the load-phase
+    duration and the guarantee below fails. Retiring pending reads from the
+    group commit signal (`Message::AdvanceTimelines`, on the top-priority
+    internal channel) and enqueuing them above `cmd_rx` makes them retire
+    promptly and the guarantee pass.
+    """
+
+    def __init__(self, c: Composition, conn_infos: dict[str, PgConnInfo]):
+        self.init(
+            [
+                TdPhase("""
+                    > DROP SECRET IF EXISTS pgpass CASCADE
+                    > CREATE SECRET pgpass AS 'postgres'
+                    > CREATE CONNECTION pg TO POSTGRES (
+                        HOST postgres,
+                        DATABASE postgres,
+                        USER postgres,
+                        PASSWORD SECRET pgpass
+                      )
+
+                    $ postgres-execute connection=postgres://postgres:postgres@postgres
+                    DROP PUBLICATION IF EXISTS mz_linearize_starvation;
+                    DROP TABLE IF EXISTS lin_src CASCADE;
+                    ALTER USER postgres WITH replication;
+                    CREATE TABLE lin_src (f1 INTEGER);
+                    ALTER TABLE lin_src REPLICA IDENTITY FULL;
+                    CREATE PUBLICATION mz_linearize_starvation FOR ALL TABLES;
+
+                    > CREATE SOURCE lin_source
+                      FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_linearize_starvation')
+
+                    > CREATE TABLE lin_src FROM SOURCE lin_source (REFERENCE lin_src)
+
+                    > CREATE MATERIALIZED VIEW lin_mv AS
+                      SELECT COUNT(*) FROM lin_src
+
+                    > CREATE DEFAULT INDEX ON lin_mv
+
+                    # Native table for the coordinator command flood. Writing to it
+                    # advances the same EpochMilliseconds oracle the reads wait on.
+                    > CREATE TABLE lin_flood (f1 INTEGER)
+                    """),
+                LoadPhase(
+                    duration=120,
+                    actions=[
+                        # Keep the Postgres source frontier advancing so real-time
+                        # recency keeps pushing the reads ahead of the oracle.
+                        OpenLoop(
+                            action=StandaloneQuery(
+                                "INSERT INTO lin_src VALUES (1)",
+                                conn_infos["postgres"],
+                            ),
+                            dist=Periodic(per_second=100),
+                            report_regressions=False,
+                        ),
+                    ]
+                    + [
+                        # Sustained write flood. Its group commits advance the oracle
+                        # on the high-priority branch, and its commands keep cmd_rx
+                        # saturated well past the command batch size.
+                        ClosedLoop(
+                            action=ReuseConnQuery(
+                                "INSERT INTO lin_flood VALUES (1)",
+                                conn_infos["materialized"],
+                                strict_serializable=False,
+                            ),
+                            report_regressions=False,
+                        )
+                        for _ in range(1024)
+                    ]
+                    + [
+                        # Real-time-recency strict serializable reads. These become
+                        # pending linearize reads whose retirement the flood starves.
+                        ClosedLoop(
+                            action=ReuseConnQuery(
+                                "SET REAL_TIME_RECENCY TO TRUE; SELECT * FROM lin_mv",
+                                conn_infos["materialized"],
+                                strict_serializable=True,
+                            ),
+                            report_regressions=False,
+                        )
+                        for _ in range(8)
+                    ],
+                ),
+            ],
+            guarantees={
+                "SET REAL_TIME_RECENCY TO TRUE; SELECT * FROM lin_mv (reuse connection)": {
+                    "p99": 5000,
+                },
+            },
+        )
+
+
 class MySQLReadReplica(Scenario):
     def __init__(self, c: Composition, conn_infos: dict[str, PgConnInfo]):
         self.init(

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3890,21 +3890,18 @@ impl Coordinator {
                         };
                         messages.push(Message::GroupCommitInitiate(span, Some(permit)));
                     },
-                    // `recv_many()` on `UnboundedReceiver` is cancellation safe:
-                    // https://docs.rs/tokio/1.38.0/tokio/sync/mpsc/struct.UnboundedReceiver.html#cancel-safety-1
-                    // Receive a batch of commands.
-                    count = cmd_rx.recv_many(&mut cmd_messages, MESSAGE_BATCH) => {
-                        if count == 0 {
-                            break;
-                        } else {
-                            messages.extend(cmd_messages.drain(..).map(
-                                |(otel_ctx, cmd)| Message::Command(otel_ctx, cmd),
-                            ));
-                        }
-                    },
                     // `recv()` on `UnboundedReceiver` is cancellation safe:
                     // https://docs.rs/tokio/1.38.0/tokio/sync/mpsc/struct.UnboundedReceiver.html#cancel-safety
                     // Receive a single command.
+                    //
+                    // Placed above `cmd_rx`: a pending read must first be
+                    // sequenced off `cmd_rx` before it can be enqueued here, so
+                    // this branch is causally downstream of `cmd_rx` and cannot
+                    // outrun it. That makes it safe above `cmd_rx` without
+                    // starving user command intake, and moving a read into the
+                    // pending set is only a cheap map insert. Below `cmd_rx` this
+                    // branch is starved by a sustained write flood, so the reads
+                    // never enter the pending set and never retire.
                     Some(pending_read_txn) = strict_serializable_reads_rx.recv() => {
                         let mut pending_read_txns = vec![pending_read_txn];
                         while let Ok(pending_read_txn) = strict_serializable_reads_rx.try_recv() {
@@ -3921,6 +3918,18 @@ impl Coordinator {
                         }
                         messages.push(Message::LinearizeReads);
                     }
+                    // `recv_many()` on `UnboundedReceiver` is cancellation safe:
+                    // https://docs.rs/tokio/1.38.0/tokio/sync/mpsc/struct.UnboundedReceiver.html#cancel-safety-1
+                    // Receive a batch of commands.
+                    count = cmd_rx.recv_many(&mut cmd_messages, MESSAGE_BATCH) => {
+                        if count == 0 {
+                            break;
+                        } else {
+                            messages.extend(cmd_messages.drain(..).map(
+                                |(otel_ctx, cmd)| Message::Command(otel_ctx, cmd),
+                            ));
+                        }
+                    },
                     // `tick()` on `Interval` is cancel-safe:
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                     // Receive a single command.
@@ -3948,6 +3957,14 @@ impl Coordinator {
                     // sub-millisecond), the lower branches (including the idle
                     // watchdog) stay reachable. See the pin above for why the
                     // future is persisted rather than recreated per iteration.
+                    //
+                    // This branch sits below `cmd_rx`, so a sustained write flood
+                    // starves it. That is fine: under load, retirement instead
+                    // rides `Message::AdvanceTimelines`, which group commit emits
+                    // on the top-priority internal channel after advancing the
+                    // oracle. This branch is the idle-period path, keeping read
+                    // latency low when there is no group commit traffic to carry
+                    // the re-check.
                     () = linearize_reads_notified.as_mut() => {
                         linearize_reads_notified.set(linearize_reads_notify.notified());
                         messages.push(Message::LinearizeReads);

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -107,6 +107,14 @@ impl Coordinator {
             }
             Message::AdvanceTimelines => {
                 self.advance_timelines().boxed_local().await;
+                // Group commit emits `AdvanceTimelines` on the top-priority
+                // internal channel after advancing the oracle. Retiring pending
+                // reads here couples retirement to the only signal that can make
+                // a read ready, on a branch that a write flood cannot starve.
+                // The `LinearizeReads` re-check branch sits below `cmd_rx` and is
+                // starved under sustained load, so this is the load-bearing
+                // retirement path when writes are flowing.
+                self.message_linearize_reads().boxed_local().await;
             }
             Message::ClusterEvent(event) => self.message_cluster_event(event).boxed_local().await,
             Message::CancelPendingPeeks { conn_id } => {


### PR DESCRIPTION
Follow-up to #37316. That fix stopped the linearize re-check from starving group commit, but left a residual priority inversion: in the biased coordinator select, both the branch enqueuing a pending strict serializable read and the re-check branch sit below `cmd_rx`, so a sustained write flood starves retirement even while the same flood advances the oracle past the read's timestamp on the higher group commit branch. The read stays pending until the flood drains. Repro and evidence in https://github.com/MaterializeInc/materialize/pull/37316#discussion_r3542436439.

Reordering only relocates the victim. Instead, retirement rides its causal signal: `message_linearize_reads` now runs from the `Message::AdvanceTimelines` handler, which group commit emits on the top-priority internal channel after advancing the oracle. The enqueue branch moves above `cmd_rx` (safe because it is causally downstream of `cmd_rx` and cannot outrun it). The re-check branch stays below `cmd_rx` as the idle-period path.

Adds def-'s `LinearizeReadStarvation` parallel-benchmark scenario as a regression guard and records the priority-inversion class in the adapter guide.

Draft: local build is currently broken, so the benchmark RED→GREEN has not been re-run locally. Left as draft pending that verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)