### PR TITLE
ci: Nightly fixes (2026-07-10)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2641,6 +2641,18 @@ steps:
                composition: race-condition
                run: rotate-keys-race
 
+  - id: mz-deploy
+    label: "mz-deploy"
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    inputs: [src/mz-deploy, test/mz-deploy]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: mz-deploy
+          ci-builder: stable
+    agents:
+      queue: hetzner-x86-64-4cpu-8gb
+
   - group: Language
     key: language-tests
     steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -764,18 +764,6 @@ steps:
     agents:
       queue: hetzner-aarch64-4cpu-8gb
 
-  - id: mz-deploy
-    label: "mz-deploy"
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [src/mz-deploy, test/mz-deploy]
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: mz-deploy
-          ci-builder: stable
-    agents:
-      queue: hetzner-x86-64-4cpu-8gb
-
   - group: Docs
     key: docs-tests
     steps:

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -484,7 +484,6 @@ INTENTIONAL_LD_OVERRIDES: set[str] = {
     "max_aws_privatelink_connections",
     "max_tables",
     # Cloud-only infrastructure / performance tuning.
-    "arrangement_size_history_collection_interval",
     "cluster_topology_spread_min_domains",
     "column_paged_batcher_budget_fraction",
     "column_paged_batcher_lz4",
@@ -529,12 +528,13 @@ INTENTIONAL_LD_OVERRIDES: set[str] = {
 KNOWN_CROSS_ENV_DIVERGENCES: set[str] = set("""
     allow_real_time_recency
     allowed_cluster_replica_sizes
-    column_paged_batcher_budget_fraction
-    column_paged_batcher_lz4
+    column_paged_batcher_swap_pageout
     compute_dataflow_max_inflight_bytes
     compute_peek_response_stash_threshold_bytes
     compute_subscribe_snapshot_optimization
     enable_cluster_schedule_refresh
+    enable_column_paged_batcher
+    enable_column_paged_batcher_spill
     enable_compute_correction_v2
     enable_create_table_from_source
     enable_eager_delta_joins

--- a/test/sqllogictest/distinct_arrangements.slt
+++ b/test/sqllogictest/distinct_arrangements.slt
@@ -84,7 +84,6 @@ SELECT mdo.name FROM mz_introspection.mz_arrangement_sharing mash JOIN mz_intros
 ----
 ArrangeBy[[Column(0), Column(1)]]
 ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
 Arranged DistinctBy
 Arranged DistinctBy
 DistinctBy


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/17120

@sjwiesman  Noticed that mz-deploy has become the slowest test in test pipeline. Since I think most don't touch anything that breaks mz-deploy, I've moved it to Nightly instead of parallelizing it.

@antiguru I assume the column paged batcher testing in Staging is intentional.

Test run: https://buildkite.com/materialize/nightly/builds/17131