### PR TITLE
service: CTP controller-assigned process identity (RFC, alt to #36876)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6605,6 +6605,7 @@ dependencies = [
  "derivative",
  "differential-dataflow",
  "futures",
+ "itertools 0.14.0",
  "mz-build-info",
  "mz-cluster-client",
  "mz-compute-types",

--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -42,7 +42,9 @@ class Clusterd(Service):
     ) -> None:
         environment = [
             "CLUSTERD_LOG_FILTER",
-            f"CLUSTERD_GRPC_HOST={name}",
+            # Replica-scoped CTP identity prefix. clusterd appends its process
+            # ordinal to form the full identity it advertises in the handshake.
+            f"CLUSTERD_CTP_IDENTITY={name}",
             # For old Mz versions
             "CLUSTERD_USE_CTP=true",
             "MZ_SOFT_ASSERTIONS=1",

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -69,4 +69,10 @@ pub struct ClusterReplicaLocation {
     /// the replica. Connections from the controller to these addresses
     /// are sent commands, and send responses back.
     pub ctl_addrs: Vec<String>,
+    /// The expected CTP identity of each process, parallel to `ctl_addrs`.
+    ///
+    /// Entry `i` is the identity the controller expects process `i` to advertise in the CTP
+    /// handshake, or `None` to skip the check for that process. A mismatch means the connection
+    /// reached the wrong process (e.g. stale DNS or a reused pod IP).
+    pub ctl_identities: Vec<Option<String>>,
 }

--- a/src/clusterd-test-driver/src/ctp.rs
+++ b/src/clusterd-test-driver/src/ctp.rs
@@ -41,6 +41,8 @@ pub async fn connect_and_hello(compute_addr: &str) -> anyhow::Result<ComputeCtpC
     let version = mz_persist_client::BUILD_INFO.semver_version();
     let mut client = Client::<ComputeCommand, ComputeResponse>::connect(
         compute_addr,
+        // Test driver dials a specific address directly, so skip the CTP identity check.
+        None,
         version,
         Duration::from_secs(30),
         Duration::from_secs(60),

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -81,12 +81,17 @@ struct Args {
         default_value = "127.0.0.1:6878"
     )]
     internal_http_listen_addr: SocketAddr,
-    /// The FQDN of this process, for GRPC request validation.
+    /// Controller-assigned identity for this process, echoed in the CTP handshake so the
+    /// controller can detect misrouted/stale connections.
     ///
-    /// Not providing this value or setting it to the empty string disables host validation for
-    /// GRPC requests.
-    #[clap(long, env = "GRPC_HOST", value_name = "NAME")]
-    grpc_host: Option<String>,
+    /// The value is the replica-scoped prefix `<cluster_id>/<replica_id>`. This process appends
+    /// its own ordinal (`--process`) to form the full identity, because the ordinal is only known
+    /// to the running process. Kubernetes StatefulSet pods share a single arg template, so the
+    /// controller cannot bake the ordinal into a per-pod arg.
+    ///
+    /// Not providing this value or setting it to the empty string disables the CTP identity check.
+    #[clap(long, env = "CTP_IDENTITY", value_name = "TOKEN")]
+    ctp_identity: Option<String>,
 
     // === Timely cluster options. ===
     /// Configuration for the storage Timely cluster.
@@ -414,7 +419,12 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         None,
     );
 
-    let grpc_host = args.grpc_host.and_then(|h| (!h.is_empty()).then_some(h));
+    // Compose the full CTP identity by appending this process's ordinal to the controller-assigned
+    // prefix. Empty or unset disables the check by leaving the identity `None`.
+    let ctp_identity = args
+        .ctp_identity
+        .and_then(|prefix| (!prefix.is_empty()).then_some(prefix))
+        .map(|prefix| format!("{prefix}/{}", args.process));
     let cluster_server_metrics = ClusterServerMetrics::register_with(&metrics_registry);
 
     let mut storage_timely_config = args.storage_timely_config;
@@ -459,7 +469,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         transport::serve(
             args.storage_controller_listen_addr,
             BUILD_INFO.semver_version(),
-            grpc_host.clone(),
+            ctp_identity.clone(),
             Duration::MAX,
             storage_client_builder,
             cluster_server_metrics.for_server("storage"),
@@ -491,7 +501,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         transport::serve(
             args.compute_controller_listen_addr,
             BUILD_INFO.semver_version(),
-            grpc_host.clone(),
+            ctp_identity.clone(),
             Duration::MAX,
             compute_client_builder,
             cluster_server_metrics.for_server("compute"),

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -17,6 +17,7 @@ chrono.workspace = true
 derivative.workspace = true
 differential-dataflow.workspace = true
 futures.workspace = true
+itertools.workspace = true
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
 mz-compute-types = { path = "../compute-types" }

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{self, AtomicBool};
 use std::time::{Duration, Instant};
 
 use anyhow::bail;
+use itertools::Itertools;
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_compute_types::dyncfgs::ENABLE_COMPUTE_REPLICA_EXPIRATION;
@@ -181,8 +182,16 @@ impl ReplicaTask {
                 .unwrap_or(Duration::MAX);
 
             let connect_start = Instant::now();
+            let addrs = self
+                .config
+                .location
+                .ctl_addrs
+                .iter()
+                .cloned()
+                .zip_eq(self.config.location.ctl_identities.iter().cloned())
+                .collect();
             let connect_result = ComputeCtpClient::connect_partitioned(
-                self.config.location.ctl_addrs.clone(),
+                addrs,
                 version,
                 connect_timeout,
                 keepalive_timeout,

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -467,10 +467,14 @@ impl Controller {
                 storagectl_addrs,
                 computectl_addrs,
             }) => {
+                // Unmanaged replicas are not launched by us, so we have no controller-assigned
+                // identity to expect. Skip the CTP identity check for every process.
                 compute_location = ClusterReplicaLocation {
+                    ctl_identities: vec![None; computectl_addrs.len()],
                     ctl_addrs: computectl_addrs,
                 };
                 storage_location = ClusterReplicaLocation {
+                    ctl_identities: vec![None; storagectl_addrs.len()],
                     ctl_addrs: storagectl_addrs,
                 };
                 metrics_task = None;
@@ -486,11 +490,23 @@ impl Controller {
                     enable_worker_core_affinity,
                     enable_storage_introspection_logs,
                 )?;
+                // Expect each process to advertise the same per-ordinal CTP identity that we pass
+                // it via `--ctp-identity` in `provision_replica`. This catches connections that
+                // reach the wrong replica or wrong process ordinal.
+                let ctl_identities = |addrs: &[String]| -> Vec<Option<String>> {
+                    (0..addrs.len())
+                        .map(|i| Some(format!("{cluster_id}/{replica_id}/{i}")))
+                        .collect()
+                };
+                let storagectl_addrs = service.addresses("storagectl");
+                let computectl_addrs = service.addresses("computectl");
                 storage_location = ClusterReplicaLocation {
-                    ctl_addrs: service.addresses("storagectl"),
+                    ctl_identities: ctl_identities(&storagectl_addrs),
+                    ctl_addrs: storagectl_addrs,
                 };
                 compute_location = ClusterReplicaLocation {
-                    ctl_addrs: service.addresses("computectl"),
+                    ctl_identities: ctl_identities(&computectl_addrs),
+                    ctl_addrs: computectl_addrs,
                 };
                 metrics_task = Some(metrics_task_join_handle);
 
@@ -763,6 +779,16 @@ impl Controller {
                         ),
                         format!("--opentelemetry-resource=cluster_id={}", cluster_id),
                         format!("--opentelemetry-resource=replica_id={}", replica_id),
+                        // Replica-scoped CTP identity prefix. clusterd appends its process ordinal
+                        // to form the full `<cluster_id>/<replica_id>/<ordinal>` identity, matching
+                        // the per-process `ctl_identities` we expect on the controller side. The
+                        // ordinal cannot be baked in here because Kubernetes StatefulSet pods share
+                        // one arg template.
+                        //
+                        // NOTE: The deploy generation/incarnation is intentionally not part of the
+                        // identity yet. This token catches wrong-replica and wrong-ordinal
+                        // misrouting, but not a same-identity stale pod.
+                        format!("--ctp-identity={cluster_id}/{replica_id}"),
                         format!("--persist-pubsub-url={}", persist_pubsub_url),
                         format!("--environment-id={}", environment_id),
                         format!(

--- a/src/service/src/transport.rs
+++ b/src/service/src/transport.rs
@@ -59,36 +59,25 @@ impl<Out: Message, In: Message> Client<Out, In> {
     ///
     /// This call resolves once a connection with the server host was either established, was
     /// rejected, or timed out.
+    ///
+    /// `expected_identity` is the CTP identity the client expects the server to advertise. The
+    /// handshake is rejected if both sides provide an identity and they differ. `None` disables
+    /// the check.
     pub async fn connect(
         address: &str,
+        expected_identity: Option<String>,
         version: Version,
         connect_timeout: Duration,
         idle_timeout: Duration,
         metrics: impl Metrics<Out, In>,
     ) -> anyhow::Result<Self> {
-        let dest_host = host_from_address(address);
         let stream = mz_ore::future::timeout(connect_timeout, Stream::connect(address)).await?;
         info!(%address, "ctp: connected to server");
 
-        let conn = Connection::start(stream, version, dest_host, idle_timeout, metrics).await?;
+        let conn =
+            Connection::start(stream, version, expected_identity, idle_timeout, metrics).await?;
         Ok(Self { conn })
     }
-}
-
-/// Helper function to extract the host part from an address string.
-///
-/// This function assumes addresses to be of the form `<host>:<port>` or `<protocol>:<host>:<port>`
-/// and yields `None` otherwise.
-fn host_from_address(address: &str) -> Option<String> {
-    let mut p = address.split(':');
-    let (host, port) = match (p.next(), p.next(), p.next(), p.next()) {
-        (Some(host), Some(port), None, None) => (host, port),
-        (Some(_protocol), Some(host), Some(port), None) => (host, port),
-        _ => return None,
-    };
-
-    let _: u16 = port.parse().ok()?;
-    Some(host.into())
 }
 
 impl<Out, In> Client<Out, In>
@@ -98,16 +87,20 @@ where
     (Out, In): Partitionable<Out, In>,
 {
     /// Create a `Partitioned` client that connects through CTP.
+    ///
+    /// Each address is paired with the CTP identity the client expects that peer to advertise. An
+    /// identity of `None` disables the check for that peer.
     pub async fn connect_partitioned(
-        addresses: Vec<String>,
+        addresses: Vec<(String, Option<String>)>,
         version: Version,
         connect_timeout: Duration,
         idle_timeout: Duration,
         metrics: impl Metrics<Out, In>,
     ) -> anyhow::Result<Partitioned<Self, Out, In>> {
-        let connects = addresses.iter().map(|addr| {
+        let connects = addresses.iter().map(|(addr, expected_identity)| {
             Self::connect(
                 addr,
+                expected_identity.clone(),
                 version.clone(),
                 connect_timeout,
                 idle_timeout,
@@ -138,7 +131,7 @@ impl<Out: Message, In: Message> GenericClient<Out, In> for Client<Out, In> {
 pub async fn serve<In, Out, H>(
     address: SocketAddr,
     version: Version,
-    server_fqdn: Option<String>,
+    peer_identity: Option<String>,
     idle_timeout: Duration,
     handler_fn: impl Fn() -> H,
     metrics: impl Metrics<Out, In>,
@@ -171,7 +164,7 @@ where
 
         let handler = handler_fn();
         let version = version.clone();
-        let server_fqdn = server_fqdn.clone();
+        let peer_identity = peer_identity.clone();
         let metrics = metrics.clone();
         let (cancel_tx, cancel_rx) = oneshot::channel();
 
@@ -183,7 +176,7 @@ where
                     stream,
                     handler,
                     version,
-                    server_fqdn,
+                    peer_identity,
                     idle_timeout,
                     cancel_rx,
                     metrics,
@@ -203,7 +196,7 @@ async fn serve_connection<In, Out, H>(
     stream: Stream,
     mut handler: H,
     version: Version,
-    server_fqdn: Option<String>,
+    peer_identity: Option<String>,
     timeout: Duration,
     cancel_rx: oneshot::Receiver<()>,
     metrics: impl Metrics<Out, In>,
@@ -213,7 +206,7 @@ where
     Out: Message,
     H: GenericClient<In, Out>,
 {
-    let mut conn = Connection::start(stream, version, server_fqdn, timeout, metrics).await?;
+    let mut conn = Connection::start(stream, version, peer_identity, timeout, metrics).await?;
 
     let mut cancel_rx = cancel_rx;
     loop {
@@ -271,7 +264,7 @@ impl<Out: Message, In: Message> Connection<Out, In> {
     async fn start(
         stream: Stream,
         version: Version,
-        server_fqdn: Option<String>,
+        peer_identity: Option<String>,
         mut timeout: Duration,
         metrics: impl Metrics<Out, In>,
     ) -> anyhow::Result<Self> {
@@ -292,7 +285,7 @@ impl<Out: Message, In: Message> Connection<Out, In> {
         let mut reader = metrics::Reader::new(reader, metrics.clone());
         let mut writer = metrics::Writer::new(writer, metrics.clone());
 
-        handshake(&mut reader, &mut writer, version, server_fqdn).await?;
+        handshake(&mut reader, &mut writer, version, peer_identity).await?;
 
         let (out_tx, out_rx) = mpsc::unbounded_channel();
         let (in_tx, in_rx) = mpsc::unbounded_channel();
@@ -424,7 +417,7 @@ async fn handshake<R, W>(
     mut reader: R,
     mut writer: W,
     version: Version,
-    server_fqdn: Option<String>,
+    peer_identity: Option<String>,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -437,7 +430,7 @@ where
 
     let hello = Hello {
         version: version.clone(),
-        server_fqdn: server_fqdn.clone(),
+        peer_identity: peer_identity.clone(),
     };
     write_message(&mut writer, Some(&hello)).await?;
 
@@ -448,15 +441,17 @@ where
 
     let Hello {
         version: peer_version,
-        server_fqdn: peer_server_fqdn,
+        peer_identity: advertised_identity,
     } = read_message(&mut reader).await?;
 
     if peer_version != version {
         bail!("version mismatch: {peer_version} != {version}");
     }
-    if let (Some(other), Some(mine)) = (&peer_server_fqdn, &server_fqdn) {
+    // Both sides carry a controller-assigned identity. When both are present and disagree, the
+    // connection reached the wrong process (e.g. stale DNS or reused pod IP), so reject it.
+    if let (Some(other), Some(mine)) = (&advertised_identity, &peer_identity) {
         if other != mine {
-            bail!("server FQDN mismatch: {other} != {mine}");
+            bail!("CTP peer identity mismatch: {other} != {mine}");
         }
     }
 
@@ -468,8 +463,12 @@ where
 struct Hello {
     /// The version of the originating endpoint.
     version: Version,
-    /// The FQDN of the server endpoint.
-    server_fqdn: Option<String>,
+    /// The controller-assigned identity of the originating process.
+    ///
+    /// This is an opaque token, not a hostname. The controller assigns each replica process an
+    /// identity and echoes the same value when connecting, so a connection that lands on the
+    /// wrong process can be detected and rejected.
+    peer_identity: Option<String>,
 }
 
 /// Write a message into the given writer.

--- a/src/service/tests/transport.rs
+++ b/src/service/tests/transport.rs
@@ -57,15 +57,25 @@ async fn connect_ctp<Out: Message, In: Message>(
 ) -> transport::Client<Out, In> {
     Retry::default()
         .retry_async(|_| {
-            transport::Client::connect(address, version.clone(), timeout, timeout, metrics.clone())
+            transport::Client::connect(
+                address,
+                None,
+                version.clone(),
+                timeout,
+                timeout,
+                metrics.clone(),
+            )
         })
         .await
         .expect("retries forever")
 }
 
 /// Helper for connecting to a CTP server that retries until it encounters the expected error.
+///
+/// `expected_identity` is the CTP identity the client expects the server to advertise.
 async fn connect_ctp_error<Out: Message, In: Message>(
     address: &str,
+    expected_identity: Option<String>,
     version: Version,
     expected_error: &str,
 ) -> anyhow::Result<()> {
@@ -73,6 +83,7 @@ async fn connect_ctp_error<Out: Message, In: Message>(
         .retry_async(async |_| {
             let result = transport::Client::<(), ()>::connect(
                 address,
+                expected_identity.clone(),
                 version.clone(),
                 TIMEOUT,
                 TIMEOUT,
@@ -211,6 +222,7 @@ fn test_handshake_magic_mismatch() {
     sim.client("client", async move {
         connect_ctp_error::<(), ()>(
             "turmoil:server:7777",
+            None,
             VERSION,
             "invalid protocol magic: 0xbad",
         )
@@ -257,6 +269,7 @@ fn test_handshake_version_mismatch() {
     sim.client("client", async move {
         connect_ctp_error::<(), ()>(
             "turmoil:server:7777",
+            None,
             CLIENT_VERSION,
             "version mismatch: 1.2.3 != 1.2.4",
         )
@@ -270,7 +283,7 @@ fn test_handshake_version_mismatch() {
 
 #[test] // allow(test-attribute)
 #[cfg_attr(miri, ignore)] // too slow
-fn test_handshake_fqdn_mismatch() {
+fn test_handshake_identity_mismatch() {
     let mut sim = setup();
 
     sim.host("server", move || async {
@@ -284,7 +297,7 @@ fn test_handshake_fqdn_mismatch() {
             transport::serve(
                 "turmoil:0.0.0.0:7777".parse().unwrap(),
                 VERSION,
-                Some("wrong.server".into()),
+                Some("wrong-process".into()),
                 TIMEOUT,
                 move || handler.lock().unwrap().take().unwrap(),
                 NoopMetrics,
@@ -300,8 +313,9 @@ fn test_handshake_fqdn_mismatch() {
     sim.client("client", async move {
         connect_ctp_error::<(), ()>(
             "turmoil:server:7777",
+            Some("expected-process".into()),
             VERSION,
-            "server FQDN mismatch: wrong.server != server",
+            "CTP peer identity mismatch: wrong-process != expected-process",
         )
         .await?;
 

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -875,8 +875,16 @@ impl ReplicaTask {
                 .http2_keep_alive_timeout
                 .unwrap_or(Duration::MAX);
 
+            let addrs = self
+                .config
+                .location
+                .ctl_addrs
+                .iter()
+                .cloned()
+                .zip_eq(self.config.location.ctl_identities.iter().cloned())
+                .collect();
             let connect_result = StorageCtpClient::connect_partitioned(
-                self.config.location.ctl_addrs.clone(),
+                addrs,
                 version,
                 connect_timeout,
                 keepalive_timeout,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2079,10 +2079,10 @@ def workflow_test_drop_during_reconciliation(c: Composition) -> None:
         Clusterd(
             name="clusterd1",
             environment_extra=[
-                # Disable GRPC host checking. We are connecting through a
-                # proxy, so the host in the request URI doesn't match
-                # clusterd's fqdn.
-                "CLUSTERD_GRPC_HOST=",
+                # Disable the CTP identity check. We are connecting through a
+                # proxy, so we don't require the replica to advertise a
+                # matching identity.
+                "CLUSTERD_CTP_IDENTITY=",
             ],
         ),
         Testdrive(
@@ -2321,10 +2321,10 @@ def workflow_test_clusterd_death_detection(c: Composition) -> None:
         Clusterd(
             name="clusterd1",
             environment_extra=[
-                # Disable GRPC host checking. We are connecting through a
-                # proxy, so the host in the request URI doesn't match
-                # clusterd's fqdn.
-                "CLUSTERD_GRPC_HOST=",
+                # Disable the CTP identity check. We are connecting through a
+                # proxy, so we don't require the replica to advertise a
+                # matching identity.
+                "CLUSTERD_CTP_IDENTITY=",
             ],
         ),
     ):


### PR DESCRIPTION
**Draft / RFC.** Alternative to #36876 for the CTP host-check question, per review discussion.

## Problem

The distroless migration (#36099) deletes `clusterd/ci/entrypoint.sh`, which set `CLUSTERD_GRPC_HOST=$(hostname --fqdn)`. That value fed the CTP handshake's `server_fqdn` check (`src/service/src/transport.rs`), which rejects a controller connection whose dialed host does not match the replica's own FQDN. So #36099 silently disables that guard on Kubernetes, and #36876 proposed removing it outright.

Review (thanks @def-) pushed back: the check is a real correctness guard, not just defense in depth. The controller builds an ordered replica address list and the `Partitioned` client uses the connection **index** to route command shards (compute sends all commands to shard 0), so a connection that lands on the wrong process can corrupt the partition mapping, and the new connection cancels the legitimate one. Kubernetes runs replicas with zero termination grace and reused pod identities, so stale DNS / pod-IP reuse are realistic.

## Why not just re-plumb the FQDN

We could feed the pod FQDN back to distroless clusterd (downward API / an arg) and keep the existing check. But the mechanism is vestigial: the command transport is **CTP** (a custom bincode-over-TCP protocol), not gRPC. The `--grpc-host` name is a leftover from when it was gRPC. Since we own CTP, we can carry a proper controller-assigned identity instead of a DNS hostname.

## This change

Replace the `server_fqdn` string in the CTP `Hello` with a controller-assigned **identity token**, verified per address slot. The handshake compare logic is unchanged (symmetric: reject when both sides present a value and they differ). Only the value and how each side obtains it change:

- The controller assigns each replica process the identity `<cluster_id>/<replica_id>/<ordinal>` and expects that exact value for the corresponding address slot (`src/controller/src/clusters.rs`).
- clusterd advertises the same identity in its handshake (`src/clusterd/src/lib.rs`). The controller passes the replica-scoped prefix `<cluster_id>/<replica_id>` via `--ctp-identity`; clusterd appends its own `--process` ordinal. (The ordinal cannot be baked into a per-pod arg because Kubernetes StatefulSet pods share one arg template.)
- `ClusterReplicaLocation` carries a `ctl_identities` list parallel to `ctl_addrs`, so the expected identity flows from launch to connect.
- `--grpc-host` / `CLUSTERD_GRPC_HOST` is replaced by `--ctp-identity` / `CTP_IDENTITY`.
- Everything stays `Option`: `None` on either side disables the check, preserving current behavior for the process orchestrator and unmanaged replicas.

This restores the guard for managed replicas and retires the misleading `grpc` naming.

## Open design questions (the point of the draft)

1. **Generation / incarnation.** The token is `<cluster>/<replica>/<ordinal>` with no incarnation component. It catches wrong-replica and wrong-ordinal misrouting, but **not** a same-identity stale pod (an old incarnation of the same replica/ordinal reachable at a reused IP). @def-'s suggestion was to include a generation. Closing this needs a durable incarnation source that both the controller's expected value and the pod's advertised value derive from. Where should that live (replica config generation? a controller-assigned per-launch epoch)?
2. **Token composition split.** clusterd assembles the ordinal onto a controller-supplied prefix (forced by the shared StatefulSet arg template). Acceptable, or do we want a fully controller-formed per-pod token (larger orchestrator change)?
3. **Coordination.** This supersedes #36876 and resolves @def-'s finding on #36099. If we take this route, #36876 is dropped and #36099 no longer needs to re-plumb the FQDN.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo test -p mz-service --test transport` (incl. renamed `test_handshake_identity_mismatch`)
- [ ] cloudtest / managed-replica connect on kind
- [ ] decide the generation question above before this leaves draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)
