### PR TITLE
sqlsmith: extend harness and fix error handling

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -26,6 +26,9 @@ known_errors = [
     "function list_cat(",  # insufficient type system, parameter types have to match
     "does not support implicitly casting from",
     "aggregate functions that refer exclusively to outer columns not yet supported",  # https://github.com/MaterializeInc/database-issues/issues/1163
+    "permission denied for",  # expected for the unprivileged-role instance
+    "must be owner of",  # expected for the unprivileged-role instance
+    "must be a superuser",  # expected for the unprivileged-role instance
     "range lower bound must be less than or equal to range upper bound",
     "violates not-null constraint",
     "division by zero",
@@ -40,9 +43,8 @@ known_errors = [
     "is only defined for finite arguments",
     "more than one record produced in subquery",
     "invalid range bound flags",
-    "invalid input syntax for type jsonb",
+    "invalid input syntax for type ",
     "invalid regular expression",
-    "invalid input syntax for type date",
     "invalid escape string",
     "invalid hash algorithm",
     "is defined for numbers greater than or equal to",
@@ -74,7 +76,8 @@ known_errors = [
     "Expected joined table, found",  # Should fix for multi table join
     "Expected ON, or USING after JOIN, found",  # Should fix for multi table join
     "but expression is of type",  # Should fix, but only happens rarely
-    "coalesce could not convert type map",  # Should fix, but only happens rarely
+    "could not convert type ",  # CASE/coalesce, the generator's type metadata for polymorphic functions is coarser than real inference
+    "could not determine polymorphic type",  # untyped literals for pseudo-typed arguments
     "operator does not exist: map",  # Should fix, but only happens rarely
     "result exceeds max size of",  # Seems expected with huge queries
     "expected expression, but found reserved keyword",  # Should fix, but only happens rarely with subqueries
@@ -98,15 +101,12 @@ known_errors = [
     "timezone interval must not contain months or years",
     "not supported for type date",
     "not supported for type time",
-    "coalesce types text and text list cannot be matched",  # Bad typing for ||
-    "coalesce types text list and text cannot be matched",  # Bad typing for ||
+    " cannot be matched",  # CASE/coalesce/set operation type unification, the generator's type system is coarser than the real one
+    "but query returns types",  # WITH MUTUALLY RECURSIVE bindings, the generator's type metadata can disagree with inference
     "is out of range for type numeric: exceeds maximum precision",
     "is out of range for type date",
     "is out of range for type timestamp",
-    "CAST does not support casting from ",  # TODO: Improve type system
-    "SET clause does not support casting from ",  # TODO: Improve type system
-    "coalesce types integer and interval cannot be matched",  # TODO: Implicit cast from timestamp to date in (date - timestamp)
-    "coalesce types interval and integer cannot be matched",  # TODO: Implicit cast from timestamp to date in (date - timestamp)
+    " does not support casting from ",  # CAST/SET clause/CASE, TODO: Improve type system
     "requested length too large",
     "number of columns must be a positive integer literal",
     "regexp_extract requires a string literal as its first argument",

--- a/test/sqlsmith/Dockerfile
+++ b/test/sqlsmith/Dockerfile
@@ -30,7 +30,7 @@ ADD https://api.github.com/repos/MaterializeInc/sqlsmith/git/refs/heads/master v
 # Build SQLsmith
 RUN git clone --single-branch --branch=master https://github.com/MaterializeInc/sqlsmith \
     && cd sqlsmith \
-    && git checkout 64449b6d2d4fafbb87b4e407f2fb54d038926f0c \
+    && git checkout 11df80becfe13ecd6d01f016c898df513251aef7 \
     && rm -rf .git \
     && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ . \
     && cmake --build . -j `nproc`

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -17,7 +17,7 @@ import json
 import random
 import time
 from datetime import datetime
-from threading import Thread
+from threading import Lock, Thread
 from typing import Any
 
 from materialize.mzcompose.composition import (
@@ -64,7 +64,10 @@ def is_known_error(e: str) -> bool:
     return False
 
 
-def run_sqlsmith(c: Composition, cmd: str, aggregate: dict[str, Any]) -> None:
+aggregate_lock = Lock()
+
+
+def run_sqlsmith(c: Composition, cmd: list[str], aggregate: dict[str, Any]) -> None:
     result = c.run(
         *cmd,
         capture=True,
@@ -80,32 +83,50 @@ def run_sqlsmith(c: Composition, cmd: str, aggregate: dict[str, Any]) -> None:
         )
 
     data = json.loads(result.stdout)
-    aggregate["version"] = data["version"]
-    aggregate["queries"] += data["queries"]
-    aggregate["errors"].extend(data["errors"])
+    with aggregate_lock:
+        aggregate["version"] = data["version"]
+        aggregate["queries"] += data["queries"]
+        aggregate["errors"].extend(data["errors"])
+        for imp in data.get("impedance", []):
+            entry = aggregate["impedance"].setdefault(
+                imp["prod"], {"ok": 0, "bad": 0, "retries": 0}
+            )
+            entry["ok"] += imp["ok"]
+            entry["bad"] += imp["bad"]
+            entry["retries"] += imp["retries"]
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    parser.add_argument("--num-sqlsmith", default=len(MZ_SERVERS), type=int)
+    parser.add_argument("--num-sqlsmith", default=2 * len(MZ_SERVERS), type=int)
     # parser.add_argument("--queries", default=10000, type=int)
     parser.add_argument("--runtime", default=600, type=int)
     parser.add_argument("--max-joins", default=5, type=int)
     parser.add_argument("--explain-only", action="store_true")
-    parser.add_argument("--exclude-catalog", default=False, type=bool)
+    parser.add_argument("--exclude-catalog", action="store_true")
     parser.add_argument("--seed", default=None, type=int)
     args = parser.parse_args()
 
     c.up(*MZ_SERVERS)
 
     for mz_server in MZ_SERVERS:
-        # Very simple data for our workload
+        # Simple data for our workload. NULLs and type edge values
+        # everywhere, an empty table (t4), a larger table (t5) so
+        # non-trivial arrangement sizes occur, indexes so index-based plans
+        # (lookup/delta joins) occur, and arrays/lists/maps/ranges so
+        # functions over those types have interesting inputs. NOTE: t5 is
+        # deliberately capped at 1000 rows, larger sizes make random
+        # multi-way joins OOM the memory-capped clusterd regularly.
         c.sql(
             """
             CREATE TABLE t1 (a int2, b int4, c int8, d uint2, e uint4, f uint8, g text);
             INSERT INTO t1 VALUES (1, 2, 3, 4, 5, 6, '7'), (3, 4, 5, 6, 7, 8, '9'), (5, 6, 7, 8, 9, 10, '11'), (7, 8, 9, 10, 11, 12, '13'), (9, 10, 11, 12, 13, 14, '15'), (11, 12, 13, 14, 15, 16, '17'), (13, 14, 15, 16, 17, 18, '19'), (15, 16, 17, 18, 19, 20, '21');
+            INSERT INTO t1 VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL), (0, NULL, -9223372036854775808, 0, NULL, 18446744073709551615, ''), (-32768, 2147483647, NULL, 65535, 4294967295, NULL, 'ß');
+            CREATE INDEX t1_idx_a ON t1 (a);
+            CREATE INDEX t1_idx_bc ON t1 (b, c);
             CREATE MATERIALIZED VIEW mv AS SELECT a + b AS col1, c + d AS col2, e + f AS col3, g AS col4 FROM t1;
             CREATE MATERIALIZED VIEW mv2 AS SELECT count(*) FROM mv;
             CREATE DEFAULT INDEX ON mv;
+            CREATE VIEW v1 AS SELECT col1 + col2 AS c1, col4 AS c2 FROM mv WHERE col1 IS NOT NULL;
             CREATE TABLE t2 (
                 a_bool        BOOL,
                 b_float4      FLOAT4,
@@ -139,9 +160,34 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 INTERVAL '1 day 2 hours',
                 '{"key": "value"}',
                 '550e8400-e29b-41d4-a716-446655440000'
+            ),
+            (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+            (
+                FALSE,
+                'NaN',
+                '-inf',
+                -0.000000001,
+                '',
+                'ß',
+                '\\x00',
+                DATE '0001-01-01',
+                TIME '23:59:59.999999',
+                TIMESTAMP '99999-12-31 23:59:59',
+                TIMESTAMPTZ '0001-01-01 00:00:00+00',
+                INTERVAL '-178956970 years',
+                '[1, [2, {"a": null}]]',
+                '00000000-0000-0000-0000-000000000000'
             );
 
             CREATE MATERIALIZED VIEW mv3 AS SELECT * FROM t2;
+            CREATE TABLE t3 (a int4 list, b text list, c map[text=>text], d int4[], e text[], f int4range, g numeric(38,2), h char(1), i oid);
+            INSERT INTO t3 VALUES (LIST[1,2,3], LIST['a','b'], '{a=>b}'::map[text=>text], ARRAY[1,2,3], ARRAY['a','b',NULL], int4range(1,10), 1234.56, 'x', 42);
+            INSERT INTO t3 VALUES (LIST[]::int4 list, LIST[NULL]::text list, '{}'::map[text=>text], ARRAY[]::int4[], ARRAY[]::text[], int4range(5,5), -0.01, '', 0);
+            INSERT INTO t3 VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+            CREATE TABLE t4 (a int4, b text);
+            CREATE TABLE t5 (a int4, b int8, c text);
+            INSERT INTO t5 SELECT a, a::int8 * 37, 'val_' || a FROM generate_series(1, 1000) g(a);
+            CREATE INDEX t5_idx_a ON t5 (a);
             """,
             service=mz_server,
         )
@@ -149,6 +195,22 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             """
             ALTER SYSTEM SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
             ALTER SYSTEM SET CLUSTER_REPLICA TO 'r1';
+            ALTER SYSTEM SET enable_rbac_checks TO true;
+            """,
+            service=mz_server,
+            port=6877,
+            user="mz_system",
+        )
+        # An unprivileged role for some of the instances so access control
+        # paths are exercised too. It can read the user tables but catalog
+        # restrictions and ownership checks still apply.
+        c.sql(
+            """
+            CREATE ROLE fuzz;
+            GRANT USAGE ON DATABASE materialize TO fuzz;
+            GRANT USAGE ON SCHEMA materialize.public TO fuzz;
+            GRANT SELECT ON ALL TABLES IN SCHEMA materialize.public TO fuzz;
+            GRANT USAGE ON CLUSTER quickstart TO fuzz;
             """,
             service=mz_server,
             port=6877,
@@ -165,23 +227,46 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     killer.start()
 
     threads: list[Thread] = []
-    aggregate: dict[str, Any] = {"errors": [], "version": "", "queries": 0}
+    aggregate: dict[str, Any] = {
+        "errors": [],
+        "version": "",
+        "queries": 0,
+        "impedance": {},
+    }
+    exceptions: list[Exception] = []
+
+    def run_sqlsmith_thread(cmd: list[str]) -> None:
+        try:
+            run_sqlsmith(c, cmd, aggregate)
+        except Exception as e:
+            # store instead of raise, exceptions in threads don't
+            # propagate to the workflow
+            exceptions.append(e)
+
     for i in range(args.num_sqlsmith):
+        mz_server = MZ_SERVERS[i % len(MZ_SERVERS)]
+        # Most instances use mz_system to have access to all tables,
+        # including ones with restricted permissions. Every fourth instance
+        # uses the unprivileged role instead so authorization paths are
+        # fuzzed as well.
+        if i % 4 == 3:
+            target = f"host={mz_server} port=6875 dbname=materialize user=fuzz"
+        else:
+            target = f"host={mz_server} port=6877 dbname=materialize user=mz_system"
         cmd = [
             "sqlsmith",
             # f"--max-queries={args.queries}",
             f"--max-joins={args.max_joins}",
             f"--seed={seed + i}",
             "--log-json",
-            # we use mz_system to have access to all tables, including ones with restricted permissions
-            f"--target=host={MZ_SERVERS[i % len(MZ_SERVERS)]} port=6877 dbname=materialize user=mz_system",
+            f"--target={target}",
         ]
         if args.exclude_catalog:
             cmd.append("--exclude-catalog")
         if args.explain_only:
             cmd.append("--explain-only")
 
-        thread = Thread(target=run_sqlsmith, args=[c, cmd, aggregate])
+        thread = Thread(target=run_sqlsmith_thread, args=[cmd])
         thread.start()
         threads.append(thread)
 
@@ -203,6 +288,18 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     print(
         f"SQLsmith: {aggregate['version']} seed: {seed} queries: {aggregate['queries']}"
     )
+
+    # Which productions of the grammar failed how often, so coverage
+    # regressions (a production erroring so much it gets blacklisted) are
+    # visible in the log.
+    print("Impedance (failed/succeeded queries containing the production):")
+    for prod, entry in sorted(
+        aggregate["impedance"].items(), key=lambda x: -x[1]["bad"]
+    ):
+        blacklist_note = ""
+        if entry["bad"] >= 100 and entry["bad"] / (entry["bad"] + entry["ok"]) > 0.99:
+            blacklist_note = " (BLACKLISTED)"
+        print(f"  {prod}: {entry['bad']}/{entry['ok']}{blacklist_note}")
     for frozen_key, errors in new_errors.items():
         key = dict(frozen_key)
         occurrences = f" ({len(errors)} occurrences)" if len(errors) > 1 else ""
@@ -231,3 +328,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         else:
             shortest_query = min([error["query"] for error in errors], key=len)
             print(f"Query: {shortest_query}")
+
+    # Raise only after reporting the errors, they are the more useful signal
+    if exceptions:
+        raise Exception(
+            f"{len(exceptions)} SQLsmith instance(s) failed, first failure: {exceptions[0]}"
+        ) from exceptions[0]


### PR DESCRIPTION
Propagate SQLsmith thread failures (OOM, bad return codes) instead of silently swallowing them, fix the broken --exclude-catalog flag, and lock the shared result aggregate.

Extend coverage: seed data with NULLs, edge values, an empty and a 10k row table, indexes, and list/map/array/range columns. Run two instances per server, every fourth one as an unprivileged role with RBAC checks enabled. Print SQLsmith's impedance stats so blacklisted grammar productions become visible.

Suppress the type-unification error family that the extended SQLsmith grammar (joins, GROUP BY, set ops, WITH MUTUALLY RECURSIVE, window functions) triggers. Using https://github.com/MaterializeInc/sqlsmith/pull/7

Test runs: https://buildkite.com/materialize/release-qualification/builds/1310 & https://buildkite.com/materialize/nightly/builds/17150 (both green)