### PR TITLE
adapter: cache catalog snapshots in the session

### DIFF
--- a/doc/developer/design/20260709_session_catalog_snapshot_cache.md
+++ b/doc/developer/design/20260709_session_catalog_snapshot_cache.md
@@ -1,0 +1,118 @@
+# Session catalog snapshot cache
+
+- Associated:
+  [database-issues#9593](https://github.com/MaterializeInc/database-issues/issues/9593),
+  [materialize#37533](https://github.com/MaterializeInc/materialize/pull/37533)
+
+## The Problem
+
+Every statement handled by a session task fetched a fresh catalog snapshot
+via a `Command::CatalogSnapshot` round-trip to the Coordinator, and fast path
+peeks did two of them (one in `declare` or `Bind`, one in the frontend peek
+sequencing). The handler is just an `Arc::clone`, so the cost is pure message
+volume on the Coordinator main loop. On query-heavy environments,
+`command-catalog_snapshot` was by far the largest consumer of main loop time,
+capping QPS and adding queueing delay for all other messages.
+
+## The Design
+
+Sessions cache the latest catalog snapshot and reuse it as long as the
+catalog is unchanged. The pieces:
+
+- The catalog's transient revision is mirrored in a shared atomic,
+  `Catalog::shared_transient_revision`, which all clones of a catalog share.
+  The store happens inside `Catalog::transact`, adjacent to the
+  `transient_revision` increment.
+- `PeekClient` holds a `Weak<Catalog>`, seeded at connection startup from the
+  `StartupResponse` catalog. A statement gets a cache hit when the `Weak`
+  upgrades and the snapshot reports itself current
+  (`Catalog::transient_revision_is_current`, which compares the snapshot's
+  own revision against the shared atomic the snapshot itself carries, so the
+  atomic needs no plumbing). Anything else falls back to the
+  `Command::CatalogSnapshot` round-trip and re-populates the cache.
+
+## Correctness
+
+The invariant that makes the cache correct: the atomic is bumped inside
+`Catalog::transact`, *before* `transact` returns. Everything that can reveal
+a transaction's effects (responses, notices, builtin table writes) happens
+after `transact` returns. So no client can observe evidence of a catalog
+change before the bump, and a session that has observed such evidence is
+guaranteed to see the bump on its next atomic load (delivery of the evidence
+provides the happens-before edge). A cached snapshot with a matching revision
+is therefore bit-identical to what a fresh `Command::CatalogSnapshot` would
+return. The bump must not move to a later point (for example the end of
+message handling): responses are sent mid-message, and a bump after the
+response reopens a read-your-writes race.
+
+On a mismatch, sessions refresh via the ordinary `Command::CatalogSnapshot`
+round-trip, which is processed between Coordinator messages and therefore
+never observes a mid-message intermediate state. This is also why the catalog
+is *pulled* on miss rather than *pushed* into a shared slot on change: a push
+would have to prove consistency at every publish point.
+
+In-place mutations of the Coordinator's catalog that do not bump the revision
+must remain invisible to sessions (see the corresponding entry in
+`guide-adapter.md`). The known ones at the time of writing: plan side-cache
+fills (`set_optimized_plan` / `set_physical_plan` / `set_dataflow_metainfo`,
+read only by Coordinator-side paths like `EXPLAIN <existing object>` and
+bootstrap), `EXPLAIN REPLAN`'s save-and-restore of `system_configuration`
+(net-zero), bootstrap (before any session exists), and
+`drop_temporary_schema` on connection terminate (connection-scoped,
+unreachable from other sessions).
+
+A failed `Weak::upgrade` is an expected path, not a bug: any in-place
+mutation of the Coordinator's catalog (including revision-preserving ones)
+moves it to a new allocation via `Arc::make_mut`, killing outstanding
+`Weak`s. Both a revision mismatch and a failed upgrade route to the same
+refetch.
+
+The cache does not violate the adapter's "no local-only assumptions"
+invariant any more than `Command::CatalogSnapshot` itself does: both reflect
+only this process's catalog. Read-only 0dt instances are safe because they
+halt and reboot on external catalog changes and on promotion. If catalog
+changes ever start being applied from other writers (multi-`environmentd`),
+that application path must bump the shared revision too.
+
+## Alternatives
+
+- **Strong `Arc` in the session instead of `Weak`**: rejected because idle
+  sessions would pin superseded catalog versions. `imbl::OrdMap` structural
+  sharing bounds each pinned version's marginal footprint to the path-copied
+  nodes (roughly tens of KB per catalog transaction), but with tens of
+  thousands of sessions and DDL churn this still adds up to a slow,
+  hard-to-diagnose memory leak shape. With `Weak`, reclamation is prompt and
+  deterministic, and memory plots stay legible.
+- **Pushing snapshots into a shared slot (`ArcSwap`/watch) instead of
+  pulling on miss**: rejected, see Correctness above.
+- **Interior mutability so `catalog_snapshot` takes `&self`**: `Cell` does
+  not compile (pgwire's `Send` futures hold `&SessionClient` across await
+  points, which requires `Sync`), a `Mutex` works but a survey of call sites
+  found that every caller either already had `&mut` or trivially could, so
+  plain `&mut self` won.
+
+## Performance characteristics
+
+- Steady-state hit: one `Weak::upgrade` plus one atomic load, no Coordinator
+  interaction.
+- Misses scale with `active_sessions x catalog mutation rate`. Every
+  revision bump invalidates every session's cache. Temporary-object DDL goes
+  through `transact` and therefore also bumps. If production data (the
+  `mz_catalog_snapshot_cache` miss counter) shows temp-DDL churn defeating
+  the cache, a possible follow-up is to exempt connection-local temp-item
+  transactions from the global bump. Other sessions cannot see those items,
+  but the owning session must then still be invalidated through a
+  session-local mechanism.
+- The design is never worse than the pre-cache behavior: the worst case
+  degenerates to a round-trip per statement, which was the status quo.
+
+## Observability
+
+- `mz_catalog_snapshot_cache{context, result}`: cache hits and misses.
+- `mz_catalog_arc_strong_count` / `mz_catalog_arc_weak_count`: sampled by
+  the catalog info metrics task; in-flight snapshot users, and how many
+  sessions cache the current catalog version.
+- `mz_catalog_snapshot_seconds` now only observes misses.
+- Rollout acceptance signal: the `command-catalog_snapshot` message kind in
+  `mz_slow_message_handling_sum` drops to a periodic trickle (system
+  parameter sync and the info metrics task remain on the round-trip).

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -224,6 +224,17 @@ If you need conflict detection, evaluate the precondition atomically with the
 commit, a real compare-and-append against the durable store. A check that merely
 precedes the write on the loop is not that, even when it reads the right state.
 
+### Catalog mutations must bump the transient revision or stay invisible
+
+Sessions cache catalog snapshots and reuse them while
+`Catalog::transient_revision` is unchanged (see
+`doc/developer/design/20260709_session_catalog_snapshot_cache.md`). Only
+`Catalog::transact` bumps the revision. So when adding a new way to mutate
+the Coordinator's in-memory catalog, either route it through `transact` or
+keep the change invisible to session-visible catalog reads (name resolution,
+planning). Otherwise sessions serve stale catalogs where today they would see
+the change.
+
 ## Rejected Optimizations
 
 This section records specific optimizations that have been attempted and found

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -295,6 +295,14 @@ metrics:
   help: The time it takes to allocate IDs in the durable catalog.
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
+- name: mz_catalog_arc_strong_count
+  help: 'The number of strong references to the current catalog snapshot: roughly, in-flight users plus a small constant baseline.'
+  source: src/adapter/src/metrics.rs
+  visibility: internal
+- name: mz_catalog_arc_weak_count
+  help: 'The number of weak references to the current catalog snapshot: sessions whose snapshot cache points at the current catalog version (older versions are not counted). Drops on catalog changes and recovers as session caches repopulate.'
+  source: src/adapter/src/metrics.rs
+  visibility: internal
 - name: mz_catalog_collection_entries
   help: Total number of entries, after consolidation, per catalog collection.
   labels:
@@ -315,6 +323,13 @@ metrics:
   help: Time taken to rebuild the catalog info metrics from a catalog snapshot.
   source: src/adapter/src/coord/info_metrics.rs
   visibility: internal
+- name: mz_catalog_snapshot_cache
+  help: Hits and misses of the session-side catalog snapshot cache. A miss costs a Coordinator round-trip.
+  labels:
+  - context
+  - result
+  source: src/adapter/src/metrics.rs
+  visibility: internal
 - name: mz_catalog_snapshot_consolidations
   help: Count of snapshot consolidation passes.
   source: src/catalog/src/durable/metrics.rs
@@ -328,20 +343,20 @@ metrics:
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
 - name: mz_catalog_snapshot_seconds_bucket
-  help: The time it takes to run `catalog_snapshot` when fetching the catalog.
+  help: The time it takes to fetch a catalog snapshot from the Coordinator. Only observed on session snapshot cache misses.
   labels:
   - context
   - le
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_catalog_snapshot_seconds_count
-  help: The time it takes to run `catalog_snapshot` when fetching the catalog.
+  help: The time it takes to fetch a catalog snapshot from the Coordinator. Only observed on session snapshot cache misses.
   labels:
   - context
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_catalog_snapshot_seconds_sum
-  help: The time it takes to run `catalog_snapshot` when fetching the catalog.
+  help: The time it takes to fetch a catalog snapshot from the Coordinator. Only observed on session snapshot cache misses.
   labels:
   - context
   source: src/adapter/src/metrics.rs

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -15,6 +15,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use futures::future::BoxFuture;
 use futures::{Future, FutureExt};
@@ -140,6 +141,19 @@ pub struct Catalog {
     expr_cache_handle: Option<ExpressionCacheHandle>,
     storage: Arc<tokio::sync::Mutex<Box<dyn mz_catalog::durable::DurableCatalogState>>>,
     transient_revision: u64,
+    /// The latest `transient_revision`, shared by all clones of this catalog.
+    /// While `transient_revision` is this clone's own revision, frozen when
+    /// the snapshot was taken, this field always tracks the latest revision
+    /// across all clones. Comparing the two lets a snapshot holder detect
+    /// from off-thread whether its snapshot is still current, via
+    /// [`Catalog::transient_revision_is_current`], without a Coordinator
+    /// round-trip (see `PeekClient::catalog_snapshot`).
+    ///
+    /// The store happens in `transact`, before the transaction's effects can
+    /// be observed anywhere (responses, notices, builtin table writes), so a
+    /// session that has observed any evidence of a catalog change is
+    /// guaranteed to see the corresponding bump.
+    shared_transient_revision: Arc<AtomicU64>,
 }
 
 // Implement our own Clone because derive can't unless S is Clone, which it's
@@ -151,6 +165,7 @@ impl Clone for Catalog {
             expr_cache_handle: self.expr_cache_handle.clone(),
             storage: Arc::clone(&self.storage),
             transient_revision: self.transient_revision,
+            shared_transient_revision: Arc::clone(&self.shared_transient_revision),
         }
     }
 }
@@ -308,6 +323,18 @@ impl Catalog {
     /// restart on every load.
     pub fn transient_revision(&self) -> u64 {
         self.transient_revision
+    }
+
+    /// Reports whether this catalog's transient revision is still the latest,
+    /// i.e., whether no catalog transaction has committed since this snapshot
+    /// was taken. Can be called on a snapshot from off-thread, without a
+    /// Coordinator round-trip. See the field documentation on
+    /// `shared_transient_revision`.
+    pub fn transient_revision_is_current(&self) -> bool {
+        self.transient_revision
+            == self
+                .shared_transient_revision
+                .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Creates a debug catalog from the current
@@ -2433,6 +2460,8 @@ mod tests {
             .await
             .expect("unable to open debug catalog");
             assert_eq!(catalog.transient_revision(), 1);
+            assert!(catalog.transient_revision_is_current());
+            let snapshot = catalog.clone();
             let commit_ts = catalog.current_upper().await;
             catalog
                 .transact(
@@ -2447,6 +2476,10 @@ mod tests {
                 .await
                 .expect("failed to transact");
             assert_eq!(catalog.transient_revision(), 2);
+            assert!(catalog.transient_revision_is_current());
+            // The pre-transaction snapshot detects its own staleness through
+            // the shared latest revision.
+            assert!(!snapshot.transient_revision_is_current());
             catalog.expire().await;
         }
         {

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -14,6 +14,7 @@ mod builtin_schema_migration;
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 
 use futures::future::{BoxFuture, FutureExt};
@@ -567,6 +568,7 @@ impl Catalog {
                 state,
                 expr_cache_handle,
                 transient_revision: 1,
+                shared_transient_revision: Arc::new(AtomicU64::new(1)),
                 storage: Arc::new(tokio::sync::Mutex::new(storage)),
             };
 

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -12,6 +12,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use std::sync::atomic;
 use std::time::Duration;
 
 use itertools::Itertools;
@@ -521,6 +522,13 @@ impl Catalog {
         drop(storage);
         if let Some(new_state) = new_state {
             self.transient_revision += 1;
+            // Publish the new revision before returning. Everything that can
+            // reveal this transaction's effects (responses, notices, builtin
+            // table writes) happens after `transact` returns, so any session
+            // that has observed such evidence is guaranteed to see this bump
+            // and refresh its cached catalog snapshot.
+            self.shared_transient_revision
+                .store(self.transient_revision, atomic::Ordering::SeqCst);
             self.state = new_state;
         }
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -289,6 +289,7 @@ impl Client {
 
         let peek_client = PeekClient::new(
             self.clone(),
+            &catalog,
             storage_collections,
             transient_id_gen,
             optimizer_metrics,
@@ -557,7 +558,11 @@ Issue a SQL query to get started. Need help?
     }
 
     /// Returns a snapshot of the catalog.
-    pub async fn catalog_snapshot(&self) -> Arc<Catalog> {
+    ///
+    /// Does a Coordinator round-trip. Session-bound callers should
+    /// prefer [`SessionClient::catalog_snapshot`], which serves from the
+    /// session's snapshot cache.
+    pub async fn catalog_snapshot_expensive(&self) -> Arc<Catalog> {
         let (tx, rx) = oneshot::channel();
         self.send(Command::CatalogSnapshot { tx });
         let CatalogSnapshot { catalog } = rx.await.expect("coordinator unexpectedly gone");
@@ -785,13 +790,12 @@ impl SessionClient {
         // would route differently from the same statement issued
         // directly.
         //
-        // On a successful unroll, `unroll_sql_execute` also returns a
-        // catalog snapshot (threaded through to avoid taking a second
-        // one) and begins EXECUTE-level statement logging on the outer
-        // portal — so `mz_statement_execution_history` records
-        // `EXECUTE foo (...)`, not the inner SQL — installing the
-        // resulting `ExecuteContextGuard` into `outer_ctx_extra`.
-        let (portal_name, catalog) = self
+        // On a successful unroll, `unroll_sql_execute` also begins
+        // EXECUTE-level statement logging on the outer portal, so that
+        // `mz_statement_execution_history` records `EXECUTE foo (...)`
+        // rather than the inner SQL, and installs the resulting
+        // `ExecuteContextGuard` into `outer_ctx_extra`.
+        let portal_name = self
             .unroll_sql_execute(portal_name, &mut outer_ctx_extra)
             .await?;
 
@@ -799,7 +803,7 @@ impl SessionClient {
         // If unsupported, fall back to the Coordinator path.
         // TODO(peek-seq): wire up cancel_future
         let peek_result = self
-            .try_frontend_peek(&portal_name, catalog, &mut outer_ctx_extra)
+            .try_frontend_peek(&portal_name, &mut outer_ctx_extra)
             .await?;
         if let Some(resp) = peek_result {
             debug!("frontend peek succeeded");
@@ -839,22 +843,19 @@ impl SessionClient {
     /// surfaces an internal error if that invariant is ever violated.
     ///
     /// When the portal does not bind an `EXECUTE` — the common case —
-    /// returns the original portal name and `None`, costing only a portal
-    /// lookup. On unroll, also returns the catalog snapshot taken here so
-    /// the caller can thread it into `try_frontend_peek`, which reuses it
-    /// instead of taking its own.
+    /// returns the original portal name, costing only a portal lookup.
     async fn unroll_sql_execute(
         &mut self,
         portal_name: String,
         outer_ctx_extra: &mut Option<ExecuteContextGuard>,
-    ) -> Result<(String, Option<Arc<Catalog>>), AdapterError> {
+    ) -> Result<String, AdapterError> {
         let (stmt, params, outer_logging, outer_lifecycle_timestamps) = {
             let session = self.session.as_ref().expect("SessionClient invariant");
             let portal = match session.get_portal_unverified(&portal_name) {
                 Some(p) => p,
                 // No portal: let `try_frontend_peek` surface the
                 // standard "missing portal" error.
-                None => return Ok((portal_name, None)),
+                None => return Ok(portal_name),
             };
             match &portal.stmt {
                 Some(stmt) => (
@@ -863,14 +864,14 @@ impl SessionClient {
                     Arc::clone(&portal.logging),
                     portal.lifecycle_timestamps.clone(),
                 ),
-                None => return Ok((portal_name, None)),
+                None => return Ok(portal_name),
             }
         };
 
         // Only EXECUTE statements need unrolling. Bail out before taking a
         // catalog snapshot in the (overwhelmingly common) non-EXECUTE case.
         if !matches!(&*stmt, Statement::Execute(_)) {
-            return Ok((portal_name, None));
+            return Ok(portal_name);
         }
 
         let catalog = self.catalog_snapshot("unroll_sql_execute").await;
@@ -973,7 +974,7 @@ impl SessionClient {
             *outer_ctx_extra = Some(ExecuteContextGuard::new(logging_id, dummy_tx));
         }
 
-        Ok((new_portal_name, Some(catalog)))
+        Ok(new_portal_name)
     }
 
     /// Helper for [`Self::unroll_sql_execute`]: plans the outer
@@ -1112,26 +1113,19 @@ impl SessionClient {
         self.session = Some(session);
     }
 
-    /// Fetches the catalog.
+    /// Fetches the catalog, served from the session-side snapshot cache when
+    /// the catalog is unchanged since the cached snapshot was taken. See
+    /// [`PeekClient::catalog_snapshot`].
     #[instrument(level = "debug")]
-    pub async fn catalog_snapshot(&self, context: &str) -> Arc<Catalog> {
-        let start = std::time::Instant::now();
-        let CatalogSnapshot { catalog } = self
-            .send_without_session(|tx| Command::CatalogSnapshot { tx })
-            .await;
-        self.inner()
-            .metrics()
-            .catalog_snapshot_seconds
-            .with_label_values(&[context])
-            .observe(start.elapsed().as_secs_f64());
-        catalog
+    pub async fn catalog_snapshot(&mut self, context: &str) -> Arc<Catalog> {
+        self.peek_client.catalog_snapshot(context).await
     }
 
     /// Dumps the catalog to a JSON string.
     ///
     /// No authorization is performed, so access to this function must be limited to internal
     /// servers or superusers.
-    pub async fn dump_catalog(&self) -> Result<CatalogDump, AdapterError> {
+    pub async fn dump_catalog(&mut self) -> Result<CatalogDump, AdapterError> {
         let catalog = self.catalog_snapshot("dump_catalog").await;
         catalog.dump().map_err(AdapterError::from)
     }
@@ -1141,7 +1135,7 @@ impl SessionClient {
     ///
     /// No authorization is performed, so access to this function must be limited to internal
     /// servers or superusers.
-    pub async fn check_catalog(&self) -> Result<(), serde_json::Value> {
+    pub async fn check_catalog(&mut self) -> Result<(), serde_json::Value> {
         let catalog = self.catalog_snapshot("check_catalog").await;
         catalog.check_consistency()
     }
@@ -1464,13 +1458,12 @@ impl SessionClient {
     pub(crate) async fn try_frontend_peek(
         &mut self,
         portal_name: &str,
-        catalog: Option<Arc<Catalog>>,
         outer_ctx_extra: &mut Option<ExecuteContextGuard>,
     ) -> Result<Option<ExecuteResponse>, AdapterError> {
         if self.enable_frontend_peek_sequencing {
             let session = self.session.as_mut().expect("SessionClient invariant");
             self.peek_client
-                .try_frontend_peek(portal_name, catalog, session, outer_ctx_extra)
+                .try_frontend_peek(portal_name, session, outer_ctx_extra)
                 .await
         } else {
             Ok(None)

--- a/src/adapter/src/config/sync.rs
+++ b/src/adapter/src/config/sync.rs
@@ -145,7 +145,7 @@ async fn sync_scoped_params(
     }
     *maybe_dirty = true;
 
-    let catalog = client.catalog_snapshot().await;
+    let catalog = client.catalog_snapshot_expensive().await;
 
     // Push the desired state to the coordinator, which holds the working copy
     // and resolves each layer at its boundary: the controller's per-replica

--- a/src/adapter/src/coord/info_metrics.rs
+++ b/src/adapter/src/coord/info_metrics.rs
@@ -21,6 +21,7 @@
 //! catalog. It's okay if the info metrics are not exactly up to date and
 //! eventually consistent.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use mz_adapter_types::dyncfgs::CATALOG_INFO_METRICS_RECONCILE_INTERVAL;
@@ -28,6 +29,7 @@ use mz_catalog::memory::objects::{
     CatalogItem, Cluster, ClusterReplica, ClusterVariant, DataSourceDesc,
 };
 use mz_controller::clusters::ReplicaLocation;
+use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::{
     DeleteOnDropGauge, Histogram, MetricTag, MetricVisibility, MetricsRegistry, UIntGaugeVec,
@@ -277,6 +279,8 @@ impl Coordinator {
     pub(crate) fn spawn_catalog_info_metrics_task(&self) {
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let mut metrics = CatalogInfoMetrics::new(&self.catalog_info_metrics_registry);
+        let catalog_arc_strong_count = self.metrics.catalog_arc_strong_count.clone();
+        let catalog_arc_weak_count = self.metrics.catalog_arc_weak_count.clone();
         task::spawn(|| "catalog_info_metrics", async move {
             loop {
                 let (tx, rx) = oneshot::channel();
@@ -291,6 +295,14 @@ impl Coordinator {
                 let Ok(CatalogSnapshot { catalog }) = rx.await else {
                     break;
                 };
+
+                // Sample the reference counts of the current catalog
+                // allocation. The strong count includes this task's own
+                // snapshot. The weak count is the number of session catalog
+                // caches pointing at the current allocation (sessions caching
+                // an older version are not counted).
+                catalog_arc_strong_count.set(u64::cast_from(Arc::strong_count(&catalog)));
+                catalog_arc_weak_count.set(u64::cast_from(Arc::weak_count(&catalog)));
 
                 // The reconcile cadence is a dyncfg; a zero interval disables
                 // reconciliation.

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -78,7 +78,6 @@ impl PeekClient {
     pub(crate) async fn try_frontend_peek(
         &mut self,
         portal_name: &str,
-        catalog: Option<Arc<Catalog>>,
         session: &mut Session,
         outer_ctx_extra: &mut Option<ExecuteContextGuard>,
     ) -> Result<Option<ExecuteResponse>, AdapterError> {
@@ -97,16 +96,7 @@ impl PeekClient {
             }
         }
 
-        // TODO(peek-seq): This snapshot is wasted when we end up bailing out from the frontend peek
-        // sequencing. We could solve this is with that optimization where we
-        // continuously keep a catalog snapshot in the session, and only get a new one when the
-        // catalog revision has changed, which we could see with an atomic read.
-        // But anyhow, this problem will just go away when we reach the point that we never fall
-        // back to the old sequencing.
-        let catalog = match catalog {
-            Some(c) => c,
-            None => self.catalog_snapshot("try_frontend_peek").await,
-        };
+        let catalog = self.catalog_snapshot("try_frontend_peek").await;
 
         // Extract things from the portal.
         let (stmt, params, logging, lifecycle_timestamps) = {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mz_ore::metric;
-use mz_ore::metrics::{MetricTag, MetricVisibility, MetricsRegistry};
+use mz_ore::metrics::{MetricTag, MetricVisibility, MetricsRegistry, UIntGauge};
 use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
 use mz_sql::session::user::User;
@@ -52,6 +52,9 @@ pub struct Metrics {
     pub result_rows_first_to_last_byte_seconds: HistogramVec,
     pub pgwire_ensure_transaction_seconds: HistogramVec,
     pub catalog_snapshot_seconds: HistogramVec,
+    pub catalog_snapshot_cache: IntCounterVec,
+    pub catalog_arc_strong_count: UIntGauge,
+    pub catalog_arc_weak_count: UIntGauge,
     pub pgwire_recv_scheduling_delay_ms: HistogramVec,
     pub catalog_transact_seconds: HistogramVec,
     pub apply_catalog_implications_seconds: Histogram,
@@ -241,9 +244,28 @@ impl Metrics {
             )),
             catalog_snapshot_seconds: registry.register(metric!(
                 name: "mz_catalog_snapshot_seconds",
-                help: "The time it takes to run `catalog_snapshot` when fetching the catalog.",
+                help: "The time it takes to fetch a catalog snapshot from the Coordinator. \
+                       Only observed on session snapshot cache misses.",
                 var_labels: ["context"],
                 buckets: histogram_seconds_buckets(0.001, 512.0),
+            )),
+            catalog_snapshot_cache: registry.register(metric!(
+                name: "mz_catalog_snapshot_cache",
+                help: "Hits and misses of the session-side catalog snapshot cache. A miss \
+                       costs a Coordinator round-trip.",
+                var_labels: ["context", "result"],
+            )),
+            catalog_arc_strong_count: registry.register(metric!(
+                name: "mz_catalog_arc_strong_count",
+                help: "The number of strong references to the current catalog snapshot: roughly, \
+                       in-flight users plus a small constant baseline.",
+            )),
+            catalog_arc_weak_count: registry.register(metric!(
+                name: "mz_catalog_arc_weak_count",
+                help: "The number of weak references to the current catalog snapshot: sessions \
+                       whose snapshot cache points at the current catalog version (older \
+                       versions are not counted). Drops on catalog changes and recovers as \
+                       session caches repopulate.",
             )),
             pgwire_recv_scheduling_delay_ms: registry.register(metric!(
                 name: "mz_pgwire_recv_scheduling_delay_ms",

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use differential_dataflow::consolidation::consolidate;
 use mz_compute_client::controller::error::{CollectionMissing, InstanceMissing};
@@ -53,6 +53,13 @@ pub type StorageCollectionsHandle =
 #[derive(Debug)]
 pub struct PeekClient {
     coordinator_client: Client,
+    /// Cache of the latest catalog snapshot. Serves
+    /// [`PeekClient::catalog_snapshot`] without a Coordinator round-trip
+    /// while the catalog's transient revision is unchanged.
+    ///
+    /// Holds a `Weak` so that an idle session does not keep a superseded
+    /// catalog version alive.
+    catalog_cache: Weak<Catalog>,
     /// Channels to talk to each compute Instance task directly. Lazily populated.
     /// Note that these are never cleaned up. In theory, this could lead to a very slow memory leak
     /// if a long-running user session keeps peeking on clusters that are being created and dropped
@@ -72,8 +79,12 @@ pub struct PeekClient {
 
 impl PeekClient {
     /// Creates a PeekClient.
+    ///
+    /// `catalog` seeds the catalog snapshot cache, so that the session's
+    /// first statements don't need a `Command::CatalogSnapshot` round-trip.
     pub fn new(
         coordinator_client: Client,
+        catalog: &Arc<Catalog>,
         storage_collections: StorageCollectionsHandle,
         transient_id_gen: Arc<TransientIdGen>,
         optimizer_metrics: OptimizerMetrics,
@@ -82,6 +93,7 @@ impl PeekClient {
     ) -> Self {
         Self {
             coordinator_client,
+            catalog_cache: Arc::downgrade(catalog),
             compute_instances: Default::default(), // lazily populated
             storage_collections,
             transient_id_gen,
@@ -128,18 +140,53 @@ impl PeekClient {
         Ok(self.oracles.get_mut(&timeline).expect("ensured above"))
     }
 
-    /// Fetch a snapshot of the catalog for use in frontend peek sequencing.
-    /// Records the time taken in the adapter metrics, labeled by `context`.
-    pub async fn catalog_snapshot(&self, context: &str) -> Arc<Catalog> {
+    /// Fetch a snapshot of the catalog.
+    ///
+    /// Serves from the session-side cache when the catalog's transient
+    /// revision is unchanged since the cached snapshot was taken (see
+    /// [`Catalog::transient_revision_is_current`]). An unchanged revision
+    /// means the cached snapshot is identical to what a fresh fetch would
+    /// return. Otherwise falls back to a `Command::CatalogSnapshot`
+    /// round-trip and re-populates the cache.
+    ///
+    /// Cache misses record the round-trip time in the adapter metrics,
+    /// labeled by `context`. Hits and misses are counted in
+    /// `catalog_snapshot_cache`.
+    pub async fn catalog_snapshot(&mut self, context: &str) -> Arc<Catalog> {
+        // NOTE: The upgrade can fail even when the revision is unchanged: any
+        // in-place mutation of the Coordinator's catalog (including
+        // revision-preserving ones) moves it to a new allocation, and the
+        // cached allocation is freed once its last user drops. We then fall
+        // through to a refetch.
+        let cached = self
+            .catalog_cache
+            .upgrade()
+            .filter(|catalog| catalog.transient_revision_is_current());
+        if let Some(catalog) = cached {
+            self.coordinator_client
+                .metrics()
+                .catalog_snapshot_cache
+                .with_label_values(&[context, "hit"])
+                .inc();
+            return catalog;
+        }
+
+        // The cache is empty, stale, or its allocation is gone: do the
+        // round-trip.
         let start = std::time::Instant::now();
         let CatalogSnapshot { catalog } = self
             .call_coordinator(|tx| Command::CatalogSnapshot { tx })
             .await;
-        self.coordinator_client
-            .metrics()
+        let metrics = self.coordinator_client.metrics();
+        metrics
             .catalog_snapshot_seconds
             .with_label_values(&[context])
             .observe(start.elapsed().as_secs_f64());
+        metrics
+            .catalog_snapshot_cache
+            .with_label_values(&[context, "miss"])
+            .inc();
+        self.catalog_cache = Arc::downgrade(&catalog);
         catalog
     }
 

--- a/src/environmentd/src/http/catalog.rs
+++ b/src/environmentd/src/http/catalog.rs
@@ -18,14 +18,14 @@ use mz_adapter::catalog::InjectedAuditEvent;
 
 use crate::http::AuthedClient;
 
-pub async fn handle_catalog_dump(client: AuthedClient) -> impl IntoResponse {
+pub async fn handle_catalog_dump(mut client: AuthedClient) -> impl IntoResponse {
     match client.client.dump_catalog().await.map(|c| c.into_string()) {
         Ok(res) => Ok((TypedHeader(ContentType::json()), res)),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
 }
 
-pub async fn handle_catalog_check(client: AuthedClient) -> impl IntoResponse {
+pub async fn handle_catalog_check(mut client: AuthedClient) -> impl IntoResponse {
     let response = match client.client.check_catalog().await {
         Ok(_) => serde_json::Value::String("".to_string()),
         Err(inconsistencies) => serde_json::json!({ "err": inconsistencies }),

--- a/src/environmentd/src/http/cluster.rs
+++ b/src/environmentd/src/http/cluster.rs
@@ -258,7 +258,7 @@ struct ClustersTemplate<'a> {
 /// Handler for the clusters overview page.
 ///
 /// Displays a table of all cluster replicas with links to their HTTP endpoints.
-pub(crate) async fn handle_clusters(client: AuthedClient) -> impl IntoResponse {
+pub(crate) async fn handle_clusters(mut client: AuthedClient) -> impl IntoResponse {
     // Look up names from the catalog
     let catalog = client.client.catalog_snapshot("clusters_page").await;
 

--- a/src/environmentd/src/http/metrics_public.rs
+++ b/src/environmentd/src/http/metrics_public.rs
@@ -40,7 +40,7 @@ use crate::http::cluster::{
 /// Aggregates environmentd's local metrics with every clusterd replica's
 /// `/metrics` output.
 pub(crate) async fn handle_public_metrics(
-    client: AuthedClient,
+    mut client: AuthedClient,
     Extension(config): Extension<Arc<ClusterProxyConfig>>,
     Extension(metrics_registry): Extension<MetricsRegistry>,
 ) -> Response {


### PR DESCRIPTION
### Motivation

Implements SQL-505. Also part of https://github.com/MaterializeInc/database-issues/issues/9593 as the first item of the "Further performance optimizations" section.

Sessions fetched a fresh catalog snapshot via a `Command::CatalogSnapshot` round-trip to the Coordinator for every statement, two per fast path peek. On query-heavy environments this is by far the largest consumer of coordinator main loop time, even though the handler is just an `Arc::clone`: it is pure message-volume cost. Caching the snapshot in the session removes essentially all of this traffic, and reduces queueing delay for every other message on the coordinator loop.

For more context, see https://materializeinc.slack.com/archives/C0854GU86HL/p1783533892481119?thread_ts=1783452325.719879&cid=C0854GU86HL where a user is running into query latency issues when the Coordinator is overloaded.

### Description

Sessions now cache the latest catalog snapshot (a `Weak<Catalog>` in `PeekClient`) and reuse it while the catalog's transient revision is unchanged. The revision is mirrored in a shared atomic that is bumped inside `Catalog::transact`, before any effect of a transaction can be observed, so a session that has seen evidence of a catalog change always refreshes. Anything else (revision mismatch, or the cached allocation is gone) falls back to the existing round-trip, which linearizes through the coordinator loop.

The design, the full correctness argument, rejected alternatives, and observability are in the new design doc included in this PR: `doc/developer/design/20260709_session_catalog_snapshot_cache.md`. Also, `doc/developer/guide-adapter.md` gains a short entry with the one rule future catalog changes must respect: bump the revision or stay invisible to sessions.

Also renames the session-less, uncached `Client::catalog_snapshot` to `catalog_snapshot_expensive`.

### Verification

- Existing sqllogictest, testdrive, and platform-checks coverage exercises the cache and its DDL-driven invalidation on every statement. Parallel-workload (concurrent DDL vs. peeks) is the most relevant nightly stress.
- The catalog revision unit test now also asserts that the shared atomic mirrors the transient revision, and that a pre-transaction snapshot detects its own staleness.
- Rollout acceptance signal: the `command-catalog_snapshot` message kind in `mz_slow_message_handling_sum` drops to a periodic trickle, and `mz_catalog_snapshot_cache` misses stay near zero outside DDL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Nightly runs:
- https://buildkite.com/materialize/nightly/builds/17097
