### PR TITLE
adapter: rewrite temporary dependents when applying a replacement MV

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1092,7 +1092,7 @@ impl Catalog {
                 tx.remove_item(replacement_id)?;
 
                 new_entry.id = replacement_id;
-                tx_replace_item(tx, state, id, new_entry)?;
+                tx_replace_item(tx, state, id, new_entry, &mut temporary_item_updates)?;
 
                 let comment_id = CommentObjectId::MaterializedView(replacement_id);
                 tx.drop_comments(&[comment_id].into())?;
@@ -2966,17 +2966,33 @@ fn tx_replace_item(
     state: &CatalogState,
     id: CatalogItemId,
     new_entry: CatalogEntry,
+    temporary_item_updates: &mut Vec<(TemporaryItem, StateDiff)>,
 ) -> Result<(), AdapterError> {
     let new_id = new_entry.id;
 
     // Rewrite dependent objects to point to the new ID.
     for use_id in new_entry.referenced_by() {
+        let dependent = state.get_entry(use_id);
+
+        // Temporary items live only in the in-memory catalog, never in the durable
+        // transaction. They must be rewritten via `temporary_item_updates`. Routing them
+        // through `tx.update_item` would be a no-op (they are not in `tx`), leaving the
+        // temporary object referencing the removed `id` and tripping the catalog
+        // consistency check. Mirrors how `Op::RenameItem` handles temporary dependents.
+        if dependent.item().is_temporary() {
+            let mut rewritten = dependent.clone();
+            rewritten.item = rewritten.item.replace_item_refs(id, new_id);
+            temporary_item_updates.push((dependent.clone().into(), StateDiff::Retraction));
+            temporary_item_updates.push((rewritten.into(), StateDiff::Addition));
+            continue;
+        }
+
         // The dependent might be dropped in the same tx, so check.
         if tx.get_item(use_id).is_none() {
             continue;
         }
 
-        let mut dependent = state.get_entry(use_id).clone();
+        let mut dependent = dependent.clone();
         dependent.item = dependent.item.replace_item_refs(id, new_id);
         tx.update_item(*use_id, dependent.into())?;
     }

--- a/test/sqllogictest/replacement-materialized-views.slt
+++ b/test/sqllogictest/replacement-materialized-views.slt
@@ -206,6 +206,51 @@ statement ok
 DROP MATERIALIZED VIEW mv CASCADE
 
 
+# Regression test (SQL-504): applying a replacement must rewrite TEMPORARY dependents
+# of the target, not only durable ones. `tx_replace_item` rewrites the target's
+# dependents to point at the survivor, but temporary objects live only in the
+# in-memory catalog, never in the durable catalog transaction, so an earlier version
+# skipped them. The temporary view was then left referencing the removed target,
+# tripping the catalog consistency check (MissingUses) and aborting the coordinator.
+# A non-temporary dependent has always been rewritten correctly; the temporary one is
+# the regression.
+
+statement ok
+CREATE TABLE tt (a int, b int)
+
+statement ok
+INSERT INTO tt VALUES (1, 10)
+
+statement ok
+CREATE MATERIALIZED VIEW mv504 AS SELECT a, b FROM tt
+
+statement ok
+CREATE REPLACEMENT MATERIALIZED VIEW rp504 FOR mv504 AS SELECT a + 1 AS a, b FROM tt
+
+statement ok
+CREATE TEMPORARY VIEW tv504 AS SELECT a FROM mv504
+
+# Before the fix this aborted the coordinator with a MissingUses consistency panic.
+statement ok
+ALTER MATERIALIZED VIEW mv504 APPLY REPLACEMENT rp504
+
+# The temporary view survives and was rewritten to read through the applied
+# replacement (a + 1), rather than dangling on the now-removed target.
+query I
+SELECT a FROM tv504
+----
+2
+
+statement ok
+DROP VIEW tv504
+
+statement ok
+DROP MATERIALIZED VIEW mv504 CASCADE
+
+statement ok
+DROP TABLE tt
+
+
 # Test: privileges are preserved after replacement
 
 statement ok


### PR DESCRIPTION
`ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` rewrites the target's dependents to point at the survivor via `tx_replace_item`. The rewrite loop skipped any dependent absent from the durable catalog transaction. Temporary objects (temp views, materialized views, indexes) live only in the in-memory catalog and are never part of the durable transaction, so a temporary dependent of the target was skipped. It was then left referencing the removed target, which tripped the catalog consistency check (`MissingUses`) and aborted the coordinator. The failure needs no concurrency: creating a temporary view on the target and applying the replacement in a single session reproduces it.

Route temporary dependents through `temporary_item_updates` (an in-memory retract plus add of the rewritten item), mirroring how `Op::RenameItem` already handles its temporary dependents. Non-temporary dependents are unchanged.

Closes: https://linear.app/materializeinc/issue/SQL-504