### PR TITLE
benchmark: fix correctness bugs in the three benchmark frameworks

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import copy
 import time
 
 from materialize.feature_benchmark.aggregation import Aggregation
@@ -49,10 +50,21 @@ class Benchmark:
         self._performance_aggregation = aggregation_class()
         self._default_size = default_size
         self._seed = seed
+        self._measure_memory = measure_memory
 
-        if measure_memory:
-            self._memory_mz_aggregation = aggregation_class()
-            self._memory_clusterd_aggregation = aggregation_class()
+        # Always create the memory aggregations so run() can return them and
+        # run_measurement can reference them unconditionally; whether they are
+        # populated is gated by self._measure_memory.
+        self._memory_mz_aggregation = aggregation_class()
+        self._memory_clusterd_aggregation = aggregation_class()
+
+        # Each measurement stream gets its own filter so the warmup discard
+        # counter is not shared. self._filter is the performance stream; a
+        # single shared FilterFirst(3) would spend all three discards on the
+        # first iteration (wallclock + both memory measurements), dropping only
+        # one warmup iteration instead of three.
+        self._memory_mz_filter = copy.deepcopy(filter)
+        self._memory_clusterd_filter = copy.deepcopy(filter)
 
     def create_scenario_instance(self) -> Scenario:
         scale = self._scenario_cls.SCALE
@@ -176,14 +188,18 @@ class Benchmark:
 
         self._collect_performance_measurement(i, performance_measurement)
 
-        if self._memory_mz_aggregation:
+        if self._measure_memory:
             self._collect_memory_measurement(
-                i, MeasurementType.MEMORY_MZ, self._memory_mz_aggregation
+                i,
+                MeasurementType.MEMORY_MZ,
+                self._memory_mz_aggregation,
+                self._memory_mz_filter,
             )
-
-        if self._memory_clusterd_aggregation:
             self._collect_memory_measurement(
-                i, MeasurementType.MEMORY_CLUSTERD, self._memory_clusterd_aggregation
+                i,
+                MeasurementType.MEMORY_CLUSTERD,
+                self._memory_clusterd_aggregation,
+                self._memory_clusterd_filter,
             )
 
         return performance_measurement
@@ -209,7 +225,11 @@ class Benchmark:
             self._performance_aggregation.append_measurement(performance_measurement)
 
     def _collect_memory_measurement(
-        self, i: int, memory_measurement_type: MeasurementType, aggregation: Aggregation
+        self,
+        i: int,
+        memory_measurement_type: MeasurementType,
+        aggregation: Aggregation,
+        filter: Filter,
     ) -> None:
         if memory_measurement_type == MeasurementType.MEMORY_MZ:
             value = self._executor.DockerMemMz()
@@ -224,6 +244,6 @@ class Benchmark:
         )
 
         if memory_measurement.value > 0:
-            if not self._filter or not self._filter.filter(memory_measurement):
+            if not filter or not filter.filter(memory_measurement):
                 print(f"{i} {memory_measurement}")
                 aggregation.append_measurement(memory_measurement)

--- a/misc/python/materialize/feature_benchmark/benchmark_result.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_result.py
@@ -84,7 +84,11 @@ class BenchmarkScenarioMetric(Generic[T]):
         return self._points[0]
 
     def points_this(self) -> list[T]:
-        return self._points
+        # Only the THIS-side value. _points also holds the OTHER (baseline)
+        # value at index 1 for the this-vs-other comparison, but it must not
+        # leak into THIS-side stats (e.g. the analytics min/max/mean/variance),
+        # which would otherwise mix HEAD with the baseline.
+        return self._points[:1]
 
     def this_as_str(self) -> str:
         if self.this() is None:

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -231,6 +231,11 @@ class ReuseConnQuery(Action):
         self.query = query
         self.conn_info = conn_info
         self.strict_serializable = strict_serializable
+        # An OpenLoop dispatches a single shared action instance to the worker
+        # pool, so under backlog several threads can call _run concurrently.
+        # psycopg forbids concurrent use of one cursor/connection, so serialize
+        # access to the reused connection.
+        self.lock = threading.Lock()
         self._reconnect()
 
     def _reconnect(self) -> None:
@@ -242,7 +247,8 @@ class ReuseConnQuery(Action):
         )
 
     def _run(self, conns: queue.Queue):
-        execute_query(self.cur, self.query)
+        with self.lock:
+            execute_query(self.cur, self.query)
 
     def __str__(self) -> str:
         return f"{self.query} (reuse connection)"
@@ -255,16 +261,23 @@ class PooledQuery(Action):
 
     def _run(self, conns: queue.Queue):
         conn = conns.get()
-        with conn.cursor() as cur:
+        try:
             try:
-                execute_query(cur, self.query)
+                with conn.cursor() as cur:
+                    execute_query(cur, self.query)
             except psycopg.OperationalError as e:
                 print(f"Connection failed on query '{self.query}', reconnecting: {e}")
                 conn.close()
                 conn = self.conn_info.connect()
-                execute_query(cur, self.query)
-        conns.task_done()
-        conns.put(conn)
+                conn.autocommit = True
+                with conn.cursor() as cur:
+                    execute_query(cur, self.query)
+        finally:
+            # Always return a slot to the pool, even if the retry also failed.
+            # Otherwise repeated failures drain the pool and pooled actions
+            # block forever on conns.get().
+            conns.task_done()
+            conns.put(conn)
 
     def __str__(self) -> str:
         return f"{self.query} (pooled)"
@@ -348,7 +361,10 @@ class OpenLoop(PhaseAction):
         state: State,
     ) -> None:
         for start_time in self.dist.generate(duration, str(self.action), state):
-            jobs.put(lambda: self.action.run(start_time, conns, state))
+            # Bind start_time now. A late-bound closure would read the loop's
+            # latest value once a backlogged job finally runs, dropping the
+            # queue-wait time this open-loop benchmark exists to measure.
+            jobs.put(lambda st=start_time: self.action.run(st, conns, state))
 
 
 class ClosedLoop(PhaseAction):
@@ -430,6 +446,11 @@ def run_job(jobs: queue.Queue) -> None:
             if not job:
                 return
             job()
+        except Exception as e:
+            # Keep the worker alive on action failures. A dying worker would
+            # never consume its teardown() sentinel, so jobs.join() would
+            # deadlock and hang the run instead of failing fast.
+            print(f"Job failed, continuing: {e}")
         finally:
             jobs.task_done()
 

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -367,7 +367,7 @@ class ConnectRead(Scenario):
                 ),
             ],
             guarantees={
-                "SELECT * FROM t4 (pooled)": {"qps": 35, "max": 700},
+                "SELECT 1 (standalone)": {"qps": 35, "max": 700},
             },
         )
 

--- a/misc/python/materialize/scalability/executor/benchmark_executor.py
+++ b/misc/python/materialize/scalability/executor/benchmark_executor.py
@@ -118,10 +118,12 @@ class BenchmarkExecutor:
         # Targeted retries: re-run both baseline and HEAD at regressed
         # concurrency levels. Re-running only HEAD is not sufficient because
         # the baseline may have had an anomalously good measurement.
+        did_retry = False
         for retry in range(MAX_RETRIES_ON_REGRESSION):
             if not outcome.has_regressions():
                 break
 
+            did_retry = True
             regressed_concurrencies = [r.concurrency for r in outcome.regressions]
             print(
                 f"Potential regression in workload {workload_name} at concurrencies "
@@ -207,6 +209,14 @@ class BenchmarkExecutor:
                 baseline_result,
                 other_endpoint_result,
             )
+
+        if did_retry:
+            # Persist the retried measurements over the original run's. Without
+            # this the CSVs, plots, and test-analytics upload keep the anomalous
+            # first-run numbers while pass/fail is decided on the retried ones,
+            # so a green run could still upload the regression.
+            self._persist_workload_result(baseline_result)
+            self._persist_workload_result(other_endpoint_result)
 
         return outcome
 
@@ -487,3 +497,21 @@ class BenchmarkExecutor:
         )
 
         self.result.append_workload_result(endpoint_version_info, result)
+
+    def _persist_workload_result(self, result: WorkloadResult) -> None:
+        """Record a workload result and (over)write its CSVs.
+
+        Safe to call again after retries: append_workload_result replaces the
+        prior entry for the same endpoint and workload, and the CSVs are
+        rewritten from the final dataframes."""
+        endpoint_version_name = result.endpoint.try_load_version()
+        pathlib.Path(paths.endpoint_dir(endpoint_version_name)).mkdir(
+            parents=True, exist_ok=True
+        )
+        result.df_totals.to_csv(
+            paths.df_totals_csv(endpoint_version_name, result.workload.name())
+        )
+        result.df_details.to_csv(
+            paths.df_details_csv(endpoint_version_name, result.workload.name())
+        )
+        self._record_results(result)

--- a/misc/python/materialize/scalability/operation/scalability_operation.py
+++ b/misc/python/materialize/scalability/operation/scalability_operation.py
@@ -51,7 +51,11 @@ class SqlOperationWithInput(Operation):
             cursor.execute(self.sql_statement_based_on_input(data).encode("utf8"))
             cursor.fetchall()
         except ProgrammingError as e:
-            assert "the last operation didn't produce records" in str(e)
+            # fetchall() on a statement that returns no rows (INSERT, DDL, ...)
+            # raises this benign error; anything else is a real SQL failure and
+            # must propagate with its original message and stack.
+            if "the last operation didn't produce records" not in str(e):
+                raise
 
         return data
 

--- a/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
@@ -15,6 +15,12 @@ from materialize.test_analytics.data.base_data_storage import BaseDataStorage
 from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
+def _as_double_literal(value: float | None) -> str:
+    # `value or 'NULL::DOUBLE'` would turn a legitimate 0.0 into NULL, so test
+    # explicitly for None.
+    return "NULL::DOUBLE" if value is None else str(value)
+
+
 @dataclass
 class FeatureBenchmarkResultEntry:
     scenario_name: str
@@ -70,14 +76,14 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     {result_entry.cycle},
                     {as_sanitized_literal(result_entry.scale)},
                     {result_entry.is_regression},
-                    {result_entry.wallclock.result or 'NULL::DOUBLE'},
+                    {_as_double_literal(result_entry.wallclock.result)},
                     NULL::INT,  -- to be removed when we remove the "messages" column
-                    {result_entry.memory_mz.result or 'NULL::DOUBLE'},
-                    {result_entry.memory_clusterd.result or 'NULL::DOUBLE'},
-                    {result_entry.wallclock.min or 'NULL::DOUBLE'},
-                    {result_entry.wallclock.max or 'NULL::DOUBLE'},
-                    {result_entry.wallclock.mean or 'NULL::DOUBLE'},
-                    {result_entry.wallclock.variance or 'NULL::DOUBLE'}
+                    {_as_double_literal(result_entry.memory_mz.result)},
+                    {_as_double_literal(result_entry.memory_clusterd.result)},
+                    {_as_double_literal(result_entry.wallclock.min)},
+                    {_as_double_literal(result_entry.wallclock.max)},
+                    {_as_double_literal(result_entry.wallclock.mean)},
+                    {_as_double_literal(result_entry.wallclock.variance)}
                 ;
                 """)
 
@@ -117,14 +123,14 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     {as_sanitized_literal(discarded_entry.scenario_name)},
                     {discarded_entry.cycle},
                     {discarded_entry.is_regression},
-                    {discarded_entry.wallclock.result or 'NULL::DOUBLE'},
+                    {_as_double_literal(discarded_entry.wallclock.result)},
                     NULL::INT,  -- to be removed when we remove the "messages" column
-                    {discarded_entry.memory_mz.result or 'NULL::DOUBLE'},
-                    {discarded_entry.memory_clusterd.result or 'NULL::DOUBLE'},
-                    {discarded_entry.wallclock.min or 'NULL::DOUBLE'},
-                    {discarded_entry.wallclock.max or 'NULL::DOUBLE'},
-                    {discarded_entry.wallclock.mean or 'NULL::DOUBLE'},
-                    {discarded_entry.wallclock.variance or 'NULL::DOUBLE'}
+                    {_as_double_literal(discarded_entry.memory_mz.result)},
+                    {_as_double_literal(discarded_entry.memory_clusterd.result)},
+                    {_as_double_literal(discarded_entry.wallclock.min)},
+                    {_as_double_literal(discarded_entry.wallclock.max)},
+                    {_as_double_literal(discarded_entry.wallclock.mean)},
+                    {_as_double_literal(discarded_entry.wallclock.variance)}
                 ;
                 """)
 

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -31,6 +31,7 @@ from materialize.feature_benchmark.benchmark_result_selection import (
 )
 from materialize.feature_benchmark.report import (
     Report,
+    ReportMeasurement,
     determine_scenario_classes_with_regressions,
 )
 from materialize.mz_version import MzVersion
@@ -226,14 +227,15 @@ def run_one_scenario(
                 additional_system_parameter_defaults[param_name] = param_value
 
         mz_image = f"{image_registry()}/materialized:{tag}" if tag else None
-        # TODO: Better azurite support detection
         mz = create_mz_service(
             mz_image,
             size,
             additional_system_parameter_defaults,
-            args.azurite and instance == "this",
+            args.azurite,
         )
-        clusterd_image = f"materialize/clusterd:{tag}" if tag else None
+        # Keep clusterd on the same registry as materialized; both services of
+        # one instance must be pulled from the same place.
+        clusterd_image = f"{image_registry()}/clusterd:{tag}" if tag else None
         clusterd = create_clusterd_service(
             clusterd_image,
             size,
@@ -245,14 +247,16 @@ def run_one_scenario(
                 f"Unable to find materialize image with tag {tag}, proceeding with latest instead!"
             )
             mz_image = f"{image_registry()}/materialized:latest"
-            # TODO: Better azurite support detection
             mz = create_mz_service(
                 mz_image,
                 size,
                 additional_system_parameter_defaults,
-                args.azurite and instance == "this",
+                args.azurite,
             )
-            clusterd_image = f"materialize/clusterd:{tag}" if tag else None
+            # Fall back to latest for clusterd too, so the two services of the
+            # instance stay on a matching tag instead of pairing latest
+            # materialized with a missing-tag clusterd.
+            clusterd_image = f"{image_registry()}/clusterd:latest"
             clusterd = create_clusterd_service(
                 clusterd_image,
                 size,
@@ -914,6 +918,10 @@ def _create_feature_benchmark_result_entry(
     scenario_version = report.get_scenario_version(scenario_name)
     measurements = report.measurements_of_this(scenario_name)
 
+    # Memory measurement types are absent when running with --no-measure-memory,
+    # so fall back to an empty measurement instead of a KeyError.
+    empty_measurement: ReportMeasurement[float] = ReportMeasurement([None])
+
     return feature_benchmark_result_storage.FeatureBenchmarkResultEntry(
         scenario_name=scenario_name,
         scenario_group=scenario_group,
@@ -922,6 +930,8 @@ def _create_feature_benchmark_result_entry(
         scale=scale or "default",
         is_regression=is_regression,
         wallclock=measurements[MeasurementType.WALLCLOCK],
-        memory_mz=measurements[MeasurementType.MEMORY_MZ],
-        memory_clusterd=measurements[MeasurementType.MEMORY_CLUSTERD],
+        memory_mz=measurements.get(MeasurementType.MEMORY_MZ, empty_measurement),
+        memory_clusterd=measurements.get(
+            MeasurementType.MEMORY_CLUSTERD, empty_measurement
+        ),
     )

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -12,6 +12,7 @@ Benchmark with scenarios combining closed and open loops, can run multiple
 actions concurrently, measures various kinds of statistics.
 """
 
+import argparse
 import gc
 import os
 import time
@@ -442,6 +443,14 @@ def run_once(
         ]
         target = parse_pg_conn_string(args.mz_url)
     else:
+        additional_system_parameter_defaults = (
+            ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS | {"max_connections": "100000"}
+        )
+        if params is not None:
+            for param in params.split(";"):
+                param_name, param_value = param.split("=")
+                additional_system_parameter_defaults[param_name] = param_value
+
         overrides = [
             Materialized(
                 image=f"{image_registry()}/materialized:{tag}" if tag else None,
@@ -449,11 +458,9 @@ def run_once(
                 soft_assertions=False,
                 external_metadata_store=True,
                 external_blob_store=True,
-                # TODO: Better azurite support detection
-                blob_store_is_azure=args.azurite and bool(tag),
+                blob_store_is_azure=args.azurite,
                 sanity_restart=False,
-                additional_system_parameter_defaults=ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS
-                | {"max_connections": "100000"},
+                additional_system_parameter_defaults=additional_system_parameter_defaults,
                 metadata_store="cockroach",
             ),
             Testdrive(
@@ -461,8 +468,7 @@ def run_once(
                 seed=1,
                 metadata_store="cockroach",
                 external_blob_store=True,
-                # TODO: Better azurite support detection
-                blob_store_is_azure=args.azurite and bool(tag),
+                blob_store_is_azure=args.azurite,
             ),
         ]
         target = None
@@ -531,10 +537,14 @@ def run_once(
                     # Don't let the garbage collector interfere with our measurements
                     gc.disable()
                 scenario.run(c, state)
+            finally:
+                # teardown() must run even if scenario.run() raised, otherwise
+                # its worker threads (up to thread_pool_size, non-daemon) never
+                # stop and block interpreter shutdown until the CI step times
+                # out. gc.enable() likewise must be reached on the failure path.
                 scenario.teardown()
                 gc.collect()
                 gc.enable()
-            finally:
                 new_stats, new_failures = report(
                     mz_string,
                     scenario,
@@ -718,7 +728,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     parser.add_argument(
         "--guarantees",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Check guarantees defined by test scenarios",
     )
@@ -865,6 +875,15 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             suffix=f"this_run{run_number}",
             sqlite_store=args.sqlite_store,
         )
+        # Drop any prior-run entry for the scenarios we just ran before adding
+        # this run's. all_this_stats is keyed by scenario instance and each
+        # rerun creates a fresh instance, so without this a retried scenario
+        # would be uploaded once per attempt (including the failed first one).
+        all_this_stats = {
+            scenario: scenario_stats
+            for scenario, scenario_stats in all_this_stats.items()
+            if type(scenario).name() not in retried_scenario_names
+        }
         all_this_stats.update(this_stats)
         # Replace guarantee failures for retried scenarios, keep others
         guarantee_failures = [

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -308,13 +308,20 @@ def get_baseline_and_other_endpoints(
     use_balancerd = args.use_balancerd
     baseline_endpoint: Endpoint | None = None
     other_endpoints: list[Endpoint] = []
-    for i, specified_target in enumerate(args.target):
+    # --materialize-url is appended once per remote target, so index it by the
+    # number of remote targets seen so far rather than the overall target
+    # position (which is wrong as soon as targets are mixed, e.g. HEAD + remote).
+    remote_target_index = 0
+    for specified_target in args.target:
         endpoint: Endpoint | None = None
 
         if specified_target == TARGET_MATERIALIZE_LOCAL:
             endpoint = MaterializeLocal()
         elif specified_target == TARGET_MATERIALIZE_REMOTE:
-            endpoint = MaterializeRemote(materialize_url=args.materialize_url[i])
+            endpoint = MaterializeRemote(
+                materialize_url=args.materialize_url[remote_target_index]
+            )
+            remote_target_index += 1
         elif specified_target == TARGET_POSTGRES:
             endpoint = PostgresContainer(composition=c)
         elif specified_target == TARGET_HEAD:


### PR DESCRIPTION
Parallel benchmark:
- Wire --this-params/--other-params into the Mz instance (were ignored).
- Bind start_time per open-loop job so queue-wait latency is measured under backlog instead of dropped.
- Fix PooledQuery reconnect: use a fresh cursor, set autocommit, and always return the slot to the pool so failures can't drain it.
- Keep worker threads alive on action failure and always run teardown(), so a failed scenario fails fast instead of deadlocking on jobs.join().
- Make --guarantees toggleable via BooleanOptionalAction.
- Serialize ReuseConnQuery so open-loop dispatch can't drive one cursor from multiple threads.
- Deduplicate retried scenarios before the analytics upload.
- Fix ConnectRead's guarantee key so it matches its action.
- Apply --azurite to both compared instances.

Feature benchmark:
- Don't crash under --no-measure-memory, and guard the upload's memory keys.
- Give each measurement stream its own warmup filter (discard 3 runs, not 1).
- Upload only THIS-side values instead of mixing in the baseline, and keep a legitimate 0.0 from becoming NULL.
- Pull clusterd from the same registry as materialized and fall back to :latest together on a missing tag.
- Apply --azurite to both instances.

Scalability:
- Persist retried measurements to the CSVs, plots, and analytics upload rather than only using them for pass/fail.
- Index --materialize-url by remote-target count so mixed targets work.
- Re-raise real SQL errors instead of asserting on the message text.

Test run: https://buildkite.com/materialize/nightly/builds/17106