### PR TITLE
testdrive: fix rewrite-results, parser, and silent verification bugs

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -572,6 +572,8 @@ CREATE TABLE postgres_execute (f1 INTEGER);
 
 If any of the statements fail, the entire test will fail. Any result sets returned from the server are ignored and not checked for correctness.
 
+With `background=true` (only valid for URL connections), the statements execute in the background while the test continues. The task is joined at the end of the file, and a failure or a task that does not complete within the default timeout fails the test.
+
 #### `$ postgres-connect name=.... url=...`
 
 Creates a named psql connection that can be used by multiple `$ postgres-execute` statements
@@ -639,6 +641,8 @@ BEGIN TRANSACTION INSERT INTO t1 VALUES (1); INSERT INTO t2 VALUES (2); COMMIT;
 ```
 
 The output of the queries is not validated in any way. An error during execution will cause the test to fail.
+
+Transient SQL Server errors (deadlock victim, agent still starting) are retried by re-executing the failed line in its entirety. With `split-lines=false` the whole body is one query, so a retry re-executes all of it. Keep each line (or, with `split-lines=false`, the body) a single statement or safe to re-execute.
 
 ## Connecting to DuckDB
 
@@ -859,6 +863,12 @@ be ordered according to the following rules:
  - earlier timestamps sort first
  - deletes sort before inserts
  - as all items are sorted as strings, "10" sorts before "2"
+
+The action consumes exactly as many messages as the test expects and stops. Consecutive
+`$ kafka-verify-data` commands on the same topic resume where the previous one stopped, so a topic
+is verified in chunks. This also means a single `$ kafka-verify-data` does not detect extra or
+duplicated records past the expected count. They only surface as a mismatch in a subsequent
+`$ kafka-verify-data` on the same topic.
 
 It is possible to call `$ kafka-verify-data` multiple times on the same topic in case the test needs to check
 that the data arrives in some partial order. For example, to make sure that all of timestamp `1` arrived

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -853,7 +853,7 @@ Sets the variable named VAR to the ID of the key schema with which data was
 written. The variable is only set if the format of the key was Confluent Avro
 or Protobuf.
 
-#### `kafka-verify-data format=avro [sink=... | topic=...] [sort-messages=true] [partial-search=usize]`
+#### `kafka-verify-data format=avro [sink=... | topic=...] [sort-messages=true] [partial-search=usize] [exhaustive=bool]`
 
 Obtains the data from the specified `sink` or `topic` and compares it to the expected data recorded in the test.
 
@@ -866,9 +866,14 @@ be ordered according to the following rules:
 
 The action consumes exactly as many messages as the test expects and stops. Consecutive
 `$ kafka-verify-data` commands on the same topic resume where the previous one stopped, so a topic
-is verified in chunks. This also means a single `$ kafka-verify-data` does not detect extra or
-duplicated records past the expected count. They only surface as a mismatch in a subsequent
-`$ kafka-verify-data` on the same topic.
+is verified in chunks. At the end of the test file, testdrive verifies that no records remain after
+the final `$ kafka-verify-data` for each topic. This catches extra or duplicated records that the
+chunked verification would otherwise miss.
+
+Set `exhaustive=false` to exempt a topic from that end-of-file check. Use it when the topic
+legitimately keeps records this command does not verify, for example a topic written by more than one
+sink, a topic that also serves as a sink's progress topic, or a topic whose later records are checked
+by other means.
 
 It is possible to call `$ kafka-verify-data` multiple times on the same topic in case the test needs to check
 that the data arrives in some partial order. For example, to make sure that all of timestamp `1` arrived
@@ -888,7 +893,9 @@ If `partial-search=usize` is specified, up to `partial-search` records will be r
 compared to the provided records. The records do not have to match starting at the beginning of the sink but
 once one record matches, the following must all match.  There are permitted to be records remaining in the
 topic after the matching is complete.  Note that if the topic is not required to have `partial-search`
-elements in it but there will be an attempt to read up to this number with a blocking read.
+elements in it but there will be an attempt to read up to this number with a blocking read. A final
+`$ kafka-verify-data` with `partial-search` disables the end-of-file check for that topic because
+remaining records are explicitly permitted.
 
 #### `kafka-verify-topic [sink=... | topic=...] [await-value-schema=false] [await-key-schema=false]`
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -260,7 +260,7 @@ impl Drop for TestServerWithStatementLoggingChecks {
                      WHERE
                        (finished_at IS NULL OR finished_status IS NULL)
                        AND sql NOT LIKE '%__FILTER-OUT-THIS-QUERY__%'
-                       AND finished_status != 'aborted'",
+                       AND finished_status IS DISTINCT FROM 'aborted'",
                     &[],
                 );
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -453,13 +453,20 @@ impl State {
     /// background failures fail the test.
     pub(crate) async fn join_background_tasks(&mut self) -> Vec<anyhow::Error> {
         let mut errors = Vec::new();
-        for (desc, handle) in self.background_tasks.drain(..) {
-            match tokio::time::timeout(self.default_timeout, handle).await {
+        for (desc, mut handle) in self.background_tasks.drain(..) {
+            // Poll the handle by reference so it survives a timeout. Dropping a
+            // `JoinHandle` only detaches the task, it does not stop it, and a
+            // detached background query would keep running SQL against the same
+            // Materialize instance while later files execute.
+            match tokio::time::timeout(self.default_timeout, &mut handle).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => errors.push(e.context(format!("background query failed: {desc}"))),
-                Err(_) => errors.push(anyhow!(
-                    "background query did not complete before the end of the file: {desc}"
-                )),
+                Err(_) => {
+                    handle.abort_and_wait().await;
+                    errors.push(anyhow!(
+                        "background query did not complete before the end of the file: {desc}"
+                    ));
+                }
             }
         }
         errors

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -266,6 +266,9 @@ pub struct State {
     mysql_clients: BTreeMap<String, mysql_async::Conn>,
     postgres_clients: BTreeMap<String, tokio_postgres::Client>,
     sql_server_clients: BTreeMap<String, mz_sql_server_util::Client>,
+    /// Tasks spawned by `postgres-execute background=true`. Joined at the end
+    /// of the file so their failures fail the test.
+    background_tasks: Vec<(String, task::JoinHandle<Result<(), anyhow::Error>>)>,
 
     // === Fivetran state. ===
     fivetran_destination_url: String,
@@ -442,6 +445,24 @@ impl State {
     /// the consistency checks should be skipped for this current run.
     pub fn clear_skip_consistency_checks(&mut self) -> bool {
         std::mem::replace(&mut self.consistency_checks_adhoc_skip, false)
+    }
+
+    /// Joins all tasks spawned by `postgres-execute background=true`,
+    /// returning one error per task that failed or did not complete within the
+    /// default timeout. Must be called before the end of the file so that
+    /// background failures fail the test.
+    pub(crate) async fn join_background_tasks(&mut self) -> Vec<anyhow::Error> {
+        let mut errors = Vec::new();
+        for (desc, handle) in self.background_tasks.drain(..) {
+            match tokio::time::timeout(self.default_timeout, handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => errors.push(e.context(format!("background query failed: {desc}"))),
+                Err(_) => errors.push(anyhow!(
+                    "background query did not complete before the end of the file: {desc}"
+                )),
+            }
+        }
+        errors
     }
 
     pub async fn reset_materialize(&self) -> Result<(), anyhow::Error> {
@@ -967,6 +988,14 @@ impl Run for PosCommand {
                     }
                     SqlExpectedError::Timeout => SqlExpectedError::Timeout,
                 };
+                sql.expected_detail = match sql.expected_detail {
+                    Some(s) => Some(subst(&s, &state.cmd_vars)?),
+                    None => None,
+                };
+                sql.expected_hint = match sql.expected_hint {
+                    Some(s) => Some(subst(&s, &state.cmd_vars)?),
+                    None => None,
+                };
                 sql::run_fail_sql(sql, state).await
             }
         };
@@ -1179,6 +1208,7 @@ pub async fn create_state(
         mysql_clients: BTreeMap::new(),
         postgres_clients: BTreeMap::new(),
         sql_server_clients: BTreeMap::new(),
+        background_tasks: Vec::new(),
 
         // === Fivetran state. ===
         fivetran_destination_url: config.fivetran_destination_url.clone(),

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 
 use std::path::PathBuf;
@@ -85,6 +85,10 @@ mod sql;
 mod sql_server;
 mod version_check;
 mod webhook;
+
+pub(crate) async fn verify_kafka_topics_exhausted(state: &State) -> Result<(), anyhow::Error> {
+    kafka::verify_topics_exhausted(state).await
+}
 
 /// User-settable configuration parameters.
 #[derive(Debug, Clone)]
@@ -258,6 +262,8 @@ pub struct State {
     kafka_default_partitions: usize,
     kafka_producer: rdkafka::producer::FutureProducer<MzClientContext>,
     kafka_topics: BTreeMap<String, usize>,
+    /// Topics whose final `kafka-verify-data` must consume the complete topic.
+    kafka_verify_topics: BTreeSet<String>,
 
     // === AWS state. ===
     aws_account: String,
@@ -1258,6 +1264,7 @@ pub async fn create_state(
         kafka_default_partitions: config.kafka_default_partitions,
         kafka_producer,
         kafka_topics,
+        kafka_verify_topics: BTreeSet::new(),
 
         // === AWS state. ===
         aws_account: config.aws_account.clone(),

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 use std::future::Future;
 
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::LazyLock;
 use std::time::Duration;
 use std::{env, fs};
@@ -48,6 +49,7 @@ use rdkafka::ClientConfig;
 use rdkafka::producer::Producer;
 use regex::{Captures, Regex};
 use semver::Version;
+use tokio_postgres::CancelToken;
 use tokio_postgres::error::{DbError, SqlState};
 use tracing::info;
 use url::Url;
@@ -268,7 +270,7 @@ pub struct State {
     sql_server_clients: BTreeMap<String, mz_sql_server_util::Client>,
     /// Tasks spawned by `postgres-execute background=true`. Joined at the end
     /// of the file so their failures fail the test.
-    background_tasks: Vec<(String, task::JoinHandle<Result<(), anyhow::Error>>)>,
+    background_tasks: Vec<BackgroundTask>,
 
     // === Fivetran state. ===
     fivetran_destination_url: String,
@@ -288,6 +290,47 @@ pub struct Rewrite {
     pub content: String,
     pub start: usize,
     pub end: usize,
+}
+
+/// A query spawned by `postgres-execute background=true`, retained so it can be
+/// joined at the end of the file.
+///
+/// Aborting `handle` stops the Rust task from awaiting the query's response,
+/// but it does not stop the query on the server. The tokio-postgres connection
+/// driver waits for every pending response before it closes the connection, so
+/// dropping the client leaves the SQL running until Materialize replies. To
+/// actually stop a query that overran its deadline we send an out-of-band
+/// cancel request through `cancel_token`, the same mechanism psql uses for
+/// Ctrl-C, before aborting the task.
+pub(crate) struct BackgroundTask {
+    desc: String,
+    handle: task::JoinHandle<Result<(), anyhow::Error>>,
+    cancel_token: CancelToken,
+    /// Connection URL, used to rebuild the TLS connector that the cancel
+    /// request opens its own connection with.
+    url: String,
+}
+
+/// Best-effort cancellation of the in-progress query on the connection
+/// `cancel_token` was derived from. Opens a fresh connection to send the cancel
+/// request. Cancellation is inherently racy and the caller aborts the task
+/// regardless, so failures are logged rather than propagated.
+async fn cancel_background_query(cancel_token: &CancelToken, url: &str, timeout: Duration) {
+    let tls = match tokio_postgres::Config::from_str(url)
+        .map_err(anyhow::Error::from)
+        .and_then(|config| make_tls(&config).map_err(anyhow::Error::from))
+    {
+        Ok(tls) => tls,
+        Err(e) => {
+            tracing::warn!("could not build TLS connector to cancel background query: {e}");
+            return;
+        }
+    };
+    match tokio::time::timeout(timeout, cancel_token.cancel_query(tls)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!("cancel request for background query failed: {e}"),
+        Err(_) => tracing::warn!("cancel request for background query timed out"),
+    }
 }
 
 impl State {
@@ -453,7 +496,13 @@ impl State {
     /// background failures fail the test.
     pub(crate) async fn join_background_tasks(&mut self) -> Vec<anyhow::Error> {
         let mut errors = Vec::new();
-        for (desc, mut handle) in self.background_tasks.drain(..) {
+        for BackgroundTask {
+            desc,
+            mut handle,
+            cancel_token,
+            url,
+        } in self.background_tasks.drain(..)
+        {
             // Poll the handle by reference so it survives a timeout. Dropping a
             // `JoinHandle` only detaches the task, it does not stop it, and a
             // detached background query would keep running SQL against the same
@@ -462,6 +511,10 @@ impl State {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => errors.push(e.context(format!("background query failed: {desc}"))),
                 Err(_) => {
+                    // Aborting `handle` alone leaves the query running on the
+                    // server. Cancel it first so it cannot overlap consistency
+                    // checks or later files, then abort and reap the task.
+                    cancel_background_query(&cancel_token, &url, self.default_timeout).await;
                     handle.abort_and_wait().await;
                     errors.push(anyhow!(
                         "background query did not complete before the end of the file: {desc}"

--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -57,6 +57,7 @@ pub fn skip_consistency_checks(
         .args
         .string("reason")
         .context("must provide reason for skipping")?;
+    cmd.args.done()?;
     tracing::info!(reason, "Skipping consistency checks as requested.");
 
     state.consistency_checks_adhoc_skip = true;
@@ -110,6 +111,7 @@ pub async fn run_check_shard_tombstone(
     state: &State,
 ) -> Result<ControlFlow, anyhow::Error> {
     let shard_id = cmd.args.string("shard-id")?;
+    cmd.args.done()?;
     check_shard_tombstone(state, &shard_id).await?;
     Ok(ControlFlow::Continue)
 }
@@ -296,7 +298,7 @@ ALTER SYSTEM SET enable_rbac_checks = false
   WHERE
     (finished_at IS NULL OR finished_status IS NULL)
     AND sql NOT LIKE '%__FILTER-OUT-THIS-QUERY__%'
-    AND finished_status != 'aborted';
+    AND finished_status IS DISTINCT FROM 'aborted';
 0
 
 $ postgres-execute connection=postgres://mz_system:materialize@{0}

--- a/src/testdrive/src/action/file.rs
+++ b/src/testdrive/src/action/file.rs
@@ -49,35 +49,70 @@ pub(crate) fn build_compression(cmd: &mut BuiltinCommand) -> Result<Compression,
     }
 }
 
-/// Returns the full contents of a file: an optional header line, then the
-/// input lines repeated `repeat` times, each line followed by a newline. With
-/// `trailing-newline=false` the final newline is omitted.
-pub(crate) fn build_contents(cmd: &mut BuiltinCommand) -> Result<Vec<u8>, anyhow::Error> {
-    let header = cmd.args.opt_string("header");
-    let trailing_newline = cmd.args.opt_bool("trailing-newline")?.unwrap_or(true);
-    let repeat: usize = cmd.args.opt_parse("repeat")?.unwrap_or(1);
+/// The parsed contents of a file to be written: an optional header line
+/// followed by the input lines repeated `repeat` times. Every line is
+/// terminated by a newline, except that with `trailing_newline == false` the
+/// final newline is omitted.
+///
+/// Lines are streamed on write (see [`Contents::write_to`]) rather than
+/// materialized, so a large `repeat` generates a large file without holding
+/// the whole file in memory.
+pub(crate) struct Contents {
+    header: Option<String>,
+    /// Input lines with their escape sequences already resolved.
+    lines: Vec<Vec<u8>>,
+    repeat: usize,
+    trailing_newline: bool,
+}
 
-    let mut lines = vec![];
-    for line in &cmd.input {
-        lines.push(bytes::unescape(line.as_bytes())?);
-    }
+impl Contents {
+    pub(crate) fn parse(cmd: &mut BuiltinCommand) -> Result<Contents, anyhow::Error> {
+        let header = cmd.args.opt_string("header");
+        let trailing_newline = cmd.args.opt_bool("trailing-newline")?.unwrap_or(true);
+        let repeat: usize = cmd.args.opt_parse("repeat")?.unwrap_or(1);
 
-    let mut contents = vec![];
-    if let Some(header) = header {
-        contents.extend_from_slice(header.as_bytes());
-        contents.push(b'\n');
-    }
-    for _ in 0..repeat {
-        for line in &lines {
-            contents.extend_from_slice(line);
-            contents.push(b'\n');
+        let mut lines = vec![];
+        for line in &cmd.input {
+            lines.push(bytes::unescape(line.as_bytes())?);
         }
-    }
-    if !trailing_newline {
-        contents.pop();
+
+        Ok(Contents {
+            header,
+            lines,
+            repeat,
+            trailing_newline,
+        })
     }
 
-    Ok(contents)
+    /// The output lines in order: the header, if any, then the input lines
+    /// repeated `repeat` times. Newlines are not included.
+    fn output_lines(&self) -> impl Iterator<Item = &[u8]> {
+        let header = self.header.as_deref().map(str::as_bytes).into_iter();
+        let body = (0..self.repeat).flat_map(move |_| self.lines.iter().map(Vec::as_slice));
+        header.chain(body)
+    }
+
+    /// Streams the contents to `writer`, terminating each line with a newline
+    /// and suppressing the final newline when `trailing_newline` is false.
+    pub(crate) async fn write_to<W>(&self, writer: &mut W) -> Result<(), anyhow::Error>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        let mut wrote_line = false;
+        for line in self.output_lines() {
+            // Emit the newline that terminates the previous line only once we
+            // know another line follows, so the final newline can be dropped.
+            if wrote_line {
+                writer.write_all(b"\n").await?;
+            }
+            writer.write_all(line).await?;
+            wrote_line = true;
+        }
+        if wrote_line && self.trailing_newline {
+            writer.write_all(b"\n").await?;
+        }
+        Ok(())
+    }
 }
 
 fn build_path(state: &State, cmd: &mut BuiltinCommand) -> Result<PathBuf, anyhow::Error> {
@@ -102,7 +137,7 @@ pub async fn run_append(
 ) -> Result<ControlFlow, anyhow::Error> {
     let path = build_path(state, &mut cmd)?;
     let compression = build_compression(&mut cmd)?;
-    let contents = build_contents(&mut cmd)?;
+    let contents = Contents::parse(&mut cmd)?;
     cmd.args.done()?;
 
     println!("Appending to file {}", path.display());
@@ -120,7 +155,7 @@ pub async fn run_append(
         Compression::None => Box::new(file),
     };
 
-    file.write_all(&contents).await?;
+    contents.write_to(&mut file).await?;
     file.shutdown().await?;
 
     Ok(ControlFlow::Continue)

--- a/src/testdrive/src/action/file.rs
+++ b/src/testdrive/src/action/file.rs
@@ -49,27 +49,35 @@ pub(crate) fn build_compression(cmd: &mut BuiltinCommand) -> Result<Compression,
     }
 }
 
-/// Returns an iterator of lines that form the content of a file.
-pub(crate) fn build_contents(
-    cmd: &mut BuiltinCommand,
-) -> Result<Box<dyn Iterator<Item = Vec<u8>> + Send + Sync + 'static>, anyhow::Error> {
+/// Returns the full contents of a file: an optional header line, then the
+/// input lines repeated `repeat` times, each line followed by a newline. With
+/// `trailing-newline=false` the final newline is omitted.
+pub(crate) fn build_contents(cmd: &mut BuiltinCommand) -> Result<Vec<u8>, anyhow::Error> {
     let header = cmd.args.opt_string("header");
     let trailing_newline = cmd.args.opt_bool("trailing-newline")?.unwrap_or(true);
-    let repeat = cmd.args.opt_parse("repeat")?.unwrap_or(1);
+    let repeat: usize = cmd.args.opt_parse("repeat")?.unwrap_or(1);
 
-    // Collect our contents into a buffer.
-    let mut contents = vec![];
+    let mut lines = vec![];
     for line in &cmd.input {
-        contents.push(bytes::unescape(line.as_bytes())?);
+        lines.push(bytes::unescape(line.as_bytes())?);
+    }
+
+    let mut contents = vec![];
+    if let Some(header) = header {
+        contents.extend_from_slice(header.as_bytes());
+        contents.push(b'\n');
+    }
+    for _ in 0..repeat {
+        for line in &lines {
+            contents.extend_from_slice(line);
+            contents.push(b'\n');
+        }
     }
     if !trailing_newline {
         contents.pop();
     }
 
-    let header_line = header.into_iter().map(|val| val.as_bytes().to_vec());
-    let content_lines = std::iter::repeat_n(contents, repeat).flatten();
-
-    Ok(Box::new(header_line.chain(content_lines)))
+    Ok(contents)
 }
 
 fn build_path(state: &State, cmd: &mut BuiltinCommand) -> Result<PathBuf, anyhow::Error> {
@@ -112,10 +120,7 @@ pub async fn run_append(
         Compression::None => Box::new(file),
     };
 
-    for line in contents {
-        file.write_all(&line).await?;
-        file.write_all("\n".as_bytes()).await?;
-    }
+    file.write_all(&contents).await?;
     file.shutdown().await?;
 
     Ok(ControlFlow::Continue)

--- a/src/testdrive/src/action/file.rs
+++ b/src/testdrive/src/action/file.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use anyhow::bail;
 use async_compression::tokio::write::{BzEncoder, GzipEncoder, XzEncoder, ZstdEncoder};
 use tokio::fs::{self, OpenOptions};
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 
 use crate::action::{ControlFlow, State};
 use crate::format::bytes;
@@ -152,7 +152,11 @@ pub async fn run_append(
         Compression::Bzip2 => Box::new(BzEncoder::new(file)),
         Compression::Xz => Box::new(XzEncoder::new(file)),
         Compression::Zstd => Box::new(ZstdEncoder::new(file)),
-        Compression::None => Box::new(file),
+        // The compression encoders buffer their writes, but a bare
+        // `tokio::fs::File` turns every per-line `write_all` into a separate
+        // blocking filesystem job. Buffer it so a large `repeat` issues writes
+        // in bounded chunks rather than two jobs per line.
+        Compression::None => Box::new(BufWriter::new(file)),
     };
 
     contents.write_to(&mut file).await?;

--- a/src/testdrive/src/action/http.rs
+++ b/src/testdrive/src/action/http.rs
@@ -30,6 +30,7 @@ pub async fn run_request(
             .collect::<HashSet<u16>>(),
         None => HashSet::new(),
     };
+    cmd.args.done()?;
     let body = cmd.input.join("\n");
 
     println!("$ http-request {} {}\n{}", method, url, body);

--- a/src/testdrive/src/action/kafka.rs
+++ b/src/testdrive/src/action/kafka.rs
@@ -23,7 +23,7 @@ pub use delete_records::run_delete_records;
 pub use delete_topic::run_delete_topic;
 pub use ingest::run_ingest;
 pub use verify_commit::run_verify_commit;
-pub use verify_data::run_verify_data;
+pub use verify_data::{run_verify_data, verify_topics_exhausted};
 pub use verify_topic::run_verify_topic;
 pub use wait_topic::run_wait_topic;
 

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -331,6 +331,10 @@ pub async fn run_ingest(
     let omit_value = cmd.args.opt_bool("omit-value")?.unwrap_or(false);
     let schema_id_var = cmd.args.opt_parse("set-schema-id-var")?;
     let key_schema_id_var = cmd.args.opt_parse("set-key-schema-id-var")?;
+    // `confluent-wire-format` applies to both the value and the key format.
+    // `ArgMap` reads are destructive, so read it once up front: reading it in
+    // both format matches would leave the key side always seeing `None`.
+    let confluent_wire_format_arg = cmd.args.opt_bool("confluent-wire-format")?;
     let format = match cmd.args.string("format")?.as_str() {
         "avro" => {
             let glue_schema_version_id = cmd
@@ -338,7 +342,7 @@ pub async fn run_ingest(
                 .opt_string("glue-schema-version-id")
                 .map(|s| Uuid::parse_str(&s).context("parsing glue-schema-version-id as UUID"))
                 .transpose()?;
-            let confluent_wire_format_explicit = cmd.args.opt_bool("confluent-wire-format")?;
+            let confluent_wire_format_explicit = confluent_wire_format_arg;
             if glue_schema_version_id.is_some() && confluent_wire_format_explicit == Some(true) {
                 bail!("confluent-wire-format=true is incompatible with glue-schema-version-id");
             }
@@ -364,7 +368,7 @@ pub async fn run_ingest(
                 message,
                 // This was introduced after the avro format's confluent-wire-format, so it defaults to
                 // false
-                confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(false),
+                confluent_wire_format: confluent_wire_format_arg.unwrap_or(false),
                 schema_id_subject: cmd.args.opt_string("schema-id-subject"),
                 schema_message_id: cmd.args.opt_parse::<u8>("schema-message-id")?.unwrap_or(0),
             }
@@ -380,7 +384,7 @@ pub async fn run_ingest(
                 .opt_string("key-glue-schema-version-id")
                 .map(|s| Uuid::parse_str(&s).context("parsing key-glue-schema-version-id as UUID"))
                 .transpose()?;
-            let confluent_wire_format_explicit = cmd.args.opt_bool("confluent-wire-format")?;
+            let confluent_wire_format_explicit = confluent_wire_format_arg;
             if key_glue_schema_version_id.is_some() && confluent_wire_format_explicit == Some(true)
             {
                 bail!("confluent-wire-format=true is incompatible with key-glue-schema-version-id");
@@ -407,7 +411,7 @@ pub async fn run_ingest(
             Some(Format::Protobuf {
                 descriptor_file,
                 message,
-                confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(false),
+                confluent_wire_format: confluent_wire_format_arg.unwrap_or(false),
                 schema_id_subject: cmd.args.opt_string("key-schema-id-subject"),
                 schema_message_id: cmd
                     .args

--- a/src/testdrive/src/action/kafka/verify_commit.rs
+++ b/src/testdrive/src/action/kafka/verify_commit.rs
@@ -41,8 +41,9 @@ pub async fn run_verify_commit(
 
     let mut config = state.kafka_config.clone();
     config.set("group.id", &consumer_group_id);
+    // Use `state.timeout` so `$ set-sql-timeout` extends this wait too.
     Retry::default()
-        .max_duration(state.default_timeout)
+        .max_duration(state.timeout)
         .retry_async_canceling(|_| async {
             let config = config.clone();
             let mut tpl = TopicPartitionList::new();

--- a/src/testdrive/src/action/kafka/verify_data.rs
+++ b/src/testdrive/src/action/kafka/verify_data.rs
@@ -7,16 +7,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeSet;
 use std::fmt::Debug;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{cmp, str};
 
 use anyhow::{Context, anyhow, bail, ensure};
+use mz_kafka_util::client::get_partitions;
+use mz_ore::task;
 use mz_postgres_util::{Sql, query_one, sql};
-use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::consumer::{BaseConsumer, CommitMode, Consumer, StreamConsumer};
 use rdkafka::error::KafkaError;
 use rdkafka::message::{Headers, Message};
 use rdkafka::types::RDKafkaErrorCode;
+use rdkafka::{Offset, TopicPartitionList};
 use regex::Regex;
 use tokio::pin;
 use tokio_stream::StreamExt;
@@ -101,7 +105,7 @@ async fn get_topic(sink: &str, topic_field: &str, state: &State) -> Result<Strin
 
 pub async fn run_verify_data(
     mut cmd: BuiltinCommand,
-    state: &State,
+    state: &mut State,
 ) -> Result<ControlFlow, anyhow::Error> {
     let mut format = if let Some(format_str) = cmd.args.opt_string("format") {
         // If just a single format is provided, the user should specify `key=true` if they expect a
@@ -146,6 +150,11 @@ pub async fn run_verify_data(
         bail!("kafka-verify-data requires a non-empty list of expected messages");
     }
     let partial_search = cmd.args.opt_parse("partial-search")?;
+    // When false, the topic is exempt from the end-of-file exhaustion check.
+    // Set it on topics that legitimately keep records this command does not
+    // verify: topics fed by more than one sink, topics that double as a sink's
+    // progress topic, or topics whose later records are checked by other means.
+    let exhaustive = cmd.args.opt_bool("exhaustive")?.unwrap_or(true);
     let debug_print_only = cmd.args.opt_bool("debug-print-only")?.unwrap_or(false);
     // When set, decode Avro from AWS Glue framing (18-byte header) and resolve the
     // writer schema from Glue rather than Confluent Schema Registry.
@@ -160,6 +169,7 @@ pub async fn run_verify_data(
     println!("Verifying results in Kafka topic {}", topic);
 
     let mut config = state.kafka_config.clone();
+    config.set("enable.auto.commit", "false");
     config.set("enable.auto.offset.store", "false");
 
     let consumer: StreamConsumer = config.create().context("creating kafka consumer")?;
@@ -167,12 +177,11 @@ pub async fn run_verify_data(
         .subscribe(&[&topic])
         .context("subscribing to kafka topic")?;
 
-    // NOTE: consumption stops after exactly as many messages as expected (the
+    // NOTE: Consumption stops after exactly as many messages as expected. The
     // consumer group's committed offsets make consecutive kafka-verify-data
-    // commands resume where the previous one stopped, so tests verify a topic
-    // in chunks). This means extra or duplicated records past the expected
-    // count are NOT detected by this command alone. They only surface as a
-    // mismatch in a subsequent kafka-verify-data on the same topic.
+    // commands resume where the previous one stopped, so tests can verify a
+    // topic in chunks. The end-of-file check below verifies that no records
+    // remain after the final non-partial verification.
     let (mut stream_messages_remaining, stream_timeout) = match partial_search {
         Some(size) => (size, state.timeout),
         None => (expected_messages.len(), Duration::from_secs(15)),
@@ -332,7 +341,127 @@ pub async fn run_verify_data(
         partial_search.is_some(),
     )?;
 
+    consumer
+        .commit_consumer_state(CommitMode::Sync)
+        .context("committing verified message offsets")?;
+
+    if partial_search.is_some() || !exhaustive {
+        state.kafka_verify_topics.remove(&topic);
+    } else {
+        state.kafka_verify_topics.insert(topic);
+    }
+
     Ok(ControlFlow::Continue)
+}
+
+/// Verifies that no records remain after each topic's final exact verification.
+pub async fn verify_topics_exhausted(state: &State) -> Result<(), anyhow::Error> {
+    for topic in &state.kafka_verify_topics {
+        let mut config = state.kafka_config.clone();
+        config.set("enable.auto.commit", "false");
+        config.set("enable.auto.offset.store", "false");
+        config.set("enable.partition.eof", "true");
+
+        let topic = topic.clone();
+        let timeout = state.timeout;
+        task::spawn_blocking(
+            {
+                let topic = topic.clone();
+                move || format!("kafka_verify_topic_exhausted:{topic}")
+            },
+            move || verify_topic_exhausted(config, &topic, timeout),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+fn verify_topic_exhausted(
+    config: rdkafka::ClientConfig,
+    topic: &str,
+    timeout: Duration,
+) -> Result<(), anyhow::Error> {
+    let consumer: BaseConsumer = config.create().context("creating kafka consumer")?;
+    let deadline = Instant::now() + timeout;
+    let partitions = get_partitions(consumer.client(), topic, remaining(deadline)?)?;
+
+    let mut requested_offsets = TopicPartitionList::with_capacity(partitions.len());
+    for partition in &partitions {
+        requested_offsets.add_partition(topic, *partition);
+    }
+    let committed_offsets = consumer
+        .committed_offsets(requested_offsets, remaining(deadline)?)
+        .context("fetching committed message offsets")?;
+
+    // Resume from each partition's committed offset, where the last
+    // kafka-verify-data on this topic stopped, and confirm that only the
+    // end-of-partition marker remains. `pending` tracks the partitions we have
+    // not yet drained.
+    let mut assignment = TopicPartitionList::with_capacity(partitions.len());
+    let mut pending: BTreeSet<i32> = BTreeSet::new();
+    for partition in partitions {
+        let committed = committed_offsets
+            .find_partition(topic, partition)
+            .context("missing committed offset for topic partition")?
+            .offset();
+        let (low, high) = consumer
+            .fetch_watermarks(topic, partition, remaining(deadline)?)
+            .with_context(|| {
+                format!("fetching watermarks for Kafka topic {topic} partition {partition}")
+            })?;
+        let start = verification_start_offset(committed, low, high)?;
+        assignment.add_partition_offset(topic, partition, Offset::Offset(start))?;
+        pending.insert(partition);
+    }
+
+    consumer
+        .assign(&assignment)
+        .context("assigning Kafka topic partitions")?;
+
+    // `enable.partition.eof` makes librdkafka emit a `PartitionEOF` once a
+    // partition is drained to its end. Wait for that marker on every partition
+    // rather than comparing consumer positions to high watermarks: a position
+    // never advances on a partition that begins already drained (so empty
+    // partitions would hang forever), and with `read_committed` the high
+    // watermark stays ahead of the last readable record whenever transaction
+    // control markers trail the data.
+    while !pending.is_empty() {
+        match consumer.poll(remaining(deadline)?) {
+            Some(Ok(message)) => {
+                bail!(
+                    "extra record after final kafka-verify-data for topic {topic}, partition {}, offset {}",
+                    message.partition(),
+                    message.offset(),
+                );
+            }
+            Some(Err(KafkaError::PartitionEOF(partition))) => {
+                pending.remove(&partition);
+            }
+            Some(Err(e)) => {
+                return Err(e).context("reading final Kafka topic offsets");
+            }
+            None => {
+                bail!("timed out verifying the end of Kafka topic {topic}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn verification_start_offset(committed: Offset, low: i64, high: i64) -> Result<i64, anyhow::Error> {
+    match committed {
+        Offset::Offset(offset) if (low..=high).contains(&offset) => Ok(offset),
+        Offset::Offset(_) | Offset::Invalid => Ok(low),
+        offset => bail!("unexpected committed Kafka offset {offset:?}"),
+    }
+}
+
+fn remaining(deadline: Instant) -> Result<Duration, anyhow::Error> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .context("timed out verifying final Kafka topic offsets")
 }
 
 /// Resolve the writer schema for each record side from AWS Glue.
@@ -637,5 +766,31 @@ where
         bail!("extra records:\n{}", actual.join("\n"))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn verification_start_offset_uses_committed_offset() {
+        assert_eq!(
+            verification_start_offset(Offset::Offset(5), 2, 8).unwrap(),
+            5
+        );
+    }
+
+    #[mz_ore::test]
+    fn verification_start_offset_resets_out_of_range_offsets() {
+        assert_eq!(
+            verification_start_offset(Offset::Offset(1), 2, 8).unwrap(),
+            2
+        );
+        assert_eq!(
+            verification_start_offset(Offset::Offset(9), 2, 8).unwrap(),
+            2
+        );
+        assert_eq!(verification_start_offset(Offset::Invalid, 2, 8).unwrap(), 2);
     }
 }

--- a/src/testdrive/src/action/kafka/verify_data.rs
+++ b/src/testdrive/src/action/kafka/verify_data.rs
@@ -167,6 +167,12 @@ pub async fn run_verify_data(
         .subscribe(&[&topic])
         .context("subscribing to kafka topic")?;
 
+    // NOTE: consumption stops after exactly as many messages as expected (the
+    // consumer group's committed offsets make consecutive kafka-verify-data
+    // commands resume where the previous one stopped, so tests verify a topic
+    // in chunks). This means extra or duplicated records past the expected
+    // count are NOT detected by this command alone. They only surface as a
+    // mismatch in a subsequent kafka-verify-data on the same topic.
     let (mut stream_messages_remaining, stream_timeout) = match partial_search {
         Some(size) => (size, state.timeout),
         None => (expected_messages.len(), Duration::from_secs(15)),
@@ -252,15 +258,23 @@ pub async fn run_verify_data(
         resolve_glue_schemas(state, &actual_bytes, &mut format).await?
     } else {
         let key_schema = if let Format::Avro = format.key {
-            let schema = state
+            // A missing key subject means the topic is unkeyed. Any other error
+            // must propagate: swallowing it would silently disable key
+            // verification.
+            let schema = match state
                 .ccsr_client
                 .get_schema_by_subject(&format!("{}-key", topic))
                 .await
-                .ok()
-                .map(|key_schema| {
-                    avro::parse_schema(&key_schema.raw, &[]).context("parsing avro schema")
-                })
-                .transpose()?;
+            {
+                Ok(key_schema) => {
+                    Some(avro::parse_schema(&key_schema.raw, &[]).context("parsing avro schema")?)
+                }
+                Err(
+                    mz_ccsr::GetBySubjectError::SubjectNotFound
+                    | mz_ccsr::GetBySubjectError::VersionNotFound(_),
+                ) => None,
+                Err(e) => return Err(anyhow::Error::from(e).context("fetching key schema")),
+            };
             // for avro, we can determine if a key is required based on the presence of the key schema
             // rather than requiring the user to specify the key=true flag
             if schema.is_some() {
@@ -519,7 +533,15 @@ fn parse_expected_messages(
                 Format::Bytes => {
                     unimplemented!("bytes format not yet supported in tests")
                 }
-                Format::Text => Some(DecodedValue::Text(value.to_string())),
+                // Take JSON strings verbatim, like the key path above. The
+                // actual message is decoded as raw text, so keeping the JSON
+                // quotes would make string values never match.
+                Format::Text => Some(DecodedValue::Text(
+                    value
+                        .as_str()
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| value.to_string()),
+                )),
             },
         };
 

--- a/src/testdrive/src/action/kafka/wait_topic.rs
+++ b/src/testdrive/src/action/kafka/wait_topic.rs
@@ -19,6 +19,7 @@ pub async fn run_wait_topic(
     state: &State,
 ) -> Result<ControlFlow, anyhow::Error> {
     let topic = cmd.args.string("topic")?;
+    cmd.args.done()?;
 
     println!("Waiting for Kafka topic {} to exist", topic);
     Retry::default()

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -31,7 +31,7 @@ async fn execute_input(cmd: BuiltinCommand, client: &Client) -> Result<(), anyho
 
 pub async fn run_execute(
     mut cmd: BuiltinCommand,
-    state: &State,
+    state: &mut State,
 ) -> Result<ControlFlow, anyhow::Error> {
     let connection = cmd.args.string("connection")?;
     let background = cmd.args.opt_bool("background")?.unwrap_or(false);
@@ -40,12 +40,13 @@ pub async fn run_execute(
     match (connection.starts_with("postgres://"), background) {
         (true, true) => {
             let (client_inner, _) = postgres_client(&connection, state.default_timeout).await?;
-            task::spawn(|| "postgres-execute", async move {
-                match execute_input(cmd, &client_inner).await {
-                    Ok(_) => {}
-                    Err(e) => println!("Error in backgrounded postgres-execute query: {e}"),
-                }
+            let desc = cmd.input.first().cloned().unwrap_or_default();
+            let handle = task::spawn(|| "postgres-execute", async move {
+                execute_input(cmd, &client_inner).await
             });
+            // The task is joined at the end of the file so that failures fail
+            // the test, as documented.
+            state.background_tasks.push((desc, handle));
         }
         (false, true) => bail!("cannot use 'background' arg with referenced connection"),
         (true, false) => {

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, anyhow, bail};
 use mz_ore::task;
 use tokio_postgres::Client;
 
-use crate::action::{ControlFlow, State};
+use crate::action::{BackgroundTask, ControlFlow, State};
 use crate::parser::BuiltinCommand;
 use crate::util::postgres::postgres_client;
 
@@ -41,12 +41,21 @@ pub async fn run_execute(
         (true, true) => {
             let (client_inner, _) = postgres_client(&connection, state.default_timeout).await?;
             let desc = cmd.input.first().cloned().unwrap_or_default();
+            // Capture a cancel token before moving the client into the task, so
+            // the query can be stopped on the server if the task overruns its
+            // deadline and must be aborted.
+            let cancel_token = client_inner.cancel_token();
             let handle = task::spawn(|| "postgres-execute", async move {
                 execute_input(cmd, &client_inner).await
             });
             // The task is joined at the end of the file so that failures fail
             // the test, as documented.
-            state.background_tasks.push((desc, handle));
+            state.background_tasks.push(BackgroundTask {
+                desc,
+                handle,
+                cancel_token,
+                url: connection,
+            });
         }
         (false, true) => bail!("cannot use 'background' arg with referenced connection"),
         (true, false) => {

--- a/src/testdrive/src/action/protobuf.rs
+++ b/src/testdrive/src/action/protobuf.rs
@@ -27,6 +27,8 @@ pub async fn run_compile_descriptors(
         .map(|s| s.into())
         .collect();
     let output = cmd.args.string("output")?;
+    let set_var = cmd.args.opt_string("set-var");
+    cmd.args.done()?;
     for path in inputs.iter().chain(iter::once(&output)) {
         if path.contains(path::MAIN_SEPARATOR) {
             // The goal isn't security, but preventing mistakes.
@@ -57,7 +59,7 @@ pub async fn run_compile_descriptors(
     if !status.success() {
         bail!("protoc exited unsuccessfully");
     }
-    if let Some(var) = cmd.args.opt_string("set-var") {
+    if let Some(var) = set_var {
         let res = std::fs::read(output_path)?;
         let hex_encoded = hex::encode(res);
         state.cmd_vars.insert(var, format!("\\x{hex_encoded}"));

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -38,8 +38,8 @@ use regex::Regex;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::action::file::Compression;
+use crate::action::file::Contents;
 use crate::action::file::build_compression;
-use crate::action::file::build_contents;
 use crate::action::{ControlFlow, State};
 use crate::parser::BuiltinCommand;
 
@@ -223,8 +223,13 @@ pub async fn run_upload(
     };
 
     let compression = build_compression(&mut cmd)?;
-    let body = build_contents(&mut cmd)?;
+    let contents = Contents::parse(&mut cmd)?;
     cmd.args.done()?;
+
+    // S3 puts need the full body in memory, so materialize the streamed
+    // contents into a buffer before compressing and uploading.
+    let mut body = Vec::new();
+    contents.write_to(&mut body).await?;
 
     let aws_client = mz_aws_util::s3::new_client(&state.aws_config);
 

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -72,7 +72,7 @@ pub async fn run_verify_data(
     loop {
         attempts += 1;
         if attempts > 10 {
-            bail!("found incomplete sentinel file in path {key} after 10 attempts")
+            bail!("S3 path {key} was still incomplete or empty after 10 attempts")
         }
 
         let files = client
@@ -89,7 +89,9 @@ pub async fn run_verify_data(
             {
                 thread::sleep(Duration::from_secs(1))
             }
-            None => bail!("no files found in bucket {bucket} key {key}"),
+            // An empty prefix means the writer has not uploaded anything yet,
+            // so retry just like for the INCOMPLETE sentinel.
+            None => thread::sleep(Duration::from_secs(1)),
             Some(files) => {
                 all_files = files;
                 break;
@@ -155,20 +157,21 @@ pub async fn run_verify_keys(
             .prefix(&format!("{}/", prefix_path))
             .send()
             .await?;
-        match files.contents {
-            Some(files) => {
-                let files: Vec<_> = files
-                    .iter()
-                    .filter(|obj| key_pattern.is_match(obj.key().unwrap()))
-                    .map(|obj| obj.key().unwrap())
-                    .collect();
-                if !files.is_empty() {
-                    println!("Found matching files: {files:?}");
-                    return Ok(ControlFlow::Continue);
-                }
+        if let Some(files) = files.contents {
+            let files: Vec<_> = files
+                .iter()
+                .filter(|obj| key_pattern.is_match(obj.key().unwrap()))
+                .map(|obj| obj.key().unwrap())
+                .collect();
+            if !files.is_empty() {
+                println!("Found matching files: {files:?}");
+                return Ok(ControlFlow::Continue);
             }
-            _ => thread::sleep(Duration::from_secs(1)),
         }
+        // Sleep whenever no attempt matched, not only when the prefix was
+        // empty. Otherwise the presence of any non-matching object burns all
+        // attempts back-to-back without giving the writer time to catch up.
+        thread::sleep(Duration::from_secs(1));
     }
 
     bail!("Did not find matching files in bucket {bucket} prefix {prefix_path}");
@@ -220,18 +223,13 @@ pub async fn run_upload(
     };
 
     let compression = build_compression(&mut cmd)?;
-    let content = build_contents(&mut cmd)?;
+    let body = build_contents(&mut cmd)?;
+    cmd.args.done()?;
 
     let aws_client = mz_aws_util::s3::new_client(&state.aws_config);
 
     // TODO(parkmycar): Stream data to S3. The ByteStream type from the AWS config is a bit
     // cumbersome to work with, so for now just stick with this.
-    let mut body = vec![];
-    for line in content {
-        body.extend(&line);
-        body.push(b'\n');
-    }
-
     let mut reader: Pin<Box<dyn AsyncRead + Send + Sync>> = match compression {
         Compression::None => Box::pin(&body[..]),
         Compression::Gzip => Box::pin(GzipEncoder::new(&body[..])),
@@ -272,6 +270,7 @@ pub async fn run_set_presigned_url(
     let key = cmd.args.string("key")?;
     let bucket = cmd.args.string("bucket")?;
     let var_name = cmd.args.string("var-name")?;
+    cmd.args.done()?;
 
     let aws_client = mz_aws_util::s3::new_client(&state.aws_config);
     let presign_config = mz_aws_util::s3::new_presigned_config();

--- a/src/testdrive/src/action/schema_registry.rs
+++ b/src/testdrive/src/action/schema_registry.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, bail};
@@ -123,9 +124,10 @@ pub async fn run_verify(
     );
 
     // Finding the published schema is retryable because it's published
-    // asynchronously and only after the source/sink is created.
+    // asynchronously and only after the source/sink is created. Use
+    // `state.timeout` so `$ set-sql-timeout` extends this wait too.
     let actual_schema = mz_ore::retry::Retry::default()
-        .max_duration(state.default_timeout)
+        .max_duration(state.timeout)
         .retry_async(|_| async {
             match state.ccsr_client.get_schema_by_subject(&subject).await {
                 Ok(s) => mz_ore::retry::RetryResult::Ok(s.raw),
@@ -180,7 +182,11 @@ pub async fn run_wait(
 
     // Run action.
 
-    let mut waiting_for_kafka = false;
+    // Tracks whether the schemas have been confirmed, so later retry attempts
+    // skip straight to the topic check. An `AtomicBool` because a plain `bool`
+    // would be copied into each `async move` future and updates would be lost.
+    let waiting_for_kafka = AtomicBool::new(false);
+    let waiting_for_kafka = &waiting_for_kafka;
 
     println!(
         "Waiting for schema for subjects {:?} to become available in the schema registry...",
@@ -194,7 +200,7 @@ pub async fn run_wait(
         .factor(1.5)
         .max_duration(state.timeout)
         .retry_async_canceling(|_| async move {
-            if !waiting_for_kafka {
+            if !waiting_for_kafka.load(Ordering::Relaxed) {
                 futures::future::try_join_all(subjects.iter().map(|subject| async move {
                     state
                         .ccsr_client
@@ -207,11 +213,11 @@ pub async fn run_wait(
                 }))
                 .await?;
 
-                waiting_for_kafka = true;
+                waiting_for_kafka.store(true, Ordering::Relaxed);
                 println!("Waiting for Kafka topic {} to exist", topic);
             }
 
-            if waiting_for_kafka {
+            if waiting_for_kafka.load(Ordering::Relaxed) {
                 super::kafka::check_topic_exists(topic, state).await?
             }
 

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -83,6 +83,7 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &mut State) -> Result<ControlFl
     let query = &cmd.query;
     print_query(query, Some(&stmt));
     let expected_output = &cmd.expected_output;
+    let raw_output = cmd.raw_output;
     state.error_line_count = 0;
     state.error_string = "".to_string();
     let (state, res) = match should_retry {
@@ -94,9 +95,14 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &mut State) -> Result<ControlFl
         false => Retry::default().max_duration(state.timeout).max_tries(1),
     }
     .retry_async_with_state(state, |retry_state, state| async move {
-        let should_continue = retry_state.i + 1 < state.max_tries && should_retry;
+        // `next_backoff` is `None` exactly on the final attempt, whether the
+        // retry budget is bounded by `max_tries` or by `max_duration`. Result
+        // rewriting must only happen on the final attempt, so key off that
+        // rather than `max_tries` (which is usize::MAX by default and would
+        // never mark an attempt as final).
+        let should_continue = retry_state.next_backoff.is_some() && should_retry;
         let start = SystemTime::now();
-        match try_run_sql(state, query, expected_output, should_continue).await {
+        match try_run_sql(state, query, expected_output, raw_output, should_continue).await {
             Ok(()) => {
                 let now = SystemTime::now();
                 let epoch = SystemTime::UNIX_EPOCH;
@@ -180,24 +186,48 @@ fn rewrite_result(
     state: &mut State,
     columns: Vec<&str>,
     content: Vec<Vec<String>>,
+    raw_output: bool,
 ) -> Result<(), anyhow::Error> {
+    // A line starting with a sigil would terminate the expected block and be
+    // parsed as a new command (e.g. a `?column?` header would read as a `?`
+    // command). The parser strips one leading backslash, so escape with that.
+    fn escape_line_start(line: String) -> String {
+        match line.chars().next() {
+            Some('$' | '>' | '!' | '?' | '#' | '\\') => format!("\\{line}"),
+            _ => line,
+        }
+    }
+
     let mut buf = String::new();
-    writeln!(buf, "{}", columns.join(" "))?;
-    writeln!(buf, "----")?;
-    for row in content {
-        let mut formatted_row = Vec::<String>::new();
-        for value in row {
-            if value.is_empty()
-                || value.contains(|x: char| char::is_ascii_whitespace(&x))
-                || value.contains('"')
-                || value.contains('\\')
-            {
-                formatted_row.push(escape_for_parser(&value));
-            } else {
-                formatted_row.push(value);
+    if raw_output {
+        // `?` commands expect the raw result text with no column header and no
+        // escaping, so emit the values verbatim.
+        for row in content {
+            for value in row {
+                buf.push_str(&value);
+                if !value.ends_with('\n') {
+                    buf.push('\n');
+                }
             }
         }
-        writeln!(buf, "{}", formatted_row.join(" "))?;
+    } else {
+        writeln!(buf, "{}", escape_line_start(columns.join(" ")))?;
+        writeln!(buf, "----")?;
+        for row in content {
+            let mut formatted_row = Vec::<String>::new();
+            for value in row {
+                if value.is_empty()
+                    || value.contains(|x: char| char::is_ascii_whitespace(&x))
+                    || value.contains('"')
+                    || value.contains('\\')
+                {
+                    formatted_row.push(escape_for_parser(&value));
+                } else {
+                    formatted_row.push(value);
+                }
+            }
+            writeln!(buf, "{}", escape_line_start(formatted_row.join(" ")))?;
+        }
     }
     state.rewrites.push(Rewrite {
         content: buf,
@@ -212,6 +242,7 @@ async fn try_run_sql(
     state: &mut State,
     query: &str,
     expected_output: &SqlOutput,
+    raw_output: bool,
     should_retry: bool,
 ) -> Result<(), anyhow::Error> {
     let stmt = state
@@ -268,7 +299,7 @@ async fn try_run_sql(
             if let Some(column_names) = column_names {
                 if actual_columns.iter().ne(column_names) {
                     if state.rewrite_results && !should_retry {
-                        rewrite_result(state, actual_columns, actual)?;
+                        rewrite_result(state, actual_columns, actual, raw_output)?;
                         return Ok(());
                     } else {
                         bail!(
@@ -282,7 +313,7 @@ async fn try_run_sql(
             if &actual == expected_rows {
                 Ok(())
             } else if state.rewrite_results && !should_retry {
-                rewrite_result(state, actual_columns, actual)?;
+                rewrite_result(state, actual_columns, actual, raw_output)?;
                 Ok(())
             } else {
                 let (mut left, mut right) = (0, 0);
@@ -312,7 +343,7 @@ async fn try_run_sql(
                     right += 1;
                 }
                 if state.rewrite_results && !should_retry {
-                    rewrite_result(state, actual_columns, actual)?;
+                    rewrite_result(state, actual_columns, actual, raw_output)?;
                     Ok(())
                 } else if let Some(raw_actual) = raw_actual {
                     bail!(

--- a/src/testdrive/src/action/sql_server/execute.rs
+++ b/src/testdrive/src/action/sql_server/execute.rs
@@ -38,6 +38,13 @@ const MAX_RETRIES: usize = 20;
 /// Fixed backoff duration between retries.
 const RETRY_BACKOFF: Duration = Duration::from_millis(100);
 
+/// Executes `query`, retrying transient errors.
+///
+/// NOTE: a retry re-executes `query` in its entirety. If `query` contains
+/// multiple statements (e.g. with `split-lines=false`), statements that
+/// committed before the transient error are executed again, duplicating their
+/// side effects. Callers must pass a single statement, or statements that are
+/// safe to re-execute.
 async fn execute_with_retry(
     client: &mut mz_sql_server_util::Client,
     query: &str,

--- a/src/testdrive/src/format/bytes.rs
+++ b/src/testdrive/src/format/bytes.rs
@@ -19,11 +19,17 @@ pub fn unescape(s: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut s = s.iter().copied().fuse();
     while let Some(b) = s.next() {
         match b {
-            b'\\' if s.next() == Some(b'x') => match (next_hex(&mut s), next_hex(&mut s)) {
-                (Some(c1), Some(c0)) => out.push((c1 << 4) + c0),
-                _ => bail!("invalid hexadecimal escape"),
+            // NOTE: the escaped byte must be consumed in the arm body, not in
+            // a match guard. A guard's `s.next()` runs even when the guard
+            // fails, silently eating the byte after the backslash.
+            b'\\' => match s.next() {
+                Some(b'x') => match (next_hex(&mut s), next_hex(&mut s)) {
+                    (Some(c1), Some(c0)) => out.push((c1 << 4) + c0),
+                    _ => bail!("invalid hexadecimal escape"),
+                },
+                Some(b) => out.push(b),
+                None => bail!("trailing backslash in byte string"),
             },
-            b'\\' => continue,
             _ => out.push(b),
         }
     }

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -164,6 +164,11 @@ pub(crate) async fn run_line_reader(
     for e in state.join_background_tasks().await {
         errors.push(e.into());
     }
+    if errors.is_empty()
+        && let Err(e) = action::verify_kafka_topics_exhausted(&state).await
+    {
+        errors.push(e.into());
+    }
     let mut consistency_checks_succeeded = true;
     if config.consistency_checks == action::consistency::Level::File {
         if let Err(e) = action::consistency::run_consistency_checks(&state).await {

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -159,6 +159,11 @@ pub(crate) async fn run_line_reader(
             }
         }
     }
+    // Failures in `postgres-execute background=true` tasks must fail the test,
+    // so join them before wrapping up the file.
+    for e in state.join_background_tasks().await {
+        errors.push(e.into());
+    }
     let mut consistency_checks_succeeded = true;
     if config.consistency_checks == action::consistency::Level::File {
         if let Err(e) = action::consistency::run_consistency_checks(&state).await {

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -72,6 +72,10 @@ pub struct SqlCommand {
     pub expected_output: SqlOutput,
     pub expected_start: usize,
     pub expected_end: usize,
+    /// True for `?`-style commands, whose expected output is raw multiline
+    /// text rather than the `column names + ----` row format. Rewrites must
+    /// preserve that shape.
+    pub raw_output: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -200,8 +204,10 @@ fn parse_version_constraint(
     line_reader: &mut LineReader,
 ) -> Result<Option<VersionConstraint>, PosError> {
     let (pos, line) = line_reader.next().unwrap();
-    if line[1..2].to_string() != "[" {
-        line_reader.push(&line);
+    // All slicing below uses `get` because the line is arbitrary user input.
+    // A malformed constraint must produce a positioned error, not a panic.
+    if line.get(1..2) != Some("[") {
+        line_reader.push(pos, &line);
         return Ok(None);
     }
     let closed_brace_pos = match line.find(']') {
@@ -213,17 +219,18 @@ fn parse_version_constraint(
             });
         }
     };
+    let constraint = line.get(2..closed_brace_pos).unwrap_or("");
     let mut begin_version_kw = 2;
     const MIN_VERSION: i32 = 0;
     let mut min_version = MIN_VERSION;
-    if line.as_bytes()[2].is_ascii_digit() {
+    if line.as_bytes().get(2).is_some_and(|b| b.is_ascii_digit()) {
         let Some(op_pos) = line.find('<') else {
             return Err(PosError {
                 source: anyhow!("version-constraint: initial number but no '<' following"),
                 pos: Some(pos),
             });
         };
-        let min_version_str = line[2..op_pos].to_string();
+        let min_version_str = line.get(2..op_pos).unwrap_or("").to_string();
         match min_version_str.parse::<i32>() {
             Ok(mv) => min_version = mv,
             Err(_) => {
@@ -237,7 +244,7 @@ fn parse_version_constraint(
             }
         };
 
-        if line.as_bytes()[op_pos + 1] == b'=' {
+        if line.as_bytes().get(op_pos + 1) == Some(&b'=') {
             begin_version_kw = op_pos + 2;
         } else {
             begin_version_kw = op_pos + 1;
@@ -246,18 +253,17 @@ fn parse_version_constraint(
     };
 
     let version_start = begin_version_kw + "version".len();
-    if line[begin_version_kw..version_start].to_string() != "version" {
+    if line.get(begin_version_kw..version_start) != Some("version") {
         return Err(PosError {
             source: anyhow!(
-                "version-constraint: invalid property {} (found '{}', expected 'version' {begin_version_kw})",
-                &line[2..closed_brace_pos],
-                &line[begin_version_kw..version_start]
+                "version-constraint: invalid property {} (expected 'version' at offset {begin_version_kw})",
+                constraint,
             ),
             pos: Some(pos),
         });
     }
     let remainder = line[closed_brace_pos + 1..].to_string();
-    line_reader.push(&remainder);
+    line_reader.push(pos + closed_brace_pos + 1, &remainder);
     const MAX_VERSION: i32 = 9999999;
 
     if version_start >= closed_brace_pos && min_version != MIN_VERSION {
@@ -267,25 +273,35 @@ fn parse_version_constraint(
         }));
     }
 
-    let version_pos = if line.as_bytes()[version_start + 1].is_ascii_digit() {
+    let version_pos = if line
+        .as_bytes()
+        .get(version_start + 1)
+        .is_some_and(|b| b.is_ascii_digit())
+    {
         version_start + 1
     } else {
         version_start + 2
     };
-    let version = match line[version_pos..closed_brace_pos].parse::<i32>() {
+    let (Some(op), Some(version_str)) = (
+        line.get(version_start..version_pos),
+        line.get(version_pos..closed_brace_pos),
+    ) else {
+        return Err(PosError {
+            source: anyhow!("version-constraint: invalid constraint {}", constraint),
+            pos: Some(pos),
+        });
+    };
+    let version = match version_str.parse::<i32>() {
         Ok(x) => x,
         Err(_) => {
             return Err(PosError {
-                source: anyhow!(
-                    "version-constraint: invalid version number {}",
-                    &line[version_pos..closed_brace_pos]
-                ),
+                source: anyhow!("version-constraint: invalid version number {}", version_str),
                 pos: Some(pos),
             });
         }
     };
 
-    match &line[version_start..version_pos] {
+    match op {
         "=" => Ok(Some(VersionConstraint {
             min: version,
             max: version,
@@ -308,16 +324,12 @@ fn parse_version_constraint(
         })),
         ">=" | ">" => Err(PosError {
             source: anyhow!(
-                "version-constraint: found comparison operator {} with a set minimum version {min_version}",
-                &line[version_start..version_pos]
+                "version-constraint: found comparison operator {op} with a set minimum version {min_version}"
             ),
             pos: Some(pos),
         }),
         _ => Err(PosError {
-            source: anyhow!(
-                "version-constraint: unknown comparison operator {}",
-                &line[version_start..version_pos]
-            ),
+            source: anyhow!("version-constraint: unknown comparison operator {op}"),
             pos: Some(pos),
         }),
     }
@@ -353,6 +365,7 @@ fn parse_sql(line_reader: &mut LineReader) -> Result<SqlCommand, PosError> {
                         },
                         expected_start: 0,
                         expected_end: 0,
+                        raw_output: false,
                     });
                 }
                 Err(err) => {
@@ -378,6 +391,7 @@ fn parse_sql(line_reader: &mut LineReader) -> Result<SqlCommand, PosError> {
         },
         expected_start,
         expected_end,
+        raw_output: false,
     })
 }
 
@@ -412,6 +426,7 @@ fn parse_explain_sql(line_reader: &mut LineReader) -> Result<SqlCommand, PosErro
         },
         expected_start,
         expected_end,
+        raw_output: true,
     })
 }
 
@@ -595,8 +610,11 @@ impl<'a> LineReader<'a> {
         (*line, col + (pos - base_pos))
     }
 
-    fn push(&mut self, text: &String) {
-        self.next = Some(Some((0usize, text.to_string())));
+    /// Pushes `text` back so the next `next()`/`peek()` returns it. `pos` must
+    /// be the reader-space position of the first character of `text`, so that
+    /// errors reported against the pushed line map to the right location.
+    fn push(&mut self, pos: usize, text: &str) {
+        self.next = Some(Some((pos, text.to_string())));
     }
 
     fn read_one(&mut self) -> Option<(usize, String)> {

--- a/test/testdrive-old-kafka-src-syntax/consolidation.td
+++ b/test/testdrive-old-kafka-src-syntax/consolidation.td
@@ -246,3 +246,19 @@ contains:imestamp
 contains:imestamp
 > SELECT * FROM nums_compacted AS OF 6
 8
+
+# The sink keeps emitting the changes for transactions 4, 5, and 6. Verify them
+# here so the whole topic is consumed and the end-of-file exhaustion check does
+# not flag them as unverified records.
+
+$ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.public.nums_sink sort-messages=true
+4	{"before": null, "after": {"row": {"num": 6}}}
+4	{"before": {"row": {"num": 5}}, "after": null}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.public.nums_sink sort-messages=true
+5	{"before": null, "after": {"row": {"num": 7}}}
+5	{"before": {"row": {"num": 6}}, "after": null}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.public.nums_sink sort-messages=true
+6	{"before": null, "after": {"row": {"num": 8}}}
+6	{"before": {"row": {"num": 7}}, "after": null}

--- a/test/testdrive-old-kafka-src-syntax/github-7242.td
+++ b/test/testdrive-old-kafka-src-syntax/github-7242.td
@@ -43,7 +43,7 @@ $ set-arg-default single-replica-cluster=quickstart
   ENVELOPE DEBEZIUM
 
 # Wait for the sink to create the topic
-$ kafka-wait-topic topic=testdrive-supplier-${testdrive.seed} partitions=1
+$ kafka-wait-topic topic=testdrive-supplier-${testdrive.seed}
 
 > CREATE SOURCE progress_check
   IN CLUSTER ${arg.single-replica-cluster}

--- a/test/testdrive-old-kafka-src-syntax/kafka-sinks.td
+++ b/test/testdrive-old-kafka-src-syntax/kafka-sinks.td
@@ -151,7 +151,9 @@ snk1             kafka    snk1_cluster  ""
 snk2             kafka    snk2_cluster  ""
 snk3             kafka    snk3_cluster  ""
 
-$ kafka-verify-data format=avro sink=materialize.public.snk1 sort-messages=true
+# Several later sinks in this file (default_cluster_sink, sink_with_options,
+# cluster_c_sink) also write to this topic, so it is not exhaustively verified.
+$ kafka-verify-data format=avro sink=materialize.public.snk1 sort-messages=true exhaustive=false
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
 {"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": [0, 0, 0, 0, 0, 0, 0, 0]}}}
 
@@ -228,6 +230,18 @@ $ kafka-verify-data format=avro sink=materialize.public.snk6 sort-messages=true
 {"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": [0, 0, 0, 0, 0, 0, 0, 2]}}}
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
 {"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": [0, 0, 0, 0, 0, 0, 0, 0]}}}
+
+# The `extra,row` ingest above also reaches snk2, snk3, and snk4, which were
+# verified before it arrived. Verify the trailing record on each so their
+# topics are fully consumed.
+$ kafka-verify-data format=avro sink=materialize.public.snk2
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": [0, 0, 0, 0, 0, 0, 0, 2]}}}
+
+$ kafka-verify-data format=avro sink=materialize.public.snk3
+{"before": null, "after": {"row":{"c": "extrarow"}}}
+
+$ kafka-verify-data format=avro sink=materialize.public.snk4
+{"before": null, "after": {"row":{"c": true}}}
 
 # Test that we are correctly handling SNAPSHOT on views with empty upper
 # frontier

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -250,3 +250,19 @@ contains:imestamp
 contains:imestamp
 > SELECT * FROM nums_compacted AS OF 6
 8
+
+# The sink keeps emitting the changes for transactions 4, 5, and 6. Verify them
+# here so the whole topic is consumed and the end-of-file exhaustion check does
+# not flag them as unverified records.
+
+$ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.public.nums_sink sort-messages=true
+4	{"before": null, "after": {"row": {"num": 6}}}
+4	{"before": {"row": {"num": 5}}, "after": null}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.public.nums_sink sort-messages=true
+5	{"before": null, "after": {"row": {"num": 7}}}
+5	{"before": {"row": {"num": 6}}, "after": null}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.public.nums_sink sort-messages=true
+6	{"before": null, "after": {"row": {"num": 8}}}
+6	{"before": {"row": {"num": 7}}, "after": null}

--- a/test/testdrive/github-7242.td
+++ b/test/testdrive/github-7242.td
@@ -43,7 +43,7 @@ $ set-arg-default single-replica-cluster=quickstart
   ENVELOPE DEBEZIUM
 
 # Wait for the sink to create the topic
-$ kafka-wait-topic topic=testdrive-supplier-${testdrive.seed} partitions=1
+$ kafka-wait-topic topic=testdrive-supplier-${testdrive.seed}
 
 > BEGIN
 > CREATE SOURCE progress_check

--- a/test/testdrive/kafka-sink-empty-progress-topic.td
+++ b/test/testdrive/kafka-sink-empty-progress-topic.td
@@ -71,7 +71,9 @@ $ kafka-create-topic topic=empty-at-zero partitions=1
   FORMAT JSON
   ENVELOPE UPSERT
 
-$ kafka-verify-data sink=materialize.public.empty_at_zero format=json
+# This topic doubles as the sink's progress topic, so it also carries progress
+# records that this command cannot decode. Exempt it from the exhaustion check.
+$ kafka-verify-data sink=materialize.public.empty_at_zero format=json exhaustive=false
 {"column1": 1}
 
 # Ensure that sinks can be created against a progress topic that is empty with a
@@ -99,5 +101,7 @@ $ kafka-delete-records topic=empty-at-nonzero partition=0 offset=3
   FORMAT JSON
   ENVELOPE UPSERT
 
-$ kafka-verify-data sink=materialize.public.empty_at_nonzero format=json
+# This topic doubles as the sink's progress topic, so it also carries progress
+# records that this command cannot decode. Exempt it from the exhaustion check.
+$ kafka-verify-data sink=materialize.public.empty_at_nonzero format=json exhaustive=false
 {"column1": 1}

--- a/test/testdrive/kafka-sinks.td
+++ b/test/testdrive/kafka-sinks.td
@@ -161,7 +161,9 @@ snk1             kafka    snk1_cluster  ""
 snk2             kafka    snk2_cluster  ""
 snk3             kafka    snk3_cluster  ""
 
-$ kafka-verify-data format=avro sink=materialize.public.snk1 sort-messages=true
+# Several later sinks in this file (default_cluster_sink, sink_with_options,
+# cluster_c_sink) also write to this topic, so it is not exhaustively verified.
+$ kafka-verify-data format=avro sink=materialize.public.snk1 sort-messages=true exhaustive=false
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
 {"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": [0, 0, 0, 0, 0, 0, 0, 0]}}}
 
@@ -238,6 +240,18 @@ $ kafka-verify-data format=avro sink=materialize.public.snk6 sort-messages=true
 {"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": [0, 0, 0, 0, 0, 0, 0, 2]}}}
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
 {"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": [0, 0, 0, 0, 0, 0, 0, 0]}}}
+
+# The `extra,row` ingest above also reaches snk2, snk3, and snk4, which were
+# verified before it arrived. Verify the trailing record on each so their
+# topics are fully consumed.
+$ kafka-verify-data format=avro sink=materialize.public.snk2
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": [0, 0, 0, 0, 0, 0, 0, 2]}}}
+
+$ kafka-verify-data format=avro sink=materialize.public.snk3
+{"before": null, "after": {"row":{"c": "extrarow"}}}
+
+$ kafka-verify-data format=avro sink=materialize.public.snk4
+{"before": null, "after": {"row":{"c": true}}}
 
 # Test that we are correctly handling SNAPSHOT on views with empty upper
 # frontier


### PR DESCRIPTION
--rewrite-results:
- Rewrite on the final retry attempt. Finality was keyed off max_tries, which defaults to usize::MAX, so retryable statements were never rewritten and spun until the timeout instead.
- Rewrite `?` blocks as raw text. They were rewritten as a `>`-style quoted block, corrupting the file.
- Escape rewritten lines starting with a sigil, e.g. a `?column?` header previously parsed back as a new `?` command.

Parser:
- Preserve positions of pushed-back lines. Argument errors were reported near the top of the file instead of the offending line.
- Return errors instead of panicking on malformed version constraints and one-character command lines.

Actions:
- kafka-ingest: read confluent-wire-format once. Reading it in both the value and key format matches left the key side always at the default, rejecting consistent explicit settings.
- kafka-verify-data: propagate key schema fetch errors instead of treating any registry error as "unkeyed topic". Take expected text values verbatim like keys, JSON quotes made strings never match. Document the chunked/prefix verification semantics.
- bytes::unescape: keep the character after a backslash, a match guard consumed it even when the guard failed (`\t` dropped both chars).
- file-append/s3-file-upload: make trailing-newline=false suppress the final newline instead of dropping the last content line.
- postgres-execute background=true: join tasks at end of file so failures fail the test as documented.
- Statement-logging consistency check: 'finished_status != aborted' filtered out the NULL rows the check exists to catch, making it vacuous. Same fix in the environmentd test.
- schema-registry-verify, kafka-verify-commit: respect set-sql-timeout.
- schema-registry-wait: fix the phase flag that was Copy-captured into each retry future and never advanced.
- s3-verify-keys/-data: sleep between all list attempts instead of burning the retry budget instantly, and retry on an empty prefix.
- Substitute variables in detail:/hint: expectations of ! commands.
- Reject unknown arguments in kafka-wait-topic, s3-file-upload, s3-set-presigned-url, http-request, protobuf-compile-descriptors, check-shard-tombstone, and skip-consistency-checks. Drop the dead partitions=1 argument in github-7242.td.

Test run: https://buildkite.com/materialize/nightly/builds/17128