### PR TITLE
adapter: Disable `arrangement_size_history_collection_interval` also in SM

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -281,7 +281,8 @@ pub const CONSOLE_OIDC_SCOPES: Config<&'static str> = Config::new(
 /// Interval at which to collect per-object arrangement size snapshots for the history table.
 pub const ARRANGEMENT_SIZE_HISTORY_COLLECTION_INTERVAL: Config<Duration> = Config::new(
     "arrangement_size_history_collection_interval",
-    Duration::from_hours(1),
+    // Disabled by default until https://github.com/MaterializeInc/materialize/pull/37455 lands.
+    Duration::ZERO,
     "Interval at which to collect and snapshot per-object arrangement sizes \
      into mz_internal.mz_object_arrangement_size_history.",
 );


### PR DESCRIPTION
Can be enabled again with https://github.com/MaterializeInc/materialize/pull/37455

This is already disabled in LD for Cloud, but needs to be disabled in SM as well. Noticed at a user here:
https://materializeinc.slack.com/archives/C0854GU86HL/p1783523549448219?thread_ts=1783452325.719879&cid=C0854GU86HL

Will need to be re-enabled also in LD, once the above PR is rolled out to all prod users and the fix is verified by looking at coordinator message metrics in staging and canaries. See this thread for how this looked in Grafana:
https://materializeinc.slack.com/archives/CTESPM7FU/p1778694810244889?thread_ts=1778508034.797449&cid=CTESPM7FU
