### PR TITLE
containers: move the materialized image to a debian-slim base

### DIFF
--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -20,6 +20,9 @@ FROM debian:13-slim
 
 ARG CI_SANITIZER=none
 
+ARG BUILD_PROFILE=optimize
+LABEL build.profile=$BUILD_PROFILE
+
 RUN groupadd --system --gid=999 materialize \
     && useradd --system --gid=999 --uid=999 --create-home materialize \
     && apt-get update \

--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -14,7 +14,9 @@ MZFROM console AS console
 # Statically-linked `ssh` client, used by the SSH tunnel feature.
 MZFROM openssh-static AS openssh-static
 
-MZFROM ubuntu-base
+# Debian 13, matching the distroless base env/clusterd use so every Materialize
+# binary runs on the same glibc and system libraries.
+FROM debian:13-slim
 
 ARG CI_SANITIZER=none
 
@@ -24,9 +26,11 @@ RUN groupadd --system --gid=999 materialize \
     && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends \
         ca-certificates \
         curl \
+        eatmydata \
         gettext-base \
+        liblzma5 \
         nginx \
-        postgresql-16 \
+        postgresql-17 \
         tini \
     && if [ "$CI_SANITIZER" != "none" ]; then \
         TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends llvm; \
@@ -35,22 +39,22 @@ RUN groupadd --system --gid=999 materialize \
     && apt-get clean \
     && rm -rf /var/lib/postgresql \
     # Remove unused PostgreSQL binaries (keep only postgres, initdb, pg_isready, pg_ctl, psql) \
-    && find /usr/lib/postgresql/16/bin -type f \
+    && find /usr/lib/postgresql/17/bin -type f \
         ! -name postgres ! -name initdb ! -name pg_isready ! -name pg_ctl ! -name psql \
         -delete \
     # Remove PostgreSQL client binaries except psql \
     && find /usr/bin -name 'pg_*' -delete \
     # Remove docs, man pages \
-    && rm -rf /usr/share/postgresql/16/man \
+    && rm -rf /usr/share/postgresql/17/man \
     && rm -rf /usr/share/doc/postgresql* \
     # Remove LLVM bitcode (PostgreSQL JIT support, not used) \
-    && rm -rf /usr/lib/postgresql/16/lib/bitcode \
+    && rm -rf /usr/lib/postgresql/17/lib/bitcode \
     # Remove pgxs (extension build infrastructure) \
-    && rm -rf /usr/lib/postgresql/16/lib/pgxs \
+    && rm -rf /usr/lib/postgresql/17/lib/pgxs \
     # Remove static libraries \
     && find /usr/lib/postgresql -name '*.a' -delete \
     # Remove unused extension SQL files (keep only plpgsql which is needed for initdb) \
-    && find /usr/share/postgresql/16/extension -type f \
+    && find /usr/share/postgresql/17/extension -type f \
         ! -name 'plpgsql*' -delete \
     # Remove nginx docs and unnecessary files \
     && rm -rf /usr/share/doc/nginx* \
@@ -58,6 +62,11 @@ RUN groupadd --system --gid=999 materialize \
     && mkdir -p /mzdata /scratch /var/run/postgresql /var/lib/nginx /var/log/nginx \
     && touch /run/nginx.pid \
     && chown -R materialize /mzdata /scratch /var/run/postgresql /var/lib/nginx /var/log/nginx /run/nginx.pid
+
+# FoundationDB client library, dynamically linked by materialized. Keep this
+# version identical to the COPY in ubuntu-base and distroless-prod-base: all
+# three share one FoundationDB cluster during a rolling upgrade.
+COPY --from=foundationdb/foundationdb:7.3.71 /usr/lib/libfdb_c.so /usr/lib/
 
 COPY postgresql.conf pg_hba.conf /etc/postgresql/
 

--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -14,8 +14,8 @@ MZFROM console AS console
 # Statically-linked `ssh` client, used by the SSH tunnel feature.
 MZFROM openssh-static AS openssh-static
 
-# Debian 13, matching the distroless base env/clusterd use so every Materialize
-# binary runs on the same glibc and system libraries.
+# In production, we use distroless images based on Debian 13.
+# We retain apt and install more packages in this image for development.
 FROM debian:13-slim
 
 ARG CI_SANITIZER=none

--- a/misc/images/materialized-base/postgresql.conf
+++ b/misc/images/materialized-base/postgresql.conf
@@ -10,7 +10,7 @@
 data_directory = '/mzdata/postgres'
 hba_file = '/etc/postgresql/pg_hba.conf'
 ident_file = '/mzdata/postgres/pg_ident.conf'
-external_pid_file = '/var/run/postgresql/16-main.pid'
+external_pid_file = '/var/run/postgresql/17-main.pid'
 listen_addresses = '*'
 port = 26257
 max_connections = 5000

--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -90,9 +90,6 @@ class Clusterd(Service):
         # Override the materialized entrypoint so that `clusterd` is invoked
         # via the command rather than via the entrypoint. This keeps
         # `c.exec()` working (it prepends the entrypoint to exec commands).
-        # Note: mzcompose uses the Ubuntu-based `materialized` image (with
-        # tini/bash), while production uses the distroless `clusterd` image.
-        # Keep this in mind when debugging CI-vs-prod discrepancies.
         config["entrypoint"] = ["tini", "--"]
 
         # Depending on the Docker Compose version, this may either work or be

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -15,7 +15,7 @@ COPY listener_configs/v26_32_0/ /listener_configs/
 
 USER materialize
 
-RUN /usr/lib/postgresql/16/bin/initdb -D /mzdata/postgres -U root --auth-local=trust
+RUN /usr/lib/postgresql/17/bin/initdb -D /mzdata/postgres -U root --auth-local=trust
 
 COPY materialized entrypoint.sh /usr/local/bin/
 

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -63,12 +63,12 @@ if ! is_truthy "${MZ_NO_BUILTIN_POSTGRES:-0}"; then
   # Should exist already, but /mzdata might be overwritten with a fresh volume
   if [ ! -f $PGDATA/PG_VERSION ]; then
     mkdir -p $PGDATA
-    /usr/lib/postgresql/16/bin/initdb -D $PGDATA -U $PGUSER --auth-local=trust
+    /usr/lib/postgresql/17/bin/initdb -D $PGDATA -U $PGUSER --auth-local=trust
   fi
 
   # Might have been killed hard
   rm -f $PGDATA/postmaster.pid
-  /usr/lib/postgresql/16/bin/postgres -D $PGDATA \
+  /usr/lib/postgresql/17/bin/postgres -D $PGDATA \
       -c listen_addresses='*' \
       -c unix_socket_directories=/var/run/postgresql \
       -c config_file=/etc/postgresql/postgresql.conf > /mzdata/postgres/postgres.log 2>&1 &
@@ -76,7 +76,7 @@ if ! is_truthy "${MZ_NO_BUILTIN_POSTGRES:-0}"; then
 
   trap 'kill -INT $PGPID; wait $PGPID' SIGTERM SIGINT
 
-  until /usr/lib/postgresql/16/bin/pg_isready > /dev/null 2>&1; do
+  until /usr/lib/postgresql/17/bin/pg_isready > /dev/null 2>&1; do
     sleep 0.01
   done
 


### PR DESCRIPTION
Move the all-in-one `materialized` image from an Ubuntu base to **`debian:13-slim`**, so every Materialize binary runs on the same userland.

## Why

`environmentd` and `clusterd` run on a distroless `cc-debian13` base (debian 13, glibc 2.41), while `materialized` still ran on Ubuntu. That meant the same binaries executed against different glibc and system-library versions, a source of behavior drift that's easy to miss. Basing `materialized` on `debian:13-slim` puts all three on one userland (debian 13 / glibc 2.41).

## PostgreSQL 16 → 17

`materialized` bundles PostgreSQL as its metadata store. debian 13 (trixie) ships PostgreSQL **17** in its own repositories, so the bundle moves to 17 rather than adding a third-party apt repo to pin 16. This image explicitly **does not support version upgrades** (see its entrypoint warning), so the major-version change carries no data-directory migration path. First start `initdb`s a fresh pg17 data dir as before.

One caveat, in already-unsupported territory: a `/mzdata` volume initialized by an older pg16 image is not readable by pg17 (the entrypoint would `initdb` only on an empty dir), so reusing such a volume requires re-initializing. This is the demo/quickstart image, not a supported upgrade path.

## Details

- Runtime libraries previously inherited from `ubuntu-base` are now provided directly: `libfdb_c.so` (copied from the pinned `foundationdb` image, kept in sync with `ubuntu-base`/`distroless-prod-base`), `liblzma`, and `eatmydata`.
- The existing PostgreSQL and nginx trimming (keep only the five server binaries, drop docs/JIT bitcode/pgxs/static libs/unused extensions) is preserved, retargeted to the `/17/` paths.
- `ubuntu-base` and its other consumers are untouched.

## Test plan
- [x] Standalone image on `debian:13-slim` builds and resolves every dependency: postgres 17.10 + psql, nginx, `envsubst`, tini, `libfdb_c.so`, `liblzma.so.5`; glibc 2.41 (matching the distroless base); binary trim intact (`initdb pg_ctl pg_isready postgres psql`).
- [ ] CI image build + the `materialized`/quickstart smoke tests.

Stacked on the environmentd/clusterd distroless migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
