### PR TITLE
doc: document IdP requirements for MCP client OAuth on self-managed SSO

### DIFF
--- a/doc/user/content/headless/okta-custom-authorization-server-warning.md
+++ b/doc/user/content/headless/okta-custom-authorization-server-warning.md
@@ -1,0 +1,13 @@
+---
+headless: true
+---
+
+{{< warning >}}
+Use a **custom authorization server** (e.g., `.../oauth2/default`), not the
+Okta **org authorization server** (the bare org URL, without an
+`/oauth2/...` path). Access tokens issued by the org authorization server
+have a fixed `aud` claim and cannot carry custom claims or scopes, which
+breaks the [Client Credentials flow](#client-credentials-flow) and
+[MCP clients](#connecting-mcp-clients). Custom authorization servers,
+including `default`, require Okta's API Access Management feature.
+{{< /warning >}}

--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -321,8 +321,13 @@ URL: `<baseURL>/api/mcp/agent`.
 
 {{< tab "Self-Managed" >}}
 
-Self-Managed deployments using OAuth require SSO, which uses TLS. Get your MCP
-server URL from the Materialize Console:
+Self-Managed deployments using OAuth require SSO, which uses TLS. Your
+identity provider may also need additional configuration for MCP clients, such
+as a pre-registered OAuth client if your IdP does not support anonymous
+dynamic client registration. See [Connecting MCP
+clients](/security/self-managed/sso/#connecting-mcp-clients).
+
+Get your MCP server URL from the Materialize Console:
 
 1. Log in via the Materialize Console.
 

--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -363,6 +363,21 @@ In the following, replace `<baseURL>` with the MCP server URL from [Step
      "<baseURL>/api/mcp/agent"
    ```
 
+   For Self-Managed deployments using OAuth with a pre-registered OIDC
+   client, add `--client-id` and `--callback-port`:
+
+   ```sh
+   claude mcp add --transport http "materialize-agent" \
+     "<baseURL>/api/mcp/agent" \
+     --client-id <YOUR_CLIENT_ID> --callback-port 8080
+   ```
+
+   The `--callback-port` value must match the
+   `http://localhost:<port>/callback` redirect URI registered on the OIDC
+   client. See [Connecting MCP
+   clients](/security/self-managed/sso/#connecting-mcp-clients) for
+   the full IdP configuration.
+
 1. Restart Claude Code. On first connection, your browser opens to complete
    sign-in and connect.
 

--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -372,7 +372,7 @@ In the following, replace `<baseURL>` with the MCP server URL from [Step
      --client-id <YOUR_CLIENT_ID> --callback-port 8080
    ```
 
-   The `--callback-port` value must match the
+   The `--callback-port` value must match the port in the
    `http://localhost:<port>/callback` redirect URI registered on the OIDC
    client. See [Connecting MCP
    clients](/security/self-managed/sso/#connecting-mcp-clients) for

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -77,8 +77,13 @@ server URL: `<baseURL>/api/mcp/developer`.
 
 {{< tab "Self-Managed" >}}
 
-Self-Managed deployments using OAuth require SSO, which uses TLS. Get your MCP
-server URL from the Materialize Console:
+Self-Managed deployments using OAuth require SSO, which uses TLS. Your
+identity provider may also need additional configuration for MCP clients, such
+as a pre-registered OAuth client if your IdP does not support anonymous
+dynamic client registration. See [Connecting MCP
+clients](/security/self-managed/sso/#connecting-mcp-clients).
+
+Get your MCP server URL from the Materialize Console:
 
 1. Log in via the Materialize Console.
 1. Click the **Connect** link (lower-left corner) to open the **Connect** modal

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -118,6 +118,21 @@ your MCP client. The `materialize-developer` MCP server URL has the form:
      <baseURL>/api/mcp/developer
    ```
 
+   For Self-Managed deployments using OAuth with a pre-registered OIDC
+   client, add `--client-id` and `--callback-port`:
+
+   ```sh
+   claude mcp add --transport http materialize-developer \
+     <baseURL>/api/mcp/developer \
+     --client-id <YOUR_CLIENT_ID> --callback-port 8080
+   ```
+
+   The `--callback-port` value must match the port in the
+   `http://localhost:<port>/callback` redirect URI registered on the OIDC
+   client. See [Connecting MCP
+   clients](/security/self-managed/sso/#connecting-mcp-clients) for
+   the full IdP configuration.
+
    {{% include-headless "/headless/mcp-endpoint-baseurl-replacements" %}}
 
 1. Restart Claude Code. On first connection, your browser opens to complete

--- a/doc/user/content/integrations/mcp-server/mcp-server-troubleshooting.md
+++ b/doc/user/content/integrations/mcp-server/mcp-server-troubleshooting.md
@@ -76,6 +76,8 @@ printf '<user>:<password>' | base64
 echo '<your-base64-token>' | base64 --decode
 ```
 
+Make sure the decoded output matches `user:password` exactly.
+
 ## OAuth sign-in fails (Self-Managed)
 
 **Symptom:** The browser sign-in fails at the identity provider (for example,
@@ -90,5 +92,3 @@ tokens, and the authorization server audience in `oidc_audience`.
 **Fix:** See [Connecting MCP
 clients](/security/self-managed/sso/#connecting-mcp-clients) for the
 requirements and a troubleshooting table.
-
-Make sure the decoded output matches `user:password` exactly.

--- a/doc/user/content/integrations/mcp-server/mcp-server-troubleshooting.md
+++ b/doc/user/content/integrations/mcp-server/mcp-server-troubleshooting.md
@@ -76,4 +76,19 @@ printf '<user>:<password>' | base64
 echo '<your-base64-token>' | base64 --decode
 ```
 
+## OAuth sign-in fails (Self-Managed)
+
+**Symptom:** The browser sign-in fails at the identity provider (for example,
+with a registration error or `invalid_scope`), or sign-in completes but the
+client reports that the credentials were rejected on connect.
+
+**Cause:** OAuth for Self-Managed deployments relies on your SSO identity
+provider. Most enterprise IdPs need additional configuration for MCP clients,
+such as a pre-registered OAuth client, an authentication claim in access
+tokens, and the authorization server audience in `oidc_audience`.
+
+**Fix:** See [Connecting MCP
+clients](/security/self-managed/sso/#connecting-mcp-clients) for the
+requirements and a troubleshooting table.
+
 Make sure the decoded output matches `user:password` exactly.

--- a/doc/user/content/integrations/mcp-server/mcp-server-troubleshooting.md
+++ b/doc/user/content/integrations/mcp-server/mcp-server-troubleshooting.md
@@ -89,6 +89,8 @@ provider. Most enterprise IdPs need additional configuration for MCP clients,
 such as a pre-registered OAuth client, an authentication claim in access
 tokens, and the authorization server audience in `oidc_audience`.
 
-**Fix:** See [Connecting MCP
-clients](/security/self-managed/sso/#connecting-mcp-clients) for the
-requirements and a troubleshooting table.
+**Fix:** See the [SSO troubleshooting
+table](/security/self-managed/sso/#troubleshooting) for the specific symptoms
+and resolutions, and the [Connecting MCP
+clients](/security/self-managed/sso/#connecting-mcp-clients) section for the
+full IdP configuration requirements.

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -492,6 +492,8 @@ is established, it persists until disconnected, regardless of token expiry.
 
 ## Connecting MCP clients
 
+*Available starting in v26.30*
+
 Materialize provides built-in [MCP servers](/integrations/mcp-server/) at
 `/api/mcp/agent` and `/api/mcp/developer`. When SSO is enabled, MCP clients
 can authenticate with OAuth instead of an [MCP
@@ -548,12 +550,6 @@ claude mcp add --transport http materialize-agent \
 
 The `--callback-port` value must match the `http://localhost:<port>/callback`
 redirect URI registered on the OIDC client.
-
-{{< note >}}
-Deployments behind a load balancer or proxy that rewrites the `Host` header
-must set the `http_host_name` configuration so that the URLs Materialize
-publishes in its resource metadata are correct.
-{{</ note >}}
 
 ## Provisioning roles
 

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -89,6 +89,16 @@ additional applications in the [Service accounts](#service-accounts) section.
 
    **Custom domains:** When the authorization server **Issuer** is set to **Dynamic (based on Request Domain)**, Okta issues tokens whose `iss` claim uses your custom domain (for example, `https://sso.your-org.com/oauth2/default`) instead of the default Okta URL. Configure the `oidc_issuer` system parameter in Materialize to match that issuer value exactly.
 
+   {{< warning >}}
+   Use a **custom authorization server** (e.g., `.../oauth2/default`), not the
+   Okta **org authorization server** (the bare org URL, without an
+   `/oauth2/...` path). Access tokens issued by the org authorization server
+   have a fixed `aud` claim and cannot carry custom claims or scopes, which
+   breaks the [Client Credentials flow](#client-credentials-flow) and
+   [MCP clients](#connecting-mcp-clients). Custom authorization servers,
+   including `default`, require Okta's API Access Management feature.
+   {{</ warning >}}
+
 1. Go to the **Assignments** tab and assign the users or groups that should have
    access to Materialize.
 
@@ -479,6 +489,71 @@ Materialize validates the token at **connection time only**. Once a connection
 is established, it persists until disconnected, regardless of token expiry.
 {{</ note >}}
 
+
+## Connecting MCP clients
+
+Materialize provides built-in [MCP servers](/integrations/mcp-server/) at
+`/api/mcp/agent` and `/api/mcp/developer`. When SSO is enabled, MCP clients
+can authenticate with OAuth instead of an [MCP
+token](/integrations/mcp-server/mcp-agent/#method-2-token-based-authentication).
+Materialize publishes OAuth 2.0 Protected Resource Metadata ([RFC
+9728](https://datatracker.ietf.org/doc/html/rfc9728)) at
+`/.well-known/oauth-protected-resource`, which MCP-aware clients use to
+discover your identity provider automatically.
+
+Unlike the console, which authenticates with an ID token, MCP clients present
+an OAuth **access token**. Access tokens have additional requirements:
+
+1. **Pre-register an OIDC client for MCP.** The MCP specification expects the
+   IdP to support anonymous Dynamic Client Registration ([RFC
+   7591](https://datatracker.ietf.org/doc/html/rfc7591)). Most enterprise
+   IdPs, including Okta, do not allow anonymous registration, so MCP clients
+   fail during registration (in Okta, with HTTP 403 `E0000005`). Instead,
+   create or reuse a public OIDC client with PKCE, add
+   `http://localhost:<port>/callback` as a sign-in redirect URI, and configure
+   the MCP client with the client ID explicitly.
+
+1. **Include the authentication claim in access tokens.** IdPs typically
+   include claims like `email` only in ID tokens. If
+   `oidc_authentication_claim` is set to `email`, configure your authorization
+   server to add an `email` claim to access tokens (in Okta, a claim with
+   value `user.email`, included in the access token). Otherwise Materialize
+   rejects the token because the authentication claim is missing.
+
+1. **Add the authorization server audience to `oidc_audience`.** The `aud`
+   claim of an access token is the authorization server's audience value, not
+   the client ID. For Okta's default authorization server this is
+   `api://default`:
+
+   ```mzsql
+   -- Make sure to add to the array if already set
+   ALTER SYSTEM SET oidc_audience = '["YOUR_CLIENT_ID", "api://default"]';
+   ```
+
+1. **Optional: define an `mcp.read` scope.** Materialize advertises the
+   `mcp.read` scope in its resource metadata. The scope is not enforced by
+   Materialize (authorization happens through
+   [RBAC](/security/self-managed/access-control/)), but clients that request
+   advertised scopes fail against IdPs that reject unknown scopes, such as
+   Okta, unless the scope exists on the authorization server.
+
+For example, to connect Claude Code to the `materialize-agent` MCP server with
+a pre-registered client:
+
+```shell
+claude mcp add --transport http materialize-agent \
+  https://<host>:6876/api/mcp/agent \
+  --client-id <YOUR_CLIENT_ID> --callback-port 8080
+```
+
+The `--callback-port` value must match the `http://localhost:<port>/callback`
+redirect URI registered on the OIDC client.
+
+{{< note >}}
+Deployments behind a load balancer or proxy that rewrites the `Host` header
+must set the `http_host_name` configuration so that the URLs Materialize
+publishes in its resource metadata are correct.
+{{</ note >}}
 
 ## Provisioning roles
 
@@ -944,6 +1019,9 @@ DROP ROLE <username>;
 | "Invalid token" error on psql connection | Wrong or expired JWT token | Obtain a fresh token; verify `oidc_issuer` matches the token's `iss` claim |
 | "Audience validation failed" | Client ID not in `oidc_audience` | Add the client ID to `oidc_audience`: `ALTER SYSTEM SET oidc_audience = '["your-client-id"]'` |
 | User gets wrong role name | `oidc_authentication_claim` set to wrong claim | Verify the claim name and check the JWT contents (e.g., using [jwt.io](https://jwt.io)) |
+| MCP client fails during registration with the IdP (HTTP 403) | The IdP does not support anonymous Dynamic Client Registration | Pre-register an OIDC client and configure the MCP client with its client ID. See [Connecting MCP clients](#connecting-mcp-clients) |
+| MCP client login fails with `invalid_scope` | The client requested the advertised `mcp.read` scope, which does not exist on the authorization server | Add an `mcp.read` scope to the authorization server, or configure the client to request only standard scopes |
+| MCP client completes login but the connection is rejected | Access token `aud` is not in `oidc_audience`, or the authentication claim is missing from access tokens | See [Connecting MCP clients](#connecting-mcp-clients) |
 
 To inspect the current OIDC configuration, login as `mz_system` and run the following SQL:
 

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -89,15 +89,7 @@ additional applications in the [Service accounts](#service-accounts) section.
 
    **Custom domains:** When the authorization server **Issuer** is set to **Dynamic (based on Request Domain)**, Okta issues tokens whose `iss` claim uses your custom domain (for example, `https://sso.your-org.com/oauth2/default`) instead of the default Okta URL. Configure the `oidc_issuer` system parameter in Materialize to match that issuer value exactly.
 
-   {{% warning %}}
-Use a **custom authorization server** (e.g., `.../oauth2/default`), not the
-Okta **org authorization server** (the bare org URL, without an
-`/oauth2/...` path). Access tokens issued by the org authorization server
-have a fixed `aud` claim and cannot carry custom claims or scopes, which
-breaks the [Client Credentials flow](#client-credentials-flow) and
-[MCP clients](#connecting-mcp-clients). Custom authorization servers,
-including `default`, require Okta's API Access Management feature.
-   {{% /warning %}}
+   {{% include-headless "/headless/okta-custom-authorization-server-warning" %}}
 
 1. Go to the **Assignments** tab and assign the users or groups that should have
    access to Materialize.
@@ -525,16 +517,21 @@ an OAuth **access token**. Access tokens have additional requirements:
 1. **Add the authorization server audience to `oidc_audience`.** The `aud`
    claim of an access token is the authorization server's audience value, not
    the client ID. For Okta's default authorization server this is
-   `api://default`:
+   `api://default`. Materialize also validates ID tokens (browser sign-in),
+   whose `aud` claim is the console client ID, so both values must be
+   present in `oidc_audience`. Add the audience entries to the array,
+   preserving any existing values:
 
    ```mzsql
-   -- YOUR_CLIENT_ID is the console app's client ID from Step 1, which is the
-   -- `aud` value on ID tokens (browser sign-in). The `api://default` entry is
-   -- the authorization server's audience, which is the `aud` value on access
-   -- tokens (MCP OAuth sign-in). Both must be present so tokens from either
-   -- flow validate; add to the array if oidc_audience is already set.
    ALTER SYSTEM SET oidc_audience = '["YOUR_CLIENT_ID", "api://default"]';
    ```
+
+   If several applications share this authorization server, consider
+   creating a Materialize-dedicated custom authorization server in Okta so
+   only tokens issued for Materialize carry the `api://materialize`-style
+   audience. Otherwise any application on the same authorization server
+   receives tokens with `aud=api://default`, which Materialize would then
+   accept.
 
 1. **Optional: define an `mcp.read` scope.** Materialize advertises the
    `mcp.read` scope in its resource metadata. The scope is not enforced by
@@ -543,17 +540,26 @@ an OAuth **access token**. Access tokens have additional requirements:
    advertised scopes fail against IdPs that reject unknown scopes, such as
    Okta, unless the scope exists on the authorization server.
 
-For example, to connect Claude Code to the `materialize-agent` MCP server with
-a pre-registered client:
+1. **Optional: add the `offline_access` scope for refresh tokens.** MCP
+   clients typically request `offline_access` so they can refresh access
+   tokens without a new browser sign-in. Okta and most enterprise IdPs
+   require this scope to exist on the authorization server. If the client
+   fails to reconnect after the first access token expires, add
+   `offline_access` to the authorization server's scopes.
 
-```shell
-claude mcp add --transport http materialize-agent \
-  https://<host>:6876/api/mcp/agent \
-  --client-id <YOUR_CLIENT_ID> --callback-port 8080
-```
+1. **Connect your MCP client.** For example, to connect Claude Code to the
+   `materialize-agent` MCP server with a pre-registered client:
 
-The `--callback-port` value must match the `http://localhost:<port>/callback`
-redirect URI registered on the OIDC client.
+   ```shell
+   claude mcp add --transport http materialize-agent \
+     https://<host>:6876/api/mcp/agent \
+     --client-id <YOUR_CLIENT_ID> --callback-port 8080
+   ```
+
+   The `--callback-port` value must match the
+   `http://localhost:<port>/callback` redirect URI registered on the OIDC
+   client. For more information, see
+   [MCP servers](/integrations/mcp-server/).
 
 {{< note >}}
 Deployments behind a load balancer or proxy that rewrites the `Host` header

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -89,15 +89,15 @@ additional applications in the [Service accounts](#service-accounts) section.
 
    **Custom domains:** When the authorization server **Issuer** is set to **Dynamic (based on Request Domain)**, Okta issues tokens whose `iss` claim uses your custom domain (for example, `https://sso.your-org.com/oauth2/default`) instead of the default Okta URL. Configure the `oidc_issuer` system parameter in Materialize to match that issuer value exactly.
 
-   {{< warning >}}
-   Use a **custom authorization server** (e.g., `.../oauth2/default`), not the
-   Okta **org authorization server** (the bare org URL, without an
-   `/oauth2/...` path). Access tokens issued by the org authorization server
-   have a fixed `aud` claim and cannot carry custom claims or scopes, which
-   breaks the [Client Credentials flow](#client-credentials-flow) and
-   [MCP clients](#connecting-mcp-clients). Custom authorization servers,
-   including `default`, require Okta's API Access Management feature.
-   {{</ warning >}}
+   {{% warning %}}
+Use a **custom authorization server** (e.g., `.../oauth2/default`), not the
+Okta **org authorization server** (the bare org URL, without an
+`/oauth2/...` path). Access tokens issued by the org authorization server
+have a fixed `aud` claim and cannot carry custom claims or scopes, which
+breaks the [Client Credentials flow](#client-credentials-flow) and
+[MCP clients](#connecting-mcp-clients). Custom authorization servers,
+including `default`, require Okta's API Access Management feature.
+   {{% /warning %}}
 
 1. Go to the **Assignments** tab and assign the users or groups that should have
    access to Materialize.
@@ -492,7 +492,7 @@ is established, it persists until disconnected, regardless of token expiry.
 
 ## Connecting MCP clients
 
-*Available starting in v26.30*
+*OAuth sign-in for MCP clients is available starting in v26.31.*
 
 Materialize provides built-in [MCP servers](/integrations/mcp-server/) at
 `/api/mcp/agent` and `/api/mcp/developer`. When SSO is enabled, MCP clients
@@ -528,7 +528,11 @@ an OAuth **access token**. Access tokens have additional requirements:
    `api://default`:
 
    ```mzsql
-   -- Make sure to add to the array if already set
+   -- YOUR_CLIENT_ID is the console app's client ID from Step 1, which is the
+   -- `aud` value on ID tokens (browser sign-in). The `api://default` entry is
+   -- the authorization server's audience, which is the `aud` value on access
+   -- tokens (MCP OAuth sign-in). Both must be present so tokens from either
+   -- flow validate; add to the array if oidc_audience is already set.
    ALTER SYSTEM SET oidc_audience = '["YOUR_CLIENT_ID", "api://default"]';
    ```
 

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -551,6 +551,12 @@ claude mcp add --transport http materialize-agent \
 The `--callback-port` value must match the `http://localhost:<port>/callback`
 redirect URI registered on the OIDC client.
 
+{{< note >}}
+Deployments behind a load balancer or proxy that rewrites the `Host` header
+must set the `http_host_name` configuration so that the URLs Materialize
+publishes in its resource metadata are correct.
+{{</ note >}}
+
 ## Provisioning roles
 
 ### Mapping IdP users to Materialize roles

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -326,7 +326,7 @@ for details on rollout configuration.
 Configure the OIDC system parameters to connect Materialize to your identity
 provider. You can use either a
 [ConfigMap](/self-managed-deployments/configuration-system-parameters/#configure-system-parameters-via-configmap)
-or SQL commands, but it is strongly recommended to use a ConfigMap. See [Configure via Configmap](#configure-via-configmap) for more details.
+or SQL commands, but it is strongly recommended to use a ConfigMap. See [Configure via ConfigMap](#configure-via-configmap) for more details.
 
 ### OIDC system parameters
 
@@ -424,7 +424,7 @@ ID token from the command line using [`oauth2c`](https://github.com/cloudentity/
 This is useful when configuring a non-interactive client like dbt or Terraform.
 
 1. **Confirm `http://localhost:9876/callback` is registered as a redirect URI**
-   on the console OIDC client (added in
+   on the Materialize Console OIDC client (added in
    [Step 1](#step-1-configure-your-identity-provider)). `oauth2c` listens on
    this URL during the auth code exchange.
 
@@ -459,7 +459,7 @@ your token expires.
 
 ### Get a token from the Materialize console
 
-Clicking "Connect" in the Materialize console will provide you with an ID token that you can use to connect.
+Clicking "Connect" in the Materialize Console will provide you with an ID token that you can use to connect.
 
 ![Materialize Console connect instructions for OIDC](/images/console/console-connect-oidc.png "Materialize Console connect screen for OIDC")
 
@@ -495,73 +495,64 @@ Materialize publishes OAuth 2.0 Protected Resource Metadata ([RFC
 `/.well-known/oauth-protected-resource`, which MCP-aware clients use to
 discover your identity provider automatically.
 
-Unlike the console, which authenticates with an ID token, MCP clients present
-an OAuth **access token**. Access tokens have additional requirements:
+Unlike the Console, which authenticates with an ID token, MCP clients present an
+OAuth **access token**. Access tokens have additional configuration
+requirements:
 
-The steps below are grouped by where each change happens: in your IdP,
-in Materialize, and in your MCP client.
-
-**In your IdP**
+### Configure your IdP
 
 1. **Pre-register an OIDC client for MCP.** The MCP specification expects the
    IdP to support anonymous Dynamic Client Registration ([RFC
-   7591](https://datatracker.ietf.org/doc/html/rfc7591)). Most enterprise
-   IdPs, including Okta, do not allow anonymous registration, so MCP clients
-   fail during registration (in Okta, with HTTP 403 `E0000005`). Instead,
-   create or reuse a public OIDC client with PKCE, add
+   7591](https://datatracker.ietf.org/doc/html/rfc7591)). Most enterprise IdPs,
+   including Okta, do not allow anonymous registration, causing MCP clients to
+   fail during registration (in Okta, with HTTP 403 `E0000005`). Instead, create
+   or reuse a public OIDC client with PKCE, add
    `http://localhost:<port>/callback` as a sign-in redirect URI, and configure
    the MCP client with the client ID explicitly.
 
-1. **Include the authentication claim in access tokens.** IdPs typically
-   include claims like `email` only in ID tokens. If
-   `oidc_authentication_claim` is set to `email`, configure your authorization
-   server to add an `email` claim to access tokens (in Okta, a claim with
-   value `user.email`, included in the access token). Otherwise Materialize
-   rejects the token because the authentication claim is missing.
+1. **Include the authentication claim in access tokens.** IdPs typically include
+   claims like `email` only in ID tokens. If `oidc_authentication_claim` is set
+   to `email`, configure your authorization server to add an `email` claim to
+   access tokens (in Okta, a claim with value `user.email` included in the
+   access token). Otherwise, Materialize rejects the token because it does not
+   contain the configured authentication claim.
 
-1. **Recommended: use a Materialize-dedicated authorization server audience.**
-   Sharing one authorization server audience across multiple applications
-   means Materialize would accept any token that carries that audience,
-   regardless of which application it was issued for. Okta's own guidance is
-   to make the `aud` claim specific to each API (for example,
-   `api://materialize` rather than the shared `api://default`). Create a
-   custom authorization server whose audience identifies Materialize
-   specifically, and note that audience value for the Materialize
+1. **Use a Materialize-dedicated audience.** Configure your IdP so that the
+   access tokens carry an `aud` value specifically for Materialize (e.g., in
+   Okta, create a custom authorization server; in Entra ID, an exposed-API
+   Application ID URI). Note the audience value for the Materialize
    configuration step below.
 
-1. **Optional: define an `mcp.read` scope.** Materialize advertises the
-   `mcp.read` scope in its resource metadata. The scope is not enforced by
-   Materialize (authorization happens through
-   [RBAC](/security/self-managed/access-control/)), but clients that request
-   advertised scopes fail against IdPs that reject unknown scopes, such as
-   Okta, unless the scope exists on the authorization server.
+1. **Optional. Define an `mcp.read` scope.** Materialize advertises the
+   `mcp.read` scope in its resource metadata. Although Materialize does not
+   enforce the scope (authorization happens through
+   [RBAC](/security/self-managed/access-control/)), clients that request
+   advertised scopes fail against IdPs (such as Okta) that reject unknown scopes
+   unless the scope exists on the authorization server.
 
-1. **Optional: add the `offline_access` scope for refresh tokens.** MCP
+1. **Optional. Add the `offline_access` scope for refresh tokens.** MCP
    clients typically request `offline_access` so they can refresh access
    tokens without a new browser sign-in. Okta and most enterprise IdPs
    require this scope to exist on the authorization server. If the client
    fails to reconnect after the first access token expires, add
    `offline_access` to the authorization server's scopes.
 
-**In Materialize**
+### Configure Materialize
 
 1. **Add the authorization server's audience value to `oidc_audience`.** For
    access tokens, the `aud` claim is the authorization server's configured
-   audience. Use the Materialize-dedicated audience from the IdP step above
-   (recommended). Okta's default authorization server value is `api://default`
-   and works as a quick-start, but is not recommended for deployments that
-   host other applications on the same IdP.
+   audience. Use the Materialize-dedicated audience from the IdP step above.
 
    Materialize also validates ID tokens (browser sign-in), whose `aud` is the
-   console client ID, so both values must be present in `oidc_audience`. Add
+   Console client ID, so both values must be present in `oidc_audience`. Add
    the audience values to the existing array, preserving any entries already
    present. For example:
 
    ```mzsql
-   ALTER SYSTEM SET oidc_audience = '["CONSOLE_CLIENT_ID", "api://materialize"]';
+   ALTER SYSTEM SET oidc_audience = '["<CONSOLE_CLIENT_ID>", "<MZ_SPECIFIC_AUDIENCE>"]';
    ```
 
-**In your MCP client**
+### Configure your MCP client
 
 1. **Connect.** For example, to connect Claude Code to the
    `materialize-agent` MCP server with a pre-registered client:
@@ -828,7 +819,7 @@ for automated systems that do not have a user context.
 `oidc_audience` is an array of values. Before running the `ALTER SYSTEM SET
 oidc_audience` examples below, check the current value with `SHOW oidc_audience;`
 and **append** the new audience rather than overwriting it. Otherwise you may
-remove the console's audience or other configured values.
+remove the Materialize Console's audience or other configured values.
 {{</ note >}}
 
 {{< tabs >}}
@@ -909,15 +900,14 @@ remove the console's audience or other configured values.
      --data-urlencode "client_secret=YOUR_SERVICE_CLIENT_SECRET"
    ```
 
-1. Ensure `oidc_audience` includes the expected audience value for tokens
-   from your authorization server. In Okta, the `aud` claim is set to the
-   authorization server's audience (configured in **Security** > **API** >
-   your auth server > **Settings**), not the client ID. For the default
-   authorization server, this is typically `api://default`:
+1. Ensure `oidc_audience` includes the expected audience value for tokens from
+   your authorization server. In Okta, the `aud` claim is set to the
+   authorization server's audience (configured in **Security** > **API** > your
+   auth server > **Settings**), not the client ID:
 
    ```mzsql
    -- Make sure to add to the array if already set
-   ALTER SYSTEM SET oidc_audience = '["api://default"]';
+   ALTER SYSTEM SET oidc_audience = '["<CONSOLE_CLIENT_ID>", "<YOUR_AUDIENCE_VALUE>"]';
    ```
 
 1. Extract the `access_token` from the JSON response and use it to connect:
@@ -966,7 +956,7 @@ remove the console's audience or other configured values.
 
    ```mzsql
    -- Make sure to add to the array if already set
-   ALTER SYSTEM SET oidc_audience = '["YOUR_SERVICE_CLIENT_ID"]';
+   ALTER SYSTEM SET oidc_audience = '["<CONSOLE_CLIENT_ID>","<YOUR_SERVICE_CLIENT_ID>"]';
    ```
 
 1. Extract the `access_token` from the JSON response and use it to connect:
@@ -1004,7 +994,7 @@ remove the console's audience or other configured values.
 
    ```mzsql
    -- Make sure to add to the array if already set
-   ALTER SYSTEM SET oidc_audience = '["YOUR_AUDIENCE_VALUE"]';
+   ALTER SYSTEM SET oidc_audience = '["<CONSOLE_CLIENT_ID>", "<YOUR_AUDIENCE_VALUE>"]';
    ```
 
 1. Extract the `access_token` from the JSON response and use it to connect:
@@ -1042,7 +1032,7 @@ DROP ROLE <username>;
 |---------|---------------|------------|
 | Console does not show SSO login option | `console_oidc_client_id` and `console_oidc_scopes` are not set | Set `console_oidc_client_id` to your OIDC client ID |
 | SSO login redirects fail | Incorrect IdP configuration | Verify the redirect URI is set to `https://<your-console-domain>/auth/callback` and the IdP application type is set as a Single Page Application |
-| SSO login redirects to login page | Materialize database is rejecting the token | Verify that the token generated by your IdP includes the required claims.
+| SSO login redirects to login page | Materialize database is rejecting the token | Verify that the token generated by your IdP includes the required claims. |
 | environmentd fails to upgrade | external_login_password_mz_system not set | Ensure the external_login_password_mz_system is configured |
 | "Invalid token" error on psql connection | Wrong or expired JWT token | Obtain a fresh token; verify `oidc_issuer` matches the token's `iss` claim |
 | "Audience validation failed" | Client ID not in `oidc_audience` | Add the client ID to `oidc_audience`: `ALTER SYSTEM SET oidc_audience = '["your-client-id"]'` |

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -498,6 +498,11 @@ discover your identity provider automatically.
 Unlike the console, which authenticates with an ID token, MCP clients present
 an OAuth **access token**. Access tokens have additional requirements:
 
+The steps below are grouped by where each change happens: in your IdP,
+in Materialize, and in your MCP client.
+
+**In your IdP**
+
 1. **Pre-register an OIDC client for MCP.** The MCP specification expects the
    IdP to support anonymous Dynamic Client Registration ([RFC
    7591](https://datatracker.ietf.org/doc/html/rfc7591)). Most enterprise
@@ -514,24 +519,15 @@ an OAuth **access token**. Access tokens have additional requirements:
    value `user.email`, included in the access token). Otherwise Materialize
    rejects the token because the authentication claim is missing.
 
-1. **Add the authorization server audience to `oidc_audience`.** The `aud`
-   claim of an access token is the authorization server's audience value, not
-   the client ID. For Okta's default authorization server this is
-   `api://default`. Materialize also validates ID tokens (browser sign-in),
-   whose `aud` claim is the console client ID, so both values must be
-   present in `oidc_audience`. Add the audience entries to the array,
-   preserving any existing values:
-
-   ```mzsql
-   ALTER SYSTEM SET oidc_audience = '["YOUR_CLIENT_ID", "api://default"]';
-   ```
-
-   If several applications share this authorization server, consider
-   creating a Materialize-dedicated custom authorization server in Okta so
-   only tokens issued for Materialize carry the `api://materialize`-style
-   audience. Otherwise any application on the same authorization server
-   receives tokens with `aud=api://default`, which Materialize would then
-   accept.
+1. **Recommended: use a Materialize-dedicated authorization server audience.**
+   Sharing one authorization server audience across multiple applications
+   means Materialize would accept any token that carries that audience,
+   regardless of which application it was issued for. Okta's own guidance is
+   to make the `aud` claim specific to each API (for example,
+   `api://materialize` rather than the shared `api://default`). Create a
+   custom authorization server whose audience identifies Materialize
+   specifically, and note that audience value for the Materialize
+   configuration step below.
 
 1. **Optional: define an `mcp.read` scope.** Materialize advertises the
    `mcp.read` scope in its resource metadata. The scope is not enforced by
@@ -547,7 +543,25 @@ an OAuth **access token**. Access tokens have additional requirements:
    fails to reconnect after the first access token expires, add
    `offline_access` to the authorization server's scopes.
 
-1. **Connect your MCP client.** For example, to connect Claude Code to the
+**In Materialize**
+
+1. **Add the authorization server audience to `oidc_audience`.** The `aud`
+   claim of an access token is the authorization server's audience value, not
+   the client ID. Use the Materialize-dedicated audience from the IdP step
+   above (recommended); Okta's default authorization server value is
+   `api://default` and works as a quick-start but is not recommended for
+   deployments that host other applications on the same IdP. Materialize
+   also validates ID tokens (browser sign-in), whose `aud` claim is the
+   console client ID, so both values must be present in `oidc_audience`. Add
+   the audience entries to the array, preserving any existing values:
+
+   ```mzsql
+   ALTER SYSTEM SET oidc_audience = '["YOUR_CLIENT_ID", "api://materialize"]';
+   ```
+
+**In your MCP client**
+
+1. **Connect.** For example, to connect Claude Code to the
    `materialize-agent` MCP server with a pre-registered client:
 
    ```shell
@@ -556,7 +570,7 @@ an OAuth **access token**. Access tokens have additional requirements:
      --client-id <YOUR_CLIENT_ID> --callback-port 8080
    ```
 
-   The `--callback-port` value must match the
+   The `--callback-port` value must match the port in the
    `http://localhost:<port>/callback` redirect URI registered on the OIDC
    client. For more information, see
    [MCP servers](/integrations/mcp-server/).

--- a/doc/user/content/security/self-managed/sso.md
+++ b/doc/user/content/security/self-managed/sso.md
@@ -361,9 +361,9 @@ data:
   system-params.json: |
     {
       "oidc_issuer": "YOUR_OIDC_ISSUER",
-      "oidc_audience": "[\"YOUR_CLIENT_ID\"]",
+      "oidc_audience": "[\"CONSOLE_CLIENT_ID\"]",
       "oidc_authentication_claim": "email",
-      "console_oidc_client_id": "YOUR_CLIENT_ID",
+      "console_oidc_client_id": "CONSOLE_CLIENT_ID",
       "console_oidc_scopes": "openid email"
     }
 ```
@@ -388,9 +388,9 @@ even when OIDC is enabled.
 
 ```mzsql
 ALTER SYSTEM SET oidc_issuer = 'https://your-org.okta.com/oauth2/default';
-ALTER SYSTEM SET oidc_audience = '["YOUR_CLIENT_ID"]';
+ALTER SYSTEM SET oidc_audience = '["CONSOLE_CLIENT_ID"]';
 ALTER SYSTEM SET oidc_authentication_claim = 'email';
-ALTER SYSTEM SET console_oidc_client_id = 'YOUR_CLIENT_ID';
+ALTER SYSTEM SET console_oidc_client_id = 'CONSOLE_CLIENT_ID';
 ALTER SYSTEM SET console_oidc_scopes = 'openid email';
 ```
 
@@ -545,18 +545,20 @@ in Materialize, and in your MCP client.
 
 **In Materialize**
 
-1. **Add the authorization server audience to `oidc_audience`.** The `aud`
-   claim of an access token is the authorization server's audience value, not
-   the client ID. Use the Materialize-dedicated audience from the IdP step
-   above (recommended); Okta's default authorization server value is
-   `api://default` and works as a quick-start but is not recommended for
-   deployments that host other applications on the same IdP. Materialize
-   also validates ID tokens (browser sign-in), whose `aud` claim is the
+1. **Add the authorization server's audience value to `oidc_audience`.** For
+   access tokens, the `aud` claim is the authorization server's configured
+   audience. Use the Materialize-dedicated audience from the IdP step above
+   (recommended). Okta's default authorization server value is `api://default`
+   and works as a quick-start, but is not recommended for deployments that
+   host other applications on the same IdP.
+
+   Materialize also validates ID tokens (browser sign-in), whose `aud` is the
    console client ID, so both values must be present in `oidc_audience`. Add
-   the audience entries to the array, preserving any existing values:
+   the audience values to the existing array, preserving any entries already
+   present. For example:
 
    ```mzsql
-   ALTER SYSTEM SET oidc_audience = '["YOUR_CLIENT_ID", "api://materialize"]';
+   ALTER SYSTEM SET oidc_audience = '["CONSOLE_CLIENT_ID", "api://materialize"]';
    ```
 
 **In your MCP client**


### PR DESCRIPTION
Document the identity provider requirements for connecting MCP clients via OAuth on Self-Managed deployments with SSO: a pre-registered client (most IdPs reject the anonymous dynamic client registration the MCP spec relies on), the authentication claim and authorization server audience needed for access token validation, and the optional `mcp.read` scope. Also warns against using the Okta org authorization server and adds matching troubleshooting entries.

As per the thread [here](https://materializeinc.slack.com/archives/C09ERRA0YAK/p1783537952603329)