### PR TITLE
docs: Clarify that subquery ORDER BY is ignored by order-sensitive aggregates

### DIFF
--- a/doc/user/content/headless/aggregate-input-order-ignored.md
+++ b/doc/user/content/headless/aggregate-input-order-ignored.md
@@ -1,0 +1,8 @@
+---
+headless: true
+---
+
+Any `ORDER BY` applied before the aggregate function is evaluated, such as in
+a feeding subquery, is ignored. Unless `ORDER BY` is included in the aggregate
+function call itself, the order in which the values are aggregated is
+unspecified.

--- a/doc/user/content/sql/functions/array_agg.md
+++ b/doc/user/content/sql/functions/array_agg.md
@@ -23,10 +23,7 @@ _value_ | [any](../../types) | The values you want aggregated.
 
 `array_agg` returns the aggregated values as an [array](../../types/array/).
 
-Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
-ignored. The order in which values are aggregated is otherwise unspecified. To
-aggregate in a specific order, specify `ORDER BY` within the aggregate function
-call itself.
+{{% include-headless "/headless/aggregate-input-order-ignored" %}}
 
 ## Details
 

--- a/doc/user/content/sql/functions/array_agg.md
+++ b/doc/user/content/sql/functions/array_agg.md
@@ -23,8 +23,10 @@ _value_ | [any](../../types) | The values you want aggregated.
 
 `array_agg` returns the aggregated values as an [array](../../types/array/).
 
-This function always executes on the data from `value` as if it were sorted in ascending order before the function call. Any specified ordering is
-ignored. If you need to perform aggregation in a specific order, you must specify `ORDER BY` within the aggregate function call itself. Otherwise incoming rows are not guaranteed any order.
+Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
+ignored. The order in which values are aggregated is otherwise unspecified. To
+aggregate in a specific order, specify `ORDER BY` within the aggregate function
+call itself.
 
 ## Details
 

--- a/doc/user/content/sql/functions/jsonb_agg.md
+++ b/doc/user/content/sql/functions/jsonb_agg.md
@@ -24,8 +24,10 @@ _expression_ | [jsonb](../../types) | The values you want aggregated.
 
 `jsonb_agg` returns the aggregated values as a `jsonb` array.
 
-This function always executes on the data from `value` as if it were sorted in ascending order before the function call. Any specified ordering is
-ignored. If you need to perform aggregation in a specific order, you must specify `ORDER BY` within the aggregate function call itself. Otherwise incoming rows are not guaranteed any order.
+Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
+ignored. The order in which values are aggregated is otherwise unspecified. To
+aggregate in a specific order, specify `ORDER BY` within the aggregate function
+call itself.
 
 ## Details
 

--- a/doc/user/content/sql/functions/jsonb_agg.md
+++ b/doc/user/content/sql/functions/jsonb_agg.md
@@ -24,10 +24,7 @@ _expression_ | [jsonb](../../types) | The values you want aggregated.
 
 `jsonb_agg` returns the aggregated values as a `jsonb` array.
 
-Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
-ignored. The order in which values are aggregated is otherwise unspecified. To
-aggregate in a specific order, specify `ORDER BY` within the aggregate function
-call itself.
+{{% include-headless "/headless/aggregate-input-order-ignored" %}}
 
 ## Details
 

--- a/doc/user/content/sql/functions/jsonb_object_agg.md
+++ b/doc/user/content/sql/functions/jsonb_object_agg.md
@@ -31,10 +31,7 @@ pair is retained in the output.
 
 If `keys` is null for any input row, that entry pair will be dropped.
 
-Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
-ignored. The order in which values are aggregated is otherwise unspecified. To
-aggregate in a specific order, specify `ORDER BY` within the aggregate function
-call itself.
+{{% include-headless "/headless/aggregate-input-order-ignored" %}}
 
 ### Usage in dataflows
 

--- a/doc/user/content/sql/functions/jsonb_object_agg.md
+++ b/doc/user/content/sql/functions/jsonb_object_agg.md
@@ -31,8 +31,10 @@ pair is retained in the output.
 
 If `keys` is null for any input row, that entry pair will be dropped.
 
-This function always executes on the data from `value` as if it were sorted in ascending order before the function call. Any specified ordering is
-ignored. If you need to perform aggregation in a specific order, you must specify `ORDER BY` within the aggregate function call itself. Otherwise incoming rows are not guaranteed any order.
+Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
+ignored. The order in which values are aggregated is otherwise unspecified. To
+aggregate in a specific order, specify `ORDER BY` within the aggregate function
+call itself.
 
 ### Usage in dataflows
 

--- a/doc/user/content/sql/functions/list_agg.md
+++ b/doc/user/content/sql/functions/list_agg.md
@@ -24,10 +24,7 @@ _value_    | `text`  | The values to concatenate.
 
 `list_agg` returns a [`list`](/sql/types/list) value.
 
-Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
-ignored. The order in which values are aggregated is otherwise unspecified. To
-aggregate in a specific order, specify `ORDER BY` within the aggregate function
-call itself.
+{{% include-headless "/headless/aggregate-input-order-ignored" %}}
 
 ## Details
 

--- a/doc/user/content/sql/functions/list_agg.md
+++ b/doc/user/content/sql/functions/list_agg.md
@@ -24,8 +24,10 @@ _value_    | `text`  | The values to concatenate.
 
 `list_agg` returns a [`list`](/sql/types/list) value.
 
-This function always executes on the data from `value` as if it were sorted in ascending order before the function call. Any specified ordering is
-ignored. If you need to perform aggregation in a specific order, you must specify `ORDER BY` within the aggregate function call itself. Otherwise incoming rows are not guaranteed any order.
+Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
+ignored. The order in which values are aggregated is otherwise unspecified. To
+aggregate in a specific order, specify `ORDER BY` within the aggregate function
+call itself.
 
 ## Details
 

--- a/doc/user/content/sql/functions/string_agg.md
+++ b/doc/user/content/sql/functions/string_agg.md
@@ -27,10 +27,7 @@ _delimiter_  | `text`  | The value to precede each concatenated value.
 
 `string_agg` returns a [`text`](/sql/types/text) value.
 
-Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
-ignored. The order in which values are aggregated is otherwise unspecified. To
-aggregate in a specific order, specify `ORDER BY` within the aggregate function
-call itself.
+{{% include-headless "/headless/aggregate-input-order-ignored" %}}
 
 ### Usage in dataflows
 

--- a/doc/user/content/sql/functions/string_agg.md
+++ b/doc/user/content/sql/functions/string_agg.md
@@ -27,8 +27,10 @@ _delimiter_  | `text`  | The value to precede each concatenated value.
 
 `string_agg` returns a [`text`](/sql/types/text) value.
 
-This function always executes on the data from `value` as if it were sorted in ascending order before the function call. Any specified ordering is
-ignored. If you need to perform aggregation in a specific order, you must specify `ORDER BY` within the aggregate function call itself. Otherwise incoming rows are not guaranteed any order.
+Any `ORDER BY` applied to the input rows, for example in a feeding subquery, is
+ignored. The order in which values are aggregated is otherwise unspecified. To
+aggregate in a specific order, specify `ORDER BY` within the aggregate function
+call itself.
 
 ### Usage in dataflows
 
@@ -48,49 +50,6 @@ CREATE VIEW bar AS SELECT string_agg(foo_view.bar, ',');
 ```
 
 ## Examples
-
-```mzsql
-SELECT string_agg(column1, column2)
-FROM (
-    VALUES ('z', ' !'), ('a', ' @'), ('m', ' #')
-);
-```
-```nofmt
- string_agg
-------------
- a #m !z
-```
-
-Note that in the following example, the `ORDER BY` of the subquery feeding into `string_agg` gets ignored.
-
-```mzsql
-SELECT column1, column2
-FROM (
-    VALUES ('z', ' !'), ('a', ' @'), ('m', ' #')
-) ORDER BY column1 DESC;
-```
-```nofmt
- column1 | column2
----------+---------
- z       |  !
- m       |  #
- a       |  @
-```
-
-```mzsql
-SELECT string_agg(column1, column2)
-FROM (
-    SELECT column1, column2
-    FROM (
-        VALUES ('z', ' !'), ('a', ' @'), ('m', ' #')
-    ) f ORDER BY column1 DESC
-) g;
-```
-```nofmt
- string_agg
-------------
- a #m !z
-```
 
 ```mzsql
 SELECT string_agg(b, ',' ORDER BY a DESC) FROM table;

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1806,6 +1806,17 @@ pub fn plan_nested_query(
         project,
         group_size_hints,
     } = qcx.checked_recur_mut(|qcx| plan_query(qcx, q))?;
+    // A nested query is an unordered relation. Its `ORDER BY` is only observable
+    // in combination with a row-limiting clause (`LIMIT`/`OFFSET`), which selects
+    // which rows survive. Without such a clause the ordering has no defined
+    // meaning, so it is dropped rather than materialized into a `TopK`.
+    //
+    // NOTE: This diverges from PostgreSQL, where an order-sensitive aggregate
+    // (`array_agg`, `string_agg`, ...) in the outer query observes a sorted
+    // subquery's output as an executor artifact. That behavior is not guaranteed
+    // by the SQL standard and PostgreSQL itself documents it as fragile. Callers
+    // that need a specific aggregation order must use the in-aggregate
+    // `agg(value ORDER BY ...)` form instead.
     if limit.is_some()
         || !offset
             .clone()


### PR DESCRIPTION
PostgreSQL honors an `ORDER BY` in a subquery that feeds an order-sensitive aggregate (`array_agg`, `string_agg`, ...) as an executor artifact, so `array_agg(i) FROM (SELECT ... ORDER BY ...)` comes out sorted.
This is not guaranteed by the SQL standard, and Materialize does not reproduce it: a nested query is an unordered relation whose `ORDER BY` is dropped unless combined with a row-limiting clause.
Aggregation order must be requested with the in-aggregate `agg(value ORDER BY ...)` form.

This documents the divergence at the drop site in `plan_nested_query`, and replaces the shared boilerplate across `array_agg`, `string_agg`, `list_agg`, `jsonb_agg`, and `jsonb_object_agg`.
It previously claimed both "as if sorted in ascending order" and "not guaranteed any order"; it now states the aggregation order is unspecified without an in-aggregate `ORDER BY`.
Reference examples that documented the implementation-defined ascending order as if guaranteed are removed.

No behavior change.

CLU-160
