### PR TITLE
workload-replay: fix replay under-delivery and capture bugs

### DIFF
--- a/misc/python/materialize/cli/mz_workload_capture.py
+++ b/misc/python/materialize/cli/mz_workload_capture.py
@@ -40,6 +40,50 @@ def to_sql_string(q: bytes | SQL | Composable | LiteralString, conn) -> str:
     return q
 
 
+def parse_mz_list(text: str) -> list[str]:
+    """Parse a Materialize `list` text literal like `{a,"b,c"}` into its
+    elements.
+
+    Handles quoting and backslash escaping so schema names containing commas or
+    quotes survive, and returns `[]` for the empty list `{}` (a naive
+    `text[1:-1].split(",")` would yield `[""]`).
+    """
+    assert text.startswith("{") and text.endswith(
+        "}"
+    ), f"Unexpected search path: {text}"
+    inner = text[1:-1]
+    if inner == "":
+        return []
+    elements: list[str] = []
+    i = 0
+    n = len(inner)
+    while i < n:
+        if inner[i] == '"':
+            i += 1
+            buf: list[str] = []
+            while i < n:
+                if inner[i] == "\\" and i + 1 < n:
+                    buf.append(inner[i + 1])
+                    i += 2
+                elif inner[i] == '"':
+                    i += 1
+                    break
+                else:
+                    buf.append(inner[i])
+                    i += 1
+            elements.append("".join(buf))
+            if i < n and inner[i] == ",":
+                i += 1
+        else:
+            j = inner.find(",", i)
+            if j == -1:
+                elements.append(inner[i:])
+                break
+            elements.append(inner[i:j])
+            i = j + 1
+    return elements
+
+
 VERBOSE = False
 
 
@@ -52,20 +96,37 @@ def query(
         print(f"\n> {to_sql_string(sql, conn)}")
 
     cancel_timer: threading.Timer | None = None
+    # The timer fires conn.cancel() on a background thread. Guard it with a flag
+    # so a timeout firing just as the query completes can't cancel whatever the
+    # connection runs next: threading.Timer.cancel() only helps if the callback
+    # has not started yet.
+    cancel_lock = threading.Lock()
+    done = False
+
+    def cancel_if_running() -> None:
+        with cancel_lock:
+            if not done:
+                conn.cancel()
 
     try:
         if timeout is not None:
-            cancel_timer = threading.Timer(timeout, conn.cancel)
+            cancel_timer = threading.Timer(timeout, cancel_if_running)
             cancel_timer.start()
 
         with conn.cursor() as cur:
             cur.execute(sql)
-            return cur.fetchall()
+            rows = cur.fetchall()
+        with cancel_lock:
+            done = True
+        return rows
     except psycopg.errors.QueryCanceled:
         if VERBOSE:
             print("Too slow")
         return []
     except KeyboardInterrupt:
+        # NOTE: Ctrl-C cancels the in-flight query and, unless verbose, re-runs
+        # it once with no timeout so a slow-but-wanted result can still be
+        # captured. A second Ctrl-C during that re-run aborts for real.
         conn.cancel()
         if VERBOSE:
             raise
@@ -112,13 +173,23 @@ def attach_source_statistics_internal(
         del source["messages_total"]
     if "messages_second" in source:
         del source["messages_second"]
+    # Real time when the subscribe starts. The historical burst streams every
+    # update through the current frontier (well past end_time), so once the
+    # progress frontier reaches this point the burst is done: an active source
+    # would already have hit the data break below, and an idle one can stop here
+    # instead of blocking ~60s of real time per source.
+    subscribe_start = time.time()
     with conn.cursor() as cur:
         cur.execute("SET CLUSTER = mz_catalog_server")
+        # mz_source_statistics_with_history has one row per (id, replica_id).
+        # Aggregate across replicas with max() so the counters don't interleave.
+        # Replicas ingest redundantly, so the furthest-along value is the
+        # source's progress (summing would multiply it by the replica count).
         sql = SQL("""
             SUBSCRIBE (
                 SELECT
-                    messages_received,
-                    bytes_received
+                    max(messages_received),
+                    max(bytes_received)
                 FROM mz_internal.mz_source_statistics_with_history
                 WHERE id = {}
             )
@@ -137,7 +208,7 @@ def attach_source_statistics_internal(
             if mz_diff == -1:
                 continue
             if mz_progress:
-                if mz_timestamp / 1000 > end_time + 60:
+                if mz_timestamp / 1000 > subscribe_start:
                     break
                 continue
             if "bytes_total" not in source:
@@ -182,7 +253,12 @@ def attach_avg_column_sizes(
         for col in obj["columns"]
     ]
 
-    query_sql = SQL("SELECT {} FROM {}.{}.{} LIMIT 100").format(
+    # LIMIT must be inside the subquery so it samples 100 rows before
+    # aggregating. Applied to the aggregate result it would be a no-op that
+    # still scans the whole table.
+    query_sql = SQL(
+        "SELECT {} FROM (SELECT * FROM {}.{}.{} LIMIT 100) AS sample"
+    ).format(
         SQL(", ").join(avg_exprs),
         Identifier(db),
         Identifier(schema),
@@ -482,7 +558,6 @@ def main() -> int:
             workload["databases"][db][schema]["views"][view] = obj
 
     with timed("Fetching materialized views"):
-        time.time()
         for mv_id, mv, schema, db in query(
             conn,
             "SELECT mz_materialized_views.id, mz_materialized_views.name, mz_schemas.name, mz_databases.name FROM mz_materialized_views JOIN mz_schemas ON mz_materialized_views.schema_id = mz_schemas.id JOIN mz_databases ON mz_schemas.database_id = mz_databases.id",
@@ -571,15 +646,12 @@ def main() -> int:
                 "SELECT sql, cluster_name, database_name, search_path, statement_type, finished_status, params, transaction_isolation, session_id, transaction_id, began_at, finished_at - began_at, result_size FROM mz_internal.mz_recent_activity_log WHERE began_at > {} ORDER BY began_at ASC"
             ).format(Literal(datetime.fromtimestamp(start_time, tz=timezone.utc))),
         ):
-            assert (
-                search_path[0] == "{" and search_path[-1] == "}"
-            ), f"Unexpected search path: {search_path}"
             workload["queries"].append(
                 {
                     "sql": sql,
                     "cluster": cluster,
                     "database": database,
-                    "search_path": search_path[1:-1].split(","),
+                    "search_path": parse_mz_list(search_path),
                     "statement_type": statement_type,
                     "finished_status": finished_status,
                     "params": params,
@@ -632,7 +704,6 @@ def main() -> int:
     if args.output == "-":
         yaml.dump(workload, sys.stdout, Dumper=yaml.CSafeDumper)
     else:
-        time.time()
         with timed(f"Writing workload to {args.output}"):
             with open(args.output, "w") as f:
                 yaml.dump(workload, f, Dumper=yaml.CSafeDumper)

--- a/misc/python/materialize/workload_replay/column.py
+++ b/misc/python/materialize/workload_replay/column.py
@@ -111,8 +111,9 @@ class Column:
 
     def kafka_value(self, rng: random.Random) -> Any:
         """Generate a value suitable for Kafka serialization."""
-        if self.default and rng.randrange(10) == 0 and self.default != "NULL":
-            return str(self.default)
+        # The captured default is a SQL expression (now(), 'x'::text, ...), not
+        # a typed value, so it can't be injected into an Avro-serialized field
+        # or a webhook body. Only value() (which builds SQL) can use it.
         if self.nullable and rng.randrange(10) == 0:
             return None
 
@@ -140,16 +141,18 @@ class Column:
             return long_tail_float(-1_000_000_000.0, 1_000_000_000.0, rng=rng)
 
         elif self.typ in ("text", "bytea"):
+            # Raw string: Avro serialization and webhook bodies must not carry
+            # the SQL quotes that literal() would add.
             shaped = self._shaped_text(rng)
             if shaped is not None:
-                return literal(shaped)
-            return literal(long_tail_text(self.chars, 100, self._hot_strings, rng=rng))
+                return shaped
+            return long_tail_text(self.chars, 100, self._hot_strings, rng=rng)
 
         elif self.typ in ("character", "character varying"):
             shaped = self._shaped_text(rng)
             if shaped is not None:
-                return literal(shaped)
-            return literal(long_tail_text(self.chars, 10, self._hot_strings, rng=rng))
+                return shaped
+            return long_tail_text(self.chars, 10, self._hot_strings, rng=rng)
 
         elif self.typ == "uuid":
             return str(uuid.UUID(int=rng.getrandbits(128), version=4))
@@ -214,8 +217,16 @@ class Column:
 
     def value(self, rng: random.Random, in_query: bool = True) -> Any:
         """Generate a value suitable for SQL queries or COPY operations."""
-        if self.default and rng.randrange(10) == 0 and self.default != "NULL":
-            return str(self.default) if in_query else self.default
+        # The captured default is a SQL expression (now(), 'x'::text, ...), so it
+        # is only valid spliced into a SQL statement. As a COPY text datum it
+        # would be inserted literally (e.g. the text "now()"), so skip it there.
+        if (
+            in_query
+            and self.default
+            and rng.randrange(10) == 0
+            and self.default != "NULL"
+        ):
+            return str(self.default)
 
         if self.nullable and rng.randrange(10) == 0:
             return "NULL" if in_query else None

--- a/misc/python/materialize/workload_replay/data.py
+++ b/misc/python/materialize/workload_replay/data.py
@@ -204,6 +204,10 @@ def _mysql_chunk(
         with conn.cursor() as cur:
             cur.execute(stmt)
 
+    # The connection is opened with autocommit=False, so without this commit
+    # the implicit InnoDB transaction is discarded on close and the source
+    # snapshots empty.
+    conn.commit()
     conn.close()
     return num_rows
 
@@ -543,6 +547,23 @@ def create_ingestions(
                             print(e)
                             stop_event.set()
                             raise
+
+                    threads.append(
+                        PropagatingThread(
+                            target=continuous_ingestion_webhook,
+                            name=f"ingest-{pretty_name}",
+                            args=(
+                                db,
+                                schema,
+                                name,
+                                source,
+                                pretty_name,
+                                batch_size,
+                                period_s,
+                                random.Random(random.randrange(SEED_RANGE)),
+                            ),
+                        )
+                    )
 
                 elif not source.get("children", {}):
                     if "messages_second" not in source:

--- a/misc/python/materialize/workload_replay/executor.py
+++ b/misc/python/materialize/workload_replay/executor.py
@@ -309,6 +309,12 @@ def benchmark(
         "schema-registry",
         "ssh-bastion-host",
         "testdrive",
+        # Object-store and Iceberg-catalog state must be reset too, else it
+        # persists between the reference and current runs of a comparison.
+        "polaris",
+        "polaris-bootstrap",
+        "minio",
+        "azurite",
     ]
 
     # When scale_data is false, use 100% initial data

--- a/misc/python/materialize/workload_replay/ingest.py
+++ b/misc/python/materialize/workload_replay/ingest.py
@@ -393,6 +393,10 @@ def ingest(
 
         with conn.cursor() as cur:
             cur.execute(stmt)
+        # The connection is opened with autocommit=False, so without this commit
+        # the implicit InnoDB transaction is discarded on close and no rows are
+        # ingested.
+        conn.commit()
         conn.close()
 
     elif source["type"] == "kafka":

--- a/misc/python/materialize/workload_replay/objects.py
+++ b/misc/python/materialize/workload_replay/objects.py
@@ -554,9 +554,12 @@ def run_create_objects_part_1(
                         time.sleep(1)
 
                 if source["type"] == "webhook":
-                    # Checking secrets makes ingestion into webhooks difficult, remove the check instead
+                    # Checking secrets makes ingestion into webhooks difficult, remove the check instead.
+                    # Anchor to end-of-string rather than a trailing semicolon:
+                    # raw captures end with ';', but the anonymizer re-renders
+                    # statements without one, and the CHECK clause is always last.
                     source["create_sql"] = re.sub(
-                        r"\s*CHECK\s*\(.*?\)\s*;",
+                        r"\s*CHECK\s*\(.*?\)\s*;?\s*$",
                         "",
                         source["create_sql"],
                         flags=re.DOTALL | re.IGNORECASE,

--- a/misc/python/materialize/workload_replay/replay.py
+++ b/misc/python/materialize/workload_replay/replay.py
@@ -22,7 +22,7 @@ import time
 from typing import Any
 
 import psycopg
-from psycopg.sql import SQL, Literal
+from psycopg.sql import SQL, Identifier, Literal
 
 from materialize.mzcompose.composition import Composition
 
@@ -62,7 +62,16 @@ def run_query(
         )
         cur.execute(SQL("SET cluster = {}").format(Literal(query["cluster"])))
         cur.execute(SQL("SET database = {}").format(Literal(query["database"])))
-        cur.execute(f"SET search_path = {','.join(query['search_path'])}".encode())
+        # Quote each schema as an identifier so names with special characters
+        # survive, and skip empty entries (an empty captured search_path would
+        # otherwise render as "SET search_path =", a syntax error).
+        search_path = [s for s in query["search_path"] if s]
+        if search_path:
+            cur.execute(
+                SQL("SET search_path = {}").format(
+                    SQL(", ").join(Identifier(s) for s in search_path)
+                )
+            )
 
         stats["total"] += 1
 
@@ -74,25 +83,44 @@ def run_query(
             start_time = time.time()
 
             if query["statement_type"] == "subscribe":
-                if query.get("duration"):
-                    duration = query["duration"]
-                    cur.execute(
-                        SQL("SET LOCAL statement_timeout = {}").format(
-                            Literal(int(duration * 1000))
-                        )
-                    )
-                    end_deadline = start_time + duration
+                # cur.stream() blocks on the socket waiting for the next
+                # SUBSCRIBE row, so over quiet data the per-row deadline and
+                # stop_event checks below never run and the worker thread would
+                # hang past shutdown. A watchdog cancels the query to unblock the
+                # read. statement_timeout can't do this: SUBSCRIBE is exempt from
+                # it, and SET LOCAL would evaporate anyway on the autocommit
+                # connection sql_connection() returns.
+                duration = query.get("duration")
+                deadline = start_time + duration if duration else None
+                subscribe_done = threading.Event()
+
+                def cancel_subscribe() -> None:
+                    while not subscribe_done.is_set():
+                        if stop_event.is_set():
+                            break
+                        if deadline is not None and time.time() >= deadline:
+                            break
+                        subscribe_done.wait(timeout=0.5)
+                    if not subscribe_done.is_set():
+                        conn.cancel()
+
+                watchdog = threading.Thread(
+                    target=cancel_subscribe, name="subscribe-watchdog"
+                )
+                watchdog.start()
                 row_count = 0
                 try:
                     for row in cur.stream(sql.encode(), params):
                         row_count += 1
-                        if query.get("duration"):
-                            if time.time() >= end_deadline:
-                                break
                         if stop_event.is_set():
-                            return
+                            break
+                        if deadline is not None and time.time() >= deadline:
+                            break
                 except psycopg.errors.QueryCanceled:
                     pass
+                finally:
+                    subscribe_done.set()
+                    watchdog.join()
 
                 end_time = time.time()
                 stats["timings"].append((sql, end_time - start_time))

--- a/misc/python/materialize/workload_replay/replay_test.py
+++ b/misc/python/materialize/workload_replay/replay_test.py
@@ -11,6 +11,10 @@
 
 from __future__ import annotations
 
+import random
+
+from materialize.cli.mz_workload_capture import parse_mz_list
+from materialize.workload_replay.column import Column
 from materialize.workload_replay.replay import pg_params_to_psycopg
 
 
@@ -30,3 +34,36 @@ def test_pg_params_to_psycopg_binds_redacted_params_as_null() -> None:
         "SELECT * FROM t WHERE id = $1 AND note = $2", ["<REDACTED>", "kept"]
     )
     assert params == [None, "kept"]
+
+
+def test_parse_mz_list_handles_empty_and_quoting() -> None:
+    # An empty list must be [], not [""] (which renders as an invalid
+    # "SET search_path =" during replay).
+    assert parse_mz_list("{}") == []
+    assert parse_mz_list("{public}") == ["public"]
+    assert parse_mz_list("{public,other}") == ["public", "other"]
+    # Quoted elements may contain commas and escaped quotes.
+    assert parse_mz_list('{public,"weird,name"}') == ["public", "weird,name"]
+    assert parse_mz_list(r'{"a\"b"}') == ['a"b']
+
+
+def test_column_value_does_not_emit_default_expr_into_copy() -> None:
+    # The captured default is a SQL expression. It is fine spliced into SQL, but
+    # as a COPY text datum it would be inserted literally (e.g. the text
+    # "now()") and fail to parse, so value(in_query=False) must never return it.
+    col = Column("c", "timestamp with time zone", False, "now()", None)
+    copy_values = {
+        col.value(random.Random(seed), in_query=False) for seed in range(200)
+    }
+    assert "now()" not in copy_values
+    sql_values = {col.value(random.Random(seed), in_query=True) for seed in range(200)}
+    assert "now()" in sql_values
+
+
+def test_kafka_value_is_raw_and_never_a_default_expr() -> None:
+    # Avro-serialized fields and webhook bodies need raw values, not the SQL
+    # default expression and not SQL-quoted strings.
+    col = Column("c", "text", False, "'x'::text", None)
+    values = {col.kafka_value(random.Random(seed)) for seed in range(200)}
+    assert "'x'::text" not in values
+    assert all(not v.startswith("'") for v in values if isinstance(v, str))

--- a/misc/python/materialize/workload_replay/util.py
+++ b/misc/python/materialize/workload_replay/util.py
@@ -197,13 +197,15 @@ def resolve_tag(tag: str) -> str | None:
 
 
 def update_captured_workloads_repo() -> None:
-    """Clone or update the captured-workloads repository."""
+    """Clone the captured-workloads repository and check out the pinned commit."""
     path = pathlib.Path(MZ_ROOT / "test" / "workload-replay" / "captured-workloads")
-    if (path / ".git").is_dir():
-        commit = "598060c6cf4c2d69730a1313a46704f8663e24fa"
-        spawn.runv(["git", "-C", str(path), "fetch"])
-        spawn.runv(["git", "-C", str(path), "checkout", commit])
-    else:
+    # Pin the commit so replay is reproducible. This must be applied to fresh
+    # clones (every CI run) too, not only to pre-existing checkouts.
+    commit = "598060c6cf4c2d69730a1313a46704f8663e24fa"
+    public_url = "https://github.com/MaterializeInc/captured-workloads"
+
+    used_token = False
+    if not (path / ".git").is_dir():
         path.mkdir(exist_ok=True)
         if ui.env_is_truthy("CI"):
             github_token = os.environ.get(
@@ -212,24 +214,21 @@ def update_captured_workloads_repo() -> None:
             assert (
                 github_token
             ), "GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN or GITHUB_TOKEN must be set in CI"
+            # check=True so a failed clone fails here, not later as a confusing
+            # "no workload files found".
             subprocess.run(
                 [
                     "git",
                     "clone",
                     f"https://materializebot:{urllib.parse.quote(github_token, safe='')}@github.com/MaterializeInc/captured-workloads",
                     str(path),
-                ]
+                ],
+                check=True,
             )
+            used_token = True
         else:
             try:
-                spawn.runv(
-                    [
-                        "git",
-                        "clone",
-                        "https://github.com/MaterializeInc/captured-workloads",
-                        str(path),
-                    ]
-                )
+                spawn.runv(["git", "clone", public_url, str(path)])
             except:
                 spawn.runv(
                     [
@@ -239,6 +238,13 @@ def update_captured_workloads_repo() -> None:
                         str(path),
                     ]
                 )
+
+    spawn.runv(["git", "-C", str(path), "fetch"])
+    spawn.runv(["git", "-C", str(path), "checkout", commit])
+
+    if used_token:
+        # Don't leave the access token behind in .git/config.
+        spawn.runv(["git", "-C", str(path), "remote", "set-url", "origin", public_url])
 
 
 def get_paths(globs: list[str]) -> list[pathlib.Path]:

--- a/test/workload-replay/mzcompose.py
+++ b/test/workload-replay/mzcompose.py
@@ -164,6 +164,19 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     def run(file: pathlib.Path) -> None:
+        # Anonymized captures reuse object names (cluster_0, db_0, ...) across
+        # files and test() does not clean up between them, so reset all state
+        # first. Otherwise the second file fails on duplicate CREATE
+        # CLUSTER/DATABASE. Resetting before each run also recovers cleanly when
+        # a previous file failed partway through.
+        service_names = [s.name for s in SERVICES]
+        try:
+            c.kill(*service_names)
+        except Exception:
+            pass
+        c.rm(*service_names, destroy_volumes=True)
+        c.rm_volumes("mzdata")
+
         with open(file) as f:
             workload = yaml.load(f, Loader=yaml.CSafeLoader)
         # When scale_data is false, use 100% initial data


### PR DESCRIPTION
Replay: commit MySQL initial-data and continuous-ingestion writes (autocommit=False was silently rolling them back), actually start the webhook continuous-ingestion thread, cancel SUBSCRIBE via a watchdog instead of the no-op SET LOCAL statement_timeout, and anchor the webhook CHECK-strip regex to end-of-string so it also matches anonymized captures. Stop injecting the captured default SQL expression into COPY data and Avro/webhook values, and stop SQL-quoting Kafka text. Reset all state between files in workflow_default, and tear down polaris/minio/ azurite in the benchmark comparison.

Capture: sample in a subquery for --avg-column-size, always pin the captured-workloads commit (fresh clones included) and strip the token from .git/config, aggregate source statistics across replicas and drop the ~60s-per-idle-source wait, parse search_path as a proper list, guard the cancel-timer race, and remove stray time.time() calls.

Test runs: https://buildkite.com/materialize/release-qualification/builds/1304 & https://buildkite.com/materialize/nightly/builds/17119