### PR TITLE
balancerd: fix http, ip-forwarding, and user nightly test failures

### DIFF
--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -672,6 +672,10 @@ impl PgwireBalancer {
                         warn!("client-caused connection failure: {details:#}");
                         SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
                     }
+                    ResolveError::Upstream(details) => {
+                        warn!("upstream not available: {details:#}");
+                        SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
+                    }
                     ResolveError::Internal(details) => {
                         error!("resolving connection destination: {details:#}");
                         SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
@@ -1343,12 +1347,20 @@ pub enum BalancerResolver {
 enum ResolveError {
     #[error("invalid password")]
     InvalidPassword,
-    /// A failure caused by client input, e.g. a bogus SNI that does not resolve
-    /// or a protocol violation. An unauthenticated client can trigger these at
-    /// will, so they are logged at `warn!`, not `error!`, to avoid making
-    /// client noise look like server faults and spamming the error log.
+    /// A client protocol violation, e.g. sending the wrong message during
+    /// startup. An unauthenticated client can trigger these at will, so they
+    /// are logged at `warn!`, not `error!`, to avoid making client noise look
+    /// like server faults and spamming the error log.
     #[error("internal error")]
     Client(#[source] anyhow::Error),
+    /// The tenant's upstream backend could not be reached, e.g. its hostname
+    /// did not resolve. Reported to the client with a distinct, non-leaking
+    /// message rather than a generic internal error, so a down environment is
+    /// not mistaken for a balancerd bug. Logged at `warn!`: a bogus SNI reaches
+    /// this from an unauthenticated client, and a genuinely down environment is
+    /// an operational condition, not a balancerd fault.
+    #[error("upstream server not available")]
+    Upstream(#[source] anyhow::Error),
     /// A server-side fault.
     #[error("internal error")]
     Internal(#[from] anyhow::Error),
@@ -1403,12 +1415,13 @@ impl BalancerResolver {
                 let has_sni = servername.is_some();
                 let resolved_addr = match (servername, sni_resolver.as_ref()) {
                     (Some(servername), Some(SniTemplate { template, port })) => {
-                        // The servername is client-supplied, so a resolution
-                        // failure here is a client error, not a server fault.
+                        // A resolution failure here means the tenant's backend
+                        // is unreachable (or the client sent a bogus SNI). Not
+                        // a server fault.
                         let (addr, tenant) = dns_resolver
                             .resolve_sni(template, *port, servername)
                             .await
-                            .map_err(ResolveError::Client)?;
+                            .map_err(ResolveError::Upstream)?;
                         debug!("pgwire SNI resolved tenant: {:?}", tenant);
                         ResolvedAddr {
                             addr,
@@ -1450,8 +1463,12 @@ impl BalancerResolver {
                             format!("invalid port in addr_template: {}", port_str)
                         })?;
                         // The tenant is already known from authentication, so
-                        // skip the CNAME lookup that resolve() would do.
-                        let addr = dns_resolver.resolve_addr(hostname, port).await?;
+                        // skip the CNAME lookup that resolve() would do. A
+                        // failure here means the tenant's backend is unreachable.
+                        let addr = dns_resolver
+                            .resolve_addr(hostname, port)
+                            .await
+                            .map_err(ResolveError::Upstream)?;
                         let tenant = auth_session.tenant_id().to_string();
                         debug!("Frontegg resolved tenant: {}", tenant);
                         ResolvedAddr {

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -682,9 +682,17 @@ def workflow_mz_not_running(c: Composition) -> None:
         sql_cursor(c)
         raise RuntimeError("connect() expected to fail")
     except OperationalError as e:
+        # With Mz down, balancerd cannot reach the upstream and reports an
+        # opaque error to the client (it does not leak the internal DNS or
+        # connection failure): "internal error" when the tenant hostname
+        # cannot be resolved, "upstream server not available" when it resolves
+        # but the connection is refused. The remaining strings are client-side
+        # failures that can occur depending on how the connection drops.
         assert any(
             expected in str(e)
             for expected in [
+                "internal error",
+                "upstream server not available",
                 "No route to host",
                 "Connection timed out",
                 "failure in name resolution",
@@ -692,7 +700,7 @@ def workflow_mz_not_running(c: Composition) -> None:
                 "Name or service not known",
                 "SSL connection has been closed unexpectedly",
             ]
-        )
+        ), f"unexpected error connecting with Mz down: {e}"
     except:
         raise RuntimeError("connect() threw an unexpected exception")
 

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -155,7 +155,11 @@ SERVICES = [
             "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
             f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
             f"--frontegg-admin-role={ADMIN_ROLE}",
-            "--https-sni-resolver-template=sni.test:6876",
+            # HTTPS resolves directly to materialized. The generic HTTPS tests
+            # (http, ip-forwarding) do not run dnsmasq, so this must resolve
+            # without the sni.test CNAME. Workflows that exercise SNI routing
+            # over pgwire start dnsmasq and rely on the pgwire template below.
+            "--https-sni-resolver-template=materialized:6876",
             "--pgwire-sni-resolver-template=sni.test:6875",
             "--tls-key=/secrets/balancerd.key",
             "--tls-cert=/secrets/balancerd.crt",

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -227,15 +227,22 @@ def grant_all_admin_user(c: Composition):
 
 
 # Assert that contains is present in balancer metrics.
+# Per-connection metrics (tx/rx) are only recorded once the proxied connection
+# closes, and there is a short delay between the client disconnecting and
+# balancerd recording them, so poll for a few seconds.
 def assert_metrics(c: Composition, contains: str):
-    result = c.exec(
-        "materialized",
-        "curl",
-        "http://balancerd:6878/metrics",
-        "-s",
-        capture=True,
-    )
-    assert contains in result.stdout
+    for _ in range(20):
+        result = c.exec(
+            "materialized",
+            "curl",
+            "http://balancerd:6878/metrics",
+            "-s",
+            capture=True,
+        )
+        if contains in result.stdout:
+            return
+        time.sleep(0.5)
+    raise AssertionError(f"{contains!r} not found in balancerd metrics")
 
 
 def sql_cursor(
@@ -727,9 +734,11 @@ def workflow_user(c: Composition) -> None:
         ),
     ):
         c.up("balancerd", "dnsmasq", "frontegg-mock", "materialized")
-        # Metrics aren't recorded until the connection has closed
-        # Non-admin user.
-        with contextlib.closing(sql_cursor(c, email=OTHER_USER)) as cursor:
+        # Non-admin user. Close the connection, not just the cursor: the tx/rx
+        # metrics are only recorded once balancerd finishes proxying, which
+        # happens when the client connection closes.
+        cursor = sql_cursor(c, email=OTHER_USER)
+        with contextlib.closing(cursor.connection):
             try:
                 cursor.execute("DROP DATABASE materialize CASCADE")
                 raise RuntimeError("execute() expected to fail")
@@ -740,7 +749,6 @@ def workflow_user(c: Composition) -> None:
 
             cursor.execute("SELECT current_user()")
             assert OTHER_USER in str(cursor.fetchall())
-            cursor.close()
 
         assert_metrics(c, 'mz_balancer_tenant_connection_active{source="pgwire"')
         assert_metrics(c, 'mz_balancer_tenant_connection_rx{source="pgwire"')

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -682,12 +682,12 @@ def workflow_mz_not_running(c: Composition) -> None:
         sql_cursor(c)
         raise RuntimeError("connect() expected to fail")
     except OperationalError as e:
-        # With Mz down, balancerd cannot reach the upstream and reports an
-        # opaque error to the client (it does not leak the internal DNS or
-        # connection failure): "internal error" when the tenant hostname
-        # cannot be resolved, "upstream server not available" when it resolves
-        # but the connection is refused. The remaining strings are client-side
-        # failures that can occur depending on how the connection drops.
+        # With Mz down, balancerd cannot reach the tenant's backend and reports
+        # it to the client as "upstream server not available" (a resolve
+        # failure and a refused connection both surface this way), without
+        # leaking the underlying DNS or connection error. The remaining strings
+        # are defensive fallbacks for client-side failures depending on how the
+        # connection drops.
         assert any(
             expected in str(e)
             for expected in [


### PR DESCRIPTION
Fixes balancerd nightly workflow failures. Two independent root causes, both test-side; balancerd itself behaves correctly in all cases.

## 1. `http` and `ip-forwarding` — SNI template regression (#33955)

#33955 changed the default `--https-sni-resolver-template` from `materialized:6876` to `sni.test:6876`. `sni.test` only resolves through the dnsmasq CNAME, but these two workflows don't run dnsmasq, so balancerd gets `ServFail`, fails to resolve the upstream, and drops the HTTPS connection with no response (`RemoteDisconnected`). balancerd does not crash — this is a graceful resolution failure.

These workflows exercise the generic HTTPS proxy (endpoint + client-IP forwarding), not SNI routing, so they don't need the CNAME. Point the default HTTPS template back at `materialized`, which resolves via docker's embedded DNS without dnsmasq. SNI routing stays covered over pgwire, which keeps the `sni.test` template and starts dnsmasq. (`workflow_plaintext` already runs `http` this way with `--https-resolver-template=materialized:6876`.)

## 2. `user` — connection never closed, so tx/rx metrics never recorded

`workflow_user` asserts `mz_balancer_tenant_connection_rx{source="pgwire"}` but closed only the cursor, not the connection. balancerd records per-connection tx/rx only after the proxied connection closes (when `copy_bidirectional` returns), so with the connection held open the metric was never recorded and the assertion failed deterministically. This is a latent test bug, not caused by #33955 — the metric-emitting code and this workflow's connection path (Frontegg, no SNI) are unchanged by that PR.

Close the connection instead of the cursor, and poll in `assert_metrics` to cover the brief close-to-record delay.

## Verification

Full `bin/mzcompose --find balancerd run default` passes with both fixes; `http`, `ip-forwarding`, and `user` also verified individually from clean state.