### PR TITLE
balancerd: reland SNI route refactor (#33955) with nightly test fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,38 +3168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
-]
-
-[[package]]
-name = "domain"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7ff15f82df7d5086fb15dfc1c1e96598a6ded9829840a9bcfa1fa3ccd8d01d"
-dependencies = [
- "bumpalo",
- "bytes",
- "domain-macros",
- "futures-util",
- "hashbrown 0.14.5",
- "log",
- "moka",
- "octseq",
- "rand 0.8.5",
- "smallvec",
- "time",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "domain-macros"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1a6796ad411f6812d691955066ad27450196bfb181bb91b66a643cc3e8f5b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4261,7 +4235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
- "allocator-api2",
 ]
 
 [[package]]
@@ -4370,6 +4343,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ede5cfa60c958e60330d65163adbc4211e15a2653ad80eb0cce878de120121"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4943,6 +4962,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d72a21f6a71a6c4c3160e095e8925861f5119dd26ef71acee1b9146f74f76c8"
+dependencies = [
+ "socket2 0.6.4",
+ "widestring",
+ "windows-sys 0.61.1",
+ "winreg",
 ]
 
 [[package]]
@@ -6257,8 +6288,8 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
- "domain",
  "futures",
+ "hickory-resolver",
  "humantime",
  "hyper 1.9.0",
  "hyper-openssl",
@@ -6289,6 +6320,7 @@ dependencies = [
  "rustls",
  "semver",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-metrics",
  "tokio-openssl",
@@ -9457,20 +9489,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "octseq"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126c3ca37c9c44cec575247f43a3e4374d8927684f129d2beeb0d2cef262fe12"
-dependencies = [
- "bytes",
- "smallvec",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -11338,6 +11364,12 @@ dependencies = [
  "tracing",
  "wasmtimer",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "retain_mut"
@@ -14175,6 +14207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14428,6 +14466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,7 +355,6 @@ differential-dataflow = "0.24.0"
 differential-dogs3 = "0.24.0"
 digest = "0.10.7"
 dirs = "6.0.0"
-domain = { version = "0.11.1", default-features = false, features = ["resolv"] }
 duckdb = { version = "1.4.3", default-features = false, features = ["native-tls"] }
 dynfmt = { version = "0.1.5", features = ["curly"] }
 either = "1.16.0"
@@ -380,6 +379,7 @@ headers = "0.4.1"
 hex = "0.4.3"
 hex-literal = "1.1.0"
 hibitset = "0.6.4"
+hickory-resolver = "0.25.2"
 hmac = "0.12.1"
 http = "1.4.0"
 http-body-util = "0.1.3"

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -17,8 +17,8 @@ bytes.workspace = true
 bytesize.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["env"] }
-domain.workspace = true
 futures.workspace = true
+hickory-resolver.workspace = true
 humantime.workspace = true
 hyper.workspace = true
 hyper-openssl.workspace = true
@@ -44,6 +44,7 @@ prometheus.workspace = true
 proxy-header.workspace = true
 rustls.workspace = true
 semver.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tokio-openssl.workspace = true
 tokio-postgres.workspace = true

--- a/src/balancerd/src/bin/balancerd.rs
+++ b/src/balancerd/src/bin/balancerd.rs
@@ -15,14 +15,14 @@
 use std::error::Error;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use domain::resolv::StubResolver;
 use jsonwebtoken::DecodingKey;
 use mz_balancerd::{
-    BUILD_INFO, BalancerConfig, BalancerService, CancellationResolver, FronteggResolver, Resolver,
-    SniResolver,
+    BUILD_INFO, BalancerConfig, BalancerResolver, BalancerService, CancellationResolver,
+    FronteggResolver, SniTemplate, TenantDnsResolver,
 };
 use mz_frontegg_auth::{
     Authenticator, AuthenticatorConfig, DEFAULT_REFRESH_DROP_FACTOR,
@@ -253,13 +253,15 @@ pub async fn run(
             if !cancellation_resolver_dir.is_dir() {
                 anyhow::bail!("{cancellation_resolver_dir:?} is not a directory");
             }
+
             (
-                Resolver::MultiTenant(
-                    FronteggResolver {
+                BalancerResolver::MultiTenant {
+                    dns: Arc::new(TenantDnsResolver::new()?),
+                    frontegg: FronteggResolver {
                         auth,
                         addr_template,
                     },
-                    match args.pgwire_sni_resolver_template {
+                    sni: match args.pgwire_sni_resolver_template {
                         None => None,
                         Some(template) => {
                             let (template, port) = template
@@ -273,14 +275,10 @@ pub async fn run(
                                     )
                                 })
                                 .expect("invalid port for pgwire_sni_resolver_template");
-                            Some(SniResolver {
-                                resolver: StubResolver::new(),
-                                template,
-                                port,
-                            })
+                            Some(SniTemplate { template, port })
                         }
                     },
-                ),
+                },
                 CancellationResolver::Directory(cancellation_resolver_dir),
             )
         }
@@ -297,7 +295,7 @@ pub async fn run(
             drop(addrs);
 
             (
-                Resolver::Static(addr.clone()),
+                BalancerResolver::Static(addr.clone()),
                 CancellationResolver::Static(addr),
             )
         }

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -20,10 +20,9 @@ mod codec;
 mod dyncfgs;
 
 use std::collections::BTreeMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -31,11 +30,14 @@ use anyhow::Context;
 use axum::response::IntoResponse;
 use axum::{Router, routing};
 use bytes::BytesMut;
-use domain::base::{Name, Rtype};
-use domain::rdata::AllRecordData;
-use domain::resolv::StubResolver;
 use futures::TryFutureExt;
 use futures::stream::BoxStream;
+use hickory_resolver::config::LookupIpStrategy;
+use hickory_resolver::lookup_ip::LookupIp;
+use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::proto::rr::RecordType;
+use hickory_resolver::system_conf::read_system_conf;
+use hickory_resolver::{Resolver, TokioResolver};
 use hyper::StatusCode;
 use hyper_util::rt::TokioIo;
 use launchdarkly_server_sdk as ld;
@@ -94,7 +96,7 @@ pub struct BalancerConfig {
     /// DNS resolver for pgwire cancellation requests
     cancellation_resolver: CancellationResolver,
     /// DNS resolver.
-    resolver: Resolver,
+    resolver: BalancerResolver,
     https_sni_addr_template: String,
     tls: Option<TlsCertConfig>,
     internal_tls: bool,
@@ -117,7 +119,7 @@ impl BalancerConfig {
         pgwire_listen_addr: SocketAddr,
         https_listen_addr: SocketAddr,
         cancellation_resolver: CancellationResolver,
-        resolver: Resolver,
+        resolver: BalancerResolver,
         https_sni_addr_template: String,
         tls: Option<TlsCertConfig>,
         internal_tls: bool,
@@ -320,6 +322,15 @@ impl BalancerService {
         let https_addr = self.https.0.local_addr();
         let internal_http_addr = self.internal_http.0.local_addr();
 
+        // The HTTPS balancer always resolves through a TenantDnsResolver. In
+        // multi-tenant mode it shares the pgwire resolver so both listeners use
+        // one resolver. In static mode pgwire does not resolve through it, so
+        // HTTPS gets its own.
+        let shared_dns = match self.cfg.resolver.shared_dns() {
+            Some(dns) => dns,
+            None => Arc::new(TenantDnsResolver::new()?),
+        };
+
         {
             let pgwire = PgwireBalancer {
                 resolver: Arc::new(self.cfg.resolver),
@@ -352,9 +363,9 @@ impl BalancerService {
                 panic!("expected port in https_addr_template");
             };
             let port: u16 = port.parse().expect("unexpected port");
-            let resolver = StubResolver::new();
+
             let https = HttpsBalancer {
-                resolver: Arc::from(resolver),
+                resolver: shared_dns,
                 tls: https_tls,
                 resolve_template: Arc::from(addr),
                 port,
@@ -611,7 +622,7 @@ struct PgwireBalancer {
     tls: Option<ReloadingTlsConfig>,
     internal_tls: bool,
     cancellation_resolver: Arc<CancellationResolver>,
-    resolver: Arc<Resolver>,
+    resolver: Arc<BalancerResolver>,
     metrics: ServerMetrics,
     now: NowFn,
 }
@@ -622,7 +633,7 @@ impl PgwireBalancer {
         conn: &'a mut FramedConn<A>,
         version: i32,
         params: BTreeMap<String, String>,
-        resolver: &Resolver,
+        resolver: &BalancerResolver,
         tls_mode: Option<TlsMode>,
         internal_tls: bool,
         metrics: &ServerMetrics,
@@ -655,11 +666,19 @@ impl PgwireBalancer {
         let resolved = match resolver.resolve(conn, user, metrics).await {
             Ok(v) => v,
             Err(err) => {
+                let sql_state = match &err {
+                    ResolveError::InvalidPassword => SqlState::INVALID_PASSWORD,
+                    ResolveError::Client(details) => {
+                        warn!("client-caused connection failure: {details:#}");
+                        SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
+                    }
+                    ResolveError::Internal(details) => {
+                        error!("resolving connection destination: {details:#}");
+                        SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
+                    }
+                };
                 return conn
-                    .send(ErrorResponse::fatal(
-                        SqlState::INVALID_PASSWORD,
-                        err.to_string(),
-                    ))
+                    .send(ErrorResponse::fatal(sql_state, err.to_string()))
                     .await;
             }
         };
@@ -1085,7 +1104,7 @@ async fn cancel_request(
 }
 
 struct HttpsBalancer {
-    resolver: Arc<StubResolver>,
+    resolver: Arc<TenantDnsResolver>,
     tls: Option<ReloadingSslContext>,
     resolve_template: Arc<str>,
     port: u16,
@@ -1096,89 +1115,52 @@ struct HttpsBalancer {
 
 impl HttpsBalancer {
     async fn resolve(
-        resolver: &StubResolver,
+        resolver: &TenantDnsResolver,
         resolve_template: &str,
         port: u16,
         servername: Option<&str>,
     ) -> Result<ResolvedAddr, anyhow::Error> {
-        let addr = match &servername {
-            Some(servername) => resolve_template.replace("{}", servername),
-            None => resolve_template.to_string(),
+        let (addr, tenant) = match servername {
+            Some(sni) => resolver.resolve_sni(resolve_template, port, sni).await?,
+            None => {
+                // Without SNI, resolve the template as is. Not expected for
+                // HTTPS in practice.
+                debug!("https hostname (no SNI): {}:{}", resolve_template, port);
+                resolver.resolve(resolve_template, port).await?
+            }
         };
-        debug!("https address: {addr}");
-
-        // When we lookup the address using SNI, we get a hostname (`3dl07g8zmj91pntk4eo9cfvwe` for
-        // example), which you convert into a different form for looking up the environment address
-        // `blncr-3dl07g8zmj91pntk4eo9cfvwe`. When you do a DNS lookup in kubernetes for
-        // `blncr-3dl07g8zmj91pntk4eo9cfvwe`, you get a CNAME response pointing at environmentd
-        // `environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local`. This
-        // is of the form `<service>.<namespace>.svc.cluster.local`. That `<namespace>` is the same
-        // as the environment name, and is based on the tenant ID. `environment-<tenant_id>-<index>`
-        // We currently only support a single environment per tenant in a region, so `<index>` is
-        // always 0. Do not rely on this ending in `-0` so in the future multiple envds are
-        // supported.
-
-        // Attempt to get a tenant.
-        let tenant = resolver.tenant(&addr).await;
-
-        // Now do the regular ip lookup, regardless of if there was a CNAME.
-        let envd_addr = lookup(&format!("{addr}:{port}")).await?;
 
         Ok(ResolvedAddr {
-            addr: envd_addr,
+            addr,
             password: None,
             tenant,
         })
     }
 }
 
-trait StubResolverExt {
-    async fn tenant(&self, addr: &str) -> Option<String>;
-}
-
-impl StubResolverExt for StubResolver {
-    /// Finds the tenant of a DNS address. Errors or lack of cname resolution here are ok, because
-    /// this is only used for metrics.
-    async fn tenant(&self, addr: &str) -> Option<String> {
-        let Ok(dname) = Name::<Vec<_>>::from_str(addr) else {
-            return None;
-        };
-        debug!("resolving tenant for {:?}", addr);
-        // Lookup the CNAME. If there's a CNAME, find the tenant.
-        let lookup = self.query((dname, Rtype::CNAME)).await;
-        if let Ok(lookup) = lookup {
-            if let Ok(answer) = lookup.answer() {
-                let res = answer.limit_to::<AllRecordData<_, _>>();
-                for record in res {
-                    let Ok(record) = record else {
-                        continue;
-                    };
-                    if record.rtype() != Rtype::CNAME {
-                        continue;
-                    }
-                    let cname = record.data();
-                    let cname = cname.to_string();
-                    debug!("cname: {cname}");
-                    return extract_tenant_from_cname(&cname);
-                }
-            }
-        }
-        None
-    }
-}
-
-/// Extracts the tenant from a CNAME.
+/// Extracts the tenant ID from an environmentd CNAME target.
+///
+/// The CNAME points at the environmentd service, of the form
+/// `<service>.<namespace>.svc.cluster.local`, e.g.
+/// `environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local`.
+/// The `<namespace>` is the environment name `environment-<tenant_id>-<index>`,
+/// where `<tenant_id>` is the tenant's UUID and `<index>` is the environment
+/// generation.
+///
+/// NOTE: `<index>` is currently always 0, since a tenant has one environment
+/// per region, but this does not rely on that so that multiple environments
+/// per tenant can be supported later.
 fn extract_tenant_from_cname(cname: &str) -> Option<String> {
     let mut parts = cname.split('.');
     let _service = parts.next();
     let Some(namespace) = parts.next() else {
         return None;
     };
-    // Trim off the starting `environmentd-`.
+    // Trim off the starting `environment-`.
     let Some((_, namespace)) = namespace.split_once('-') else {
         return None;
     };
-    // Trim off the ending `-0` (or some other number).
+    // Trim off the ending `-<index>`.
     let Some((tenant, _)) = namespace.rsplit_once('-') else {
         return None;
     };
@@ -1189,6 +1171,16 @@ fn extract_tenant_from_cname(cname: &str) -> Option<String> {
         return None;
     };
     Some(tenant.to_string())
+}
+
+/// Strips the surrounding brackets from an IPv6 host literal, e.g. `[::1]`
+/// becomes `::1`. Leaves other hosts unchanged. This lets a bracketed IPv6
+/// literal in an address template parse as an `IpAddr` and resolve, matching
+/// what `tokio::net::lookup_host` accepts.
+fn strip_ipv6_brackets(host: &str) -> &str {
+    host.strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host)
 }
 
 impl mz_server_core::Server for HttpsBalancer {
@@ -1321,9 +1313,10 @@ impl mz_server_core::Server for HttpsBalancer {
     }
 }
 
+/// Template for constructing the destination hostname from a TLS SNI
+/// servername. `{}` is replaced with the first label of the servername.
 #[derive(Debug)]
-pub struct SniResolver {
-    pub resolver: StubResolver,
+pub struct SniTemplate {
     pub template: String,
     pub port: u16,
 }
@@ -1332,29 +1325,70 @@ trait ClientStream: AsyncRead + AsyncWrite + Unpin + Send {}
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> ClientStream for T {}
 
 #[derive(Debug)]
-pub enum Resolver {
+pub enum BalancerResolver {
     Static(String),
-    MultiTenant(FronteggResolver, Option<SniResolver>),
+    MultiTenant {
+        dns: Arc<TenantDnsResolver>,
+        frontegg: FronteggResolver,
+        sni: Option<SniTemplate>,
+    },
 }
 
-impl Resolver {
+/// An error resolving a connection's destination.
+///
+/// The `Display` of this error is sent to unauthenticated clients, so it must
+/// not contain internal details such as hostnames. Those belong in the source
+/// error attached to each variant, which is only logged.
+#[derive(Debug, thiserror::Error)]
+enum ResolveError {
+    #[error("invalid password")]
+    InvalidPassword,
+    /// A failure caused by client input, e.g. a bogus SNI that does not resolve
+    /// or a protocol violation. An unauthenticated client can trigger these at
+    /// will, so they are logged at `warn!`, not `error!`, to avoid making
+    /// client noise look like server faults and spamming the error log.
+    #[error("internal error")]
+    Client(#[source] anyhow::Error),
+    /// A server-side fault.
+    #[error("internal error")]
+    Internal(#[from] anyhow::Error),
+}
+
+impl From<io::Error> for ResolveError {
+    fn from(e: io::Error) -> Self {
+        ResolveError::Internal(e.into())
+    }
+}
+
+impl BalancerResolver {
+    /// Returns a clone of the shared DNS resolver if in multi-tenant mode.
+    /// This allows sharing the resolver with other components like HttpsBalancer.
+    pub fn shared_dns(&self) -> Option<Arc<TenantDnsResolver>> {
+        match self {
+            BalancerResolver::Static(_) => None,
+            BalancerResolver::MultiTenant { dns, .. } => Some(Arc::clone(dns)),
+        }
+    }
+
     async fn resolve<A>(
         &self,
         conn: &mut FramedConn<A>,
         user: &str,
         metrics: &ServerMetrics,
-    ) -> Result<ResolvedAddr, anyhow::Error>
+    ) -> Result<ResolvedAddr, ResolveError>
     where
         A: AsyncRead + AsyncWrite + Unpin,
     {
         match self {
-            Resolver::MultiTenant(
-                FronteggResolver {
-                    auth,
-                    addr_template,
-                },
-                sni_resolver,
-            ) => {
+            BalancerResolver::MultiTenant {
+                dns: dns_resolver,
+                frontegg:
+                    FronteggResolver {
+                        auth,
+                        addr_template,
+                    },
+                sni: sni_resolver,
+            } => {
                 let servername = match conn.inner() {
                     Conn::Ssl(ssl_stream) => {
                         ssl_stream.ssl().servername(NameType::HOST_NAME).map(|sn| {
@@ -1367,23 +1401,15 @@ impl Resolver {
                     Conn::Unencrypted(_) => None,
                 };
                 let has_sni = servername.is_some();
-                // We found an SNi
-                let resolved_addr = match (servername, sni_resolver) {
-                    (
-                        Some(servername),
-                        Some(SniResolver {
-                            resolver: stub_resolver,
-                            template: sni_addr_template,
-                            port,
-                        }),
-                    ) => {
-                        let sni_addr = sni_addr_template.replace("{}", servername);
-                        let tenant = stub_resolver.tenant(&sni_addr).await;
-                        let sni_addr = format!("{sni_addr}:{port}");
-                        let addr = lookup(&sni_addr).await?;
-                        if tenant.is_some() {
-                            debug!("SNI header found for tenant {:?}", tenant);
-                        }
+                let resolved_addr = match (servername, sni_resolver.as_ref()) {
+                    (Some(servername), Some(SniTemplate { template, port })) => {
+                        // The servername is client-supplied, so a resolution
+                        // failure here is a client error, not a server fault.
+                        let (addr, tenant) = dns_resolver
+                            .resolve_sni(template, *port, servername)
+                            .await
+                            .map_err(ResolveError::Client)?;
+                        debug!("pgwire SNI resolved tenant: {:?}", tenant);
                         ResolvedAddr {
                             addr,
                             password: None,
@@ -1396,7 +1422,11 @@ impl Resolver {
                         conn.flush().await?;
                         let password = match conn.recv().await? {
                             Some(FrontendMessage::Password { password }) => password,
-                            _ => anyhow::bail!("expected Password message"),
+                            _ => {
+                                return Err(ResolveError::Client(anyhow::anyhow!(
+                                    "expected Password message"
+                                )));
+                            }
                         };
 
                         // balancerd only needs the validated tenant_id to route
@@ -1407,22 +1437,27 @@ impl Resolver {
                             Ok((auth_session, _)) => auth_session,
                             Err(e) => {
                                 warn!("pgwire connection failed authentication: {}", e);
-                                // TODO: fix error codes.
-                                anyhow::bail!("invalid password");
+                                return Err(ResolveError::InvalidPassword);
                             }
                         };
 
-                        let addr =
+                        let hostname_with_port =
                             addr_template.replace("{}", &auth_session.tenant_id().to_string());
-                        let addr = lookup(&addr).await?;
-                        let tenant = Some(auth_session.tenant_id().to_string());
-                        if tenant.is_some() {
-                            debug!("SNI header NOT found for tenant {:?}", tenant);
-                        }
+                        let (hostname, port_str) = hostname_with_port
+                            .rsplit_once(':')
+                            .ok_or_else(|| anyhow::anyhow!("port required in addr_template"))?;
+                        let port: u16 = port_str.parse().with_context(|| {
+                            format!("invalid port in addr_template: {}", port_str)
+                        })?;
+                        // The tenant is already known from authentication, so
+                        // skip the CNAME lookup that resolve() would do.
+                        let addr = dns_resolver.resolve_addr(hostname, port).await?;
+                        let tenant = auth_session.tenant_id().to_string();
+                        debug!("Frontegg resolved tenant: {}", tenant);
                         ResolvedAddr {
                             addr,
                             password: Some(password),
-                            tenant,
+                            tenant: Some(tenant),
                         }
                     }
                 };
@@ -1435,8 +1470,13 @@ impl Resolver {
 
                 Ok(resolved_addr)
             }
-            Resolver::Static(addr) => {
-                let addr = lookup(addr).await?;
+            BalancerResolver::Static(addr) => {
+                // We don't want any caching here so we just use the standard
+                // tokio resolver.
+                let Some(addr) = tokio::net::lookup_host(addr).await?.next() else {
+                    return Err(anyhow::anyhow!("{addr} did not resolve to any addresses").into());
+                };
+
                 Ok(ResolvedAddr {
                     addr,
                     password: None,
@@ -1447,15 +1487,138 @@ impl Resolver {
     }
 }
 
-/// Returns the first IP address resolved from the provided hostname.
-async fn lookup(name: &str) -> Result<SocketAddr, anyhow::Error> {
-    let mut addrs = tokio::net::lookup_host(name).await?;
-    match addrs.next() {
-        Some(addr) => Ok(addr),
-        None => {
-            error!("{name} did not resolve to any addresses");
-            anyhow::bail!("internal error")
+/// Creates a resolver from the system DNS configuration.
+///
+/// Caching is delegated to the infrastructure (node-local DNS), so this
+/// resolver does no caching of its own. Fails if the system DNS configuration
+/// cannot be read. We must not fall back to hickory's default config (Google
+/// public DNS) here, that would leak internal hostnames to an external party
+/// and could not resolve them anyway.
+fn create_resolver() -> Result<TokioResolver, anyhow::Error> {
+    let (config, mut opts) = read_system_conf().context("reading system DNS configuration")?;
+    opts.cache_size = 0;
+    // Query A records first and AAAA only on failure, rather than both.
+    opts.ip_strategy = LookupIpStrategy::Ipv4thenIpv6;
+
+    Ok(
+        Resolver::builder_with_config(config, TokioConnectionProvider::default())
+            .with_options(opts)
+            .build(),
+    )
+}
+
+/// Resolves tenant hostnames for pgwire and HTTPS routing.
+///
+/// Caching is delegated to the infrastructure (node-local DNS), so every
+/// lookup issues a query. CNAMEs are resolved separately from A records only
+/// because the CNAME carries the tenant, not for caching reasons.
+#[derive(Debug)]
+pub struct TenantDnsResolver {
+    resolver: TokioResolver,
+}
+
+impl TenantDnsResolver {
+    /// Creates a new resolver. Fails if the system DNS configuration cannot be
+    /// read.
+    pub fn new() -> Result<Self, anyhow::Error> {
+        Ok(Self {
+            resolver: create_resolver()?,
+        })
+    }
+
+    /// Resolves the CNAME a hostname points at, if any.
+    async fn resolve_cname(&self, hostname: &str) -> Option<String> {
+        match self.resolver.lookup(hostname, RecordType::CNAME).await {
+            Ok(cname_response) => {
+                if let Some(cname_record) = cname_response.iter().next() {
+                    if let Some(cname_data) = cname_record.as_cname() {
+                        let cname = cname_data.to_string();
+                        debug!("CNAME for {}: {}", hostname, cname);
+                        return Some(cname);
+                    }
+                }
+                None
+            }
+            Err(e) => {
+                debug!("CNAME lookup failed for {}: {}", hostname, e);
+                None
+            }
         }
+    }
+
+    /// Resolves the A records for a hostname.
+    async fn resolve_a(&self, hostname: &str) -> Result<LookupIp, anyhow::Error> {
+        self.resolver
+            .lookup_ip(hostname)
+            .await
+            .with_context(|| format!("resolving A records for {}", hostname))
+    }
+
+    /// Resolves the environment address for a TLS SNI servername.
+    ///
+    /// `servername` is the first label of the SNI host, e.g.
+    /// `3dl07g8zmj91pntk4eo9cfvwe`. Substituting it into `template` (e.g.
+    /// `blncr-{}`) yields a Kubernetes hostname like
+    /// `blncr-3dl07g8zmj91pntk4eo9cfvwe`, which resolves via a CNAME to the
+    /// environmentd service, e.g.
+    /// `environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local`.
+    /// The tenant is extracted from that CNAME. See
+    /// `extract_tenant_from_cname`.
+    pub async fn resolve_sni(
+        &self,
+        template: &str,
+        port: u16,
+        servername: &str,
+    ) -> Result<(SocketAddr, Option<String>), anyhow::Error> {
+        let hostname = template.replace("{}", servername);
+        debug!("SNI hostname: {}", hostname);
+        self.resolve(&hostname, port).await
+    }
+
+    /// Resolves the address for a hostname, skipping CNAME resolution and
+    /// tenant extraction. Use when the tenant is already known.
+    async fn resolve_addr(&self, host: &str, port: u16) -> Result<SocketAddr, anyhow::Error> {
+        let host = strip_ipv6_brackets(host);
+        // IP literals need no resolution. Resolving them through hickory
+        // would walk the search domain list first when ndots is large, as it
+        // is in Kubernetes.
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return Ok(SocketAddr::new(ip, port));
+        }
+        Self::first_addr(self.resolve_a(host).await?, port)
+    }
+
+    /// Resolves the address and tenant from a hostname and port.
+    ///
+    /// The tenant is extracted from the CNAME if the hostname points at one.
+    async fn resolve(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> Result<(SocketAddr, Option<String>), anyhow::Error> {
+        let host = strip_ipv6_brackets(host);
+        // IP literals need no resolution and carry no tenant CNAME.
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return Ok((SocketAddr::new(ip, port), None));
+        }
+
+        // The CNAME carries the tenant, so resolve it separately to extract it.
+        let (ips, tenant) = if let Some(cname) = self.resolve_cname(host).await {
+            let tenant = extract_tenant_from_cname(&cname);
+            (self.resolve_a(&cname).await?, tenant)
+        } else {
+            (self.resolve_a(host).await?, None)
+        };
+
+        Ok((Self::first_addr(ips, port)?, tenant))
+    }
+
+    /// Returns the first resolved IP as a socket address.
+    fn first_addr(ips: LookupIp, port: u16) -> Result<SocketAddr, anyhow::Error> {
+        ips.iter()
+            .next()
+            .map(|ip| SocketAddr::new(ip, port))
+            .ok_or_else(|| anyhow::anyhow!("no A records found in DNS response"))
     }
 }
 
@@ -1482,6 +1645,12 @@ mod tests {
             ("", None),
             (
                 "environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local",
+                Some("58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3"),
+            ),
+            (
+                // Trailing dot from an absolute DNS name, as returned by the
+                // resolver.
+                "environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local.",
                 Some("58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3"),
             ),
             (
@@ -1528,5 +1697,16 @@ mod tests {
                 "{name} got {cname:?} expected {expect:?}"
             );
         }
+    }
+
+    #[mz_ore::test]
+    fn test_strip_ipv6_brackets() {
+        assert_eq!(strip_ipv6_brackets("[::1]"), "::1");
+        assert_eq!(strip_ipv6_brackets("[2001:db8::1]"), "2001:db8::1");
+        // Hosts without a matched bracket pair are left untouched.
+        assert_eq!(strip_ipv6_brackets("127.0.0.1"), "127.0.0.1");
+        assert_eq!(strip_ipv6_brackets("host.example.com"), "host.example.com");
+        assert_eq!(strip_ipv6_brackets("[unclosed"), "[unclosed");
+        assert_eq!(strip_ipv6_brackets("unopened]"), "unopened]");
     }
 }

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -672,6 +672,10 @@ impl PgwireBalancer {
                         warn!("client-caused connection failure: {details:#}");
                         SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
                     }
+                    ResolveError::Upstream(details) => {
+                        warn!("upstream not available: {details:#}");
+                        SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
+                    }
                     ResolveError::Internal(details) => {
                         error!("resolving connection destination: {details:#}");
                         SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION
@@ -1343,12 +1347,20 @@ pub enum BalancerResolver {
 enum ResolveError {
     #[error("invalid password")]
     InvalidPassword,
-    /// A failure caused by client input, e.g. a bogus SNI that does not resolve
-    /// or a protocol violation. An unauthenticated client can trigger these at
-    /// will, so they are logged at `warn!`, not `error!`, to avoid making
-    /// client noise look like server faults and spamming the error log.
+    /// A client protocol violation, e.g. sending the wrong message during
+    /// startup. An unauthenticated client can trigger these at will, so they
+    /// are logged at `warn!`, not `error!`, to avoid making client noise look
+    /// like server faults and spamming the error log.
     #[error("internal error")]
     Client(#[source] anyhow::Error),
+    /// The tenant's upstream backend could not be reached, e.g. its hostname
+    /// did not resolve. Reported to the client with a distinct, non-leaking
+    /// message rather than a generic internal error, so a down environment is
+    /// not mistaken for a balancerd bug. Logged at `warn!`: a bogus SNI reaches
+    /// this from an unauthenticated client, and a genuinely down environment is
+    /// an operational condition, not a balancerd fault.
+    #[error("upstream server not available")]
+    Upstream(#[source] anyhow::Error),
     /// A server-side fault.
     #[error("internal error")]
     Internal(#[from] anyhow::Error),
@@ -1403,12 +1415,13 @@ impl BalancerResolver {
                 let has_sni = servername.is_some();
                 let resolved_addr = match (servername, sni_resolver.as_ref()) {
                     (Some(servername), Some(SniTemplate { template, port })) => {
-                        // The servername is client-supplied, so a resolution
-                        // failure here is a client error, not a server fault.
+                        // A resolution failure here means the tenant's backend
+                        // is unreachable (or the client sent a bogus SNI). Not
+                        // a server fault.
                         let (addr, tenant) = dns_resolver
                             .resolve_sni(template, *port, servername)
                             .await
-                            .map_err(ResolveError::Client)?;
+                            .map_err(ResolveError::Upstream)?;
                         debug!("pgwire SNI resolved tenant: {:?}", tenant);
                         ResolvedAddr {
                             addr,
@@ -1450,8 +1463,12 @@ impl BalancerResolver {
                             format!("invalid port in addr_template: {}", port_str)
                         })?;
                         // The tenant is already known from authentication, so
-                        // skip the CNAME lookup that resolve() would do.
-                        let addr = dns_resolver.resolve_addr(hostname, port).await?;
+                        // skip the CNAME lookup that resolve() would do. A
+                        // failure here means the tenant's backend is unreachable.
+                        let addr = dns_resolver
+                            .resolve_addr(hostname, port)
+                            .await
+                            .map_err(ResolveError::Upstream)?;
                         let tenant = auth_session.tenant_id().to_string();
                         debug!("Frontegg resolved tenant: {}", tenant);
                         ResolvedAddr {

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -18,12 +18,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
-use domain::resolv::StubResolver;
 use futures::StreamExt;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use mz_balancerd::{
-    BUILD_INFO, BalancerConfig, BalancerService, CancellationResolver, FronteggResolver, Resolver,
-    SniResolver,
+    BUILD_INFO, BalancerConfig, BalancerResolver, BalancerService, CancellationResolver,
+    FronteggResolver, SniTemplate, TenantDnsResolver,
 };
 use mz_environmentd::test_util::{self, Ca, make_pg_tls};
 use mz_frontegg_auth::{
@@ -144,21 +143,23 @@ async fn test_balancer() {
 
     let resolvers = vec![
         (
-            Resolver::Static(envd_server.sql_local_addr().to_string()),
+            BalancerResolver::Static(envd_server.sql_local_addr().to_string()),
             CancellationResolver::Static(envd_server.sql_local_addr().to_string()),
         ),
         (
-            Resolver::MultiTenant(
-                FronteggResolver {
+            BalancerResolver::MultiTenant {
+                dns: Arc::new(
+                    TenantDnsResolver::new().expect("system DNS configuration is readable"),
+                ),
+                frontegg: FronteggResolver {
                     auth: frontegg_auth,
                     addr_template: envd_server.sql_local_addr().to_string(),
                 },
-                Some(SniResolver {
-                    resolver: StubResolver::new(),
+                sni: Some(SniTemplate {
                     template: envd_server.sql_local_addr().ip().to_string(),
                     port: envd_server.sql_local_addr().port(),
                 }),
-            ),
+            },
             CancellationResolver::Directory(cancel_dir.path().to_owned()),
         ),
     ];
@@ -180,7 +181,7 @@ async fn test_balancer() {
     for (resolver, cancellation_resolver) in resolvers {
         let (mut reload_tx, reload_rx) = futures::channel::mpsc::channel(1);
         let ticker = Box::pin(reload_rx);
-        let is_multi_tenant_resolver = matches!(resolver, Resolver::MultiTenant(_, _));
+        let is_multi_tenant_resolver = matches!(resolver, BalancerResolver::MultiTenant { .. });
         let balancer_cfg = BalancerConfig::new(
             &BUILD_INFO,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
@@ -229,6 +230,30 @@ async fn test_balancer() {
 
         let res: i32 = pg_client.query_one("SELECT 2", &[]).await.unwrap().get(0);
         assert_eq!(res, 2);
+
+        // A wrong password on the Frontegg (multi-tenant) path must fail with
+        // SQLSTATE 28P01 and the exact opaque message "invalid password", with
+        // no internal detail leaked to the client.
+        if is_multi_tenant_resolver {
+            let wrong_password = format!("mzp_{}{}", Uuid::new_v4(), Uuid::new_v4());
+            let bad_conn_str = format!(
+                "user={frontegg_user} password={wrong_password} host={} port={} sslmode=require",
+                balancer_pgwire_listen.ip(),
+                balancer_pgwire_listen.port()
+            );
+            let err = match tokio_postgres::connect(&bad_conn_str, tls.clone()).await {
+                Ok(_) => panic!("connection with wrong password should have failed"),
+                Err(e) => e,
+            };
+            let db_err = err
+                .as_db_error()
+                .expect("expected a database error from the server");
+            assert_eq!(
+                db_err.code(),
+                &tokio_postgres::error::SqlState::INVALID_PASSWORD
+            );
+            assert_eq!(db_err.message(), "invalid password");
+        }
 
         // Assert cancellation is propagated.
         let cancel = pg_client.cancel_token();

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -26,6 +26,7 @@ from typing import Any
 from urllib.parse import quote
 
 import pg8000
+import psycopg
 import requests
 from pg8000.exceptions import InterfaceError
 from psycopg import Cursor
@@ -125,12 +126,19 @@ SERVICES = [
             # balancerd.
             DnsmasqEntry(
                 type="cname",
-                key="materialized",
+                key="sni.test",
                 value="environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local",
             ),
             DnsmasqEntry(
                 type="address",
                 key="environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local",
+                value=STATIC_IPS["materialized"],
+            ),
+            # An A record with no CNAME, to exercise the resolver's no-CNAME
+            # fallback path (see workflow_pgwire_with_sni_no_cname).
+            DnsmasqEntry(
+                type="address",
+                key="direct.test",
                 value=STATIC_IPS["materialized"],
             ),
         ],
@@ -147,8 +155,8 @@ SERVICES = [
             "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
             f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
             f"--frontegg-admin-role={ADMIN_ROLE}",
-            "--https-sni-resolver-template=materialized:6876",
-            "--pgwire-sni-resolver-template=materialized:6875",
+            "--https-sni-resolver-template=sni.test:6876",
+            "--pgwire-sni-resolver-template=sni.test:6875",
             "--tls-key=/secrets/balancerd.key",
             "--tls-cert=/secrets/balancerd.crt",
             "--internal-tls",
@@ -236,6 +244,29 @@ def sql_cursor(
         sslmode="require",
         startup_params=startup_params,
     )
+
+
+def sni_sql_cursor(
+    c: Composition, service="balancerd", email="u1@example.com"
+) -> Cursor:
+    """Connect so that the client sends TLS SNI, unlike sql_cursor.
+
+    libpq only sends SNI when host is a hostname, so connecting to 127.0.0.1
+    silently takes balancerd's Frontegg resolver path instead of the SNI
+    path. host=localhost supplies the SNI while hostaddr pins the TCP
+    connection to 127.0.0.1.
+    """
+    conn = psycopg.connect(
+        host="localhost",
+        hostaddr="127.0.0.1",
+        port=c.default_port(service),
+        user=email,
+        password=app_password(email),
+        dbname="materialize",
+        sslmode="require",
+    )
+    conn.autocommit = True
+    return conn.cursor()
 
 
 def pg8000_sql_cursor(
@@ -673,9 +704,8 @@ def workflow_user(c: Composition) -> None:
                 "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
                 f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
                 f"--frontegg-admin-role={ADMIN_ROLE}",
-                "--https-sni-resolver-template=materialized:6876",
-                # We want to use the frontegg resolver in this
-                "--pgwire-sni-resolver-template=materialized:6875",
+                "--https-sni-resolver-template=sni.test:6876",
+                "--pgwire-sni-resolver-template=sni.test:6875",
                 "--tls-key=/secrets/balancerd.key",
                 "--tls-cert=/secrets/balancerd.crt",
                 "--internal-tls",
@@ -773,10 +803,71 @@ def workflow_pgwire_with_sni(c: Composition) -> None:
         "materialized",
         Service("testdrive", idle=True),
     )
-    # We're going to run this using ssl and, notably, without frontegg mock.
-    # This should mean that we need to rely on SNI to do tenant resolution
-    cursor = sql_cursor(c)
+    # The cursor must send SNI for balancerd to take the SNI resolution path,
+    # and frontegg mock is not necessarily up, so Frontegg resolution cannot
+    # be relied on as a fallback.
+    cursor = sni_sql_cursor(c)
     cursor.execute("select 1;")
+    # The tenant is extracted from the CNAME behind the SNI template (see the
+    # dnsmasq entries).
+    assert_metrics(
+        c,
+        'mz_balancer_tenant_pgwire_sni_count{has_sni="true",tenant="58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3"}',
+    )
+
+
+def workflow_pgwire_with_sni_no_cname(c: Composition) -> None:
+    """Like workflow_pgwire_with_sni, but the SNI templates resolve directly
+    to an A record with no CNAME, exercising the resolver's no-CNAME fallback
+    path (no tenant can be extracted, but routing must still work).
+
+    This mirrors self-managed deployments, where orchestratord points the
+    resolver templates at plain Kubernetes services that resolve to A records
+    without a CNAME. It is also the degraded path in cloud when a CNAME
+    lookup transiently fails."""
+    with c.override(
+        Balancerd(
+            command=[
+                "--startup-log-filter=debug",
+                "service",
+                "--pgwire-listen-addr=0.0.0.0:6875",
+                "--https-listen-addr=0.0.0.0:6876",
+                "--internal-http-listen-addr=0.0.0.0:6878",
+                "--frontegg-resolver-template=materialized:6875",
+                "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
+                f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
+                f"--frontegg-admin-role={ADMIN_ROLE}",
+                "--https-sni-resolver-template=direct.test:6876",
+                "--pgwire-sni-resolver-template=direct.test:6875",
+                "--tls-key=/secrets/balancerd.key",
+                "--tls-cert=/secrets/balancerd.crt",
+                "--internal-tls",
+                "--tls-mode=require",
+                "--default-config=balancerd_inject_proxy_protocol_header_http=true",
+                # Nonsensical but we don't need cancellations here
+                "--cancellation-resolver-dir=/secrets/",
+            ],
+            depends_on=["test-certs"],
+            volumes=[
+                "secrets:/secrets",
+            ],
+            dns=[STATIC_IPS["dnsmasq"]],
+            networks={"balancerd": {"ipv4_address": STATIC_IPS["balancerd"]}},
+        ),
+    ):
+        c.up(
+            "balancerd",
+            "dnsmasq",
+            "materialized",
+            Service("testdrive", idle=True),
+        )
+        cursor = sni_sql_cursor(c)
+        cursor.execute("select 1;")
+        # Routing worked, but with no CNAME there is no tenant to extract.
+        assert_metrics(
+            c,
+            'mz_balancer_tenant_pgwire_sni_count{has_sni="true",tenant="unknown"}',
+        )
 
 
 def workflow_split_proxy_header(c: Composition) -> None:

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -682,9 +682,17 @@ def workflow_mz_not_running(c: Composition) -> None:
         sql_cursor(c)
         raise RuntimeError("connect() expected to fail")
     except OperationalError as e:
+        # With Mz down, balancerd cannot reach the upstream and reports an
+        # opaque error to the client (it does not leak the internal DNS or
+        # connection failure): "internal error" when the tenant hostname
+        # cannot be resolved, "upstream server not available" when it resolves
+        # but the connection is refused. The remaining strings are client-side
+        # failures that can occur depending on how the connection drops.
         assert any(
             expected in str(e)
             for expected in [
+                "internal error",
+                "upstream server not available",
                 "No route to host",
                 "Connection timed out",
                 "failure in name resolution",
@@ -692,7 +700,7 @@ def workflow_mz_not_running(c: Composition) -> None:
                 "Name or service not known",
                 "SSL connection has been closed unexpectedly",
             ]
-        )
+        ), f"unexpected error connecting with Mz down: {e}"
     except:
         raise RuntimeError("connect() threw an unexpected exception")
 

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -155,7 +155,11 @@ SERVICES = [
             "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
             f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
             f"--frontegg-admin-role={ADMIN_ROLE}",
-            "--https-sni-resolver-template=sni.test:6876",
+            # HTTPS resolves directly to materialized. The generic HTTPS tests
+            # (http, ip-forwarding) do not run dnsmasq, so this must resolve
+            # without the sni.test CNAME. Workflows that exercise SNI routing
+            # over pgwire start dnsmasq and rely on the pgwire template below.
+            "--https-sni-resolver-template=materialized:6876",
             "--pgwire-sni-resolver-template=sni.test:6875",
             "--tls-key=/secrets/balancerd.key",
             "--tls-cert=/secrets/balancerd.crt",

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -227,15 +227,22 @@ def grant_all_admin_user(c: Composition):
 
 
 # Assert that contains is present in balancer metrics.
+# Per-connection metrics (tx/rx) are only recorded once the proxied connection
+# closes, and there is a short delay between the client disconnecting and
+# balancerd recording them, so poll for a few seconds.
 def assert_metrics(c: Composition, contains: str):
-    result = c.exec(
-        "materialized",
-        "curl",
-        "http://balancerd:6878/metrics",
-        "-s",
-        capture=True,
-    )
-    assert contains in result.stdout
+    for _ in range(20):
+        result = c.exec(
+            "materialized",
+            "curl",
+            "http://balancerd:6878/metrics",
+            "-s",
+            capture=True,
+        )
+        if contains in result.stdout:
+            return
+        time.sleep(0.5)
+    raise AssertionError(f"{contains!r} not found in balancerd metrics")
 
 
 def sql_cursor(
@@ -727,9 +734,11 @@ def workflow_user(c: Composition) -> None:
         ),
     ):
         c.up("balancerd", "dnsmasq", "frontegg-mock", "materialized")
-        # Metrics aren't recorded until the connection has closed
-        # Non-admin user.
-        with contextlib.closing(sql_cursor(c, email=OTHER_USER)) as cursor:
+        # Non-admin user. Close the connection, not just the cursor: the tx/rx
+        # metrics are only recorded once balancerd finishes proxying, which
+        # happens when the client connection closes.
+        cursor = sql_cursor(c, email=OTHER_USER)
+        with contextlib.closing(cursor.connection):
             try:
                 cursor.execute("DROP DATABASE materialize CASCADE")
                 raise RuntimeError("execute() expected to fail")
@@ -740,7 +749,6 @@ def workflow_user(c: Composition) -> None:
 
             cursor.execute("SELECT current_user()")
             assert OTHER_USER in str(cursor.fetchall())
-            cursor.close()
 
         assert_metrics(c, 'mz_balancer_tenant_connection_active{source="pgwire"')
         assert_metrics(c, 'mz_balancer_tenant_connection_rx{source="pgwire"')

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -682,12 +682,12 @@ def workflow_mz_not_running(c: Composition) -> None:
         sql_cursor(c)
         raise RuntimeError("connect() expected to fail")
     except OperationalError as e:
-        # With Mz down, balancerd cannot reach the upstream and reports an
-        # opaque error to the client (it does not leak the internal DNS or
-        # connection failure): "internal error" when the tenant hostname
-        # cannot be resolved, "upstream server not available" when it resolves
-        # but the connection is refused. The remaining strings are client-side
-        # failures that can occur depending on how the connection drops.
+        # With Mz down, balancerd cannot reach the tenant's backend and reports
+        # it to the client as "upstream server not available" (a resolve
+        # failure and a refused connection both surface this way), without
+        # leaking the underlying DNS or connection error. The remaining strings
+        # are defensive fallbacks for client-side failures depending on how the
+        # connection drops.
         assert any(
             expected in str(e)
             for expected in [


### PR DESCRIPTION
Relands #33955 (Balancerd - refactor SNI route), which was reverted in #37570 to unblock a release. The refactor itself is sound; the revert was only to buy time to fix the balancerd nightly failures it exposed. This PR brings it back **with those fixes applied**.

The first commit un-reverts #37570; the rest are the fixes, each a separate commit for review.

## Fixes included

1. **`http` / `ip-forwarding`** — the refactor changed the default `--https-sni-resolver-template` to `sni.test`, which only resolves via the dnsmasq CNAME; these workflows don't run dnsmasq, so balancerd couldn't resolve the upstream and dropped the connection. Point the default HTTPS template back at `materialized` (resolvable via docker's embedded DNS). SNI routing stays covered over pgwire.

2. **`user`** — the workflow asserted the pgwire tenant `tx`/`rx` metrics but closed only the cursor, not the connection. Those metrics are recorded when the proxied connection closes, so they were never emitted. Close the connection, and poll in `assert_metrics` for the brief close-to-record window.

3. **`mz-not-running`** — the error-hardening made balancerd report an opaque message to clients on resolve/connect failure instead of the raw DNS error the test matched. Accept balancerd's hardened messages.

4. **UX: upstream failures** — when a tenant's backend can't be reached, balancerd reported a generic `"internal error"`, which reads like a balancerd bug rather than the environment being down. Report `"upstream server not available"` (already used for connection refusals) for resolve failures too, making the resolve- and connect-failure cases consistent. The message stays opaque, so no internal detail leaks.

The full balancerd nightly suite (`bin/mzcompose --find balancerd run default`) passes with these fixes.