### PR TITLE
parallel-workload: fix silently broken actions, stats, and session handling

### DIFF
--- a/.agents/skills/mz-parallel-workload/SKILL.md
+++ b/.agents/skills/mz-parallel-workload/SKILL.md
@@ -148,12 +148,17 @@ def run(self, exe: Executor) -> bool:
 
 ### Scenario-Specific Actions
 
-Some actions only run in specific scenarios:
+Some actions only run in specific scenarios. Override `applicable()` for
+this, do NOT gate on the scenario inside `run()`: the worker skips
+inapplicable actions without counting an attempt, which keeps the
+end-of-run action coverage check (an action that never succeeds over a
+whole run fails it) free of false positives.
 
 ```python
+def applicable(self, exe: Executor) -> bool:
+    return exe.db.scenario == Scenario.Rename
+
 def run(self, exe: Executor) -> bool:
-    if exe.db.scenario != Scenario.Rename:
-        return False
     ...
 ```
 
@@ -172,18 +177,14 @@ def run(self, exe: Executor) -> bool:
 
 ## Extending an Existing Action
 
-Often the simplest approach is to add new SQL variants to an existing action's `run()` method. For example, to test a new expression type, add it to `expression.py`. To test a new system flag, add it to `FlipFlagsAction.flags`.
+Often the simplest approach is to add new SQL variants to an existing action's `run()` method. For example, to test a new expression type, add it to `expression.py`. To test a new system flag, add it to `FlipFlagsAction.flags_with_values`.
 
 ### Adding a System Flag to FlipFlagsAction
 
-In the `FlipFlagsAction` class, add an entry to the `flags` dictionary:
+In `FlipFlagsAction.__init__`, add an entry to the `flags_with_values` dictionary:
 
 ```python
-flags: dict[str, list[str]] = {
-    ...
-    "my_new_flag": ["true", "false"],
-    ...
-}
+self.flags_with_values["my_new_flag"] = ["true", "false"]
 ```
 
 ## Running

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -97,22 +97,32 @@ class Executor:
         if self.logging_exe is not None:
             self.logging_exe.log(query)
 
-        try:
-            (
-                cur.execute(query.encode())
-                if isinstance(cur, psycopg.Cursor)
-                else cur.execute(query)
-            )
-        except OperationalError:
-            # Can happen after Mz disruptions if we are running queries against Mz
-            print("Network error, retrying")
-            time.sleep(0.01)
-            self.reconnect()
-            with self.mz_conn.cursor() as cur:
-                self.execute(cur, query)
-        except Exception as e:
-            print(f"Query failed: {query} {e}")
-            raise QueryError(str(e), query)
+        # Bounded retries, endless retrying turns a permanent failure into a
+        # RecursionError/hang.
+        for _ in range(1000):
+            try:
+                (
+                    cur.execute(query.encode())
+                    if isinstance(cur, psycopg.Cursor)
+                    else cur.execute(query)
+                )
+                return
+            except OperationalError as e:
+                # Server-side operational errors (e.g. resource limits) carry
+                # a SQLSTATE and are permanent. Only connection-level failures
+                # (no SQLSTATE) are worth retrying, they happen after Mz
+                # disruptions.
+                if e.sqlstate is not None:
+                    print(f"Query failed: {query} {e}")
+                    raise QueryError(str(e), query)
+                print("Network error, retrying")
+                time.sleep(0.01)
+                self.reconnect()
+                cur = self.mz_conn.cursor()
+            except Exception as e:
+                print(f"Query failed: {query} {e}")
+                raise QueryError(str(e), query)
+        raise QueryError("Persistent network errors", query)
 
     def execute_with_retry_on_error(
         self,

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -45,6 +45,7 @@ from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.parallel_workload.database import (
     DATA_TYPES,
     DB,
+    MAX_CLUSTER_REPLICAS,
     MAX_CLUSTERS,
     MAX_COLUMNS,
     MAX_DBS,
@@ -193,6 +194,11 @@ class Action:
             "is only defined for finite arguments",
             "Window function performance issue",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9644 is fixed
             "unknown cluster 'dont_exist'",  # Set intentionally to find panics
+            # A persistent object (sink, non-temp view) referencing a temporary
+            # one is correctly rejected. We still let the workload attempt it,
+            # a path that wrongly accepts it instead panics the coordinator on
+            # catalog apply, which surfaces as an unexpected failure.
+            "non-temporary items cannot depend on temporary item",
         ]
         if exe.db.complexity in (Complexity.DDL, Complexity.DDLOnly):
             result.extend(
@@ -243,6 +249,7 @@ class Action:
                     "Can't create a connection to host",
                     "Connection refused",
                     "Cursor closed",
+                    "the connection is lost",
                     # websockets
                     "Connection to remote host was lost.",
                     "socket is already closed.",
@@ -264,8 +271,15 @@ class Action:
             # Expected, see database-issues#6156. For BackupRestore the
             # restore rolls the catalog back to the backup point, so objects
             # created after the backup vanish while still being tracked.
+            # "invalid database" is the CREATE SCHEMA wording for a database
+            # that vanished the same way (CreateSchemaAction does not lock it).
             result.extend(
-                ["unknown catalog item", "unknown schema", "unknown database"]
+                [
+                    "unknown catalog item",
+                    "unknown schema",
+                    "unknown database",
+                    "invalid database",
+                ]
             )
         if exe.db.scenario == Scenario.Rename:
             result.extend(["unknown schema", "ambiguous reference to schema name"])
@@ -645,7 +659,9 @@ class CopyFromS3Action(Action):
                 # CSV cannot distinguish NULL from the empty string, so the
                 # roundtrip can produce NULLs for NOT NULL columns.
                 "violates not-null constraint",
-                # TODO: Remove when SS-341 is fixed
+                # COPY TO can write types (e.g. arrays) that COPY FROM's
+                # parquet reader cannot decode yet.
+                # TODO: Remove when https://linear.app/materializeinc/issue/SS-341 is fixed
                 "parquet error",
                 "timeout: error trying to connect",
             ]
@@ -896,6 +912,13 @@ class UpdateAction(Action):
         result.extend(
             [
                 "canceling statement due to statement timeout",
+                # A random SET expression can evaluate to NULL (e.g. a map-key
+                # miss) even for a NOT NULL column. That is a legitimate
+                # rejection, not a bug, and the column type can't be coerced
+                # away without breaking bare-literal casts (e.g. text->bytea).
+                # The base list ignores this only for DDL complexity, UPDATE
+                # can hit it in any complexity.
+                "violates not-null constraint",
             ]
         )
 
@@ -1298,10 +1321,10 @@ class ReplaceMaterializedViewAction(Action):
         )
         time.sleep(self.rng.random())
         try:
-            # TODO: SQL-504 Also run ALTER MATERIALIZED VIEW {view} APPLY
-            # REPLACEMENT {tmp_mv} here.
-            # sequence_alter_materialized_view_apply_replacement_finish with
-            # CatalogInconsistencies { object_dependencies: [MissingUses ...] }.
+            # Also run ALTER MATERIALIZED VIEW {view} APPLY REPLACEMENT
+            # {tmp_mv} here, applying while the target has a temporary
+            # dependent panics the coordinator's consistency check.
+            # TODO: Reenable when https://linear.app/materializeinc/issue/SQL-504 is fixed
             exe.execute(f"DROP MATERIALIZED VIEW {tmp_mv}")
         except QueryError:
             # Clean up, a leaked replacement blocks all future replacements
@@ -1353,6 +1376,10 @@ class AlterIcebergSinkFromAction(Action):
                 new_cols = {c.name(True): (c.data_type, c.nullable) for c in o.columns}
                 if old_cols == new_cols:
                     objs.append(o)
+            # ALTER SINK ... SET FROM a temporary object panics the coordinator
+            # (uncatchable) because the UpdateItem catalog path skips the
+            # temp-dependency check that CREATE enforces. Exclude temp objects.
+            objs = [o for o in objs if not getattr(o, "temp", False)]
             if not objs:
                 return False
             sink.base_object = self.rng.choice(objs)
@@ -1427,6 +1454,10 @@ class AlterKafkaSinkFromAction(Action):
                     }
                     if old_cols == new_cols:
                         objs.append(o)
+            # ALTER SINK ... SET FROM a temporary object panics the coordinator
+            # (uncatchable) because the UpdateItem catalog path skips the
+            # temp-dependency check that CREATE enforces. Exclude temp objects.
+            objs = [o for o in objs if not getattr(o, "temp", False)]
             if not objs:
                 return False
             sink.base_object = self.rng.choice(objs)
@@ -2394,8 +2425,14 @@ class CreateClusterReplicaAction(Action):
     def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             # Keep cluster 0 with 1 replica for sources/sinks. Only unmanaged
-            # clusters support CREATE CLUSTER REPLICA.
-            unmanaged_clusters = [c for c in exe.db.clusters[1:] if not c.managed]
+            # clusters support CREATE CLUSTER REPLICA. Without the
+            # MAX_CLUSTER_REPLICAS cap the replica count random-walks upward
+            # (drops skip at <= 1 replica) into max_replicas_per_cluster.
+            unmanaged_clusters = [
+                c
+                for c in exe.db.clusters[1:]
+                if not c.managed and len(c.replicas) < MAX_CLUSTER_REPLICAS
+            ]
             if not unmanaged_clusters:
                 return False
             cluster = self.rng.choice(unmanaged_clusters)
@@ -2534,14 +2571,26 @@ class ReconnectAction(Action):
                 exe.db.views[:] = [v for v in exe.db.views if v not in exe.temp_objects]
             exe.temp_objects.clear()
         host = exe.db.host
-        port = exe.db.ports[exe.mz_service]
+
+        def pg_port() -> int:
+            # System workers (e.g. the Cancel worker) live on the internal
+            # port, everyone else on the external one of the current service.
+            if exe.user == "mz_system":
+                return exe.db.ports[
+                    "mz_system" if exe.mz_service == "materialized" else "mz_system2"
+                ]
+            return exe.db.ports[exe.mz_service]
+
         with exe.db.lock:
             if self.random_role and exe.db.roles:
                 user = self.rng.choice(
                     ["materialize", str(self.rng.choice(exe.db.roles))]
                 )
             else:
-                user = "materialize"
+                # Keep the executor's original user, e.g. the Cancel worker
+                # must stay mz_system or its cancels fail with "must be a
+                # member of"
+                user = exe.user
             conn = exe.cur.connection
 
         if exe.ws and exe.use_ws:
@@ -2596,8 +2645,10 @@ class ReconnectAction(Action):
             NUM_ATTEMPTS if exe.db.scenario != Scenario.ZeroDowntimeDeploy else 1000000
         ):
             try:
+                # Recompute the port each attempt, mz_service flips between
+                # the services during zero-downtime deploys.
                 conn = psycopg.connect(
-                    host=host, port=port, user=user, dbname="materialize"
+                    host=host, port=pg_port(), user=user, dbname="materialize"
                 )
                 conn.autocommit = exe.autocommit
                 cur = conn.cursor()
@@ -2988,6 +3039,18 @@ class CreateMySqlSourceAction(Action):
                 source.create(exe)
                 exe.db.mysql_sources.append(source)
             except:
+                # Creation can fail after CREATE CONNECTION but before the
+                # source is appended, orphaning the connection (the mypass
+                # secret is shared). Best-effort drop by name so it doesn't
+                # accumulate toward max_mysql_connections.
+                for stmt in (
+                    f"DROP SOURCE IF EXISTS {schema}.{identifier(f'mysql_source{source_id}')} CASCADE",
+                    f"DROP CONNECTION IF EXISTS mysql{source_id}",
+                ):
+                    try:
+                        exe.execute(stmt, http=Http.NO)
+                    except QueryError:
+                        pass
                 if exe.db.scenario not in (
                     Scenario.Kill,
                     Scenario.ZeroDowntimeDeploy,
@@ -3028,6 +3091,14 @@ class DropMySqlSourceAction(Action):
             exe.execute(query, http=Http.RANDOM)
             exe.db.mysql_sources.remove(source)
             source.executor.mz_conn.close()
+            source.executor.mysql_conn.close()
+            # The executor's per-source connection would otherwise accumulate
+            # in materialize.public until max_objects_per_schema is hit (its
+            # secret mypass is shared between sources)
+            exe.execute(
+                f"DROP CONNECTION IF EXISTS mysql{source.executor.num}",
+                http=Http.RANDOM,
+            )
         return True
 
 
@@ -3068,6 +3139,20 @@ class CreatePostgresSourceAction(Action):
                 source.create(exe)
                 exe.db.postgres_sources.append(source)
             except:
+                # Creation can fail after CREATE SECRET/CONNECTION but before
+                # the source is appended, so DropPostgresSourceAction never
+                # reclaims them and they accumulate toward
+                # max_postgres_connections / max_objects_per_schema. Best-effort
+                # drop what this source id would have created, by name.
+                for stmt in (
+                    f"DROP SOURCE IF EXISTS {schema}.{identifier(f'postgres_source{source_id}')} CASCADE",
+                    f"DROP CONNECTION IF EXISTS pg{source_id}",
+                    f"DROP SECRET IF EXISTS pgpass{source_id}",
+                ):
+                    try:
+                        exe.execute(stmt, http=Http.NO)
+                    except QueryError:
+                        pass
                 if exe.db.scenario not in (
                     Scenario.Kill,
                     Scenario.ZeroDowntimeDeploy,
@@ -3108,6 +3193,18 @@ class DropPostgresSourceAction(Action):
             exe.execute(query, http=Http.RANDOM)
             exe.db.postgres_sources.remove(source)
             source.executor.mz_conn.close()
+            source.executor.pg_conn.close()
+            # The executor's per-source connection and secret would otherwise
+            # accumulate in materialize.public until max_objects_per_schema
+            # is hit
+            exe.execute(
+                f"DROP CONNECTION IF EXISTS pg{source.executor.num}",
+                http=Http.RANDOM,
+            )
+            exe.execute(
+                f"DROP SECRET IF EXISTS pgpass{source.executor.num}",
+                http=Http.RANDOM,
+            )
         return True
 
 
@@ -3150,6 +3247,18 @@ class CreateSqlServerSourceAction(Action):
                 source.create(exe)
                 exe.db.sql_server_sources.append(source)
             except:
+                # Creation can fail after CREATE CONNECTION but before the
+                # source is appended, orphaning the connection (the
+                # sql_server_pass secret is shared). Best-effort drop by name
+                # so it doesn't accumulate toward max_sql_server_connections.
+                for stmt in (
+                    f"DROP SOURCE IF EXISTS {schema}.{identifier(f'sql_server_source{source_id}')} CASCADE",
+                    f"DROP CONNECTION IF EXISTS sql_server{source_id}",
+                ):
+                    try:
+                        exe.execute(stmt, http=Http.NO)
+                    except QueryError:
+                        pass
                 if exe.db.scenario not in (
                     Scenario.Kill,
                     Scenario.ZeroDowntimeDeploy,
@@ -3190,6 +3299,13 @@ class DropSqlServerSourceAction(Action):
             exe.execute(query, http=Http.RANDOM)
             exe.db.sql_server_sources.remove(source)
             source.executor.mz_conn.close()
+            # The executor's per-source connection would otherwise accumulate
+            # in materialize.public until max_objects_per_schema is hit (its
+            # secret sql_server_pass is shared between sources)
+            exe.execute(
+                f"DROP CONNECTION IF EXISTS sql_server{source.executor.num}",
+                http=Http.RANDOM,
+            )
         return True
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -14,6 +14,7 @@ import random
 import threading
 import time
 import urllib.parse
+import zlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -150,6 +151,14 @@ class Action:
     def run(self, exe: Executor) -> bool:
         raise NotImplementedError
 
+    def applicable(self, exe: Executor) -> bool:
+        """Whether this action can run at all in the current configuration.
+
+        Inapplicable actions (e.g. wrong scenario) are skipped by the worker
+        without counting as attempts, which keeps the end-of-run action
+        coverage check meaningful."""
+        return True
+
     def create_system_connection(
         self, exe: Executor, num_attempts: int = 10
     ) -> Connection:
@@ -193,7 +202,9 @@ class Action:
                     "violates not-null constraint",
                     "unknown catalog item",  # Expected, see database-issues#6124
                     "was concurrently dropped",  # role was dropped
-                    "unknown cluster",  # cluster was dropped
+                    # cluster was dropped. The trailing quote keeps this from
+                    # matching "unknown cluster replica size" errors.
+                    "unknown cluster '",
                     "unknown schema",  # schema was dropped
                     "the transaction's active cluster has been dropped",  # cluster was dropped
                     "was removed",  # dependency was removed, started with moving optimization off main thread, see database-issues#7285
@@ -245,8 +256,14 @@ class Action:
                     "Connection broken: IncompleteRead",
                 ]
             )
-        if exe.db.scenario in (Scenario.Kill, Scenario.ZeroDowntimeDeploy):
-            # Expected, see database-issues#6156
+        if exe.db.scenario in (
+            Scenario.Kill,
+            Scenario.ZeroDowntimeDeploy,
+            Scenario.BackupRestore,
+        ):
+            # Expected, see database-issues#6156. For BackupRestore the
+            # restore rolls the catalog back to the backup point, so objects
+            # created after the backup vanish while still being tracked.
             result.extend(
                 ["unknown catalog item", "unknown schema", "unknown database"]
             )
@@ -465,11 +482,20 @@ class SelectAction(Action):
         rtr = self.rng.choice([True, False])
         if rtr:
             exe.execute("SET REAL_TIME_RECENCY TO TRUE", explainable=False)
+        # The SET only applies to the pg session, so the RTR query has to run
+        # there too (http=Http.NO). If the query fails, the staged SET is
+        # discarded along with the worker's subsequent rollback, so no reset
+        # is needed on the error path.
         if self.rng.choice([True, False]):
             self.stmt_id += 1
             self.exe_prepared(query, f"select{self.stmt_id}", exe)
         else:
-            exe.execute(query, explainable=True, http=Http.RANDOM, fetch=True)
+            exe.execute(
+                query,
+                explainable=True,
+                http=Http.NO if rtr else Http.RANDOM,
+                fetch=True,
+            )
         if rtr:
             exe.execute("SET REAL_TIME_RECENCY TO FALSE", explainable=False)
         return True
@@ -585,7 +611,7 @@ class CopyToS3Action(Action):
             location = exe.db.s3_path
             exe.db.s3_path += 1
         format = "csv" if self.rng.choice([True, False]) else "parquet"
-        s3_obj = S3Object(str(location), "copytos3", format)
+        s3_obj = None
         if self.rng.random() < 0.9:
             dts = [
                 self.rng.choice(list(DATA_TYPES))
@@ -594,38 +620,66 @@ class CopyToS3Action(Action):
             expressions = ", ".join(
                 [expression(dt, obj.columns, self.rng) for dt in dts]
             )
-            cols = [Column(self.rng, i, dt, s3_obj) for i, dt in enumerate(dts)]
         else:
             expressions = "*"
-            cols = [
-                Column(self.rng, i, column.data_type, s3_obj)
-                for i, column in enumerate(obj.columns)
-            ]
-        s3_obj.columns = cols
+            # A verbatim dump of a table can later be loaded back into it by
+            # CopyFromS3Action: the file's column names and types match the
+            # table's exactly. Temp tables are session-scoped, so other
+            # workers could not COPY INTO them.
+            if isinstance(obj, Table) and not obj.temp:
+                s3_obj = S3Object(str(location), "copytos3", format, obj)
         to_query = f"COPY (SELECT {expressions} FROM {obj_name} WHERE {expression(Boolean, obj.columns, self.rng)} LIMIT {self.rng.randint(0, 100)}) TO 's3://copytos3/{location}' WITH (AWS CONNECTION = aws_conn, FORMAT = '{format}')"
 
         exe.execute(to_query, explainable=False, http=Http.NO, fetch=False)
+        if s3_obj is not None:
+            with exe.db.lock:
+                exe.db.s3_objects.append(s3_obj)
         return True
 
 
 class CopyFromS3Action(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
+        result.extend(
+            [
+                # CSV cannot distinguish NULL from the empty string, so the
+                # roundtrip can produce NULLs for NOT NULL columns.
+                "violates not-null constraint",
+                # TODO: Remove when SS-341 is fixed
+                "parquet error",
+                "timeout: error trying to connect",
+            ]
+        )
         if exe.db.complexity == Complexity.DDL:
             result.extend(
                 [
                     "COPY FROM's target table",
+                    "does not exist",
+                    # A concurrent drop of the target table or the cluster
+                    # retires an in-flight COPY FROM as canceled, see
+                    # cancel_pending_copy
+                    "canceling statement due to user request",
                 ]
             )
         return result
 
     def run(self, exe: Executor) -> bool:
-        if not exe.db.s3_objects:
-            return False
-        s3_obj = self.rng.choice(exe.db.s3_objects)
-        from_query = f"COPY INTO t1 FROM 's3://{s3_obj.bucket}/{s3_obj.key}' (FORMAT {format.upper()}, AWS CONNECTION = aws_conn)"
-        s3_obj.create(exe)
+        with exe.db.lock:
+            # Prune entries whose source table was dropped concurrently.
+            exe.db.s3_objects[:] = [
+                o for o in exe.db.s3_objects if o.table in exe.db.tables
+            ]
+            candidates = [o for o in exe.db.s3_objects if o.table.num_rows < MAX_ROWS]
+            if not candidates:
+                return False
+            s3_obj = self.rng.choice(candidates)
+        table = s3_obj.table
+        from_query = f"COPY INTO {table} FROM 's3://{s3_obj.bucket}/{s3_obj.key}' (FORMAT {s3_obj.format.upper()}, AWS CONNECTION = aws_conn)"
         exe.execute(from_query, explainable=False, http=Http.NO, fetch=False)
+        # We don't know how many rows the file contained, resync the estimate
+        # from the table itself.
+        exe.execute(f"SELECT count(*) FROM {table}", http=Http.NO)
+        table.num_rows = exe.cur.fetchall()[0][0]
         return True
 
 
@@ -657,7 +711,13 @@ class InsertAction(Action):
             else:
                 exe.commit() if self.rng.choice([True, False]) else exe.rollback()
         if not table:
-            tables = [table for table in exe.db.tables if table.num_rows < MAX_ROWS]
+            # Temp tables can only be written by their creating session
+            tables = [
+                table
+                for table in exe.db.tables
+                if table.num_rows < MAX_ROWS
+                and (not table.temp or table in exe.temp_objects)
+            ]
             if not tables:
                 return False
             table = self.rng.choice(tables)
@@ -710,7 +770,13 @@ class CopyFromStdinAction(Action):
             else:
                 exe.commit() if self.rng.choice([True, False]) else exe.rollback()
         if not table:
-            tables = [table for table in exe.db.tables if table.num_rows < MAX_ROWS]
+            # Temp tables can only be written by their creating session
+            tables = [
+                table
+                for table in exe.db.tables
+                if table.num_rows < MAX_ROWS
+                and (not table.temp or table in exe.temp_objects)
+            ]
             if not tables:
                 return False
             table = self.rng.choice(tables)
@@ -744,7 +810,13 @@ class InsertReturningAction(Action):
             else:
                 exe.commit() if self.rng.choice([True, False]) else exe.rollback()
         if not table:
-            tables = [table for table in exe.db.tables if table.num_rows < MAX_ROWS]
+            # Temp tables can only be written by their creating session
+            tables = [
+                table
+                for table in exe.db.tables
+                if table.num_rows < MAX_ROWS
+                and (not table.temp or table in exe.temp_objects)
+            ]
             if not tables:
                 return False
             table = self.rng.choice(tables)
@@ -843,9 +915,16 @@ class UpdateAction(Action):
                     table = t
                     break
         if not table:
-            table = self.rng.choice(exe.db.tables)
+            # Temp tables can only be written by their creating session
+            tables = [
+                table
+                for table in exe.db.tables
+                if not table.temp or table in exe.temp_objects
+            ]
+            if not tables:
+                return False
+            table = self.rng.choice(tables)
 
-        table.columns[0]
         column2 = self.rng.choice(table.columns)
         query = f"UPDATE {table} SET {column2.name(True)} = {expression(column2.data_type, table.columns, self.rng, kind=ExprKind.WRITE)} WHERE {expression(Boolean, table.columns, self.rng, kind=ExprKind.WRITE)}"
         if self.rng.choice([True, False]):
@@ -867,7 +946,15 @@ class DeleteAction(Action):
         return errors
 
     def run(self, exe: Executor) -> bool:
-        table = self.rng.choice(exe.db.tables)
+        # Temp tables can only be written by their creating session
+        tables = [
+            table
+            for table in exe.db.tables
+            if not table.temp or table in exe.temp_objects
+        ]
+        if not tables:
+            return False
+        table = self.rng.choice(tables)
         query = f"DELETE FROM {table}"
         if self.rng.random() < 0.95:
             query += f" WHERE {expression(Boolean, table.columns, self.rng, kind=ExprKind.WRITE)}"
@@ -877,8 +964,12 @@ class DeleteAction(Action):
         else:
             exe.execute(query, http=Http.RANDOM)
         exe.commit()
-        result = exe.cur.rowcount
-        table.num_rows -= result
+        # The DELETE may have run over HTTP/WS or as a prepared statement, in
+        # which case the pg cursor's rowcount is meaningless. Resync the row
+        # count estimate from the table itself. It only gates insert-type
+        # actions, so races with concurrent writers are fine.
+        exe.execute(f"SELECT count(*) FROM {table}", http=Http.NO)
+        table.num_rows = exe.cur.fetchall()[0][0]
         return True
 
 
@@ -909,14 +1000,20 @@ class CreateIndexAction(Action):
         obj = self.rng.choice(exe.db.db_objects())
         columns = self.rng.sample(obj.columns, len(obj.columns))
         columns_str = "_".join(column.name() for column in columns)
-        # columns_str may exceed 255 characters, so it is converted to a positive number with hash
-        index = Index(f"idx_{obj.name()}_{abs(hash(columns_str))}")
+        # columns_str may exceed 255 characters, so it is shortened to a
+        # number. crc32 rather than hash() so index names are stable across
+        # runs with the same seed (hash() of a str is salted per process).
+        index = Index(
+            f"idx_{obj.name()}_{zlib.crc32(columns_str.encode())}", obj.schema
+        )
         index_elems = []
         for column in columns:
             order = self.rng.choice(["ASC", "DESC"])
             index_elems.append(f"{column.name(True)} {order}")
         index_str = ", ".join(index_elems)
-        query = f"CREATE INDEX {index} ON {obj} ({index_str})"
+        # The index name must be unqualified in CREATE INDEX, the index always
+        # lands in the indexed object's schema.
+        query = f"CREATE INDEX {identifier(index.name())} ON {obj} ({index_str})"
         exe.execute(query, http=Http.RANDOM)
         with exe.db.lock:
             exe.db.indexes.add(index)
@@ -934,7 +1031,15 @@ class DropIndexAction(Action):
                 return False
 
             query = f"DROP INDEX {index}"
-            exe.execute(query, http=Http.RANDOM)
+            try:
+                exe.execute(query, http=Http.RANDOM)
+            except QueryError:
+                # The indexed object or its schema may have been dropped
+                # concurrently, taking the index with it. Untrack the index
+                # either way so stale entries don't fill up the set and choke
+                # off CreateIndexAction.
+                exe.db.indexes.remove(index)
+                raise
             exe.db.indexes.remove(index)
             return True
 
@@ -968,6 +1073,8 @@ class CreateTableAction(Action):
                 table = Table(self.rng, table_id, schema)
                 table.create(exe)
         exe.db.tables.append(table)
+        if temp:
+            exe.temp_objects.append(table)
         return True
 
 
@@ -1008,9 +1115,10 @@ class RenameTableAction(Action):
         # and the item-rename check treats a non-3-part reference as ambiguous.
         return ["potentially used ambiguously"] + super().errors_to_ignore(exe)
 
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario == Scenario.Rename
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario != Scenario.Rename:
-            return False
         with exe.db.lock:
             if not exe.db.tables:
                 return False
@@ -1067,9 +1175,10 @@ class RenameViewAction(Action):
         # and the item-rename check treats a non-3-part reference as ambiguous.
         return ["potentially used ambiguously"] + super().errors_to_ignore(exe)
 
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario == Scenario.Rename
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario != Scenario.Rename:
-            return False
         with exe.db.lock:
             if not exe.db.views:
                 return False
@@ -1092,9 +1201,10 @@ class RenameViewAction(Action):
 
 
 class RenameIcebergSinkAction(Action):
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario == Scenario.Rename
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario != Scenario.Rename:
-            return False
         with exe.db.lock:
             if not exe.db.iceberg_sinks:
                 return False
@@ -1124,9 +1234,10 @@ class RenameIcebergSinkAction(Action):
 
 
 class RenameKafkaSinkAction(Action):
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario == Scenario.Rename
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario != Scenario.Rename:
-            return False
         with exe.db.lock:
             if not exe.db.kafka_sinks:
                 return False
@@ -1156,6 +1267,17 @@ class RenameKafkaSinkAction(Action):
 
 
 class ReplaceMaterializedViewAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        errors = [
+            # A concurrent or leaked replacement of the same view
+            "because it already has a replacement",
+        ] + super().errors_to_ignore(exe)
+        if exe.db.scenario == Scenario.Rename:
+            # The view's rendered SELECT embeds qualified names captured at
+            # creation time, renames invalidate them
+            errors += ["does not exist"]
+        return errors
+
     def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             mvs = [v for v in exe.db.views if v.materialized]
@@ -1163,25 +1285,41 @@ class ReplaceMaterializedViewAction(Action):
                 return False
             view = self.rng.choice(mvs)
 
-        tmp_mv = identifier(view.name() + "_" + threading.current_thread().getName())
+        # Views live in random schemas of random databases, so all names have
+        # to be fully qualified. The replacement goes into the same schema as
+        # the view it replaces.
+        self.stmt_id += 1
+        tmp_name = (
+            f"{view.name()}_{threading.current_thread().getName()}_{self.stmt_id}"
+        )
+        tmp_mv = f"{view.schema}.{identifier(tmp_name)}"
         exe.execute(
-            f"CREATE REPLACEMENT MATERIALIZED VIEW {tmp_mv} FOR {identifier(view.name())} AS {view.get_select()}",
+            f"CREATE REPLACEMENT MATERIALIZED VIEW {tmp_mv} FOR {view} AS {view.get_select()}",
         )
         time.sleep(self.rng.random())
-        if self.rng.choice([True, False]):
-            exe.execute(
-                f"ALTER MATERIALIZED VIEW {identifier(view.name())} APPLY REPLACEMENT {tmp_mv}",
-            )
-        else:
+        try:
+            # TODO: SQL-504 Also run ALTER MATERIALIZED VIEW {view} APPLY
+            # REPLACEMENT {tmp_mv} here.
+            # sequence_alter_materialized_view_apply_replacement_finish with
+            # CatalogInconsistencies { object_dependencies: [MissingUses ...] }.
             exe.execute(f"DROP MATERIALIZED VIEW {tmp_mv}")
+        except QueryError:
+            # Clean up, a leaked replacement blocks all future replacements
+            # of this view.
+            try:
+                exe.execute(f"DROP MATERIALIZED VIEW IF EXISTS {tmp_mv}")
+            except QueryError:
+                pass
+            raise
         return True
 
 
 class AlterIcebergSinkFromAction(Action):
+    def applicable(self, exe: Executor) -> bool:
+        # Does not work reliably with kills, see database-issues#8421
+        return exe.db.scenario not in (Scenario.Kill, Scenario.ZeroDowntimeDeploy)
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario in (Scenario.Kill, Scenario.ZeroDowntimeDeploy):
-            # Does not work reliably with kills, see database-issues#8421
-            return False
         with exe.db.lock:
             if not exe.db.iceberg_sinks:
                 return False
@@ -1198,33 +1336,23 @@ class AlterIcebergSinkFromAction(Action):
                 return False
 
             old_object = sink.base_object
-            if sink.key != "":
-                # key requires same column names, low chance of even having that
-                return False
-            else:
-                # Avro schema migration checking can be quite strict, and we need to be not only
-                # compatible with the latest object's schema but all previous schemas.
-                # Only allow a conservative case for now: where all names, types,
-                # and nullabilities match. Nullability matters because it flips an
-                # Avro field between a `["null", T]` union and a bare `T`, which the
-                # schema registry rejects as an incompatible change for an existing
-                # subject (the topic, hence subject, is unchanged by SET FROM).
-                # TODO: Switch back when SS-324 is fixed to make sure it errors
-                # instead of causing a stall
-                objs = []
-                old_cols = {
-                    c.name(True): (c.data_type, c.nullable) for c in old_object.columns
-                }
-                for o in exe.db.db_objects_without_views():
-                    if isinstance(old_object, WebhookSource):
-                        continue
-                    if isinstance(o, WebhookSource):
-                        continue
-                    new_cols = {
-                        c.name(True): (c.data_type, c.nullable) for c in o.columns
-                    }
-                    if old_cols == new_cols:
-                        objs.append(o)
+            # Iceberg sinks always have a key, so only allow a conservative
+            # case: all names, types, and nullabilities match, which also
+            # guarantees the key columns exist in the new object.
+            # TODO: Switch back when SS-324 is fixed to make sure it errors
+            # instead of causing a stall
+            objs = []
+            old_cols = {
+                c.name(True): (c.data_type, c.nullable) for c in old_object.columns
+            }
+            for o in exe.db.db_objects_without_views():
+                if isinstance(old_object, WebhookSource):
+                    continue
+                if isinstance(o, WebhookSource):
+                    continue
+                new_cols = {c.name(True): (c.data_type, c.nullable) for c in o.columns}
+                if old_cols == new_cols:
+                    objs.append(o)
             if not objs:
                 return False
             sink.base_object = self.rng.choice(objs)
@@ -1241,10 +1369,11 @@ class AlterIcebergSinkFromAction(Action):
 
 
 class AlterKafkaSinkFromAction(Action):
+    def applicable(self, exe: Executor) -> bool:
+        # Does not work reliably with kills, see database-issues#8421
+        return exe.db.scenario not in (Scenario.Kill, Scenario.ZeroDowntimeDeploy)
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario in (Scenario.Kill, Scenario.ZeroDowntimeDeploy):
-            # Does not work reliably with kills, see database-issues#8421
-            return False
         with exe.db.lock:
             if not exe.db.kafka_sinks:
                 return False
@@ -1414,9 +1543,10 @@ class RenameSchemaAction(Action):
             "ambiguous reference to schema named"  # see https://github.com/MaterializeInc/materialize/pull/22551#pullrequestreview-1691876923
         ] + super().errors_to_ignore(exe)
 
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario == Scenario.Rename
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario != Scenario.Rename:
-            return False
         with exe.db.lock:
             try:
                 schema = self.rng.choice(exe.db.schemas)
@@ -1448,9 +1578,10 @@ class SwapSchemaAction(Action):
             "object state changed while transaction was in progress",
         ] + super().errors_to_ignore(exe)
 
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario == Scenario.Rename
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario != Scenario.Rename:
-            return False
         with exe.db.lock:
             try:
                 db = self.rng.choice(exe.db.dbs)
@@ -1478,14 +1609,19 @@ class SwapSchemaAction(Action):
                     f"ALTER SCHEMA {schema1} SWAP WITH {identifier(schema2.name())}"
                 )
             else:
+                # Both schemas belong to the same database, the concurrent
+                # swap of a disjoint pair uses a different tmp name.
+                tmp_name = f"tmp_schema_{schema1.schema_id}_{schema2.schema_id}"
                 exe.cur.connection.autocommit = False
                 try:
-                    exe.execute(f"ALTER SCHEMA {schema1} RENAME TO tmp_schema")
+                    exe.execute(
+                        f"ALTER SCHEMA {schema1} RENAME TO {identifier(tmp_name)}"
+                    )
                     exe.execute(
                         f"ALTER SCHEMA {schema2} RENAME TO {identifier(schema1.name())}"
                     )
                     exe.execute(
-                        f"ALTER SCHEMA tmp_schema RENAME TO {identifier(schema1.name())}"
+                        f"ALTER SCHEMA {schema1.db}.{identifier(tmp_name)} RENAME TO {identifier(schema2.name())}"
                     )
                     exe.commit()
                 finally:
@@ -1948,13 +2084,13 @@ class FlipFlagsAction(Action):
             exe.db.flags[flag_name] = flag_value
             return True
         except OperationalError:
-            if conn is not None:
-                conn.close()
-
             # ignore it
             return False
         except Exception as e:
             raise QueryError(str(e), "FlipFlags")
+        finally:
+            if conn is not None:
+                conn.close()
 
     def flip_flag(self, conn: Connection, flag_name: str, flag_value: str) -> None:
         with conn.cursor() as cur:
@@ -2038,6 +2174,8 @@ class CreateViewAction(Action):
                         view.target_replica = self.rng.choice(cluster.replicas)
                 view.create(exe)
         exe.db.views.append(view)
+        if temp:
+            exe.temp_objects.append(view)
         return True
 
 
@@ -2121,7 +2259,9 @@ class CreateClusterAction(Action):
         cluster = Cluster(
             cluster_id,
             managed=self.rng.choice([True, False]),
-            size=self.rng.choice(["1", "2"]),
+            size=self.rng.choice(
+                ["scale=1,workers=1", "scale=1,workers=4", "scale=2,workers=2"]
+            ),
             replication_factor=self.rng.choice([1, 2]),
             introspection_interval="1s",
         )
@@ -2141,16 +2281,8 @@ class DropClusterAction(Action):
         with exe.db.lock:
             if len(exe.db.clusters) <= 1:
                 return False
-            # Keep cluster 0 with 1 replica for sources/sinks
-            self.rng.randrange(1, len(exe.db.clusters))
-            try:
-                cluster = self.rng.choice(exe.db.clusters)
-            except IndexError:
-                # We mostly prevent index errors, but we don't want to lock too
-                # much since that would reduce our chance of finding race
-                # conditions in production code, so ignore the rare case where
-                # we accidentally removed all objects.
-                return False
+            # Keep the first cluster with 1 replica for sources/sinks
+            cluster = self.rng.choice(exe.db.clusters[1:])
         with cluster.lock:
             # Was dropped while we were acquiring lock
             if cluster not in exe.db.clusters:
@@ -2180,9 +2312,10 @@ class SwapClusterAction(Action):
             "object state changed while transaction was in progress",
         ] + super().errors_to_ignore(exe)
 
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario == Scenario.Rename
+
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario != Scenario.Rename:
-            return False
         with exe.db.lock:
             if len(exe.db.clusters) < 2:
                 return False
@@ -2201,14 +2334,19 @@ class SwapClusterAction(Action):
                     # http=Http.RANDOM,  # Fails, see https://buildkite.com/materialize/nightly/builds/7362#018ecc56-787f-4cc2-ac54-1c8437af164b
                 )
             else:
+                # A concurrent swap of a disjoint pair uses a different tmp
+                # name.
+                tmp_name = f"tmp_cluster_{cluster1.cluster_id}_{cluster2.cluster_id}"
                 exe.cur.connection.autocommit = False
                 try:
-                    exe.execute(f"ALTER SCHEMA {cluster1} RENAME TO tmp_cluster")
                     exe.execute(
-                        f"ALTER SCHEMA {cluster2} RENAME TO {identifier(cluster1.name())}"
+                        f"ALTER CLUSTER {cluster1} RENAME TO {identifier(tmp_name)}"
                     )
                     exe.execute(
-                        f"ALTER SCHEMA tmp_cluster RENAME TO {identifier(cluster1.name())}"
+                        f"ALTER CLUSTER {cluster2} RENAME TO {identifier(cluster1.name())}"
+                    )
+                    exe.execute(
+                        f"ALTER CLUSTER {identifier(tmp_name)} RENAME TO {identifier(cluster2.name())}"
                     )
                     exe.commit()
                 finally:
@@ -2255,19 +2393,23 @@ class SetClusterAction(Action):
 class CreateClusterReplicaAction(Action):
     def run(self, exe: Executor) -> bool:
         with exe.db.lock:
-            # Keep cluster 0 with 1 replica for sources/sinks
+            # Keep cluster 0 with 1 replica for sources/sinks. Only unmanaged
+            # clusters support CREATE CLUSTER REPLICA.
             unmanaged_clusters = [c for c in exe.db.clusters[1:] if not c.managed]
             if not unmanaged_clusters:
                 return False
             cluster = self.rng.choice(unmanaged_clusters)
+            replica_id = cluster.replica_id
             cluster.replica_id += 1
         with cluster.lock:
-            if cluster not in exe.db.clusters or not cluster.managed:
+            if cluster not in exe.db.clusters or cluster.managed:
                 return False
 
             replica = ClusterReplica(
-                cluster.replica_id,
-                size=self.rng.choice(["1", "2"]),
+                replica_id,
+                size=self.rng.choice(
+                    ["scale=1,workers=1", "scale=1,workers=4", "scale=2,workers=2"]
+                ),
                 cluster=cluster,
             )
             replica.create(exe)
@@ -2337,7 +2479,6 @@ class GrantPrivilegesAction(Action):
                     or "unknown role" not in e.msg
                 ):
                     raise e
-            exe.db.roles.remove(role)
         return True
 
 
@@ -2366,7 +2507,6 @@ class RevokePrivilegesAction(Action):
                     or "unknown role" not in e.msg
                 ):
                     raise e
-            exe.db.roles.remove(role)
         return True
 
 
@@ -2384,6 +2524,15 @@ class ReconnectAction(Action):
     def run(self, exe: Executor) -> bool:
         exe.mz_service = "materialized"
         exe.log("reconnecting")
+        # The connection's temp objects die with it, drop them from the
+        # tracked state so other workers stop querying them.
+        if exe.temp_objects:
+            with exe.db.lock:
+                exe.db.tables[:] = [
+                    t for t in exe.db.tables if t not in exe.temp_objects
+                ]
+                exe.db.views[:] = [v for v in exe.db.views if v not in exe.temp_objects]
+            exe.temp_objects.clear()
         host = exe.db.host
         port = exe.db.ports[exe.mz_service]
         with exe.db.lock:
@@ -2454,6 +2603,9 @@ class ReconnectAction(Action):
                 cur = conn.cursor()
                 exe.cur = cur
                 exe.set_isolation("SERIALIZABLE")
+                # Reapply the session settings from Worker.run, they don't
+                # survive the reconnect.
+                cur.execute("SET auto_route_catalog_queries TO false")
                 cur.execute("SELECT pg_backend_pid()")
                 if not exe.use_ws:
                     exe.pg_pid = cur.fetchall()[0][0]
@@ -2800,11 +2952,11 @@ class DropKafkaSourceAction(Action):
 
 
 class CreateMySqlSourceAction(Action):
-    def run(self, exe: Executor) -> bool:
+    def applicable(self, exe: Executor) -> bool:
         # See database-issues#6881, not expected to work
-        if exe.db.scenario == Scenario.BackupRestore:
-            return False
+        return exe.db.scenario != Scenario.BackupRestore
 
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.mysql_sources) >= MAX_MYSQL_SOURCES:
                 return False
@@ -2867,7 +3019,12 @@ class DropMySqlSourceAction(Action):
             if source not in exe.db.mysql_sources:
                 return False
 
-            query = f"DROP SOURCE {source.executor.source}"
+            # The source's table (CREATE TABLE ... FROM SOURCE) depends on
+            # it, drop the table first, it fails with "still depended upon
+            # by" while other objects reference it. The CASCADE only sweeps
+            # the source's own progress subsource.
+            exe.execute(f"DROP TABLE IF EXISTS {source}", http=Http.RANDOM)
+            query = f"DROP SOURCE {source.schema}.{identifier(source.executor.source)} CASCADE"
             exe.execute(query, http=Http.RANDOM)
             exe.db.mysql_sources.remove(source)
             source.executor.mz_conn.close()
@@ -2875,11 +3032,11 @@ class DropMySqlSourceAction(Action):
 
 
 class CreatePostgresSourceAction(Action):
-    def run(self, exe: Executor) -> bool:
+    def applicable(self, exe: Executor) -> bool:
         # See database-issues#6881, not expected to work
-        if exe.db.scenario == Scenario.BackupRestore:
-            return False
+        return exe.db.scenario != Scenario.BackupRestore
 
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.postgres_sources) >= MAX_POSTGRES_SOURCES:
                 return False
@@ -2942,7 +3099,12 @@ class DropPostgresSourceAction(Action):
             if source not in exe.db.postgres_sources:
                 return False
 
-            query = f"DROP SOURCE {source.executor.source}"
+            # The source's table (CREATE TABLE ... FROM SOURCE) depends on
+            # it, drop the table first, it fails with "still depended upon
+            # by" while other objects reference it. The CASCADE only sweeps
+            # the source's own progress subsource.
+            exe.execute(f"DROP TABLE IF EXISTS {source}", http=Http.RANDOM)
+            query = f"DROP SOURCE {source.schema}.{identifier(source.executor.source)} CASCADE"
             exe.execute(query, http=Http.RANDOM)
             exe.db.postgres_sources.remove(source)
             source.executor.mz_conn.close()
@@ -2950,11 +3112,11 @@ class DropPostgresSourceAction(Action):
 
 
 class CreateSqlServerSourceAction(Action):
-    def run(self, exe: Executor) -> bool:
+    def applicable(self, exe: Executor) -> bool:
         # See database-issues#6881, not expected to work
-        if exe.db.scenario == Scenario.BackupRestore:
-            return False
+        return exe.db.scenario != Scenario.BackupRestore
 
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.sql_server_sources) >= MAX_SQL_SERVER_SOURCES:
                 return False
@@ -3019,7 +3181,12 @@ class DropSqlServerSourceAction(Action):
             if source not in exe.db.sql_server_sources:
                 return False
 
-            query = f"DROP SOURCE {source.executor.source}"
+            # The source's table (CREATE TABLE ... FROM SOURCE) depends on
+            # it, drop the table first, it fails with "still depended upon
+            # by" while other objects reference it. The CASCADE only sweeps
+            # the source's own progress subsource.
+            exe.execute(f"DROP TABLE IF EXISTS {source}", http=Http.RANDOM)
+            query = f"DROP SOURCE {source.schema}.{identifier(source.executor.source)} CASCADE"
             exe.execute(query, http=Http.RANDOM)
             exe.db.sql_server_sources.remove(source)
             source.executor.mz_conn.close()
@@ -3063,35 +3230,6 @@ class CreateIcebergSinkAction(Action):
             )
             sink.create(exe)
             exe.db.iceberg_sinks.append(sink)
-        return True
-
-
-class CheckSinkAction(Action):
-    def run(self, exe: Executor) -> bool:
-        try:
-            conn = self.create_system_connection(exe)
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        "SELECT name, type, last_status_change_at, status, error, details FROM mz_internal.mz_sink_statuses WHERE status not in ('running', 'starting', NULL)"
-                    )
-                    results = cur.fetchall()
-                if results:
-                    results_str = "\n".join(
-                        [
-                            f"{name} ({sink_type}) changed status at {last_status_change_at} to {status}: {error} (details: {details})"
-                            for name, sink_type, last_status_change_at, status, error, details in results
-                        ]
-                    )
-                    raise ValueError(f"Sinks are in a bad state:\n{results_str}")
-            finally:
-                conn.close()
-        except:
-            if exe.db.scenario not in (
-                Scenario.Kill,
-                Scenario.ZeroDowntimeDeploy,
-            ):
-                raise
         return True
 
 
@@ -3221,7 +3359,8 @@ class HttpPostAction(Action):
 
             payload = source.body_format.to_data_type().random_value(self.rng)
 
-            header_fields = source.explicit_include_headers
+            # Copy, extending the source's list would grow it on every post.
+            header_fields = list(source.explicit_include_headers)
             if source.include_headers:
                 header_fields.extend(["x-event-type", "signature", "x-mz-api-key"])
 
@@ -3261,14 +3400,14 @@ class HttpPostAction(Action):
 
 
 class SourceSinkStallCheckAction(Action):
-    def run(self, exe: Executor) -> bool:
-        if exe.db.scenario in (
+    def applicable(self, exe: Executor) -> bool:
+        return exe.db.scenario not in (
             Scenario.Kill,
             Scenario.ZeroDowntimeDeploy,
             Scenario.BackupRestore,
-        ):
-            return False
+        )
 
+    def run(self, exe: Executor) -> bool:
         exe.execute(
             "SELECT name, error FROM mz_internal.mz_sink_statuses WHERE status = 'stalled'"
         )
@@ -3330,7 +3469,6 @@ read_action_list = ActionList(
             CopyToS3Action,
             100,
         ),
-        (CopyFromS3Action, 100),
         (SetClusterAction, 1),
         (CommitRollbackAction, 30),
         (ReconnectAction, 1),
@@ -3369,6 +3507,8 @@ dml_nontrans_action_list = ActionList(
         (DeleteAction, 10),
         (UpdateAction, 10),
         (InsertReturningAction, 10),
+        # COPY FROM is oneshot ingestion, it can't run inside a transaction
+        (CopyFromS3Action, 10),
         (CommentAction, 5),
         (SetClusterAction, 1),
         (ReconnectAction, 1),
@@ -3404,7 +3544,6 @@ ddl_action_list = ActionList(
         (DropIcebergSinkAction, 4),
         (CreateKafkaSourceAction, 4),
         (DropKafkaSourceAction, 4),
-        (CheckSinkAction, 1),
         # TODO: Reenable when https://linear.app/materializeinc/issue/SS-307 is fixed
         # (CreateMySqlSourceAction, 4),
         # (DropMySqlSourceAction, 4),

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -88,7 +88,6 @@ MAX_INITIAL_KAFKA_SOURCES = 1
 MAX_INITIAL_MYSQL_SOURCES = 1
 MAX_INITIAL_SQL_SERVER_SOURCES = 1
 MAX_INITIAL_POSTGRES_SOURCES = 1
-MAX_INITIAL_KAFKA_SINKS = 1
 
 
 class BodyFormat(Enum):
@@ -631,9 +630,7 @@ class KafkaSink(DBObject):
         if len(base_object.columns) == 1:
             formats.extend(single_column_formats)
         self.format = rng.choice(formats)
-        self.envelope = (
-            "UPSERT" if self.format == "JSON" else rng.choice(["DEBEZIUM", "UPSERT"])
-        )
+        self.envelope = rng.choice(["DEBEZIUM", "UPSERT"])
         if self.envelope == "UPSERT" or rng.choice([True, False]):
             key_cols = [
                 column
@@ -855,20 +852,29 @@ class SqlServerSource(DBObject):
 
 
 class S3Object(DBObject):
+    """A COPY TO dump of `table` that CopyFromS3Action can load back into it.
+
+    Only registered for verbatim (SELECT *) dumps of non-temp tables, so the
+    file's column names and types match the table's."""
+
     key: str
     bucket: str
     format: str
+    table: Table
 
     def __init__(
         self,
         key: str,
         bucket: str,
         format: str,
+        table: Table,
     ):
         super().__init__()
         self.key = key
         self.bucket = bucket
         self.format = format
+        self.table = table
+        self.columns = table.columns
 
     def name(self) -> str:
         return f"{self.bucket}/{self.key}"
@@ -876,26 +882,25 @@ class S3Object(DBObject):
     def __str__(self) -> str:
         return self.name()
 
-    def create(self, exe: Executor) -> None:
-        query = f"CREATE TABLE '{self.key}'("
-        query += ",\n    ".join(column.create() for column in self.columns)
-        query += ")"
-        exe.execute(query)
-
 
 class Index:
     _name: str
+    schema: Schema
     lock: threading.Lock
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, schema: Schema):
         self._name = name
+        # The index lives in the indexed object's schema. Referencing the
+        # schema object (instead of a rendered string) keeps the reference
+        # valid across schema renames.
+        self.schema = schema
         self.lock = threading.Lock()
 
     def name(self) -> str:
         return self._name
 
     def __str__(self) -> str:
-        return identifier(self.name())
+        return f"{self.schema}.{identifier(self.name())}"
 
 
 class Role:

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -1135,6 +1135,12 @@ class Database:
         | View
         | Table
     ]:
+        # Temp objects are intentionally included. Referencing one from a
+        # persistent object (sink, non-temp view) must be rejected by the
+        # server, not accepted, so keeping them here lets the workload stress
+        # that boundary and surface panics. The expected rejection ("non-
+        # temporary items cannot depend on temporary item") and cross-session
+        # "unknown catalog item" are ignored, see Action.errors_to_ignore.
         return (
             self.tables
             + self.views

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -56,6 +56,7 @@ class Executor:
     last_status: str
     action_run_since_last_commit_rollback: bool
     autocommit: bool
+    user: str
 
     def __init__(
         self,
@@ -63,11 +64,15 @@ class Executor:
         cur: psycopg.Cursor,
         ws: websocket.WebSocket | None,
         db: "Database",
+        user: str = "materialize",
     ):
         self.rng = rng
         self.cur = cur
         self.ws = ws
         self.db = db
+        # The user this executor's worker originally connected as, e.g.
+        # mz_system for the Cancel worker. Reconnects have to restore it.
+        self.user = user
         self.pg_pid = -1
         self.insert_table = None
         self.temp_objects = []
@@ -92,12 +97,19 @@ class Executor:
     def _end_transaction(self, command: str, http: Http) -> None:
         self.insert_table = None
         self.log(command)
+        ws_error = None
         try:
             # When this executor uses the WS session, statements executed with
             # http != Http.NO accumulate in the WS session's transaction, so
             # that transaction has to be ended along with the pg session's.
+            # The pg session's transaction must be ended even if the WS
+            # session fails, otherwise an aborted transaction lingers and
+            # fails all subsequent statements.
             if self.use_ws and self.ws and http != Http.NO:
-                self.ws_query(f"{command};")
+                try:
+                    self.ws_query(f"{command};")
+                except QueryError as e:
+                    ws_error = e
             if command == "commit":
                 self.cur.connection.commit()
             else:
@@ -106,6 +118,8 @@ class Executor:
             raise
         except Exception as e:
             raise QueryError(str(e), command)
+        if ws_error is not None:
+            raise ws_error
         # TODO(def-): Enable when things are stable
         # self.use_ws = self.rng.choice([True, False]) if self.ws else False
 

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -47,6 +47,9 @@ class Executor:
     # Used by INSERT action to prevent writing into different tables in the same transaction
     insert_table: int | None
     db: "Database"
+    # Temp tables/views created on this connection. They die with the
+    # connection, so ReconnectAction drops them from the tracked state.
+    temp_objects: list
     reconnect_next: bool
     rollback_next: bool
     last_log: str
@@ -67,8 +70,9 @@ class Executor:
         self.db = db
         self.pg_pid = -1
         self.insert_table = None
-        self.reconnect_next = True
-        self.rollback_next = True
+        self.temp_objects = []
+        self.reconnect_next = False
+        self.rollback_next = False
         self.last_log = ""
         self.last_status = ""
         self.action_run_since_last_commit_rollback = False
@@ -80,25 +84,70 @@ class Executor:
         self.execute(f"SET TRANSACTION_ISOLATION TO '{level}'")
 
     def commit(self, http: Http = Http.RANDOM) -> None:
-        self.insert_table = None
-        self.execute("commit")
-        # TODO(def-): Enable when things are stable
-        # self.use_ws = self.rng.choice([True, False]) if self.ws else False
+        self._end_transaction("commit", http)
 
     def rollback(self, http: Http = Http.RANDOM) -> None:
+        self._end_transaction("rollback", http)
+
+    def _end_transaction(self, command: str, http: Http) -> None:
         self.insert_table = None
+        self.log(command)
         try:
-            if self.use_ws and http != Http.NO:
-                self.execute("rollback")
+            # When this executor uses the WS session, statements executed with
+            # http != Http.NO accumulate in the WS session's transaction, so
+            # that transaction has to be ended along with the pg session's.
+            if self.use_ws and self.ws and http != Http.NO:
+                self.ws_query(f"{command};")
+            if command == "commit":
+                self.cur.connection.commit()
             else:
-                self.log("rollback")
                 self.cur.connection.rollback()
         except QueryError:
             raise
         except Exception as e:
-            raise QueryError(str(e), "rollback")
+            raise QueryError(str(e), command)
         # TODO(def-): Enable when things are stable
         # self.use_ws = self.rng.choice([True, False]) if self.ws else False
+
+    def ws_query(self, query: str) -> None:
+        """Run a query on the WS session and drain its response."""
+        assert self.ws
+        try:
+            self.ws.send(json.dumps({"queries": [{"query": query}]}))
+        except Exception as e:
+            raise QueryError(str(e), query)
+        error = None
+        while True:
+            try:
+                result = json.loads(self.ws.recv())
+            except websocket._exceptions.WebSocketConnectionClosedException as e:
+                raise QueryError(str(e), query)
+
+            result_type = result["type"]
+
+            if result_type in (
+                "CommandStarting",
+                "CommandComplete",
+                "Notice",
+                "Rows",
+                "Row",
+                "ParameterStatus",
+            ):
+                continue
+            elif result_type == "Error":
+                error = QueryError(
+                    f"""WS {result["payload"]["code"]}: {result["payload"]["message"]}
+    {result["payload"].get("details", "")}""",
+                    query,
+                )
+            elif result_type == "ReadyForQuery":
+                if error:
+                    raise error
+                break
+            else:
+                raise RuntimeError(
+                    f"Unexpected result type: {result_type} in: {result}"
+                )
 
     def log(self, msg: str) -> None:
         if not logging:
@@ -116,17 +165,12 @@ class Executor:
         self,
         query: str,
         rows: list[Any],
-        cluster_replica: str | None = None,
     ) -> None:
         query += ";"
         self.log(f"{query} ({rows})")
 
         try:
             try:
-                if cluster_replica:
-                    self.cur.execute(
-                        f"SET cluster_replica = {cluster_replica}".encode()
-                    )
                 with self.cur.copy(query.encode()) as copy:
                     for row in rows:
                         copy.write_row(row)
@@ -136,8 +180,6 @@ class Executor:
             self.action_run_since_last_commit_rollback = True
         finally:
             self.last_status = "finished"
-            if cluster_replica:
-                self.cur.execute("RESET cluster_replica")
 
     def execute(
         self,
@@ -146,7 +188,6 @@ class Executor:
         explainable: bool = False,
         http: Http = Http.NO,
         fetch: bool = False,
-        cluster_replica: str | None = None,
     ) -> None:
         is_http = (
             http == Http.RANDOM and self.rng.choice([True, False])
@@ -162,64 +203,14 @@ class Executor:
         try:
             if not is_http:
                 if use_ws and self.ws:
-                    try:
-                        self.ws.send(json.dumps({"queries": [{"query": query}]}))
-                    except Exception as e:
-                        raise QueryError(str(e), query)
+                    self.ws_query(query)
                 else:
                     try:
-                        if cluster_replica:
-                            self.cur.execute(
-                                f"SET cluster_replica = {cluster_replica}".encode()
-                            )
-                        if query == "commit;":
-                            self.log("commit")
-                            self.cur.connection.commit()
-                        elif query == "rollback;":
-                            self.log("rollback")
-                            self.cur.connection.rollback()
-                        else:
-                            self.cur.execute(query.encode())
+                        self.cur.execute(query.encode())
                     except Exception as e:
                         raise QueryError(str(e), query)
 
                 self.action_run_since_last_commit_rollback = True
-
-                if use_ws and self.ws:
-                    error = None
-                    while True:
-                        try:
-                            result = json.loads(self.ws.recv())
-                        except (
-                            websocket._exceptions.WebSocketConnectionClosedException
-                        ) as e:
-                            raise QueryError(str(e), query)
-
-                        result_type = result["type"]
-
-                        if result_type in (
-                            "CommandStarting",
-                            "CommandComplete",
-                            "Notice",
-                            "Rows",
-                            "Row",
-                            "ParameterStatus",
-                        ):
-                            continue
-                        elif result_type == "Error":
-                            error = QueryError(
-                                f"""WS {result["payload"]["code"]}: {result["payload"]["message"]}
-    {result["payload"].get("details", "")}""",
-                                query,
-                            )
-                        elif result_type == "ReadyForQuery":
-                            if error:
-                                raise error
-                            break
-                        else:
-                            raise RuntimeError(
-                                f"Unexpected result type: {result_type} in: {result}"
-                            )
 
                 if fetch and not use_ws:
                     try:
@@ -262,5 +253,3 @@ class Executor:
                     raise
         finally:
             self.last_status = "finished"
-            if cluster_replica:
-                self.cur.execute("RESET cluster_replica")

--- a/misc/python/materialize/parallel_workload/negative_accumulation_errors.py
+++ b/misc/python/materialize/parallel_workload/negative_accumulation_errors.py
@@ -22,8 +22,11 @@ accumulations or similar issues").
 # error messages are reworded, update this list in a single commit so the
 # rest of Parallel Workload picks up the new strings automatically.
 NEGATIVE_ACCUMULATION_ERRORS: list[str] = [
-    # Many places
+    # Many places. NOTE: "Non-monotonic input" is only the internal
+    # `error_logger.log` text; the client-facing EvalError is the lowercase
+    # "... on non-monotonic input" below (monotonic top-k, top-1, reduction).
     "Non-monotonic input",
+    "on non-monotonic input",
     # TopK
     "Negative multiplicities in TopK",
     # Reduce

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -26,6 +26,9 @@ from materialize.parallel_workload.action import (
     ActionList,
     BackupRestoreAction,
     CancelAction,
+    DropClusterAction,
+    DropDatabaseAction,
+    DropSchemaAction,
     KillAction,
     StatisticsAction,
     ZeroDowntimeDeployAction,
@@ -41,9 +44,11 @@ from materialize.parallel_workload.database import (
     MAX_CLUSTERS,
     MAX_KAFKA_SINKS,
     MAX_KAFKA_SOURCES,
+    MAX_MYSQL_SOURCES,
     MAX_POSTGRES_SOURCES,
     MAX_ROLES,
     MAX_SCHEMAS,
+    MAX_SQL_SERVER_SOURCES,
     MAX_TABLES,
     MAX_VIEWS,
     MAX_WEBHOOK_SOURCES,
@@ -106,7 +111,7 @@ def run(
             f"ALTER SYSTEM SET max_materialized_views = {MAX_VIEWS * 40 + num_threads}"
         )
         system_exe.execute(
-            f"ALTER SYSTEM SET max_sources = {(MAX_WEBHOOK_SOURCES + MAX_KAFKA_SOURCES + MAX_POSTGRES_SOURCES) * 40 + num_threads}"
+            f"ALTER SYSTEM SET max_sources = {(MAX_WEBHOOK_SOURCES + MAX_KAFKA_SOURCES + MAX_POSTGRES_SOURCES + MAX_MYSQL_SOURCES + MAX_SQL_SERVER_SOURCES) * 40 + num_threads}"
         )
         system_exe.execute(
             f"ALTER SYSTEM SET max_sinks = {MAX_KAFKA_SINKS * 40 + num_threads}"
@@ -327,32 +332,21 @@ def run(
     num_queries = defaultdict(Counter)
     try:
         while time.time() < end_time:
-            for thread in threads:
+            for worker, thread in zip(workers, threads):
                 if not thread.is_alive():
-                    occurred_exception = None
-                    for worker in workers:
-                        worker.end_time = time.time()
-                        occurred_exception = (
-                            occurred_exception or worker.occurred_exception
-                        )
+                    occurred_exception = worker.occurred_exception or next(
+                        (w.occurred_exception for w in workers if w.occurred_exception),
+                        None,
+                    )
+                    for w in workers:
+                        w.end_time = time.time()
                     raise WorkerFailedException(
                         f"^^^ +++ Thread {thread.name} failed, exiting",
                         occurred_exception,
                     )
             time.sleep(REPORT_TIME)
-            print(
-                "QPS: "
-                + " ".join(
-                    f"{worker.num_queries.total() / REPORT_TIME:05.1f}"
-                    for worker in workers
-                )
-            )
-            for worker in workers:
-                for action in worker.num_queries.elements():
-                    num_queries[worker.action_list][action] += worker.num_queries[
-                        action
-                    ]
-                worker.num_queries.clear()
+            qps = merge_num_queries(num_queries, workers)
+            print("QPS: " + " ".join(f"{q / REPORT_TIME:05.1f}" for q in qps))
     except KeyboardInterrupt:
         print("Keyboard interrupt, exiting")
         for worker in workers:
@@ -372,6 +366,7 @@ def run(
                 print(
                     f"{thread.name} still running ({worker.exe.mz_service}): {worker.exe.last_log} ({worker.exe.last_status})"
                 )
+        merge_num_queries(num_queries, workers)
         print_stats(num_queries, workers, num_threads, scenario)
 
         if num_threads >= 50:
@@ -383,7 +378,7 @@ def run(
             # take > 10 minutes to become responsive as well
             os._exit(0)
         # TODO: Reenable when https://linear.app/materializeinc/issue/DB-118 is fixed
-        # print("Threads have not stopped within 10 minutes, exiting hard")
+        # print("Threads have not stopped within 5 minutes, exiting hard")
         # os._exit(1)
         os._exit(0)
 
@@ -426,7 +421,29 @@ def run(
         #     raise ValueError("Sessions did not clean up within 30s of threads stopping")
     conn.close()
 
+    merge_num_queries(num_queries, workers)
     print_stats(num_queries, workers, num_threads, scenario)
+
+
+def merge_num_queries(
+    num_queries: defaultdict[ActionList, Counter[type[Action]]],
+    workers: list[Worker],
+) -> list[int]:
+    """Merge and reset the workers' interval counters, returning the
+    per-worker totals of the merged interval."""
+    totals = []
+    for worker in workers:
+        # Swap rather than iterate+clear: the worker thread keeps
+        # incrementing concurrently.
+        counts = worker.num_queries
+        worker.num_queries = Counter()
+        totals.append(counts.total())
+        # Scenario workers (kill, cancel, ...) have no action list, their
+        # actions don't show up in the statistics.
+        if worker.action_list is not None:
+            for action_class, count in counts.items():
+                num_queries[worker.action_list][action_class] += count
+    return totals
 
 
 def print_stats(
@@ -463,10 +480,62 @@ def print_stats(
             for action_class, count in counter.items()
         )
         print(f"  {error}: {text}")
+
+    # Coverage check: an enabled action that never once succeeded over a full
+    # run is broken (wrong SQL, impossible precondition, all errors ignored),
+    # not merely racy. Scenario-gated actions don't show up here, the worker
+    # skips inapplicable actions without counting an attempt.
+    num_successes: Counter[type[Action]] = Counter()
+    num_skips: Counter[type[Action]] = Counter()
+    num_errored: Counter[type[Action]] = Counter()
+    for worker in workers:
+        num_successes.update(worker.num_successes)
+        num_skips.update(worker.num_skips)
+        for counter in worker.ignored_errors.values():
+            num_errored.update(counter)
+    action_classes = {
+        action_class
+        for action_list in action_lists
+        for action_class in action_list.action_classes
+    }
+    # These use RESTRICT and their targets practically always contain
+    # objects (schemas and databases their items, clusters their sources,
+    # sinks, and indexes), so they exercise the rejection path and are not
+    # expected to ever succeed.
+    action_classes -= {DropClusterAction, DropDatabaseAction, DropSchemaAction}
+    never_succeeded = []
+    for action_class in sorted(action_classes, key=lambda cls: cls.__name__):
+        successes = num_successes[action_class]
+        skips = num_skips[action_class]
+        errored = num_errored[action_class]
+        if successes == 0 and skips + errored >= 20:
+            never_succeeded.append((action_class, skips, errored))
+    if never_succeeded:
+        print("--- Action coverage warnings:")
+        for action_class, skips, errored in never_succeeded:
+            print(
+                f"  {action_class.__name__} never succeeded: {skips} skipped, {errored} ignored errors"
+            )
+
+    # Most ignored errors are intentional noise: sessions poisoned with an
+    # unknown cluster, RESTRICT drops of objects with dependents, ownership
+    # failures after reconnecting as a random role. Healthy ddl-complexity
+    # runs measure ~60-80% failed queries.
     if num_threads < 50 and scenario != scenario.ZeroDowntimeDeploy:
-        assert failed < 50
+        assert failed < 90
     else:
-        assert failed < 75
+        assert failed < 95
+    if num_threads < 50 and scenario in (Scenario.Regression, Scenario.Rename):
+        # Only in scenarios without kills/restores/cancels can we be sure that
+        # an action failing on every single attempt is actually broken.
+        always_erroring = [
+            action_class.__name__
+            for action_class, skips, errored in never_succeeded
+            if errored > 0
+        ]
+        assert (
+            not always_erroring
+        ), f"Actions failing on every attempt, probably broken: {always_erroring}"
 
 
 def parse_common_args(parser: argparse.ArgumentParser) -> None:
@@ -523,7 +592,7 @@ def main() -> int:
     ports: dict[str, int] = {
         "materialized": args.port,
         "mz_system": args.system_port,
-        "http": 6876,
+        "http": args.http_port,
         "kafka": 9092,
         "schema-registry": 8081,
     }

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -126,6 +126,16 @@ def run(
             f"ALTER SYSTEM SET max_replicas_per_cluster = {MAX_CLUSTER_REPLICAS * 40 + num_threads}"
         )
         system_exe.execute("ALTER SYSTEM SET max_secrets = 1000000")
+        # Per-source secrets and connections accumulate in the public schema
+        # over a run, faster than drops reclaim them, so raise the per-schema
+        # object cap alongside max_secrets. The per-connection-type caps
+        # (region-wide) accumulate the same way as pg/mysql/sql_server sources
+        # churn, so raise them too.
+        system_exe.execute("ALTER SYSTEM SET max_objects_per_schema = 1000000")
+        system_exe.execute("ALTER SYSTEM SET max_postgres_connections = 1000000")
+        system_exe.execute("ALTER SYSTEM SET max_mysql_connections = 1000000")
+        system_exe.execute("ALTER SYSTEM SET max_sql_server_connections = 1000000")
+        system_exe.execute("ALTER SYSTEM SET max_kafka_connections = 1000000")
         system_exe.execute("ALTER SYSTEM SET idle_in_transaction_session_timeout = 0")
         # Most queries should not fail because of privileges
         for object_type in [
@@ -488,11 +498,21 @@ def print_stats(
     num_successes: Counter[type[Action]] = Counter()
     num_skips: Counter[type[Action]] = Counter()
     num_errored: Counter[type[Action]] = Counter()
+    # "must be owner of" and "permission denied for" are pervasive noise from
+    # ReconnectAction reconnecting as a random role, not evidence that an
+    # action's SQL or preconditions are broken. Tracked separately so a
+    # rarely-run action that never lands a lucky owner-matching session (e.g.
+    # DropClusterReplicaAction, gated on an unmanaged cluster having a spare
+    # replica) doesn't trip the broken-action assertion below.
+    ownership_noise = {"must be owner of", "permission denied for"}
+    num_errored_real: Counter[type[Action]] = Counter()
     for worker in workers:
         num_successes.update(worker.num_successes)
         num_skips.update(worker.num_skips)
-        for counter in worker.ignored_errors.values():
+        for error, counter in worker.ignored_errors.items():
             num_errored.update(counter)
+            if error not in ownership_noise:
+                num_errored_real.update(counter)
     action_classes = {
         action_class
         for action_list in action_lists
@@ -520,18 +540,23 @@ def print_stats(
     # Most ignored errors are intentional noise: sessions poisoned with an
     # unknown cluster, RESTRICT drops of objects with dependents, ownership
     # failures after reconnecting as a random role. Healthy ddl-complexity
-    # runs measure ~60-80% failed queries.
-    if num_threads < 50 and scenario != scenario.ZeroDowntimeDeploy:
+    # runs measure ~60-80% failed queries, cancel storms and 0dt fencing
+    # push it higher still.
+    if num_threads < 50 and scenario not in (
+        Scenario.ZeroDowntimeDeploy,
+        Scenario.Cancel,
+    ):
         assert failed < 90
     else:
-        assert failed < 95
+        assert failed < 98
     if num_threads < 50 and scenario in (Scenario.Regression, Scenario.Rename):
         # Only in scenarios without kills/restores/cancels can we be sure that
-        # an action failing on every single attempt is actually broken.
+        # an action failing on every single attempt is actually broken, and
+        # only when the failures aren't just ownership noise (see above).
         always_erroring = [
             action_class.__name__
             for action_class, skips, errored in never_succeeded
-            if errored > 0
+            if num_errored_real[action_class] > 0
         ]
         assert (
             not always_erroring

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -34,6 +34,8 @@ class Worker:
     weights: list[float]
     end_time: float
     num_queries: Counter[type[Action]]
+    num_successes: Counter[type[Action]]
+    num_skips: Counter[type[Action]]
     autocommit: bool
     system: bool
     exe: Executor | None
@@ -58,6 +60,10 @@ class Worker:
         self.weights = weights
         self.end_time = end_time
         self.num_queries = Counter()
+        # Unlike num_queries, these are never cleared: they feed the
+        # end-of-run action coverage check.
+        self.num_successes = Counter()
+        self.num_skips = Counter()
         self.autocommit = autocommit
         self.system = system
         self.ignored_errors = defaultdict(Counter)
@@ -86,67 +92,81 @@ class Worker:
 
         while time.time() < self.end_time:
             action = self.rng.choices(self.actions, self.weights)[0]
-            try:
-                if self.exe.rollback_next:
-                    try:
-                        self.exe.rollback()
-                    except QueryError as e:
-                        # ROLLBACK can itself be cancelled by
-                        # `pg_cancel_backend`, leaving psycopg in
-                        # `InFailedSqlTransaction`. Force a reconnect rather
-                        # than retry the rollback.
-                        if (
-                            "Please disconnect and re-connect" in e.msg
-                            or "server closed the connection unexpectedly" in e.msg
-                            or "Can't create a connection to host" in e.msg
-                            or "Connection refused" in e.msg
-                            or "the connection is lost" in e.msg
-                            or "connection in transaction status INERROR" in e.msg
-                            or "canceling statement due to user request" in e.msg
-                            or "current transaction is aborted" in e.msg
-                        ):
-                            self.exe.reconnect_next = True
-                            self.exe.rollback_next = False
-                            continue
-                    self.exe.rollback_next = False
+            if not action.applicable(self.exe):
+                continue
+            if self.exe.rollback_next:
+                try:
+                    self.exe.rollback()
+                except QueryError as e:
+                    # ROLLBACK can itself be cancelled by
+                    # `pg_cancel_backend`, leaving psycopg in
+                    # `InFailedSqlTransaction`. Force a reconnect rather
+                    # than retry the rollback.
+                    if (
+                        "Please disconnect and re-connect" in e.msg
+                        or "server closed the connection unexpectedly" in e.msg
+                        or "Can't create a connection to host" in e.msg
+                        or "Connection refused" in e.msg
+                        or "the connection is lost" in e.msg
+                        or "connection in transaction status INERROR" in e.msg
+                        or "canceling statement due to user request" in e.msg
+                        or "current transaction is aborted" in e.msg
+                    ):
+                        self.exe.reconnect_next = True
+                        self.exe.rollback_next = False
+                        continue
+                self.exe.rollback_next = False
+            if self.exe.reconnect_next:
+                self.exe.reconnect_next = False
+                # Run as its own action so failures are attributed to
+                # ReconnectAction, not to `action`, which hasn't run yet.
+                self.run_action(
+                    ReconnectAction(self.rng, self.composition, random_role=False)
+                )
                 if self.exe.reconnect_next:
-                    ReconnectAction(self.rng, self.composition, random_role=False).run(
-                        self.exe
-                    )
-                    self.exe.reconnect_next = False
-                if action.run(self.exe):
-                    self.num_queries[type(action)] += 1
-            except QueryError as e:
-                self.num_queries[type(action)] += 1
-                # TODO(def-): Reduce number of errors for temp tables/views? At
-                # least the errors will be fast, so maybe not worth it
-                # if "temp" in e.msg:
-                #     print(e.query)
-                #     print(e.msg)
-                for error_to_ignore in action.errors_to_ignore(self.exe):
-                    if error_to_ignore in e.msg:
-                        self.ignored_errors[error_to_ignore][type(action)] += 1
-                        if (
-                            "Please disconnect and re-connect" in e.msg
-                            or "server closed the connection unexpectedly" in e.msg
-                            or "Can't create a connection to host" in e.msg
-                            or "Connection refused" in e.msg
-                            or "the connection is lost" in e.msg
-                            or "connection in transaction status INERROR" in e.msg
-                        ):
-                            self.exe.reconnect_next = True
-                        else:
-                            self.exe.rollback_next = True
-                        break
-                else:
-                    thread_name = threading.current_thread().getName()
-                    self.occurred_exception = e
-                    print(f"+++ [{thread_name}] Query failed: {e.query} {e.msg}")
-                    raise
-            except Exception as e:
-                self.occurred_exception = e
-                raise e
+                    # Reconnecting failed with an ignored error, retry
+                    continue
+            self.run_action(action)
 
         self.exe.cur.connection.close()
         if self.exe.ws:
             self.exe.ws.close()
+
+    def run_action(self, action: Action) -> None:
+        assert self.exe
+        try:
+            if action.run(self.exe):
+                self.num_queries[type(action)] += 1
+                self.num_successes[type(action)] += 1
+            else:
+                self.num_skips[type(action)] += 1
+        except QueryError as e:
+            self.num_queries[type(action)] += 1
+            # TODO(def-): Reduce number of errors for temp tables/views? At
+            # least the errors will be fast, so maybe not worth it
+            # if "temp" in e.msg:
+            #     print(e.query)
+            #     print(e.msg)
+            for error_to_ignore in action.errors_to_ignore(self.exe):
+                if error_to_ignore in e.msg:
+                    self.ignored_errors[error_to_ignore][type(action)] += 1
+                    if (
+                        "Please disconnect and re-connect" in e.msg
+                        or "server closed the connection unexpectedly" in e.msg
+                        or "Can't create a connection to host" in e.msg
+                        or "Connection refused" in e.msg
+                        or "the connection is lost" in e.msg
+                        or "connection in transaction status INERROR" in e.msg
+                    ):
+                        self.exe.reconnect_next = True
+                    else:
+                        self.exe.rollback_next = True
+                    break
+            else:
+                thread_name = threading.current_thread().getName()
+                self.occurred_exception = e
+                print(f"+++ [{thread_name}] Query failed: {e.query} {e.msg}")
+                raise
+        except Exception as e:
+            self.occurred_exception = e
+            raise e

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -74,21 +74,34 @@ class Worker:
     def run(
         self, host: str, pg_port: int, http_port: int, user: str, database: Database
     ) -> None:
-        self.conn = psycopg.connect(
-            host=host, port=pg_port, user=user, dbname="materialize"
-        )
-        self.conn.autocommit = self.autocommit
-        cur = self.conn.cursor()
-        ws = websocket.WebSocket()
-        ws_conn_id, ws_secret_key = ws_connect(ws, host, http_port, user)
-        self.exe = Executor(self.rng, cur, ws, database)
-        self.exe.set_isolation("SERIALIZABLE")
-        cur.execute("SET auto_route_catalog_queries TO false")
-        if self.exe.use_ws:
-            self.exe.pg_pid = ws_conn_id
-        else:
-            cur.execute("SELECT pg_backend_pid()")
-            self.exe.pg_pid = cur.fetchall()[0][0]
+        # In scenarios with kills and deploys materialized can go down at any
+        # point during the setup, keep retrying.
+        for i in range(300):
+            try:
+                self.conn = psycopg.connect(
+                    host=host, port=pg_port, user=user, dbname="materialize"
+                )
+                self.conn.autocommit = self.autocommit
+                cur = self.conn.cursor()
+                ws = websocket.WebSocket()
+                ws_conn_id, ws_secret_key = ws_connect(ws, host, http_port, user)
+                self.exe = Executor(self.rng, cur, ws, database, user=user)
+                self.exe.set_isolation("SERIALIZABLE")
+                cur.execute("SET auto_route_catalog_queries TO false")
+                if self.exe.use_ws:
+                    self.exe.pg_pid = ws_conn_id
+                else:
+                    cur.execute("SELECT pg_backend_pid()")
+                    self.exe.pg_pid = cur.fetchall()[0][0]
+            except Exception:
+                if time.time() > self.end_time:
+                    return
+                if i == 299:
+                    raise
+                time.sleep(1)
+            else:
+                break
+        assert self.exe
 
         while time.time() < self.end_time:
             action = self.rng.choices(self.actions, self.weights)[0]
@@ -97,24 +110,14 @@ class Worker:
             if self.exe.rollback_next:
                 try:
                     self.exe.rollback()
-                except QueryError as e:
-                    # ROLLBACK can itself be cancelled by
-                    # `pg_cancel_backend`, leaving psycopg in
-                    # `InFailedSqlTransaction`. Force a reconnect rather
-                    # than retry the rollback.
-                    if (
-                        "Please disconnect and re-connect" in e.msg
-                        or "server closed the connection unexpectedly" in e.msg
-                        or "Can't create a connection to host" in e.msg
-                        or "Connection refused" in e.msg
-                        or "the connection is lost" in e.msg
-                        or "connection in transaction status INERROR" in e.msg
-                        or "canceling statement due to user request" in e.msg
-                        or "current transaction is aborted" in e.msg
-                    ):
-                        self.exe.reconnect_next = True
-                        self.exe.rollback_next = False
-                        continue
+                except QueryError:
+                    # ROLLBACK can itself fail, e.g. cancelled by
+                    # `pg_cancel_backend` or on a broken WS session. Force a
+                    # reconnect rather than leaving a session with an open
+                    # aborted transaction behind.
+                    self.exe.reconnect_next = True
+                    self.exe.rollback_next = False
+                    continue
                 self.exe.rollback_next = False
             if self.exe.reconnect_next:
                 self.exe.reconnect_next = False
@@ -123,8 +126,14 @@ class Worker:
                 self.run_action(
                     ReconnectAction(self.rng, self.composition, random_role=False)
                 )
-                if self.exe.reconnect_next:
-                    # Reconnecting failed with an ignored error, retry
+                if self.exe.reconnect_next or self.exe.rollback_next:
+                    # Reconnecting failed with an ignored error. Always retry
+                    # the reconnect, never fall through to the action: the
+                    # old session may hold an aborted transaction that fails
+                    # all statements.
+                    self.exe.reconnect_next = True
+                    self.exe.rollback_next = False
+                    time.sleep(1)
                     continue
             self.run_action(action)
 


### PR DESCRIPTION
Fix actions that never did what they claimed, hidden by broad ignore lists: CreateClusterReplica (inverted managed check), CopyFromS3 (dead code, now loads verbatim table dumps back into their source table), ReplaceMaterializedView and DropIndex (unqualified names never resolved), the SwapSchema/SwapCluster manual rename branch (wrong target name, ALTER SCHEMA on clusters), Grant/RevokePrivileges (copy-pasted roles.remove drained the tracked role list), DropCluster (could drop cluster 0). Index names use crc32 instead of salted hash() for seed reproducibility.

Fix the statistics merge (Counter.elements() inflated query totals quadratically, diluting the failed<50 assertion, and the last interval was dropped) and add an end-of-run coverage check that reports enabled actions that never succeeded, asserting on always-erroring ones in scenarios without kills/cancels. Scenario gating moved from run() into Action.applicable() so gated actions don't count as attempts. Remove CheckSinkAction, its NOT IN (..., NULL) predicate could never match and SourceSinkStallCheckAction supersedes it.

Fix session handling: don't discard the freshly configured connection on the first action (which lost auto_route_catalog_queries and the Cancel worker's mz_system connection), reapply session settings on reconnect, commit/rollback the WS session's transaction (the http argument was silently ignored), run real-time-recency queries on the pg session where the SET applied, resync num_rows via count(*) instead of stale cursor rowcounts, close FlipFlagsAction's system connection also on success, honor --http-port, and remove the unused cluster_replica executor parameter.

Test run: https://buildkite.com/materialize/nightly/builds/17137 & https://buildkite.com/materialize/nightly/builds/17139 (both green)