### PR TITLE
Exclude enable_rbac_checks from LaunchDarkly sync

### DIFF
--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
@@ -77,8 +77,8 @@
       {
         "name": "enableRbac",
         "type": "Bool",
-        "description": "Whether to enable role based access control. Defaults to false.",
-        "default": false,
+        "description": "Whether to enable role based access control. Defaults to true.",
+        "default": true,
         "required": false,
         "deprecated": false
       },

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -244,4 +244,16 @@ mod tests {
 
         assert!(!sync.synchronized().is_empty());
     }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    fn test_rbac_not_ld_controllable() {
+        // Remote configuration must not be able to disable access control or
+        // its own kill switch. See `SystemVars::iter_synced`.
+        let vars = SystemVars::default();
+        let sync = SynchronizedParameters::new(vars);
+
+        assert!(!sync.is_synchronized("enable_rbac_checks"));
+        assert!(!sync.is_synchronized("enable_launchdarkly"));
+    }
 }

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -879,6 +879,12 @@ pub mod v1alpha1 {
 pub mod v1 {
     use super::*;
 
+    /// Serde default for spec fields that are on unless explicitly disabled.
+    /// Also surfaced as the schema default in the generated CRD.
+    fn default_true() -> bool {
+        true
+    }
+
     #[derive(
         CustomResource,
         Clone,
@@ -995,8 +1001,8 @@ pub mod v1 {
         /// How to authenticate with Materialize.
         #[serde(default)]
         pub authenticator_kind: AuthenticatorKind,
-        /// Whether to enable role based access control. Defaults to false.
-        #[serde(default)]
+        /// Whether to enable role based access control. Defaults to true.
+        #[serde(default = "default_true")]
         pub enable_rbac: bool,
 
         /// The value used by environmentd (via the --environment-id flag) to
@@ -1849,6 +1855,32 @@ mod tests {
             &serde_json::json!(DEFAULT_ROLLOUT_REQUEST_TIMEOUT),
             "rolloutRequestTimeout schema default missing/wrong in generated CRD",
         );
+    }
+
+    #[mz_ore::test]
+    fn enable_rbac_schema_defaults() {
+        // RBAC defaults on in v1. v1alpha1 keeps the historical default of
+        // off, since flipping the default of an already-served version would
+        // silently enable RBAC for existing deployments that omit the field.
+        for (crd, expected) in [
+            (
+                <super::v1::Materialize as kube::CustomResourceExt>::crd(),
+                true,
+            ),
+            (
+                <super::v1alpha1::Materialize as kube::CustomResourceExt>::crd(),
+                false,
+            ),
+        ] {
+            let crd = serde_json::to_value(crd).expect("CRD serializes");
+            let default = &crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+                ["properties"]["enableRbac"]["default"];
+            assert_eq!(
+                default,
+                &serde_json::json!(expected),
+                "enableRbac schema default missing/wrong in generated CRD",
+            );
+        }
     }
 
     #[mz_ore::test]

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -272,7 +272,7 @@ export MZ_BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILT
 export MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR="${MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR:-0}"
 export MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR="${MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR:-0}"
 
-export MZ_SYSTEM_PARAMETER_DEFAULT="${MZ_SYSTEM_PARAMETER_DEFAULT:-allowed_cluster_replica_sizes=\"25cc\",\"50cc\",\"100cc\",\"200cc\",\"300cc\",\"400cc\",\"600cc\",\"800cc\",\"1200cc\",\"1600cc\",\"3200cc\";enable_rbac_checks=false;enable_statement_lifecycle_logging=false;statement_logging_default_sample_rate=0;statement_logging_max_sample_rate=0;memory_limiter_interval=0}"
+export MZ_SYSTEM_PARAMETER_DEFAULT="${MZ_SYSTEM_PARAMETER_DEFAULT:-allowed_cluster_replica_sizes=\"25cc\",\"50cc\",\"100cc\",\"200cc\",\"300cc\",\"400cc\",\"600cc\",\"800cc\",\"1200cc\",\"1600cc\",\"3200cc\";enable_statement_lifecycle_logging=false;statement_logging_default_sample_rate=0;statement_logging_max_sample_rate=0;memory_limiter_interval=0}"
 
 
 if ! is_truthy "${MZ_NO_TELEMETRY:-0}"; then

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1421,8 +1421,14 @@ impl SystemVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk. Compared to [`SystemVars::iter`], this should omit vars
     /// that shouldn't be synced by SystemParameterFrontend.
+    ///
+    /// `enable_launchdarkly` is excluded so the remote configuration system
+    /// cannot disable its own kill switch. `enable_rbac_checks` is excluded so
+    /// remote configuration cannot turn off access control. Both may only be
+    /// changed through `ALTER SYSTEM` or startup defaults.
     pub fn iter_synced(&self) -> impl Iterator<Item = &dyn Var> {
-        self.iter().filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name)
+        self.iter()
+            .filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name && v.name() != ENABLE_RBAC_CHECKS.name)
     }
 
     /// Returns an iterator over the configuration parameters that can be overriden per-Session.

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -162,8 +162,10 @@ SESSION_VARIABLES = {
     # Pseudo-variables added by SessionVars::iter.
     "mz_version",
     "is_superuser",
-    # The LaunchDarkly kill switch, explicitly excluded from iter_synced.
+    # The LaunchDarkly kill switch and the RBAC enforcement flag, explicitly
+    # excluded from iter_synced so remote configuration cannot change them.
     "enable_launchdarkly",
+    "enable_rbac_checks",
 }
 
 # Tag used by `test/launchdarkly` and `ci/cleanup/launchdarkly.py` for the
@@ -268,7 +270,6 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_projection_pushdown_after_relation_cse
     enable_public_metrics_endpoint
     enable_raise_statement
-    enable_rbac_checks
     enable_redacted_test_option
     enable_repeat_row
     enable_repeat_row_non_negative


### PR DESCRIPTION
### Motivation

Access control should not be disableable through remote configuration. The
LaunchDarkly sync loop applies any system parameter in
`SystemVars::iter_synced`, and `enable_rbac_checks` is in that set today, so
an LD flag with that name could turn off RBAC fleet-wide in production. No
such flag currently exists (`enable_rbac_checks` sits on the
`KNOWN_MISSING_FROM_LD` allowlist of the flag-consistency check), so this
change freezes the status quo rather than altering any live value.

Tracked in [SEC-650](https://linear.app/materializeinc/issue/SEC-650).
Stacked on #37571.

### Mechanism

`iter_synced` is the single enforcement point: the frontend's `pull` iterates
only `SynchronizedParameters::synchronized()` (derived from `iter_synced`),
the backend's `push` only propagates `modified()` (same filter), and the
scoped per-cluster/per-replica override evaluation partitions `iter_synced`
by scope. Excluding a parameter there removes it from every sync path at
once. This is the same mechanism that already protects `enable_launchdarkly`
from disabling its own kill switch.

### User-facing effects

None. `enable_rbac_checks` remains settable by superusers via `ALTER SYSTEM`
and by operators via startup defaults (`--system-parameter-default`), which is
how the self-managed v1alpha1 opt-out is wired. Only the remote-configuration
channel is removed.

### Tests

* New `test_rbac_not_ld_controllable` unit test asserts
  `enable_rbac_checks` and `enable_launchdarkly` are not in the synchronized
  set.
* The LaunchDarkly flag-consistency check moves `enable_rbac_checks` from
  `KNOWN_MISSING_FROM_LD` to the excluded-from-sync list next to
  `enable_launchdarkly`.

The nightly LaunchDarkly integration test should be run against this branch
before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
