### PR TITLE
persist: Wake shard upper waiters on upper advance, not any seqno bump

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -2670,6 +2670,10 @@ metrics:
   help: count of watch notifications sent to a non-empty broadcast channel
   source: src/persist-client/src/internal/metrics.rs
   visibility: internal
+- name: mz_persist_watch_notify_upper_sent
+  help: count of upper-advance watch notifications sent to a non-empty broadcast channel
+  source: src/persist-client/src/internal/metrics.rs
+  visibility: internal
 - name: mz_persist_watch_notify_wait_finished
   help: count of watch wait calls resolved
   source: src/persist-client/src/internal/metrics.rs

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -2671,7 +2671,7 @@ metrics:
   source: src/persist-client/src/internal/metrics.rs
   visibility: internal
 - name: mz_persist_watch_notify_upper_sent
-  help: count of upper-advance watch notifications sent to a non-empty broadcast channel
+  help: count of strict shard upper advances signaled to upper waiters
   source: src/persist-client/src/internal/metrics.rs
   visibility: internal
 - name: mz_persist_watch_notify_wait_finished

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -30,6 +30,7 @@ use mz_persist::location::{
     VersionedData,
 };
 use mz_persist_types::{Codec, Codec64};
+use timely::PartialOrder;
 use timely::progress::Timestamp;
 use tokio::sync::{Mutex, OnceCell};
 use tracing::debug;
@@ -696,11 +697,16 @@ impl<K, V, T, D> LockingTypedState<K, V, T, D> {
         f(&state)
     }
 
-    pub(crate) fn write_lock<R, F: FnOnce(&mut TypedState<K, V, T, D>) -> R>(
-        &self,
-        metrics: &LockMetrics,
-        f: F,
-    ) -> R {
+    pub(crate) fn write_lock<R, F>(&self, metrics: &LockMetrics, f: F) -> R
+    where
+        F: FnOnce(&mut TypedState<K, V, T, D>) -> R,
+        // Bounds needed to read the shard upper. All callers are in contexts that
+        // already satisfy these (they mutate a fully-typed shard state).
+        K: Codec,
+        V: Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Codec64,
+    {
         metrics.acquire_count.inc();
         let mut state = match self.state.try_write() {
             Ok(x) => x,
@@ -716,11 +722,18 @@ impl<K, V, T, D> LockingTypedState<K, V, T, D> {
             Err(TryLockError::Poisoned(err)) => panic!("state read lock poisoned: {}", err),
         };
         let seqno_before = state.seqno;
+        // Snapshot the upper before the modification so we can tell whether it
+        // advanced. Cheap: the upper is typically a single-element antichain.
+        let upper_before = state.upper().clone();
         let ret = f(&mut state);
         let seqno_after = state.seqno;
         debug_assert!(seqno_after >= seqno_before);
         if seqno_after > seqno_before {
-            self.notifier.notify(seqno_after);
+            // Only wake upper waiters when the upper actually advanced. The seqno
+            // bumps for many non-data reasons (GC, rollups, since-downgrades,
+            // other writers' CaAs) and those must not re-activate upper waiters.
+            let upper_advanced = PartialOrder::less_than(&upper_before, state.upper());
+            self.notifier.notify(seqno_after, upper_advanced);
         }
         // For now, make sure to notify while under lock. It's possible to move
         // this out of the lock window, see [StateWatchNotifier::notify].

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -30,7 +30,6 @@ use mz_persist::location::{
     VersionedData,
 };
 use mz_persist_types::{Codec, Codec64};
-use timely::PartialOrder;
 use timely::progress::Timestamp;
 use tokio::sync::{Mutex, OnceCell};
 use tracing::debug;
@@ -601,7 +600,7 @@ impl StateCache {
 pub(crate) struct LockingTypedState<K, V, T, D> {
     shard_id: ShardId,
     state: RwLock<TypedState<K, V, T, D>>,
-    notifier: StateWatchNotifier,
+    notifier: StateWatchNotifier<T>,
     cfg: Arc<PersistConfig>,
     metrics: Arc<Metrics>,
     shard_metrics: Arc<ShardMetrics>,
@@ -641,10 +640,16 @@ impl<K: Codec, V: Codec, T, D> LockingTypedState<K, V, T, D> {
         cfg: Arc<PersistConfig>,
         subscription_token: Arc<ShardSubscriptionToken>,
         diagnostics: &Diagnostics,
-    ) -> Self {
+    ) -> Self
+    where
+        // Bounds needed to seed the notifier with the shard's current upper.
+        T: Timestamp + Lattice + Codec64,
+        D: Codec64,
+    {
+        let notifier = StateWatchNotifier::new(Arc::clone(&metrics), initial_state.upper().clone());
         Self {
             shard_id,
-            notifier: StateWatchNotifier::new(Arc::clone(&metrics)),
+            notifier,
             state: RwLock::new(initial_state),
             cfg: Arc::clone(&cfg),
             shard_metrics: metrics.shards.shard(&shard_id, &diagnostics.shard_name),
@@ -722,18 +727,15 @@ impl<K, V, T, D> LockingTypedState<K, V, T, D> {
             Err(TryLockError::Poisoned(err)) => panic!("state read lock poisoned: {}", err),
         };
         let seqno_before = state.seqno;
-        // Snapshot the upper before the modification so we can tell whether it
-        // advanced. Cheap: the upper is typically a single-element antichain.
-        let upper_before = state.upper().clone();
         let ret = f(&mut state);
         let seqno_after = state.seqno;
         debug_assert!(seqno_after >= seqno_before);
         if seqno_after > seqno_before {
-            // Only wake upper waiters when the upper actually advanced. The seqno
-            // bumps for many non-data reasons (GC, rollups, since-downgrades,
-            // other writers' CaAs) and those must not re-activate upper waiters.
-            let upper_advanced = PartialOrder::less_than(&upper_before, state.upper());
-            self.notifier.notify(seqno_after, upper_advanced);
+            // The notifier only advances the upper waiters' signal on a strict
+            // upper advance. The seqno bumps for many non-data reasons (GC,
+            // rollups, since-downgrades, other writers' CaAs) and those must not
+            // re-activate upper waiters.
+            self.notifier.notify(seqno_after, state.upper());
         }
         // For now, make sure to notify while under lock. It's possible to move
         // this out of the lock window, see [StateWatchNotifier::notify].
@@ -809,7 +811,7 @@ impl<K, V, T, D> LockingTypedState<K, V, T, D> {
         }
     }
 
-    pub(crate) fn notifier(&self) -> &StateWatchNotifier {
+    pub(crate) fn notifier(&self) -> &StateWatchNotifier<T> {
         &self.notifier
     }
 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -867,7 +867,7 @@ where
         }
         let mut watch_fut = std::pin::pin!(
             watch
-                .wait_for_seqno_ge(seqno.next())
+                .wait_for_upper_seqno_ge(seqno.next())
                 .map(Wake::Watch)
                 .instrument(trace_span!("snapshot::watch"))
         );
@@ -956,7 +956,7 @@ where
                 Wake::Watch(watch) => {
                     watch_fut.set(
                         watch
-                            .wait_for_seqno_ge(seqno.next())
+                            .wait_for_upper_seqno_ge(seqno.next())
                             .map(Wake::Watch)
                             .instrument(trace_span!("snapshot::watch")),
                     );

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -867,7 +867,7 @@ where
         }
         let mut watch_fut = std::pin::pin!(
             watch
-                .wait_for_upper_seqno_ge(seqno.next())
+                .wait_for_upper_past(frontier)
                 .map(Wake::Watch)
                 .instrument(trace_span!("snapshot::watch"))
         );
@@ -956,7 +956,7 @@ where
                 Wake::Watch(watch) => {
                     watch_fut.set(
                         watch
-                            .wait_for_upper_seqno_ge(seqno.next())
+                            .wait_for_upper_past(frontier)
                             .map(Wake::Watch)
                             .instrument(trace_span!("snapshot::watch")),
                     );

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2299,6 +2299,7 @@ pub struct WatchMetrics {
     pub(crate) wait_resolved_via_watch: IntCounter,
     pub(crate) wait_resolved_via_sleep: IntCounter,
     pub(crate) notify_sent: IntCounter,
+    pub(crate) notify_upper_sent: IntCounter,
     pub(crate) notify_noop: IntCounter,
     pub(crate) notify_recv: IntCounter,
     pub(crate) notify_lagged: IntCounter,
@@ -2328,6 +2329,10 @@ impl WatchMetrics {
             notify_sent: registry.register(metric!(
                 name: "mz_persist_watch_notify_sent",
                 help: "count of watch notifications sent to a non-empty broadcast channel",
+            )),
+            notify_upper_sent: registry.register(metric!(
+                name: "mz_persist_watch_notify_upper_sent",
+                help: "count of upper-advance watch notifications sent to a non-empty broadcast channel",
             )),
             notify_noop: registry.register(metric!(
                 name: "mz_persist_watch_notify_noop",

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2332,7 +2332,7 @@ impl WatchMetrics {
             )),
             notify_upper_sent: registry.register(metric!(
                 name: "mz_persist_watch_notify_upper_sent",
-                help: "count of upper-advance watch notifications sent to a non-empty broadcast channel",
+                help: "count of strict shard upper advances signaled to upper waiters",
             )),
             notify_noop: registry.register(metric!(
                 name: "mz_persist_watch_notify_noop",

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -22,27 +22,42 @@ use crate::internal::metrics::Metrics;
 #[derive(Debug)]
 pub struct StateWatchNotifier {
     metrics: Arc<Metrics>,
-    tx: broadcast::Sender<SeqNo>,
+    /// Fires on every strict seqno advance. Used by waiters that care about any
+    /// state change (e.g. lease/seqno machinery via [StateWatch::wait_for_seqno_ge]).
+    seqno_tx: broadcast::Sender<SeqNo>,
+    /// Fires only when the shard upper (write frontier) strictly advances, carrying
+    /// the seqno at which that happened. Used by [StateWatch::wait_for_upper_seqno_ge]
+    /// so upper waiters (Listen/Subscribe/snapshot) don't wake on GC, rollups, or
+    /// since-downgrades that bump the seqno without moving the upper.
+    upper_tx: broadcast::Sender<SeqNo>,
 }
 
 impl StateWatchNotifier {
     pub(crate) fn new(metrics: Arc<Metrics>) -> Self {
-        let (tx, _rx) = broadcast::channel(1);
-        StateWatchNotifier { metrics, tx }
+        let (seqno_tx, _rx) = broadcast::channel(1);
+        let (upper_tx, _rx) = broadcast::channel(1);
+        StateWatchNotifier {
+            metrics,
+            seqno_tx,
+            upper_tx,
+        }
     }
 
     /// Wake up any watchers of this state.
     ///
+    /// `seqno` is the state's seqno after the modification, and `upper_advanced`
+    /// must be true iff the shard upper strictly advanced in the same modification.
+    ///
     /// This must be called while under the same lock that modified the state to
-    /// avoid any potential for out of order SeqNos in the broadcast channel.
+    /// avoid any potential for out of order SeqNos in the broadcast channels.
     ///
     /// This restriction can be lifted (i.e. we could notify after releasing the
     /// write lock), but we'd have to reason about out of order SeqNos in the
-    /// broadcast channel. In particular, if we see `RecvError::Lagged` then
+    /// broadcast channels. In particular, if we see `RecvError::Lagged` then
     /// it's possible we lost X+1 and got X, so if X isn't sufficient to return,
     /// we'd need to grab the read lock and verify the real SeqNo.
-    pub(crate) fn notify(&self, seqno: SeqNo) {
-        match self.tx.send(seqno) {
+    pub(crate) fn notify(&self, seqno: SeqNo, upper_advanced: bool) {
+        match self.seqno_tx.send(seqno) {
             // Someone got woken up.
             Ok(_) => {
                 self.metrics.watch.notify_sent.inc();
@@ -52,44 +67,66 @@ impl StateWatchNotifier {
                 self.metrics.watch.notify_noop.inc();
             }
         }
+        if upper_advanced {
+            // send only errors when there are no receivers, which is fine. A full
+            // buffer does not error: the channel drops the oldest value and the
+            // receiver observes Lagged, which is handled in wait_for_upper_seqno_ge.
+            if self.upper_tx.send(seqno).is_ok() {
+                self.metrics.watch.notify_upper_sent.inc();
+            }
+        }
     }
 }
 
 /// A reactive subscription to changes in [LockingTypedState].
 ///
-/// Invariants:
+/// This exposes two independent signals over the same state:
+/// - [Self::wait_for_seqno_ge] wakes on any strict seqno advance.
+/// - [Self::wait_for_upper_seqno_ge] wakes only when the shard upper advances.
+///
+/// Invariants (both signals):
 /// - The `state.seqno` only advances (never regresses). This is guaranteed by
 ///   LockingTypedState.
-/// - `seqno_high_water` is always <= `state.seqno`.
+/// - `*_high_water` is always <= `state.seqno`.
 /// - If `seqno_high_water` is < `state.seqno`, then we'll get a notification on
-///   `rx`. This is maintained by notifying new seqnos under the same lock which
-///   adds them.
-/// - `seqno_high_water` always holds the highest value received in the channel
-///   This is maintained by `wait_for_seqno_gt` taking an exclusive reference to
-///   self.
+///   `seqno_rx`. This is maintained by notifying new seqnos under the same lock
+///   which adds them.
+/// - If the upper advanced past the seqno recorded in `upper_seqno_high_water`,
+///   then we'll get a notification on `upper_rx`. This is maintained by notifying
+///   under the same lock that advanced the upper.
+/// - Each `*_high_water` always holds the highest value received in its channel.
+///   This is maintained by the wait methods taking an exclusive reference to self.
 #[derive(Debug)]
 pub struct StateWatch<K, V, T, D> {
     metrics: Arc<Metrics>,
     state: Arc<LockingTypedState<K, V, T, D>>,
     seqno_high_water: SeqNo,
-    rx: broadcast::Receiver<SeqNo>,
+    seqno_rx: broadcast::Receiver<SeqNo>,
+    /// The highest seqno at which we've observed the upper advance, as delivered by
+    /// `upper_rx`. Initialized to the seqno at subscribe time: any upper advance
+    /// after that point happens at a strictly greater seqno and fires `upper_rx`.
+    upper_seqno_high_water: SeqNo,
+    upper_rx: broadcast::Receiver<SeqNo>,
 }
 
 impl<K, V, T, D> StateWatch<K, V, T, D> {
     pub(crate) fn new(state: Arc<LockingTypedState<K, V, T, D>>, metrics: Arc<Metrics>) -> Self {
-        // Important! We have to subscribe to the broadcast channel _before_ we
+        // Important! We have to subscribe to the broadcast channels _before_ we
         // grab the current seqno. Otherwise, we could race with a write to
         // state and miss a notification. Tokio guarantees that "the returned
         // Receiver will receive values sent after the call to subscribe", and
         // the read_lock linearizes the subscribe to be _before_ whatever
-        // seqno_high_water we get here.
-        let rx = state.notifier().tx.subscribe();
+        // seqno we get here.
+        let seqno_rx = state.notifier().seqno_tx.subscribe();
+        let upper_rx = state.notifier().upper_tx.subscribe();
         let seqno_high_water = state.read_lock(&metrics.locks.watch, |x| x.seqno);
         StateWatch {
             metrics,
             state,
             seqno_high_water,
-            rx,
+            seqno_rx,
+            upper_seqno_high_water: seqno_high_water,
+            upper_rx,
         }
     }
 
@@ -103,7 +140,7 @@ impl<K, V, T, D> StateWatch<K, V, T, D> {
             if self.seqno_high_water >= requested {
                 break;
             }
-            match self.rx.recv().await {
+            match self.seqno_rx.recv().await {
                 Ok(x) => {
                     self.metrics.watch.notify_recv.inc();
                     assert!(x >= self.seqno_high_water);
@@ -126,6 +163,53 @@ impl<K, V, T, D> StateWatch<K, V, T, D> {
         self.metrics.watch.notify_wait_finished.inc();
         debug!(
             "wait_for_seqno_ge {} {} returning",
+            self.state.shard_id(),
+            requested
+        );
+        self
+    }
+
+    /// Blocks until the shard upper has advanced at a SeqNo >= the requested one.
+    ///
+    /// Unlike [Self::wait_for_seqno_ge], this only wakes on upper advances, not on
+    /// seqno bumps caused by GC, rollups, since-downgrades, or no-op CaAs. Callers
+    /// waiting for a specific frontier (e.g. `wait_for_upper_past`) pass the seqno
+    /// after which they need a fresh upper and re-check the upper once woken.
+    ///
+    /// This method is cancel-safe.
+    pub async fn wait_for_upper_seqno_ge(&mut self, requested: SeqNo) -> &mut Self {
+        self.metrics.watch.notify_wait_started.inc();
+        debug!(
+            "wait_for_upper_seqno_ge {} {}",
+            self.state.shard_id(),
+            requested
+        );
+        loop {
+            if self.upper_seqno_high_water >= requested {
+                break;
+            }
+            match self.upper_rx.recv().await {
+                Ok(x) => {
+                    self.metrics.watch.notify_recv.inc();
+                    assert!(x >= self.upper_seqno_high_water);
+                    self.upper_seqno_high_water = x;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    unreachable!("we're holding on to a reference to the sender")
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    self.metrics.watch.notify_lagged.inc();
+                    // Buffer (of size 1) filled up. The broadcast channel keeps
+                    // the most recent value, so loop around and read it. This does
+                    // not busy-loop: after consuming the retained value the next
+                    // recv parks until the upper advances again.
+                    continue;
+                }
+            }
+        }
+        self.metrics.watch.notify_wait_finished.inc();
+        debug!(
+            "wait_for_upper_seqno_ge {} {} returning",
             self.state.shard_id(),
             requested
         );
@@ -248,7 +332,8 @@ impl<T> AwaitableState<T> {
 mod tests {
     use std::future::Future;
     use std::pin::Pin;
-    use std::task::Context;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll, Wake, Waker};
     use std::time::Duration;
 
     use futures::FutureExt;
@@ -392,6 +477,81 @@ mod tests {
         for write in writes {
             write.await;
         }
+    }
+
+    /// A [Waker] that counts how many times it has been woken.
+    struct CountingWaker(AtomicUsize);
+
+    impl Wake for CountingWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// A shard upper waiter must not be woken by seqno bumps that don't advance
+    /// the upper (GC, rollups, since-downgrades, other writers' no-op CaAs). It
+    /// must still be woken when the upper actually advances.
+    #[mz_persist_proc::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn wait_for_upper_past_ignores_non_upper_seqno_bumps(dyncfgs: ConfigUpdates) {
+        mz_ore::test::init_logging();
+
+        let client = new_test_client(&dyncfgs).await;
+        // Disable the listen poll so the only wakeups are watch notifications.
+        client.cfg.set_config(
+            &NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF,
+            Duration::from_secs(1_000_000),
+        );
+        client
+            .cfg
+            .set_config(&NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER, 1);
+        client.cfg.set_config(
+            &NEXT_LISTEN_BATCH_RETRYER_CLAMP,
+            Duration::from_secs(1_000_000),
+        );
+
+        let shard_id = ShardId::new();
+        let (mut write, mut read) = client.expect_open::<(), (), u64, i64>(shard_id).await;
+        // A second writer so we can advance the upper while `write` is borrowed
+        // by the in-flight wait future.
+        let (mut writer2, _) = client.expect_open::<(), (), u64, i64>(shard_id).await;
+
+        // Move the upper to 10 so there's room to downgrade `since` underneath it.
+        write
+            .expect_compare_and_append(&[(((), ()), 0, 1)], 0, 10)
+            .await;
+
+        // Arm a waiter for an upper past 100. It stays pending.
+        let counter = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let waker = Waker::from(Arc::clone(&counter));
+        let mut cx = Context::from_waker(&waker);
+        let frontier = Antichain::from_elem(100);
+        let mut fut = Box::pin(write.wait_for_upper_past(&frontier));
+        assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
+        let wakes_after_arm = counter.0.load(Ordering::SeqCst);
+
+        // Bump the seqno WITHOUT advancing the upper (a since-downgrade). This is
+        // the regression: before the fix this woke the upper waiter.
+        read.downgrade_since(&Antichain::from_elem(5)).await;
+        assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
+        assert_eq!(
+            counter.0.load(Ordering::SeqCst),
+            wakes_after_arm,
+            "a non-upper seqno bump must not wake an upper waiter"
+        );
+
+        // Advancing the upper must wake the waiter and let it resolve.
+        writer2
+            .expect_compare_and_append(&[(((), ()), 10, 1)], 10, 200)
+            .await;
+        assert!(
+            counter.0.load(Ordering::SeqCst) > wakes_after_arm,
+            "an upper advance must wake the upper waiter"
+        );
+        fut.await;
     }
 
     #[mz_persist_proc::test(tokio::test)]

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -9,33 +9,37 @@
 
 //! Notifications for state changes.
 
+use differential_dataflow::lattice::Lattice;
 use mz_persist::location::SeqNo;
 use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
-use tokio::sync::{Notify, broadcast};
+use timely::PartialOrder;
+use timely::progress::{Antichain, Timestamp};
+use tokio::sync::{Notify, broadcast, watch};
 use tracing::debug;
 
 use crate::cache::LockingTypedState;
 use crate::internal::metrics::Metrics;
 
 #[derive(Debug)]
-pub struct StateWatchNotifier {
+pub struct StateWatchNotifier<T> {
     metrics: Arc<Metrics>,
     /// Fires on every strict seqno advance. Used by waiters that care about any
     /// state change (e.g. lease/seqno machinery via [StateWatch::wait_for_seqno_ge]).
     seqno_tx: broadcast::Sender<SeqNo>,
-    /// Fires only when the shard upper (write frontier) strictly advances, carrying
-    /// the seqno at which that happened. Used by [StateWatch::wait_for_upper_seqno_ge]
-    /// so upper waiters (Listen/Subscribe/snapshot) don't wake on GC, rollups, or
-    /// since-downgrades that bump the seqno without moving the upper.
-    upper_tx: broadcast::Sender<SeqNo>,
+    /// Holds the current shard upper (write frontier), advanced only when the upper
+    /// strictly moves forward. Used by [StateWatch::wait_for_upper_past] so upper
+    /// waiters (Listen/Subscribe/snapshot) don't wake on GC, rollups, or since-
+    /// downgrades that bump the seqno without moving the upper. The watch channel
+    /// coalesces: a waiter always reads the latest upper, never a stale intermediate.
+    upper_tx: watch::Sender<Antichain<T>>,
 }
 
-impl StateWatchNotifier {
-    pub(crate) fn new(metrics: Arc<Metrics>) -> Self {
+impl<T: Timestamp + Lattice> StateWatchNotifier<T> {
+    pub(crate) fn new(metrics: Arc<Metrics>, initial_upper: Antichain<T>) -> Self {
         let (seqno_tx, _rx) = broadcast::channel(1);
-        let (upper_tx, _rx) = broadcast::channel(1);
+        let (upper_tx, _rx) = watch::channel(initial_upper);
         StateWatchNotifier {
             metrics,
             seqno_tx,
@@ -45,18 +49,19 @@ impl StateWatchNotifier {
 
     /// Wake up any watchers of this state.
     ///
-    /// `seqno` is the state's seqno after the modification, and `upper_advanced`
-    /// must be true iff the shard upper strictly advanced in the same modification.
+    /// `seqno` is the state's seqno after the modification, and `upper` is the
+    /// shard upper after the modification.
     ///
     /// This must be called while under the same lock that modified the state to
-    /// avoid any potential for out of order SeqNos in the broadcast channels.
+    /// avoid any potential for out of order SeqNos in the seqno broadcast channel,
+    /// and so the watched upper never regresses.
     ///
     /// This restriction can be lifted (i.e. we could notify after releasing the
     /// write lock), but we'd have to reason about out of order SeqNos in the
-    /// broadcast channels. In particular, if we see `RecvError::Lagged` then
+    /// broadcast channel. In particular, if we see `RecvError::Lagged` then
     /// it's possible we lost X+1 and got X, so if X isn't sufficient to return,
     /// we'd need to grab the read lock and verify the real SeqNo.
-    pub(crate) fn notify(&self, seqno: SeqNo, upper_advanced: bool) {
+    pub(crate) fn notify(&self, seqno: SeqNo, upper: &Antichain<T>) {
         match self.seqno_tx.send(seqno) {
             // Someone got woken up.
             Ok(_) => {
@@ -67,13 +72,19 @@ impl StateWatchNotifier {
                 self.metrics.watch.notify_noop.inc();
             }
         }
-        if upper_advanced {
-            // send only errors when there are no receivers, which is fine. A full
-            // buffer does not error: the channel drops the oldest value and the
-            // receiver observes Lagged, which is handled in wait_for_upper_seqno_ge.
-            if self.upper_tx.send(seqno).is_ok() {
-                self.metrics.watch.notify_upper_sent.inc();
+        // Advance the watched upper only on a strict advance. send_if_modified does
+        // not require live receivers and never errors, so an advance is recorded
+        // even when no one waits; a later subscriber reads the up-to-date value.
+        let upper_advanced = self.upper_tx.send_if_modified(|current| {
+            if PartialOrder::less_than(current, upper) {
+                current.clone_from(upper);
+                true
+            } else {
+                false
             }
+        });
+        if upper_advanced {
+            self.metrics.watch.notify_upper_sent.inc();
         }
     }
 }
@@ -82,41 +93,40 @@ impl StateWatchNotifier {
 ///
 /// This exposes two independent signals over the same state:
 /// - [Self::wait_for_seqno_ge] wakes on any strict seqno advance.
-/// - [Self::wait_for_upper_seqno_ge] wakes only when the shard upper advances.
+/// - [Self::wait_for_upper_past] wakes only when the shard upper advances.
 ///
-/// Invariants (both signals):
+/// Invariants:
 /// - The `state.seqno` only advances (never regresses). This is guaranteed by
 ///   LockingTypedState.
-/// - `*_high_water` is always <= `state.seqno`.
+/// - `seqno_high_water` is always <= `state.seqno`.
 /// - If `seqno_high_water` is < `state.seqno`, then we'll get a notification on
 ///   `seqno_rx`. This is maintained by notifying new seqnos under the same lock
 ///   which adds them.
-/// - If the upper advanced past the seqno recorded in `upper_seqno_high_water`,
-///   then we'll get a notification on `upper_rx`. This is maintained by notifying
-///   under the same lock that advanced the upper.
-/// - Each `*_high_water` always holds the highest value received in its channel.
-///   This is maintained by the wait methods taking an exclusive reference to self.
+/// - `seqno_high_water` always holds the highest value received on `seqno_rx`.
+///   This is maintained by the wait method taking an exclusive reference to self.
+/// - `upper_rx` holds the shard upper, advanced under the same lock that advances
+///   the upper. It coalesces, so a waiter always observes the latest upper.
 #[derive(Debug)]
 pub struct StateWatch<K, V, T, D> {
     metrics: Arc<Metrics>,
     state: Arc<LockingTypedState<K, V, T, D>>,
     seqno_high_water: SeqNo,
     seqno_rx: broadcast::Receiver<SeqNo>,
-    /// The highest seqno at which we've observed the upper advance, as delivered by
-    /// `upper_rx`. Initialized to the seqno at subscribe time: any upper advance
-    /// after that point happens at a strictly greater seqno and fires `upper_rx`.
-    upper_seqno_high_water: SeqNo,
-    upper_rx: broadcast::Receiver<SeqNo>,
+    upper_rx: watch::Receiver<Antichain<T>>,
 }
 
 impl<K, V, T, D> StateWatch<K, V, T, D> {
     pub(crate) fn new(state: Arc<LockingTypedState<K, V, T, D>>, metrics: Arc<Metrics>) -> Self {
-        // Important! We have to subscribe to the broadcast channels _before_ we
-        // grab the current seqno. Otherwise, we could race with a write to
+        // Important! We have to subscribe to the seqno broadcast channel _before_
+        // we grab the current seqno. Otherwise, we could race with a write to
         // state and miss a notification. Tokio guarantees that "the returned
         // Receiver will receive values sent after the call to subscribe", and
         // the read_lock linearizes the subscribe to be _before_ whatever
         // seqno we get here.
+        //
+        // The upper watch needs no such care: it retains the latest upper, and
+        // `subscribe` hands the receiver that value, so a waiter reads the current
+        // upper directly and parks only for the next advance.
         let seqno_rx = state.notifier().seqno_tx.subscribe();
         let upper_rx = state.notifier().upper_tx.subscribe();
         let seqno_high_water = state.read_lock(&metrics.locks.watch, |x| x.seqno);
@@ -125,7 +135,6 @@ impl<K, V, T, D> StateWatch<K, V, T, D> {
             state,
             seqno_high_water,
             seqno_rx,
-            upper_seqno_high_water: seqno_high_water,
             upper_rx,
         }
     }
@@ -169,49 +178,41 @@ impl<K, V, T, D> StateWatch<K, V, T, D> {
         self
     }
 
-    /// Blocks until the shard upper has advanced at a SeqNo >= the requested one.
+    /// Blocks until the shard upper has advanced past `frontier`.
     ///
     /// Unlike [Self::wait_for_seqno_ge], this only wakes on upper advances, not on
-    /// seqno bumps caused by GC, rollups, since-downgrades, or no-op CaAs. Callers
-    /// waiting for a specific frontier (e.g. `wait_for_upper_past`) pass the seqno
-    /// after which they need a fresh upper and re-check the upper once woken.
+    /// seqno bumps caused by GC, rollups, since-downgrades, or no-op CaAs.
     ///
     /// This method is cancel-safe.
-    pub async fn wait_for_upper_seqno_ge(&mut self, requested: SeqNo) -> &mut Self {
+    pub async fn wait_for_upper_past(&mut self, frontier: &Antichain<T>) -> &mut Self
+    where
+        T: Timestamp,
+    {
         self.metrics.watch.notify_wait_started.inc();
         debug!(
-            "wait_for_upper_seqno_ge {} {}",
+            "wait_for_upper_past {} {:?}",
             self.state.shard_id(),
-            requested
+            frontier.elements()
         );
         loop {
-            if self.upper_seqno_high_water >= requested {
+            // Bind the comparison so the borrow guard drops before the await.
+            let past = PartialOrder::less_than(frontier, &*self.upper_rx.borrow_and_update());
+            if past {
                 break;
             }
-            match self.upper_rx.recv().await {
-                Ok(x) => {
-                    self.metrics.watch.notify_recv.inc();
-                    assert!(x >= self.upper_seqno_high_water);
-                    self.upper_seqno_high_water = x;
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    unreachable!("we're holding on to a reference to the sender")
-                }
-                Err(broadcast::error::RecvError::Lagged(_)) => {
-                    self.metrics.watch.notify_lagged.inc();
-                    // Buffer (of size 1) filled up. The broadcast channel keeps
-                    // the most recent value, so loop around and read it. This does
-                    // not busy-loop: after consuming the retained value the next
-                    // recv parks until the upper advances again.
-                    continue;
-                }
-            }
+            // `changed` only errors once every sender has dropped. We hold the
+            // state Arc that owns the notifier's sender, so it outlives us.
+            self.upper_rx
+                .changed()
+                .await
+                .expect("notifier sender outlives the watch");
+            self.metrics.watch.notify_recv.inc();
         }
         self.metrics.watch.notify_wait_finished.inc();
         debug!(
-            "wait_for_upper_seqno_ge {} {} returning",
+            "wait_for_upper_past {} {:?} returning",
             self.state.shard_id(),
-            requested
+            frontier.elements()
         );
         self
     }


### PR DESCRIPTION
### Motivation

`StateWatchNotifier` fired a single `broadcast::Sender<SeqNo>` on every strict seqno advance, and `Machine::wait_for_upper_past` (the wait behind `Listen`, `Subscribe`, and snapshots) armed on it.
A shard's seqno bumps for many non-data reasons: GC, rollups, since-downgrades including each reader's own lease heartbeat, and other writers' compare-and-appends.
One notifier per shard fans out to every reader on that shard, so each such bump woke every upper waiter, which re-read the unchanged upper, emitted nothing, and re-armed.
On compute replicas this unparks the timely workers hundreds of times a second doing no-op work, which pins a per-cluster idle CPU floor that is flat across replica size.

### Change

Split the notifier into two channels.
The existing seqno-gated channel is still used by the lease/since machinery via `wait_for_seqno_ge`.
A new upper-gated channel fires only when the shard upper strictly advances, and `wait_for_upper_past` routes to a new `wait_for_upper_seqno_ge` on it.
GC, rollup, and since-downgrade churn therefore no longer re-activates upper waiters.

Gating happens at the single write choke point, `LockingTypedState::write_lock`, which covers both local compare-and-appends and pubsub `push_diff` from other processes.
It compares the shard upper before and after the mutation and reports whether it advanced.
Subscription happens before reading the seqno in `StateWatch::new`, and every upper advance goes through this choke point, so a waiter cannot miss a wakeup, including advances learned via pubsub.
The existing backoff-sleep arm remains as the fallback for the pubsub-down case.

Adds the `mz_persist_watch_notify_upper_sent` internal metric to observe the upper channel.

### Tests

Adds a `mz-persist-client` unit test that asserts a seqno bump which does not advance the upper (a since-downgrade) does not wake an upper waiter, while an upper advance does.
The existing `state_watch`, `state_watch_listen_snapshot`, and `seqno_leases` tests continue to encode the seqno-channel and liveness behavior.

Draft: pending behavioral verification on a loaded cluster (expected drop in the tokio-main `remote_schedule` rate and the no-op timely wakeup rate on an idle/frozen-input cluster) and a persist owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
