### PR TITLE
SS-337: sql-server-cdc: add workflow for testing against real Azure SQL

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -280,6 +280,12 @@ case "$cmd" in
                 --env AZURE_SERVICE_ACCOUNT_USERNAME
                 --env AZURE_SERVICE_ACCOUNT_PASSWORD
                 --env AZURE_SERVICE_ACCOUNT_TENANT
+                # For test/sql-server-cdc `azure` workflow
+                --env AZURE_SQL_HOST
+                --env AZURE_SQL_PORT
+                --env AZURE_SQL_DATABASE
+                --env AZURE_SQL_USER
+                --env AZURE_SQL_PASSWORD
                 --env GCP_SERVICE_ACCOUNT_JSON
                 # For test/gcp Iceberg E2E
                 --env ICEBERG_GCS_BUCKET

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -566,6 +566,24 @@ steps:
       # See: <https://github.com/microsoft/mssql-docker/issues/864>
       queue: hetzner-x86-64-8cpu-16gb
 
+  - id: sql-server-cdc-azure
+    label: "SQL Server (Azure SQL Database)"
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    inputs: [test/sql-server-cdc]
+    # Runs against a single shared Azure SQL Database, so only one build may
+    # touch it at a time.
+    concurrency: 1
+    concurrency_group: 'sql-server-cdc-azure'
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: sql-server-cdc
+          run: azure
+    agents:
+      queue: hetzner-x86-64-4cpu-8gb
+    # Requires AZURE_SQL_* credentials in the CI secrets `env` file.
+    skip: "Pending Azure SQL Database credentials in the CI secrets bucket"
+
   - id: http-auth
     label: HTTP auth
     depends_on: build-aarch64

--- a/test/sql-server-cdc/azure/happy-path.td
+++ b/test/sql-server-cdc/azure/happy-path.td
@@ -1,0 +1,90 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Core CDC happy path against Azure SQL Database: TLS, snapshot + streaming, and
+# capture-instance selection. This is the end-to-end exercise of the
+# engine-edition gating, since a successful CREATE SOURCE requires the SQL
+# Server Agent check to be skipped for Azure SQL Database.
+
+$ sql-server-connect name=sql-server
+server=tcp:${arg.azure-sql-host},${arg.azure-sql-port};Encrypt=true;TrustServerCertificate=true;User ID={${arg.azure-sql-user}};Password={${arg.azure-sql-password}};Database=${arg.azure-sql-database}
+
+$ sql-server-execute name=sql-server
+CREATE TABLE mz_azure_t1 (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'mz_azure_t1', @role_name = NULL, @supports_net_changes = 0;
+INSERT INTO mz_azure_t1 VALUES ('a', 'hello world'), ('b', 'foobar'), ('c', 'anotha one');
+
+> CREATE SECRET IF NOT EXISTS azure_sql_pass AS '${arg.azure-sql-password}'
+
+# Azure SQL Database mandates encryption. Validate the trust-all path...
+> CREATE CONNECTION azure_conn TO SQL SERVER (
+    HOST '${arg.azure-sql-host}',
+    PORT ${arg.azure-sql-port},
+    DATABASE '${arg.azure-sql-database}',
+    USER '${arg.azure-sql-user}',
+    PASSWORD = SECRET azure_sql_pass,
+    SSL MODE required
+  );
+
+> VALIDATE CONNECTION azure_conn;
+
+# ...and the path that verifies Azure's certificate against the system CA roots.
+> CREATE CONNECTION azure_conn_verify TO SQL SERVER (
+    HOST '${arg.azure-sql-host}',
+    PORT ${arg.azure-sql-port},
+    DATABASE '${arg.azure-sql-database}',
+    USER '${arg.azure-sql-user}',
+    PASSWORD = SECRET azure_sql_pass,
+    SSL MODE verify
+  );
+
+> VALIDATE CONNECTION azure_conn_verify;
+
+> CREATE SOURCE mz_azure_src
+  FROM SQL SERVER CONNECTION azure_conn;
+
+> CREATE TABLE mz_azure_t1 FROM SOURCE mz_azure_src (REFERENCE dbo.mz_azure_t1);
+
+> SELECT * FROM mz_azure_t1;
+a "hello world"
+b foobar
+c "anotha one"
+
+# Streaming: insert, update, and delete should all propagate.
+$ sql-server-execute name=sql-server
+INSERT INTO mz_azure_t1 VALUES ('d', 'streamed');
+UPDATE mz_azure_t1 SET val_col = 'updated' WHERE key_col = 'a';
+DELETE FROM mz_azure_t1 WHERE key_col = 'b';
+
+> SELECT * FROM mz_azure_t1;
+a updated
+c "anotha one"
+d streamed
+
+# Capture-instance selection: when a table has multiple capture instances,
+# Materialize selects the one with the most recent create_date. We drop a column
+# before creating the second (newer) instance, so picking the newest is
+# observable in the projected schema.
+$ sql-server-execute name=sql-server
+CREATE TABLE mz_azure_ci (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
+INSERT INTO mz_azure_ci VALUES ('a', 'first'), ('b', 'second');
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'mz_azure_ci', @role_name = NULL, @supports_net_changes = 0, @capture_instance = 'zebra';
+ALTER TABLE mz_azure_ci DROP COLUMN val_col;
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'mz_azure_ci', @role_name = NULL, @supports_net_changes = 0, @capture_instance = 'apple';
+
+> CREATE SOURCE mz_azure_ci_src
+  FROM SQL SERVER CONNECTION azure_conn;
+
+> CREATE TABLE mz_azure_ci FROM SOURCE mz_azure_ci_src (REFERENCE dbo.mz_azure_ci);
+
+# The newest instance ('apple') reflects the dropped column, so only key_col
+# is present.
+> SELECT * FROM mz_azure_ci;
+a
+b

--- a/test/sql-server-cdc/azure/privileges.td
+++ b/test/sql-server-cdc/azure/privileges.td
@@ -1,0 +1,100 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Provision a least-privilege Materialize user following the steps in the Azure
+# SQL Database ingestion guide, and validate that it can ingest. Namespaced
+# `mz_ci_*` names are used in place of the guide's `materialize` /
+# `materialize_role` to avoid colliding with real objects on a shared database.
+# The provisioning mirrors the guide:
+#   - a contained database user with a password,
+#   - a gating role for the capture instances,
+#   - db_datareader for SELECT on the source and cdc change tables, and
+#   - VIEW DATABASE STATE in place of the server-scoped VIEW SERVER STATE.
+
+$ sql-server-connect name=sql-server
+server=tcp:${arg.azure-sql-host},${arg.azure-sql-port};Encrypt=true;TrustServerCertificate=true;User ID={${arg.azure-sql-user}};Password={${arg.azure-sql-password}};Database=${arg.azure-sql-database}
+
+$ sql-server-execute name=sql-server
+CREATE USER mz_ci_materialize WITH PASSWORD = '${arg.mz-least-priv-password}';
+CREATE ROLE mz_ci_role;
+ALTER ROLE mz_ci_role ADD MEMBER mz_ci_materialize;
+ALTER ROLE db_datareader ADD MEMBER mz_ci_materialize;
+GRANT VIEW DATABASE STATE TO mz_ci_materialize;
+
+# Source table, with CDC gated by the role created above.
+$ sql-server-execute name=sql-server
+CREATE TABLE mz_azure_priv (key_col int PRIMARY KEY, val_col int);
+INSERT INTO mz_azure_priv VALUES (1, 10), (2, 20), (3, 30);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'mz_azure_priv', @role_name = 'mz_ci_role', @supports_net_changes = 0;
+
+> CREATE SECRET IF NOT EXISTS mz_least_priv_pass AS '${arg.mz-least-priv-password}'
+
+> CREATE CONNECTION azure_priv_conn TO SQL SERVER (
+    HOST '${arg.azure-sql-host}',
+    PORT ${arg.azure-sql-port},
+    DATABASE '${arg.azure-sql-database}',
+    USER 'mz_ci_materialize',
+    PASSWORD = SECRET mz_least_priv_pass,
+    SSL MODE required
+  );
+
+> VALIDATE CONNECTION azure_priv_conn;
+
+> CREATE SOURCE mz_azure_priv_src
+  FROM SQL SERVER CONNECTION azure_priv_conn;
+
+> CREATE TABLE mz_azure_priv FROM SOURCE mz_azure_priv_src (REFERENCE dbo.mz_azure_priv);
+
+> SELECT * FROM mz_azure_priv;
+1 10
+2 20
+3 30
+
+# Negative check: a user provisioned the same way but denied SELECT on the
+# capture table must be rejected. With the new syntax the table-level privilege
+# check runs when the table is added, so the bare CREATE SOURCE succeeds and the
+# CREATE TABLE ... FROM SOURCE is what fails. This confirms the permission check
+# still fires on Azure.
+$ sql-server-execute name=sql-server
+CREATE USER mz_ci_denied WITH PASSWORD = '${arg.mz-least-priv-password}';
+ALTER ROLE mz_ci_role ADD MEMBER mz_ci_denied;
+ALTER ROLE db_datareader ADD MEMBER mz_ci_denied;
+GRANT VIEW DATABASE STATE TO mz_ci_denied;
+DENY SELECT ON OBJECT::cdc.dbo_mz_azure_priv_CT(__$start_lsn) TO mz_ci_denied;
+
+> CREATE CONNECTION azure_denied_conn TO SQL SERVER (
+    HOST '${arg.azure-sql-host}',
+    PORT ${arg.azure-sql-port},
+    DATABASE '${arg.azure-sql-database}',
+    USER 'mz_ci_denied',
+    PASSWORD = SECRET mz_least_priv_pass,
+    SSL MODE required
+  );
+
+> CREATE SOURCE mz_azure_denied_src
+  FROM SQL SERVER CONNECTION azure_denied_conn;
+
+! CREATE TABLE mz_azure_denied_tbl FROM SOURCE mz_azure_denied_src (REFERENCE dbo.mz_azure_priv);
+contains:insufficient permissions
+
+# Clean up the Materialize objects and the provisioned SQL Server principals.
+# The happy-path source (mz_azure_src) is intentionally left in place for the
+# restart check.
+> DROP SOURCE mz_azure_priv_src CASCADE;
+> DROP SOURCE mz_azure_denied_src CASCADE;
+> DROP CONNECTION azure_denied_conn;
+> DROP CONNECTION azure_priv_conn;
+
+$ sql-server-execute name=sql-server split-lines=false
+DROP USER IF EXISTS mz_ci_denied;
+DROP USER IF EXISTS mz_ci_materialize;
+DROP ROLE IF EXISTS mz_ci_role;
+IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE source_object_id = OBJECT_ID('dbo.mz_azure_priv'))
+    EXEC sys.sp_cdc_disable_table @source_schema = 'dbo', @source_name = 'mz_azure_priv', @capture_instance = 'all';
+DROP TABLE IF EXISTS dbo.mz_azure_priv;

--- a/test/sql-server-cdc/azure/setup.td
+++ b/test/sql-server-cdc/azure/setup.td
@@ -1,0 +1,83 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Setup for the Azure SQL Database happy-path workflow.
+#
+# Unlike the on-prem setup, this operates inside the database named in the
+# connection (no CREATE DATABASE / USE, no msdb, no SQL Server Agent job). The
+# provided account must be a member of db_owner so it can enable CDC and manage
+# the test objects.
+
+$ sql-server-connect name=sql-server
+server=tcp:${arg.azure-sql-host},${arg.azure-sql-port};Encrypt=true;TrustServerCertificate=true;User ID={${arg.azure-sql-user}};Password={${arg.azure-sql-password}};Database=${arg.azure-sql-database}
+
+# Drop objects left over from a previous run so the workflow is idempotent
+# against a persistent database.
+$ sql-server-execute name=sql-server split-lines=false
+IF OBJECT_ID('dbo.mz_azure_t1', 'U') IS NOT NULL
+BEGIN
+    IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE source_object_id = OBJECT_ID('dbo.mz_azure_t1'))
+        EXEC sys.sp_cdc_disable_table @source_schema = 'dbo', @source_name = 'mz_azure_t1', @capture_instance = 'all';
+    DROP TABLE dbo.mz_azure_t1;
+END
+
+$ sql-server-execute name=sql-server split-lines=false
+IF OBJECT_ID('dbo.mz_azure_ci', 'U') IS NOT NULL
+BEGIN
+    IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE source_object_id = OBJECT_ID('dbo.mz_azure_ci'))
+        EXEC sys.sp_cdc_disable_table @source_schema = 'dbo', @source_name = 'mz_azure_ci', @capture_instance = 'all';
+    DROP TABLE dbo.mz_azure_ci;
+END
+
+$ sql-server-execute name=sql-server split-lines=false
+IF OBJECT_ID('dbo.mz_azure_priv', 'U') IS NOT NULL
+BEGIN
+    IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE source_object_id = OBJECT_ID('dbo.mz_azure_priv'))
+        EXEC sys.sp_cdc_disable_table @source_schema = 'dbo', @source_name = 'mz_azure_priv', @capture_instance = 'all';
+    DROP TABLE dbo.mz_azure_priv;
+END
+
+$ sql-server-execute name=sql-server split-lines=false
+IF OBJECT_ID('dbo.mz_azure_ticker', 'U') IS NOT NULL
+BEGIN
+    IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE source_object_id = OBJECT_ID('dbo.mz_azure_ticker'))
+        EXEC sys.sp_cdc_disable_table @source_schema = 'dbo', @source_name = 'mz_azure_ticker', @capture_instance = 'all';
+    DROP TABLE dbo.mz_azure_ticker;
+END
+
+$ sql-server-execute name=sql-server
+DROP TABLE IF EXISTS dbo.mz_azure_ticker_control;
+
+# Drop the provisioned users before the role so the role has no members.
+$ sql-server-execute name=sql-server split-lines=false
+DROP USER IF EXISTS mz_ci_denied;
+DROP USER IF EXISTS mz_ci_materialize;
+IF EXISTS (SELECT 1 FROM sys.database_principals WHERE name = 'mz_ci_role' AND type = 'R')
+    DROP ROLE mz_ci_role;
+
+# Enable CDC at the database level. On Azure SQL Database the capture is driven
+# by an internal scheduler, so no SQL Server Agent job is required.
+$ sql-server-execute name=sql-server split-lines=false
+IF (SELECT is_cdc_enabled FROM sys.databases WHERE database_id = DB_ID()) = 0
+    EXEC sys.sp_cdc_enable_db;
+
+$ sql-server-execute name=sql-server
+ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+# A CDC-enabled table that a background ticker constantly updates, so the
+# database-wide max LSN keeps advancing. Without this the source stalls at
+# startup waiting for the LSN to move (Azure SQL Database has no SQL Server
+# Agent to run the equivalent of the on-prem DummyTicker job). The `keep_running`
+# flag lets the workflow stop the ticker loop cleanly.
+$ sql-server-execute name=sql-server
+CREATE TABLE mz_azure_ticker (t DATETIME2);
+INSERT INTO mz_azure_ticker VALUES (SYSUTCDATETIME());
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'mz_azure_ticker', @role_name = NULL, @supports_net_changes = 0;
+CREATE TABLE mz_azure_ticker_control (keep_running BIT NOT NULL);
+INSERT INTO mz_azure_ticker_control VALUES (1);

--- a/test/sql-server-cdc/azure/ticker-stop.td
+++ b/test/sql-server-cdc/azure/ticker-stop.td
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Signal the background ticker to stop. Its loop checks this flag once per
+# second, so the ticker process exits shortly after.
+
+$ sql-server-connect name=sql-server
+server=tcp:${arg.azure-sql-host},${arg.azure-sql-port};Encrypt=true;TrustServerCertificate=true;User ID={${arg.azure-sql-user}};Password={${arg.azure-sql-password}};Database=${arg.azure-sql-database}
+
+$ sql-server-execute name=sql-server
+UPDATE dbo.mz_azure_ticker_control SET keep_running = 0;

--- a/test/sql-server-cdc/azure/ticker.td
+++ b/test/sql-server-cdc/azure/ticker.td
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Background ticker: continuously update a CDC-enabled table so the
+# database-wide max LSN keeps advancing, standing in for the on-prem DummyTicker
+# SQL Server Agent job (Azure SQL Database has no Agent). Runs in its own
+# testdrive process until the workflow flips `keep_running` off, with a bounded
+# iteration count as a fallback so it always terminates on its own.
+
+$ sql-server-connect name=ticker
+server=tcp:${arg.azure-sql-host},${arg.azure-sql-port};Encrypt=true;TrustServerCertificate=true;User ID={${arg.azure-sql-user}};Password={${arg.azure-sql-password}};Database=${arg.azure-sql-database}
+
+$ sql-server-execute name=ticker split-lines=false
+DECLARE @i INT = 0;
+WHILE (SELECT keep_running FROM dbo.mz_azure_ticker_control) = 1 AND @i < 900
+BEGIN
+    UPDATE dbo.mz_azure_ticker SET t = SYSUTCDATETIME();
+    WAITFOR DELAY '00:00:01';
+    SET @i += 1;
+END

--- a/test/sql-server-cdc/azure/verify-restart.td
+++ b/test/sql-server-cdc/azure/verify-restart.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Run after Materialize is restarted, with --no-reset so the happy-path source
+# survives. This exercises the runtime CDC re-validation on Azure SQL Database:
+# the replication operator re-checks the SQL Server Agent and the progress
+# operator re-queries restore history, both of which must be skipped for the
+# Azure SQL Database engine edition or the source would error out on restart.
+
+$ sql-server-connect name=sql-server
+server=tcp:${arg.azure-sql-host},${arg.azure-sql-port};Encrypt=true;TrustServerCertificate=true;User ID={${arg.azure-sql-user}};Password={${arg.azure-sql-password}};Database=${arg.azure-sql-database}
+
+# The source and its snapshot data survived the restart.
+> SELECT * FROM mz_azure_t1;
+a updated
+c "anotha one"
+d streamed
+
+# A new upstream change must still propagate after the restart.
+$ sql-server-execute name=sql-server
+INSERT INTO mz_azure_t1 VALUES ('e', 'after restart');
+
+> SELECT val_col FROM mz_azure_t1 WHERE key_col = 'e';
+"after restart"

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -12,6 +12,7 @@ Native SQL Server source tests, functional.
 """
 
 import glob
+import os
 import pathlib
 import random
 import threading
@@ -67,7 +68,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         print(f"Running with SQL Server version {args.sql_server_version}")
 
     def process(name: str) -> None:
-        if name in ("default", "large-scale"):
+        # `azure` runs against an external Azure SQL Database and requires
+        # credentials from the environment, so it is not part of the default run.
+        if name in ("default", "large-scale", "azure"):
             return
         with c.test_case(name):
             with c.override(
@@ -146,6 +149,93 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
         )
 
     c.test_parts(sharded_files, run)
+
+
+def workflow_azure(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """
+    Exercise the SQL Server source happy path against a real Azure SQL Database.
+
+    Connection details are read from the environment and no local SQL Server
+    container is started:
+
+        AZURE_SQL_HOST      hostname of the Azure SQL Database server
+        AZURE_SQL_PORT      port (default 1433)
+        AZURE_SQL_DATABASE  database to ingest from
+        AZURE_SQL_USER      login with db_owner on that database
+        AZURE_SQL_PASSWORD  password for that login
+
+    The password must not contain a single quote, semicolon, or closing brace,
+    as it is interpolated into a testdrive SQL string and an ADO connection
+    string.
+    """
+    parser.parse_args()
+
+    def require_env(name: str, default: str | None = None) -> str:
+        value = os.environ.get(name, default)
+        if not value:
+            raise ValueError(
+                f"{name} must be set in the environment to run the `azure` workflow"
+            )
+        return value
+
+    tvars = [
+        f"--var=azure-sql-host={require_env('AZURE_SQL_HOST')}",
+        f"--var=azure-sql-port={require_env('AZURE_SQL_PORT', '1433')}",
+        f"--var=azure-sql-database={require_env('AZURE_SQL_DATABASE')}",
+        f"--var=azure-sql-user={require_env('AZURE_SQL_USER')}",
+        f"--var=azure-sql-password={require_env('AZURE_SQL_PASSWORD')}",
+        # A distinct, complexity-compliant password for the provisioned
+        # least-privilege user. Randomized per run so state left by a crashed run
+        # cannot collide with the new one.
+        f"--var=mz-least-priv-password=Mz!{random.getrandbits(48):012x}Az",
+    ]
+
+    c.up("materialized", Service("testdrive", idle=True))
+
+    # Prepare the upstream database, including the ticker table the background
+    # thread below drives.
+    c.run_testdrive_files("--max-errors=1", *tvars, "azure/setup.td")
+
+    # Azure SQL Database has no SQL Server Agent, so nothing advances the CDC max
+    # LSN on its own. Drive a ticker from a background thread for the rest of the
+    # workflow, otherwise CREATE SOURCE stalls at startup waiting for the LSN to
+    # move. The ticker uses --no-reset so it never drops the Materialize objects
+    # created by the main thread.
+    ticker_thread = threading.Thread(
+        target=lambda: c.run_testdrive_files(
+            "--no-reset", "--max-errors=1", *tvars, "azure/ticker.td"
+        ),
+        daemon=True,
+    )
+    ticker_thread.start()
+    try:
+        # Happy path and least-privilege checks share one testdrive process so
+        # the happy-path source survives into the restart check below.
+        c.run_testdrive_files(
+            "--no-reset",
+            "--max-errors=1",
+            *tvars,
+            "azure/happy-path.td",
+            "azure/privileges.td",
+        )
+
+        # Restart Materialize and confirm the source resumes. This is where the
+        # engine-edition gating runs at runtime: the replication operator
+        # re-checks the SQL Server Agent and the progress operator re-queries
+        # restore history, both of which must be skipped for Azure SQL Database.
+        c.kill("materialized")
+        c.up("materialized", Service("testdrive", idle=True))
+        c.run_testdrive_files(
+            "--no-reset",
+            "--max-errors=1",
+            *tvars,
+            "azure/verify-restart.td",
+        )
+    finally:
+        c.run_testdrive_files(
+            "--no-reset", "--max-errors=1", *tvars, "azure/ticker-stop.td"
+        )
+        ticker_thread.join()
 
 
 def workflow_no_agent(c: Composition, parser: WorkflowArgumentParser) -> None:


### PR DESCRIPTION
Adds Azure SQL tests to the nightly pipeline. Skipped by default because the infra is not in place yet. 

These are a basic set of tests that look to exercise the areas where SQL Server and Azure SQL differ.  I didn't add an automated SSH tunnel test, choosing to run it manually to avoid having a whole bunch of extra code setup to handle the key management. It might be worth adding it in the future once we get the direct connect tests working. It will be a substantial diff on its own.

It is possible to run it manually as a local test by setting up an Azure SQL instance and setting the appropriate env variables.