### PR TITLE
SS-337: Add support for Azure SQL

### DIFF
--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -591,6 +591,12 @@ pub async fn ensure_database_cdc_enabled(client: &mut Client) -> Result<(), SqlS
 pub async fn get_latest_restore_history_id(
     client: &mut Client,
 ) -> Result<Option<i32>, SqlServerError> {
+    // Azure SQL Database does not expose `msdb`, so restore history is
+    // unavailable and restore detection does not apply.
+    if !client.engine_edition().await?.has_restore_history() {
+        return Ok(None);
+    }
+
     static LATEST_RESTORE_ID_QUERY: &str = "SELECT TOP 1 restore_history_id \
         FROM msdb.dbo.restorehistory \
         WHERE destination_database_name = DB_NAME() \
@@ -771,10 +777,111 @@ pub async fn ensure_snapshot_isolation_enabled(client: &mut Client) -> Result<()
     Ok(())
 }
 
+/// The engine edition of a SQL Server instance, as reported by
+/// `SERVERPROPERTY('EngineEdition')`.
+///
+/// Materialize adjusts some CDC setup and monitoring behavior based on the
+/// edition. Azure SQL Database in particular has no SQL Server Agent and no
+/// accessible `msdb`, so the agent and restore-history checks do not apply
+/// there.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?view=sql-server-ver17>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineEdition {
+    /// Personal or Desktop Engine (1).
+    PersonalOrDesktop,
+    /// Standard, Web, or Business Intelligence (2).
+    Standard,
+    /// Enterprise, Enterprise Eval, or Developer (3).
+    Enterprise,
+    /// Express and Express-derived editions (4).
+    Express,
+    /// Azure SQL Database (5).
+    AzureSqlDatabase,
+    /// Azure Synapse Analytics (6).
+    AzureSynapseAnalytics,
+    /// Azure SQL Managed Instance (8).
+    AzureSqlManagedInstance,
+    /// Azure SQL Edge (9).
+    AzureSqlEdge,
+    /// Azure Synapse serverless SQL pool (11).
+    AzureSynapseServerlessSqlPool,
+    /// An edition not otherwise recognized, carrying the raw
+    /// `SERVERPROPERTY('EngineEdition')` value.
+    Other(i32),
+}
+
+impl EngineEdition {
+    /// Whether this edition runs a SQL Server Agent that hosts the CDC capture
+    /// and cleanup jobs. Azure SQL Database uses an internal scheduler instead
+    /// and does not expose `sys.dm_server_services`.
+    pub fn has_sql_server_agent(&self) -> bool {
+        !matches!(self, EngineEdition::AzureSqlDatabase)
+    }
+
+    /// Whether `msdb.dbo.restorehistory` is queryable. Azure SQL Database does
+    /// not expose `msdb`, so restore history is unavailable there.
+    pub fn has_restore_history(&self) -> bool {
+        !matches!(self, EngineEdition::AzureSqlDatabase)
+    }
+}
+
+impl From<i32> for EngineEdition {
+    fn from(value: i32) -> Self {
+        match value {
+            1 => EngineEdition::PersonalOrDesktop,
+            2 => EngineEdition::Standard,
+            3 => EngineEdition::Enterprise,
+            4 => EngineEdition::Express,
+            5 => EngineEdition::AzureSqlDatabase,
+            6 => EngineEdition::AzureSynapseAnalytics,
+            8 => EngineEdition::AzureSqlManagedInstance,
+            9 => EngineEdition::AzureSqlEdge,
+            11 => EngineEdition::AzureSynapseServerlessSqlPool,
+            other => EngineEdition::Other(other),
+        }
+    }
+}
+
+/// Returns the [`EngineEdition`] of the SQL Server instance the `client` is
+/// connected to.
+///
+/// tiberius does not surface the engine edition, so we query
+/// `SERVERPROPERTY('EngineEdition')`, which is returned as a `sql_variant` and
+/// cast to an integer.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?view=sql-server-ver17>
+pub async fn get_engine_edition(client: &mut Client) -> Result<EngineEdition, SqlServerError> {
+    static ENGINE_EDITION_QUERY: &str = "SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT);";
+    let result = client.simple_query(ENGINE_EDITION_QUERY).await?;
+
+    match &result[..] {
+        [row] => {
+            let raw = row.try_get::<i32, _>(0)?.ok_or_else(|| {
+                SqlServerError::InvariantViolated(
+                    "SERVERPROPERTY('EngineEdition') returned NULL".to_string(),
+                )
+            })?;
+            Ok(EngineEdition::from(raw))
+        }
+        other => Err(SqlServerError::InvariantViolated(format!(
+            "expected one row, got {other:?}"
+        ))),
+    }
+}
+
 /// Ensure the SQL Server Agent is running.
+///
+/// Azure SQL Database has no SQL Server Agent (CDC is driven by an internal
+/// scheduler and `sys.dm_server_services` is unavailable), so the check is
+/// skipped for that edition.
 ///
 /// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-server-services-transact-sql?view=azuresqldb-current&viewFallbackFrom=sql-server-ver17>
 pub async fn ensure_sql_server_agent_running(client: &mut Client) -> Result<(), SqlServerError> {
+    if !client.engine_edition().await?.has_sql_server_agent() {
+        return Ok(());
+    }
+
     static AGENT_STATUS_QUERY: &str = "SELECT status_desc FROM sys.dm_server_services WHERE servicename LIKE 'SQL Server Agent%';";
     let result = client.simple_query(AGENT_STATUS_QUERY).await?;
 
@@ -1019,8 +1126,33 @@ pub async fn validate_source_privileges(
 
 #[cfg(test)]
 mod tests {
-    use super::DDLEvent;
+    use super::{DDLEvent, EngineEdition};
     use std::sync::Arc;
+
+    #[mz_ore::test]
+    fn test_engine_edition_mapping() {
+        assert_eq!(EngineEdition::from(2), EngineEdition::Standard);
+        assert_eq!(EngineEdition::from(3), EngineEdition::Enterprise);
+        assert_eq!(EngineEdition::from(5), EngineEdition::AzureSqlDatabase);
+        assert_eq!(
+            EngineEdition::from(8),
+            EngineEdition::AzureSqlManagedInstance
+        );
+        // Unrecognized values are preserved rather than dropped.
+        assert_eq!(EngineEdition::from(42), EngineEdition::Other(42));
+
+        // Only Azure SQL Database lacks an agent and `msdb` restore history.
+        assert!(!EngineEdition::AzureSqlDatabase.has_sql_server_agent());
+        assert!(!EngineEdition::AzureSqlDatabase.has_restore_history());
+        for edition in [
+            EngineEdition::Enterprise,
+            EngineEdition::AzureSqlManagedInstance,
+            EngineEdition::Other(42),
+        ] {
+            assert!(edition.has_sql_server_agent());
+            assert!(edition.has_restore_history());
+        }
+    }
 
     #[mz_ore::test]
     fn test_ddl_event_is_compatible() {

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -37,6 +37,7 @@ pub use desc::{ProtoSqlServerColumnDesc, ProtoSqlServerTableDesc};
 use crate::cdc::Lsn;
 use crate::config::TunnelConfig;
 use crate::desc::SqlServerColumnDecodeType;
+use crate::inspect::EngineEdition;
 
 /// Higher level wrapper around a [`tiberius::Client`] that models transaction
 /// management like other database clients.
@@ -45,6 +46,9 @@ pub struct Client {
     tx: UnboundedSender<Request>,
     // The configuration used to create this client.
     config: Config,
+    // Cached engine edition of the connected instance. Immutable for the life
+    // of a connection, so we query it at most once and reuse it.
+    engine_edition: Option<EngineEdition>,
 }
 // While a Client could implement Clone, it's not obvious how multiple Clients
 // using the same SQL Server connection would interact, so ban it for now.
@@ -130,7 +134,11 @@ impl Client {
         // TODO(sql_server2): Add a lot more logging here like the Postgres and MySQL clients have.
 
         Ok((
-            Client { tx, config },
+            Client {
+                tx,
+                config,
+                engine_edition: None,
+            },
             Connection {
                 rx,
                 client,
@@ -325,6 +333,17 @@ impl Client {
                 "expected one row, got {other:?}"
             ))),
         }
+    }
+
+    /// Returns the [`EngineEdition`] of the connected instance, querying it on
+    /// first access and caching the result for the life of this [`Client`].
+    pub async fn engine_edition(&mut self) -> Result<EngineEdition, SqlServerError> {
+        if let Some(edition) = self.engine_edition {
+            return Ok(edition);
+        }
+        let edition = crate::inspect::get_engine_edition(self).await?;
+        self.engine_edition = Some(edition);
+        Ok(edition)
     }
 
     /// Return a [`CdcStream`] that can be used to track changes for the specified


### PR DESCRIPTION
Adds ability to configure Azure SQL as a Materialize source.

There are a few differences between SQL Server and Azure SQL, specifically no CDC agent and no restore history. The majority of the change is just capturing and caching the engine edition.  

Alternatively, the engine information could be captured at purification time, but then it's repeated in every `SqlServerSourceExportDetails`, which didn't make much sense. The query to get the server version is cheap, doesn't require any special privileges, and the client will grab it lazily + cache it.

Tested against Azure SQL locally (see PR https://github.com/MaterializeInc/materialize/pull/37553 for the tests). I also manually created and tested with an SSH bastion. I need to do a little more leg work to see how/if these fit into CI.

There is a related docs PR as well: https://github.com/MaterializeInc/materialize/pull/37550