### PR TITLE
Pipeline peek burst

### DIFF
--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -27,6 +27,7 @@ check_all_files_referenced_in_ci() {
         -not -wholename "./test/cargo-fuzz/mzcompose.py" `# Enabled in release qualification later in the cargo-fuzz stack` \
         -not -wholename "./test/mzcompose_examples/mzcompose.py" `# Example only` \
         -not -wholename "./test/get-cloud-hostname/mzcompose.py" `# Utility, no test` \
+        -not -wholename "./test/pipeline-benchmark/mzcompose.py" `# Only run manually` \
         | sed -e "s|.*/\([^/]*\)/mzcompose.py|\1|")
     while read -r composition; do
         if ! grep -q "composition: $composition" ci/*/pipeline.template.yml; then

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -246,6 +246,16 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "enable_pipelined_peek_shared_timestamp",
+            "true" if version >= MzVersion.parse_mz("v26.34.0-dev") else "false",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
+            "enable_pipelined_peek_overlap",
+            "true" if version >= MzVersion.parse_mz("v26.34.0-dev") else "false",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_scoped_system_parameters",
             "false",
             ["true", "false"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1678,6 +1678,10 @@ class FlipFlagsAction(Action):
             "true",
             "false",
         ]
+        self.flags_with_values["enable_pipelined_peek_shared_timestamp"] = (
+            BOOLEAN_FLAG_VALUES
+        )
+        self.flags_with_values["enable_pipelined_peek_overlap"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_case_literal_transform"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_cast_elimination"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_fixed_correlated_cte_lowering"] = (

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -114,7 +114,7 @@ pub const ENABLE_FRONTEND_SUBSCRIBES: Config<bool> = Config::new(
 /// reuse it, never a statement that arrived afterwards.
 pub const ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP: Config<bool> = Config::new(
     "enable_pipelined_peek_shared_timestamp",
-    false,
+    true,
     "Share one timestamp-oracle read_ts across a burst of pipelined peeks on a connection.",
 );
 
@@ -129,7 +129,7 @@ pub const ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP: Config<bool> = Config::new(
 /// `enable_pipelined_peek_shared_timestamp`. Requires the frontend-peek path.
 pub const ENABLE_PIPELINED_PEEK_OVERLAP: Config<bool> = Config::new(
     "enable_pipelined_peek_overlap",
-    false,
+    true,
     "Overlap the compute-result awaits of a burst of pipelined peeks on a connection.",
 );
 

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -101,6 +101,23 @@ pub const ENABLE_FRONTEND_SUBSCRIBES: Config<bool> = Config::new(
     "Enable sending subscribes down the new frontend-peek path.",
 );
 
+/// Share a single timestamp-oracle `read_ts` across a burst of pipelined
+/// peeks on one connection.
+///
+/// When a client pipelines statements (sends them without waiting for each
+/// response), the frontend-peek path still reads a fresh oracle timestamp per
+/// query, one round-trip each. All queries in such a burst have arrived before
+/// any response is sent, so a single `read_ts` taken during the burst is within
+/// the real-time bounds of every one of them (the same argument that makes
+/// `BatchingTimestampOracle` correct). This reuses that timestamp across the
+/// burst, removing the extra round-trips. Only the pgwire-drained burst may
+/// reuse it, never a statement that arrived afterwards.
+pub const ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP: Config<bool> = Config::new(
+    "enable_pipelined_peek_shared_timestamp",
+    false,
+    "Share one timestamp-oracle read_ts across a burst of pipelined peeks on a connection.",
+);
+
 /// The plan insights notice will not investigate fast path clusters if plan optimization took longer than this.
 pub const PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION: Config<Duration> = Config::new(
     "plan_insights_notice_fast_path_clusters_optimize_duration",
@@ -362,6 +379,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&ENABLE_FRONTEND_SUBSCRIBES)
+        .add(&ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)
         .add(&ENABLE_EXPRESSION_CACHE)
         .add(&ENABLE_PASSWORD_AUTH)

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -118,6 +118,21 @@ pub const ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP: Config<bool> = Config::new(
     "Share one timestamp-oracle read_ts across a burst of pipelined peeks on a connection.",
 );
 
+/// Overlap the compute-result awaits of a burst of pipelined peeks.
+///
+/// A fast-path peek returns a deferred row stream: the peek is issued to the
+/// cluster and the result is awaited later, while sending rows. Normally pgwire
+/// processes one statement fully before the next, so those awaits serialize.
+/// With this on, pgwire issues every peek in a drained pipeline burst first
+/// (deferring each statement's wire responses), then drains the row streams in
+/// order, so the cluster works on all the peeks concurrently. Composes with
+/// `enable_pipelined_peek_shared_timestamp`. Requires the frontend-peek path.
+pub const ENABLE_PIPELINED_PEEK_OVERLAP: Config<bool> = Config::new(
+    "enable_pipelined_peek_overlap",
+    false,
+    "Overlap the compute-result awaits of a burst of pipelined peeks on a connection.",
+);
+
 /// The plan insights notice will not investigate fast path clusters if plan optimization took longer than this.
 pub const PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION: Config<Duration> = Config::new(
     "plan_insights_notice_fast_path_clusters_optimize_duration",
@@ -380,6 +395,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&ENABLE_FRONTEND_SUBSCRIBES)
         .add(&ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP)
+        .add(&ENABLE_PIPELINED_PEEK_OVERLAP)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)
         .add(&ENABLE_EXPRESSION_CACHE)
         .add(&ENABLE_PASSWORD_AUTH)

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -306,6 +306,7 @@ impl Client {
             peek_client,
             enable_frontend_peek_sequencing: false, // initialized below, once we have a ConnCatalog
             enable_pipelined_peek_shared_timestamp: false, // initialized below
+            enable_pipelined_peek_overlap: false,   // initialized below
         };
 
         let session = client.session();
@@ -453,8 +454,12 @@ Issue a SQL query to get started. Need help?
         let enable_pipelined_peek_shared_timestamp =
             mz_adapter_types::dyncfgs::ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP
                 .get(catalog.system_vars().dyncfgs());
+        let enable_pipelined_peek_overlap =
+            mz_adapter_types::dyncfgs::ENABLE_PIPELINED_PEEK_OVERLAP
+                .get(catalog.system_vars().dyncfgs());
         client.enable_frontend_peek_sequencing = enable_frontend_peek_sequencing;
         client.enable_pipelined_peek_shared_timestamp = enable_pipelined_peek_shared_timestamp;
+        client.enable_pipelined_peek_overlap = enable_pipelined_peek_overlap;
 
         Ok(client)
     }
@@ -642,6 +647,9 @@ pub struct SessionClient {
     /// peeks (`ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP`). Cached at startup like
     /// `enable_frontend_peek_sequencing`.
     enable_pipelined_peek_shared_timestamp: bool,
+    /// Whether to overlap the compute-result awaits of a pipelined burst of
+    /// peeks (`ENABLE_PIPELINED_PEEK_OVERLAP`). Cached at startup.
+    enable_pipelined_peek_overlap: bool,
 }
 
 impl SessionClient {
@@ -657,12 +665,20 @@ impl SessionClient {
         self.peek_client.end_pipeline_burst();
     }
 
-    /// Whether the pgwire layer should drain pipelined messages into a burst so
-    /// its peeks can share a read timestamp. Requires both the frontend-peek
-    /// path (where sharing takes effect) and the burst feature flag; inert by
-    /// default.
+    /// Whether the pgwire layer should drain pipelined messages into a burst.
+    /// Requires the frontend-peek path (where the optimizations take effect) and
+    /// at least one burst feature flag; inert by default.
     pub fn should_drain_pipeline_burst(&self) -> bool {
-        self.enable_frontend_peek_sequencing && self.enable_pipelined_peek_shared_timestamp
+        self.enable_frontend_peek_sequencing
+            && (self.enable_pipelined_peek_shared_timestamp || self.enable_pipelined_peek_overlap)
+    }
+
+    /// Whether the pgwire layer should process a drained burst by issuing all
+    /// its peeks first and then draining their row streams in order, overlapping
+    /// the compute-result awaits. When false a drained burst is processed
+    /// serially (only `enable_pipelined_peek_shared_timestamp` takes effect).
+    pub fn should_overlap_pipeline_burst(&self) -> bool {
+        self.enable_frontend_peek_sequencing && self.enable_pipelined_peek_overlap
     }
 
     /// Parses a SQL expression, reporting failures as a telemetry event if

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -305,6 +305,7 @@ impl Client {
             segment_client: self.segment_client.clone(),
             peek_client,
             enable_frontend_peek_sequencing: false, // initialized below, once we have a ConnCatalog
+            enable_pipelined_peek_shared_timestamp: false, // initialized below
         };
 
         let session = client.session();
@@ -443,9 +444,17 @@ Issue a SQL query to get started. Need help?
             }
         }
 
-        client.enable_frontend_peek_sequencing = ENABLE_FRONTEND_PEEK_SEQUENCING
+        // Read both connection-cached flags while `catalog` (which borrows the
+        // session, and thus `client`) is still alive, then assign them once the
+        // borrow has ended.
+        let enable_frontend_peek_sequencing = ENABLE_FRONTEND_PEEK_SEQUENCING
             .require(catalog.system_vars())
             .is_ok();
+        let enable_pipelined_peek_shared_timestamp =
+            mz_adapter_types::dyncfgs::ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP
+                .get(catalog.system_vars().dyncfgs());
+        client.enable_frontend_peek_sequencing = enable_frontend_peek_sequencing;
+        client.enable_pipelined_peek_shared_timestamp = enable_pipelined_peek_shared_timestamp;
 
         Ok(client)
     }
@@ -629,9 +638,33 @@ pub struct SessionClient {
     // check the actual feature flag value at every peek (without a Coordinator call) once we'll
     // always have a catalog snapshot at hand.
     pub enable_frontend_peek_sequencing: bool,
+    /// Whether to drain and share one read timestamp across a pipelined burst of
+    /// peeks (`ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP`). Cached at startup like
+    /// `enable_frontend_peek_sequencing`.
+    enable_pipelined_peek_shared_timestamp: bool,
 }
 
 impl SessionClient {
+    /// Open a burst of pipelined peeks that may share one oracle read timestamp.
+    /// The pgwire layer calls this after draining a run of already-arrived
+    /// pipelined messages. See [`PeekClient::begin_pipeline_burst`].
+    pub fn begin_pipeline_burst(&mut self) {
+        self.peek_client.begin_pipeline_burst();
+    }
+
+    /// Close the current pipeline burst. See [`PeekClient::end_pipeline_burst`].
+    pub fn end_pipeline_burst(&mut self) {
+        self.peek_client.end_pipeline_burst();
+    }
+
+    /// Whether the pgwire layer should drain pipelined messages into a burst so
+    /// its peeks can share a read timestamp. Requires both the frontend-peek
+    /// path (where sharing takes effect) and the burst feature flag; inert by
+    /// default.
+    pub fn should_drain_pipeline_burst(&self) -> bool {
+        self.enable_frontend_peek_sequencing && self.enable_pipelined_peek_shared_timestamp
+    }
+
     /// Parses a SQL expression, reporting failures as a telemetry event if
     /// possible.
     pub fn parse<'a>(
@@ -816,6 +849,11 @@ impl SessionClient {
             // `Command::Execute` will handle it.
             // (This is not true if we bailed out _after_ the frontend peek sequencing has already
             // begun its own statement logging. That case would be a bug.)
+
+            // This statement is not a frontend read-only peek, so it may write.
+            // Drop any shared pipeline-burst timestamp so a following peek
+            // re-reads and observes the write (read-your-writes).
+            self.peek_client.dirty_pipeline_burst();
         }
 
         let response = self

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -593,11 +593,18 @@ impl PeekClient {
         let needs_linearized_read_ts =
             Coordinator::needs_linearized_read_ts(&isolation_level, when);
 
+        // A burst of pipelined autocommit peeks may share one oracle read_ts
+        // (see `PeekClient::burst_read_ts`). Only implicit (single-statement)
+        // transactions participate, so explicit-transaction timestamp handling
+        // is untouched. Outside an open burst this is a no-op and each query
+        // reads a fresh timestamp as before.
+        let share_burst_ts = session.transaction().is_implicit()
+            && mz_adapter_types::dyncfgs::ENABLE_PIPELINED_PEEK_SHARED_TIMESTAMP
+                .get(catalog.system_config().dyncfgs());
+
         let oracle_read_ts = match timeline {
             Some(timeline) if needs_linearized_read_ts => {
-                let oracle = self.ensure_oracle(timeline).await?;
-                let oracle_read_ts = oracle.read_ts().await;
-                Some(oracle_read_ts)
+                Some(self.burst_read_ts(timeline, share_burst_ts).await?)
             }
             Some(_) | None => None,
         };

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -49,6 +49,23 @@ use crate::{AdapterError, Client, CollectionIdBundle, ReadHolds, statement_loggi
 pub type StorageCollectionsHandle =
     Arc<dyn mz_storage_client::storage_collections::StorageCollections + Send + Sync>;
 
+/// A shared read timestamp for a burst of pipelined peeks on one connection.
+///
+/// When the pgwire layer drains a run of already-arrived pipelined messages it
+/// opens a burst (`begin_pipeline_burst`). The first peek of each timeline
+/// fetches a `read_ts` and records it here. Because every message in the burst
+/// had arrived before that fetch, the timestamp is within the real-time bounds
+/// of all of them, so the rest of the burst reuses it instead of paying another
+/// oracle round-trip. This is the `BatchingTimestampOracle` correctness argument
+/// applied across a pipeline (see `guide-adapter.md`).
+///
+/// A write dirties the burst (`dirty`), dropping the cached timestamps so a
+/// following peek re-reads and observes the write (read-your-writes).
+#[derive(Debug, Default)]
+struct PipelineBurst {
+    read_ts: BTreeMap<Timeline, Timestamp>,
+}
+
 /// Clients needed for peek sequencing in the Adapter Frontend.
 #[derive(Debug)]
 pub struct PeekClient {
@@ -60,6 +77,9 @@ pub struct PeekClient {
     /// Holds a `Weak` so that an idle session does not keep a superseded
     /// catalog version alive.
     catalog_cache: Weak<Catalog>,
+    /// Shared read timestamp for the current burst of pipelined peeks, if the
+    /// pgwire layer has opened one. `None` outside a burst.
+    pipeline_burst: Option<PipelineBurst>,
     /// Channels to talk to each compute Instance task directly. Lazily populated.
     /// Note that these are never cleaned up. In theory, this could lead to a very slow memory leak
     /// if a long-running user session keeps peeking on clusters that are being created and dropped
@@ -94,6 +114,7 @@ impl PeekClient {
         Self {
             coordinator_client,
             catalog_cache: Arc::downgrade(catalog),
+            pipeline_burst: None,
             compute_instances: Default::default(), // lazily populated
             storage_collections,
             transient_id_gen,
@@ -122,6 +143,56 @@ impl PeekClient {
             .get(&compute_instance)
             .expect("ensured above")
             .clone())
+    }
+
+    /// Open a burst of pipelined peeks that may share one oracle `read_ts`.
+    ///
+    /// The caller (pgwire) must only open a burst once it has drained a run of
+    /// messages that had *already arrived* on the connection, so a timestamp
+    /// fetched during the burst is within every statement's real-time bounds.
+    pub fn begin_pipeline_burst(&mut self) {
+        self.pipeline_burst = Some(PipelineBurst::default());
+    }
+
+    /// Close the current burst, dropping any shared timestamps. The next
+    /// statement is read fresh from the socket and may have arrived after the
+    /// shared timestamp, so it must not reuse it.
+    pub fn end_pipeline_burst(&mut self) {
+        self.pipeline_burst = None;
+    }
+
+    /// Drop the burst's cached timestamps without closing the burst. Called
+    /// when a statement other than a frontend read-only peek runs (it may have
+    /// written), so a following peek re-reads and observes the write.
+    pub fn dirty_pipeline_burst(&mut self) {
+        if let Some(burst) = &mut self.pipeline_burst {
+            burst.read_ts.clear();
+        }
+    }
+
+    /// Fetch a linearized `read_ts` for `timeline`, reusing the current burst's
+    /// shared timestamp when `share` is set and one has already been taken for
+    /// this timeline. Outside a burst (or when `share` is false) this always
+    /// takes a fresh timestamp, matching the non-pipelined behavior.
+    pub async fn burst_read_ts(
+        &mut self,
+        timeline: Timeline,
+        share: bool,
+    ) -> Result<Timestamp, AdapterError> {
+        if share {
+            if let Some(burst) = &self.pipeline_burst {
+                if let Some(ts) = burst.read_ts.get(&timeline) {
+                    return Ok(*ts);
+                }
+            }
+        }
+        let ts = self.ensure_oracle(timeline.clone()).await?.read_ts().await;
+        if share {
+            if let Some(burst) = &mut self.pipeline_burst {
+                burst.read_ts.insert(timeline, ts);
+            }
+        }
+        Ok(ts)
     }
 
     pub async fn ensure_oracle(

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1151,6 +1151,23 @@ impl TransactionStatus {
         }
     }
 
+    /// Whether the pgwire layer may gather pipelined statements into a shared
+    /// burst while the session is in this state.
+    ///
+    /// True only for the autocommit extended-query states: `Default` (idle,
+    /// before a statement's transaction starts) and `Started` (a single-query
+    /// implicit transaction). An explicit transaction (`InTransaction`,
+    /// `Failed`) or a multi-statement implicit query (`InTransactionImplicit`)
+    /// may resume a portal across statements (a partial `Execute`, a cursor
+    /// `FETCH`), which a burst that defers row streaming cannot preserve, so
+    /// those run serially.
+    pub fn allows_pipeline_burst(&self) -> bool {
+        matches!(
+            self,
+            TransactionStatus::Default | TransactionStatus::Started(_)
+        )
+    }
+
     /// Whether the transaction's ops are DDL.
     pub fn is_ddl(&self) -> bool {
         match self {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -642,6 +642,9 @@ where
         tokio_metrics_intervals,
         pending: VecDeque::new(),
         in_burst: false,
+        capturing: None,
+        defer_peek: false,
+        deferred_peek: None,
     };
 
     select! {
@@ -861,6 +864,36 @@ where
     /// Whether a pipeline burst is currently open (see `pending`). While open,
     /// no further draining happens; it closes on the next socket read.
     in_burst: bool,
+    /// When `Some`, `send` appends to this buffer instead of writing to the
+    /// socket. Used by the pipelined-peek overlap path to defer a statement's
+    /// early responses (BindComplete, RowDescription) while later peeks in the
+    /// burst are issued, so they can be flushed in the correct order afterwards.
+    capturing: Option<Vec<BackendMessage>>,
+    /// When set, `send_execute_response` stashes a streaming/immediate peek
+    /// response into `deferred_peek` instead of awaiting and sending its rows.
+    /// The overlap path issues all peeks this way, then drains them in order.
+    defer_peek: bool,
+    /// The peek stashed by the last `send_execute_response` under `defer_peek`.
+    deferred_peek: Option<DeferredPeek>,
+}
+
+/// A peek response whose rows are streamed later, once every peek in a
+/// pipelined burst has been issued (see `run_overlapped_burst`).
+struct DeferredPeek {
+    response: ExecuteResponse,
+    row_desc: Option<RelationDesc>,
+    portal_name: String,
+    max_rows: ExecuteCount,
+    execute_started: Instant,
+}
+
+/// One statement's deferred pgwire output in a pipelined-peek burst, emitted in
+/// statement order after all peeks are issued.
+enum BurstItem {
+    /// Captured early responses (BindComplete, RowDescription, ...).
+    Messages(Vec<BackendMessage>),
+    /// A peek whose rows (and compute-result await) are produced at emit time.
+    Peek(DeferredPeek),
 }
 
 enum SendRowsEndedReason {
@@ -925,6 +958,248 @@ where
             }
         }
         drained
+    }
+
+    /// Drive a drained pipelined burst with compute-await overlap: issue every
+    /// peek before sending any rows (so the cluster runs them concurrently),
+    /// then emit each statement's responses in statement order. `first_*`
+    /// describe the Execute that opened the burst; its Bind/Describe were
+    /// already sent, so only its response onward is deferred.
+    ///
+    /// Correctness leans on read-only peeks: each issued peek owns its read
+    /// holds and result stream independently of the session transaction, so
+    /// committing a statement's implicit transaction (as the normal path does,
+    /// at the next Bind) before its rows are drained does not disturb it.
+    /// Anything the burst does not drive falls back to the normal loop via
+    /// `pending`, and on error the rest is handed to the normal loop (which
+    /// rejects it under the now-aborted transaction, matching Postgres pipeline
+    /// semantics), so correctness never depends on the burst's shape.
+    async fn run_overlapped_burst(
+        &mut self,
+        first_portal: String,
+        first_max_rows: ExecuteCount,
+        first_received: Option<EpochMillis>,
+        mut drained: VecDeque<FrontendMessage>,
+    ) -> Result<State, io::Error> {
+        self.adapter_client.begin_pipeline_burst();
+        self.in_burst = true;
+        let mut items: Vec<BurstItem> = Vec::new();
+
+        // Issue the triggering Execute (its Bind/Describe already went out).
+        let (captured, peek, state) = self
+            .issue_burst_execute(first_portal, first_max_rows, first_received)
+            .await?;
+        items.extend(captured.map(BurstItem::Messages));
+        items.extend(peek.map(BurstItem::Peek));
+        if !matches!(state, State::Ready) {
+            return self.end_burst_to_pending(items, drained, state).await;
+        }
+        self.mark_implicit_commit();
+
+        while let Some(msg) = drained.pop_front() {
+            match msg {
+                FrontendMessage::Bind {
+                    portal_name,
+                    statement_name,
+                    param_formats,
+                    raw_params,
+                    result_formats,
+                } => {
+                    self.capturing = Some(Vec::new());
+                    let state = self
+                        .bind(
+                            portal_name,
+                            statement_name,
+                            param_formats,
+                            raw_params,
+                            result_formats,
+                        )
+                        .await;
+                    let captured = self.capturing.take().unwrap_or_default();
+                    let state = state?;
+                    items.push(BurstItem::Messages(captured));
+                    if !matches!(state, State::Ready) {
+                        return self.end_burst_to_pending(items, drained, state).await;
+                    }
+                }
+                FrontendMessage::DescribePortal { name } => {
+                    self.capturing = Some(Vec::new());
+                    let state = self.describe_portal(&name).await;
+                    let captured = self.capturing.take().unwrap_or_default();
+                    let state = state?;
+                    items.push(BurstItem::Messages(captured));
+                    if !matches!(state, State::Ready) {
+                        return self.end_burst_to_pending(items, drained, state).await;
+                    }
+                }
+                FrontendMessage::DescribeStatement { name } => {
+                    self.capturing = Some(Vec::new());
+                    let state = self.describe_statement(&name).await;
+                    let captured = self.capturing.take().unwrap_or_default();
+                    let state = state?;
+                    items.push(BurstItem::Messages(captured));
+                    if !matches!(state, State::Ready) {
+                        return self.end_burst_to_pending(items, drained, state).await;
+                    }
+                }
+                FrontendMessage::Parse {
+                    name,
+                    sql,
+                    param_types,
+                } => {
+                    self.capturing = Some(Vec::new());
+                    let state = self.parse(name, sql, param_types).await;
+                    let captured = self.capturing.take().unwrap_or_default();
+                    let state = state?;
+                    items.push(BurstItem::Messages(captured));
+                    if !matches!(state, State::Ready) {
+                        return self.end_burst_to_pending(items, drained, state).await;
+                    }
+                }
+                FrontendMessage::Execute {
+                    portal_name,
+                    max_rows,
+                } => {
+                    let max_rows = match usize::try_from(max_rows) {
+                        Ok(0) | Err(_) => ExecuteCount::All,
+                        Ok(n) => ExecuteCount::Count(n),
+                    };
+                    let (captured, peek, state) = self
+                        .issue_burst_execute(portal_name, max_rows, None)
+                        .await?;
+                    items.extend(captured.map(BurstItem::Messages));
+                    items.extend(peek.map(BurstItem::Peek));
+                    if !matches!(state, State::Ready) {
+                        return self.end_burst_to_pending(items, drained, state).await;
+                    }
+                    self.mark_implicit_commit();
+                }
+                FrontendMessage::Sync => {
+                    let state = self.flush_burst(items).await?;
+                    self.end_burst();
+                    if !matches!(state, State::Ready) {
+                        return Ok(state);
+                    }
+                    return self.sync().await;
+                }
+                FrontendMessage::Flush => {
+                    let state = self.flush_burst(std::mem::take(&mut items)).await?;
+                    self.flush().await?;
+                    if !matches!(state, State::Ready) {
+                        self.end_burst();
+                        return Ok(state);
+                    }
+                    // Keep collecting after a Flush.
+                }
+                other => {
+                    // A message type the burst does not drive: emit what we have,
+                    // then hand this message and the rest to the normal loop.
+                    let state = self.flush_burst(items).await?;
+                    self.end_burst();
+                    drained.push_front(other);
+                    self.pending = drained;
+                    return Ok(state);
+                }
+            }
+        }
+
+        // Ran out of drained messages without a Sync (more may still arrive).
+        // Emit what we have; the burst closes on the next socket read.
+        let state = self.flush_burst(items).await?;
+        self.end_burst();
+        Ok(state)
+    }
+
+    /// Issue one Execute in the overlap path: run the normal execute flow with
+    /// output captured and the response deferred. Returns any captured early
+    /// messages (notices, or an error from the pre-execute checks), the deferred
+    /// response (if one was produced), and the resulting state.
+    async fn issue_burst_execute(
+        &mut self,
+        portal_name: String,
+        max_rows: ExecuteCount,
+        received: Option<EpochMillis>,
+    ) -> Result<(Option<Vec<BackendMessage>>, Option<DeferredPeek>, State), io::Error> {
+        self.capturing = Some(Vec::new());
+        self.defer_peek = true;
+        let state = self
+            .execute(
+                portal_name,
+                max_rows,
+                portal_exec_message,
+                None,
+                ExecuteTimeout::None,
+                None,
+                received,
+            )
+            .await;
+        self.defer_peek = false;
+        let captured = self.capturing.take().unwrap_or_default();
+        let state = state?;
+        let captured = (!captured.is_empty()).then_some(captured);
+        Ok((captured, self.deferred_peek.take(), state))
+    }
+
+    /// Emit deferred burst items in statement order. Peeks are sent here, which
+    /// is where their (now overlapped) compute results are awaited.
+    async fn flush_burst(&mut self, items: Vec<BurstItem>) -> Result<State, io::Error> {
+        let mut state = State::Ready;
+        for item in items {
+            match item {
+                BurstItem::Messages(msgs) => self.send_all(msgs).await?,
+                BurstItem::Peek(p) => {
+                    state = self
+                        .send_execute_response(
+                            p.response,
+                            p.row_desc,
+                            p.portal_name,
+                            p.max_rows,
+                            portal_exec_message,
+                            None,
+                            ExecuteTimeout::None,
+                            p.execute_started,
+                        )
+                        .await?;
+                    if !matches!(state, State::Ready) {
+                        return Ok(state);
+                    }
+                }
+            }
+        }
+        Ok(state)
+    }
+
+    /// Flush pending deferred items, close the burst, and hand any remaining
+    /// drained messages to the normal loop. Used on error: the rest is processed
+    /// under the now-aborted transaction (skip-to-Sync semantics).
+    async fn end_burst_to_pending(
+        &mut self,
+        items: Vec<BurstItem>,
+        drained: VecDeque<FrontendMessage>,
+        state: State,
+    ) -> Result<State, io::Error> {
+        let flush_state = self.flush_burst(items).await?;
+        self.end_burst();
+        self.pending = drained;
+        Ok(if !matches!(flush_state, State::Ready) {
+            flush_state
+        } else {
+            state
+        })
+    }
+
+    fn end_burst(&mut self) {
+        self.adapter_client.end_pipeline_burst();
+        self.in_burst = false;
+    }
+
+    /// Mark the current implicit transaction for commit, as the normal Execute
+    /// path does, so the next `ensure_transaction` (at the following Bind or
+    /// Sync) commits it.
+    fn mark_implicit_commit(&mut self) {
+        if self.adapter_client.session().transaction().is_implicit() {
+            self.txn_needs_commit = true;
+        }
     }
 
     #[instrument(level = "debug")]
@@ -1029,22 +1304,6 @@ where
                 portal_name,
                 max_rows,
             }) => {
-                // If the client has pipelined further messages that have already
-                // arrived, drain them now so this peek and they can share a
-                // single oracle read timestamp (see the `PeekClient` burst
-                // methods). We drain before executing, so the timestamp taken
-                // during this peek is within every drained statement's real-time
-                // bounds. Only on the frontend-peek path, and not when already
-                // inside a drained burst (avoids re-draining newer messages into
-                // the same burst).
-                if self.adapter_client.should_drain_pipeline_burst() && !self.in_burst {
-                    let drained = self.drain_buffered();
-                    if !drained.is_empty() {
-                        self.adapter_client.begin_pipeline_burst();
-                        self.in_burst = true;
-                        self.pending.extend(drained);
-                    }
-                }
                 let max_rows = match usize::try_from(max_rows) {
                     Ok(0) | Err(_) => ExecuteCount::All, // If `max_rows < 0`, no limit.
                     Ok(n) => ExecuteCount::Count(n),
@@ -1052,36 +1311,67 @@ where
                 let execute_root_span =
                     tracing::info_span!(parent: None, "advance_ready", otel.name = message_name);
                 execute_root_span.follows_from(tracing::Span::current());
-                let state = self
-                    .execute(
-                        portal_name,
-                        max_rows,
-                        portal_exec_message,
-                        None,
-                        ExecuteTimeout::None,
-                        None,
-                        Some(received),
-                    )
-                    .instrument(execute_root_span)
-                    .await?;
-                // In PostgreSQL, when using the extended query protocol, some statements may
-                // trigger an eager commit of the current implicit transaction,
-                // see: <https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=f92944137>.
-                //
-                // In Materialize, however, we eagerly commit every statement outside of an explicit
-                // transaction when using the extended query protocol. This allows us to eliminate
-                // the possibility of a multiple statement implicit transaction, which in turn
-                // allows us to apply single-statement optimizations to queries issued in implicit
-                // transactions in the extended query protocol.
-                //
-                // We don't immediately commit here to allow users to page through the portal if
-                // necessary. Committing the transaction would destroy the portal before the next
-                // Execute command has a chance to resume it. So we instead mark the transaction
-                // for commit the next time that `ensure_transaction` is called.
-                if self.adapter_client.session().transaction().is_implicit() {
-                    self.txn_needs_commit = true;
+
+                // If the client has pipelined further messages that have already
+                // arrived, drain them into a burst so its peeks can share a read
+                // timestamp (`enable_pipelined_peek_shared_timestamp`) and/or
+                // overlap their compute-result awaits (`enable_pipelined_peek_overlap`).
+                // We drain before executing, so a shared timestamp is within
+                // every drained statement's real-time bounds. Not when already
+                // inside a drained burst (avoids re-draining newer messages).
+                let drained = if self.adapter_client.should_drain_pipeline_burst() && !self.in_burst
+                {
+                    self.drain_buffered()
+                } else {
+                    Vec::new()
+                };
+
+                if !drained.is_empty() && self.adapter_client.should_overlap_pipeline_burst() {
+                    // Overlap: issue every peek, then drain their row streams in
+                    // order. This drives the triggering Execute, the drained
+                    // statements, and their transactions itself.
+                    self.run_overlapped_burst(portal_name, max_rows, Some(received), drained.into())
+                        .instrument(execute_root_span)
+                        .await?
+                } else {
+                    if !drained.is_empty() {
+                        // Shared-timestamp only: process the burst serially, one
+                        // statement per loop iteration, sharing the read_ts.
+                        self.adapter_client.begin_pipeline_burst();
+                        self.in_burst = true;
+                        self.pending.extend(drained);
+                    }
+                    let state = self
+                        .execute(
+                            portal_name,
+                            max_rows,
+                            portal_exec_message,
+                            None,
+                            ExecuteTimeout::None,
+                            None,
+                            Some(received),
+                        )
+                        .instrument(execute_root_span)
+                        .await?;
+                    // In PostgreSQL, when using the extended query protocol, some statements may
+                    // trigger an eager commit of the current implicit transaction,
+                    // see: <https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=f92944137>.
+                    //
+                    // In Materialize, however, we eagerly commit every statement outside of an explicit
+                    // transaction when using the extended query protocol. This allows us to eliminate
+                    // the possibility of a multiple statement implicit transaction, which in turn
+                    // allows us to apply single-statement optimizations to queries issued in implicit
+                    // transactions in the extended query protocol.
+                    //
+                    // We don't immediately commit here to allow users to page through the portal if
+                    // necessary. Committing the transaction would destroy the portal before the next
+                    // Execute command has a chance to resume it. So we instead mark the transaction
+                    // for commit the next time that `ensure_transaction` is called.
+                    if self.adapter_client.session().transaction().is_implicit() {
+                        self.txn_needs_commit = true;
+                    }
+                    state
                 }
-                state
             }
             Some(FrontendMessage::DescribeStatement { name }) => {
                 self.describe_statement(&name).await?
@@ -1960,6 +2250,14 @@ where
         M: Into<BackendMessage>,
     {
         let message: BackendMessage = message.into();
+
+        // In capture mode, buffer the message instead of writing it, so the
+        // pipelined-peek overlap path can reorder it after issuing later peeks.
+        if let Some(buf) = &mut self.capturing {
+            buf.push(message);
+            return Ok(());
+        }
+
         let is_error =
             matches!(&message, BackendMessage::ErrorResponse(e) if e.severity.is_error());
 
@@ -2018,6 +2316,24 @@ where
         timeout: ExecuteTimeout,
         execute_started: Instant,
     ) -> Result<State, io::Error> {
+        // Overlap path: defer sending this statement's response so later peeks
+        // in the burst can be issued first (a peek's rows are only awaited when
+        // sent). Everything needed to send later is stashed; the burst driver
+        // re-enters this function with `defer_peek` cleared. Applies to any
+        // response type, so a non-peek statement in the burst still sends its
+        // response in order; only read-only peeks actually benefit from the
+        // deferral, and the burst is entered only on that opt-in path.
+        if self.defer_peek {
+            self.deferred_peek = Some(DeferredPeek {
+                response,
+                row_desc,
+                portal_name,
+                max_rows,
+                execute_started,
+            });
+            return Ok(State::Ready);
+        }
+
         let mut tag = response.tag();
 
         macro_rules! command_complete {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -645,6 +645,7 @@ where
         capturing: None,
         defer_peek: false,
         deferred_peek: None,
+        burst_bail: None,
     };
 
     select! {
@@ -875,6 +876,23 @@ where
     defer_peek: bool,
     /// The peek stashed by the last `send_execute_response` under `defer_peek`.
     deferred_peek: Option<DeferredPeek>,
+    /// Set by `send_execute_response` under `defer_peek` when it hits a response
+    /// that must talk to the client directly (COPY, SUBSCRIBE) and so can be
+    /// neither captured nor deferred. The burst driver flushes what it has, ends
+    /// the burst, and runs this response in normal mode. See `run_overlapped_burst`.
+    burst_bail: Option<BurstBail>,
+}
+
+/// A response that cannot participate in a pipelined-overlap burst because it
+/// interacts with the client socket directly (COPY FROM/TO, SUBSCRIBE). It is
+/// re-dispatched through `send_execute_response` in normal mode after the burst
+/// flushes and ends.
+struct BurstBail {
+    response: ExecuteResponse,
+    row_desc: Option<RelationDesc>,
+    portal_name: String,
+    max_rows: ExecuteCount,
+    execute_started: Instant,
 }
 
 /// A peek response whose rows are streamed later, once every peek in a
@@ -885,6 +903,24 @@ struct DeferredPeek {
     portal_name: String,
     max_rows: ExecuteCount,
     execute_started: Instant,
+    /// Portal-derived state captured while the portal was still valid, so the
+    /// rows can be streamed after the portal is gone (rebound or committed away
+    /// by later statements in the burst).
+    detached: DetachedPeek,
+}
+
+/// The portal-derived inputs `send_rows` normally reads from the session portal,
+/// captured at peek-issue time for a deferred pipelined-overlap peek. By the
+/// time such a peek streams its rows a later statement in the burst may have
+/// rebound its portal (typically the unnamed portal `""`) or committed the
+/// implicit transaction that owned it, so the portal can no longer be consulted.
+/// A frontend read-only peek's row stream owns its read holds independently of
+/// the session transaction, so only this metadata needs preserving.
+struct DetachedPeek {
+    /// The bound result formats, already padded to the result arity at Bind.
+    result_formats: Vec<Format>,
+    /// The statement-type label for the first-to-last-byte metric.
+    statement_type: &'static str,
 }
 
 /// One statement's deferred pgwire output in a pipelined-peek burst, emitted in
@@ -960,6 +996,20 @@ where
         drained
     }
 
+    /// Receive the next frontend message, taking from the drained `pending`
+    /// buffer before the socket. Statement handlers that read further client
+    /// messages mid-statement (COPY FROM STDIN) must use this rather than
+    /// `conn.recv` directly, so a burst's drained messages (e.g. the statement's
+    /// own trailing `Sync`, which COPY mode absorbs) are seen in wire order
+    /// instead of being stranded in `pending` and misinterpreted later.
+    async fn recv_msg(&mut self) -> Result<Option<FrontendMessage>, io::Error> {
+        if let Some(message) = self.pending.pop_front() {
+            Ok(Some(message))
+        } else {
+            self.conn.recv().await
+        }
+    }
+
     /// Drive a drained pipelined burst with compute-await overlap: issue every
     /// peek before sending any rows (so the cluster runs them concurrently),
     /// then emit each statement's responses in statement order. `first_*`
@@ -991,6 +1041,9 @@ where
             .await?;
         items.extend(captured.map(BurstItem::Messages));
         items.extend(peek.map(BurstItem::Peek));
+        if let Some(bail) = self.burst_bail.take() {
+            return self.end_burst_with_bail(items, bail, drained).await;
+        }
         if !matches!(state, State::Ready) {
             return self.end_burst_to_pending(items, drained, state).await;
         }
@@ -1069,31 +1122,23 @@ where
                         .await?;
                     items.extend(captured.map(BurstItem::Messages));
                     items.extend(peek.map(BurstItem::Peek));
+                    if let Some(bail) = self.burst_bail.take() {
+                        return self.end_burst_with_bail(items, bail, drained).await;
+                    }
                     if !matches!(state, State::Ready) {
                         return self.end_burst_to_pending(items, drained, state).await;
                     }
                     self.mark_implicit_commit();
                 }
-                FrontendMessage::Sync => {
-                    let state = self.flush_burst(items).await?;
-                    self.end_burst();
-                    if !matches!(state, State::Ready) {
-                        return Ok(state);
-                    }
-                    return self.sync().await;
-                }
-                FrontendMessage::Flush => {
-                    let state = self.flush_burst(std::mem::take(&mut items)).await?;
-                    self.flush().await?;
-                    if !matches!(state, State::Ready) {
-                        self.end_burst();
-                        return Ok(state);
-                    }
-                    // Keep collecting after a Flush.
-                }
                 other => {
-                    // A message type the burst does not drive: emit what we have,
-                    // then hand this message and the rest to the normal loop.
+                    // A message the burst does not drive itself (Sync, Flush, a
+                    // simple Query, ...): emit the peeks issued so far (this is
+                    // where the overlap pays off, e.g. all peeks before a
+                    // trailing Sync are issued before any rows drain), then hand
+                    // this message and the rest back to the normal loop via
+                    // `pending`. Routing Sync/Flush through the normal loop keeps
+                    // their handling in one place and ensures no drained message
+                    // is dropped.
                     let state = self.flush_burst(items).await?;
                     self.end_burst();
                     drained.push_front(other);
@@ -1158,6 +1203,7 @@ where
                             None,
                             ExecuteTimeout::None,
                             p.execute_started,
+                            Some(p.detached),
                         )
                         .await?;
                     if !matches!(state, State::Ready) {
@@ -1186,6 +1232,45 @@ where
         } else {
             state
         })
+    }
+
+    /// Finish a burst that hit a response which must talk to the client
+    /// directly (COPY, SUBSCRIBE; see `BurstBail`). Emit the peeks issued before
+    /// it in statement order, end the burst, then run that response in normal
+    /// mode, and hand any remaining drained messages to the normal loop.
+    async fn end_burst_with_bail(
+        &mut self,
+        items: Vec<BurstItem>,
+        bail: BurstBail,
+        drained: VecDeque<FrontendMessage>,
+    ) -> Result<State, io::Error> {
+        let flush_state = self.flush_burst(items).await?;
+        self.end_burst();
+        // Restore the drained messages to `pending` before running the bailed
+        // statement. A COPY reads them via `recv_msg` (so COPY mode absorbs its
+        // own trailing `Sync`, as it would on the socket); anything else is
+        // handled by the normal loop after this statement completes.
+        self.pending = drained;
+        if !matches!(flush_state, State::Ready) {
+            // A peek issued before this statement errored; per skip-to-Sync the
+            // interactive statement does not run (its response is dropped, and
+            // the client is already skipping to the next Sync).
+            return Ok(flush_state);
+        }
+        // `defer_peek` and `capturing` were cleared when the burst issued this
+        // statement, so this runs normally, straight to the socket.
+        self.send_execute_response(
+            bail.response,
+            bail.row_desc,
+            bail.portal_name,
+            bail.max_rows,
+            portal_exec_message,
+            None,
+            ExecuteTimeout::None,
+            bail.execute_started,
+            None,
+        )
+        .await
     }
 
     fn end_burst(&mut self) {
@@ -1318,15 +1403,35 @@ where
                 // overlap their compute-result awaits (`enable_pipelined_peek_overlap`).
                 // We drain before executing, so a shared timestamp is within
                 // every drained statement's real-time bounds. Not when already
-                // inside a drained burst (avoids re-draining newer messages).
-                let drained = if self.adapter_client.should_drain_pipeline_burst() && !self.in_burst
+                // inside a drained burst (avoids re-draining newer messages), and
+                // only from an autocommit state: an explicit or multi-statement
+                // implicit transaction may resume a portal across statements,
+                // which a burst cannot serve (see `allows_pipeline_burst`).
+                let drained = if self.adapter_client.should_drain_pipeline_burst()
+                    && !self.in_burst
+                    && self
+                        .adapter_client
+                        .session()
+                        .transaction()
+                        .allows_pipeline_burst()
                 {
                     self.drain_buffered()
                 } else {
                     Vec::new()
                 };
 
-                if !drained.is_empty() && self.adapter_client.should_overlap_pipeline_burst() {
+                // Only worth a burst if the drain caught another statement to
+                // overlap or share a timestamp with. A lone trailing Sync/Flush,
+                // which every single-statement query produces, is no pipeline: a
+                // burst would add cost and (via `run_overlapped_burst` ->
+                // `issue_burst_execute`) call-stack depth below the planner for
+                // no benefit. See the recursion-limit regression in
+                // database-issues#9996.
+                let has_pipelined_stmt = drained
+                    .iter()
+                    .any(|msg| matches!(msg, FrontendMessage::Execute { .. }));
+
+                if has_pipelined_stmt && self.adapter_client.should_overlap_pipeline_burst() {
                     // Overlap: issue every peek, then drain their row streams in
                     // order. This drives the triggering Execute, the drained
                     // statements, and their transactions itself.
@@ -1334,11 +1439,17 @@ where
                         .instrument(execute_root_span)
                         .await?
                 } else {
-                    if !drained.is_empty() {
+                    if has_pipelined_stmt {
                         // Shared-timestamp only: process the burst serially, one
                         // statement per loop iteration, sharing the read_ts.
                         self.adapter_client.begin_pipeline_burst();
                         self.in_burst = true;
+                        self.pending.extend(drained);
+                    } else {
+                        // No pipelined statement, but the drain may still have
+                        // pulled this statement's trailing Sync/Flush off the
+                        // socket. Replay it via `pending` (no burst opened) so the
+                        // normal loop handles it.
                         self.pending.extend(drained);
                     }
                     let state = self
@@ -1419,7 +1530,20 @@ where
     }
 
     async fn advance_drain(&mut self) -> Result<State, io::Error> {
-        let message = self.conn.recv().await?;
+        // Drain buffered burst messages before the socket, exactly as
+        // `advance_ready` does. A burst that errors returns `State::Drain` with
+        // its trailing messages (including the `Sync` that ends the skip) still
+        // in `pending`; reading the socket instead would block forever waiting
+        // for a `Sync` that has already arrived.
+        let message = if let Some(message) = self.pending.pop_front() {
+            Some(message)
+        } else {
+            if self.in_burst {
+                self.adapter_client.end_pipeline_burst();
+                self.in_burst = false;
+            }
+            self.conn.recv().await?
+        };
         if message.is_some() {
             self.adapter_client
                 .remove_idle_in_transaction_session_timeout();
@@ -1498,6 +1622,7 @@ where
                     None,
                     ExecuteTimeout::None,
                     execute_started,
+                    None,
                 )
                 .await
             }
@@ -1964,6 +2089,7 @@ where
                                 fetch_portal_name,
                                 timeout,
                                 execute_started,
+                                None,
                             )
                             .await
                         }
@@ -1985,6 +2111,7 @@ where
                             get_response,
                             fetch_portal_name,
                             timeout,
+                            None,
                         )
                         .await
                     {
@@ -2315,16 +2442,79 @@ where
         fetch_portal_name: Option<String>,
         timeout: ExecuteTimeout,
         execute_started: Instant,
+        // `Some` when re-entered from the pipelined-overlap flush to stream a
+        // deferred peek whose portal may be gone. Forwarded to `send_rows`.
+        detached: Option<DetachedPeek>,
     ) -> Result<State, io::Error> {
-        // Overlap path: defer sending this statement's response so later peeks
-        // in the burst can be issued first (a peek's rows are only awaited when
-        // sent). Everything needed to send later is stashed; the burst driver
-        // re-enters this function with `defer_peek` cleared. Applies to any
-        // response type, so a non-peek statement in the burst still sends its
-        // response in order; only read-only peeks actually benefit from the
-        // deferral, and the burst is entered only on that opt-in path.
-        if self.defer_peek {
+        // Overlap path: defer sending this peek's rows so later peeks in the
+        // burst can be issued first (a peek's rows are only awaited when sent).
+        // We only defer a peek that is safe to stream after its portal is gone:
+        //
+        //   * A row-streaming peek. These are the only responses that benefit,
+        //     and the only ones whose `send_rows` reaches into the session
+        //     portal that a later statement in the burst may destroy.
+        //   * Fetching all rows. A partial fetch (`max_rows` limited) leaves
+        //     rows in its portal for a later `Execute`/`FETCH` to resume, which
+        //     detached streaming cannot preserve, so run it inline instead.
+        //   * In an implicit transaction. A peek in an explicit transaction may
+        //     have its portal resumed later in the transaction, so it too must
+        //     keep the live portal and run inline. (Bursts are only entered from
+        //     an implicit transaction, but a `BEGIN` earlier in the burst can
+        //     open an explicit one.)
+        //
+        // Every other response is emitted immediately (into the burst's capture
+        // buffer, preserving statement order) and never touches a portal that
+        // could go away. Capturing the portal-derived state here, while the
+        // portal is still valid, lets the deferred send avoid the portal.
+        if self.defer_peek
+            && matches!(
+                response,
+                ExecuteResponse::SendingRowsStreaming { .. }
+                    | ExecuteResponse::SendingRowsImmediate { .. }
+            )
+            && matches!(max_rows, ExecuteCount::All)
+            && self.adapter_client.session().transaction().is_implicit()
+        {
+            let portal = self
+                .adapter_client
+                .session()
+                .get_portal_unverified(&portal_name)
+                .expect("portal exists when issuing a deferred peek");
+            let detached = DetachedPeek {
+                result_formats: portal.result_formats.clone(),
+                statement_type: portal
+                    .stmt
+                    .as_ref()
+                    .map(|stmt| metrics::statement_type_label_value(stmt.deref()))
+                    .unwrap_or("no-statement"),
+            };
             self.deferred_peek = Some(DeferredPeek {
+                response,
+                row_desc,
+                portal_name,
+                max_rows,
+                execute_started,
+                detached,
+            });
+            return Ok(State::Ready);
+        }
+
+        // A response that talks to the client socket directly (COPY streams a
+        // CopyResponse and then reads/writes CopyData, SUBSCRIBE streams rows as
+        // they arrive) cannot run inside a burst: its output would be captured
+        // instead of sent, and draining would disturb its client I/O. Hand it
+        // back to the burst driver, which flushes what it has, ends the burst,
+        // and re-dispatches this response in normal mode. Detected here, before
+        // any such I/O begins.
+        if self.defer_peek
+            && matches!(
+                response,
+                ExecuteResponse::CopyFrom { .. }
+                    | ExecuteResponse::CopyTo { .. }
+                    | ExecuteResponse::Subscribing { .. }
+            )
+        {
+            self.burst_bail = Some(BurstBail {
                 response,
                 row_desc,
                 portal_name,
@@ -2401,6 +2591,7 @@ where
                     get_response,
                     fetch_portal_name,
                     timeout,
+                    detached,
                 )
                 .instrument(span)
                 .await
@@ -2428,6 +2619,7 @@ where
                     get_response,
                     fetch_portal_name,
                     timeout,
+                    detached,
                 )
                 .instrument(span)
                 .await
@@ -2489,6 +2681,8 @@ where
                         get_response,
                         fetch_portal_name,
                         timeout,
+                        // Subscribes are never deferred by the overlap path.
+                        None,
                     )
                     .await
                 {
@@ -2728,6 +2922,12 @@ where
         get_response: GetResponse,
         fetch_portal_name: Option<String>,
         timeout: ExecuteTimeout,
+        // `Some` for a deferred pipelined-overlap peek whose portal may already
+        // be gone. In that mode `send_rows` uses the captured result formats and
+        // never reads or writes the session portal (`portal_name`); see
+        // [`DetachedPeek`]. A detached peek is always a non-FETCH read-only peek,
+        // so `fetch_portal_name` is `None` and portal resumption never applies.
+        detached: Option<DetachedPeek>,
     ) -> Result<(State, SendRowsEndedReason), io::Error> {
         // If this portal is being executed from a FETCH then we need to use the result
         // format type of the outer portal.
@@ -2736,13 +2936,16 @@ where
         } else {
             &portal_name
         };
-        let result_formats = self
-            .adapter_client
-            .session()
-            .get_portal_unverified(result_format_portal_name)
-            .expect("valid fetch portal name for send rows")
-            .result_formats
-            .clone();
+        let result_formats = match &detached {
+            Some(detached) => detached.result_formats.clone(),
+            None => self
+                .adapter_client
+                .session()
+                .get_portal_unverified(result_format_portal_name)
+                .expect("valid fetch portal name for send rows")
+                .result_formats
+                .clone(),
+        };
 
         let (mut wait_once, mut deadline) = match timeout {
             ExecuteTimeout::None => (false, None),
@@ -2753,8 +2956,11 @@ where
             ExecuteTimeout::WaitOnce => (true, None),
         };
 
-        // Sanity check that the various `RelationDesc`s match up.
-        {
+        // Sanity check that the various `RelationDesc`s match up. Skipped for a
+        // detached peek: `row_desc` is already the authoritative description
+        // captured at issue time, and the portal it would check against may have
+        // been rebound to a different statement or committed away.
+        if detached.is_none() {
             let portal_name_desc = &self
                 .adapter_client
                 .session()
@@ -2925,12 +3131,6 @@ where
             }
         }
 
-        let portal = self
-            .adapter_client
-            .session()
-            .get_portal_unverified_mut(&portal_name)
-            .expect("valid portal name for send rows");
-
         let saw_rows = rows.remaining.saw_rows;
         let no_more_rows = rows.no_more_rows();
         let metric_recorded = rows.remaining.metric_recorded;
@@ -2941,8 +3141,17 @@ where
         }
 
         // Always return rows back, even if it's empty. This prevents an unclosed
-        // portal from re-executing after it has been emptied.
-        *portal.state = PortalState::InProgress(Some(rows));
+        // portal from re-executing after it has been emptied. Skipped for a
+        // detached peek: it is a single-shot autocommit peek whose portal is
+        // gone, so there is nothing to resume and no portal to write to.
+        if detached.is_none() {
+            let portal = self
+                .adapter_client
+                .session()
+                .get_portal_unverified_mut(&portal_name)
+                .expect("valid portal name for send rows");
+            *portal.state = PortalState::InProgress(Some(rows));
+        }
 
         let fetch_portal = fetch_portal_name.map(|name| {
             self.adapter_client
@@ -2956,16 +3165,22 @@ where
         // Attend to metrics if there are no more rows. Only record once per stream
         // to avoid polluting the histogram when an exhausted cursor is FETCHed again.
         if no_more_rows && !metric_recorded {
-            let statement_type = if let Some(stmt) = &self
-                .adapter_client
-                .session()
-                .get_portal_unverified(&portal_name)
-                .expect("valid portal name for send_rows")
-                .stmt
-            {
-                metrics::statement_type_label_value(stmt.deref())
-            } else {
-                "no-statement"
+            let statement_type = match &detached {
+                // The portal is gone; use the label captured at issue time.
+                Some(detached) => detached.statement_type,
+                None => {
+                    if let Some(stmt) = &self
+                        .adapter_client
+                        .session()
+                        .get_portal_unverified(&portal_name)
+                        .expect("valid portal name for send_rows")
+                        .stmt
+                    {
+                        metrics::statement_type_label_value(stmt.deref())
+                    } else {
+                        "no-statement"
+                    }
+                }
             };
             let duration = if saw_rows {
                 recorded_first_row_instant
@@ -3242,7 +3457,7 @@ where
                 // the error, otherwise they'd be misinterpreted as top-level
                 // protocol messages and cause a deadlock.
                 loop {
-                    match self.conn.recv().await? {
+                    match self.recv_msg().await? {
                         Some(FrontendMessage::CopyData(_)) => {}
                         Some(FrontendMessage::CopyDone) | Some(FrontendMessage::CopyFail(_)) => {
                             break;
@@ -3288,7 +3503,7 @@ where
         // Receive loop: accumulate CopyData, split at row boundaries,
         // round-robin raw chunks to parallel batch builder workers.
         loop {
-            let message = self.conn.recv().await?;
+            let message = self.recv_msg().await?;
             match message {
                 Some(FrontendMessage::CopyData(buf)) => {
                     if saw_end_marker {
@@ -3396,7 +3611,7 @@ where
         // avoid desynchronizing the protocol state machine.
         if !saw_copy_done {
             loop {
-                match self.conn.recv().await? {
+                match self.recv_msg().await? {
                     Some(FrontendMessage::CopyData(_)) => {}
                     Some(FrontendMessage::CopyDone) | Some(FrontendMessage::CopyFail(_)) => {
                         break;

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryFrom;
 use std::future::Future;
 use std::ops::Deref;
@@ -640,6 +640,8 @@ where
         adapter_client,
         txn_needs_commit: false,
         tokio_metrics_intervals,
+        pending: VecDeque::new(),
+        in_burst: false,
     };
 
     select! {
@@ -852,6 +854,13 @@ where
     adapter_client: mz_adapter::SessionClient,
     txn_needs_commit: bool,
     tokio_metrics_intervals: I,
+    /// Pipelined messages that had already arrived and were drained ahead of a
+    /// peek so the burst can share one read timestamp. Processed before reading
+    /// the socket again. See `drain_buffered` and the `Execute` handler.
+    pending: VecDeque<FrontendMessage>,
+    /// Whether a pipeline burst is currently open (see `pending`). While open,
+    /// no further draining happens; it closes on the next socket read.
+    in_burst: bool,
 }
 
 enum SendRowsEndedReason {
@@ -894,6 +903,30 @@ where
         }
     }
 
+    /// Pull messages that have already arrived on the connection without
+    /// blocking, up to a cap. Used to gather a pipelined burst so its peeks can
+    /// share one read timestamp: every returned message had arrived before this
+    /// call, the precondition for reusing a timestamp taken afterwards.
+    ///
+    /// `recv()` is cancel-safe, so polling it once with `now_or_never` and
+    /// dropping an unfinished future loses no data. A terminal result (EOF or
+    /// error) reached mid-drain is not re-enqueued; the next socket read
+    /// observes the same terminal state. Bursts only form on a live connection
+    /// with buffered input, where that case is not hit.
+    fn drain_buffered(&mut self) -> Vec<FrontendMessage> {
+        // Bound the burst so a client streaming without pause cannot make us
+        // buffer without limit.
+        const MAX_BURST: usize = 1024;
+        let mut drained = Vec::new();
+        while drained.len() < MAX_BURST {
+            match self.conn.recv().now_or_never() {
+                Some(Ok(Some(message))) => drained.push(message),
+                _ => break,
+            }
+        }
+        drained
+    }
+
     #[instrument(level = "debug")]
     async fn advance_ready(&mut self) -> Result<State, io::Error> {
         // Start a new metrics interval before the `recv()` call.
@@ -901,31 +934,45 @@ where
             .next()
             .expect("infinite iterator");
 
-        // Handle timeouts first so we don't execute any statements when there's a pending timeout.
-        let message = select! {
-            biased;
+        // Process any drained pipeline messages before reading the socket
+        // again. These had already arrived when we drained them, so they belong
+        // to the current burst and may share its read timestamp. Only once they
+        // are exhausted do we read the socket, where a message may be newer than
+        // the burst's shared timestamp, so we close the burst first.
+        let message = if let Some(message) = self.pending.pop_front() {
+            Some(message)
+        } else {
+            if self.in_burst {
+                self.adapter_client.end_pipeline_burst();
+                self.in_burst = false;
+            }
 
-            // `recv_timeout()` is cancel-safe as per it's docs.
-            Some(timeout) = self.adapter_client.recv_timeout() => {
-                let err: AdapterError = timeout.into();
-                let conn_id = self.adapter_client.session().conn_id();
-                tracing::warn!("session timed out, conn_id {}", conn_id);
+            // Handle timeouts first so we don't execute any statements when there's a pending timeout.
+            select! {
+                biased;
 
-                // Process the error, doing any state cleanup.
-                let error_response = err.into_response(Severity::Fatal);
-                let error_state = self.send_error_and_get_state(error_response).await;
+                // `recv_timeout()` is cancel-safe as per it's docs.
+                Some(timeout) = self.adapter_client.recv_timeout() => {
+                    let err: AdapterError = timeout.into();
+                    let conn_id = self.adapter_client.session().conn_id();
+                    tracing::warn!("session timed out, conn_id {}", conn_id);
 
-                // Terminate __after__ we do any cleanup.
-                self.adapter_client.terminate().await;
+                    // Process the error, doing any state cleanup.
+                    let error_response = err.into_response(Severity::Fatal);
+                    let error_state = self.send_error_and_get_state(error_response).await;
 
-                // We must wait for the client to send a request before we can send the error response.
-                // Due to the PG wire protocol, we can't send an ErrorResponse unless it is in response
-                // to a client message.
-                let _ = self.conn.recv().await?;
-                return error_state;
-            },
-            // `recv()` is cancel-safe as per it's docs.
-            message = self.conn.recv() => message?,
+                    // Terminate __after__ we do any cleanup.
+                    self.adapter_client.terminate().await;
+
+                    // We must wait for the client to send a request before we can send the error response.
+                    // Due to the PG wire protocol, we can't send an ErrorResponse unless it is in response
+                    // to a client message.
+                    let _ = self.conn.recv().await?;
+                    return error_state;
+                },
+                // `recv()` is cancel-safe as per it's docs.
+                message = self.conn.recv() => message?,
+            }
         };
 
         // Take the metrics since just before the `recv`.
@@ -982,6 +1029,22 @@ where
                 portal_name,
                 max_rows,
             }) => {
+                // If the client has pipelined further messages that have already
+                // arrived, drain them now so this peek and they can share a
+                // single oracle read timestamp (see the `PeekClient` burst
+                // methods). We drain before executing, so the timestamp taken
+                // during this peek is within every drained statement's real-time
+                // bounds. Only on the frontend-peek path, and not when already
+                // inside a drained burst (avoids re-draining newer messages into
+                // the same burst).
+                if self.adapter_client.should_drain_pipeline_burst() && !self.in_burst {
+                    let drained = self.drain_buffered();
+                    if !drained.is_empty() {
+                        self.adapter_client.begin_pipeline_burst();
+                        self.in_burst = true;
+                        self.pending.extend(drained);
+                    }
+                }
                 let max_rows = match usize::try_from(max_rows) {
                     Ok(0) | Err(_) => ExecuteCount::All, // If `max_rows < 0`, no limit.
                     Ok(n) => ExecuteCount::Count(n),

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -264,6 +264,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_paused_cluster_readhold_downgrade
     enable_persist_streaming_compaction
     enable_persist_streaming_snapshot_and_fetch
+    enable_pipelined_peek_shared_timestamp
     enable_primary_key_not_enforced
     enable_projection_pushdown_after_relation_cse
     enable_public_metrics_endpoint

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -264,6 +264,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_paused_cluster_readhold_downgrade
     enable_persist_streaming_compaction
     enable_persist_streaming_snapshot_and_fetch
+    enable_pipelined_peek_overlap
     enable_pipelined_peek_shared_timestamp
     enable_primary_key_not_enforced
     enable_projection_pushdown_after_relation_cse

--- a/test/pipeline-benchmark/mzcompose.py
+++ b/test/pipeline-benchmark/mzcompose.py
@@ -11,29 +11,33 @@
 Measures the speedup of libpq/psycopg pipeline mode against Materialize and,
 for reference, against Postgres.
 
-Pipeline mode batches extended-protocol messages: the client sends every
-Parse/Bind/Execute before reading any response, instead of waiting for the
-result of each query before sending the next. Its only effect is removing the
-per-query network round-trip.
+Pipeline mode batches extended-protocol messages so a client sends every
+Parse/Bind/Execute before reading any response, removing the per-query network
+round-trip. Two workloads isolate different costs:
 
-Two workloads isolate different costs:
+- `SELECT 1`, a constant, where server work is near-zero (and, being a constant,
+  it skips timestamp selection) so the round-trip dominates.
+- an indexed point lookup `SELECT v FROM t WHERE k = $1`, a real peek that under
+  strict serializability pays a timestamp-oracle round-trip and a compute-peek
+  round-trip per query.
 
-- `SELECT 1` is a constant. It does almost no server-side work (and, being a
-  constant, skips timestamp selection entirely), so the measured difference
-  between sequential and pipeline is essentially the round-trip.
-- The indexed point lookup `SELECT v FROM t WHERE k = $1` is a real peek. Under
-  strict serializability (Materialize's default) every such query pays a
-  timestamp-oracle round-trip, which pipeline mode cannot overlap today because
-  the pgwire connection processes statements strictly serially. This is the
-  case that motivates server-side pipelining.
+For Materialize it also A/Bs two server-side pipelining optimizations, toggled
+via mz_system before connecting:
 
-The benchmark reports, per workload and system, the sequential (baseline)
-throughput, the pipelined throughput, and the resulting speedup, then compares
-the two systems.
+- `enable_pipelined_peek_shared_timestamp` (+sharedTS): one oracle read_ts per
+  pipelined burst.
+- `enable_pipelined_peek_overlap` (+overlap): issue every peek in the burst
+  before draining any result, overlapping the compute-result awaits.
+
+On loopback the network round-trip is tiny, which understates pipeline mode.
+`--latency-ms N` routes the connections through Toxiproxy with ~N ms of added
+round-trip latency, which is closer to a real deployment.
 """
 
+import json
 import statistics
 import time
+import urllib.request
 from collections.abc import Callable, Sequence
 
 import psycopg
@@ -41,18 +45,26 @@ import psycopg
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import Postgres
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
 from materialize.util import PgConnInfo
+
+# Toxiproxy needs to publish the proxy listen ports (not just its API port) so
+# the benchmark, which runs on the host, can connect through them.
+_TOXIPROXY = Toxiproxy()
+_TOXIPROXY.config["ports"] = [8474, 6875, 5432]
 
 SERVICES = [
     Materialized(),
     Postgres(),
+    _TOXIPROXY,
 ]
 
 N_ROWS = 10000
 
 # Identical DDL on both systems: a keyed table with a secondary index, so
 # `WHERE k = $1` is an indexed point lookup rather than a scan. INSERT runs
-# before CREATE INDEX so the index is built with data already present.
+# before CREATE INDEX so the index is built with data already present. `v == k`,
+# which the correctness check relies on.
 SETUP = [
     b"DROP TABLE IF EXISTS pipeline_bench CASCADE",
     b"CREATE TABLE pipeline_bench (k int4, v int4)",
@@ -60,17 +72,27 @@ SETUP = [
     b"CREATE INDEX pipeline_bench_k_idx ON pipeline_bench (k)",
 ]
 
+POINT_LOOKUP = b"SELECT v FROM pipeline_bench WHERE k = %s"
+
 # (label, query, params-factory). The factory returns the psycopg params tuple
 # for iteration i, or None for a parameterless query. Keys vary across the
 # table to avoid single-entry caching effects.
 Workload = tuple[str, bytes, Callable[[int], tuple] | None]
 WORKLOADS: list[Workload] = [
     ("SELECT 1 (constant)", b"SELECT 1", None),
-    (
-        "point lookup (indexed)",
-        b"SELECT v FROM pipeline_bench WHERE k = %s",
-        lambda i: (i % N_ROWS,),
-    ),
+    ("point lookup (indexed)", POINT_LOOKUP, lambda i: (i % N_ROWS,)),
+]
+
+# Targets, in report order. `(shared_ts, overlap)` are the dyncfg values set (via
+# mz_system) before the target's Materialize connection is opened; the flags are
+# cached per connection at startup, so they must be set before connect. Postgres
+# is marked with `None`.
+Target = tuple[str, tuple[bool, bool] | None]
+TARGETS: list[Target] = [
+    ("Materialize", (False, False)),
+    ("Materialize+sharedTS", (True, False)),
+    ("Materialize+overlap", (True, True)),
+    ("Postgres", None),
 ]
 
 
@@ -110,15 +132,20 @@ def run_pipeline(
     return time.perf_counter() - start
 
 
-# Targets, in report order. The bool is the value the
-# `enable_pipelined_peek_shared_timestamp` dyncfg is set to (via mz_system)
-# before that target's Materialize connection is opened; None means Postgres.
-# The flag is cached per connection at startup, so it must be set before connect.
-TARGETS: list[tuple[str, bool | None]] = [
-    ("Materialize", False),
-    ("Materialize+sharedTS", True),
-    ("Postgres", None),
-]
+def check_pipeline(conn: psycopg.Connection) -> None:
+    """Verify pipelined point lookups return the right rows.
+
+    Guards the server-side pipelining paths (+overlap defers and reorders wire
+    responses): a protocol bug there would surface as wrong or missing rows.
+    """
+    keys = list(range(64))
+    curs = [conn.cursor() for _ in keys]
+    with conn.pipeline():
+        for cur, k in zip(curs, keys):
+            cur.execute(POINT_LOOKUP, (k,))
+    for cur, k in zip(curs, keys):
+        rows = cur.fetchall()
+        assert rows == [(k,)], f"pipeline correctness: k={k} returned {rows}"
 
 
 def print_workload(
@@ -140,16 +167,20 @@ def print_workload(
                 f"{target:<22} {mode:<11} {med * 1e6:>10.1f} {best * 1e6:>10.1f} "
                 f"{1 / med:>12,.0f} {1 / best:>12,.0f}"
             )
-    # #2 effect on the best (least-contended) pipelined sample, the cleanest
-    # signal under load. The sequential rows are a control: they should match
-    # across off/on, since sequential mode opens no burst.
+    # Effect of each optimization on the best (least-contended) pipelined sample,
+    # relative to the Materialize baseline. Sequential rows are a control: they
+    # should match across targets, since sequential mode opens no burst.
     base = min(samples[("Materialize", "pipeline")])
-    shared = min(samples[("Materialize+sharedTS", "pipeline")])
+    for target, cfg in TARGETS:
+        if cfg is None or target == "Materialize":
+            continue
+        this = min(samples[(target, "pipeline")])
+        print(
+            f"  {target} best-case pipelined: {n / base:,.0f} -> {n / this:,.0f} QPS"
+            f" ({base / this:.2f}x vs baseline)"
+        )
     pg = min(samples[("Postgres", "pipeline")])
-    print(
-        f"  #2 shared-ts (best-case pipelined): {n / base:,.0f} -> {n / shared:,.0f} QPS"
-        f" ({base / shared:.2f}x)   |   vs Postgres: {(n / shared) / (n / pg):.2f}x"
-    )
+    print(f"  Postgres best-case pipelined: {n / pg:,.0f} QPS")
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -160,11 +191,28 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         default=9,
         help="Interleaved timed trials per (target, mode); median and best reported.",
     )
+    parser.add_argument(
+        "--latency-ms",
+        type=int,
+        default=0,
+        help="If >0, route connections through Toxiproxy with ~N ms added round-trip latency.",
+    )
     args = parser.parse_args()
-    n, trials = args.queries, args.trials
+    n, trials, latency = args.queries, args.trials, args.latency_ms
 
-    c.up("materialized", "postgres")
+    services = ["materialized", "postgres"]
+    if latency > 0:
+        services.append("toxiproxy")
+    c.up(*services)
 
+    mz_host, mz_port = "127.0.0.1", c.default_port("materialized")
+    pg_host, pg_port = "127.0.0.1", c.default_port("postgres")
+    if latency > 0:
+        configure_toxiproxy(c, latency)
+        mz_port = c.port("toxiproxy", 6875)
+        pg_port = c.port("toxiproxy", 5432)
+
+    # mz_system is used only to set dyncfgs; it stays on the direct connection.
     mz_system = PgConnInfo(
         user="mz_system",
         database="materialize",
@@ -173,12 +221,17 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         autocommit=True,
     )
 
-    def set_shared_ts(enabled: bool) -> None:
+    def set_flags(shared_ts: bool, overlap: bool) -> None:
         conn = mz_system.connect()
         try:
-            conn.cursor().execute(
+            cur = conn.cursor()
+            cur.execute(
                 b"ALTER SYSTEM SET enable_pipelined_peek_shared_timestamp = "
-                + (b"true" if enabled else b"false")
+                + (b"true" if shared_ts else b"false")
+            )
+            cur.execute(
+                b"ALTER SYSTEM SET enable_pipelined_peek_overlap = "
+                + (b"true" if overlap else b"false")
             )
         finally:
             conn.close()
@@ -187,8 +240,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         return PgConnInfo(
             user="materialize",
             database="materialize",
-            host="127.0.0.1",
-            port=c.default_port("materialized"),
+            host=mz_host,
+            port=mz_port,
             autocommit=True,
         )
 
@@ -196,31 +249,37 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         user="postgres",
         password="postgres",
         database="postgres",
-        host="127.0.0.1",
-        port=c.default_port("postgres"),
+        host=pg_host,
+        port=pg_port,
         autocommit=True,
     )
 
-    # Open one connection per target. The dyncfg is cached at connect, so set it
-    # (system-wide, via mz_system) right before opening each Materialize
+    # Open one connection per target. The dyncfgs are cached at connect, so set
+    # them (system-wide, via mz_system) right before opening each Materialize
     # connection. Keeping all connections open lets us interleave trials so
     # host-load drift hits every target roughly equally within a trial.
     conns: dict[str, psycopg.Connection] = {}
-    for label, dyncfg in TARGETS:
-        if dyncfg is None:
+    for label, cfg in TARGETS:
+        if cfg is None:
             conns[label] = pg_conn.connect()
         else:
-            set_shared_ts(dyncfg)
+            set_flags(*cfg)
             conns[label] = mz_conn().connect()
 
     try:
-        # One table per backend; the two Materialize connections share a DB.
+        # One table per backend; the Materialize connections share a DB.
         run_setup(conns["Materialize"])
         run_setup(conns["Postgres"])
 
+        # Verify the server-side pipelining paths return correct results before
+        # trusting their timings.
+        for label, cfg in TARGETS:
+            if cfg is not None:
+                check_pipeline(conns[label])
+
         print(
             f"\n=== Pipeline-mode benchmark ({n} queries/trial,"
-            f" {trials} interleaved trials) ==="
+            f" {trials} interleaved trials, latency={latency}ms) ==="
         )
         for label, query, param_fn in WORKLOADS:
             params: list[tuple | None] = [
@@ -249,4 +308,36 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     finally:
         for conn in conns.values():
             conn.close()
-        set_shared_ts(False)
+        set_flags(False, False)
+
+
+def configure_toxiproxy(c: Composition, latency_ms: int) -> None:
+    """Create Toxiproxy proxies in front of Materialize and Postgres with a
+    latency toxic in each direction, approximating `latency_ms` round-trip.
+    """
+    api = c.port("toxiproxy", 8474)
+
+    def post(path: str, body: dict) -> None:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{api}{path}",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req).read()
+
+    for name, listen, upstream in [
+        ("mz", "0.0.0.0:6875", "materialized:6875"),
+        ("pg", "0.0.0.0:5432", "postgres:5432"),
+    ]:
+        post("/proxies", {"name": name, "listen": listen, "upstream": upstream})
+        for stream in ("upstream", "downstream"):
+            post(
+                f"/proxies/{name}/toxics",
+                {
+                    "name": f"{name}_{stream}",
+                    "type": "latency",
+                    "stream": stream,
+                    "attributes": {"latency": latency_ms // 2, "jitter": 0},
+                },
+            )

--- a/test/pipeline-benchmark/mzcompose.py
+++ b/test/pipeline-benchmark/mzcompose.py
@@ -1,0 +1,252 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Measures the speedup of libpq/psycopg pipeline mode against Materialize and,
+for reference, against Postgres.
+
+Pipeline mode batches extended-protocol messages: the client sends every
+Parse/Bind/Execute before reading any response, instead of waiting for the
+result of each query before sending the next. Its only effect is removing the
+per-query network round-trip.
+
+Two workloads isolate different costs:
+
+- `SELECT 1` is a constant. It does almost no server-side work (and, being a
+  constant, skips timestamp selection entirely), so the measured difference
+  between sequential and pipeline is essentially the round-trip.
+- The indexed point lookup `SELECT v FROM t WHERE k = $1` is a real peek. Under
+  strict serializability (Materialize's default) every such query pays a
+  timestamp-oracle round-trip, which pipeline mode cannot overlap today because
+  the pgwire connection processes statements strictly serially. This is the
+  case that motivates server-side pipelining.
+
+The benchmark reports, per workload and system, the sequential (baseline)
+throughput, the pipelined throughput, and the resulting speedup, then compares
+the two systems.
+"""
+
+import statistics
+import time
+from collections.abc import Callable, Sequence
+
+import psycopg
+
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.postgres import Postgres
+from materialize.util import PgConnInfo
+
+SERVICES = [
+    Materialized(),
+    Postgres(),
+]
+
+N_ROWS = 10000
+
+# Identical DDL on both systems: a keyed table with a secondary index, so
+# `WHERE k = $1` is an indexed point lookup rather than a scan. INSERT runs
+# before CREATE INDEX so the index is built with data already present.
+SETUP = [
+    b"DROP TABLE IF EXISTS pipeline_bench CASCADE",
+    b"CREATE TABLE pipeline_bench (k int4, v int4)",
+    f"INSERT INTO pipeline_bench SELECT g, g FROM generate_series(0, {N_ROWS - 1}) g".encode(),
+    b"CREATE INDEX pipeline_bench_k_idx ON pipeline_bench (k)",
+]
+
+# (label, query, params-factory). The factory returns the psycopg params tuple
+# for iteration i, or None for a parameterless query. Keys vary across the
+# table to avoid single-entry caching effects.
+Workload = tuple[str, bytes, Callable[[int], tuple] | None]
+WORKLOADS: list[Workload] = [
+    ("SELECT 1 (constant)", b"SELECT 1", None),
+    (
+        "point lookup (indexed)",
+        b"SELECT v FROM pipeline_bench WHERE k = %s",
+        lambda i: (i % N_ROWS,),
+    ),
+]
+
+
+def run_setup(conn: psycopg.Connection) -> None:
+    cur = conn.cursor()
+    for stmt in SETUP:
+        cur.execute(stmt)
+
+
+def run_sequential(
+    conn: psycopg.Connection, query: bytes, params: Sequence[tuple | None]
+) -> float:
+    """One request/response round-trip per query (extended protocol + Sync)."""
+    cur = conn.cursor()
+    start = time.perf_counter()
+    for p in params:
+        cur.execute(query, p)
+        cur.fetchall()
+    return time.perf_counter() - start
+
+
+def run_pipeline(
+    conn: psycopg.Connection, query: bytes, params: Sequence[tuple | None]
+) -> float:
+    """All queries are sent before any response is read.
+
+    Uses a distinct cursor per query so every result set is retained. Exiting
+    the pipeline block flushes and syncs, populating each cursor.
+    """
+    curs = [conn.cursor() for _ in params]
+    start = time.perf_counter()
+    with conn.pipeline():
+        for cur, p in zip(curs, params):
+            cur.execute(query, p)
+    for cur in curs:
+        cur.fetchall()
+    return time.perf_counter() - start
+
+
+# Targets, in report order. The bool is the value the
+# `enable_pipelined_peek_shared_timestamp` dyncfg is set to (via mz_system)
+# before that target's Materialize connection is opened; None means Postgres.
+# The flag is cached per connection at startup, so it must be set before connect.
+TARGETS: list[tuple[str, bool | None]] = [
+    ("Materialize", False),
+    ("Materialize+sharedTS", True),
+    ("Postgres", None),
+]
+
+
+def print_workload(
+    label: str, n: int, samples: dict[tuple[str, str], list[float]]
+) -> None:
+    """`samples` maps (target, mode) to per-trial total-time samples."""
+    print(f"\n### {label}")
+    header = (
+        f"{'Target':<22} {'Mode':<11} {'median us':>10} {'best us':>10} "
+        f"{'median QPS':>12} {'best QPS':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+    for target, _ in TARGETS:
+        for mode in ("sequential", "pipeline"):
+            s = samples[(target, mode)]
+            med, best = statistics.median(s) / n, min(s) / n
+            print(
+                f"{target:<22} {mode:<11} {med * 1e6:>10.1f} {best * 1e6:>10.1f} "
+                f"{1 / med:>12,.0f} {1 / best:>12,.0f}"
+            )
+    # #2 effect on the best (least-contended) pipelined sample, the cleanest
+    # signal under load. The sequential rows are a control: they should match
+    # across off/on, since sequential mode opens no burst.
+    base = min(samples[("Materialize", "pipeline")])
+    shared = min(samples[("Materialize+sharedTS", "pipeline")])
+    pg = min(samples[("Postgres", "pipeline")])
+    print(
+        f"  #2 shared-ts (best-case pipelined): {n / base:,.0f} -> {n / shared:,.0f} QPS"
+        f" ({base / shared:.2f}x)   |   vs Postgres: {(n / shared) / (n / pg):.2f}x"
+    )
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument("--queries", type=int, default=2000, help="Queries per trial.")
+    parser.add_argument(
+        "--trials",
+        type=int,
+        default=9,
+        help="Interleaved timed trials per (target, mode); median and best reported.",
+    )
+    args = parser.parse_args()
+    n, trials = args.queries, args.trials
+
+    c.up("materialized", "postgres")
+
+    mz_system = PgConnInfo(
+        user="mz_system",
+        database="materialize",
+        host="127.0.0.1",
+        port=c.port("materialized", 6877),
+        autocommit=True,
+    )
+
+    def set_shared_ts(enabled: bool) -> None:
+        conn = mz_system.connect()
+        try:
+            conn.cursor().execute(
+                b"ALTER SYSTEM SET enable_pipelined_peek_shared_timestamp = "
+                + (b"true" if enabled else b"false")
+            )
+        finally:
+            conn.close()
+
+    def mz_conn() -> PgConnInfo:
+        return PgConnInfo(
+            user="materialize",
+            database="materialize",
+            host="127.0.0.1",
+            port=c.default_port("materialized"),
+            autocommit=True,
+        )
+
+    pg_conn = PgConnInfo(
+        user="postgres",
+        password="postgres",
+        database="postgres",
+        host="127.0.0.1",
+        port=c.default_port("postgres"),
+        autocommit=True,
+    )
+
+    # Open one connection per target. The dyncfg is cached at connect, so set it
+    # (system-wide, via mz_system) right before opening each Materialize
+    # connection. Keeping all connections open lets us interleave trials so
+    # host-load drift hits every target roughly equally within a trial.
+    conns: dict[str, psycopg.Connection] = {}
+    for label, dyncfg in TARGETS:
+        if dyncfg is None:
+            conns[label] = pg_conn.connect()
+        else:
+            set_shared_ts(dyncfg)
+            conns[label] = mz_conn().connect()
+
+    try:
+        # One table per backend; the two Materialize connections share a DB.
+        run_setup(conns["Materialize"])
+        run_setup(conns["Postgres"])
+
+        print(
+            f"\n=== Pipeline-mode benchmark ({n} queries/trial,"
+            f" {trials} interleaved trials) ==="
+        )
+        for label, query, param_fn in WORKLOADS:
+            params: list[tuple | None] = [
+                param_fn(i) if param_fn else None for i in range(n)
+            ]
+            # Warm every target (connection, server caches, index hydration).
+            for conn in conns.values():
+                run_sequential(conn, query, params)
+                run_pipeline(conn, query, params)
+
+            samples: dict[tuple[str, str], list[float]] = {
+                (target, mode): []
+                for target, _ in TARGETS
+                for mode in ("sequential", "pipeline")
+            }
+            for _ in range(trials):
+                for target, _ in TARGETS:
+                    samples[(target, "sequential")].append(
+                        run_sequential(conns[target], query, params)
+                    )
+                for target, _ in TARGETS:
+                    samples[(target, "pipeline")].append(
+                        run_pipeline(conns[target], query, params)
+                    )
+            print_workload(label, n, samples)
+    finally:
+        for conn in conns.values():
+            conn.close()
+        set_shared_ts(False)


### PR DESCRIPTION
```
  Loopback (latency=0), point lookup, best-case pipelined QPS:

  ┌────────────────────────┬───────┬─────────────┐
  │         Target         │  QPS  │ vs baseline │
  ├────────────────────────┼───────┼─────────────┤
  │ Materialize (baseline) │   943 │       1.00× │
  ├────────────────────────┼───────┼─────────────┤
  │ +sharedTS (#2)         │ 1,044 │       1.11× │
  ├────────────────────────┼───────┼─────────────┤
  │ +overlap (#1)          │ 1,235 │       1.31× │
  └────────────────────────┴───────┴─────────────┘

  With 5 ms simulated RTT (toxiproxy), point lookup:

  ┌──────────────────────┬────────────┬───────────┬───────────────┐
  │        Target        │    Mode    │ per-query │      QPS      │
  ├──────────────────────┼────────────┼───────────┼───────────────┤
  │ Materialize baseline │ sequential │  5,727 µs │           175 │
  ├──────────────────────┼────────────┼───────────┼───────────────┤
  │ Materialize baseline │ pipeline   │    977 µs │         1,024 │
  ├──────────────────────┼────────────┼───────────┼───────────────┤
  │ +sharedTS            │ pipeline   │    893 µs │ 1,120 (1.09×) │
  ├──────────────────────┼────────────┼───────────┼───────────────┤
  │ +overlap             │ pipeline   │    757 µs │ 1,321 (1.29×) │
  └──────────────────────┴────────────┴───────────┴───────────────┘
```