### PR TITLE
server: serve HTTP/2 on environmentd and balancerd HTTP endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "base64 0.22.1",
@@ -1295,7 +1295,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -3054,7 +3054,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4578,7 +4578,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4797,7 +4797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -4891,7 +4891,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4978,7 +4978,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5188,7 +5188,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -6976,6 +6976,7 @@ dependencies = [
  "tokio-metrics",
  "tokio-postgres",
  "tokio-stream",
+ "tokio-tungstenite 0.29.0",
  "tower 0.5.3",
  "tower-http",
  "tower-sessions",
@@ -6984,7 +6985,7 @@ dependencies = [
  "tracing-capture",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.29.0",
  "url",
  "uuid",
 ]
@@ -10508,7 +10509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -10529,7 +10530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11481,7 +11482,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -12604,7 +12605,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -12623,7 +12624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -13021,7 +13022,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -13490,6 +13503,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,7 +307,9 @@ aws-smithy-runtime = { version = "1.9.8", features = ["connector-hyper-0-14-x"] 
 aws-smithy-runtime-api = "1.10.0"
 aws-smithy-types = { version = "1.1.8", features = ["byte-stream-poll-next"] }
 aws-types = "1.3.9"
-axum = { version = "0.8.8", features = ["ws"] }
+# 0.8.9 minimum: 0.8.8 has a method-routing bug that registers CONNECT
+# handlers (needed for WebSockets over HTTP/2) under OPTIONS.
+axum = { version = "0.8.9", features = ["http2", "ws"] }
 axum-extra = { version = "0.12.5", features = ["typed-header"] }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 azure_core = "0.21.0"
@@ -384,12 +386,12 @@ http = "1.4.0"
 http-body-util = "0.1.3"
 httparse = "1.8.0"
 humantime = "2.3.0"
-hyper = { version = "1.9.0", features = ["http1", "server"] }
+hyper = { version = "1.9.0", features = ["client", "http1", "http2", "server"] }
 # hyper 0.14 is used by AWS SDK. Used to override the DNS resolver used by the SDK,
 # which can only be done by constructing the HTTP Client
 hyper-0-14 = { package = "hyper", version = "0.14", features = ["client", "tcp"] }
 hyper-openssl = "0.10.2"
-hyper-util = "0.1.20"
+hyper-util = { version = "0.1.20", features = ["server-auto", "tokio"] }
 tower-service = "0.3.3"
 iceberg = "0.9.0"
 iceberg-catalog-rest = "0.9.0"
@@ -480,7 +482,9 @@ rdkafka = { version = "0.29.0", features = ["cmake-build", "libz-static", "ssl-v
 rdkafka-sys = { version = "4.3.0", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = "1.12.3"
 regex-syntax = "0.8.10"
-reqwest = { version = "0.12.28", features = ["blocking", "charset", "cookies", "default-tls", "http2", "json", "native-tls-vendored", "stream"] }
+# `native-tls-alpn` is required for reqwest to negotiate HTTP/2 via ALPN with
+# the native-tls backend; without it clients silently stay on HTTP/1.1.
+reqwest = { version = "0.12.28", features = ["blocking", "charset", "cookies", "default-tls", "http2", "json", "native-tls-alpn", "native-tls-vendored", "stream"] }
 reqwest-middleware = { version = "0.4.2", features = ["json"] }
 reqwest-retry = "0.8.0"
 rlimit = "0.11.0"
@@ -541,6 +545,7 @@ tokio-openssl = "0.6.5"
 tokio-postgres = "0.7.15"
 tokio-stream = "0.1.18"
 tokio-test = "0.4.5"
+tokio-tungstenite = "0.29.0"
 tokio-util = "0.7.18"
 toml = "0.8.22"
 toml_edit = { version = "0.22.26", features = ["serde"] }
@@ -557,7 +562,7 @@ tracing-capture = "0.1.0"
 tracing-core = "0.1.35"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "json", "tracing-log"] }
-tungstenite = "0.28.0"
+tungstenite = "0.29.0"
 turmoil = "0.7.2"
 uncased = "0.9.10"
 unicode-normalization = "0.1.25"

--- a/deny.toml
+++ b/deny.toml
@@ -159,6 +159,10 @@ skip = [
     { name = "rand_core", version = "0.10.1" },
     { name = "getrandom", version = "0.4.2" },
     { name = "cpufeatures", version = "0.3.0" },
+    # Held back by kube-client; axum 0.8.9 uses tungstenite 0.29 for
+    # WebSockets.
+    { name = "tungstenite", version = "0.28.0" },
+    { name = "tokio-tungstenite", version = "0.28.0" },
 ]
 
 [[bans.deny]]

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -34,10 +34,9 @@ use bytes::BytesMut;
 use domain::base::{Name, Rtype};
 use domain::rdata::AllRecordData;
 use domain::resolv::StubResolver;
-use futures::TryFutureExt;
 use futures::stream::BoxStream;
 use hyper::StatusCode;
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use launchdarkly_server_sdk as ld;
 use mz_build_info::{BuildInfo, build_info};
 use mz_dyncfg::ConfigSet;
@@ -461,8 +460,11 @@ impl mz_server_core::Server for InternalHttpServer {
         let conn = TokioIo::new(conn);
 
         Box::pin(async {
-            let http = hyper::server::conn::http1::Builder::new();
-            http.serve_connection(conn, service).err_into().await
+            // Serve HTTP/1.1 or HTTP/2 (h2c via preface sniffing).
+            let http = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+            http.serve_connection(conn, service)
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
         })
     }
 }
@@ -1213,28 +1215,32 @@ impl mz_server_core::Server for HttpsBalancer {
             let active_guard = inner_metrics.active_connections();
             let result: Result<_, anyhow::Error> = Box::pin(async move {
                 let peer_addr = peer_addr.context("fetching peer addr")?;
-                let (mut client_stream, servername): (Box<dyn ClientStream>, Option<String>) =
-                    match tls_context {
-                        Some(tls_context) => {
-                            let mut ssl_stream =
-                                SslStream::new(Ssl::new(&tls_context.get())?, conn)?;
-                            if let Err(e) = Pin::new(&mut ssl_stream).accept().await {
-                                let _ = ssl_stream.get_mut().shutdown().await;
-                                return Err(e.into());
-                            }
-                            let servername: Option<String> =
-                                ssl_stream.ssl().servername(NameType::HOST_NAME).map(|sn| {
-                                    match sn.split_once('.') {
-                                        Some((left, _right)) => left,
-                                        None => sn,
-                                    }
-                                    .into()
-                                });
-                            debug!("Found sni servername: {servername:?} (https)");
-                            (Box::new(ssl_stream), servername)
+                let (mut client_stream, servername, client_h2): (
+                    Box<dyn ClientStream>,
+                    Option<String>,
+                    bool,
+                ) = match tls_context {
+                    Some(tls_context) => {
+                        let mut ssl_stream = SslStream::new(Ssl::new(&tls_context.get())?, conn)?;
+                        if let Err(e) = Pin::new(&mut ssl_stream).accept().await {
+                            let _ = ssl_stream.get_mut().shutdown().await;
+                            return Err(e.into());
                         }
-                        _ => (Box::new(conn), None),
-                    };
+                        let servername: Option<String> =
+                            ssl_stream.ssl().servername(NameType::HOST_NAME).map(|sn| {
+                                match sn.split_once('.') {
+                                    Some((left, _right)) => left,
+                                    None => sn,
+                                }
+                                .into()
+                            });
+                        debug!("Found sni servername: {servername:?} (https)");
+                        let client_h2 =
+                            ssl_stream.ssl().selected_alpn_protocol() == Some(b"h2".as_slice());
+                        (Box::new(ssl_stream), servername, client_h2)
+                    }
+                    _ => (Box::new(conn), None, false),
+                };
                 let resolved =
                     Self::resolve(&resolver, &resolve_template, port, servername.as_deref())
                         .await?;
@@ -1246,23 +1252,28 @@ impl mz_server_core::Server for HttpsBalancer {
                     Ok(stream) => stream,
                     Err(e) => {
                         error!("failed to connect to upstream server: {e}");
-                        let body = "upstream server not available";
                         // We know this is an HTTPs stream (see name
                         // HttpsBalancer), but we actually don't care what type
                         // of traffic it is and we only use raw tcp streams.In
                         // order to respond with HTTP we have to write this as a
-                        // raw http message.
-                        let response = format!(
-                            "HTTP/1.1 502 Bad Gateway\r\n\
-                             Content-Type: text/plain\r\n\
-                             Content-Length: {}\r\n\
-                             Connection: close\r\n\
-                             \r\n\
-                             {}",
-                            body.len(),
-                            body
-                        );
-                        let _ = client_stream.write_all(response.as_bytes()).await;
+                        // raw http message. This raw message is only
+                        // intelligible to HTTP/1 clients, though: clients that
+                        // negotiated HTTP/2 via ALPN just get a closed
+                        // connection.
+                        if !client_h2 {
+                            let body = "upstream server not available";
+                            let response = format!(
+                                "HTTP/1.1 502 Bad Gateway\r\n\
+                                 Content-Type: text/plain\r\n\
+                                 Content-Length: {}\r\n\
+                                 Connection: close\r\n\
+                                 \r\n\
+                                 {}",
+                                body.len(),
+                                body
+                            );
+                            let _ = client_stream.write_all(response.as_bytes()).await;
+                        }
                         let _ = client_stream.shutdown().await;
                         return Ok(());
                     }

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -263,6 +263,29 @@ async fn test_balancer() {
         let resp_x509 = X509::from_der(tlsinfo.peer_certificate().unwrap()).unwrap();
         let server_x509 = X509::from_pem(&std::fs::read(&server_cert).unwrap()).unwrap();
         assert_eq!(resp_x509, server_x509);
+        // The default client negotiates HTTP/2 with balancerd via ALPN; the
+        // HTTP/2 stream is byte-proxied through to environmentd.
+        assert_eq!(resp.version(), reqwest::Version::HTTP_2);
+        assert_contains!(resp.text().await.unwrap(), "12234");
+
+        // HTTP/1.1-only clients are still served.
+        let http1_client = reqwest::Client::builder()
+            .add_root_certificate(
+                reqwest::Certificate::from_pem(&ca.cert.to_pem().unwrap()).unwrap(),
+            )
+            .pool_max_idle_per_host(0)
+            .http1_only()
+            .build()
+            .unwrap();
+        let resp = http1_client
+            .post(&https_url)
+            .header("Content-Type", "application/json")
+            .basic_auth(frontegg_user, Some(&frontegg_password))
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.version(), reqwest::Version::HTTP_11);
         assert_contains!(resp.text().await.unwrap(), "12234");
 
         // Generate new certs. Install only the key, reload, and make sure the old cert is still in
@@ -381,5 +404,15 @@ async fn test_balancer() {
             })
             .await
             .unwrap();
+
+        // The internal HTTP server serves h2c (HTTP/2 with prior knowledge)
+        // alongside HTTP/1.1.
+        let h2c_client = reqwest::Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .unwrap();
+        let resp = h2c_client.get(&metrics_url).send().await.unwrap();
+        assert_eq!(resp.version(), reqwest::Version::HTTP_2);
+        assert!(resp.status().is_success());
     }
 }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -150,6 +150,7 @@ serde_urlencoded.workspace = true
 similar-asserts.workspace = true
 timely.workspace = true
 tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-tungstenite.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -68,7 +68,7 @@ use axum::extract::{ConnectInfo, DefaultBodyLimit, FromRequestParts, Query, Requ
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum::{Extension, Json, Router, routing};
-use futures::future::{Shared, TryFutureExt};
+use futures::future::Shared;
 use headers::authorization::{Authorization, Basic, Bearer};
 use headers::{HeaderMapExt, HeaderName};
 use http::header::{AUTHORIZATION, CONTENT_TYPE};
@@ -76,7 +76,7 @@ use http::uri::Scheme;
 use http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use hyper_openssl::SslStream;
 use hyper_openssl::client::legacy::MaybeHttpsStream;
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use mz_adapter::session::{Session as AdapterSession, SessionConfig as AdapterSessionConfig};
 use mz_adapter::{AdapterError, AdapterNotice, Client, SessionClient, WebhookAppenderCache};
 use mz_adapter_types::dyncfgs::OIDC_GROUP_CLAIM;
@@ -321,7 +321,12 @@ impl HttpServer {
             base_router = base_router.merge(base_group);
 
             let mut ws_router = Router::new()
-                .route("/api/experimental/sql", routing::get(sql::handle_sql_ws))
+                // WebSockets arrive as a GET with the `Upgrade` header on
+                // HTTP/1.1 and as an extended CONNECT (RFC 8441) on HTTP/2.
+                .route(
+                    "/api/experimental/sql",
+                    routing::get(sql::handle_sql_ws).connect(sql::handle_sql_ws),
+                )
                 .with_state(WsState {
                     frontegg,
                     oidc_rx: oidc_rx.clone(),
@@ -714,11 +719,16 @@ impl Server for HttpServer {
                 .into_make_service_with_connect_info::<SocketAddr>();
             let tower_svc = make_tower_svc.call(peer_addr).await.unwrap();
             let hyper_svc = hyper::service::service_fn(|req| tower_svc.clone().call(req));
-            let http = hyper::server::conn::http1::Builder::new();
-            http.serve_connection(conn, hyper_svc)
-                .with_upgrades()
-                .err_into()
+            // Serve HTTP/1.1 or HTTP/2, detected via TLS ALPN or, on
+            // plaintext connections, by sniffing the HTTP/2 preface.
+            let mut http = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+            // Advertise RFC 8441 extended CONNECT so that clients can open
+            // WebSockets over HTTP/2. Clients that don't support it (or that
+            // negotiated HTTP/1.1) still use the HTTP/1.1 upgrade path.
+            http.http2().enable_connect_protocol();
+            http.serve_connection_with_upgrades(conn, hyper_svc)
                 .await
+                .map_err(|e| anyhow::anyhow!(e))
         })
     }
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -7165,3 +7165,264 @@ fn test_inject_audit_events_malformed() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
+
+// Test that the HTTP server negotiates HTTP/2 over TLS via ALPN and that
+// HTTP/1.1-only clients can still connect.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_http2_tls() {
+    let ca = Ca::new_root("test ca").unwrap();
+    let (server_cert, server_key) = ca
+        .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+        .unwrap();
+    let server = test_util::TestHarness::default()
+        .with_tls(server_cert, server_key)
+        .start()
+        .await;
+
+    let https_url = Url::parse(&format!("https://{}/api/sql", server.http_local_addr())).unwrap();
+    let json: serde_json::Value = serde_json::from_str(r#"{ "query": "SELECT 42;" }"#).unwrap();
+    let ca_cert = reqwest::Certificate::from_pem(&ca.cert.to_pem().unwrap()).unwrap();
+
+    // A client that supports HTTP/2 negotiates it via ALPN.
+    let client = reqwest::Client::builder()
+        .add_root_certificate(ca_cert.clone())
+        .build()
+        .unwrap();
+    let response = client
+        .post(https_url.clone())
+        .json(&json)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.version(), reqwest::Version::HTTP_2);
+    assert!(response.status().is_success());
+    assert_contains!(response.text().await.unwrap(), "42");
+
+    // An HTTP/1.1-only client is still served.
+    let client = reqwest::Client::builder()
+        .add_root_certificate(ca_cert)
+        .http1_only()
+        .build()
+        .unwrap();
+    let response = client.post(https_url).json(&json).send().await.unwrap();
+    assert_eq!(response.version(), reqwest::Version::HTTP_11);
+    assert!(response.status().is_success());
+    assert_contains!(response.text().await.unwrap(), "42");
+}
+
+// Test that plaintext listeners serve both HTTP/1.1 and HTTP/2 (h2c via
+// prior knowledge).
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_http2_cleartext() {
+    let server = test_util::TestHarness::default().start().await;
+
+    let http_url = Url::parse(&format!("http://{}/api/sql", server.http_local_addr())).unwrap();
+    let json: serde_json::Value = serde_json::from_str(r#"{ "query": "SELECT 42;" }"#).unwrap();
+
+    // HTTP/2 with prior knowledge (h2c).
+    let client = reqwest::Client::builder()
+        .http2_prior_knowledge()
+        .build()
+        .unwrap();
+    let response = client
+        .post(http_url.clone())
+        .json(&json)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.version(), reqwest::Version::HTTP_2);
+    assert!(response.status().is_success());
+    assert_contains!(response.text().await.unwrap(), "42");
+
+    // Plain HTTP/1.1 is unchanged.
+    let response = reqwest::Client::new()
+        .post(http_url)
+        .json(&json)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.version(), reqwest::Version::HTTP_11);
+    assert!(response.status().is_success());
+    assert_contains!(response.text().await.unwrap(), "42");
+}
+
+// Test WebSockets over HTTP/2 (RFC 8441 extended CONNECT): authentication
+// works over an HTTP/2 stream, bad credentials are rejected, and the HTTP/1.1
+// WebSocket upgrade (the downgrade path) keeps working against the same
+// server.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_http2_websocket_auth() {
+    use futures::{SinkExt, StreamExt};
+    use mz_auth::password::Password;
+
+    type WsStream =
+        tokio_tungstenite::WebSocketStream<hyper_util::rt::TokioIo<hyper::upgrade::Upgraded>>;
+
+    // Reads messages until the initial ReadyForQuery, mirroring
+    // `test_util::auth_with_ws_impl` for async streams.
+    async fn read_until_ready(ws: &mut WsStream) -> Result<Vec<WebSocketResponse>, anyhow::Error> {
+        let mut msgs = Vec::new();
+        loop {
+            let msg = ws
+                .next()
+                .await
+                .ok_or_else(|| anyhow::anyhow!("ws stream ended"))??;
+            match msg {
+                Message::Text(text) => {
+                    let msg: WebSocketResponse = serde_json::from_str(&text).unwrap();
+                    match msg {
+                        WebSocketResponse::ReadyForQuery(_) => return Ok(msgs),
+                        msg => msgs.push(msg),
+                    }
+                }
+                Message::Ping(_) => continue,
+                Message::Close(frame) => anyhow::bail!("ws closed: {frame:?}"),
+                other => panic!("unexpected message: {other:?}"),
+            }
+        }
+    }
+
+    let server = test_util::TestHarness::default()
+        .with_system_parameter_default("enable_password_auth".to_string(), "true".to_string())
+        .with_password_auth(Password("mz_system_password".to_owned()))
+        .start()
+        .await;
+
+    // Opens a WebSocket over an HTTP/2 stream via extended CONNECT.
+    let connect_ws_http2 = || async {
+        let tcp = tokio::net::TcpStream::connect(server.http_local_addr())
+            .await
+            .unwrap();
+        let (mut sender, conn) =
+            hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new())
+                .handshake::<_, http_body_util::Empty<bytes::Bytes>>(hyper_util::rt::TokioIo::new(
+                    tcp,
+                ))
+                .await
+                .unwrap();
+        // The client can only send extended CONNECT after the server's
+        // SETTINGS frame advertising it has arrived, so drive the connection
+        // until it has been processed.
+        let mut conn = Box::pin(conn);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !conn.is_extended_connect_protocol_enabled() {
+            assert!(
+                Instant::now() < deadline,
+                "server did not advertise RFC 8441 extended CONNECT"
+            );
+            let _ = futures::poll!(conn.as_mut());
+            tokio::task::yield_now().await;
+        }
+        task::spawn(|| "h2_ws_conn", async move {
+            let _ = conn.await;
+        });
+        let req = Request::builder()
+            .method("CONNECT")
+            .extension(hyper::ext::Protocol::from_static("websocket"))
+            .uri("/api/experimental/sql")
+            .header("host", server.http_local_addr().to_string())
+            .header("sec-websocket-version", "13")
+            .body(http_body_util::Empty::<bytes::Bytes>::new())
+            .unwrap();
+        let response = sender.send_request(req).await.unwrap();
+        assert_eq!(response.version(), http::Version::HTTP_2);
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "headers: {:?}",
+            response.headers()
+        );
+        let upgraded = hyper::upgrade::on(response).await.unwrap();
+        tokio_tungstenite::WebSocketStream::from_raw_socket(
+            hyper_util::rt::TokioIo::new(upgraded),
+            tungstenite::protocol::Role::Client,
+            None,
+        )
+        .await
+    };
+
+    let auth_json = |password: &str| {
+        serde_json::to_string(&WebSocketAuth::Basic {
+            user: "mz_system".into(),
+            password: Password(password.to_owned()),
+            options: BTreeMap::default(),
+        })
+        .unwrap()
+    };
+
+    // WebSocket over HTTP/2 with valid credentials: authenticates and runs a
+    // query.
+    let mut ws = connect_ws_http2().await;
+    ws.send(Message::Text(auth_json("mz_system_password").into()))
+        .await
+        .unwrap();
+    read_until_ready(&mut ws).await.unwrap();
+    ws.send(Message::Text(r#"{"query": "SELECT 'row42'"}"#.into()))
+        .await
+        .unwrap();
+    let mut saw_row = false;
+    loop {
+        match ws.next().await.unwrap().unwrap() {
+            Message::Text(text) => match serde_json::from_str(&text).unwrap() {
+                WebSocketResponse::Row(row) => {
+                    assert_eq!(row, vec![serde_json::json!("row42")]);
+                    saw_row = true;
+                }
+                WebSocketResponse::ReadyForQuery(_) => break,
+                _ => {}
+            },
+            Message::Ping(_) => continue,
+            other => panic!("unexpected message: {other:?}"),
+        }
+    }
+    assert!(saw_row, "expected a row from SELECT over HTTP/2 WebSocket");
+
+    // WebSocket over HTTP/2 with bad credentials: the server closes the
+    // socket without revealing detail.
+    let mut ws = connect_ws_http2().await;
+    ws.send(Message::Text(auth_json("wrong_password").into()))
+        .await
+        .unwrap();
+    let err = read_until_ready(&mut ws).await.unwrap_err();
+    assert_contains!(err.to_string(), "unauthorized");
+
+    // Downgrade: the same server still serves HTTP/1.1 WebSocket upgrades,
+    // with the same authentication behavior.
+    let (mut ws, _resp) = tungstenite::connect(server.ws_addr()).unwrap();
+    test_util::auth_with_ws_impl(
+        &mut ws,
+        Message::Text(auth_json("mz_system_password").into()),
+    )
+    .unwrap();
+    ws.send(Message::Text(r#"{"query": "SELECT 'row42'"}"#.into()))
+        .unwrap();
+    let mut saw_row = false;
+    loop {
+        match ws.read().unwrap() {
+            Message::Text(text) => match serde_json::from_str(&text).unwrap() {
+                WebSocketResponse::Row(row) => {
+                    assert_eq!(row, vec![serde_json::json!("row42")]);
+                    saw_row = true;
+                }
+                WebSocketResponse::ReadyForQuery(_) => break,
+                _ => {}
+            },
+            Message::Ping(_) => continue,
+            other => panic!("unexpected message: {other:?}"),
+        }
+    }
+    assert!(
+        saw_row,
+        "expected a row from SELECT over HTTP/1.1 WebSocket"
+    );
+
+    // HTTP/1.1 with bad credentials is also still rejected.
+    let (mut ws, _resp) = tungstenite::connect(server.ws_addr()).unwrap();
+    let err =
+        test_util::auth_with_ws_impl(&mut ws, Message::Text(auth_json("wrong_password").into()))
+            .unwrap_err();
+    assert_contains!(format!("{err:?}"), "unauthorized");
+}

--- a/src/server-core/src/lib.rs
+++ b/src/server-core/src/lib.rs
@@ -29,7 +29,7 @@ use mz_ore::error::ErrorExt;
 use mz_ore::netio::AsyncReady;
 use mz_ore::option::OptionExt;
 use mz_ore::task::JoinSetExt;
-use openssl::ssl::{SslAcceptor, SslContext, SslFiletype, SslMethod};
+use openssl::ssl::{AlpnError, SslAcceptor, SslContext, SslFiletype, SslMethod, select_next_proto};
 use proxy_header::{ParseConfig, ProxiedAddress, ProxyHeader};
 use schemars::JsonSchema;
 use scopeguard::ScopeGuard;
@@ -492,6 +492,13 @@ impl TlsCertConfig {
         // ciphers. We once tried to use the modern preset, but it was
         // incompatible with Fivetran, and presumably other JDBC-based tools.
         let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls())?;
+        // Negotiate HTTP/2 or HTTP/1.1 via ALPN for clients that request it.
+        // This context is shared with pgwire listeners, but pgwire clients do
+        // not send the ALPN extension, in which case `NOACK` omits ALPN from
+        // the handshake entirely rather than rejecting the connection.
+        builder.set_alpn_select_callback(|_ssl, client_protos| {
+            select_next_proto(b"\x02h2\x08http/1.1", client_protos).ok_or(AlpnError::NOACK)
+        });
         builder.set_certificate_chain_file(&self.cert)?;
         builder.set_private_key_file(&self.key, SslFiletype::PEM)?;
         Ok(builder.build().into_context())


### PR DESCRIPTION
### Description

Negotiate HTTP/2 or HTTP/1.1 via TLS ALPN and serve both protocols with hyper's auto builder (h2c via preface sniffing on plaintext listeners). HTTP/1.1-only clients are unaffected. pgwire listeners share the TLS context, but pgwire clients do not send ALPN, so the negotiation callback no-ops for them.

balancerd remains a byte proxy for HTTPS: HTTP/2 frames pass through to environmentd unchanged. Its raw HTTP/1.1 502 fallback is now skipped for clients that negotiated h2, and its internal HTTP server serves h2c.

Also accept WebSockets over HTTP/2 (RFC 8441 extended CONNECT): environmentd advertises SETTINGS_ENABLE_CONNECT_PROTOCOL and the /api/experimental/sql route accepts CONNECT in addition to GET. This requires axum >= 0.8.9, as 0.8.8 has a method-routing bug that registers CONNECT handlers under OPTIONS. The axum bump pulls tungstenite 0.29, which duplicates the 0.28 pinned by kube-client, so deny.toml gains skip entries for the old versions.

Tests: HTTP/2 over TLS with HTTP/1.1 downgrade, h2c prior knowledge, WebSocket authentication (valid and invalid credentials) over both HTTP/2 and HTTP/1.1, and h2/h1.1/h2c assertions through balancerd.

Remove these sections if your commit already has a good description!

### Motivation
Bring us to a newer standardized protocol. http2 has been around since 2015 and is supported by all major browsers. It's not a huge perf win, but it is nice

```
┌────────────────────────────────────────┬─────────┬─────────┬───────┬───────────┐
│       Scenario (console pattern)       │ h1 wall │ h2 wall │ h1/h2 │ p95 ratio │
├────────────────────────────────────────┼─────────┼─────────┼───────┼───────────┤
│ 200 sequential SELECT 1 (polling)      │ 1522ms  │ 1431ms  │ 1.06x │ 1.01x     │
├────────────────────────────────────────┼─────────┼─────────┼───────┼───────────┤
│ 32 concurrent × 10 (page load)         │ 876ms   │ 520ms   │ 1.68x │ 1.50x     │
├────────────────────────────────────────┼─────────┼─────────┼───────┼───────────┤
│ Fresh TLS conn per request (cold)      │ 283ms   │ 288ms   │ 0.98x │ 1.15x     │
├────────────────────────────────────────┼─────────┼─────────┼───────┼───────────┤
│ 250KB result, sequential (data fetch)  │ 2701ms  │ 2730ms  │ 0.99x │ 0.99x     │
├────────────────────────────────────────┼─────────┼─────────┼───────┼───────────┤
│ 8 × 250KB concurrent (dashboard panes) │ 1438ms  │ 811ms   │ 1.77x │ 1.77x     │
├────────────────────────────────────────┼─────────┼─────────┼───────┼───────────┤
│ 100 concurrent small (busy page load)  │ 929ms   │ 472ms   │ 1.97x │ 1.83x     │
└────────────────────────────────────────┴─────────┴─────────┴───────┴───────────┘
```



### Verification

Tests added, will also deploy on my personal stack before marking the PR as ready. 
