### PR TITLE
ci: Fix dead CI tooling and silent failure suppression

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -72,7 +72,11 @@ esac
 arch_gcc=${MZ_DEV_CI_BUILDER_ARCH:-$(arch_gcc)}
 arch_go=$(arch_go "$arch_gcc")
 
-cid_file=ci/builder/.${flavor%%-*}.cidfile
+# Base name for per-invocation container ID files. `run` appends a unique
+# suffix so concurrent invocations of the same flavor do not race on docker's
+# --cidfile, which refuses to start if the file already exists. `root-shell`
+# reads the most recently written one.
+cid_file_prefix=ci/builder/.${flavor%%-*}
 
 rust_components=rustc,cargo,rust-std-$arch_gcc-unknown-linux-gnu,llvm-tools-preview
 if [[ $rust_version = nightly ]]; then
@@ -199,6 +203,7 @@ case "$cmd" in
         ;;
     run)
         docker_command=()
+        cid_file="$cid_file_prefix.$$.cidfile"
 
         detach_container=false
         interactive=false
@@ -444,6 +449,12 @@ case "$cmd" in
             args+=(--volume "$GIT_ROOT_DIR:$GIT_ROOT_DIR")
         fi
         rm -f "$cid_file"
+        # Remove the per-invocation cidfile on exit for foreground runs. A
+        # detached container outlives this process, so leave its cidfile for
+        # root-shell to find.
+        if [[ $detach_container != "true" ]]; then
+            trap 'rm -f "$cid_file"' EXIT
+        fi
         image="$image_registry/ci-builder:$tag"
         # Try downloading the image a few times in case of registry flakiness
         if [[ "${CI:-}" ]]; then
@@ -454,6 +465,12 @@ case "$cmd" in
         docker run "${args[@]}" "$image" eatmydata "${docker_command[@]}"
         ;;
     root-shell)
+        # Cidfile names are fully controlled (no spaces/newlines), so ls -t is safe.
+        # shellcheck disable=SC2012
+        cid_file=$(ls -t "$cid_file_prefix".*.cidfile 2>/dev/null | head -n1)
+        if [[ -z "$cid_file" || ! -s "$cid_file" ]]; then
+            die "no running ci-builder container found for flavor \"$flavor\""
+        fi
         docker exec --interactive --tty --user 0:0 "$(<"$cid_file")" eatmydata ci/builder/root-shell.sh
         ;;
     *)

--- a/bin/ci-python-imports
+++ b/bin/ci-python-imports
@@ -13,10 +13,44 @@
 # composition. This is a separate script instead of a module to prevent
 # polluting namespaces and inherting a polluted namespace.
 
+import argparse
+import ast
 import os
 import sys
-import argparse
+
 from materialize import MZ_ROOT
+
+PY_ROOT = MZ_ROOT / "misc" / "python"
+
+
+def module_to_file(module: str) -> str | None:
+    """Resolve a dotted `materialize.*` module name to its source file, without
+    importing it."""
+    rel = module.replace(".", "/")
+    for candidate in (PY_ROOT / f"{rel}.py", PY_ROOT / rel / "__init__.py"):
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def imported_materialize_modules(tree: ast.AST) -> set[str]:
+    """Dotted `materialize.*` module names referenced by any import statement in
+    the file, including imports nested inside functions or conditionals (which a
+    runtime sys.modules snapshot would miss)."""
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue
+            modules.add(node.module)
+            # `from pkg import name` may be importing a submodule `pkg.name`.
+            for alias in node.names:
+                modules.add(f"{node.module}.{alias.name}")
+    return {m for m in modules if m.startswith("materialize")}
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(
@@ -31,19 +65,41 @@ namespaces and inherting a polluted namespace.""",
     args = parser.parse_args()
 
     sys.path.insert(1, args.path)
-    import mzcompose
+    import mzcompose  # noqa: F401
 
+    files: set[str] = set()
+    # Runtime view: modules imported at module scope, including any resolved
+    # dynamically (e.g. via importlib) as the composition module loaded.
     for key, module in sys.modules.items():
-        if not key.startswith("materialize."):
+        if key.startswith("materialize.") and getattr(module, "__file__", None):
+            files.add(os.path.realpath(module.__file__))
+
+    # Static view: also follow imports that only execute inside functions or
+    # conditionals, which the runtime snapshot above misses. Walk the
+    # composition and every reachable materialize file via the AST.
+    visited: set[str] = set()
+    stack = [os.path.join(args.path, "mzcompose.py"), *files]
+    while stack:
+        path = os.path.realpath(stack.pop())
+        if path in visited:
             continue
-        if module.__file__ is not None:
-            print(os.path.relpath(module.__file__, MZ_ROOT))
-        # Ignore all not explicitly imported files of the module
-        # else:
-        #     for path in module.__path__:
-        #         for file in os.listdir(path):
-        #             if file.endswith(".py"):
-        #                 print(os.path.relpath(os.path.join(path, file), MZ_ROOT))
+        visited.add(path)
+        try:
+            with open(path, encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=path)
+        except (OSError, SyntaxError):
+            continue
+        for module in imported_materialize_modules(tree):
+            file = module_to_file(module)
+            if file is not None:
+                files.add(os.path.realpath(file))
+                stack.append(file)
+
+    for file in sorted(files):
+        print(os.path.relpath(file, MZ_ROOT))
+
+    return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/bin/ci-slt
+++ b/bin/ci-slt
@@ -15,4 +15,4 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-exec ci/slt/slt.sh "$@"
+exec bin/mzcompose --find sqllogictest run fast-tests "$@"

--- a/bin/ci-validate-profraws
+++ b/bin/ci-validate-profraws
@@ -20,13 +20,22 @@ rm -rf profraws
 mkdir profraws
 
 PROFRAW_CHECK_JOBS="$(nproc 2>/dev/null)"
+# Exclude the profraws/ working dir: it lives under the search root, so without
+# this the concurrent workers below re-discover the copies they just wrote and
+# delete them. A failed cp must not delete the original and must fail the run,
+# so copy before removing and exit non-zero if the copy did not succeed.
 # shellcheck disable=SC2016
-find . -name '*.profraw' -print0 | xargs -0 -n 1 -P "$PROFRAW_CHECK_JOBS" \
+find . -name '*.profraw' -not -path './profraws/*' -print0 \
+    | xargs -0 -r -n 1 -P "$PROFRAW_CHECK_JOBS" \
     sh -c 'f="$1"
         echo "$f"
-        cp "$f" profraws/
+        if ! cp "$f" profraws/; then
+            echo "Failed to copy $f" >&2
+            exit 1
+        fi
         rm -f "$f"
         if ! rust-profdata merge -o /dev/null "profraws/$(basename "$f")"; then
+            echo "Invalid profraw discarded: $f" >&2
             rm -f "profraws/$(basename "$f")"
         fi' _
 

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -23,7 +23,6 @@ import argparse
 import copy
 import hashlib
 import os
-import subprocess
 import sys
 import threading
 import traceback
@@ -309,6 +308,7 @@ so it is executed.""",
     if (
         (args.pipeline == "test" or trim_for_pr_nightly)
         and not os.getenv("CI_TEST_IDS")
+        and not os.getenv("CI_TEST_SELECTION")
         and fail_build_reason is None
     ):
         if "ci-no-trim" in pr_labels:
@@ -534,6 +534,16 @@ def increase_agents_timeouts(
                 step["skip"] = True
 
 
+def rewrite_step_dependency(step: dict[str, Any], old: str, new: str) -> None:
+    """Rewrite a single dependency of a step, handling both the string and
+    list forms of depends_on."""
+    d = step.get("depends_on")
+    if d == old:
+        step["depends_on"] = new
+    elif isinstance(d, list):
+        step["depends_on"] = [new if dep == old else dep for dep in d]
+
+
 def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
     """Switch jobs to AWS if Hetzner is currently overloaded"""
     # If Hetzner is entirely broken, you have to take these actions to switch everything back to AWS:
@@ -648,30 +658,26 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
         if agent == "hetzner-aarch64-2cpu-4gb":
             if "hetzner-x86-64-2cpu-4gb" not in stuck:
                 step["agents"]["queue"] = "hetzner-x86-64-2cpu-4gb"
-                if step.get("depends_on") == "build-aarch64":
-                    step["depends_on"] = "build-x86_64"
+                rewrite_step_dependency(step, "build-aarch64", "build-x86_64")
             else:
                 step["agents"]["queue"] = "linux-aarch64"
         elif agent == "hetzner-aarch64-4cpu-8gb":
             if "hetzner-x86-64-4cpu-8gb" not in stuck:
                 step["agents"]["queue"] = "hetzner-x86-64-4cpu-8gb"
-                if step.get("depends_on") == "build-aarch64":
-                    step["depends_on"] = "build-x86_64"
+                rewrite_step_dependency(step, "build-aarch64", "build-x86_64")
             else:
                 step["agents"]["queue"] = "linux-aarch64"
         elif agent == "hetzner-aarch64-8cpu-16gb":
             if "hetzner-x86-64-8cpu-16gb" not in stuck:
                 step["agents"]["queue"] = "hetzner-x86-64-8cpu-16gb"
-                if step.get("depends_on") == "build-aarch64":
-                    step["depends_on"] = "build-x86_64"
+                rewrite_step_dependency(step, "build-aarch64", "build-x86_64")
             else:
                 step["agents"]["queue"] = "linux-aarch64-medium"
 
         elif agent == "hetzner-aarch64-16cpu-32gb":
             if "hetzner-x86-64-12cpu-24gb" not in stuck:
                 step["agents"]["queue"] = "hetzner-x86-64-12cpu-24gb"
-                if step.get("depends_on") == "build-aarch64":
-                    step["depends_on"] = "build-x86_64"
+                rewrite_step_dependency(step, "build-aarch64", "build-x86_64")
             else:
                 step["agents"]["queue"] = "linux-aarch64-medium"
 
@@ -908,8 +914,10 @@ def trim_test_selection_id(pipeline: Any, step_ids_to_run: set[int]) -> None:
                 "analyze",
                 "build-x86_64",
                 "build-aarch64",
-                "build-x86_64-lto",
-                "build-aarch64-lto",
+                "build-x86_64-no-lto",
+                "build-aarch64-no-lto",
+                "build-x86_64-asan",
+                "build-aarch64-asan",
                 "devel-docker-tags",
             )
             and not step.get("async")
@@ -931,8 +939,10 @@ def trim_test_selection_name(pipeline: Any, steps_to_run: set[str]) -> None:
                 "analyze",
                 "build-x86_64",
                 "build-aarch64",
-                "build-x86_64-lto",
-                "build-aarch64-lto",
+                "build-x86_64-no-lto",
+                "build-aarch64-no-lto",
+                "build-x86_64-asan",
+                "build-aarch64-asan",
                 "devel-docker-tags",
             )
             and not step.get("async")
@@ -1212,18 +1222,34 @@ def remove_dependencies_on_prs(
         or os.environ["BUILDKITE_BRANCH"].startswith("dependabot/")
     ):
         return
+    build_image_exists = {
+        "build-x86_64": hash_check[Arch.X86_64][1],
+        "build-aarch64": hash_check[Arch.AARCH64][1],
+    }
     for step in steps(pipeline):
         if step.get("id") in (
             "upload-debug-symbols-x86_64",
             "upload-debug-symbols-aarch64",
         ):
             continue
-        if step.get("depends_on") in ("build-x86_64", "build-aarch64"):
-            if step["depends_on"] == "build-x86_64" and hash_check[Arch.X86_64][1]:
-                continue
-            if step["depends_on"] == "build-aarch64" and hash_check[Arch.AARCH64][1]:
-                continue
-            step.setdefault("env", {})["CI_WAITING_FOR_BUILD"] = step["depends_on"]
+        d = step.get("depends_on")
+        if d is None:
+            continue
+        deps = [d] if isinstance(d, str) else list(d)
+        # Drop dependencies on builds whose image isn't published yet, so the
+        # test starts immediately and keeps retrying for the Docker image.
+        to_remove = [
+            dep
+            for dep in deps
+            if dep in build_image_exists and not build_image_exists[dep]
+        ]
+        if not to_remove:
+            continue
+        step.setdefault("env", {})["CI_WAITING_FOR_BUILD"] = to_remove[-1]
+        remaining = [dep for dep in deps if dep not in to_remove]
+        if remaining:
+            step["depends_on"] = remaining
+        else:
             del step["depends_on"]
 
 
@@ -1277,51 +1303,57 @@ def trim_builds(
 _github_changed_files: set[str] | None = None
 
 
-def have_paths_changed(globs: Iterable[str]) -> bool:
-    """Reports whether the specified globs have diverged from origin/main."""
-    global _github_changed_files
+def _changed_files_from_main() -> set[str]:
+    """Files that diverged from origin/main, via the GitHub compare API with a
+    local git fallback."""
     try:
-        if not _github_changed_files:
-            head = spawn.capture(["git", "rev-parse", "HEAD"]).strip()
-            headers = {"Accept": "application/vnd.github+json"}
-            if token := os.getenv(
-                "GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN"
-            ) or os.getenv("GITHUB_TOKEN"):
-                headers["Authorization"] = f"Bearer {token}"
+        head = spawn.capture(["git", "rev-parse", "HEAD"]).strip()
+        headers = {"Accept": "application/vnd.github+json"}
+        if token := os.getenv("GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN") or os.getenv(
+            "GITHUB_TOKEN"
+        ):
+            headers["Authorization"] = f"Bearer {token}"
 
-            resp = requests.get(
-                f"https://api.github.com/repos/materializeinc/materialize/compare/main...{head}",
-                headers=headers,
-            )
-            resp.raise_for_status()
-            _github_changed_files = {
-                f["filename"] for f in resp.json().get("files", [])
-            }
-
-        for file in spawn.capture(["git", "ls-files", *globs]).splitlines():
-            if file in _github_changed_files:
-                return True
-        return False
+        resp = requests.get(
+            f"https://api.github.com/repos/materializeinc/materialize/compare/main...{head}",
+            headers=headers,
+        )
+        resp.raise_for_status()
+        files = resp.json().get("files", [])
+        # The compare API caps its file list at 300. Beyond that the list is
+        # truncated, and trusting it would silently treat changed files as
+        # unchanged and trim their tests, so fall back to a local diff.
+        if len(files) >= 300:
+            raise RuntimeError("compare API file list truncated at 300 files")
+        return {f["filename"] for f in files}
     except Exception as e:
         # Try locally if Github is down or the change has not been pushed yet when running locally
         print(f"Failed to get changed files from Github, running locally: {e}")
 
         # Make sure we have an up to date view of main.
         command = ["git", "fetch"]
-        if spawn.capture(["git", "rev-parse", "--is-shallow-repository"]) == "true":
+        if (
+            spawn.capture(["git", "rev-parse", "--is-shallow-repository"]).strip()
+            == "true"
+        ):
             command.append("--unshallow")
         spawn.runv(command + ["origin", "main"])
 
-        diff = subprocess.run(
-            ["git", "diff", "--no-patch", "--quiet", "origin/main...", "--", *globs]
+        return set(
+            spawn.capture(["git", "diff", "--name-only", "origin/main..."]).splitlines()
         )
-        if diff.returncode == 0:
-            return False
-        elif diff.returncode == 1:
+
+
+def have_paths_changed(globs: Iterable[str]) -> bool:
+    """Reports whether the specified globs have diverged from origin/main."""
+    global _github_changed_files
+    if _github_changed_files is None:
+        _github_changed_files = _changed_files_from_main()
+
+    for file in spawn.capture(["git", "ls-files", *globs]).splitlines():
+        if file in _github_changed_files:
             return True
-        else:
-            diff.check_returncode()
-            raise RuntimeError("unreachable")
+    return False
 
 
 def trim_ci_glue_exempt_steps(pipeline: Any) -> None:

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -1212,7 +1212,7 @@ def remove_dependencies_on_prs(
     pipeline_name: str,
     hash_check: dict[Arch, tuple[str, bool]],
 ) -> None:
-    """On PRs in test pipeline remove dependencies on the build, start up tests immediately, they keep retrying for the Docker image"""
+    """On test-pipeline PRs, let single-architecture consumers retry for their image instead of waiting for its build."""
     if pipeline_name != "test":
         return
     if (
@@ -1236,17 +1236,19 @@ def remove_dependencies_on_prs(
         if d is None:
             continue
         deps = [d] if isinstance(d, str) else list(d)
-        # Drop dependencies on builds whose image isn't published yet, so the
-        # test starts immediately and keeps retrying for the Docker image.
-        to_remove = [
-            dep
-            for dep in deps
-            if dep in build_image_exists and not build_image_exists[dep]
-        ]
-        if not to_remove:
+        build_deps = [dep for dep in deps if dep in build_image_exists]
+        # CI_WAITING_FOR_BUILD tracks one build's status. A multi-architecture
+        # consumer needs every build, so it cannot safely use that contract.
+        if len(build_deps) > 1:
             continue
-        step.setdefault("env", {})["CI_WAITING_FOR_BUILD"] = to_remove[-1]
-        remaining = [dep for dep in deps if dep not in to_remove]
+        # Drop the build dependency whose image isn't published yet, so the
+        # consumer starts immediately and keeps retrying for the Docker image.
+        missing_build_deps = [dep for dep in build_deps if not build_image_exists[dep]]
+        if not missing_build_deps:
+            continue
+        waiting_for_build = missing_build_deps[0]
+        step.setdefault("env", {})["CI_WAITING_FOR_BUILD"] = waiting_for_build
+        remaining = [dep for dep in deps if dep != waiting_for_build]
         if remaining:
             step["depends_on"] = remaining
         else:

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -169,6 +169,7 @@ cleanup() {
   {
     bin/ci-builder run stable trufflehog --no-update --no-verification --filter-entropy 5.0 --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro,fmfw,logzio,qase,cannyio,uplead,tatumio filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
   } &
+  TRUFFLEHOG_PID=$!
   artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 
   unset CI_EXTRA_ARGS # We don't want extra args for the annotation
@@ -176,12 +177,23 @@ cleanup() {
   CI_ANNOTATE_ERRORS_RESULT=0
   # We have to upload artifacts before ci-annotate-errors, so that the annotations can link to the artifacts
   buildkite-agent artifact upload "$artifacts_str" &
-  wait
+  UPLOAD_PID=$!
+  # Wait only for the background jobs spawned above, by explicit PID. A bare
+  # `wait` never returns when this cleanup runs as the SIGTERM trap of a
+  # timed-out job: the trap interrupted the script's outer `wait "$pid"`, whose
+  # stale job-table entry makes bare `wait` hang, eating the cancellation grace
+  # period before error annotation and cleanup ever run.
+  wait "$TRUFFLEHOG_PID" "$UPLOAD_PID"
   bin/ci-builder run stable bin/ci-annotate-errors --test-cmd="$TEST_CMD" --test-result="$TEST_RESULT" "${artifacts[@]}" trufflehog.log > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
   buildkite-agent artifact upload "ci-annotate-errors.log" &
 
-  # File should not be empty, see database-issues#7569
-  test -s kubectl-get-logs-previous.log
+  # File should not be empty, see database-issues#7569. An empty file means no
+  # pods were found at all, which is a broken environment. This runs under
+  # `set +e`, so enforce it explicitly instead of relying on the exit status.
+  if [ ! -s kubectl-get-logs-previous.log ]; then
+      echo "+++ kubectl-get-logs-previous.log is empty, failing (see database-issues#7569)"
+      CI_ANNOTATE_ERRORS_RESULT=1
+  fi
 
   ci_unimportant_heading "cloudtest: Resetting..."
   bin/ci-builder run stable test/cloudtest/reset

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -87,14 +87,18 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     chmod 777 coverage/
 fi
 
-STOP_RUNNING=false
+HEAP_PROFILE_PID=""
 
 if is_truthy "${CI_HEAP_PROFILES:-}"; then
-    (while [ "$STOP_RUNNING" != "true" ]; do
+    (while true; do
          sleep 30
          bin/ci-builder run stable --detach bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
      done
     ) &
+    # Track the loop's PID so cleanup can stop it. Assigning a shared variable
+    # cannot reach the subshell, which has its own copy, so the loop would
+    # otherwise keep spawning containers throughout the whole teardown.
+    HEAP_PROFILE_PID=$!
 fi
 
 EXTRA_ARGS=$(echo "${CI_EXTRA_ARGS:-}" | jq -r ".[\"$BUILDKITE_STEP_KEY\"] // \"\"")
@@ -273,7 +277,10 @@ cleanup() {
 
   TRUFFLEHOG_PID=""
   if is_truthy "${CI_HEAP_PROFILES:-}"; then
-      STOP_RUNNING=true
+      [ -n "$HEAP_PROFILE_PID" ] && kill "$HEAP_PROFILE_PID" 2>/dev/null || true
+      # ci-annotate-errors is passed trufflehog.log unconditionally below, but
+      # the trufflehog scan is skipped here, so create an empty log for it.
+      touch trufflehog.log
   else
       ci_unimportant_heading "Running trufflehog to scan artifacts for secrets & uploading artifacts"
       {

--- a/ci/test/lint-main/before/git-fetch-target.sh
+++ b/ci/test/lint-main/before/git-fetch-target.sh
@@ -16,6 +16,6 @@ cd "$(dirname "$0")/../../../.."
 . misc/shlib/shlib.bash
 . misc/buildkite/git.bash
 
-if [[ "${1:-}" != --offline ]]; then
+if [[ "${MZ_LINT_OFFLINE:-}" != 1 ]]; then
   fetch_pr_target_branch
 fi

--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -29,7 +29,10 @@ check_all_files_referenced_in_ci() {
         -not -wholename "./test/get-cloud-hostname/mzcompose.py" `# Utility, no test` \
         | sed -e "s|.*/\([^/]*\)/mzcompose.py|\1|")
     while read -r composition; do
-        if ! grep -q "composition: $composition" ci/*/pipeline.template.yml; then
+        # Anchor at end of line, otherwise a composition whose name prefixes
+        # another (e.g. "cluster" vs "cluster-isolation") passes the check even
+        # when none of its own steps exist.
+        if ! grep -qE "composition: $composition$" ci/*/pipeline.template.yml; then
             echo "mzcompose composition \"$composition\" is unused in any CI pipeline file"
             RETURN=1
         fi

--- a/ci/test/lint-main/checks/check-protobuf.sh
+++ b/ci/test/lint-main/checks/check-protobuf.sh
@@ -25,10 +25,14 @@ if ! buf --version >/dev/null 2>/dev/null; then
 fi
 
 CURRENT_GIT_BRANCH=$(try git branch --show-current)
-IN_BUILDKITE=in_ci
+IN_BUILDKITE=0
 IN_BUILDKITE_PR=0
 ON_MAIN_BRANCH=0
 IN_LOCAL_NON_MAIN_BRANCH=0
+
+if [[ "${BUILDKITE:-}" == "true" ]]; then
+  IN_BUILDKITE=1
+fi
 
 if [[ ${BUILDKITE_PULL_REQUEST:-false} != "false" ]]; then
   IN_BUILDKITE_PR=1
@@ -42,10 +46,10 @@ if [[ "$IN_BUILDKITE" != 1 && "$ON_MAIN_BRANCH" != 1 ]]; then
   IN_LOCAL_NON_MAIN_BRANCH=1
 fi
 
-echo $IN_BUILDKITE_PR
-echo $IN_LOCAL_NON_MAIN_BRANCH
-
-if [[ $IN_BUILDKITE_PR || $IN_LOCAL_NON_MAIN_BRANCH ]]; then
+# The breaking-change check compares against the target branch, so only run it
+# where that comparison is meaningful. Note that `[[ $VAR ]]` tests whether the
+# string is non-empty, so "0" would be true; compare explicitly.
+if [[ $IN_BUILDKITE_PR == 1 || $IN_LOCAL_NON_MAIN_BRANCH == 1 ]]; then
   # see ./ci/test/lint-buf/README.md
 
   ci_collapsed_heading "Verify that protobuf config is up-to-date"
@@ -78,6 +82,12 @@ check_no_map_fields() {
   local -A seen=()
   local stack=("$root")
   local failed=0
+  # The recursion below skips missing files (imports may resolve elsewhere),
+  # but a missing root would turn the whole check into a silent no-op.
+  if [[ ! -f "$root" ]]; then
+    echo "error: root proto $root does not exist"
+    return 1
+  fi
   while [[ ${#stack[@]} -gt 0 ]]; do
     local file="${stack[-1]}"
     unset 'stack[-1]'

--- a/ci/test/lint-main/checks/check-python-version.sh
+++ b/ci/test/lint-main/checks/check-python-version.sh
@@ -30,7 +30,14 @@ if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
     try uv venv --python 3.10 "$py310_venv"
     try uv pip compile --python-version 3.10 ci/builder/requirements.txt
     try uv pip install --python "$py310_venv/bin/python" --requirement ci/builder/requirements.txt
-    try git_files '*.py' | xargs "$py310_venv/bin/python" -m compileall -q
+    # Wrap the compileall (the actual work) in `try`, not git_files, and keep it
+    # out of a pipeline: `try` in a pipeline runs in a subshell and loses its
+    # accounting. Guard against empty input too, otherwise compileall with no
+    # file arguments compiles all of sys.path instead of the repo.
+    py_files=$(git_files '*.py')
+    if [[ -n "$py_files" ]]; then
+        try xargs "$py310_venv/bin/python" -m compileall -q <<< "$py_files"
+    fi
 fi
 
 try_status_report

--- a/ci/test/lint-main/checks/check-slack-links.sh
+++ b/ci/test/lint-main/checks/check-slack-links.sh
@@ -25,12 +25,15 @@ if [[ "${BUILDKITE_BRANCH:-}" == "main" || "$CURRENT_GIT_BRANCH" == "main" ]]; t
   exit 0
 fi
 
-if [[ "${1:-}" == --offline ]]; then
+if [[ "${MZ_LINT_OFFLINE:-}" == 1 ]]; then
   echo "Skipping Slack link check in offline mode."
   exit 0
 fi
 
-COMMON_ANCESTOR=$(git merge-base HEAD FETCH_HEAD)
+# Use the remote-tracking ref, not FETCH_HEAD: FETCH_HEAD is a plain file that a
+# concurrently-running check (check-protobuf) rewrites with its own fetch, while
+# git updates remote-tracking refs atomically.
+COMMON_ANCESTOR=$(git merge-base HEAD "$MZ_REPO_REF/$MZ_REPO_PULL_REQUEST_BASE_BRANCH")
 
 # Look for added lines containing Slack links in the diff against main.
 SLACK_LINES=$(git diff "$COMMON_ANCESTOR" HEAD -U0 | grep -E '^\+.*materializeinc\.slack\.com' || true)

--- a/misc/buildkite/git.bash
+++ b/misc/buildkite/git.bash
@@ -17,8 +17,15 @@ MZ_REPO_REF="${BUILDKITE_REPO_REF:-origin}"
 MZ_REPO_PULL_REQUEST_BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
 
 if [[ "${BUILDKITE:-}" != "true" ]]; then
-  # when running locally, our origin may point to a fork of the repo but we want the mz repo
-  MZ_REPO_REF=$(git remote -v | grep -i "MaterializeInc/materialize" | grep "fetch" | head -n1 | cut -f1)
+  # when running locally, our origin may point to a fork of the repo but we want the mz repo.
+  # Keep the default ref if no such remote exists (a fork-only clone). The `|| true`
+  # is required: grep exits non-zero when there is no match, and head closing the pipe
+  # early makes upstream grep exit with SIGPIPE, either of which would abort this
+  # sourced script under `set -euo pipefail` and kill the check with no output.
+  mz_repo_ref=$(git remote -v | grep -i "MaterializeInc/materialize" | grep "fetch" | head -n1 | cut -f1 || true)
+  if [[ -n "$mz_repo_ref" ]]; then
+    MZ_REPO_REF="$mz_repo_ref"
+  fi
 fi
 
 configure_git_user_if_in_buildkite() {

--- a/misc/python/materialize/buildkite_insights/buildkite_api/generic_api.py
+++ b/misc/python/materialize/buildkite_insights/buildkite_api/generic_api.py
@@ -94,7 +94,7 @@ def _perform_get_request(request_path: str, params: dict[str, Any]) -> Response:
         print("Authentication token is not specified or empty!")
 
     url = f"{BUILDKITE_API_URL}/{request_path}"
-    response = requests.get(headers=headers, url=url, params=params)
+    response = requests.get(headers=headers, url=url, params=params, timeout=60)
 
     if response.status_code == STATUS_CODE_RATE_LIMIT_EXCEEDED:
         raise RateLimitExceeded([])

--- a/misc/python/materialize/ci_util/__init__.py
+++ b/misc/python/materialize/ci_util/__init__.py
@@ -64,12 +64,18 @@ def get_artifacts() -> Any:
                 f"https://agent.buildkite.com/v3/builds/{build_id}/artifacts/search",
                 params=payload,
                 headers={"Authorization": f"Token {token}"},
+                timeout=30,
             )
             res.raise_for_status()
             break
-        except:
+        except Exception as e:
+            # Artifact info only supplies links for annotations, so on repeated
+            # failure degrade to no artifacts rather than crashing the caller
+            # and losing all annotations. A bare except would also swallow
+            # KeyboardInterrupt.
+            print(f"Failed to get artifacts (attempt {attempt + 1}/{attempts}): {e}")
             if attempt == attempts - 1:
-                raise
+                return []
             time.sleep(5)
 
     assert res

--- a/misc/python/materialize/ci_util/upload_debug_symbols_to_polarsignals.py
+++ b/misc/python/materialize/ci_util/upload_debug_symbols_to_polarsignals.py
@@ -294,9 +294,12 @@ def upload_debug_data_to_polarsignals(
 
         with tempfile.NamedTemporaryFile() as tarball:
             _create_source_tarball(repo, bin_path, tarball)
-            result = result or _upload_source_tarball_to_polarsignals(
+            # Assign first, then combine. `result or upload(...)` would
+            # short-circuit and never run the upload once result is True.
+            uploaded = _upload_source_tarball_to_polarsignals(
                 repo, bin_path, tarball, build_id, token
             )
+            result = result and uploaded
     return result
 
 

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -145,7 +145,7 @@ IGNORE_RE = re.compile(
     # Expected in restart test
     ( restart-materialized-1\ \ \|\ thread\ 'coordinator'\ panicked\ at\ 'can't\ persist\ timestamp
     # Expected in restart test
-    | restart-materialized-1\ *|\ thread\ 'coordinator'\ panicked\ at\ 'external\ operation\ .*\ failed\ unrecoverably.*
+    | restart-materialized-1\ *\|\ thread\ 'coordinator'\ panicked\ at\ 'external\ operation\ .*\ failed\ unrecoverably.*
     # Expected in cluster test
     | cluster-clusterd[12]-1\ .*\ halting\ process:\ new\ timely\ configuration\ does\ not\ match\ existing\ timely\ configuration
     | cluster-clusterd1-1\ .*\ replica\ expired
@@ -668,8 +668,10 @@ def annotate_logged_errors(
                 if match and issue.info["state"] == "CLOSED":
                     if issue.apply_to and issue.apply_to not in (
                         step_key.lower(),
-                        buildkite_label.lower(),
+                        buildkite_label.lower().rstrip("01234567889 "),
                     ):
+                        continue
+                    if issue.location and issue.location != location:
                         continue
 
                     if issue.info["number"] not in already_reported_issue_numbers:
@@ -719,7 +721,12 @@ def annotate_logged_errors(
                     location: str = error.file
                     location_url = None
 
-                handle_error(error.match.decode("utf-8"), None, location, location_url)
+                handle_error(
+                    error.match.decode("utf-8", errors="replace"),
+                    None,
+                    location,
+                    location_url,
+                )
             elif isinstance(error, JunitError):
                 if "in Code Coverage" in error.text or "covered" in error.message:
                     msg = "\n".join(filter(None, [error.message, error.text]))
@@ -926,15 +933,24 @@ def _collect_errors_in_logs(data: Any, log_file_name: str) -> list[ErrorLog]:
 def _collect_service_panics_in_logs(data: Any, log_file_name: str) -> list[ErrorLog]:
     collected_panics = []
 
-    open_panics = {}
+    open_panics: dict[bytes, bytes] = {}
+
+    def flush_open_panic(service: bytes) -> None:
+        # A panic whose following log line we never saw: a second panic of the
+        # same service interleaving, or a panic at end of file. Emit it without
+        # its trailing message rather than crashing the annotator. Both cases
+        # are otherwise rare enough that losing the message is acceptable.
+        panic_without_ts = TIMESTAMP_IN_PANIC_RE.sub(b"", open_panics.pop(service))
+        if not IGNORE_RE.search(panic_without_ts):
+            collected_panics.append(ErrorLog(panic_without_ts, log_file_name))
+
     for line in iter(data.readline, b""):
         # Don't try to match regexes on HUGE lines, since it can take too long
         line = line.rstrip(b"\n")[:8192]
         if match := PANIC_IN_SERVICE_START_RE.match(line):
             service = match.group("service")
-            assert (
-                service not in open_panics
-            ), f"Two panics of same service {service} interleaving: {line}"
+            if service in open_panics:
+                flush_open_panic(service)
             open_panics[service] = line
         elif open_panics:
             if match := SERVICES_LOG_LINE_RE.match(line):
@@ -951,7 +967,8 @@ def _collect_service_panics_in_logs(data: Any, log_file_name: str) -> list[Error
                             panic_without_ts + b" " + match.group("msg"), log_file_name
                         )
                     )
-    assert not open_panics, f"Panic log never finished: {open_panics}"
+    for service in list(open_panics):
+        flush_open_panic(service)
 
     return collected_panics
 
@@ -1001,9 +1018,20 @@ def get_failures_on_main(test_analytics: TestAnalyticsDb) -> BuildHistory:
         test_analytics.on_data_retrieval_failed(e)
 
     print("Loading build history from buildkite instead")
-    return _get_failures_on_main_from_buildkite(
-        pipeline_slug=pipeline_slug, step_key=step_key, parallel_job=parallel_job
-    )
+    try:
+        return _get_failures_on_main_from_buildkite(
+            pipeline_slug=pipeline_slug, step_key=step_key, parallel_job=parallel_job
+        )
+    except Exception as e:
+        # Build history is informational, so a failure here (e.g. a Buildkite
+        # API hiccup) must not crash the annotator and turn an otherwise
+        # green job red.
+        print(
+            f"Loading build history from buildkite failed, continuing without it: {e}"
+        )
+        return BuildHistory(
+            pipeline=pipeline_slug, branch="main", last_build_step_outcomes=[]
+        )
 
 
 def _get_failures_on_main_from_buildkite(

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -289,7 +289,10 @@ def filter_changed_lines(issue_refs: list[IssueRef]) -> list[IssueRef]:
         if issue_ref.text is not None
         and any(
             (issue_ref.filename, issue_ref.line_number + i) in changed_lines
-            for i in range(issue_ref.text.count("\n"))
+            # text is stripped, so an N-line comment block has N-1 newlines.
+            # range(count + 1) covers all N lines, including a single-line ref
+            # (0 newlines) and the last line of a multi-line block.
+            for i in range(issue_ref.text.count("\n") + 1)
         )
     ]
 

--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -24,12 +24,16 @@ from materialize import MZ_ROOT, buildkite, ci_util
 #   been covered in end-to-end tests.
 # - Negative values indicate that the line has only been covered in unit tests.
 Coverage = dict[str, OrderedDict[int, int | None]]
+# Normalizes an absolute lcov SF path to a repo-relative path so it can be
+# matched against the keys from find_modified_lines(). Only the buildkite
+# alternative yields an actual repo file (starting with `src/`). The external
+# and rustlib alternatives exist so the assert below does not fire on
+# dependency sources, they never match a modified repo file.
 SOURCE_RE = re.compile(
     r"""
-    ( src/(.*$)"
-    | external/(.*$)
+    ( external/(.*$)
     | /usr/local/lib/rustlib/(.*$)
-    | /var/lib/buildkite-agent/builds/buildkite-.*/materialize/[^/]*/src/(.*$)
+    | /var/lib/buildkite-agent/builds/buildkite-.*/materialize/[^/]*/(src/.*$)
     )""",
     re.VERBOSE,
 )
@@ -103,7 +107,10 @@ def mark_covered_lines(
             else:
                 result = SOURCE_RE.search(content)
                 assert result, f"not found: {content}"
-                file = result.group(1)
+                # Group 1 is the outer alternation, which for buildkite paths is
+                # the full absolute path. The repo-relative path is the innermost
+                # matched group, i.e. the last non-None capture.
+                file = [g for g in result.groups() if g is not None][-1]
         # DA:111,15524
         # DA:112,0
         # DA:113,15901
@@ -174,7 +181,9 @@ ci-coverage-pr-report creates a code coverage report for CI.""",
     parser.add_argument("tests", nargs="+", help="all other lcov files from test runs")
     args = parser.parse_args()
 
-    result = subprocess.run(["git", "diff"], check=True, capture_output=True)
+    # Compare against HEAD so staged-but-uncommitted changes are detected too.
+    # get_report() runs `git reset --hard`, which would otherwise destroy them.
+    result = subprocess.run(["git", "diff", "HEAD"], check=True, capture_output=True)
     output = result.stdout.decode("utf-8").strip()
     assert not output, f"Has to run on clean git state: \n{output}"
 

--- a/misc/python/materialize/cli/ci_upload_heap_profiles.py
+++ b/misc/python/materialize/cli/ci_upload_heap_profiles.py
@@ -63,16 +63,17 @@ def main() -> int:
                 capture_output=True,
             )
 
-    services = json.loads(
-        subprocess.run(
-            mzcompose + ["ps", "--format", "json"], text=True, capture_output=True
-        ).stdout
-    )
+    # `docker compose ps --format json` emits newline-delimited JSON (one
+    # object per service), not a single JSON array.
+    ps_output = subprocess.run(
+        mzcompose + ["ps", "--format", "json"], text=True, capture_output=True
+    ).stdout
+    services = [json.loads(line) for line in ps_output.splitlines() if line.strip()]
     for service in services:
         image = service["Image"].rsplit(":", 1)[0]
         ghcr_prefix = "ghcr.io/materializeinc/"
         if image.startswith(ghcr_prefix):
-            image.removeprefix(ghcr_prefix)
+            image = image.removeprefix(ghcr_prefix)
         if image == "materialize/clusterd":
             threads.append(
                 Thread(

--- a/misc/python/materialize/cli/lint-cargo.py
+++ b/misc/python/materialize/cli/lint-cargo.py
@@ -88,9 +88,9 @@ def check_workspace_dependencies(workspace: Workspace) -> bool:
 def main() -> None:
     workspace = Workspace(MZ_ROOT)
     lints = [check_rust_versions, check_default_members, check_workspace_dependencies]
-    success = True
-    for lint in lints:
-        success = success and lint(workspace)
+    # Run every lint, then combine. `success and lint(...)` would short-circuit
+    # and skip the remaining lints after the first failure, under-reporting.
+    success = all([lint(workspace) for lint in lints])
     if not success:
         sys.exit(1)
 

--- a/misc/python/materialize/cli/lint.py
+++ b/misc/python/materialize/cli/lint.py
@@ -39,16 +39,21 @@ def main() -> int:
     verbose_output = args.verbose
     offline = args.offline
 
-    manager = LintManager(print_duration, verbose_output, offline)
+    # Signal offline mode through the environment rather than a CLI flag.
+    # Only a couple of checks care about it, and passing --offline as an
+    # argument to the rest would be misinterpreted (e.g. as a git pathspec).
+    if offline:
+        os.environ["MZ_LINT_OFFLINE"] = "1"
+
+    manager = LintManager(print_duration, verbose_output)
     return_code = manager.run()
     return return_code
 
 
 class LintManager:
-    def __init__(self, print_duration: bool, verbose_output: bool, offline: bool):
+    def __init__(self, print_duration: bool, verbose_output: bool):
         self.print_duration = print_duration
         self.verbose_output = verbose_output
-        self.offline = offline
 
     def run(self) -> int:
         failed_checks = self.run_and_validate_if_no_previous_failures(
@@ -105,8 +110,6 @@ class LintManager:
         tasks = []
         for lint_file in lint_files:
             command = [str(checks_path / lint_file)]
-            if self.offline:
-                command.append("--offline")
             tasks.append((lint_file, command))
 
         return run_parallel(

--- a/misc/python/materialize/cli/lint_test_flags.py
+++ b/misc/python/materialize/cli/lint_test_flags.py
@@ -22,7 +22,10 @@ from materialize.mzcompose import (
 )
 from materialize.parallel_workload.action import FlipFlagsAction
 
-CONFIG_REGEX = re.compile(r' Config::new\(\s*"([^"]+)"', re.MULTILINE)
+# Match both the bare `Config::new(` (imported via `use mz_dyncfg::Config`) and
+# the qualified `mz_dyncfg::Config::new(`, without matching unrelated third-party
+# Config types like `tokio_postgres::Config::new(`.
+CONFIG_REGEX = re.compile(r'(?: |mz_dyncfg::)Config::new\(\s*"([^"]+)"', re.MULTILINE)
 
 
 def main() -> int:

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -196,8 +196,14 @@ def is_ancestor(earlier: str, later: str) -> bool:
         if token := os.getenv("GITHUB_TOKEN"):
             headers["Authorization"] = f"Bearer {token}"
 
+        # GitHub resolves the ref "HEAD" server-side to the repo's default
+        # branch, not the local checkout's HEAD. Resolve it to a concrete SHA
+        # first, otherwise e.g. compare/HEAD...main becomes main...main.
+        api_earlier = rev_parse(earlier) if earlier == "HEAD" else earlier
+        api_later = rev_parse(later) if later == "HEAD" else later
+
         resp = requests.get(
-            f"https://api.github.com/repos/materializeinc/materialize/compare/{earlier}...{later}",
+            f"https://api.github.com/repos/materializeinc/materialize/compare/{api_earlier}...{api_later}",
             headers=headers,
         )
         resp.raise_for_status()
@@ -209,7 +215,10 @@ def is_ancestor(earlier: str, later: str) -> bool:
 
         # Make sure we have an up to date view of main.
         command = ["git", "fetch"]
-        if spawn.capture(["git", "rev-parse", "--is-shallow-repository"]) == "true":
+        if (
+            spawn.capture(["git", "rev-parse", "--is-shallow-repository"]).strip()
+            == "true"
+        ):
             command.append("--unshallow")
         spawn.runv(command + [get_remote(), earlier, later])
 
@@ -253,7 +262,7 @@ def fetch(
         raise RuntimeError("branch must not be specified if only_tags is set")
 
     command = ["git", "fetch"]
-    if spawn.capture(["git", "rev-parse", "--is-shallow-repository"]) == "true":
+    if spawn.capture(["git", "rev-parse", "--is-shallow-repository"]).strip() == "true":
         command.append("--unshallow")
 
     if remote:
@@ -343,7 +352,10 @@ def get_common_ancestor_commit(remote: str, branch: str) -> str:
 
         # Make sure we have an up to date view
         command = ["git", "fetch"]
-        if spawn.capture(["git", "rev-parse", "--is-shallow-repository"]) == "true":
+        if (
+            spawn.capture(["git", "rev-parse", "--is-shallow-repository"]).strip()
+            == "true"
+        ):
             command.append("--unshallow")
         spawn.runv(command + [remote, branch])
 

--- a/misc/python/materialize/github.py
+++ b/misc/python/materialize/github.py
@@ -90,6 +90,7 @@ def _search_issues_graphql(token: str, repo: str) -> list[dict[str, Any]]:
                 "Content-Type": "application/json",
             },
             json={"query": query, "variables": variables},
+            timeout=60,
         )
 
         if response.status_code != 200:
@@ -179,7 +180,7 @@ def get_known_issues_from_github(
             continue
 
         location: str | None = (
-            matches_location[0] if len(matches_location) == 1 else None
+            matches_location[0].strip() if len(matches_location) == 1 else None
         )
 
         ignore_failure = len(matches_ignore_failure) == 1 and matches_ignore_failure[
@@ -243,6 +244,7 @@ def list_release_tags(
             f"https://api.github.com/repos/{repo}/releases",
             headers=headers,
             params={"per_page": 100, "page": page},
+            timeout=60,
         )
         if response.status_code != 200:
             raise ValueError(
@@ -269,6 +271,7 @@ def create_release(
     response = requests.get(
         f"https://api.github.com/repos/{repo}/releases/tags/{tag}",
         headers=headers,
+        timeout=60,
     )
     if response.status_code == 200:
         print(f"GitHub release for {tag} already exists: {response.json()['html_url']}")
@@ -284,6 +287,7 @@ def create_release(
     response = requests.get(
         f"https://api.github.com/repos/{repo}/git/ref/tags/{tag}",
         headers=headers,
+        timeout=60,
     )
     if response.status_code != 200:
         raise ValueError(
@@ -300,6 +304,7 @@ def create_release(
             "body": body,
             "make_latest": "true" if make_latest else "false",
         },
+        timeout=60,
     )
     if response.status_code != 201:
         raise ValueError(

--- a/misc/python/materialize/linear.py
+++ b/misc/python/materialize/linear.py
@@ -69,6 +69,7 @@ def _search_issues_graphql(token: str) -> list[dict[str, Any]]:
                 "Content-Type": "application/json",
             },
             json={"query": query, "variables": variables},
+            timeout=60,
         )
 
         if response.status_code != 200:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -574,6 +574,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "persist_consensus_connection_pool_max_wait",
     "persist_consensus_connection_pool_ttl",
     "persist_consensus_connection_pool_ttl_stagger",
+    "persist_use_postgres_tuned_queries",
     "crdb_connect_timeout",
     "crdb_tcp_user_timeout",
     "crdb_keepalives_idle",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1781,6 +1781,7 @@ class FlipFlagsAction(Action):
             "persist_consensus_connection_pool_max_wait",
             "persist_consensus_connection_pool_ttl",
             "persist_consensus_connection_pool_ttl_stagger",
+            "persist_use_postgres_tuned_queries",
             "crdb_connect_timeout",
             "crdb_tcp_user_timeout",
             "crdb_keepalives_idle",


### PR DESCRIPTION
A sweep of CI/lint tooling that had regressed into reporting success while doing nothing, or into silently swallowing real failures.

Dead features reporting success:
* ci_coverage_pr_report: SOURCE_RE returned the outer alternation (full absolute path) instead of the repo-relative path, so every DA record was dropped and the report always claimed full coverage. Fix the capture and drop the dead `src/(.*$)"` alternative. Also compare against HEAD in the clean-state check so `git reset --hard` cannot destroy staged changes.
* upload_debug_symbols_to_polarsignals: `result = result or upload(...)` short-circuited, so the source tarball was built and then never uploaded.
* ci_upload_heap_profiles: parse `docker compose ps` as NDJSON and actually assign `removeprefix`; the mzcompose hook loop is now stopped by PID (a subshell variable could never be reached) and writes an empty trufflehog.log when heap profiling.
* bin/ci-slt: exec the current sqllogictest mzcompose entry point instead of the long-deleted ci/slt/slt.sh.

Silent suppression of real failures:
* ci_annotate_errors: escape the `|` in the restart-test ignore pattern (it was matching any restart-materialized line and one panic globally); mirror the shard-digit rstrip and ci-location check into the closed-issue branch; decode matched log lines with errors="replace"; make the panic collector flush interleaved / EOF panics instead of asserting; guard the buildkite build-history fallback so an API hiccup cannot turn a green job red.
* ci_closed_issues_detect: range(count + 1) so single-line and last-line references are checked.
* mkpipeline: fall back to local git when the compare API truncates at 300 files; honor CI_TEST_SELECTION; exempt the real build-*-no-lto/asan steps; rewrite list-form depends_on.
* buildkite/git: resolve HEAD to a SHA before the compare API (it otherwise resolves HEAD to the default branch, so is_in_pull_request was always false); strip the is-shallow-repository output.
* lint_test_flags: match qualified mz_dyncfg::Config::new(.
* check-mzcompose-files: anchor the composition grep.
* ci-validate-profraws: skip the working dir so workers do not delete validated copies, and fail instead of destroying originals on cp failure.

Lint plumbing:
* lint: signal offline mode via an env var instead of appending --offline to every check (most treated it as a git pathspec).
* check-protobuf: fix the always-true run gate and the literal IN_BUILDKITE, drop debug echos, and fail on a missing root proto.
* buildkite/git.bash: keep the default ref on a fork-only clone; slack-links uses the remote-tracking ref instead of the racy shared FETCH_HEAD.
* lint-cargo: run every lint instead of short-circuiting.
* check-python-version: wrap compileall (not git_files) in try and guard empty input.
* ci-builder: per-invocation cidfile so concurrent runs do not collide.
* ci-python-imports: statically follow function-local imports.
* add request timeouts to github/linear/generic_api and stop get_artifacts from swallowing KeyboardInterrupt.

Test run: https://buildkite.com/materialize/nightly/builds/17109#_