### PR TITLE
sql: Bound custom type resolution depth and total work

### DIFF
--- a/misc/python/materialize/checks/all_checks/custom_type_resolution_bound.py
+++ b/misc/python/materialize/checks/all_checks/custom_type_resolution_bound.py
@@ -1,0 +1,76 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.mz_version import MzVersion
+
+# The version that introduced the custom-type resolution bound and the flag that
+# relaxes it while re-planning persisted catalog items.
+BOUND_INTRODUCED_IN = MzVersion.parse_mz("v26.34.0-dev")
+
+RELAX_BOUND = """
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET unsafe_enable_unbounded_custom_type_resolution = on
+""".strip()
+
+RESTORE_BOUND = """
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET unsafe_enable_unbounded_custom_type_resolution
+""".strip()
+
+
+class CustomTypeResolutionBound(Check):
+    """A wide custom record type that predates the custom-type resolution bound
+    must keep loading during bootstrap after upgrade, rather than crash-looping
+    environmentd when its persisted `create_sql` is re-planned by the stricter
+    planner. See SQL-514."""
+
+    def _create_wide_type(self) -> str:
+        # `d14` resolves to ~49k sub-type nodes, within the per-root node budget.
+        # `wide` holds three `d14` fields, so its resolved tree exceeds the
+        # budget in aggregate and a version that enforces the bound rejects
+        # creating it. It is therefore only plantable by a version that predates
+        # the bound, or with the bound relaxed.
+        lines = ["> CREATE TYPE d0 AS LIST (ELEMENT TYPE = int4)"]
+        for i in range(1, 15):
+            lines.append(f"> CREATE TYPE d{i} AS (a d{i - 1}, b d{i - 1})")
+        lines.append("> CREATE TYPE wide AS (a d14, b d14, c d14)")
+        return "\n".join(lines)
+
+    def initialize(self) -> Testdrive:
+        create = self._create_wide_type()
+        if self.base_version >= BOUND_INTRODUCED_IN:
+            # This version enforces the bound, so relax it to plant `wide`,
+            # mimicking a catalog written by a version that predates the bound.
+            body = f"{RELAX_BOUND}\n\n{create}\n\n{RESTORE_BOUND}"
+        else:
+            # This version predates the bound and stores `wide` without complaint.
+            body = create
+        return Testdrive(body)
+
+    def manipulate(self) -> list[Testdrive]:
+        # The type just needs to survive the upgrade phases in the catalog. The
+        # regression is that re-planning its `create_sql` during bootstrap fails
+        # the new bound and aborts the process.
+        check_present = "> SELECT name FROM mz_types WHERE name = 'wide'\nwide"
+        return [Testdrive(check_present), Testdrive(check_present)]
+
+    def validate(self) -> Testdrive:
+        # Reaching validation means every bootstrap in the scenario re-planned
+        # `wide` successfully. A normal session still applies the bound, so
+        # resolving the grandfathered type returns the graceful planning error
+        # rather than panicking.
+        return Testdrive(
+            "> SELECT name FROM mz_types WHERE name = 'wide'\n"
+            "wide\n"
+            "\n"
+            "! SELECT NULL::wide\n"
+            "contains: custom type is too complex to resolve\n"
+        )

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1159,7 +1159,7 @@ impl CatalogType<IdReference> {
                 // a fresh budget would let a wide record materialize an
                 // unbounded type tree here even though each field is individually
                 // within the bound.
-                let mut budget = query::TypeResolutionBudget::for_root();
+                let mut budget = query::TypeResolutionBudget::for_root(catalog);
                 for f in fields {
                     let name = f.name.clone();
                     let ty = budget.resolve_child(catalog, f.type_reference, &f.type_modifiers)?;

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1155,13 +1155,14 @@ impl CatalogType<IdReference> {
         match &self {
             CatalogType::Record { fields } => {
                 let mut desc = RelationDesc::builder();
+                // Share one budget across every field. Resolving each field with
+                // a fresh budget would let a wide record materialize an
+                // unbounded type tree here even though each field is individually
+                // within the bound.
+                let mut budget = query::TypeResolutionBudget::for_root();
                 for f in fields {
                     let name = f.name.clone();
-                    let ty = query::scalar_type_from_catalog(
-                        catalog,
-                        f.type_reference,
-                        &f.type_modifiers,
-                    )?;
+                    let ty = budget.resolve_child(catalog, f.type_reference, &f.type_modifiers)?;
                     // TODO: support plumbing `NOT NULL` constraints through
                     // `CREATE TYPE`.
                     let ty = ty.nullable(true);

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -6075,11 +6075,44 @@ pub fn scalar_type_from_sql(
     }
 }
 
+/// Maximum nesting depth of a custom type. A deeper type is rejected rather than
+/// recursed into, so a long `CREATE TYPE` chain (`l0 <- l1 <- ... <- lN`) cannot
+/// overflow the stack while resolving.
+const MAX_TYPE_NESTING_DEPTH: usize = 128;
+
+/// Maximum number of sub-type resolutions performed while resolving a single
+/// custom type. A record whose fields reference the same sub-type produces a
+/// type tree that is exponential in its depth (fields hold owned copies, not
+/// shared references), so bound the total work to reject such a type before it
+/// exhausts memory / CPU rather than after.
+const MAX_TYPE_RESOLUTION_NODES: usize = 100_000;
+
 pub fn scalar_type_from_catalog(
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,
     modifiers: &[i64],
 ) -> Result<SqlScalarType, PlanError> {
+    let mut budget = MAX_TYPE_RESOLUTION_NODES;
+    scalar_type_from_catalog_inner(catalog, id, modifiers, 0, &mut budget)
+}
+
+fn scalar_type_from_catalog_inner(
+    catalog: &dyn SessionCatalog,
+    id: CatalogItemId,
+    modifiers: &[i64],
+    depth: usize,
+    budget: &mut usize,
+) -> Result<SqlScalarType, PlanError> {
+    if depth > MAX_TYPE_NESTING_DEPTH {
+        sql_bail!(
+            "custom type nesting depth exceeds limit of {}",
+            MAX_TYPE_NESTING_DEPTH
+        );
+    }
+    *budget = match budget.checked_sub(1) {
+        Some(remaining) => remaining,
+        None => sql_bail!("custom type is too complex to resolve"),
+    };
     let entry = catalog.get_item(&id);
     let type_details = match entry.type_details() {
         Some(type_details) => type_details,
@@ -6178,19 +6211,25 @@ pub fn scalar_type_from_catalog(
             match t {
                 CatalogType::Array {
                     element_reference: element_id,
-                } => Ok(SqlScalarType::Array(Box::new(scalar_type_from_catalog(
-                    catalog,
-                    *element_id,
-                    modifiers,
-                )?))),
+                } => Ok(SqlScalarType::Array(Box::new(
+                    scalar_type_from_catalog_inner(
+                        catalog,
+                        *element_id,
+                        modifiers,
+                        depth + 1,
+                        budget,
+                    )?,
+                ))),
                 CatalogType::List {
                     element_reference: element_id,
                     element_modifiers,
                 } => Ok(SqlScalarType::List {
-                    element_type: Box::new(scalar_type_from_catalog(
+                    element_type: Box::new(scalar_type_from_catalog_inner(
                         catalog,
                         *element_id,
                         element_modifiers,
+                        depth + 1,
+                        budget,
                     )?),
                     custom_id: Some(id),
                 }),
@@ -6200,26 +6239,36 @@ pub fn scalar_type_from_catalog(
                     value_reference: value_id,
                     value_modifiers,
                 } => Ok(SqlScalarType::Map {
-                    value_type: Box::new(scalar_type_from_catalog(
+                    value_type: Box::new(scalar_type_from_catalog_inner(
                         catalog,
                         *value_id,
                         value_modifiers,
+                        depth + 1,
+                        budget,
                     )?),
                     custom_id: Some(id),
                 }),
                 CatalogType::Range {
                     element_reference: element_id,
                 } => Ok(SqlScalarType::Range {
-                    element_type: Box::new(scalar_type_from_catalog(catalog, *element_id, &[])?),
+                    element_type: Box::new(scalar_type_from_catalog_inner(
+                        catalog,
+                        *element_id,
+                        &[],
+                        depth + 1,
+                        budget,
+                    )?),
                 }),
                 CatalogType::Record { fields } => {
                     let scalars: Box<[(ColumnName, SqlColumnType)]> = fields
                         .iter()
                         .map(|f| {
-                            let scalar_type = scalar_type_from_catalog(
+                            let scalar_type = scalar_type_from_catalog_inner(
                                 catalog,
                                 f.type_reference,
                                 &f.type_modifiers,
+                                depth + 1,
+                                budget,
                             )?;
                             Ok((
                                 f.name.clone(),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -6092,8 +6092,32 @@ pub fn scalar_type_from_catalog(
     id: CatalogItemId,
     modifiers: &[i64],
 ) -> Result<SqlScalarType, PlanError> {
-    let mut budget = MAX_TYPE_RESOLUTION_NODES;
-    scalar_type_from_catalog_inner(catalog, id, modifiers, 0, &mut budget)
+    let (depth_limit, mut budget) = type_resolution_limits(catalog);
+    scalar_type_from_catalog_inner(catalog, id, modifiers, 0, depth_limit, &mut budget)
+}
+
+/// The `(nesting-depth, resolution-node)` limits to apply while resolving one
+/// root custom type. See [`MAX_TYPE_NESTING_DEPTH`] and
+/// [`MAX_TYPE_RESOLUTION_NODES`] for what each guards against.
+///
+/// The limits are lifted while re-planning a persisted catalog item. The
+/// `unsafe_enable_unbounded_custom_type_resolution` flag signals this, and
+/// `SystemVars::enable_for_item_parsing` force-enables it during bootstrap. A
+/// type that an earlier version already accepted resolves to a finite tree, so
+/// its persisted `create_sql` must keep re-planning after these limits were
+/// introduced. Rejecting such a grandfathered type during rehydration would
+/// turn a graceful planning error into a fatal bootstrap panic. A later
+/// resolution in a normal user session still applies the limits and returns the
+/// graceful error.
+fn type_resolution_limits(catalog: &dyn SessionCatalog) -> (usize, usize) {
+    if catalog
+        .system_vars()
+        .unsafe_enable_unbounded_custom_type_resolution()
+    {
+        (usize::MAX, usize::MAX)
+    } else {
+        (MAX_TYPE_NESTING_DEPTH, MAX_TYPE_RESOLUTION_NODES)
+    }
 }
 
 /// Bounds the total resolution work while resolving one root custom type into a
@@ -6112,17 +6136,23 @@ pub struct TypeResolutionBudget {
     /// Sub-type resolutions remaining before the root type is rejected as too
     /// complex.
     remaining: usize,
+    /// Nesting depth past which the root type is rejected. Shared by every
+    /// child so the whole root type is bounded consistently.
+    depth_limit: usize,
 }
 
 impl TypeResolutionBudget {
     /// Creates a budget for resolving one root type, charging the root node
     /// itself against the budget. Children resolved through
     /// [`TypeResolutionBudget::resolve_child`] begin at nesting depth one,
-    /// mirroring a direct [`scalar_type_from_catalog`] call.
-    pub fn for_root() -> TypeResolutionBudget {
+    /// mirroring a direct [`scalar_type_from_catalog`] call. The limits are
+    /// relaxed for grandfathered persisted items, see [`type_resolution_limits`].
+    pub fn for_root(catalog: &dyn SessionCatalog) -> TypeResolutionBudget {
+        let (depth_limit, budget) = type_resolution_limits(catalog);
         TypeResolutionBudget {
             // The root type counts as one node.
-            remaining: MAX_TYPE_RESOLUTION_NODES - 1,
+            remaining: budget.saturating_sub(1),
+            depth_limit,
         }
     }
 
@@ -6135,7 +6165,14 @@ impl TypeResolutionBudget {
         id: CatalogItemId,
         modifiers: &[i64],
     ) -> Result<SqlScalarType, PlanError> {
-        scalar_type_from_catalog_inner(catalog, id, modifiers, 1, &mut self.remaining)
+        scalar_type_from_catalog_inner(
+            catalog,
+            id,
+            modifiers,
+            1,
+            self.depth_limit,
+            &mut self.remaining,
+        )
     }
 }
 
@@ -6144,13 +6181,11 @@ fn scalar_type_from_catalog_inner(
     id: CatalogItemId,
     modifiers: &[i64],
     depth: usize,
+    depth_limit: usize,
     budget: &mut usize,
 ) -> Result<SqlScalarType, PlanError> {
-    if depth > MAX_TYPE_NESTING_DEPTH {
-        sql_bail!(
-            "custom type nesting depth exceeds limit of {}",
-            MAX_TYPE_NESTING_DEPTH
-        );
+    if depth > depth_limit {
+        sql_bail!("custom type nesting depth exceeds limit of {}", depth_limit);
     }
     *budget = match budget.checked_sub(1) {
         Some(remaining) => remaining,
@@ -6260,6 +6295,7 @@ fn scalar_type_from_catalog_inner(
                         *element_id,
                         modifiers,
                         depth + 1,
+                        depth_limit,
                         budget,
                     )?,
                 ))),
@@ -6272,6 +6308,7 @@ fn scalar_type_from_catalog_inner(
                         *element_id,
                         element_modifiers,
                         depth + 1,
+                        depth_limit,
                         budget,
                     )?),
                     custom_id: Some(id),
@@ -6287,6 +6324,7 @@ fn scalar_type_from_catalog_inner(
                         *value_id,
                         value_modifiers,
                         depth + 1,
+                        depth_limit,
                         budget,
                     )?),
                     custom_id: Some(id),
@@ -6299,6 +6337,7 @@ fn scalar_type_from_catalog_inner(
                         *element_id,
                         &[],
                         depth + 1,
+                        depth_limit,
                         budget,
                     )?),
                 }),
@@ -6311,6 +6350,7 @@ fn scalar_type_from_catalog_inner(
                                 f.type_reference,
                                 &f.type_modifiers,
                                 depth + 1,
+                                depth_limit,
                                 budget,
                             )?;
                             Ok((

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -6096,6 +6096,49 @@ pub fn scalar_type_from_catalog(
     scalar_type_from_catalog_inner(catalog, id, modifiers, 0, &mut budget)
 }
 
+/// Bounds the total resolution work while resolving one root custom type into a
+/// `SqlScalarType`. A single budget must span the entire root type: a record's
+/// fields, and any containers nested within them, all draw from one shared pool.
+/// A type that is small field-by-field but enormous in aggregate is therefore
+/// still rejected. Resetting the budget per field would let a wide record of
+/// individually-cheap fields resolve into an unbounded type tree and exhaust
+/// memory, which is the denial of service this bound exists to prevent.
+///
+/// Use this when resolving a type that is being assembled from its parts (for
+/// example at `CREATE TYPE` time, before the root exists in the catalog) so that
+/// creation-time validation rejects exactly the types a later direct
+/// [`scalar_type_from_catalog`] call would reject.
+pub struct TypeResolutionBudget {
+    /// Sub-type resolutions remaining before the root type is rejected as too
+    /// complex.
+    remaining: usize,
+}
+
+impl TypeResolutionBudget {
+    /// Creates a budget for resolving one root type, charging the root node
+    /// itself against the budget. Children resolved through
+    /// [`TypeResolutionBudget::resolve_child`] begin at nesting depth one,
+    /// mirroring a direct [`scalar_type_from_catalog`] call.
+    pub fn for_root() -> TypeResolutionBudget {
+        TypeResolutionBudget {
+            // The root type counts as one node.
+            remaining: MAX_TYPE_RESOLUTION_NODES - 1,
+        }
+    }
+
+    /// Resolves a type referenced directly by the root (a record field, list
+    /// element, or map value) into a `SqlScalarType`, drawing from this shared
+    /// budget so that all such children of one root are bounded together.
+    pub fn resolve_child(
+        &mut self,
+        catalog: &dyn SessionCatalog,
+        id: CatalogItemId,
+        modifiers: &[i64],
+    ) -> Result<SqlScalarType, PlanError> {
+        scalar_type_from_catalog_inner(catalog, id, modifiers, 1, &mut self.remaining)
+    }
+}
+
 fn scalar_type_from_catalog_inner(
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -138,7 +138,7 @@ use crate::names::{
 use crate::normalize::{self, ident};
 use crate::plan::error::PlanError;
 use crate::plan::query::{
-    ExprContext, QueryLifetime, plan_expr, scalar_type_from_catalog, scalar_type_from_sql,
+    ExprContext, QueryLifetime, TypeResolutionBudget, plan_expr, scalar_type_from_sql,
 };
 use crate::plan::scope::Scope;
 use crate::plan::statement::ddl::connection::{INALTERABLE_OPTIONS, MUTUALLY_EXCLUSIVE_SETS};
@@ -4254,11 +4254,19 @@ pub fn plan_create_type(
     let create_sql = normalize::create_statement(scx, Statement::CreateType(stmt.clone()))?;
     let CreateTypeStatement { name, as_type, .. } = stmt;
 
+    // The type being created does not yet exist in the catalog, so its children
+    // (list element, map value, record fields) are validated directly. They all
+    // draw from one shared budget that also accounts for the root, so creation
+    // rejects exactly the types a later direct `scalar_type_from_catalog` call
+    // would reject. In particular a wide record whose fields are individually
+    // valid but collectively enormous is rejected here rather than materializing
+    // an unbounded type tree during sequencing.
     fn validate_data_type(
         scx: &StatementContext,
         data_type: ResolvedDataType,
         as_type: &str,
         key: &str,
+        budget: &mut TypeResolutionBudget,
     ) -> Result<(CatalogItemId, Vec<i64>), PlanError> {
         let (id, modifiers) = match data_type {
             ResolvedDataType::Named { id, modifiers, .. } => (id, modifiers),
@@ -4286,14 +4294,16 @@ pub fn plan_create_type(
                 bail_unsupported!("embedding char type in a list or map")
             }
             _ => {
-                // Validate that the modifiers are actually valid.
-                scalar_type_from_catalog(scx.catalog, id, &modifiers)?;
+                // Validate that the modifiers are actually valid, and that the
+                // referenced type resolves within the shared budget.
+                budget.resolve_child(scx.catalog, id, &modifiers)?;
 
                 Ok((id, modifiers))
             }
         }
     }
 
+    let mut budget = TypeResolutionBudget::for_root();
     let inner = match as_type {
         CreateTypeAs::List { options } => {
             let CreateTypeListOptionExtracted {
@@ -4302,7 +4312,8 @@ pub fn plan_create_type(
             } = CreateTypeListOptionExtracted::try_from(options)?;
             let element_type =
                 element_type.ok_or_else(|| sql_err!("ELEMENT TYPE option is required"))?;
-            let (id, modifiers) = validate_data_type(scx, element_type, "LIST ", "ELEMENT TYPE")?;
+            let (id, modifiers) =
+                validate_data_type(scx, element_type, "LIST ", "ELEMENT TYPE", &mut budget)?;
             CatalogType::List {
                 element_reference: id,
                 element_modifiers: modifiers,
@@ -4316,9 +4327,18 @@ pub fn plan_create_type(
             } = CreateTypeMapOptionExtracted::try_from(options)?;
             let key_type = key_type.ok_or_else(|| sql_err!("KEY TYPE option is required"))?;
             let value_type = value_type.ok_or_else(|| sql_err!("VALUE TYPE option is required"))?;
-            let (key_id, key_modifiers) = validate_data_type(scx, key_type, "MAP ", "KEY TYPE")?;
+            // A map's resolved type ignores the key (map keys are always text at
+            // runtime), so it is not part of the root's materialized tree and is
+            // validated under its own budget.
+            let (key_id, key_modifiers) = validate_data_type(
+                scx,
+                key_type,
+                "MAP ",
+                "KEY TYPE",
+                &mut TypeResolutionBudget::for_root(),
+            )?;
             let (value_id, value_modifiers) =
-                validate_data_type(scx, value_type, "MAP ", "VALUE TYPE")?;
+                validate_data_type(scx, value_type, "MAP ", "VALUE TYPE", &mut budget)?;
             CatalogType::Map {
                 key_reference: key_id,
                 key_modifiers,
@@ -4331,7 +4351,7 @@ pub fn plan_create_type(
             for column_def in column_defs {
                 let data_type = column_def.data_type;
                 let key = ident(column_def.name.clone());
-                let (id, modifiers) = validate_data_type(scx, data_type, "", &key)?;
+                let (id, modifiers) = validate_data_type(scx, data_type, "", &key, &mut budget)?;
                 fields.push(CatalogRecordField {
                     name: ColumnName::from(key.clone()),
                     type_reference: id,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4303,7 +4303,7 @@ pub fn plan_create_type(
         }
     }
 
-    let mut budget = TypeResolutionBudget::for_root();
+    let mut budget = TypeResolutionBudget::for_root(scx.catalog);
     let inner = match as_type {
         CreateTypeAs::List { options } => {
             let CreateTypeListOptionExtracted {
@@ -4335,7 +4335,7 @@ pub fn plan_create_type(
                 key_type,
                 "MAP ",
                 "KEY TYPE",
-                &mut TypeResolutionBudget::for_root(),
+                &mut TypeResolutionBudget::for_root(scx.catalog),
             )?;
             let (value_id, value_modifiers) =
                 validate_data_type(scx, value_type, "MAP ", "VALUE TYPE", &mut budget)?;

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1949,6 +1949,12 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
+        name: unsafe_enable_unbounded_custom_type_resolution,
+        desc: "resolving custom types without the depth and complexity limits that bound resolution work",
+        default: false,
+        enable_for_item_parsing: true,
+    },
+    {
         name: enable_within_timestamp_order_by_in_subscribe,
         desc: "`WITHIN TIMESTAMP ORDER BY ..`",
         default: false,

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -402,6 +402,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     unsafe_enable_table_check_constraint
     unsafe_enable_table_foreign_key
     unsafe_enable_table_keys
+    unsafe_enable_unbounded_custom_type_resolution
     unsafe_enable_unorchestrated_cluster_replicas
     unsafe_enable_unsafe_functions
     unsafe_enable_unstable_dependencies

--- a/test/sqllogictest/regressions.slt
+++ b/test/sqllogictest/regressions.slt
@@ -24,3 +24,452 @@ INSERT INTO t (a, b, c) VALUES (3, 'test', 1)
 # Regression test for database-issues#1555
 statement error Evaluation error: division by zero
 SELECT recip - 1 FROM (SELECT b, 1/a as recip, max(c) from t GROUP BY b, 1/a)
+
+# Regression test for a deep chain of custom LIST types: resolving it must
+# fail gracefully at a depth limit, not overflow the stack (STACK-4).
+statement ok
+CREATE TYPE l0 AS LIST (ELEMENT TYPE = int4)
+
+statement ok
+CREATE TYPE l1 AS LIST (ELEMENT TYPE = l0)
+
+statement ok
+CREATE TYPE l2 AS LIST (ELEMENT TYPE = l1)
+
+statement ok
+CREATE TYPE l3 AS LIST (ELEMENT TYPE = l2)
+
+statement ok
+CREATE TYPE l4 AS LIST (ELEMENT TYPE = l3)
+
+statement ok
+CREATE TYPE l5 AS LIST (ELEMENT TYPE = l4)
+
+statement ok
+CREATE TYPE l6 AS LIST (ELEMENT TYPE = l5)
+
+statement ok
+CREATE TYPE l7 AS LIST (ELEMENT TYPE = l6)
+
+statement ok
+CREATE TYPE l8 AS LIST (ELEMENT TYPE = l7)
+
+statement ok
+CREATE TYPE l9 AS LIST (ELEMENT TYPE = l8)
+
+statement ok
+CREATE TYPE l10 AS LIST (ELEMENT TYPE = l9)
+
+statement ok
+CREATE TYPE l11 AS LIST (ELEMENT TYPE = l10)
+
+statement ok
+CREATE TYPE l12 AS LIST (ELEMENT TYPE = l11)
+
+statement ok
+CREATE TYPE l13 AS LIST (ELEMENT TYPE = l12)
+
+statement ok
+CREATE TYPE l14 AS LIST (ELEMENT TYPE = l13)
+
+statement ok
+CREATE TYPE l15 AS LIST (ELEMENT TYPE = l14)
+
+statement ok
+CREATE TYPE l16 AS LIST (ELEMENT TYPE = l15)
+
+statement ok
+CREATE TYPE l17 AS LIST (ELEMENT TYPE = l16)
+
+statement ok
+CREATE TYPE l18 AS LIST (ELEMENT TYPE = l17)
+
+statement ok
+CREATE TYPE l19 AS LIST (ELEMENT TYPE = l18)
+
+statement ok
+CREATE TYPE l20 AS LIST (ELEMENT TYPE = l19)
+
+statement ok
+CREATE TYPE l21 AS LIST (ELEMENT TYPE = l20)
+
+statement ok
+CREATE TYPE l22 AS LIST (ELEMENT TYPE = l21)
+
+statement ok
+CREATE TYPE l23 AS LIST (ELEMENT TYPE = l22)
+
+statement ok
+CREATE TYPE l24 AS LIST (ELEMENT TYPE = l23)
+
+statement ok
+CREATE TYPE l25 AS LIST (ELEMENT TYPE = l24)
+
+statement ok
+CREATE TYPE l26 AS LIST (ELEMENT TYPE = l25)
+
+statement ok
+CREATE TYPE l27 AS LIST (ELEMENT TYPE = l26)
+
+statement ok
+CREATE TYPE l28 AS LIST (ELEMENT TYPE = l27)
+
+statement ok
+CREATE TYPE l29 AS LIST (ELEMENT TYPE = l28)
+
+statement ok
+CREATE TYPE l30 AS LIST (ELEMENT TYPE = l29)
+
+statement ok
+CREATE TYPE l31 AS LIST (ELEMENT TYPE = l30)
+
+statement ok
+CREATE TYPE l32 AS LIST (ELEMENT TYPE = l31)
+
+statement ok
+CREATE TYPE l33 AS LIST (ELEMENT TYPE = l32)
+
+statement ok
+CREATE TYPE l34 AS LIST (ELEMENT TYPE = l33)
+
+statement ok
+CREATE TYPE l35 AS LIST (ELEMENT TYPE = l34)
+
+statement ok
+CREATE TYPE l36 AS LIST (ELEMENT TYPE = l35)
+
+statement ok
+CREATE TYPE l37 AS LIST (ELEMENT TYPE = l36)
+
+statement ok
+CREATE TYPE l38 AS LIST (ELEMENT TYPE = l37)
+
+statement ok
+CREATE TYPE l39 AS LIST (ELEMENT TYPE = l38)
+
+statement ok
+CREATE TYPE l40 AS LIST (ELEMENT TYPE = l39)
+
+statement ok
+CREATE TYPE l41 AS LIST (ELEMENT TYPE = l40)
+
+statement ok
+CREATE TYPE l42 AS LIST (ELEMENT TYPE = l41)
+
+statement ok
+CREATE TYPE l43 AS LIST (ELEMENT TYPE = l42)
+
+statement ok
+CREATE TYPE l44 AS LIST (ELEMENT TYPE = l43)
+
+statement ok
+CREATE TYPE l45 AS LIST (ELEMENT TYPE = l44)
+
+statement ok
+CREATE TYPE l46 AS LIST (ELEMENT TYPE = l45)
+
+statement ok
+CREATE TYPE l47 AS LIST (ELEMENT TYPE = l46)
+
+statement ok
+CREATE TYPE l48 AS LIST (ELEMENT TYPE = l47)
+
+statement ok
+CREATE TYPE l49 AS LIST (ELEMENT TYPE = l48)
+
+statement ok
+CREATE TYPE l50 AS LIST (ELEMENT TYPE = l49)
+
+statement ok
+CREATE TYPE l51 AS LIST (ELEMENT TYPE = l50)
+
+statement ok
+CREATE TYPE l52 AS LIST (ELEMENT TYPE = l51)
+
+statement ok
+CREATE TYPE l53 AS LIST (ELEMENT TYPE = l52)
+
+statement ok
+CREATE TYPE l54 AS LIST (ELEMENT TYPE = l53)
+
+statement ok
+CREATE TYPE l55 AS LIST (ELEMENT TYPE = l54)
+
+statement ok
+CREATE TYPE l56 AS LIST (ELEMENT TYPE = l55)
+
+statement ok
+CREATE TYPE l57 AS LIST (ELEMENT TYPE = l56)
+
+statement ok
+CREATE TYPE l58 AS LIST (ELEMENT TYPE = l57)
+
+statement ok
+CREATE TYPE l59 AS LIST (ELEMENT TYPE = l58)
+
+statement ok
+CREATE TYPE l60 AS LIST (ELEMENT TYPE = l59)
+
+statement ok
+CREATE TYPE l61 AS LIST (ELEMENT TYPE = l60)
+
+statement ok
+CREATE TYPE l62 AS LIST (ELEMENT TYPE = l61)
+
+statement ok
+CREATE TYPE l63 AS LIST (ELEMENT TYPE = l62)
+
+statement ok
+CREATE TYPE l64 AS LIST (ELEMENT TYPE = l63)
+
+statement ok
+CREATE TYPE l65 AS LIST (ELEMENT TYPE = l64)
+
+statement ok
+CREATE TYPE l66 AS LIST (ELEMENT TYPE = l65)
+
+statement ok
+CREATE TYPE l67 AS LIST (ELEMENT TYPE = l66)
+
+statement ok
+CREATE TYPE l68 AS LIST (ELEMENT TYPE = l67)
+
+statement ok
+CREATE TYPE l69 AS LIST (ELEMENT TYPE = l68)
+
+statement ok
+CREATE TYPE l70 AS LIST (ELEMENT TYPE = l69)
+
+statement ok
+CREATE TYPE l71 AS LIST (ELEMENT TYPE = l70)
+
+statement ok
+CREATE TYPE l72 AS LIST (ELEMENT TYPE = l71)
+
+statement ok
+CREATE TYPE l73 AS LIST (ELEMENT TYPE = l72)
+
+statement ok
+CREATE TYPE l74 AS LIST (ELEMENT TYPE = l73)
+
+statement ok
+CREATE TYPE l75 AS LIST (ELEMENT TYPE = l74)
+
+statement ok
+CREATE TYPE l76 AS LIST (ELEMENT TYPE = l75)
+
+statement ok
+CREATE TYPE l77 AS LIST (ELEMENT TYPE = l76)
+
+statement ok
+CREATE TYPE l78 AS LIST (ELEMENT TYPE = l77)
+
+statement ok
+CREATE TYPE l79 AS LIST (ELEMENT TYPE = l78)
+
+statement ok
+CREATE TYPE l80 AS LIST (ELEMENT TYPE = l79)
+
+statement ok
+CREATE TYPE l81 AS LIST (ELEMENT TYPE = l80)
+
+statement ok
+CREATE TYPE l82 AS LIST (ELEMENT TYPE = l81)
+
+statement ok
+CREATE TYPE l83 AS LIST (ELEMENT TYPE = l82)
+
+statement ok
+CREATE TYPE l84 AS LIST (ELEMENT TYPE = l83)
+
+statement ok
+CREATE TYPE l85 AS LIST (ELEMENT TYPE = l84)
+
+statement ok
+CREATE TYPE l86 AS LIST (ELEMENT TYPE = l85)
+
+statement ok
+CREATE TYPE l87 AS LIST (ELEMENT TYPE = l86)
+
+statement ok
+CREATE TYPE l88 AS LIST (ELEMENT TYPE = l87)
+
+statement ok
+CREATE TYPE l89 AS LIST (ELEMENT TYPE = l88)
+
+statement ok
+CREATE TYPE l90 AS LIST (ELEMENT TYPE = l89)
+
+statement ok
+CREATE TYPE l91 AS LIST (ELEMENT TYPE = l90)
+
+statement ok
+CREATE TYPE l92 AS LIST (ELEMENT TYPE = l91)
+
+statement ok
+CREATE TYPE l93 AS LIST (ELEMENT TYPE = l92)
+
+statement ok
+CREATE TYPE l94 AS LIST (ELEMENT TYPE = l93)
+
+statement ok
+CREATE TYPE l95 AS LIST (ELEMENT TYPE = l94)
+
+statement ok
+CREATE TYPE l96 AS LIST (ELEMENT TYPE = l95)
+
+statement ok
+CREATE TYPE l97 AS LIST (ELEMENT TYPE = l96)
+
+statement ok
+CREATE TYPE l98 AS LIST (ELEMENT TYPE = l97)
+
+statement ok
+CREATE TYPE l99 AS LIST (ELEMENT TYPE = l98)
+
+statement ok
+CREATE TYPE l100 AS LIST (ELEMENT TYPE = l99)
+
+statement ok
+CREATE TYPE l101 AS LIST (ELEMENT TYPE = l100)
+
+statement ok
+CREATE TYPE l102 AS LIST (ELEMENT TYPE = l101)
+
+statement ok
+CREATE TYPE l103 AS LIST (ELEMENT TYPE = l102)
+
+statement ok
+CREATE TYPE l104 AS LIST (ELEMENT TYPE = l103)
+
+statement ok
+CREATE TYPE l105 AS LIST (ELEMENT TYPE = l104)
+
+statement ok
+CREATE TYPE l106 AS LIST (ELEMENT TYPE = l105)
+
+statement ok
+CREATE TYPE l107 AS LIST (ELEMENT TYPE = l106)
+
+statement ok
+CREATE TYPE l108 AS LIST (ELEMENT TYPE = l107)
+
+statement ok
+CREATE TYPE l109 AS LIST (ELEMENT TYPE = l108)
+
+statement ok
+CREATE TYPE l110 AS LIST (ELEMENT TYPE = l109)
+
+statement ok
+CREATE TYPE l111 AS LIST (ELEMENT TYPE = l110)
+
+statement ok
+CREATE TYPE l112 AS LIST (ELEMENT TYPE = l111)
+
+statement ok
+CREATE TYPE l113 AS LIST (ELEMENT TYPE = l112)
+
+statement ok
+CREATE TYPE l114 AS LIST (ELEMENT TYPE = l113)
+
+statement ok
+CREATE TYPE l115 AS LIST (ELEMENT TYPE = l114)
+
+statement ok
+CREATE TYPE l116 AS LIST (ELEMENT TYPE = l115)
+
+statement ok
+CREATE TYPE l117 AS LIST (ELEMENT TYPE = l116)
+
+statement ok
+CREATE TYPE l118 AS LIST (ELEMENT TYPE = l117)
+
+statement ok
+CREATE TYPE l119 AS LIST (ELEMENT TYPE = l118)
+
+statement ok
+CREATE TYPE l120 AS LIST (ELEMENT TYPE = l119)
+
+statement ok
+CREATE TYPE l121 AS LIST (ELEMENT TYPE = l120)
+
+statement ok
+CREATE TYPE l122 AS LIST (ELEMENT TYPE = l121)
+
+statement ok
+CREATE TYPE l123 AS LIST (ELEMENT TYPE = l122)
+
+statement ok
+CREATE TYPE l124 AS LIST (ELEMENT TYPE = l123)
+
+statement ok
+CREATE TYPE l125 AS LIST (ELEMENT TYPE = l124)
+
+statement ok
+CREATE TYPE l126 AS LIST (ELEMENT TYPE = l125)
+
+statement ok
+CREATE TYPE l127 AS LIST (ELEMENT TYPE = l126)
+
+statement ok
+CREATE TYPE l128 AS LIST (ELEMENT TYPE = l127)
+
+statement error custom type nesting depth exceeds limit
+CREATE TYPE l129 AS LIST (ELEMENT TYPE = l128)
+
+# Regression test for a record custom type whose fields reference the same
+# sub-type: its resolved type is exponential in depth, so resolution must be
+# rejected with a graceful error rather than hanging / OOMing (STACK-5).
+statement ok
+CREATE TYPE d0 AS LIST (ELEMENT TYPE = int4)
+
+statement ok
+CREATE TYPE d1 AS (a d0, b d0)
+
+statement ok
+CREATE TYPE d2 AS (a d1, b d1)
+
+statement ok
+CREATE TYPE d3 AS (a d2, b d2)
+
+statement ok
+CREATE TYPE d4 AS (a d3, b d3)
+
+statement ok
+CREATE TYPE d5 AS (a d4, b d4)
+
+statement ok
+CREATE TYPE d6 AS (a d5, b d5)
+
+statement ok
+CREATE TYPE d7 AS (a d6, b d6)
+
+statement ok
+CREATE TYPE d8 AS (a d7, b d7)
+
+statement ok
+CREATE TYPE d9 AS (a d8, b d8)
+
+statement ok
+CREATE TYPE d10 AS (a d9, b d9)
+
+statement ok
+CREATE TYPE d11 AS (a d10, b d10)
+
+statement ok
+CREATE TYPE d12 AS (a d11, b d11)
+
+statement ok
+CREATE TYPE d13 AS (a d12, b d12)
+
+statement ok
+CREATE TYPE d14 AS (a d13, b d13)
+
+statement ok
+CREATE TYPE d15 AS (a d14, b d14)
+
+statement ok
+CREATE TYPE d16 AS (a d15, b d15)
+
+statement error custom type is too complex to resolve
+CREATE TYPE d17 AS (a d16, b d16)

--- a/test/sqllogictest/regressions.slt
+++ b/test/sqllogictest/regressions.slt
@@ -493,3 +493,26 @@ d15
 # rather than materializing an unbounded type tree during sequencing.
 statement error custom type is too complex to resolve
 CREATE TYPE wide AS (a d14, b d14, c d14)
+
+# The bound is lifted while re-planning persisted catalog items during bootstrap,
+# so a type created before the bound existed keeps loading after upgrade instead
+# of crash-looping the environment. `unsafe_enable_unbounded_custom_type_resolution`
+# is the signal, force-enabled during item parsing. With it on, the otherwise
+# rejected `wide` type resolves.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET unsafe_enable_unbounded_custom_type_resolution = on
+----
+COMPLETE 0
+
+statement ok
+CREATE TYPE wide AS (a d14, b d14, c d14)
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET unsafe_enable_unbounded_custom_type_resolution
+----
+COMPLETE 0
+
+# Once the bound is back in force a normal session still rejects resolving the
+# grandfathered type, returning the graceful planning error rather than panicking.
+query error custom type is too complex to resolve
+SELECT NULL::wide

--- a/test/sqllogictest/regressions.slt
+++ b/test/sqllogictest/regressions.slt
@@ -411,11 +411,18 @@ CREATE TYPE l126 AS LIST (ELEMENT TYPE = l125)
 statement ok
 CREATE TYPE l127 AS LIST (ELEMENT TYPE = l126)
 
-statement ok
+# `l128` is rejected at creation, not just when later referenced: resolving its
+# element chain reaches the primitive leaf one level past the depth limit. The
+# whole root type is resolved under one budget, so creation rejects exactly the
+# types a later cast or column reference would.
+statement error custom type nesting depth exceeds limit
 CREATE TYPE l128 AS LIST (ELEMENT TYPE = l127)
 
-statement error custom type nesting depth exceeds limit
-CREATE TYPE l129 AS LIST (ELEMENT TYPE = l128)
+# The deepest list type that was created must actually be usable in a cast.
+query T
+SELECT pg_typeof(NULL::l127)
+----
+l127
 
 # Regression test for a record custom type whose fields reference the same
 # sub-type: its resolved type is exponential in depth, so resolution must be
@@ -468,8 +475,21 @@ CREATE TYPE d14 AS (a d13, b d13)
 statement ok
 CREATE TYPE d15 AS (a d14, b d14)
 
-statement ok
+# `d16` is rejected at creation: its two `d15` fields draw from one shared node
+# budget, so although each field is individually valid they exceed the budget
+# together. Resolving each field with a fresh budget would let `d16` be stored
+# yet be too large to ever materialize.
+statement error custom type is too complex to resolve
 CREATE TYPE d16 AS (a d15, b d15)
 
+# The deepest record type that was created must actually be usable in a cast.
+query T
+SELECT pg_typeof(NULL::d15)
+----
+d15
+
+# A wide record whose fields are each individually valid (`d14` resolves well
+# within the budget) but collectively exceed the shared node budget is rejected,
+# rather than materializing an unbounded type tree during sequencing.
 statement error custom type is too complex to resolve
-CREATE TYPE d17 AS (a d16, b d16)
+CREATE TYPE wide AS (a d14, b d14, c d14)


### PR DESCRIPTION
`scalar_type_from_catalog` resolves a custom type into an in-memory `SqlScalarType` by recursing into its referenced sub-types. Two shapes of user-created type made this pathological, both reachable at `CREATE TYPE` plan time (and any later reference):

* A deep chain of LIST/MAP types (`l0 <- l1 <- ... <- lN`) recursed N deep and overflowed the stack.
* A record type whose fields reference the same sub-type (`CREATE TYPE tN AS (a t{N-1}, b t{N-1})`) resolves to a type tree that is exponential in its depth, because record fields hold owned copies rather than shared references. Building/cloning it exhausted memory and CPU.

Bound both: reject a type nested deeper than MAX_TYPE_NESTING_DEPTH, and cap the total number of sub-type resolutions (MAX_TYPE_RESOLUTION_NODES) so an exponentially large type is rejected before it is built, rather than after. Both now return a graceful planning error.

Closes: SQL-514, SQL-513