### PR TITLE
doc: update self-managed RBAC docs for version-dependent defaults

### DIFF
--- a/doc/user/content/headless/rbac-sm/enable-rbac.md
+++ b/doc/user/content/headless/rbac-sm/enable-rbac.md
@@ -5,22 +5,20 @@ headless: true
 If RBAC is not enabled, all users have <red>**superuser**</red> privileges.
 {{</ warning >}}
 
-By default, role-based access control (RBAC) checks are not enabled (i.e.,
-enforced) when using [authentication](/security/self-managed/authentication/#configuring-authentication-type). To
-enable RBAC, set the system parameter `enable_rbac_checks` to `'on'` or `True`.
-You can enable the parameter in one of the following ways:
+Whether role-based access control (RBAC) checks are enabled (i.e., enforced)
+is controlled by the `enableRbac` field on the Materialize resource and the
+`enable_rbac_checks` system parameter:
 
-- For [local installations using
-  Kind/Minikube](/self-managed-deployments/installation/#installation-guides), set `spec.enableRbac:
-  true` option when instantiating the Materialize object.
+- For Materialize resources using the `v1` CRD, RBAC is **enabled by
+  default**. To disable RBAC, set `spec.enableRbac: false` when instantiating
+  the Materialize object.
 
-- For [Cloud deployments using Materialize's
-  Terraforms](/self-managed-deployments/installation/#installation-guides), set
-  `enable_rbac_checks` in the environment CR via the `environmentdExtraArgs`
-  flag option.
+- For Materialize resources using the `v1alpha1` CRD, RBAC is **not enabled
+  by default**. To enable RBAC, set `spec.enableRbac: true` when
+  instantiating the Materialize object.
 
-- After the Materialize instance is running, run the following command as
-  `mz_system` user:
+- After the Materialize instance is running, you can enable RBAC by running
+  the following command as the `mz_system` user:
 
   ```mzsql
   ALTER SYSTEM SET enable_rbac_checks = 'on';

--- a/doc/user/content/self-managed-deployments/upgrading/adopting-the-v1-crd.md
+++ b/doc/user/content/self-managed-deployments/upgrading/adopting-the-v1-crd.md
@@ -56,6 +56,12 @@ Terraform modules, `crd_version` defaults to `v1` starting in v4.0.0. Upgrading
 the operator to v26.30+ does not change your existing `v1alpha1` CRs or their
 behavior; you can continue using `v1alpha1` until the next major release.
 
+The two versions also differ in their default for [role-based access
+control](/security/self-managed/access-control/): new `v1` resources default
+`enableRbac` to `true`, while `v1alpha1` defaults it to `false`. Converting an
+existing resource between versions carries over its stored `enableRbac` value,
+so adopting `v1` does not change the RBAC posture of an existing instance.
+
 {{< important >}}
 
 In the next major release, all Materialize CRs will be force upgraded to `v1`.

--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
@@ -77,8 +77,8 @@
       {
         "name": "enableRbac",
         "type": "Bool",
-        "description": "Whether to enable role based access control. Defaults to false.",
-        "default": false,
+        "description": "Whether to enable role based access control. Defaults to true.",
+        "default": true,
         "required": false,
         "deprecated": false
       },

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -244,4 +244,16 @@ mod tests {
 
         assert!(!sync.synchronized().is_empty());
     }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    fn test_rbac_not_ld_controllable() {
+        // Remote configuration must not be able to disable access control or
+        // its own kill switch. See `SystemVars::iter_synced`.
+        let vars = SystemVars::default();
+        let sync = SynchronizedParameters::new(vars);
+
+        assert!(!sync.is_synchronized("enable_rbac_checks"));
+        assert!(!sync.is_synchronized("enable_launchdarkly"));
+    }
 }

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -879,6 +879,12 @@ pub mod v1alpha1 {
 pub mod v1 {
     use super::*;
 
+    /// Serde default for spec fields that are on unless explicitly disabled.
+    /// Also surfaced as the schema default in the generated CRD.
+    fn default_true() -> bool {
+        true
+    }
+
     #[derive(
         CustomResource,
         Clone,
@@ -995,8 +1001,8 @@ pub mod v1 {
         /// How to authenticate with Materialize.
         #[serde(default)]
         pub authenticator_kind: AuthenticatorKind,
-        /// Whether to enable role based access control. Defaults to false.
-        #[serde(default)]
+        /// Whether to enable role based access control. Defaults to true.
+        #[serde(default = "default_true")]
         pub enable_rbac: bool,
 
         /// The value used by environmentd (via the --environment-id flag) to
@@ -1849,6 +1855,32 @@ mod tests {
             &serde_json::json!(DEFAULT_ROLLOUT_REQUEST_TIMEOUT),
             "rolloutRequestTimeout schema default missing/wrong in generated CRD",
         );
+    }
+
+    #[mz_ore::test]
+    fn enable_rbac_schema_defaults() {
+        // RBAC defaults on in v1. v1alpha1 keeps the historical default of
+        // off, since flipping the default of an already-served version would
+        // silently enable RBAC for existing deployments that omit the field.
+        for (crd, expected) in [
+            (
+                <super::v1::Materialize as kube::CustomResourceExt>::crd(),
+                true,
+            ),
+            (
+                <super::v1alpha1::Materialize as kube::CustomResourceExt>::crd(),
+                false,
+            ),
+        ] {
+            let crd = serde_json::to_value(crd).expect("CRD serializes");
+            let default = &crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+                ["properties"]["enableRbac"]["default"];
+            assert_eq!(
+                default,
+                &serde_json::json!(expected),
+                "enableRbac schema default missing/wrong in generated CRD",
+            );
+        }
     }
 
     #[mz_ore::test]

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -239,16 +239,12 @@ impl Drop for TestServerWithStatementLoggingChecks {
             return;
         }
 
+        // mz_system is a superuser and can query mz_internal tables with RBAC
+        // enforced.
         let mut mz_client = self
             .server
             .connect_internal(postgres::NoTls)
             .expect("Failed to connect to internal SQL port for statement logging check");
-
-        // Disable RBAC checks so we can query mz_internal tables.
-        // (We don't need to restore this afterwards, since no more tests run in the same system.)
-        mz_client
-            .batch_execute("ALTER SYSTEM SET enable_rbac_checks = false")
-            .expect("Failed to disable RBAC checks");
 
         // The statement log has a 5-second buffer flush interval, so allow sufficient time.
         Retry::default()

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -272,7 +272,7 @@ export MZ_BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILT
 export MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR="${MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR:-0}"
 export MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR="${MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR:-0}"
 
-export MZ_SYSTEM_PARAMETER_DEFAULT="${MZ_SYSTEM_PARAMETER_DEFAULT:-allowed_cluster_replica_sizes=\"25cc\",\"50cc\",\"100cc\",\"200cc\",\"300cc\",\"400cc\",\"600cc\",\"800cc\",\"1200cc\",\"1600cc\",\"3200cc\";enable_rbac_checks=false;enable_statement_lifecycle_logging=false;statement_logging_default_sample_rate=0;statement_logging_max_sample_rate=0;memory_limiter_interval=0}"
+export MZ_SYSTEM_PARAMETER_DEFAULT="${MZ_SYSTEM_PARAMETER_DEFAULT:-allowed_cluster_replica_sizes=\"25cc\",\"50cc\",\"100cc\",\"200cc\",\"300cc\",\"400cc\",\"600cc\",\"800cc\",\"1200cc\",\"1600cc\",\"3200cc\";enable_statement_lifecycle_logging=false;statement_logging_default_sample_rate=0;statement_logging_max_sample_rate=0;memory_limiter_interval=0}"
 
 
 if ! is_truthy "${MZ_NO_TELEMETRY:-0}"; then

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1421,8 +1421,14 @@ impl SystemVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk. Compared to [`SystemVars::iter`], this should omit vars
     /// that shouldn't be synced by SystemParameterFrontend.
+    ///
+    /// `enable_launchdarkly` is excluded so the remote configuration system
+    /// cannot disable its own kill switch. `enable_rbac_checks` is excluded so
+    /// remote configuration cannot turn off access control. Both may only be
+    /// changed through `ALTER SYSTEM` or startup defaults.
     pub fn iter_synced(&self) -> impl Iterator<Item = &dyn Var> {
-        self.iter().filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name)
+        self.iter()
+            .filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name && v.name() != ENABLE_RBAC_CHECKS.name)
     }
 
     /// Returns an iterator over the configuration parameters that can be overriden per-Session.

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -215,9 +215,6 @@ pub struct MaterializeState {
 }
 
 pub struct State {
-    // The Config that this `State` was originally created from.
-    pub config: Config,
-
     // === Testdrive state. ===
     arg_vars: BTreeMap<String, String>,
     cmd_vars: BTreeMap<String, String>,
@@ -1121,8 +1118,6 @@ pub async fn create_state(
     };
 
     let mut state = State {
-        config: config.clone(),
-
         // === Testdrive state. ===
         arg_vars: config.arg_vars.clone(),
         cmd_vars: BTreeMap::new(),

--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -13,9 +13,8 @@ use std::io::Write as _;
 use std::str::FromStr;
 use std::time::Duration;
 
-use crate::action;
-use crate::action::{ControlFlow, Run, State};
-use crate::parser::{BuiltinCommand, LineReader, parse};
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
 use anyhow::{Context, anyhow, bail};
 use mz_ore::retry::{Retry, RetryResult};
 use mz_persist_client::{PersistLocation, ShardId};
@@ -260,14 +259,11 @@ async fn check_catalog_state(state: &State) -> Result<(), anyhow::Error> {
 /// normal `.td`s, but not after cluster tests and whatnot that kill/restart the system.
 /// (Also, this can take several seconds due to the 5 sec buffering, so we run this only in Nightly
 /// by default.)
-async fn check_statement_logging(orig_state: &State) -> Result<(), anyhow::Error> {
+async fn check_statement_logging(state: &State) -> Result<(), anyhow::Error> {
     use crate::util::postgres::postgres_client;
 
-    // Create new Testdrive state, so that we create a new session to Materialize, and we forget any
-    // weird Testdrive setting that the `.td` file before us might have set.
-    let (mut state, state_cleanup) = action::create_state(&orig_state.config).await?;
-
-    // First, query the current value of enable_rbac_checks so we can restore it later
+    // Connect as mz_system, which is a superuser and can read
+    // mz_internal.mz_recent_activity_log with RBAC enforced.
     let mz_system_url = format!(
         "postgres://mz_system:materialize@{}",
         state.materialize.internal_sql_addr
@@ -275,49 +271,38 @@ async fn check_statement_logging(orig_state: &State) -> Result<(), anyhow::Error
 
     let (client, _handle) = postgres_client(&mz_system_url, state.default_timeout)
         .await
-        .context("connecting as mz_system to query enable_rbac_checks")?;
+        .context("connecting as mz_system to check the statement log")?;
 
-    let row = query_one(&client, sql!("SHOW enable_rbac_checks"), &[])
-        .await
-        .context("querying enable_rbac_checks")?;
-
-    let original_value: String = row.get(0);
-
-    // Create a testdrive script to check that all statements have finished executing.
-    // We disable RBAC checks so we can query mz_internal tables, similar to statement-logging.td.
-    // We restore the setting to its original value at the end.
-    let check_script = format!(
-        r#"
-$ postgres-execute connection=postgres://mz_system:materialize@{0}
-ALTER SYSTEM SET enable_rbac_checks = false
-
-> SELECT count(*)
-  FROM mz_internal.mz_recent_activity_log
-  WHERE
-    (finished_at IS NULL OR finished_status IS NULL)
-    AND sql NOT LIKE '%__FILTER-OUT-THIS-QUERY__%'
-    AND finished_status != 'aborted';
-0
-
-$ postgres-execute connection=postgres://mz_system:materialize@{0}
-ALTER SYSTEM SET enable_rbac_checks = {1}
-"#,
-        state.materialize.internal_sql_addr, original_value
+    // Statement log writes are buffered and flushed every 5 seconds, so retry
+    // until in-flight statements have drained. The marker string in the query
+    // text filters the query out of its own result, since it is necessarily
+    // unfinished while it runs.
+    let check = sql!(
+        "SELECT count(*)
+        FROM mz_internal.mz_recent_activity_log
+        WHERE
+            (finished_at IS NULL OR finished_status IS NULL)
+            AND sql NOT LIKE '%__FILTER-OUT-THIS-QUERY__%'
+            AND finished_status != 'aborted'"
     );
-
-    let mut line_reader = LineReader::new(&check_script);
-    let cmds = parse(&mut line_reader).map_err(|e| anyhow!("{}", e.source))?;
-
-    for cmd in cmds {
-        cmd.run(&mut state)
-            .await
-            .map_err(|e| anyhow!("{}", e.source))?;
-    }
-
-    drop(state);
-    state_cleanup.await?;
-
-    Ok(())
+    Retry::default()
+        .max_duration(state.default_timeout)
+        .retry_async_canceling(|_| {
+            let client = &client;
+            let check = &check;
+            async move {
+                let row = query_one(client, check.clone(), &[])
+                    .await
+                    .context("querying statement log")?;
+                let count: i64 = row.get(0);
+                if count == 0 {
+                    Ok(())
+                } else {
+                    bail!("{count} statements not in a finished state");
+                }
+            }
+        })
+        .await
 }
 
 /// Checks if the provided `shard_id` is a tombstone, returning an error if it's not.

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -162,8 +162,10 @@ SESSION_VARIABLES = {
     # Pseudo-variables added by SessionVars::iter.
     "mz_version",
     "is_superuser",
-    # The LaunchDarkly kill switch, explicitly excluded from iter_synced.
+    # The LaunchDarkly kill switch and the RBAC enforcement flag, explicitly
+    # excluded from iter_synced so remote configuration cannot change them.
     "enable_launchdarkly",
+    "enable_rbac_checks",
 }
 
 # Tag used by `test/launchdarkly` and `ci/cleanup/launchdarkly.py` for the
@@ -268,7 +270,6 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_projection_pushdown_after_relation_cse
     enable_public_metrics_endpoint
     enable_raise_statement
-    enable_rbac_checks
     enable_redacted_test_option
     enable_repeat_row
     enable_repeat_row_non_negative


### PR DESCRIPTION
### Motivation

Part of making RBAC always-on
([SEC-652](https://linear.app/materializeinc/issue/SEC-652), stacked on
#37571). The self-managed docs describe RBAC as disabled by default, which
stops being true for `v1` CRD resources once #37571 ships.

### Changes

* `headless/rbac-sm/enable-rbac.md` (included by the access-control pages) now
  explains the version-dependent default: `v1` resources default RBAC on,
  `v1alpha1` resources default it off, and `ALTER SYSTEM` overrides both. The
  stale bullet about setting `enable_rbac_checks` via `environmentdExtraArgs`
  for Terraform deployments is replaced, since the Terraform modules go
  through the CRD (`crd_version` defaults to `v1` from module v4.0.0).
* The v1 CRD adoption guide gains a paragraph noting the `enableRbac` default
  difference between versions and that converting an existing resource carries
  its stored value, so adoption does not change an instance's RBAC posture.

### Notes for review

This should merge in the same release as #37571, otherwise the docs describe
behavior that has not shipped. cc docs team for timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
