### PR TITLE
SS-336: storage-client: implement glue analogue of publish_kafka_schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
- "half 2.7.1",
+ "half",
  "hashbrown 0.16.1",
  "num-complex",
  "num-integer",
@@ -330,7 +330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
 dependencies = [
  "bytes",
- "half 2.7.1",
+ "half",
  "num-bigint",
  "num-traits",
 ]
@@ -351,7 +351,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "comfy-table",
- "half 2.7.1",
+ "half",
  "lexical-core",
  "num-traits",
  "ryu",
@@ -365,7 +365,7 @@ checksum = "bf87f4ff5fc13290aa47e499a8b669a82c5977c6a1fedce22c7f542c1fd5a597"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
- "half 2.7.1",
+ "half",
  "num-integer",
  "num-traits",
 ]
@@ -407,7 +407,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "half 2.7.1",
+ "half",
 ]
 
 [[package]]
@@ -497,6 +497,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1108,14 +1118,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "bytes",
  "h2 0.3.26",
  "h2 0.4.12",
  "http 0.2.12",
+ "http 1.4.2",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "hyper 0.14.32",
+ "indexmap 2.11.4",
  "pin-project-lite",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]
@@ -1132,12 +1149,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-mocks"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9a9490933f8faa0aeb1eb9fbb8bf4f1c214b3149c61b3a4074b68030b21bd5"
+dependencies = [
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
 name = "aws-smithy-observability"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b227aa94af99a8e5ee52551cc7e3ee30a217019ef99207b6f0b7a1527685941"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1174,6 +1222,7 @@ dependencies = [
  "pin-utils",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1746,6 +1795,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +1965,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -2003,18 +2080,18 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 1.6.0",
+ "half",
 ]
 
 [[package]]
@@ -2993,6 +3070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "differential-dataflow"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,7 +3137,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4152,12 +4235,6 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
-
-[[package]]
-name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
@@ -4578,7 +4655,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4797,7 +4874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -4891,7 +4968,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4978,7 +5055,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6029,7 +6106,7 @@ dependencies = [
  "arrow",
  "chrono",
  "dec",
- "half 2.7.1",
+ "half",
  "itertools 0.14.0",
  "mz-ore",
  "mz-repr",
@@ -6116,10 +6193,12 @@ name = "mz-aws-glue-schema-registry"
 version = "0.0.0"
 dependencies = [
  "aws-sdk-glue",
+ "aws-smithy-mocks",
  "aws-smithy-runtime-api",
  "aws-types",
  "mz-ore",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]
@@ -8632,10 +8711,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-sdk-glue",
+ "aws-smithy-mocks",
  "chrono",
  "differential-dataflow",
  "futures",
  "itertools 0.14.0",
+ "mz-aws-glue-schema-registry",
  "mz-build-info",
  "mz-ccsr",
  "mz-cluster-client",
@@ -9793,7 +9875,7 @@ dependencies = [
  "chrono",
  "flate2",
  "futures",
- "half 2.7.1",
+ "half",
  "hashbrown 0.16.1",
  "lz4_flex",
  "num-bigint",
@@ -10381,6 +10463,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10507,7 +10599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -10528,7 +10620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11354,6 +11446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11480,7 +11581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -11846,6 +11947,12 @@ dependencies = [
  "url",
  "uuid",
 ]
+
+[[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "seq-macro"
@@ -12603,7 +12710,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -12622,7 +12729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,7 @@ aws-sdk-s3 = { version = "1.129.0", default-features = false, features = ["rt-to
 aws-sdk-secretsmanager = { version = "1.103.0", default-features = false, features = ["rt-tokio"] }
 aws-sdk-sts = { version = "1.41.0", default-features = false, features = ["rt-tokio"] }
 aws-sigv4 = "1.3.6"
+aws-smithy-mocks = "0.2.4"
 aws-smithy-runtime = { version = "1.9.8", features = ["connector-hyper-0-14-x"] }
 aws-smithy-runtime-api = "1.10.0"
 aws-smithy-types = { version = "1.1.8", features = ["byte-stream-poll-next"] }

--- a/src/aws-glue-schema-registry/Cargo.toml
+++ b/src/aws-glue-schema-registry/Cargo.toml
@@ -17,5 +17,12 @@ thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 
+[features]
+# Exposes constructors for injecting a mocked SDK client.
+test-util = []
+
 [dev-dependencies]
+aws-sdk-glue = { workspace = true, features = ["test-util"] }
+aws-smithy-mocks.workspace = true
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
+tokio.workspace = true

--- a/src/aws-glue-schema-registry/src/client.rs
+++ b/src/aws-glue-schema-registry/src/client.rs
@@ -46,6 +46,17 @@ impl Client {
         }
     }
 
+    /// Wraps an existing SDK client.
+    ///
+    /// Exists so tests can inject a mocked SDK client (e.g. via
+    /// `aws_smithy_mocks`). Production callers construct clients through
+    /// [`ClientConfig`](crate::ClientConfig) instead, which is why this is
+    /// gated behind the `test-util` feature.
+    #[cfg(feature = "test-util")]
+    pub fn from_sdk_client(inner: aws_sdk_glue::Client) -> Self {
+        Client { inner }
+    }
+
     /// Look up a registry by name.
     ///
     /// Returns [`GetRegistryError::NotFound`] if the registry does not exist
@@ -130,19 +141,23 @@ impl Client {
     }
 
     /// Look up the schema version whose definition byte-for-byte matches
-    /// `definition`, returning its UUID.
+    /// `definition`.
     ///
     /// This is the sink reuse path: before registering a new version, callers
     /// check whether the exact definition is already registered so that a sink
     /// restart does not create a duplicate version. Returns
     /// [`GetSchemaByDefinitionError::NotFound`] if the schema does not exist or
     /// has no version matching `definition`.
+    ///
+    /// The match is by definition only: Glue also matches versions whose
+    /// lifecycle status is `Failure` or `Deleting`, so callers must check the
+    /// returned status before reusing the version's id.
     pub async fn get_schema_by_definition(
         &self,
         registry_name: &str,
         schema_name: &str,
         definition: &str,
-    ) -> Result<Uuid, GetSchemaByDefinitionError> {
+    ) -> Result<RegisteredSchemaVersion, GetSchemaByDefinitionError> {
         let schema_id = SchemaId::builder()
             .registry_name(registry_name)
             .schema_name(schema_name)
@@ -155,23 +170,33 @@ impl Client {
             .send()
             .await
             .map_err(classify_get_schema_by_definition_error)?;
-        parse_schema_version_id(output.schema_version_id).map_err(GetSchemaByDefinitionError::Other)
+        let id = parse_schema_version_id(output.schema_version_id)
+            .map_err(GetSchemaByDefinitionError::Other)?;
+        Ok(RegisteredSchemaVersion {
+            id,
+            lifecycle_status: output.status.map(SchemaVersionLifecycleStatus::from_sdk),
+        })
     }
 
-    /// Register `definition` as a new version of an existing schema, returning
-    /// the new version's UUID.
+    /// Register `definition` as a new version of an existing schema.
     ///
     /// The schema `(registry_name, schema_name)` must already exist. Returns
     /// [`RegisterSchemaVersionError::SchemaNotFound`] if it does not, in which
     /// case the caller should create it with [`Client::create_schema`].
     /// Registering a definition identical to an existing version is idempotent
-    /// on Glue's side and returns that version's UUID.
+    /// on Glue's side and returns that version.
+    ///
+    /// Glue runs the compatibility check asynchronously: a newly registered
+    /// version comes back `Pending` and only later transitions to `Available`
+    /// or `Failure`. Callers must not use the version's id until they have
+    /// observed it `Available`, polling via
+    /// [`Client::get_schema_version_by_id`].
     pub async fn register_schema_version(
         &self,
         registry_name: &str,
         schema_name: &str,
         definition: &str,
-    ) -> Result<Uuid, RegisterSchemaVersionError> {
+    ) -> Result<RegisteredSchemaVersion, RegisterSchemaVersionError> {
         let schema_id = SchemaId::builder()
             .registry_name(registry_name)
             .schema_name(schema_name)
@@ -184,12 +209,21 @@ impl Client {
             .send()
             .await
             .map_err(classify_register_schema_version_error)?;
-        parse_schema_version_id(output.schema_version_id).map_err(RegisterSchemaVersionError::Other)
+        let id = parse_schema_version_id(output.schema_version_id)
+            .map_err(RegisterSchemaVersionError::Other)?;
+        Ok(RegisteredSchemaVersion {
+            id,
+            lifecycle_status: output.status.map(SchemaVersionLifecycleStatus::from_sdk),
+        })
     }
 
     /// Create a schema in `registry_name` with `definition` as its first version
-    /// and `compatibility` as its evolution policy, returning the first
-    /// version's UUID.
+    /// and `compatibility` as its evolution policy, returning that first
+    /// version.
+    ///
+    /// A first version has no prior version to be compatible with, so it is
+    /// usually `Available` immediately, but callers should still confirm the
+    /// returned status before using the version's id.
     ///
     /// Glue sets a schema's compatibility only at creation. This crate exposes
     /// no way to change it afterward, matching the sink's set-if-unset policy:
@@ -205,7 +239,7 @@ impl Client {
         data_format: DataFormat,
         compatibility: Compatibility,
         definition: &str,
-    ) -> Result<Uuid, CreateSchemaError> {
+    ) -> Result<RegisteredSchemaVersion, CreateSchemaError> {
         let registry_id = RegistryId::builder().registry_name(registry_name).build();
         let output = self
             .inner
@@ -218,7 +252,14 @@ impl Client {
             .send()
             .await
             .map_err(classify_create_schema_error)?;
-        parse_schema_version_id(output.schema_version_id).map_err(CreateSchemaError::Other)
+        let id =
+            parse_schema_version_id(output.schema_version_id).map_err(CreateSchemaError::Other)?;
+        Ok(RegisteredSchemaVersion {
+            id,
+            lifecycle_status: output
+                .schema_version_status
+                .map(SchemaVersionLifecycleStatus::from_sdk),
+        })
     }
 
     /// Fetch a schema's metadata by `(registry_name, schema_name)`.
@@ -349,6 +390,20 @@ impl SchemaVersion {
             lifecycle_status: output.status.map(SchemaVersionLifecycleStatus::from_sdk),
         }
     }
+}
+
+/// A schema version's identity and lifecycle status, as returned by the write
+/// path methods [`Client::get_schema_by_definition`],
+/// [`Client::register_schema_version`], and [`Client::create_schema`].
+///
+/// Glue validates new versions asynchronously, so `lifecycle_status` is often
+/// `Pending` here. A version is only usable for framing records once it is
+/// `Available`. Callers holding a non-`Available` status must poll
+/// [`Client::get_schema_version_by_id`] until it resolves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisteredSchemaVersion {
+    pub id: Uuid,
+    pub lifecycle_status: Option<SchemaVersionLifecycleStatus>,
 }
 
 /// Data format of a Glue schema.
@@ -652,7 +707,85 @@ fn classify_get_schema_error(err: SdkError<SdkGetSchemaError>) -> GetSchemaError
 
 #[cfg(test)]
 mod tests {
+    use aws_sdk_glue::operation::create_schema::CreateSchemaOutput;
+    use aws_sdk_glue::operation::get_schema_by_definition::GetSchemaByDefinitionOutput;
+    use aws_sdk_glue::operation::register_schema_version::RegisterSchemaVersionOutput;
+    use aws_smithy_mocks::{RuleMode, mock, mock_client};
+
     use super::*;
+
+    const VERSION_ID: &str = "12345678-1234-5678-1234-567812345678";
+
+    /// The write methods must surface the lifecycle status from each response:
+    /// Glue validates versions asynchronously, so callers gate on it before
+    /// using a version's id.
+    #[mz_ore::test(tokio::test)]
+    async fn write_methods_surface_lifecycle_status() {
+        let register = mock!(aws_sdk_glue::Client::register_schema_version).then_output(|| {
+            RegisterSchemaVersionOutput::builder()
+                .schema_version_id(VERSION_ID)
+                .status(SdkSchemaVersionStatus::Pending)
+                .build()
+        });
+        let by_definition =
+            mock!(aws_sdk_glue::Client::get_schema_by_definition).then_output(|| {
+                GetSchemaByDefinitionOutput::builder()
+                    .schema_version_id(VERSION_ID)
+                    .status(SdkSchemaVersionStatus::Failure)
+                    .build()
+            });
+        let create = mock!(aws_sdk_glue::Client::create_schema).then_output(|| {
+            CreateSchemaOutput::builder()
+                .schema_version_id(VERSION_ID)
+                .schema_version_status(SdkSchemaVersionStatus::Available)
+                .build()
+        });
+        let client = Client {
+            inner: mock_client!(
+                aws_sdk_glue,
+                RuleMode::MatchAny,
+                &[&register, &by_definition, &create]
+            ),
+        };
+
+        let id = Uuid::parse_str(VERSION_ID).expect("valid uuid literal");
+        assert_eq!(
+            client
+                .register_schema_version("registry", "schema", "{}")
+                .await
+                .expect("mocked register succeeds"),
+            RegisteredSchemaVersion {
+                id,
+                lifecycle_status: Some(SchemaVersionLifecycleStatus::Pending),
+            }
+        );
+        assert_eq!(
+            client
+                .get_schema_by_definition("registry", "schema", "{}")
+                .await
+                .expect("mocked lookup succeeds"),
+            RegisteredSchemaVersion {
+                id,
+                lifecycle_status: Some(SchemaVersionLifecycleStatus::Failure),
+            }
+        );
+        assert_eq!(
+            client
+                .create_schema(
+                    "registry",
+                    "schema",
+                    DataFormat::Avro,
+                    Compatibility::Backward,
+                    "{}",
+                )
+                .await
+                .expect("mocked create succeeds"),
+            RegisteredSchemaVersion {
+                id,
+                lifecycle_status: Some(SchemaVersionLifecycleStatus::Available),
+            }
+        );
+    }
 
     #[mz_ore::test]
     fn parse_schema_version_id_valid() {

--- a/src/aws-glue-schema-registry/src/lib.rs
+++ b/src/aws-glue-schema-registry/src/lib.rs
@@ -64,7 +64,7 @@ mod config;
 pub use client::{
     Client, Compatibility, CreateSchemaError, DataFormat, GetRegistryError,
     GetSchemaByDefinitionError, GetSchemaError, GetSchemaVersionError, RegisterSchemaVersionError,
-    Registry, RegistryLifecycleStatus, Schema, SchemaLifecycleStatus, SchemaVersion,
-    SchemaVersionLifecycleStatus,
+    RegisteredSchemaVersion, Registry, RegistryLifecycleStatus, Schema, SchemaLifecycleStatus,
+    SchemaVersion, SchemaVersionLifecycleStatus,
 };
 pub use config::ClientConfig;

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -16,6 +16,7 @@ chrono.workspace = true
 differential-dataflow.workspace = true
 futures.workspace = true
 itertools.workspace = true
+mz-aws-glue-schema-registry = { path = "../aws-glue-schema-registry" }
 mz-ccsr = { path = "../ccsr" }
 mz-cluster-client = { path = "../cluster-client" }
 mz-controller-types = { path = "../controller-types" }
@@ -40,6 +41,9 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+aws-sdk-glue = { workspace = true, features = ["test-util"] }
+aws-smithy-mocks.workspace = true
+mz-aws-glue-schema-registry = { path = "../aws-glue-schema-registry", features = ["test-util"] }
 mz-build-info = { path = "../build-info" }
 mz-secrets = { path = "../secrets" }
 

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -11,11 +11,17 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use anyhow::{Context, anyhow, bail};
+use mz_aws_glue_schema_registry::{
+    Client as GlueClient, Compatibility as GlueCompatibility, CreateSchemaError, DataFormat,
+    GetSchemaByDefinitionError, GetSchemaVersionError, RegisterSchemaVersionError,
+    RegisteredSchemaVersion, SchemaVersionLifecycleStatus,
+};
 use mz_ccsr::GetSubjectConfigError;
 use mz_kafka_util::admin::EnsureTopicConfig;
 use mz_kafka_util::client::MzClientContext;
 use mz_ore::collections::CollectionExt;
 use mz_ore::future::{InTask, OreFutureExt};
+use mz_ore::retry::{Retry, RetryResult};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::KafkaTopicOptions;
 use mz_storage_types::errors::ContextCreationErrorExt;
@@ -23,6 +29,7 @@ use mz_storage_types::sinks::KafkaSinkConnection;
 use rdkafka::ClientContext;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, TopicReplication};
 use tracing::warn;
+use uuid::Uuid;
 
 pub mod progress_key {
     use std::fmt;
@@ -277,4 +284,331 @@ pub async fn publish_kafka_schema(
     .context("unable to publish schema to registry in kafka sink")?;
 
     Ok(schema_id)
+}
+
+/// Register `schema` for a sink in an AWS Glue Schema Registry, returning the
+/// schema-version UUID to frame records with.
+///
+/// Reuses an already-registered definition so a sink restart does not create a
+/// duplicate version. On first publish the schema is created with
+/// `compatibility` as its evolution policy, defaulting to Glue's `BACKWARD` when
+/// unset. For an existing schema the compatibility is only read and warned on
+/// when it differs, never overwritten: Glue fixes compatibility at creation
+/// time, and the sink must not silently change a policy it may share with other
+/// producers.
+pub async fn publish_glue_schema(
+    client: GlueClient,
+    registry_name: String,
+    schema_name: String,
+    schema: String,
+    compatibility: Option<GlueCompatibility>,
+) -> Result<Uuid, anyhow::Error> {
+    async move {
+        // Reuse: if this exact definition is already registered, we're done.
+        match client
+            .get_schema_by_definition(&registry_name, &schema_name, &schema)
+            .await
+        {
+            // Glue matches by definition only, so this can return a version
+            // that failed its compatibility check or is mid-deletion. Such a
+            // version is unusable: fall through and register, which surfaces
+            // a clear error if Glue still resolves the definition to it.
+            Ok(RegisteredSchemaVersion {
+                lifecycle_status:
+                    Some(
+                        SchemaVersionLifecycleStatus::Failure
+                        | SchemaVersionLifecycleStatus::Deleting,
+                    ),
+                ..
+            }) => {}
+            Ok(registered) => {
+                warn_on_glue_compatibility_mismatch(
+                    &client,
+                    &registry_name,
+                    &schema_name,
+                    compatibility.as_ref(),
+                )
+                .await;
+                return await_glue_schema_version_available(&client, registered).await;
+            }
+            Err(GetSchemaByDefinitionError::NotFound) => {}
+            Err(e) => return Err(e).context("looking up Glue schema by definition"),
+        }
+
+        // Not yet registered. Add a version if the schema exists, else create it.
+        let registered = match client
+            .register_schema_version(&registry_name, &schema_name, &schema)
+            .await
+        {
+            Ok(registered) => {
+                warn_on_glue_compatibility_mismatch(
+                    &client,
+                    &registry_name,
+                    &schema_name,
+                    compatibility.as_ref(),
+                )
+                .await;
+                registered
+            }
+            Err(RegisterSchemaVersionError::SchemaNotFound) => {
+                // First publish: create the schema and set its compatibility.
+                let compatibility = compatibility.unwrap_or(GlueCompatibility::Backward);
+                match client
+                    .create_schema(
+                        &registry_name,
+                        &schema_name,
+                        DataFormat::Avro,
+                        compatibility,
+                        &schema,
+                    )
+                    .await
+                {
+                    Ok(registered) => registered,
+                    // Lost a race with another writer that created the schema
+                    // between our register and create. Retry the register.
+                    Err(CreateSchemaError::AlreadyExists) => client
+                        .register_schema_version(&registry_name, &schema_name, &schema)
+                        .await
+                        .context("registering Glue schema version after create race")?,
+                    Err(e) => return Err(e).context("creating Glue schema"),
+                }
+            }
+            Err(e) => return Err(e).context("registering Glue schema version"),
+        };
+        await_glue_schema_version_available(&client, registered).await
+    }
+    .run_in_task(|| "publish_glue_schema".to_string())
+    .await
+    .context("unable to publish schema to registry in kafka sink")
+}
+
+/// Wait until Glue reports the schema version `registered` as `Available`,
+/// returning its id.
+///
+/// Glue runs compatibility checks asynchronously: a freshly registered version
+/// is `Pending` and only later transitions to `Available` or `Failure`.
+/// Records must not be framed with a version id until it is `Available`,
+/// otherwise a version that fails its check leaves the topic holding ids that
+/// consumers cannot resolve. Errors if the version resolves to `Failure` or
+/// `Deleting`, or does not become `Available` within the polling deadline.
+async fn await_glue_schema_version_available(
+    client: &GlueClient,
+    registered: RegisteredSchemaVersion,
+) -> Result<Uuid, anyhow::Error> {
+    let id = registered.id;
+    // The status from the write response answers the first poll without
+    // another API call. Later polls re-fetch.
+    let mut write_status = registered.lifecycle_status;
+
+    // The timeouts are arbitrary, but are roughly similar to default AWS SDK behavior.
+    Retry::default()
+        .initial_backoff(Duration::from_millis(200))
+        .clamp_backoff(Duration::from_secs(2))
+        .max_duration(Duration::from_secs(30))
+        .retry_async(|_| {
+            let known = write_status.take();
+            async move {
+                let status = match known {
+                    Some(status) => Some(status),
+                    None => match client.get_schema_version_by_id(id).await {
+                        Ok(version) => version.lifecycle_status,
+                        Err(GetSchemaVersionError::NotFound) => {
+                            return RetryResult::FatalErr(anyhow!(
+                                "Glue schema version {id} disappeared while waiting for it \
+                                 to become available"
+                            ));
+                        }
+                        Err(e) => {
+                            return RetryResult::RetryableErr(
+                                anyhow::Error::new(e)
+                                    .context(format!("polling status of Glue schema version {id}")),
+                            );
+                        }
+                    },
+                };
+                match status {
+                    Some(SchemaVersionLifecycleStatus::Available) => RetryResult::Ok(id),
+                    Some(SchemaVersionLifecycleStatus::Failure) => RetryResult::FatalErr(anyhow!(
+                        "Glue schema version {id} failed its compatibility check"
+                    )),
+                    Some(SchemaVersionLifecycleStatus::Deleting) => {
+                        RetryResult::FatalErr(anyhow!("Glue schema version {id} is being deleted"))
+                    }
+                    status @ (Some(
+                        SchemaVersionLifecycleStatus::Pending
+                        | SchemaVersionLifecycleStatus::Unknown(_),
+                    )
+                    | None) => RetryResult::RetryableErr(anyhow!(
+                        "Glue schema version {id} is not yet available (status: {status:?})"
+                    )),
+                }
+            }
+        })
+        .await
+}
+
+/// Warn if the schema's existing compatibility differs from `desired`.
+///
+/// Best-effort and advisory only: a failed read is logged and ignored. The sink
+/// never changes an existing schema's compatibility (see [`publish_glue_schema`]),
+/// so a mismatch is surfaced for the operator, not acted on.
+async fn warn_on_glue_compatibility_mismatch(
+    client: &GlueClient,
+    registry_name: &str,
+    schema_name: &str,
+    desired: Option<&GlueCompatibility>,
+) {
+    let Some(desired) = desired else { return };
+    match client.get_schema(registry_name, schema_name).await {
+        Ok(schema) => {
+            if schema.compatibility.as_ref() != Some(desired) {
+                warn!(
+                    "Glue schema {schema_name:?} has compatibility {:?}, which does not match \
+                     the intended {desired:?}; leaving it unchanged",
+                    schema.compatibility
+                );
+            }
+        }
+        Err(e) => warn!(
+            "unable to read Glue schema {schema_name:?} compatibility to check for a mismatch: {e}"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aws_sdk_glue::operation::get_schema_by_definition::{
+        GetSchemaByDefinitionError as SdkGetSchemaByDefinitionError, GetSchemaByDefinitionOutput,
+    };
+    use aws_sdk_glue::operation::get_schema_version::GetSchemaVersionOutput;
+    use aws_sdk_glue::operation::register_schema_version::RegisterSchemaVersionOutput;
+    use aws_sdk_glue::types::SchemaVersionStatus;
+    use aws_sdk_glue::types::error::EntityNotFoundException;
+    use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
+
+    use super::*;
+
+    const PUBLISHED_ID: &str = "12345678-1234-5678-1234-567812345678";
+    const REUSED_ID: &str = "87654321-4321-8765-4321-876543218765";
+
+    /// A mocked client that panics on any request no rule covers, so each test
+    /// also asserts which Glue APIs the publish path may touch.
+    fn glue_client(rules: &[&Rule]) -> GlueClient {
+        GlueClient::from_sdk_client(mock_client!(aws_sdk_glue, RuleMode::MatchAny, rules))
+    }
+
+    async fn publish(client: GlueClient) -> Result<Uuid, anyhow::Error> {
+        publish_glue_schema(
+            client,
+            "registry".to_string(),
+            "schema".to_string(),
+            "{}".to_string(),
+            None,
+        )
+        .await
+    }
+
+    fn definition_not_found() -> Rule {
+        mock!(aws_sdk_glue::Client::get_schema_by_definition).then_error(|| {
+            SdkGetSchemaByDefinitionError::EntityNotFoundException(
+                EntityNotFoundException::builder().build(),
+            )
+        })
+    }
+
+    fn register_returns(status: SchemaVersionStatus) -> Rule {
+        mock!(aws_sdk_glue::Client::register_schema_version).then_output(move || {
+            RegisterSchemaVersionOutput::builder()
+                .schema_version_id(PUBLISHED_ID)
+                .status(status.clone())
+                .build()
+        })
+    }
+
+    /// A version that registers as `Pending` is polled until Glue reports it
+    /// `Available`.
+    #[mz_ore::test(tokio::test)]
+    async fn publish_glue_schema_waits_for_pending_version() {
+        let lookup = definition_not_found();
+        let register = register_returns(SchemaVersionStatus::Pending);
+        let poll = mock!(aws_sdk_glue::Client::get_schema_version)
+            .sequence()
+            .output(|| {
+                GetSchemaVersionOutput::builder()
+                    .schema_version_id(PUBLISHED_ID)
+                    .status(SchemaVersionStatus::Pending)
+                    .build()
+            })
+            .output(|| {
+                GetSchemaVersionOutput::builder()
+                    .schema_version_id(PUBLISHED_ID)
+                    .status(SchemaVersionStatus::Available)
+                    .build()
+            })
+            .build();
+
+        let id = publish(glue_client(&[&lookup, &register, &poll]))
+            .await
+            .expect("pending version becomes available");
+        assert_eq!(id.to_string(), PUBLISHED_ID);
+        assert_eq!(poll.num_calls(), 2);
+    }
+
+    /// A version whose asynchronous compatibility check fails surfaces an
+    /// error instead of an id that consumers could never resolve.
+    #[mz_ore::test(tokio::test)]
+    async fn publish_glue_schema_errors_on_failed_compatibility_check() {
+        let lookup = definition_not_found();
+        let register = register_returns(SchemaVersionStatus::Pending);
+        let poll = mock!(aws_sdk_glue::Client::get_schema_version).then_output(|| {
+            GetSchemaVersionOutput::builder()
+                .schema_version_id(PUBLISHED_ID)
+                .status(SchemaVersionStatus::Failure)
+                .build()
+        });
+
+        let err = publish(glue_client(&[&lookup, &register, &poll]))
+            .await
+            .expect_err("failed version must not publish");
+        assert!(
+            format!("{err:#}").contains("failed its compatibility check"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    /// A definition match in `Available` state is reused as-is, with no
+    /// registration and no status polling.
+    #[mz_ore::test(tokio::test)]
+    async fn publish_glue_schema_reuses_available_definition_match() {
+        let lookup = mock!(aws_sdk_glue::Client::get_schema_by_definition).then_output(|| {
+            GetSchemaByDefinitionOutput::builder()
+                .schema_version_id(REUSED_ID)
+                .status(SchemaVersionStatus::Available)
+                .build()
+        });
+
+        let id = publish(glue_client(&[&lookup]))
+            .await
+            .expect("available version is reused");
+        assert_eq!(id.to_string(), REUSED_ID);
+    }
+
+    /// A definition match whose version failed its compatibility check is not
+    /// reused: the definition is registered anew.
+    #[mz_ore::test(tokio::test)]
+    async fn publish_glue_schema_skips_failed_definition_match() {
+        let lookup = mock!(aws_sdk_glue::Client::get_schema_by_definition).then_output(|| {
+            GetSchemaByDefinitionOutput::builder()
+                .schema_version_id(REUSED_ID)
+                .status(SchemaVersionStatus::Failure)
+                .build()
+        });
+        let register = register_returns(SchemaVersionStatus::Available);
+
+        let id = publish(glue_client(&[&lookup, &register]))
+            .await
+            .expect("failed match falls through to registration");
+        assert_eq!(id.to_string(), PUBLISHED_ID);
+        assert_eq!(register.num_calls(), 1);
+    }
 }


### PR DESCRIPTION
Adds `publish_glue_schema to storage-client`, the Glue-backed counterpart to CSR's publish_kafka_schema.

A key correctness concern is around Glue's asynchronous version validation. A freshly registered version comes back `PENDING` and only later transitions to `AVAILABLE` or `FAILURE`. The published schema version must be `AVAILABLE` before MZ publishes the messages to ensure downstream consumers can decode the messages. 

For publish:
- Reuse the schema definition match to avoid duplicate versions on sink restart, but skip matches where version is `FAILURE`/`DELETING` (Glue matches by definition regardless of lifecycle status). `FAILURE`/`DELETING` re-registers the schema instead.
- Create the schema on first publish and set compatibility (defaulting to Glue's `BACKWARD`). Handles the create/register race with another writer by retrying the register on `AlreadyExists`.
- Never overwrite an existing schema's compatibility. The compatibility is set once at creation. Producers warn (best-effort) when the existing policy differs from the intended one.
- Poll `get_schema_version_by_id` until the version is `AVAILABLE`, erroring out on `FAILURE`/`DELETING` or if status fails to resolve within 30s. 


This also needed some glue client API changes (aws-glue-schema-registry):

- The write-path methods now return a new `RegisteredSchemaVersion { id, lifecycle_status }` instead of a bare `Uuid`, so callers can gate on lifecycle status.
- Added a `test-util` feature exposing `Client::from_sdk_client` for injecting a mocked SDK client (easiest way to test the async lifecycle of schema version status).