### PR TITLE
adapter: Add emergency logging of arriving statements

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1498,16 +1498,18 @@ impl Drop for SessionClient {
 
 /// Renders SQL for statement arrival logging: parsed and displayed with its
 /// literals redacted, which is the same redaction the statement log applies.
-/// When the text does not parse, a placeholder with the byte length is
-/// returned. Raw text is never returned, so a statement that crashes the
-/// parser is not captured, an accepted limitation.
+/// When the text does not parse or exceeds the statement batch size limit, a
+/// placeholder with the byte length is returned. Raw text is never returned,
+/// so a statement that crashes the parser is not captured, an accepted
+/// limitation.
 pub fn redact_sql_for_logging(sql: &str) -> String {
     match mz_sql_parser::parser::parse_statements_with_limit(sql) {
         Ok(Ok(stmts)) => stmts
             .into_iter()
             .map(|stmt| stmt.ast.to_ast_string_redacted())
             .join("; "),
-        Ok(Err(_)) | Err(_) => format!("<unparseable ({} bytes)>", sql.len()),
+        Ok(Err(_)) => format!("<unparseable ({} bytes)>", sql.len()),
+        Err(_) => format!("<too large ({} bytes)>", sql.len()),
     }
 }
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1505,13 +1505,16 @@ pub const REDACTED_STATEMENT_TEXT: &str = "<redacted>";
 ///
 /// Arrival logging runs before parsing (so that it catches statements that
 /// crash the parser), which rules out precise AST-based redaction. Instead we
-/// sniff for keywords. Statements that carry inline sensitive values
-/// (`CREATE SECRET`, `ALTER ROLE ... PASSWORD`, inline connection
-/// credentials) always contain one of the keywords. A false positive merely
-/// withholds one log line's text.
+/// sniff for keywords. Statements that carry inline sensitive values always
+/// contain one of the keywords: `CREATE SECRET`, `ALTER ROLE ... PASSWORD`,
+/// and the `CREATE CONNECTION` options that accept inline values (`PASSWORD`,
+/// `SASL PASSWORD`, `SECRET ACCESS KEY`, `CREDENTIAL`, `SESSION TOKEN`). A
+/// false positive merely withholds one log line's text.
 pub fn statement_might_contain_secret(text: &str) -> bool {
     let text = text.to_lowercase();
-    text.contains("secret") || text.contains("password")
+    ["secret", "password", "credential", "token"]
+        .iter()
+        .any(|keyword| text.contains(keyword))
 }
 
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -44,6 +44,7 @@ use mz_sql::session::user::SUPPORT_USER;
 use mz_sql::session::vars::{
     CLUSTER, ENABLE_FRONTEND_PEEK_SEQUENCING, OwnedVarInput, SystemVars, Var,
 };
+use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::parser::{ParserStatementError, StatementParseResult};
 use prometheus::Histogram;
 use serde_json::json;
@@ -1495,26 +1496,19 @@ impl Drop for SessionClient {
     }
 }
 
-/// Placeholder that statement arrival logging logs in place of text withheld
-/// by [`statement_might_contain_secret`].
-pub const REDACTED_STATEMENT_TEXT: &str = "<redacted>";
-
-/// Best-effort check whether statement text or bind parameters might contain
-/// a sensitive value, for statement arrival logging. Callers log
-/// [`REDACTED_STATEMENT_TEXT`] instead of text for which this returns true.
-///
-/// Arrival logging runs before parsing (so that it catches statements that
-/// crash the parser), which rules out precise AST-based redaction. Instead we
-/// sniff for keywords. Statements that carry inline sensitive values always
-/// contain one of the keywords: `CREATE SECRET`, `ALTER ROLE ... PASSWORD`,
-/// and the `CREATE CONNECTION` options that accept inline values (`PASSWORD`,
-/// `SASL PASSWORD`, `SECRET ACCESS KEY`, `CREDENTIAL`, `SESSION TOKEN`). A
-/// false positive merely withholds one log line's text.
-pub fn statement_might_contain_secret(text: &str) -> bool {
-    let text = text.to_lowercase();
-    ["secret", "password", "credential", "token"]
-        .iter()
-        .any(|keyword| text.contains(keyword))
+/// Renders SQL for statement arrival logging: parsed and displayed with its
+/// literals redacted, which is the same redaction the statement log applies.
+/// When the text does not parse, a placeholder with the byte length is
+/// returned. Raw text is never returned, so a statement that crashes the
+/// parser is not captured, an accepted limitation.
+pub fn redact_sql_for_logging(sql: &str) -> String {
+    match mz_sql_parser::parser::parse_statements_with_limit(sql) {
+        Ok(Ok(stmts)) => stmts
+            .into_iter()
+            .map(|stmt| stmt.ast.to_ast_string_redacted())
+            .join("; "),
+        Ok(Err(_)) | Err(_) => format!("<unparseable ({} bytes)>", sql.len()),
+    }
 }
 
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1121,6 +1121,12 @@ impl SessionClient {
         self.peek_client.catalog_snapshot(context).await
     }
 
+    /// Reports whether `enable_statement_arrival_logging` is on.
+    pub async fn statement_arrival_logging_enabled(&mut self) -> bool {
+        let catalog = self.catalog_snapshot("statement_arrival_logging").await;
+        catalog.system_config().enable_statement_arrival_logging()
+    }
+
     /// Dumps the catalog to a JSON string.
     ///
     /// No authorization is performed, so access to this function must be limited to internal

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1495,6 +1495,25 @@ impl Drop for SessionClient {
     }
 }
 
+/// Placeholder that statement arrival logging logs in place of text withheld
+/// by [`statement_might_contain_secret`].
+pub const REDACTED_STATEMENT_TEXT: &str = "<redacted>";
+
+/// Best-effort check whether statement text or bind parameters might contain
+/// a sensitive value, for statement arrival logging. Callers log
+/// [`REDACTED_STATEMENT_TEXT`] instead of text for which this returns true.
+///
+/// Arrival logging runs before parsing (so that it catches statements that
+/// crash the parser), which rules out precise AST-based redaction. Instead we
+/// sniff for keywords. Statements that carry inline sensitive values
+/// (`CREATE SECRET`, `ALTER ROLE ... PASSWORD`, inline connection
+/// credentials) always contain one of the keywords. A false positive merely
+/// withholds one log line's text.
+pub fn statement_might_contain_secret(text: &str) -> bool {
+    let text = text.to_lowercase();
+    text.contains("secret") || text.contains("password")
+}
+
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum TimeoutType {
     IdleInTransactionSession(TransactionId),

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1245,6 +1245,28 @@ pub(in crate::http) async fn execute_request<S: ResultSender>(
 ) -> Result<(), Error> {
     let client = &mut client.client;
 
+    if client.statement_arrival_logging_enabled().await {
+        let session = client.session();
+        let conn_id = session.conn_id();
+        let session_uuid = session.uuid();
+        match &request {
+            SqlRequest::Simple { query } => {
+                info!(
+                    %conn_id, %session_uuid, kind = "http_simple", sql = query.as_str(),
+                    "statement arrival"
+                );
+            }
+            SqlRequest::Extended { queries } => {
+                for ExtendedRequest { query, params } in queries {
+                    info!(
+                        %conn_id, %session_uuid, kind = "http_extended", sql = query, ?params,
+                        "statement arrival"
+                    );
+                }
+            }
+        }
+    }
+
     // This API prohibits executing statements with responses whose
     // semantics are at odds with an HTTP response.
     fn check_prohibited_stmts<S: ResultSender>(

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -25,9 +25,7 @@ use futures::future::BoxFuture;
 
 use http::StatusCode;
 use itertools::Itertools;
-use mz_adapter::client::{
-    REDACTED_STATEMENT_TEXT, RecordFirstRowStream, statement_might_contain_secret,
-};
+use mz_adapter::client::{RecordFirstRowStream, redact_sql_for_logging};
 use mz_adapter::session::{EndTransactionAction, TransactionStatus};
 use mz_adapter::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use mz_adapter::{
@@ -1253,28 +1251,19 @@ pub(in crate::http) async fn execute_request<S: ResultSender>(
         let session_uuid = session.uuid();
         match &request {
             SqlRequest::Simple { query } => {
-                let sql = if statement_might_contain_secret(query.as_str()) {
-                    REDACTED_STATEMENT_TEXT
-                } else {
-                    query.as_str()
-                };
-                info!(%conn_id, %session_uuid, kind = "http_simple", sql, "statement arrival");
+                info!(
+                    %conn_id, %session_uuid, kind = "http_simple",
+                    sql = %redact_sql_for_logging(query.as_str()),
+                    "statement arrival"
+                );
             }
             SqlRequest::Extended { queries } => {
                 for ExtendedRequest { query, params } in queries {
-                    let params = format!("{:?}", params);
-                    // Values bound to a sensitive statement are sensitive
-                    // themselves, so if either field trips the check, redact
-                    // both.
-                    let (sql, params) = if statement_might_contain_secret(query)
-                        || statement_might_contain_secret(&params)
-                    {
-                        (REDACTED_STATEMENT_TEXT, REDACTED_STATEMENT_TEXT)
-                    } else {
-                        (query.as_str(), params.as_str())
-                    };
+                    // Parameter values are data that redaction cannot reach,
+                    // so only their count is logged.
                     info!(
-                        %conn_id, %session_uuid, kind = "http_extended", sql, params,
+                        %conn_id, %session_uuid, kind = "http_extended",
+                        sql = %redact_sql_for_logging(query), num_params = params.len(),
                         "statement arrival"
                     );
                 }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -25,7 +25,9 @@ use futures::future::BoxFuture;
 
 use http::StatusCode;
 use itertools::Itertools;
-use mz_adapter::client::RecordFirstRowStream;
+use mz_adapter::client::{
+    REDACTED_STATEMENT_TEXT, RecordFirstRowStream, statement_might_contain_secret,
+};
 use mz_adapter::session::{EndTransactionAction, TransactionStatus};
 use mz_adapter::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use mz_adapter::{
@@ -1251,15 +1253,28 @@ pub(in crate::http) async fn execute_request<S: ResultSender>(
         let session_uuid = session.uuid();
         match &request {
             SqlRequest::Simple { query } => {
-                info!(
-                    %conn_id, %session_uuid, kind = "http_simple", sql = query.as_str(),
-                    "statement arrival"
-                );
+                let sql = if statement_might_contain_secret(query.as_str()) {
+                    REDACTED_STATEMENT_TEXT
+                } else {
+                    query.as_str()
+                };
+                info!(%conn_id, %session_uuid, kind = "http_simple", sql, "statement arrival");
             }
             SqlRequest::Extended { queries } => {
                 for ExtendedRequest { query, params } in queries {
+                    let params = format!("{:?}", params);
+                    // Values bound to a sensitive statement are sensitive
+                    // themselves, so if either field trips the check, redact
+                    // both.
+                    let (sql, params) = if statement_might_contain_secret(query)
+                        || statement_might_contain_secret(&params)
+                    {
+                        (REDACTED_STATEMENT_TEXT, REDACTED_STATEMENT_TEXT)
+                    } else {
+                        (query.as_str(), params.as_str())
+                    };
                     info!(
-                        %conn_id, %session_uuid, kind = "http_extended", sql = query, ?params,
+                        %conn_id, %session_uuid, kind = "http_extended", sql, params,
                         "statement arrival"
                     );
                 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -20,7 +20,9 @@ use byteorder::{ByteOrder, NetworkEndian};
 use csv_core::ReadRecordResult;
 use futures::future::{BoxFuture, FutureExt, pending};
 use itertools::Itertools;
-use mz_adapter::client::RecordFirstRowStream;
+use mz_adapter::client::{
+    REDACTED_STATEMENT_TEXT, RecordFirstRowStream, statement_might_contain_secret,
+};
 use mz_adapter::session::{
     EndTransactionAction, InProgressRows, LifecycleTimestamps, PortalRefMut, PortalState, Session,
     SessionConfig, TransactionStatus,
@@ -1198,7 +1200,9 @@ where
     /// carried the SQL text.
     ///
     /// Authentication payloads are never logged. COPY data is logged as its
-    /// length only.
+    /// length only. Statement text and parameters that might contain
+    /// sensitive values are replaced by a placeholder, see
+    /// [`statement_might_contain_secret`].
     async fn maybe_log_message_arrival(&mut self, message: &FrontendMessage) {
         if !self
             .adapter_client
@@ -1224,8 +1228,23 @@ where
                     .iter()
                     .map(|p| p.as_ref().map(|p| String::from_utf8_lossy(p)))
                     .collect();
+                let params = format!("{:?}", params);
+                // Values bound to a sensitive statement are sensitive
+                // themselves, so also sniff the statement this bind refers
+                // to.
+                let stmt_sensitive = session
+                    .get_prepared_statement_unverified(statement_name)
+                    .and_then(|ps| ps.stmt())
+                    .is_some_and(|stmt| {
+                        statement_might_contain_secret(&stmt.to_ast_string_simple())
+                    });
+                let params = if stmt_sensitive || statement_might_contain_secret(&params) {
+                    REDACTED_STATEMENT_TEXT
+                } else {
+                    params.as_str()
+                };
                 info!(
-                    %conn_id, %session_uuid, kind, portal_name, statement_name, ?params,
+                    %conn_id, %session_uuid, kind, portal_name, statement_name, params,
                     "statement arrival"
                 );
             }
@@ -1255,10 +1274,15 @@ where
             | FrontendMessage::CopyFail(_) => {
                 // WARNING: When adding a variant here, consider whether its payload is sensitive or
                 // bulky!
-                //
+                let contents = format!("{:?}", message);
+                let contents = if statement_might_contain_secret(&contents) {
+                    REDACTED_STATEMENT_TEXT
+                } else {
+                    contents.as_str()
+                };
                 // (The field must not be named `message`, that name is
                 // reserved for the event text in tracing.)
-                info!(%conn_id, %session_uuid, kind, contents = ?message, "statement arrival");
+                info!(%conn_id, %session_uuid, kind, contents, "statement arrival");
             }
         }
     }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -67,7 +67,7 @@ use tokio::select;
 use tokio::time::{self};
 use tokio_metrics::TaskMetrics;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{Instrument, debug, debug_span, warn};
+use tracing::{Instrument, debug, debug_span, info, warn};
 use uuid::Uuid;
 
 use crate::codec::{
@@ -947,6 +947,10 @@ where
         // only a few message types seem useful.
         let message_name = message.as_ref().map(|m| m.name()).unwrap_or_default();
 
+        if let Some(message) = &message {
+            self.maybe_log_message_arrival(message).await;
+        }
+
         let start = message.as_ref().map(|_| Instant::now());
         let next_state = match message {
             Some(FrontendMessage::Query { sql }) => {
@@ -1181,6 +1185,82 @@ where
             .with_label_values(&[message_type])
             .observe(start.elapsed().as_secs_f64());
         Ok(())
+    }
+
+    /// Logs an arriving frontend message at info level, when
+    /// `enable_statement_arrival_logging` is on. Runs before the message is
+    /// processed, so a message whose processing crashes the process still
+    /// appears in the log. The `kind` field says which message it is, and
+    /// thereby also whether the statement came in through the simple protocol
+    /// (`query`) or the extended protocol (`parse`, `bind`, `execute`, ...).
+    /// The prepared statement and portal names, together with the connection
+    /// id, allow connecting a `bind` or `execute` back to the `parse` that
+    /// carried the SQL text.
+    ///
+    /// Authentication payloads are never logged. COPY data is logged as its
+    /// length only.
+    async fn maybe_log_message_arrival(&mut self, message: &FrontendMessage) {
+        if !self
+            .adapter_client
+            .statement_arrival_logging_enabled()
+            .await
+        {
+            return;
+        }
+        let session = self.adapter_client.session();
+        let conn_id = session.conn_id();
+        let session_uuid = session.uuid();
+        let kind = message.name();
+        match message {
+            // Bind parameters arrive as raw bytes. Decode them for
+            // readability instead of Debug-printing byte arrays.
+            FrontendMessage::Bind {
+                portal_name,
+                statement_name,
+                raw_params,
+                ..
+            } => {
+                let params: Vec<_> = raw_params
+                    .iter()
+                    .map(|p| p.as_ref().map(|p| String::from_utf8_lossy(p)))
+                    .collect();
+                info!(
+                    %conn_id, %session_uuid, kind, portal_name, statement_name, ?params,
+                    "statement arrival"
+                );
+            }
+            // COPY payloads would flood the log. Log only their length.
+            FrontendMessage::CopyData(data) => {
+                info!(%conn_id, %session_uuid, kind, len = data.len(), "statement arrival");
+            }
+            // Authentication payloads must never be logged.
+            FrontendMessage::Password { .. }
+            | FrontendMessage::RawAuthentication(_)
+            | FrontendMessage::SASLInitialResponse { .. }
+            | FrontendMessage::SASLResponse(_) => {
+                info!(%conn_id, %session_uuid, kind, "statement arrival");
+            }
+            // Log the full Debug representation for all other variants.
+            FrontendMessage::Query { .. }
+            | FrontendMessage::Parse { .. }
+            | FrontendMessage::DescribeStatement { .. }
+            | FrontendMessage::DescribePortal { .. }
+            | FrontendMessage::Execute { .. }
+            | FrontendMessage::Flush
+            | FrontendMessage::Sync
+            | FrontendMessage::CloseStatement { .. }
+            | FrontendMessage::ClosePortal { .. }
+            | FrontendMessage::Terminate
+            | FrontendMessage::CopyDone
+            | FrontendMessage::CopyFail(_) => {
+                // WARNING: When adding a variant here, consider whether its payload is sensitive or
+                // bulky!
+                //
+                // (The field must not be named `message`, that name is
+                // reserved for the event text in tracing.)
+                info!(%conn_id, %session_uuid, kind, contents = ?message, "statement arrival");
+            }
+        }
     }
 
     fn parse_sql<'b>(&self, sql: &'b str) -> Result<Vec<StatementParseResult<'b>>, ErrorResponse> {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -20,9 +20,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 use csv_core::ReadRecordResult;
 use futures::future::{BoxFuture, FutureExt, pending};
 use itertools::Itertools;
-use mz_adapter::client::{
-    REDACTED_STATEMENT_TEXT, RecordFirstRowStream, statement_might_contain_secret,
-};
+use mz_adapter::client::{RecordFirstRowStream, redact_sql_for_logging};
 use mz_adapter::session::{
     EndTransactionAction, InProgressRows, LifecycleTimestamps, PortalRefMut, PortalState, Session,
     SessionConfig, TransactionStatus,
@@ -1199,10 +1197,12 @@ where
     /// id, allow connecting a `bind` or `execute` back to the `parse` that
     /// carried the SQL text.
     ///
-    /// Authentication payloads are never logged. COPY data is logged as its
-    /// length only. Statement text and parameters that might contain
-    /// sensitive values are replaced by a placeholder, see
-    /// [`statement_might_contain_secret`].
+    /// SQL text is parsed and logged with its literals redacted, the same
+    /// redaction the statement log applies. This means a statement that
+    /// crashes the parser is not captured, an accepted limitation. Bind
+    /// parameter values are data that redaction cannot reach, so only their
+    /// count is logged. Authentication payloads are never logged. COPY data
+    /// is logged as its length only.
     async fn maybe_log_message_arrival(&mut self, message: &FrontendMessage) {
         if !self
             .adapter_client
@@ -1216,35 +1216,27 @@ where
         let session_uuid = session.uuid();
         let kind = message.name();
         match message {
-            // Bind parameters arrive as raw bytes. Decode them for
-            // readability instead of Debug-printing byte arrays.
+            FrontendMessage::Query { sql } => {
+                info!(
+                    %conn_id, %session_uuid, kind, sql = %redact_sql_for_logging(sql),
+                    "statement arrival"
+                );
+            }
+            FrontendMessage::Parse { name, sql, .. } => {
+                info!(
+                    %conn_id, %session_uuid, kind, name, sql = %redact_sql_for_logging(sql),
+                    "statement arrival"
+                );
+            }
             FrontendMessage::Bind {
                 portal_name,
                 statement_name,
                 raw_params,
                 ..
             } => {
-                let params: Vec<_> = raw_params
-                    .iter()
-                    .map(|p| p.as_ref().map(|p| String::from_utf8_lossy(p)))
-                    .collect();
-                let params = format!("{:?}", params);
-                // Values bound to a sensitive statement are sensitive
-                // themselves, so also sniff the statement this bind refers
-                // to.
-                let stmt_sensitive = session
-                    .get_prepared_statement_unverified(statement_name)
-                    .and_then(|ps| ps.stmt())
-                    .is_some_and(|stmt| {
-                        statement_might_contain_secret(&stmt.to_ast_string_simple())
-                    });
-                let params = if stmt_sensitive || statement_might_contain_secret(&params) {
-                    REDACTED_STATEMENT_TEXT
-                } else {
-                    params.as_str()
-                };
                 info!(
-                    %conn_id, %session_uuid, kind, portal_name, statement_name, params,
+                    %conn_id, %session_uuid, kind, portal_name, statement_name,
+                    num_params = raw_params.len(),
                     "statement arrival"
                 );
             }
@@ -1259,10 +1251,9 @@ where
             | FrontendMessage::SASLResponse(_) => {
                 info!(%conn_id, %session_uuid, kind, "statement arrival");
             }
-            // Log the full Debug representation for all other variants.
-            FrontendMessage::Query { .. }
-            | FrontendMessage::Parse { .. }
-            | FrontendMessage::DescribeStatement { .. }
+            // Log the full Debug representation for all other variants, which
+            // carry only object names.
+            FrontendMessage::DescribeStatement { .. }
             | FrontendMessage::DescribePortal { .. }
             | FrontendMessage::Execute { .. }
             | FrontendMessage::Flush
@@ -1274,15 +1265,10 @@ where
             | FrontendMessage::CopyFail(_) => {
                 // WARNING: When adding a variant here, consider whether its payload is sensitive or
                 // bulky!
-                let contents = format!("{:?}", message);
-                let contents = if statement_might_contain_secret(&contents) {
-                    REDACTED_STATEMENT_TEXT
-                } else {
-                    contents.as_str()
-                };
+                //
                 // (The field must not be named `message`, that name is
                 // reserved for the event text in tracing.)
-                info!(%conn_id, %session_uuid, kind, contents, "statement arrival");
+                info!(%conn_id, %session_uuid, kind, contents = ?message, "statement arrival");
             }
         }
     }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1202,7 +1202,9 @@ where
     /// crashes the parser is not captured, an accepted limitation. Bind
     /// parameter values are data that redaction cannot reach, so only their
     /// count is logged. Authentication payloads are never logged. COPY data
-    /// is logged as its length only.
+    /// is logged as its length only, and only when it arrives as a stray
+    /// message in the ready state: messages consumed by the COPY subprotocol
+    /// or the post-error drain loop don't pass through here at all.
     async fn maybe_log_message_arrival(&mut self, message: &FrontendMessage) {
         if !self
             .adapter_client
@@ -1251,8 +1253,13 @@ where
             | FrontendMessage::SASLResponse(_) => {
                 info!(%conn_id, %session_uuid, kind, "statement arrival");
             }
+            // CopyFail carries a client-supplied free-text error message,
+            // which we don't log.
+            FrontendMessage::CopyFail(_) => {
+                info!(%conn_id, %session_uuid, kind, "statement arrival");
+            }
             // Log the full Debug representation for all other variants, which
-            // carry only object names.
+            // carry only object names or no payload.
             FrontendMessage::DescribeStatement { .. }
             | FrontendMessage::DescribePortal { .. }
             | FrontendMessage::Execute { .. }
@@ -1261,8 +1268,7 @@ where
             | FrontendMessage::CloseStatement { .. }
             | FrontendMessage::ClosePortal { .. }
             | FrontendMessage::Terminate
-            | FrontendMessage::CopyDone
-            | FrontendMessage::CopyFail(_) => {
+            | FrontendMessage::CopyDone => {
                 // WARNING: When adding a variant here, consider whether its payload is sensitive or
                 // bulky!
                 //

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1289,6 +1289,7 @@ impl SystemVars {
             &STATEMENT_LOGGING_TARGET_DATA_RATE,
             &STATEMENT_LOGGING_MAX_DATA_CREDIT,
             &ENABLE_INTERNAL_STATEMENT_LOGGING,
+            &ENABLE_STATEMENT_ARRIVAL_LOGGING,
             &OPTIMIZER_STATS_TIMEOUT,
             &OPTIMIZER_ONESHOT_STATS_TIMEOUT,
             &PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE,
@@ -2244,6 +2245,11 @@ impl SystemVars {
     /// Returns the `enable_internal_statement_logging` configuration parameter.
     pub fn enable_internal_statement_logging(&self) -> bool {
         *self.expect_value(&ENABLE_INTERNAL_STATEMENT_LOGGING)
+    }
+
+    /// Returns the `enable_statement_arrival_logging` configuration parameter.
+    pub fn enable_statement_arrival_logging(&self) -> bool {
+        *self.expect_value(&ENABLE_STATEMENT_ARRIVAL_LOGGING)
     }
 
     /// Returns the `optimizer_stats_timeout` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1395,6 +1395,22 @@ pub static ENABLE_INTERNAL_STATEMENT_LOGGING: VarDefinition = VarDefinition::new
     false,
 );
 
+/// When on, the SQL frontends log incoming statements and other frontend
+/// messages at info level as soon as they arrive, before processing them.
+/// This is an emergency diagnostic for statements that crash the process
+/// before they reach the statement log (or before its contents are written
+/// out to persist).
+pub static ENABLE_STATEMENT_ARRIVAL_LOGGING: VarDefinition = VarDefinition::new(
+    "enable_statement_arrival_logging",
+    // Default to off, because:
+    // - the logged text is not redacted;
+    // - adds a lot of log-volume.
+    value!(bool; false),
+    "Whether to log every incoming statement and other frontend message at info \
+    level as it arrives at the SQL frontends, before processing.",
+    false,
+);
+
 pub static AUTO_ROUTE_CATALOG_QUERIES: VarDefinition = VarDefinition::new(
     "auto_route_catalog_queries",
     value!(bool; true),

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1396,20 +1396,22 @@ pub static ENABLE_INTERNAL_STATEMENT_LOGGING: VarDefinition = VarDefinition::new
 );
 
 /// When on, the SQL frontends log incoming statements and other frontend
-/// messages at info level as soon as they arrive, before processing them.
+/// messages at info level as soon as they arrive, before processing them
+/// (except that SQL text is parsed, for redaction). Messages consumed by
+/// pgwire's COPY subprotocol or its post-error drain loop are not logged.
 ///
 /// This is an emergency diagnostic for statements that crash the process
 /// before they reach the statement log (or before its contents are written
 /// out to persist). It adds a lot of log volume, so use it only in emergencies,
 /// i.e. to debug active incidents.
 ///
-/// Redaction is best-effort, based on just string matching, see
-/// `statement_might_contain_secret`.
+/// SQL text is logged with its literals redacted, which is the same redaction
+/// the statement log applies, see `redact_sql_for_logging`.
 pub static ENABLE_STATEMENT_ARRIVAL_LOGGING: VarDefinition = VarDefinition::new(
     "enable_statement_arrival_logging",
     value!(bool; false),
-    "Whether to log every incoming statement and other frontend message at info \
-    level as it arrives at the SQL frontends, before processing. SQL text is \
+    "Whether to log incoming statements and other frontend messages at info \
+    level as they arrive at the SQL frontends, before processing. SQL text is \
     logged with its literals redacted, as in the statement log. Use it only in \
     emergencies, i.e. debugging active incidents.",
     false,

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1397,17 +1397,20 @@ pub static ENABLE_INTERNAL_STATEMENT_LOGGING: VarDefinition = VarDefinition::new
 
 /// When on, the SQL frontends log incoming statements and other frontend
 /// messages at info level as soon as they arrive, before processing them.
+///
 /// This is an emergency diagnostic for statements that crash the process
 /// before they reach the statement log (or before its contents are written
-/// out to persist).
+/// out to persist). It adds a lot of log volume, so use it only in emergencies,
+/// i.e. to debug active incidents.
+///
+/// Redaction is best-effort, based on just string matching, see
+/// `statement_might_contain_secret`.
 pub static ENABLE_STATEMENT_ARRIVAL_LOGGING: VarDefinition = VarDefinition::new(
     "enable_statement_arrival_logging",
-    // Default to off, because:
-    // - the logged text is not redacted;
-    // - adds a lot of log-volume.
     value!(bool; false),
     "Whether to log every incoming statement and other frontend message at info \
-    level as it arrives at the SQL frontends, before processing.",
+    level as it arrives at the SQL frontends, before processing. Use it only in emergencies, i.e. \
+    debugging active incidents.",
     false,
 );
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1409,8 +1409,9 @@ pub static ENABLE_STATEMENT_ARRIVAL_LOGGING: VarDefinition = VarDefinition::new(
     "enable_statement_arrival_logging",
     value!(bool; false),
     "Whether to log every incoming statement and other frontend message at info \
-    level as it arrives at the SQL frontends, before processing. Use it only in emergencies, i.e. \
-    debugging active incidents.",
+    level as it arrives at the SQL frontends, before processing. SQL text is \
+    logged with its literals redacted, as in the statement log. Use it only in \
+    emergencies, i.e. debugging active incidents.",
     false,
 );
 


### PR DESCRIPTION
### Motivation

Fixes DB-161, which came from [the stack overflow incident](https://materializeinc.slack.com/archives/C0BG9UPFMFY/p1783631298441949).

An emergency diagnostic for statements that repeatedly crash environmentd before they reach the statement log, or before the statement log is written out to persist (which happens only every few seconds).

### Description

Adds the internal system var `enable_statement_arrival_logging` (**default OFF**). When on, the pgwire and HTTP SQL frontends log every incoming statement and other frontend message at info level as soon as it arrives, before any processing beyond parsing.

- pgwire logs in `advance_ready`, before dispatching on the message. (Messages consumed by the COPY subprotocol or the post-error drain loop are not logged.)
- SQL text is logged with its literals redacted, by parsing it and using the same redacted AST display that the statement log uses. Identifiers and statement structure stay visible, for debuggability. A statement that fails to parse is logged as a placeholder with only its byte length. Consequently, a statement that crashes the parser itself is not captured at all, an accepted tradeoff (the parser's recursion guards make such crashes rare).
- Extended protocol messages log prepared statement and portal names, so an `execute` can be connected back to the `parse` that carried the SQL text, together with the connection id and session UUID. Bind parameter values are data that redaction cannot reach, so only their count is logged.
- Authentication payloads are never logged. COPY data is logged as its length only. The message match is exhaustive, so a new `FrontendMessage` variant fails compilation until the author decides how to log it.
- Even redacted statements reveal schema structure and identifiers (the same exposure as the statement log), which is one of the reasons the flag defaults to off and is not user visible. This is intended only for debugging active incidents.
- The flag is read through the session's cached catalog snapshot, so the per-message cost while the flag is off is negligible.
- `enable_statement_arrival_logging` follows the pattern of `enable_internal_statement_logging` (a plain internal bool system var, not a `feature_flags!` entry, since it gates no SQL surface).

Example log lines with the flag on:

```
INFO mz_pgwire::protocol: statement arrival conn_id=282279413 session_uuid=019f5ce6-... kind="parse" name="s2" sql=SELECT $1::text AS x, '<REDACTED>' AS y
INFO mz_pgwire::protocol: statement arrival conn_id=282279413 session_uuid=019f5ce6-... kind="bind" portal_name="" statement_name="s2" num_params=1
INFO mz_pgwire::protocol: statement arrival conn_id=282279413 session_uuid=019f5ce6-... kind="execute" contents=Execute { portal_name: "", max_rows: 0 }
INFO mz_pgwire::protocol: statement arrival conn_id=282194762 session_uuid=019f5ce6-... kind="query" sql=CREATE CONNECTION polaris TO ICEBERG CATALOG (CATALOG TYPE = 'REST', URL = 'https://catalog.example', CREDENTIAL = '<REDACTED>', WAREHOUSE = 'wh')
INFO mz_pgwire::protocol: statement arrival conn_id=282570067 session_uuid=019f5ce6-... kind="query" sql=<unparseable (25 bytes)>
```

### Verification

No tests added. Verified manually against a local environmentd: simple and extended pgwire protocol, HTTP simple and extended requests, and ALTER SYSTEM SET/RESET turning the logging on and off immediately. Also verified the literal redaction (CREATE SECRET values, inline connection credentials such as ICEBERG CREDENTIAL, string and numeric literals in queries), the placeholder for unparseable statements, and that none of the planted sensitive values appear anywhere in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(An alternative would be to add a Debug-level log line instead of a new config flag. I rejected this approach, because turning on Debug logging for the entire envd affects performance badly. We could do it per-crate, but then it just gets too complex. Flipping a simple flag is easier to get right during an incident.)
