### PR TITLE
doc: Reflect Terraform module v4.0.0 crd_version default of v1

### DIFF
--- a/doc/user/content/self-managed-deployments/installation/install-on-aws.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-aws.md
@@ -162,7 +162,7 @@ authentication mechanisms.
    | `aws_region`  | AWS region for deployment (e.g., `us-east-1`). |
    | `aws_profile` | AWS CLI profile to use. |
    | `license_key` | Materialize license key. |
-   | `crd_version` | CRD API version to use for the Materialize instance: `v1` or `v1alpha1`. |
+   | `crd_version` | CRD API version to use for the Materialize instance: `v1` (default starting in TF v4.0.0) or `v1alpha1`. |
    | `tags`        | Map of tags to apply to resources. |
 
    {{% include-from-yaml data="self_managed/installation"
@@ -173,7 +173,7 @@ authentication mechanisms.
    aws_region  = "us-east-1"
    aws_profile = "your-aws-profile"
    license_key = "your-materialize-license-key"
-   crd_version = "v1"   # v1 is available for Materialize v26.30+ and TF v3.1.1+.
+   crd_version = "v1"   # Default starting in TF v4.0.0. v1 requires Materialize v26.30+.
    tags = {
      environment = "demo"
    }

--- a/doc/user/content/self-managed-deployments/installation/install-on-azure.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-azure.md
@@ -180,7 +180,7 @@ authentication mechanisms.
    | `name_prefix`         | Prefix for all resource names (e.g., `simple-demo`). |
    | `location`            | Azure region for deployment (e.g., `westus2`). |
    | `license_key`         | Materialize license key. |
-   | `crd_version`         | CRD API version to use for the Materialize instance: `v1` or `v1alpha1`. |
+   | `crd_version`         | CRD API version to use for the Materialize instance: `v1` (default starting in TF v4.0.0) or `v1alpha1`. |
    | `tags`                | Map of tags to apply to resources. |
 
    {{% include-from-yaml data="self_managed/installation"
@@ -192,7 +192,7 @@ authentication mechanisms.
    name_prefix         = "simple-demo"
    location            = "westus2"
    license_key         = "your-materialize-license-key"
-   crd_version = "v1"   # v1 is available for Materialize v26.30+ and TF v3.1.1+.
+   crd_version = "v1"   # Default starting in TF v4.0.0. v1 requires Materialize v26.30+.
    tags = {
      environment = "demo"
    }

--- a/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
@@ -187,7 +187,7 @@ authentication mechanisms.
    | `name_prefix` | Set a prefix for all resource names (e.g., `simple-demo`) as well as your release name for the Operator |
    | `region`      | Set the GCP region for the deployment (e.g., `us-central1`).  |
    | `license_key` | Set to your Materialize license key.     |
-   | `crd_version` | CRD API version to use for the Materialize instance: `v1` or `v1alpha1`. |
+   | `crd_version` | CRD API version to use for the Materialize instance: `v1` (default starting in TF v4.0.0) or `v1alpha1`. |
    | `labels`      | Set to the labels to apply to resources. |
 
    {{% include-from-yaml data="self_managed/installation"
@@ -198,7 +198,7 @@ authentication mechanisms.
    name_prefix = "simple-demo"
    region      = "us-central1"
    license_key = "your-materialize-license-key"
-   crd_version = "v1"   # v1 is available for Materialize v26.30+ and TF v3.1.1+.
+   crd_version = "v1"   # Default starting in TF v4.0.0. v1 requires Materialize v26.30+.
    labels = {
      environment = "demo"
      created_by  = "terraform"

--- a/doc/user/content/self-managed-deployments/materialize-crd-field-descriptions/_index.md
+++ b/doc/user/content/self-managed-deployments/materialize-crd-field-descriptions/_index.md
@@ -13,5 +13,5 @@ aliases:
 
 Select the CRD API version for your Materialize deployment:
 
-- [v1 (Available starting v26.30+)](/self-managed-deployments/materialize-crd-field-descriptions/v1/)
-- [v1alpha1 (*default*)](/self-managed-deployments/materialize-crd-field-descriptions/v1alpha1/)
+- [v1 (Available starting v26.30+; Terraform module default starting in v4.0.0)](/self-managed-deployments/materialize-crd-field-descriptions/v1/)
+- [v1alpha1 (*Helm chart default*)](/self-managed-deployments/materialize-crd-field-descriptions/v1alpha1/)

--- a/doc/user/content/self-managed-deployments/materialize-crd-field-descriptions/v1.md
+++ b/doc/user/content/self-managed-deployments/materialize-crd-field-descriptions/v1.md
@@ -8,7 +8,8 @@ menu:
 ---
 
 {{< note >}}
-The `v1` CRD is available starting in v26.30 and is opt-in. If you are on
+The `v1` CRD is available starting in v26.30. It is opt-in for the Helm chart
+and the default for the Terraform modules starting in v4.0.0. If you are on
 `v1alpha1` and want a simplified rollout behavior of `v1`, see [Adopting the v1
 CRD](/self-managed-deployments/upgrading/adopting-the-v1-crd/).
 For the `v1alpha1` field descriptions, see [CRD v1alpha1 field descriptions](/self-managed-deployments/materialize-crd-field-descriptions/v1alpha1/).

--- a/doc/user/content/self-managed-deployments/materialize-crd-field-descriptions/v1alpha1.md
+++ b/doc/user/content/self-managed-deployments/materialize-crd-field-descriptions/v1alpha1.md
@@ -8,9 +8,11 @@ menu:
 ---
 
 {{< note >}}
-`v1alpha1` is the default CRD version (default). With v1alpha1, rollouts require manually rotating a UUID.
-Starting in v26.30, the [v1](/self-managed-deployments/materialize-crd-field-descriptions/v1/)
-CRD is available and provides a simplified rollout behavior.
+`v1alpha1` is the default CRD version for the Helm chart. The Terraform
+modules default to `v1` starting in v4.0.0. With v1alpha1, rollouts require
+manually rotating a UUID. Starting in v26.30, the
+[v1](/self-managed-deployments/materialize-crd-field-descriptions/v1/) CRD is
+available and provides a simplified rollout behavior.
 
 To switch to `v1`, see [Adopting the v1
 CRD](/self-managed-deployments/upgrading/adopting-the-v1-crd/).

--- a/doc/user/content/self-managed-deployments/upgrading/_index.md
+++ b/doc/user/content/self-managed-deployments/upgrading/_index.md
@@ -101,8 +101,9 @@ rollouts work.
 
 ## Rollout configuration
 
-Materialize supports two CRD API versions: `v1alpha1` (default) and `v1`
-(available starting in v26.30).
+Materialize supports two CRD API versions: `v1alpha1` and `v1` (available
+starting in v26.30). The Helm chart defaults to `v1alpha1`. The Terraform
+modules default to `v1` starting in v4.0.0.
 
 How you trigger a rollout depends on the CRD API version of your instances.
 

--- a/doc/user/content/self-managed-deployments/upgrading/adopting-the-v1-crd.md
+++ b/doc/user/content/self-managed-deployments/upgrading/adopting-the-v1-crd.md
@@ -14,9 +14,12 @@ your Materialize instances.
 
 Starting in v26.30, Materialize introduces support for a new version of the
 Materialize CRD, `v1`, which provides simplified rollouts. Previously,
-Materialize only supported `v1alpha1`; `v1alpha1` remains the default.
+Materialize only supported `v1alpha1`. The Helm chart still defaults to
+`v1alpha1`, while the [Terraform
+modules](https://github.com/MaterializeInc/materialize-terraform-self-managed)
+default to `v1` starting in v4.0.0.
 
-- **v1alpha1** (default) uses a two-step rollout: first stage the spec
+- **v1alpha1** (Helm chart default) uses a two-step rollout: first stage the spec
   change, then trigger a rollout with a new `requestRollout` UUID.
 
   ```yaml
@@ -48,9 +51,10 @@ Materialize only supported `v1alpha1`; `v1alpha1` remains the default.
     backendSecretName: materialize-backend
   ```
 
-Adopting `v1` is **opt-in** for now. Upgrading the operator to v26.30+ does not
-change your existing `v1alpha1` CRs or their behavior; you can continue using
-`v1alpha1` until the next major release.
+When using the Helm chart, adopting `v1` is **opt-in** for now. When using the
+Terraform modules, `crd_version` defaults to `v1` starting in v4.0.0. Upgrading
+the operator to v26.30+ does not change your existing `v1alpha1` CRs or their
+behavior; you can continue using `v1alpha1` until the next major release.
 
 {{< important >}}
 
@@ -84,7 +88,8 @@ If you are using the [supported Terraform
 modules](https://github.com/MaterializeInc/materialize-terraform-self-managed),
 the required infrastructure changes (cert-manager and network ingress) and
 enabling of `v1` CRD will be handled for you automatically starting in TF
-modules (**v3.1.1 or greater**).
+modules (**v3.1.1 or greater**). Starting in TF modules **v4.0.0**, the
+`materialize-instance` module also defaults `crd_version` to `v1`.
 
 - If you have already upgraded your TF modules to **v3.1.1 or greater**, the
   prerequisites are handled automatically.
@@ -246,6 +251,9 @@ crd_version     = "v1"
 request_rollout = null
 ```
 
+Starting in Terraform module version v4.0.0, `crd_version` defaults to `v1`,
+so you can also omit it.
+
 **Once on v1, an unchanged spec will not trigger a rollout.** Reapplying the
 same spec produces the same hash and the same derived `requestRollout`. Changing
 a hashed spec field produces a new value and triggers a rollout automatically.
@@ -281,4 +289,6 @@ a hashed spec field produces a new value and triggers a rollout automatically.
 
 You can go back to the `v1alpha1` rollout behavior at any time by applying your
 CR with `apiVersion: materialize.cloud/v1alpha1` and an explicit
-`requestRollout` UUID.
+`requestRollout` UUID. With the Terraform modules, set `crd_version =
+"v1alpha1"` explicitly (required starting in v4.0.0, where `crd_version`
+defaults to `v1`) and set `request_rollout` to a new UUID.

--- a/doc/user/content/self-managed-deployments/upgrading/upgrade-on-aws.md
+++ b/doc/user/content/self-managed-deployments/upgrading/upgrade-on-aws.md
@@ -96,6 +96,9 @@ module "materialize_instance" {
 
 {{< self-managed/crd-version-note "v1alpha1" >}}
 
+{{< include-from-yaml data="self_managed/upgrades"
+name="upgrade-tf-v4-crd-version-default" >}}
+
 {{< include-from-yaml data="self_managed/crd_version_checks"
 name="check-crd-version-tf" >}}
 

--- a/doc/user/content/self-managed-deployments/upgrading/upgrade-on-azure.md
+++ b/doc/user/content/self-managed-deployments/upgrading/upgrade-on-azure.md
@@ -96,6 +96,9 @@ module "materialize_instance" {
 
 {{< self-managed/crd-version-note "v1alpha1" >}}
 
+{{< include-from-yaml data="self_managed/upgrades"
+name="upgrade-tf-v4-crd-version-default" >}}
+
 {{< include-from-yaml data="self_managed/crd_version_checks"
 name="check-crd-version-tf" >}}
 

--- a/doc/user/content/self-managed-deployments/upgrading/upgrade-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/upgrading/upgrade-on-gcp.md
@@ -96,6 +96,9 @@ module "materialize_instance" {
 
 {{< self-managed/crd-version-note "v1alpha1" >}}
 
+{{< include-from-yaml data="self_managed/upgrades"
+name="upgrade-tf-v4-crd-version-default" >}}
+
 {{< include-from-yaml data="self_managed/crd_version_checks"
 name="check-crd-version-tf" >}}
 

--- a/doc/user/data/self_managed/installation.yml
+++ b/doc/user/data/self_managed/installation.yml
@@ -89,10 +89,12 @@
 - name: installation-tfvars-crd-version-tip
   content: |
     {{< tip >}}
-    [CRD API version `v1`](/self-managed-deployments/upgrading/adopting-the-v1-crd/) is available starting in Materialize v26.30 and
-    Materialize Terraform module version v3.1.1.
-    For earlier versions, or if you want to remain on the default `v1alpha1`,
-    comment out the `crd_version` line or set it to `v1alpha1`.
+    Starting in Materialize Terraform module version v4.0.0, `crd_version`
+    defaults to [CRD API version
+    `v1`](/self-managed-deployments/upgrading/adopting-the-v1-crd/). `v1`
+    requires Materialize v26.30 or greater and is available starting in
+    Terraform module version v3.1.1. To use `v1alpha1` instead, set
+    `crd_version = "v1alpha1"`.
     {{< /tip >}}
 
 - name: installation-tfvars-variables-optional

--- a/doc/user/data/self_managed/upgrades.yml
+++ b/doc/user/data/self_managed/upgrades.yml
@@ -197,6 +197,17 @@
        kubectl -n materialize-environment describe pod -l app=environmentd
        ```
 
+- name: upgrade-tf-v4-crd-version-default
+  content: |
+    {{< important >}}
+    Starting in Terraform module version v4.0.0, `crd_version` defaults to
+    `v1`. If your instance uses `v1alpha1` and you are upgrading to module
+    version v4.0.0 or greater, set `crd_version = "v1alpha1"` explicitly to
+    stay on `v1alpha1`. Otherwise, applying migrates the instance to `v1` and
+    triggers a rollout. See [Adopting the v1
+    CRD](/self-managed-deployments/upgrading/adopting-the-v1-crd/).
+    {{< /important >}}
+
 - name: upgrade-request_rollout
   content: |
     **If you are using `v1alpha1`**, you need to update your `terraform.tfvars`

--- a/doc/user/layouts/partials/self-managed/crd-version-note.html
+++ b/doc/user/layouts/partials/self-managed/crd-version-note.html
@@ -7,9 +7,10 @@
 {{- $base := strings.TrimRight "/" (urls.Parse site.BaseURL).Path -}}
 {{- $adopt := printf "%s/self-managed-deployments/upgrading/adopting-the-v1-crd/" $base -}}
 {{- if eq $v "v1alpha1" -}}
-<p><code>v1alpha1</code> is the default CRD version for a Materialize instance.
+<p><code>v1alpha1</code> is the default CRD version for the Materialize Helm
+chart. The Terraform modules default to <code>v1</code> starting in v4.0.0.
 With <code>v1alpha1</code>, instance rollouts require manually rotating a
 UUID.</p>
 {{- else -}}
-<p>The <code>v1</code> CRD is available starting in v26.30 and is opt-in. See <a href="{{ $adopt }}">Adopting the v1 CRD</a> to enable it.</p>
+<p>The <code>v1</code> CRD is available starting in v26.30. It is opt-in for the Helm chart and the default for the Terraform modules starting in v4.0.0. See <a href="{{ $adopt }}">Adopting the v1 CRD</a> to enable it.</p>
 {{- end -}}


### PR DESCRIPTION
### Motivation

Starting in [materialize-terraform-self-managed v4.0.0](https://github.com/MaterializeInc/materialize-terraform-self-managed), the `crd_version` variable defaults to `v1`. The Helm chart still defaults to `v1alpha1`. The self-managed docs previously described `v1alpha1` as the single default and `v1` as opt-in everywhere.

### Changes

* Install guides (AWS/GCP/Azure) and the shared `installation.yml` tip: mark `v1` as the default starting in TF v4.0.0 and explain how to opt out with `crd_version = "v1alpha1"`.
* Terraform upgrade guides (AWS/GCP/Azure): add a shared warning that instances on `v1alpha1` must pin `crd_version = "v1alpha1"` explicitly when upgrading to module v4.0.0 or greater, since the new default migrates them to `v1` and triggers a rollout.
* Adopting the v1 CRD page: distinguish the Helm chart default (`v1alpha1`) from the Terraform module default (`v1` starting in v4.0.0), note that `crd_version` can be omitted on v4.0.0+, and document how to return to `v1alpha1` with Terraform.
* CRD field description pages and the shared `crd-version-note.html` partial: same Helm vs Terraform default distinction. Also fixes a pre-existing "default CRD version (default)" duplication on the v1alpha1 page.

Docs-only change, no tests. Verified with a local Hugo build.

### Tips for reviewer

Please double-check the wording in the new upgrade-guide warning: it assumes that applying TF v4.0.0 with `crd_version` unset migrates an existing `v1alpha1` instance to `v1` and triggers a rollout.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)