### PR TITLE
Enable RBAC by default in the v1 Materialize CRD and the emulator

### DIFF
--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
@@ -77,8 +77,8 @@
       {
         "name": "enableRbac",
         "type": "Bool",
-        "description": "Whether to enable role based access control. Defaults to false.",
-        "default": false,
+        "description": "Whether to enable role based access control. Defaults to true.",
+        "default": true,
         "required": false,
         "deprecated": false
       },

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -879,6 +879,12 @@ pub mod v1alpha1 {
 pub mod v1 {
     use super::*;
 
+    /// Serde default for spec fields that are on unless explicitly disabled.
+    /// Also surfaced as the schema default in the generated CRD.
+    fn default_true() -> bool {
+        true
+    }
+
     #[derive(
         CustomResource,
         Clone,
@@ -995,8 +1001,8 @@ pub mod v1 {
         /// How to authenticate with Materialize.
         #[serde(default)]
         pub authenticator_kind: AuthenticatorKind,
-        /// Whether to enable role based access control. Defaults to false.
-        #[serde(default)]
+        /// Whether to enable role based access control. Defaults to true.
+        #[serde(default = "default_true")]
         pub enable_rbac: bool,
 
         /// The value used by environmentd (via the --environment-id flag) to
@@ -1849,6 +1855,32 @@ mod tests {
             &serde_json::json!(DEFAULT_ROLLOUT_REQUEST_TIMEOUT),
             "rolloutRequestTimeout schema default missing/wrong in generated CRD",
         );
+    }
+
+    #[mz_ore::test]
+    fn enable_rbac_schema_defaults() {
+        // RBAC defaults on in v1. v1alpha1 keeps the historical default of
+        // off, since flipping the default of an already-served version would
+        // silently enable RBAC for existing deployments that omit the field.
+        for (crd, expected) in [
+            (
+                <super::v1::Materialize as kube::CustomResourceExt>::crd(),
+                true,
+            ),
+            (
+                <super::v1alpha1::Materialize as kube::CustomResourceExt>::crd(),
+                false,
+            ),
+        ] {
+            let crd = serde_json::to_value(crd).expect("CRD serializes");
+            let default = &crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+                ["properties"]["enableRbac"]["default"];
+            assert_eq!(
+                default,
+                &serde_json::json!(expected),
+                "enableRbac schema default missing/wrong in generated CRD",
+            );
+        }
     }
 
     #[mz_ore::test]

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -272,7 +272,7 @@ export MZ_BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILT
 export MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR="${MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR:-0}"
 export MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR="${MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR:-0}"
 
-export MZ_SYSTEM_PARAMETER_DEFAULT="${MZ_SYSTEM_PARAMETER_DEFAULT:-allowed_cluster_replica_sizes=\"25cc\",\"50cc\",\"100cc\",\"200cc\",\"300cc\",\"400cc\",\"600cc\",\"800cc\",\"1200cc\",\"1600cc\",\"3200cc\";enable_rbac_checks=false;enable_statement_lifecycle_logging=false;statement_logging_default_sample_rate=0;statement_logging_max_sample_rate=0;memory_limiter_interval=0}"
+export MZ_SYSTEM_PARAMETER_DEFAULT="${MZ_SYSTEM_PARAMETER_DEFAULT:-allowed_cluster_replica_sizes=\"25cc\",\"50cc\",\"100cc\",\"200cc\",\"300cc\",\"400cc\",\"600cc\",\"800cc\",\"1200cc\",\"1600cc\",\"3200cc\";enable_statement_lifecycle_logging=false;statement_logging_default_sample_rate=0;statement_logging_max_sample_rate=0;memory_limiter_interval=0}"
 
 
 if ! is_truthy "${MZ_NO_TELEMETRY:-0}"; then


### PR DESCRIPTION
### Motivation

Step 1 toward enforcing RBAC everywhere. Today the effective default for
self-managed deployments and the emulator is RBAC **off**: the Materialize CRD
defaults `enableRbac` to `false` (which makes orchestratord inject
`--system-parameter-default=enable_rbac_checks=false`), and the emulator image
bakes `enable_rbac_checks=false` into its default system parameters. When RBAC
is off, every user effectively has superuser privileges. This flips the
defaults at the two places where new deployments are born, without touching
any existing deployment.

### User-facing effects

* **New Materialize custom resources created via the `v1` CRD default to RBAC
  enabled.** Setting `spec.enableRbac: false` explicitly still disables it.
  The default is surfaced in the CRD's OpenAPI schema, so the Kubernetes API
  server persists it at creation time and `kubectl explain` shows it.
* **Existing custom resources are unaffected.** Their stored objects already
  carry an explicit `enableRbac` value (the API server persisted the schema
  default when they were created), so upgrading the operator does not change
  their RBAC posture.
* **The `v1alpha1` CRD keeps its default of `false`.** Changing the default of
  an already-served API version would silently enable RBAC for existing
  deployments that omit the field. Flipping the default only at the version
  boundary follows the Kubernetes API convention, and `v1` shipped opt-in only
  recently (#35508), so its adoption surface is minimal.
* **The emulator (`materialized` image) now enforces RBAC by default.** The
  quickstart experience is preserved: the image sets `MZ_BOOTSTRAP_ROLE=materialize`,
  so the default `materialize` role keeps `CREATEDB`/`CREATECLUSTER` and
  `CREATE` on the `materialize` database, `public` schema, and `quickstart`
  cluster. Administrative statements still work as `mz_system` via the
  internal SQL port. Users can restore the old behavior by overriding
  `MZ_SYSTEM_PARAMETER_DEFAULT` or running
  `ALTER SYSTEM SET enable_rbac_checks = false` as `mz_system`.

No change to Materialize Cloud, where `enable_rbac_checks` already defaults to
`true`.

### Tests

Added `enable_rbac_schema_defaults`, which pins the `enableRbac` default in the
generated CRD OpenAPI schemas: `true` for `v1`, `false` for `v1alpha1`. The
`doc/user/data/self_managed/materialize_crd_descriptions_v1.json` change was
regenerated with `cargo run -p mz-cloud-resources --bin crd-writer v1` (the
v1alpha1 output is unchanged).

The orchestratord `EnableRBAC` modification test only exercises explicitly-set
values, so it is unaffected. It does not yet cover the omitted-field default;
happy to extend it here or in a follow-up.

### Follow-ups (not in this PR)

* Self-managed docs (`doc/user/content/headless/rbac-sm/enable-rbac.md` and
  the v1 CRD adoption guide) still describe RBAC as disabled by default and
  should be updated for the release this ships in.
* Later steps toward always-on RBAC: deprecate setting
  `enable_rbac_checks = false`, rework testdrive's consistency checker (which
  relies on temporarily disabling RBAC), and eventually remove the flag,
  the CRD field, and `enable_session_rbac_checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
