### PR TITLE
platform-checks: Add check for InvalidVersion panic

### DIFF
--- a/misc/python/materialize/checks/all_checks/builtin_version_pin.py
+++ b/misc/python/materialize/checks/all_checks/builtin_version_pin.py
@@ -1,0 +1,107 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.mz_version import MzVersion
+
+# All builtin tables in stable, user-referenceable schemas (currently all in
+# mz_catalog), including former builtin tables that later versions converted
+# to materialized views. Conversions keep the name resolvable, so creating a
+# view over an already-converted builtin is harmless, while a builtin that is
+# still a table gets poisoned by the rename below and turns the next
+# conversion into an upgrade wedge.
+#
+# mz_internal builtin tables are excluded: users cannot create views with
+# unstable dependencies, so conversions there cannot poison customer catalogs.
+# mz_role_auth is excluded because it is only readable by mz_system.
+_STABLE_BUILTIN_TABLES = [
+    "mz_array_types",
+    "mz_audit_events",
+    "mz_aws_privatelink_connections",
+    "mz_base_types",
+    "mz_cluster_replica_sizes",
+    "mz_cluster_replicas",
+    "mz_clusters",
+    "mz_columns",
+    "mz_default_privileges",
+    "mz_egress_ips",
+    "mz_functions",
+    "mz_iceberg_sinks",
+    "mz_index_columns",
+    "mz_kafka_connections",
+    "mz_kafka_sinks",
+    "mz_kafka_sources",
+    "mz_list_types",
+    "mz_map_types",
+    "mz_operators",
+    "mz_pseudo_types",
+    "mz_sinks",
+    "mz_ssh_tunnel_connections",
+    "mz_system_privileges",
+    "mz_tables",
+    "mz_types",
+    "mz_views",
+]
+
+
+def _pin_views(suffix_tables: list[str], prefix: str) -> str:
+    create = "\n".join(
+        f"> CREATE VIEW {prefix}{t} AS SELECT count(*) AS c FROM mz_catalog.{t};"
+        for t in suffix_tables
+    )
+    rename = "\n".join(
+        f"> ALTER VIEW {prefix}{t} RENAME TO {prefix}{t}_r;" for t in suffix_tables
+    )
+    return f"{create}\n{rename}"
+
+
+class BuiltinItemVersionPin(Check):
+    """Views over builtin tables must keep working when a later version
+    converts the builtin to another item type (e.g. mz_clusters became a
+    materialized view in v26.30).
+
+    With enable_alter_table_add_column on, re-parsing a persisted view pins
+    referenced builtin tables at VERSION 0 in the in-memory create_sql
+    (resolve_item_name_id pins any versioned item, not just user tables).
+    A rename then persists the pinned reference. A later version where the
+    builtin is no longer a table rejects VERSION 0 with InvalidVersion and
+    environmentd panics during catalog open, wedging the upgrade.
+    """
+
+    def _can_run(self, e: Executor) -> bool:
+        # mz_iceberg_sinks is the newest table in the list above.
+        return self.base_version >= MzVersion.parse_mz("v26.25.0")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(dedent("""
+                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER SYSTEM SET enable_alter_table_add_column = true;
+
+                """) + _pin_views(_STABLE_BUILTIN_TABLES, "builtin_pin_"))
+
+    def manipulate(self) -> list[Testdrive]:
+        # Re-run the poisoning on the intermediate versions of multi-version
+        # upgrade scenarios. In 0dt scenarios this also exercises applying a
+        # poisoned catalog update while the next generation follows the
+        # catalog in read-only mode.
+        return [
+            Testdrive(_pin_views(_STABLE_BUILTIN_TABLES, f"builtin_pin_m{i}_"))
+            for i in [1, 2]
+        ]
+
+    def validate(self) -> Testdrive:
+        selects = "\n".join(
+            f"> SELECT c >= 0 FROM {prefix}{t}_r;\ntrue"
+            for prefix in ["builtin_pin_", "builtin_pin_m1_", "builtin_pin_m2_"]
+            for t in _STABLE_BUILTIN_TABLES
+        )
+        return Testdrive(selects)


### PR DESCRIPTION
Reproduces with `bin/mzcompose --find platform-checks run default --scenario=ZeroDowntimeUpgradeEntireMzFourVersions --check=BuiltinItemVersionPin`:
```
thread 'main' panicked at src/adapter/src/catalog/apply.rs:1348:33:
PlanError(InvalidVersion { name: "mz_audit_events", version: "0" }): invalid persisted SQL: CREATE VIEW "materialize"."public"."builtin_pin_audit0" AS SELECT "pg_catalog"."count"(*) AS "c" FROM [s518 AS "mz_catalog"."mz_audit_events" VERSION 0]
   5: core::panicking::panic_fmt
   6: <mz_adapter::catalog::state::CatalogState>::apply_item_update::{closure#1}
   7: <mz_adapter::catalog::state::CatalogState>::apply_update
   8: <mz_adapter::catalog::state::CatalogState>::apply_updates_inner
   9: <mz_adapter::catalog::state::CatalogState>::with_enable_for_item_parsing::<(alloc::vec::Vec<mz_adapter::catalog::builtin_table_updates::BuiltinTableUpdate<&mz_catalog::builtin::BuiltinTable>>, alloc::vec::Vec<mz_adapter::coord::catalog_implications::parsed_state_updates::ParsedStateUpdate>), <mz_adapter::catalog::apply::ApplyState>::apply::{closure#0}::{closure#0}>
  10: <mz_adapter::catalog::apply::ApplyState>::apply::{closure#0}
  11: <mz_adapter::catalog::state::CatalogState>::apply_updates::{closure#0}::{closure#0}
  12: <tracing::instrument::Instrumented<<mz_adapter::catalog::state::CatalogState>::apply_updates::{closure#0}::{closure#0}> as core::future::future::Future>::poll
  13: <mz_adapter::catalog::state::CatalogState>::apply_updates::{closure#0}
  14: <mz_adapter::catalog::Catalog>::initialize_state::{closure#0}
  15: <tracing::instrument::Instrumented<<mz_adapter::catalog::Catalog>::initialize_state::{closure#0}> as core::future::future::Future>::poll
  16: <tracing::instrument::Instrumented<<mz_adapter::catalog::Catalog>::open::{closure#0}> as core::future::future::Future>::poll
  17: mz_adapter::coord::serve::{closure#0}
  18: <tracing::instrument::Instrumented<core::pin::Pin<alloc::boxed::Box<dyn core::future::future::Future<Output = core::result::Result<(mz_adapter::client::Handle, mz_adapter::client::Client), mz_adapter::error::AdapterError>> + core::marker::Send>>> as core::future::future::Future>::poll
  19: <mz_environmentd::Listeners>::serve::{closure#0}::{closure#0}
  20: <tracing::instrument::Instrumented<<mz_environmentd::Listeners>::serve::{closure#0}::{closure#0}> as core::future::future::Future>::poll
  21: <core::pin::Pin<alloc::boxed::Box<mz_environmentd::environmentd::main::run::{closure#17}>> as core::future::future::Future>::poll
  22: <tracing::instrument::Instrumented<core::pin::Pin<alloc::boxed::Box<mz_environmentd::environmentd::main::run::{closure#17}>>> as core::future::future::Future>::poll
  23: <tokio::runtime::park::CachedParkThread>::block_on::<tracing::instrument::Instrumented<core::pin::Pin<alloc::boxed::Box<mz_environmentd::environmentd::main::run::{closure#17}>>>>
  24: tokio::runtime::context::runtime::enter_runtime::<<tokio::runtime::scheduler::multi_thread::MultiThread>::block_on<tracing::instrument::Instrumented<core::pin::Pin<alloc::boxed::Box<mz_environmentd::environmentd::main::run::{closure#17}>>>>::{closure#0}, core::result::Result<mz_environmentd::Server, anyhow::Error>>
  25: <tokio::runtime::runtime::Runtime>::block_on::<mz_environmentd::environmentd::main::run::{closure#17}>
  26: mz_environmentd::environmentd::main::run
  27: mz_environmentd::environmentd::main::main
  28: materialized::main
```